### PR TITLE
fix: issue of preventing mouse hover when tooltip is hovering

### DIFF
--- a/src/components/_shared/outline/OutlineItemContent.tsx
+++ b/src/components/_shared/outline/OutlineItemContent.tsx
@@ -62,8 +62,7 @@ function OutlineItemContent ({
 
       <Tooltip
         title={name}
-        enterDelay={1000}
-        enterNextDelay={1000}
+        disableInteractive={true}
       >
         <div className={'flex-1 truncate'}>{name || t('menuAppHeader.defaultNewPageName')}</div>
       </Tooltip>


### PR DESCRIPTION
<!---
Thank you for submitting a pull request to the AppFlowy Web! The team will dedicate their best efforts to reviewing and approving your PR. If you have any questions or feedback, feel free to join our [Discord](https://discord.gg/wdjWUXXhtw).
-->


### **Description**
<!---
Provide a clear and concise description of the changes introduced in this pull request for AppFlowy Web. What problem does it solve? What value does it add?
-->


Fix: https://www.notion.so/appflowy/Sidebar-tooltip-sometimes-blocks-the-hand-hover-to-be-triggered-It-would-be-nice-if-we-can-move-the-17796b61692380f18b3ec291845b9c0d?pvs=4

---

### **Checklist**
<!---
Before marking your pull request as ready for review, ensure the following checklist is complete.
-->

#### **General**
- [ ] I've included relevant documentation or comments for the changes introduced.
- [ ] I've tested the changes in multiple environments (e.g., different browsers, operating systems).

#### **Testing**
- [ ] I've added or updated tests to validate the changes introduced for AppFlowy Web.

#### **Feature-Specific**
- [ ] For feature additions, I've added a preview (video, screenshot, or demo) in the "Feature Preview" section.
- [ ] I've verified that this feature integrates seamlessly with existing functionality.