### PR TITLE
fix: math equation width

### DIFF
--- a/src/components/editor/components/block-popover/MathEquationPopoverContent.tsx
+++ b/src/components/editor/components/block-popover/MathEquationPopoverContent.tsx
@@ -57,7 +57,7 @@ function MathEquationPopoverContent({
   const inputRef = useRef<HTMLTextAreaElement | null>(null);
 
   return (
-    <div className={'flex flex-col p-4 gap-3 w-[560px] max-w-[964px]'}>
+    <div className={'flex flex-col p-4 gap-3 w-[400px]'}>
       <TextField
         inputRef={(input: HTMLTextAreaElement) => {
           if (!input) return;

--- a/src/components/editor/components/block-popover/index.tsx
+++ b/src/components/editor/components/block-popover/index.tsx
@@ -85,7 +85,7 @@ function BlockPopover() {
           top: panelPosition.bottom,
           left: panelPosition.left,
         },
-        type === BlockType.ImageBlock || type === BlockType.VideoBlock ? 400 : 560,
+        400,
         type === BlockType.ImageBlock || type === BlockType.VideoBlock ? 366 : 200,
         defaultOrigins,
         16


### PR DESCRIPTION
<!---
Thank you for submitting a pull request to the AppFlowy Web! The team will dedicate their best efforts to reviewing and approving your PR. If you have any questions or feedback, feel free to join our [Discord](https://discord.gg/wdjWUXXhtw).
-->


### **Description**
<!---
Provide a clear and concise description of the changes introduced in this pull request for AppFlowy Web. What problem does it solve? What value does it add?
-->

---

### **Checklist**
<!---
Before marking your pull request as ready for review, ensure the following checklist is complete.
-->

#### **General**
- [ ] I've included relevant documentation or comments for the changes introduced.
- [ ] I've tested the changes in multiple environments (e.g., different browsers, operating systems).

#### **Testing**
- [ ] I've added or updated tests to validate the changes introduced for AppFlowy Web.

#### **Feature-Specific**
- [ ] For feature additions, I've added a preview (video, screenshot, or demo) in the "Feature Preview" section.
- [ ] I've verified that this feature integrates seamlessly with existing functionality.

## Summary by Sourcery

Standardize the block popover to use a narrower, consistent width across math equation and media popups.

Enhancements:
- Adjust the math equation popover content to use a fixed 400px width.
- Align the generic block popover width to 400px for all block types instead of varying by content type.