### PR TITLE
fix: expose error message instead of treating all errors the same mes…

### DIFF
--- a/src/components/_shared/landing-page/InvalidLink.stories.tsx
+++ b/src/components/_shared/landing-page/InvalidLink.stories.tsx
@@ -1,0 +1,50 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { withContextsMinimal } from '../../../../.storybook/decorators';
+
+import { InvalidLink } from './InvalidLink';
+
+const meta = {
+  title: 'Landing Pages/InvalidLink',
+  component: InvalidLink,
+  parameters: {
+    layout: 'fullscreen',
+  },
+  decorators: [withContextsMinimal],
+  tags: ['autodocs'],
+} satisfies Meta<typeof InvalidLink>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const ExpiredMessage: Story = {
+  args: {
+    message: 'The invitation for Tom Workspace expired on 2024-05-01 10:00 UTC.',
+  },
+};
+
+export const AlreadyAccepted: Story = {
+  args: {
+    message: 'This invitation was already accepted. Ask the workspace admin to send a new one.',
+  },
+};
+
+export const Declined: Story = {
+  args: {
+    message: 'This invitation was declined earlier and can no longer be used.',
+  },
+};
+
+export const DisabledLink: Story = {
+  args: {
+    message: 'This invite link was disabled by the workspace admin. Please request a new link.',
+  },
+};
+
+export const NoActiveMembers: Story = {
+  args: {
+    message: 'Tom Workspace currently has no active members, so its invite link is disabled.',
+  },
+};

--- a/src/components/_shared/landing-page/InvalidLink.tsx
+++ b/src/components/_shared/landing-page/InvalidLink.tsx
@@ -3,14 +3,18 @@ import { useTranslation } from 'react-i18next';
 import { ReactComponent as InvalidLinkLogo } from '@/assets/icons/invalid_link.svg';
 import LandingPage from '@/components/_shared/landing-page/LandingPage';
 
