### PR TITLE
fix: do not show template for selfhosting

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "@atlaskit/primitives": "^5.5.3",
     "@emoji-mart/data": "^1.1.2",
     "@emoji-mart/react": "^1.1.1",
+    "@emotion/is-prop-valid": "^1.4.0",
     "@emotion/react": "^11.10.6",
     "@emotion/styled": "^11.10.6",
     "@floating-ui/react": "^0.26.27",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,6 +41,9 @@ importers:
       '@emoji-mart/react':
         specifier: ^1.1.1
         version: 1.1.1(emoji-mart@5.6.0)(react@18.3.1)
+      '@emotion/is-prop-valid':
+        specifier: ^1.4.0
+        version: 1.4.0
       '@emotion/react':
         specifier: ^11.10.6
         version: 11.14.0(@types/react@18.3.21)(react@18.3.1)
@@ -199,7 +202,7 @@ importers:
         version: 3.3.0
       framer-motion:
         specifier: ^12.6.3
-        version: 12.12.1(@emotion/is-prop-valid@1.3.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 12.12.1(@emotion/is-prop-valid@1.4.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       google-protobuf:
         specifier: ^3.15.12
         version: 3.21.4
@@ -1716,8 +1719,8 @@ packages:
   '@emotion/hash@0.9.2':
     resolution: {integrity: sha512-MyqliTZGuOm3+5ZRSaaBGP3USLw6+EGykkwZns2EPC5g8jJ4z9OrdZY9apkl3+UP9+sdz76YYkwCKP5gh8iY3g==}
 
-  '@emotion/is-prop-valid@1.3.1':
-    resolution: {integrity: sha512-/ACwoqx7XQi9knQs/G0qKvv5teDMhD7bXYns9N/wM8ah8iNb8jZ2uNO0YOgiq2o2poIvVtJS2YALasQuMSQ7Kw==}
+  '@emotion/is-prop-valid@1.4.0':
+    resolution: {integrity: sha512-QgD4fyscGcbbKwJmqNvUMSE02OsHUa+lAWKdEUIJKgqe5IwRSKd7+KhibEWdaKwgjLj0DRSHA9biAIqGBk05lw==}
 
   '@emotion/memoize@0.9.0':
     resolution: {integrity: sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ==}
@@ -11073,7 +11076,7 @@ snapshots:
 
   '@emotion/hash@0.9.2': {}
 
-  '@emotion/is-prop-valid@1.3.1':
+  '@emotion/is-prop-valid@1.4.0':
     dependencies:
       '@emotion/memoize': 0.9.0
 
@@ -11109,7 +11112,7 @@ snapshots:
     dependencies:
       '@babel/runtime': 7.27.1
       '@emotion/babel-plugin': 11.13.5
-      '@emotion/is-prop-valid': 1.3.1
+      '@emotion/is-prop-valid': 1.4.0
       '@emotion/react': 11.14.0(@types/react@18.3.21)(react@18.3.1)
       '@emotion/serialize': 1.3.3
       '@emotion/use-insertion-effect-with-fallbacks': 1.2.0(react@18.3.1)
@@ -15517,13 +15520,13 @@ snapshots:
 
   fraction.js@4.3.7: {}
 
-  framer-motion@12.12.1(@emotion/is-prop-valid@1.3.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  framer-motion@12.12.1(@emotion/is-prop-valid@1.4.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       motion-dom: 12.12.1
       motion-utils: 12.12.1
       tslib: 2.8.1
     optionalDependencies:
-      '@emotion/is-prop-valid': 1.3.1
+      '@emotion/is-prop-valid': 1.4.0
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 

--- a/src/components/app/SideBarBottom.tsx
+++ b/src/components/app/SideBarBottom.tsx
@@ -1,28 +1,33 @@
 import { IconButton, Tooltip } from '@mui/material';
+import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 
 import { ReactComponent as TrashIcon } from '@/assets/icons/delete.svg';
 import { ReactComponent as TemplateIcon } from '@/assets/icons/template.svg';
 import { QuickNote } from '@/components/quick-note';
+import { isOfficialHost } from '@/utils/subscription';
 
 function SideBarBottom() {
   const { t } = useTranslation();
   const navigate = useNavigate();
+  const isOfficial = useMemo(() => isOfficialHost(), []);
 
   return (
     <div className={'sticky bottom-0 bg-surface-container-layer-00 px-4'}>
       <div className={'flex items-center  justify-around gap-1 border-t border-border-primary py-4'}>
-        <Tooltip title={t('template.label')}>
-          <IconButton
-            size={'small'}
-            onClick={() => {
-              window.open(`${window.location.origin}/templates`, '_blank');
-            }}
-          >
-            <TemplateIcon />
-          </IconButton>
-        </Tooltip>
+        {isOfficial && (
+          <Tooltip title={t('template.label')}>
+            <IconButton
+              size={'small'}
+              onClick={() => {
+                window.open(`${window.location.origin}/templates`, '_blank');
+              }}
+            >
+              <TemplateIcon />
+            </IconButton>
+          </Tooltip>
+        )}
 
         <Tooltip title={t('trash.text')}>
           <IconButton


### PR DESCRIPTION
<!---
Thank you for submitting a pull request to the AppFlowy Web! The team will dedicate their best efforts to reviewing and approving your PR. If you have any questions or feedback, feel free to join our [Discord](https://discord.gg/wdjWUXXhtw).
-->


### **Description**
<!---
Provide a clear and concise description of the changes introduced in this pull request for AppFlowy Web. What problem does it solve? What value does it add?
-->

---

### **Checklist**
<!---
Before marking your pull request as ready for review, ensure the following checklist is complete.
-->

#### **General**
- [ ] I've included relevant documentation or comments for the changes introduced.
- [ ] I've tested the changes in multiple environments (e.g., different browsers, operating systems).

#### **Testing**
- [ ] I've added or updated tests to validate the changes introduced for AppFlowy Web.

#### **Feature-Specific**
- [ ] For feature additions, I've added a preview (video, screenshot, or demo) in the "Feature Preview" section.
- [ ] I've verified that this feature integrates seamlessly with existing functionality.

## Summary by Sourcery

Restrict sidebar template access to official hosts only and update dependencies accordingly.

Bug Fixes:
- Hide the sidebar template button when the app is not running on an official host to prevent unsupported access in self-hosted environments.

Build:
- Add @emotion/is-prop-valid as a new runtime dependency in package.json.