### PR TITLE
fix: issue of display toggle h1-h6 in outline

### DIFF
--- a/src/components/editor/components/blocks/outline/utils.ts
+++ b/src/components/editor/components/blocks/outline/utils.ts
@@ -20,7 +20,7 @@ export function extractHeadings (editor: ReactEditor, maxDepth: number): Heading
           ...block,
           data: {
             level: (block as HeadingNode).data.level,
-            text: CustomEditor.getBlockTextContent(block),
+            text: CustomEditor.getBlockTextContent(block, 2),
           },
           children: [],
         } as HeadingNode);


### PR DESCRIPTION
<!---
Thank you for submitting a pull request to the AppFlowy Web! The team will dedicate their best efforts to reviewing and approving your PR. If you have any questions or feedback, feel free to join our [Discord](https://discord.gg/wdjWUXXhtw).
-->


### **Description**
<!---
Provide a clear and concise description of the changes introduced in this pull request for AppFlowy Web. What problem does it solve? What value does it add?
-->

---

### **Checklist**
<!---
Before marking your pull request as ready for review, ensure the following checklist is complete.
-->

#### **General**
- [ ] I've included relevant documentation or comments for the changes introduced.
- [ ] I've tested the changes in multiple environments (e.g., different browsers, operating systems).

#### **Testing**
- [ ] I've added or updated tests to validate the changes introduced for AppFlowy Web.

#### **Feature-Specific**
- [ ] For feature additions, I've added a preview (video, screenshot, or demo) in the "Feature Preview" section.
- [ ] I've verified that this feature integrates seamlessly with existing functionality.

## Summary by Sourcery

Bug Fixes:
- Corrected the text content extraction for headings by modifying the getBlockTextContent method to use a specific depth parameter