### PR TITLE
chore: hide share pro plan

### DIFF
--- a/src/components/app/publish-manage/PublishManage.tsx
+++ b/src/components/app/publish-manage/PublishManage.tsx
@@ -12,6 +12,7 @@ import PublishedPages from '@/components/app/publish-manage/PublishedPages';
 import PublishPagesSkeleton from '@/components/app/publish-manage/PublishPagesSkeleton';
 import UpdateNamespace from '@/components/app/publish-manage/UpdateNamespace';
 import { useCurrentUser, useService } from '@/components/main/app.hooks';
+import { isOfficialHost } from '@/utils/subscription';
 import { openUrl } from '@/utils/url';
 
 export function PublishManage({ onClose }: { onClose?: () => void }) {
@@ -175,6 +176,11 @@ export function PublishManage({ onClose }: { onClose?: () => void }) {
   const { getSubscriptions } = useAppHandlers();
   const [activeSubscription, setActiveSubscription] = React.useState<SubscriptionPlan | null>(null);
   const loadSubscription = useCallback(async () => {
+    if (!isOfficialHost()) {
+      setActiveSubscription(SubscriptionPlan.Pro);
+      return;
+    }
+
     try {
       const subscriptions = await getSubscriptions?.();
 

--- a/src/components/app/share/SharePanel.tsx
+++ b/src/components/app/share/SharePanel.tsx
@@ -10,6 +10,7 @@ import { InviteGuest } from '@/components/app/share/InviteGuest';
 import { PeopleWithAccess } from '@/components/app/share/PeopleWithAccess';
 import { UpgradeBanner } from '@/components/app/share/UpgradeBanner';
 import { useCurrentUser, useService } from '@/components/main/app.hooks';
+import { isOfficialHost } from '@/utils/subscription';
 
 function SharePanel({ viewId }: { viewId: string }) {
   const currentUser = useCurrentUser();
@@ -122,6 +123,11 @@ function SharePanel({ viewId }: { viewId: string }) {
   }, [getSubscriptions]);
 
   useEffect(() => {
+    if (!isOfficialHost()) {
+      setActiveSubscriptionPaln(SubscriptionPlan.Pro);
+      return;
+    }
+
     if (isOwner || isMember) {
       void loadSubscription();
     }
@@ -141,7 +147,7 @@ function SharePanel({ viewId }: { viewId: string }) {
           hasFullAccess={hasFullAccess}
           activeSubscriptionPlan={activeSubscriptionPlan}
         />
-        <UpgradeBanner activeSubscriptionPlan={activeSubscriptionPlan} />
+        {isOfficialHost() && <UpgradeBanner activeSubscriptionPlan={activeSubscriptionPlan} />}
         <PeopleWithAccess viewId={viewId} people={people} isLoading={isLoading} onPeopleChange={refreshPeople} />
         <GeneralAccess viewId={viewId} />
         <CopyLink />

--- a/src/components/app/workspaces/InviteMember.tsx
+++ b/src/components/app/workspaces/InviteMember.tsx
@@ -12,6 +12,7 @@ import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Progress } from '@/components/ui/progress';
+import { isOfficialHost } from '@/utils/subscription';
 
 function InviteMember({
   workspace,
@@ -48,6 +49,11 @@ function InviteMember({
   const [activeSubscriptionPlan, setActiveSubscriptionPaln] = React.useState<SubscriptionPlan | null>(null);
 
   const loadSubscription = useCallback(async () => {
+    if (!isOfficialHost()) {
+      setActiveSubscriptionPaln(SubscriptionPlan.Pro);
+      return;
+    }
+
     try {
       const subscriptions = await getSubscriptions?.();
 

--- a/src/utils/subscription.ts
+++ b/src/utils/subscription.ts
@@ -6,7 +6,7 @@
  */
 import { getConfigValue } from '@/utils/runtime-config';
 
-const OFFICIAL_HOSTNAMES = new Set(['beta.appflowy.cloud', 'test.appflowy.cloud', 'localhost:8000']);
+const OFFICIAL_HOSTNAMES = new Set(['beta.appflowy.cloud', 'test.appflowy.cloud', 'localhost']);
 
 function getBaseUrlHostname(): string | null {
     const baseUrl = getConfigValue('APPFLOWY_BASE_URL', '').trim();


### PR DESCRIPTION
<!---
Thank you for submitting a pull request to the AppFlowy Web! The team will dedicate their best efforts to reviewing and approving your PR. If you have any questions or feedback, feel free to join our [Discord](https://discord.gg/wdjWUXXhtw).
-->


### **Description**
<!---
Provide a clear and concise description of the changes introduced in this pull request for AppFlowy Web. What problem does it solve? What value does it add?
-->

---

### **Checklist**
<!---
Before marking your pull request as ready for review, ensure the following checklist is complete.
-->

#### **General**
- [ ] I've included relevant documentation or comments for the changes introduced.
- [ ] I've tested the changes in multiple environments (e.g., different browsers, operating systems).

#### **Testing**
- [ ] I've added or updated tests to validate the changes introduced for AppFlowy Web.

#### **Feature-Specific**
- [ ] For feature additions, I've added a preview (video, screenshot, or demo) in the "Feature Preview" section.
- [ ] I've verified that this feature integrates seamlessly with existing functionality.

## Summary by Sourcery

Adjust subscription handling and visibility of upgrade prompts based on whether the app is running on an official host.

Bug Fixes:
- Ensure self-hosted or non-official hosts are treated as having Pro-level access in sharing, publishing, and workspace invitation flows.

Enhancements:
- Hide the upgrade banner and avoid remote subscription checks when running on non-official hosts.
- Update the list of official hostnames to treat localhost (without port) as official for subscription logic.