### PR TITLE
fix: cypress run start server already

### DIFF
--- a/.github/workflows/web_coverage.yaml
+++ b/.github/workflows/web_coverage.yaml
@@ -43,7 +43,6 @@ jobs:
         with:
           component: true
           build: pnpm run build
-          start: pnpm run start
           browser: chrome
 
       - name: Jest run


### PR DESCRIPTION
<!---
Thank you for submitting a pull request to the AppFlowy Web! The team will dedicate their best efforts to reviewing and approving your PR. If you have any questions or feedback, feel free to join our [Discord](https://discord.gg/wdjWUXXhtw).
-->


### **Description**
<!---
Provide a clear and concise description of the changes introduced in this pull request for AppFlowy Web. What problem does it solve? What value does it add?
-->

---

### **Checklist**
<!---
Before marking your pull request as ready for review, ensure the following checklist is complete.
-->

#### **General**
- [ ] I've included relevant documentation or comments for the changes introduced.
- [ ] I've tested the changes in multiple environments (e.g., different browsers, operating systems).

#### **Testing**
- [ ] I've added or updated tests to validate the changes introduced for AppFlowy Web.

#### **Feature-Specific**
- [ ] For feature additions, I've added a preview (video, screenshot, or demo) in the "Feature Preview" section.
- [ ] I've verified that this feature integrates seamlessly with existing functionality.

## Summary by Sourcery

Remove redundant server start from Cypress coverage workflow.

Bug Fixes:
- Prevent the Cypress coverage job from starting the server twice by removing the redundant 'start: pnpm run start' step.

CI:
- Remove 'start: pnpm run start' from the .github/workflows/web_coverage.yaml configuration.