### PR TITLE
fix: use magic link type for OTP sign in

### DIFF
--- a/src/application/services/js-services/http/gotrue.ts
+++ b/src/application/services/js-services/http/gotrue.ts
@@ -61,7 +61,7 @@ export async function signInOTP ({
     }>('/verify', {
       email,
       token: code,
-      type: 'recovery',
+      type: 'magiclink',
     });
 
     const data = response?.data;
@@ -160,4 +160,3 @@ export function signInDiscord (authUrl: string) {
 
   window.open(url, '_current');
 }
-


### PR DESCRIPTION
<!---
Thank you for submitting a pull request to the AppFlowy Web! The team will dedicate their best efforts to reviewing and approving your PR. If you have any questions or feedback, feel free to join our [Discord](https://discord.gg/wdjWUXXhtw).
-->


### **Description**
<!---
Provide a clear and concise description of the changes introduced in this pull request for AppFlowy Web. What problem does it solve? What value does it add?
-->
In the current version of appflowy gotrue, both magiclink and recovery type follows the same workflow, and it is alright to use them interchangeably.

However, we are planning to modify appflowy gotrue to include additional business logic for the recovery workflow, so it now becomes necessary to use magic link for the verify token endpoint as opposed to recovery.

---

### **Checklist**
<!---
Before marking your pull request as ready for review, ensure the following checklist is complete.
-->

#### **General**
- [ ] I've included relevant documentation or comments for the changes introduced.
- [x] I've tested the changes in multiple environments (e.g., different browsers, operating systems).

#### **Testing**
- [ ] I've added or updated tests to validate the changes introduced for AppFlowy Web.

#### **Feature-Specific**
- [ ] For feature additions, I've added a preview (video, screenshot, or demo) in the "Feature Preview" section.
- [ ] I've verified that this feature integrates seamlessly with existing functionality.

## Summary by Sourcery

Bug Fixes:
- Modify the token verification type to align with upcoming changes in the authentication workflow