-export function InvalidLink() {
+type InvalidLinkProps = {
+  message?: string;
+};
+
+export function InvalidLink({ message }: InvalidLinkProps) {
   const { t } = useTranslation();
 
   return (
     <LandingPage
       Logo={InvalidLinkLogo}
       title={t('landingPage.inviteMember.invalid')}
-      description={t('landingPage.inviteMember.invalidMessage')}
+      description={message ?? t('landingPage.inviteMember.invalidMessage')}
       secondaryAction={{
         onClick: () => window.open('/app', '_self'),
         label: t('landingPage.backToHome'),

--- a/src/components/app/landing-pages/ApproveConversion.tsx
+++ b/src/components/app/landing-pages/ApproveConversion.tsx
@@ -29,6 +29,7 @@ export function ApproveConversion() {
   const [guestName, setGuestName] = useState<string>();
 
   const [isInvalid, setIsInvalid] = useState(false);
+  const [invalidMessage, setInvalidMessage] = useState<string>();
 
   const [notInvitee, setNotInvitee] = useState(false);
 
@@ -67,6 +68,7 @@ export function ApproveConversion() {
       // eslint-disable-next-line
     } catch (e: any) {
       if (e.code === ERROR_CODE.INVALID_LINK) {
+        setInvalidMessage(e.message);
         setIsInvalid(true);
       } else if (e.code === ERROR_CODE.ALREADY_JOINED) {
         setIsAlreadyMember(true);
@@ -145,7 +147,7 @@ export function ApproveConversion() {
   }
 
   if (isInvalid) {
-    return <InvalidLink />;
+    return <InvalidLink message={invalidMessage} />;
   }
 
   if (notInvitee) {

--- a/src/components/app/landing-pages/AsGuest.tsx
+++ b/src/components/app/landing-pages/AsGuest.tsx
@@ -24,6 +24,7 @@ export function AsGuest() {
   const [page, setPage] = useState<{ view_id: string; name: string } | null>(null);
 
   const [isInvalid, setIsInvalid] = useState(false);
+  const [invalidMessage, setInvalidMessage] = useState<string>();
 
   const [notInvitee, setNotInvitee] = useState(false);
 
@@ -63,6 +64,7 @@ export function AsGuest() {
       // eslint-disable-next-line
     } catch (e: any) {
       if (e.code === ERROR_CODE.INVALID_LINK) {
+        setInvalidMessage(e.message);
         setIsInvalid(true);
       } else if (e.code === ERROR_CODE.ALREADY_JOINED) {
         // do nothing
@@ -81,7 +83,7 @@ export function AsGuest() {
   }, [loadInvitation]);
 
   if (isInvalid) {
-    return <InvalidLink />;
+    return <InvalidLink message={invalidMessage} />;
   }
 
   if (notInvitee) {

--- a/src/components/app/landing-pages/InviteCode.tsx
+++ b/src/components/app/landing-pages/InviteCode.tsx
@@ -21,6 +21,7 @@ function InviteCode() {
   const [hasJoined, setHasJoined] = useState(false);
 
   const [isInValid, setIsInValid] = useState(false);
+  const [invalidMessage, setInvalidMessage] = useState<string>();
   const [workspace, setWorkspace] = useState<Workspace>();
   const [isError, setIsError] = useState(false);
 
@@ -50,6 +51,7 @@ function InviteCode() {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } catch (e: any) {
       if (e.code === ERROR_CODE.INVALID_LINK) {
+        setInvalidMessage(e.message);
         setIsInValid(true);
       } else {
         setIsError(true);
@@ -79,6 +81,7 @@ function InviteCode() {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } catch (e: any) {
       if (e.code === ERROR_CODE.INVALID_LINK) {
+        setInvalidMessage(e.message);
         setIsInValid(true);
       } else {
         setIsError(true);
@@ -101,7 +104,7 @@ function InviteCode() {
   );
 
   if (isInValid) {
-    return <InvalidLink />;
+    return <InvalidLink message={invalidMessage} />;
   }
 
   if (isError) {

--- a/src/pages/AcceptInvitationPage.tsx
+++ b/src/pages/AcceptInvitationPage.tsx
@@ -27,6 +27,7 @@ function AcceptInvitationPage() {
   const [loading, setLoading] = useState(false);
   const [notInvitee, setNotInvitee] = useState(false);
   const [isError, setIsError] = useState(false);
+  const [invalidMessage, setInvalidMessage] = useState<string>();
 
   const loadInvitation = useCallback(async () => {
     if (!service) return;
@@ -51,6 +52,7 @@ function AcceptInvitationPage() {
       }
 
       if (e.code === ERROR_CODE.INVALID_LINK) {
+        setInvalidMessage(e.message);
         setIsInValid(true);
         return;
       }
@@ -98,6 +100,7 @@ function AcceptInvitationPage() {
       // eslint-disable-next-line
     } catch (e: any) {
       if (e.code === ERROR_CODE.INVALID_LINK) {
+        setInvalidMessage(e.message);
         setIsInValid(true);
         return;
       }
@@ -126,7 +129,7 @@ function AcceptInvitationPage() {
   );
 
   if (isInValid) {
-    return <InvalidLink />;
+    return <InvalidLink message={invalidMessage} />;
   }
 
   if (notInvitee) {


### PR DESCRIPTION
…sage

<!---
Thank you for submitting a pull request to the AppFlowy Web! The team will dedicate their best efforts to reviewing and approving your PR. If you have any questions or feedback, feel free to join our [Discord](https://discord.gg/wdjWUXXhtw).
-->


### **Description**
<!---
Provide a clear and concise description of the changes introduced in this pull request for AppFlowy Web. What problem does it solve? What value does it add?
-->

---

### **Checklist**
<!---
Before marking your pull request as ready for review, ensure the following checklist is complete.
-->

#### **General**
- [ ] I've included relevant documentation or comments for the changes introduced.
- [ ] I've tested the changes in multiple environments (e.g., different browsers, operating systems).

#### **Testing**
- [ ] I've added or updated tests to validate the changes introduced for AppFlowy Web.

#### **Feature-Specific**
- [ ] For feature additions, I've added a preview (video, screenshot, or demo) in the "Feature Preview" section.
- [ ] I've verified that this feature integrates seamlessly with existing functionality.

## Summary by Sourcery

Surface specific invalid invitation error messages on landing pages instead of showing a generic invalid link message.

New Features:
- Allow the InvalidLink landing page component to display a custom error message when provided.

Enhancements:
- Propagate backend invalid-link error messages from invitation-related flows to the InvalidLink page so users see more accurate reasons for failure.
- Add Storybook stories for the InvalidLink component to showcase different invalid invitation scenarios.