### PR TITLE
chore: temporarily use 16px for icons in editor toolbar

### DIFF
--- a/src/components/editor/components/toolbar/selection-toolbar/actions/AIAssistant.tsx
+++ b/src/components/editor/components/toolbar/selection-toolbar/actions/AIAssistant.tsx
@@ -78,7 +78,7 @@ function AIAssistant() {
         onClick={onClickImproveWriting}
         tooltip={t('editor.improveWriting')}
       >
-        <ImproveWritingIcon />
+        <ImproveWritingIcon className='w-4 h-4' />
       </ActionButton>
       <AIWriterMenu
         input={content}
@@ -92,11 +92,11 @@ function AIAssistant() {
             setContent(CustomEditor.getSelectionContent(editor));
             setOpen(prev => !prev);
           }}
-          className={'!text-ai-primary !hover:text-billing-primary'}
+          className={'!text-ai-primary !hover:text-billing-primary '}
           tooltip={t('editor.askAI')}
         >
           <div className={'flex items-center justify-center'}>
-            <AskAIIcon className='w-5 h-5'/>
+            <AskAIIcon className='w-4 h-4'/>
             <TriangleDownIcon className={'text-icon-on-toolbar w-3 h-5'} />
           </div>
 

--- a/src/components/editor/components/toolbar/selection-toolbar/actions/Align.tsx
+++ b/src/components/editor/components/toolbar/selection-toolbar/actions/Align.tsx
@@ -6,9 +6,7 @@ import { ReactComponent as AlignCenterSvg } from '@/assets/icons/align_center.sv
 import { ReactComponent as AlignLeftSvg } from '@/assets/icons/align_left.svg';
 import { ReactComponent as AlignRightSvg } from '@/assets/icons/align_right.svg';
 import { Popover } from '@/components/_shared/popover';
-import {
-  useSelectionToolbarContext,
-} from '@/components/editor/components/toolbar/selection-toolbar/SelectionToolbar.hooks';
+import { useSelectionToolbarContext } from '@/components/editor/components/toolbar/selection-toolbar/SelectionToolbar.hooks';
 import { PopoverProps } from '@mui/material/Popover';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -32,13 +30,7 @@ const popoverProps: Partial<PopoverProps> = {
   },
 };
 
