### PR TITLE
fix: wrong database tab order due to date string conversion

### DIFF
--- a/src/application/database-yjs/selector.ts
+++ b/src/application/database-yjs/selector.ts
@@ -54,7 +54,7 @@ export function useDatabaseViewsSelector (_iidIndex: string, visibleViewIds?: st
       const viewsObj = views.toJSON() as Record<
         string,
         {
-          created_at: number;
+          created_at: string;
         }
       >;
 
@@ -62,7 +62,7 @@ export function useDatabaseViewsSelector (_iidIndex: string, visibleViewIds?: st
         const [, viewA] = a;
         const [, viewB] = b;
 
-        return Number(viewB.created_at) - Number(viewA.created_at);
+        return Date.parse(viewB.created_at) - Date.parse(viewA.created_at);
       });
 
       setViewIds(


### PR DESCRIPTION
<!---
Thank you for submitting a pull request to the AppFlowy Web! The team will dedicate their best efforts to reviewing and approving your PR. If you have any questions or feedback, feel free to join our [Discord](https://discord.gg/wdjWUXXhtw).
-->


### **Description**
<!---
Provide a clear and concise description of the changes introduced in this pull request for AppFlowy Web. What problem does it solve? What value does it add?
-->
When rendering the tabs for database, the tabs are ordered based on the view creation time. The view's creation time is obtained via the get folder endpoint, which returns the creation time in string format. When sorting the views, the current approach is to convert the string to number, then use it as a sorting criteria. This is inaccurate, because timestamp is a big integer, so conversion to number will lead to precision lost, resulting in wrong orders for the tab.

---

### **Checklist**
<!---
Before marking your pull request as ready for review, ensure the following checklist is complete.
-->

#### **General**
- [ ] I've included relevant documentation or comments for the changes introduced.
- [x] I've tested the changes in multiple environments (e.g., different browsers, operating systems).

#### **Testing**
- [ ] I've added or updated tests to validate the changes introduced for AppFlowy Web.

#### **Feature-Specific**
- [ ] For feature additions, I've added a preview (video, screenshot, or demo) in the "Feature Preview" section.
- [x] I've verified that this feature integrates seamlessly with existing functionality.