### PR TITLE
fix: the issue where link preview would be pasted to the next line when pasting

### DIFF
--- a/src/components/editor/plugins/withPasted.ts
+++ b/src/components/editor/plugins/withPasted.ts
@@ -61,9 +61,14 @@ export const withPasted = (editor: ReactEditor) => {
             }
           }
 
-          const currentBlockId = node.blockId as string;
-
-          CustomEditor.addBelowBlock(editor as YjsEditor, currentBlockId, BlockType.LinkPreview, { url: text } as LinkPreviewBlockData);
+          // const currentBlockId = node.blockId as string;
+          //
+          // CustomEditor.addBelowBlock(editor as YjsEditor, currentBlockId, BlockType.LinkPreview, { url: text } as LinkPreviewBlockData);
+          insertFragment(editor, [{
+            type: BlockType.LinkPreview,
+            data: { url: text } as LinkPreviewBlockData,
+            children: [{ text: '' }],
+          }]);
 
           return true;
         }
@@ -105,7 +110,7 @@ export const withPasted = (editor: ReactEditor) => {
   return editor;
 };
 
-export function insertHtmlData(editor: ReactEditor, data: DataTransfer) {
+export function insertHtmlData (editor: ReactEditor, data: DataTransfer) {
   const html = data.getData('text/html');
 
   if (html) {
@@ -120,7 +125,7 @@ export function insertHtmlData(editor: ReactEditor, data: DataTransfer) {
   return false;
 }
 
-function insertFragment(editor: ReactEditor, fragment: Node[], options = {}) {
+function insertFragment (editor: ReactEditor, fragment: Node[], options = {}) {
   console.log('insertFragment', fragment, options);
   if (!beforePasted(editor))
     return;


### PR DESCRIPTION


<!---
Thank you for submitting a pull request to the AppFlowy Web! The team will dedicate their best efforts to reviewing and approving your PR. If you have any questions or feedback, feel free to join our [Discord](https://discord.gg/wdjWUXXhtw).
-->


### **Description**
<!---
Provide a clear and concise description of the changes introduced in this pull request for AppFlowy Web. What problem does it solve? What value does it add?
-->


Fixed: https://www.notion.so/appflowy/paste-a-link-as-preview-the-target-is-placed-in-the-next-line-instead-of-the-current-line-17796b6169238095a680dec6264d1390?pvs=4

---

### **Checklist**
<!---
Before marking your pull request as ready for review, ensure the following checklist is complete.
-->

#### **General**
- [ ] I've included relevant documentation or comments for the changes introduced.
- [ ] I've tested the changes in multiple environments (e.g., different browsers, operating systems).

#### **Testing**
- [ ] I've added or updated tests to validate the changes introduced for AppFlowy Web.

#### **Feature-Specific**
- [ ] For feature additions, I've added a preview (video, screenshot, or demo) in the "Feature Preview" section.
- [ ] I've verified that this feature integrates seamlessly with existing functionality.