-export function Align({
-  blockId,
-  enabled = true,
-}: {
-  blockId?: string;
-  enabled?: boolean;
-}) {
+export function Align({ blockId, enabled = true }: { blockId?: string; enabled?: boolean }) {
   const [open, setOpen] = useState(false);
 
   const ref = useRef<HTMLButtonElement | null>(null);
@@ -62,11 +54,9 @@ export function Align({
       const node = getNode();
 
       return (node.data as BlockData).align;
-
     } catch (e) {
       return;
     }
-
   }, [getNode]);
 
   const handleClose = useCallback(() => {
@@ -82,13 +72,13 @@ export function Align({
 
     switch (align) {
       case AlignType.Left:
-        return <AlignLeftSvg className={'text-fill-default'}/>;
+        return <AlignLeftSvg className={'h-4 w-4 text-fill-default'} />;
       case 'center':
-        return <AlignCenterSvg className={'text-fill-default'}/>;
+        return <AlignCenterSvg className={'h-4 w-4 text-fill-default'} />;
       case 'right':
-        return <AlignRightSvg className={'text-fill-default'}/>;
+        return <AlignRightSvg className={'h-4 w-4 text-fill-default'} />;
       default:
-        return <AlignLeftSvg/>;
+        return <AlignLeftSvg className={'h-4 w-4'} />;
     }
   }, [getAlign]);
 
@@ -109,10 +99,9 @@ export function Align({
         } catch (e) {
           return;
         }
-
       };
     },
-    [getNode, editor, handleClose, rePosition],
+    [getNode, editor, handleClose, rePosition]
   );
 
   useEffect(() => {
@@ -147,32 +136,31 @@ export function Align({
         anchorEl={ref.current}
         {...popoverProps}
       >
-        <div className={'flex items-center px-2 h-[32px] justify-center'}>
+        <div className={'flex h-[32px] items-center justify-center px-2'}>
           <ActionButton
             active={getAlign() === AlignType.Left}
             tooltip={t('document.plugins.optionAction.left')}
             onClick={toggleAlign(AlignType.Left)}
           >
-            <AlignLeftSvg/>
+            <AlignLeftSvg className='h-4 w-4' />
           </ActionButton>
           <ActionButton
             active={getAlign() === AlignType.Center}
             tooltip={t('document.plugins.optionAction.center')}
             onClick={toggleAlign(AlignType.Center)}
           >
-            <AlignCenterSvg/>
+            <AlignCenterSvg className='h-4 w-4' />
           </ActionButton>
           <ActionButton
             active={getAlign() === AlignType.Right}
             tooltip={t('document.plugins.optionAction.right')}
             onClick={toggleAlign(AlignType.Right)}
           >
-            <AlignRightSvg/>
+            <AlignRightSvg className='h-4 w-4' />
           </ActionButton>
         </div>
       </Popover>
     </>
-
   );
 }
 

--- a/src/components/editor/components/toolbar/selection-toolbar/actions/Bold.tsx
+++ b/src/components/editor/components/toolbar/selection-toolbar/actions/Bold.tsx
@@ -32,7 +32,7 @@ export function Bold() {
         </>
       }
     >
-      <BoldSvg />
+      <BoldSvg className='h-4 w-4' />
     </ActionButton>
   );
 }

--- a/src/components/editor/components/toolbar/selection-toolbar/actions/BulletedList.tsx
+++ b/src/components/editor/components/toolbar/selection-toolbar/actions/BulletedList.tsx
@@ -32,7 +32,7 @@ export function BulletedList() {
 
   return (
     <ActionButton active={isActivated} onClick={onClick} tooltip={t('document.plugins.bulletedList')}>
-      <BulletedListSvg />
+      <BulletedListSvg className='h-4 w-4' />
     </ActionButton>
   );
 }

--- a/src/components/editor/components/toolbar/selection-toolbar/actions/Color.tsx
+++ b/src/components/editor/components/toolbar/selection-toolbar/actions/Color.tsx
@@ -215,7 +215,7 @@ function Color() {
   return (
     <>
       <ActionButton onClick={onClick} active={isActivated} tooltip={t('editor.color')}>
-        <ColorSvg />
+        <ColorSvg className='h-4 w-4' />
       </ActionButton>
       {toolbarVisible && (
         <Popover

--- a/src/components/editor/components/toolbar/selection-toolbar/actions/Formula.tsx
+++ b/src/components/editor/components/toolbar/selection-toolbar/actions/Formula.tsx
@@ -2,9 +2,7 @@ import { YjsEditor } from '@/application/slate-yjs';
 import { CustomEditor } from '@/application/slate-yjs/command';
 import { EditorMarkFormat } from '@/application/slate-yjs/types';
 import ActionButton from '@/components/editor/components/toolbar/selection-toolbar/actions/ActionButton';
-import {
-  useSelectionToolbarContext,
-} from '@/components/editor/components/toolbar/selection-toolbar/SelectionToolbar.hooks';
+import { useSelectionToolbarContext } from '@/components/editor/components/toolbar/selection-toolbar/SelectionToolbar.hooks';
 import React, { useCallback, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Transforms, Text, Editor } from 'slate';
@@ -14,9 +12,7 @@ import { ReactComponent as MathSvg } from '@/assets/icons/formula.svg';
 function Formula() {
   const { t } = useTranslation();
   const editor = useSlate() as YjsEditor;
-  const {
-    visible,
-  } = useSelectionToolbarContext();
+  const { visible } = useSelectionToolbarContext();
   const [state, setState] = React.useState({
     isActivated: false,
     hasFormulaActivated: false,
@@ -78,7 +74,7 @@ function Formula() {
     } else {
       const [entry] = editor.nodes({
         at: selection,
-        match: n => !Editor.isEditor(n) && Text.isText(n) && n.formula !== undefined,
+        match: (n) => !Editor.isEditor(n) && Text.isText(n) && n.formula !== undefined,
       });
 
       if (!entry) return;
@@ -103,7 +99,7 @@ function Formula() {
       disabled={!isActivated && (hasFormulaActivated || hasMentionActivated)}
       tooltip={t('document.plugins.createInlineMathEquation')}
     >
-      <MathSvg/>
+      <MathSvg className='h-4 w-4' />
     </ActionButton>
   );
 }

--- a/src/components/editor/components/toolbar/selection-toolbar/actions/Heading.tsx
+++ b/src/components/editor/components/toolbar/selection-toolbar/actions/Heading.tsx
@@ -73,18 +73,18 @@ export function Heading() {
 
   const getActiveButton = useCallback(() => {
     if (isActivated(1)) {
-      return <Heading1 className={'text-fill-default'} />;
+      return <Heading1 className={'h-4 w-4 text-fill-default'} />;
     }
 
     if (isActivated(2)) {
-      return <Heading2 className={'text-fill-default'} />;
+      return <Heading2 className={'h-4 w-4 text-fill-default'} />;
     }
 
     if (isActivated(3)) {
-      return <Heading3 className={'text-fill-default'} />;
+      return <Heading3 className={'h-4 w-4 text-fill-default'} />;
     }
 
-    return <Heading3 />;
+    return <Heading3 className='h-4 w-4 text-fill-default' />;
   }, [isActivated]);
 
   const [open, setOpen] = useState(false);
@@ -109,7 +109,7 @@ export function Heading() {
       >
         <div className={'flex items-center justify-center'}>
           {getActiveButton()}
-          <DownArrow className={'w-3 h-5 text-icon-on-toolbar'} />
+          <DownArrow className={'h-5 w-3 text-icon-on-toolbar'} />
         </div>
       </ActionButton>
       {toolbarVisible && (
@@ -126,13 +126,13 @@ export function Heading() {
         >
           <div className={'flex h-[32px] items-center justify-center px-2'}>
             <ActionButton active={isActivated(1)} tooltip={t('editor.heading1')} onClick={toHeading(1)}>
-              <Heading1 />
+              <Heading1 className='h-4 w-4' />
             </ActionButton>
             <ActionButton active={isActivated(2)} tooltip={t('editor.heading2')} onClick={toHeading(2)}>
-              <Heading2 />
+              <Heading2 className='h-4 w-4' />
             </ActionButton>
             <ActionButton active={isActivated(3)} tooltip={t('editor.heading3')} onClick={toHeading(3)}>
-              <Heading3 />
+              <Heading3 className='h-4 w-4' />
             </ActionButton>
           </div>
         </Popover>

--- a/src/components/editor/components/toolbar/selection-toolbar/actions/Href.tsx
+++ b/src/components/editor/components/toolbar/selection-toolbar/actions/Href.tsx
@@ -93,7 +93,7 @@ export function Href() {
   return (
     <>
       <ActionButton disabled={disabled} onClick={onClick} active={isActivated} tooltip={tooltip}>
-        <LinkSvg />
+        <LinkSvg className='h-4 w-4' />
       </ActionButton>
 
       <HrefPopover

--- a/src/components/editor/components/toolbar/selection-toolbar/actions/InlineCode.tsx
+++ b/src/components/editor/components/toolbar/selection-toolbar/actions/InlineCode.tsx
@@ -31,7 +31,7 @@ export function InlineCode() {
         </>
       }
     >
-      <CodeSvg />
+      <CodeSvg className='h-4 w-4' />
     </ActionButton>
   );
 }

--- a/src/components/editor/components/toolbar/selection-toolbar/actions/Italic.tsx
+++ b/src/components/editor/components/toolbar/selection-toolbar/actions/Italic.tsx
@@ -7,7 +7,7 @@ import { useTranslation } from 'react-i18next';
 import { useSlateStatic } from 'slate-react';
 import { ReactComponent as ItalicSvg } from '@/assets/icons/italic.svg';
 
-export function Italic () {
+export function Italic() {
   const { t } = useTranslation();
   const editor = useSlateStatic();
   const isActivated = CustomEditor.isMarkActive(editor, EditorMarkFormat.Italic);
@@ -31,7 +31,7 @@ export function Italic () {
         </>
       }
     >
-      <ItalicSvg />
+      <ItalicSvg className='h-4 w-4' />
     </ActionButton>
   );
 }

--- a/src/components/editor/components/toolbar/selection-toolbar/actions/NumberedList.tsx
+++ b/src/components/editor/components/toolbar/selection-toolbar/actions/NumberedList.tsx
@@ -32,7 +32,7 @@ export function NumberedList() {
 
   return (
     <ActionButton active={isActivated} onClick={onClick} tooltip={t('document.plugins.numberedList')}>
-      <NumberedListSvg />
+      <NumberedListSvg className='h-4 w-4' />
     </ActionButton>
   );
 }

--- a/src/components/editor/components/toolbar/selection-toolbar/actions/Paragraph.tsx
+++ b/src/components/editor/components/toolbar/selection-toolbar/actions/Paragraph.tsx
@@ -24,7 +24,7 @@ export function Paragraph() {
 
   return (
     <ActionButton active={isActive} onClick={onClick} tooltip={t('editor.text')}>
-      <ParagraphSvg />
+      <ParagraphSvg className='h-4 w-4' />
     </ActionButton>
   );
 }

--- a/src/components/editor/components/toolbar/selection-toolbar/actions/Quote.tsx
+++ b/src/components/editor/components/toolbar/selection-toolbar/actions/Quote.tsx
@@ -32,7 +32,7 @@ export function Quote() {
 
   return (
     <ActionButton active={isActivated} onClick={onClick} tooltip={t('editor.quote')}>
-      <QuoteSvg />
+      <QuoteSvg className='h-4 w-4' />
     </ActionButton>
   );
 }

--- a/src/components/editor/components/toolbar/selection-toolbar/actions/StrikeThrough.tsx
+++ b/src/components/editor/components/toolbar/selection-toolbar/actions/StrikeThrough.tsx
@@ -7,7 +7,7 @@ import { useTranslation } from 'react-i18next';
 import { useSlateStatic } from 'slate-react';
 import { ReactComponent as StrikeThroughSvg } from '@/assets/icons/strikethrough.svg';
 
-export function StrikeThrough () {
+export function StrikeThrough() {
   const { t } = useTranslation();
   const editor = useSlateStatic();
   const isActivated = CustomEditor.isMarkActive(editor, EditorMarkFormat.StrikeThrough);
@@ -31,7 +31,7 @@ export function StrikeThrough () {
         </>
       }
     >
-      <StrikeThroughSvg />
+      <StrikeThroughSvg className='h-4 w-4' />
     </ActionButton>
   );
 }

--- a/src/components/editor/components/toolbar/selection-toolbar/actions/Underline.tsx
+++ b/src/components/editor/components/toolbar/selection-toolbar/actions/Underline.tsx
@@ -31,7 +31,7 @@ export function Underline() {
         </>
       }
     >
-      <UnderlineSvg />
+      <UnderlineSvg className='h-4 w-4' />
     </ActionButton>
   );
 }


### PR DESCRIPTION
<!---
Thank you for submitting a pull request to the AppFlowy Web! The team will dedicate their best efforts to reviewing and approving your PR. If you have any questions or feedback, feel free to join our [Discord](https://discord.gg/wdjWUXXhtw).
-->


### **Description**
<!---
Provide a clear and concise description of the changes introduced in this pull request for AppFlowy Web. What problem does it solve? What value does it add?
-->

---

### **Checklist**
<!---
Before marking your pull request as ready for review, ensure the following checklist is complete.
-->

#### **General**
- [ ] I've included relevant documentation or comments for the changes introduced.
- [ ] I've tested the changes in multiple environments (e.g., different browsers, operating systems).

#### **Testing**
- [ ] I've added or updated tests to validate the changes introduced for AppFlowy Web.

#### **Feature-Specific**
- [ ] For feature additions, I've added a preview (video, screenshot, or demo) in the "Feature Preview" section.
- [ ] I've verified that this feature integrates seamlessly with existing functionality.

## Summary by Sourcery

Enhancements:
- Standardized icon sizes across various toolbar action components by adding consistent h-4 w-4 Tailwind CSS classes