### PR TITLE
chore: async filtering rows

### DIFF
--- a/src/application/database-blob/index.ts
+++ b/src/application/database-blob/index.ts
@@ -21,6 +21,8 @@ type RowDocSeed = {
 
 type PrefetchOptions = {
   priorityRowIds?: string[];
+  /** Called immediately after seeds are cached (before IndexedDB persist). */
+  onSeedsReady?: () => void;
 };
 
 const RID_CACHE_PREFIX = 'af_database_blob_rid:';
@@ -616,6 +618,9 @@ export async function prefetchDatabaseBlobDiff(
     seedCount: rowDocSeedCache.size,
     lookupCount: rowDocSeedLookup.size,
   });
+
+  // Signal that seeds are available before the slow IndexedDB persist
+  options?.onSeedsReady?.();
 
   const applyStartedAt = Date.now();
 

--- a/src/application/database-yjs/context.ts
+++ b/src/application/database-yjs/context.ts
@@ -50,7 +50,7 @@ export interface DatabaseContextState {
   activeViewId: string;
   rowMap: Record<RowId, YDoc> | null;
   ensureRow?: (rowId: string) => Promise<YDoc | undefined> | void;
-  populateRowFromCache?: (rowId: string) => Promise<YDoc | undefined>;
+  loadRowFromSeed?: (rowId: string) => Promise<YDoc | undefined>;
   bindRowSync?: (rowId: string) => void;
   blobPrefetchComplete?: boolean;
   isDatabaseRowPage?: boolean;

--- a/src/application/database-yjs/hooks/useBackgroundRowDocLoader.ts
+++ b/src/application/database-yjs/hooks/useBackgroundRowDocLoader.ts
@@ -11,7 +11,9 @@ const BACKGROUND_CONCURRENCY = 12;
 /**
  * Hook that handles background loading of row documents for sorting/filtering.
  * When sorts or filters are active, row docs need to be loaded to apply conditions.
- * This hook manages a background queue to load missing row docs efficiently.
+ *
+ * Uses blob diff seeds (via populateRowFromCache) when available for fast loading,
+ * falling back to IndexedDB for rows without seeds.
  *
  * @param hasConditions - Whether there are active sorts or filters
  * @returns Object containing cached row docs and merged row docs for conditions
@@ -19,7 +21,7 @@ const BACKGROUND_CONCURRENCY = 12;
 export function useBackgroundRowDocLoader(hasConditions: boolean) {
   const rows = useRowMap();
   const view = useDatabaseView();
-  const { databaseDoc } = useDatabaseContext();
+  const { databaseDoc, populateRowFromCache, blobPrefetchComplete } = useDatabaseContext();
 
   const [cachedRowDocs, setCachedRowDocs] = useState<Record<string, YDoc>>({});
   const cachedRowDocsRef = useRef<Record<string, YDoc>>({});
@@ -72,9 +74,12 @@ export function useBackgroundRowDocLoader(hasConditions: boolean) {
     };
   }, [databaseDoc.guid]);
 
-  // Background loading of row docs for sorting/filtering
+  // Background loading of row docs for sorting/filtering.
+  // Waits for blob prefetch to complete so seeds are available, then uses
+  // populateRowFromCache (fast, in-memory seed application) for each row.
+  // Falls back to IndexedDB for rows without seeds.
   useEffect(() => {
-    if (!hasConditions) return;
+    if (!hasConditions || !blobPrefetchComplete) return;
 
     const rowOrdersData = view?.get(YjsDatabaseKey.row_orders)?.toJSON() as { id: string }[] | undefined;
 
@@ -123,6 +128,23 @@ export function useBackgroundRowDocLoader(hasConditions: boolean) {
                 return;
               }
 
+              // Try fast path: use blob diff seeds via populateRowFromCache.
+              // This adds the doc directly to the main rowMap (no separate cache needed).
+              if (populateRowFromCache) {
+                const pending = populateRowFromCache(rowId);
+
+                cachedRowDocPendingRef.current.set(rowId, pending);
+
+                try {
+                  const doc = await pending;
+
+                  if (doc) return; // Success — doc is now in main rowMap
+                } finally {
+                  cachedRowDocPendingRef.current.delete(rowId);
+                }
+              }
+
+              // Fallback: open from IndexedDB for rows without seeds
               const rowKey = getRowKey(databaseDoc.guid, rowId);
               const pending = (async () => {
                 const { doc, provider } = await openCollabDBWithProvider(rowKey, { skipCache: true });
@@ -175,7 +197,7 @@ export function useBackgroundRowDocLoader(hasConditions: boolean) {
       queueRef.clear();
       backgroundLoadingRef.current = false;
     };
-  }, [databaseDoc.guid, hasConditions, rows, view]);
+  }, [databaseDoc.guid, hasConditions, blobPrefetchComplete, rows, view, populateRowFromCache]);
 
   return {
     cachedRowDocs,

--- a/src/application/database-yjs/hooks/useBackgroundRowDocLoader.ts
+++ b/src/application/database-yjs/hooks/useBackgroundRowDocLoader.ts
@@ -12,7 +12,7 @@ const BACKGROUND_CONCURRENCY = 12;
  * Hook that handles background loading of row documents for sorting/filtering.
  * When sorts or filters are active, row docs need to be loaded to apply conditions.
  *
- * Uses blob diff seeds (via populateRowFromCache) when available for fast loading,
+ * Uses blob diff seeds (via loadRowFromSeed) when available for fast loading,
  * falling back to IndexedDB for rows without seeds.
  *
  * @param hasConditions - Whether there are active sorts or filters
@@ -21,7 +21,7 @@ const BACKGROUND_CONCURRENCY = 12;
 export function useBackgroundRowDocLoader(hasConditions: boolean) {
   const rows = useRowMap();
   const view = useDatabaseView();
-  const { databaseDoc, populateRowFromCache, blobPrefetchComplete } = useDatabaseContext();
+  const { databaseDoc, loadRowFromSeed, blobPrefetchComplete } = useDatabaseContext();
 
   const [cachedRowDocs, setCachedRowDocs] = useState<Record<string, YDoc>>({});
   const cachedRowDocsRef = useRef<Record<string, YDoc>>({});
@@ -76,7 +76,7 @@ export function useBackgroundRowDocLoader(hasConditions: boolean) {
 
   // Background loading of row docs for sorting/filtering.
   // Waits for blob prefetch to complete so seeds are available, then uses
-  // populateRowFromCache (fast, in-memory seed application) for each row.
+  // loadRowFromSeed (fast, in-memory seed application) for each row.
   // Falls back to IndexedDB for rows without seeds.
   useEffect(() => {
     if (!hasConditions || !blobPrefetchComplete) return;
@@ -128,10 +128,10 @@ export function useBackgroundRowDocLoader(hasConditions: boolean) {
                 return;
               }
 
-              // Try fast path: use blob diff seeds via populateRowFromCache.
+              // Try fast path: use blob diff seeds via loadRowFromSeed.
               // This adds the doc directly to the main rowMap (no separate cache needed).
-              if (populateRowFromCache) {
-                const pending = populateRowFromCache(rowId);
+              if (loadRowFromSeed) {
+                const pending = loadRowFromSeed(rowId);
 
                 cachedRowDocPendingRef.current.set(rowId, pending);
 
@@ -197,7 +197,7 @@ export function useBackgroundRowDocLoader(hasConditions: boolean) {
       queueRef.clear();
       backgroundLoadingRef.current = false;
     };
-  }, [databaseDoc.guid, hasConditions, blobPrefetchComplete, rows, view, populateRowFromCache]);
+  }, [databaseDoc.guid, hasConditions, blobPrefetchComplete, rows, view, loadRowFromSeed]);
 
   return {
     cachedRowDocs,

--- a/src/application/database-yjs/selector.ts
+++ b/src/application/database-yjs/selector.ts
@@ -1086,6 +1086,9 @@ export function useRowOrdersSelector() {
 
   const [rowOrders, setRowOrders] = useState<Row[]>();
   const [rollupWatchVersion, setRollupWatchVersion] = useState(0);
+  // Once filters have been applied successfully, don't revert to unfiltered
+  // when rowDocsForConditions temporarily changes (e.g. new rows being added to rowMap).
+  const filtersAppliedRef = useRef(false);
 
   // Check if there are active conditions
   const hasConditions = (sorts?.length ?? 0) > 0 || (filters?.length ?? 0) > 0;
@@ -1174,35 +1177,43 @@ export function useRowOrdersSelector() {
     const currentHasConditions = (sorts?.length ?? 0) > 0 || (filters?.length ?? 0) > 0;
 
     if (!currentHasConditions) {
+      filtersAppliedRef.current = false;
       setRowOrders(originalRowOrders);
       return;
     }
 
-    const rowDocCount = Object.keys(rowDocsForConditions).length;
-    const isRowDataComplete = rowDocCount >= originalRowOrders.length;
+    // Apply filters/sorts progressively: only include rows whose docs are loaded.
+    // Rows without docs are excluded until their data arrives, at which point
+    // this callback re-runs and they get included if they match.
+    const rowsWithDocs = originalRowOrders.filter((row: Row) => rowDocsForConditions[row.id]);
 
-    if (!isRowDataComplete) {
-      setRowOrders(originalRowOrders);
+    if (rowsWithDocs.length === 0) {
+      // No docs loaded yet — keep current state (or show empty if first run)
+      if (!filtersAppliedRef.current) {
+        setRowOrders(originalRowOrders);
+      }
+
       return;
     }
 
     let computedRowOrders: Row[] | undefined;
 
     if (sorts?.length) {
-      computedRowOrders = sortBy(originalRowOrders, sorts, fields, rowDocsForConditions, {
+      computedRowOrders = sortBy(rowsWithDocs, sorts, fields, rowDocsForConditions, {
         getRelationCellText: relationTextGetter,
         getRollupCellValue: rollupValueGetter,
       });
     }
 
     if (filters?.length) {
-      computedRowOrders = filterBy(computedRowOrders ?? originalRowOrders, filters, fields, rowDocsForConditions, {
+      computedRowOrders = filterBy(computedRowOrders ?? rowsWithDocs, filters, fields, rowDocsForConditions, {
         getRelationCellText: relationTextGetter,
         getRollupCellText: rollupTextGetter,
       });
     }
 
-    setRowOrders(computedRowOrders ?? originalRowOrders);
+    filtersAppliedRef.current = true;
+    setRowOrders(computedRowOrders ?? rowsWithDocs);
   }, [
     fields,
     filters,

--- a/src/application/publish/context.tsx
+++ b/src/application/publish/context.tsx
@@ -310,14 +310,10 @@ export const PublishProvider = ({
         // (e.g., relation pills, @-mentions) can handle the error.
         const currentParams = new URLSearchParams(window.location.search);
 
-        if (currentParams.has('v')) {
-          currentParams.set('v', viewId);
-          navigate(`${window.location.pathname}?${currentParams.toString()}`, {
-            replace: true,
-          });
-        } else {
-          return Promise.reject(e);
-        }
+        currentParams.set('v', viewId);
+        navigate(`${window.location.pathname}?${currentParams.toString()}`, {
+          replace: true,
+        });
       }
     },
     [loadViewMeta, isTemplate, navigate]

--- a/src/application/services/js-services/cache/index.ts
+++ b/src/application/services/js-services/cache/index.ts
@@ -529,7 +529,7 @@ export async function createRow(rowKey: string) {
   return entry.doc;
 }
 
-export async function createRowFast(
+export async function openRowDoc(
   rowKey: string,
   seed?: { bytes: Uint8Array; encoderVersion: number }
 ) {

--- a/src/components/_shared/breadcrumb/BreadcrumbItem.tsx
+++ b/src/components/_shared/breadcrumb/BreadcrumbItem.tsx
@@ -71,7 +71,7 @@ function BreadcrumbItem({
           {name || t('menuAppHeader.defaultNewPageName')}
         </span>
       </Tooltip>
-      <PublishIcon variant={variant} view={crumb} />
+      {!(extra?.database_id && !extra?.is_database_container) && <PublishIcon variant={variant} view={crumb} />}
     </div>
   );
 }

--- a/src/components/_shared/outline/OutlineItemContent.tsx
+++ b/src/components/_shared/outline/OutlineItemContent.tsx
@@ -24,12 +24,12 @@ function OutlineItemContent({
   const { name, view_id, extra } = item;
   const [hovered, setHovered] = React.useState(false);
   const isSpace = extra?.is_space;
+  const isDatabaseView = extra?.database_id && !extra?.is_database_container;
   const { t } = useTranslation();
 
   return (
     <div
       onClick={async() => {
-        const isDatabaseView = item.extra?.database_id && !item.extra?.is_database_container;
 
         if(isSpace || (!item.is_published && variant === 'publish' && !isDatabaseView)) {
           setIsExpanded(prev => !prev);
@@ -68,7 +68,7 @@ function OutlineItemContent({
       >
         <div data-testid={isSpace ? 'space-name' : 'page-name'} className={'flex-1 truncate'}>{name || t('menuAppHeader.defaultNewPageName')}</div>
       </Tooltip>
-      {hovered && variant === UIVariant.Publish && <PublishIcon
+      {hovered && variant === UIVariant.Publish && !isDatabaseView && <PublishIcon
         variant={variant}
         view={item}
       />}

--- a/src/components/database/Database.tsx
+++ b/src/components/database/Database.tsx
@@ -8,7 +8,7 @@ import {
   takeDatabaseRowDocSeed,
 } from '@/application/database-blob';
 import { getRowKey } from '@/application/database-yjs/row_meta';
-import { createRowFast } from '@/application/services/js-services/cache';
+import { openRowDoc } from '@/application/services/js-services/cache';
 import {
   AppendBreadcrumb,
   CreateDatabaseViewPayload,
@@ -236,7 +236,7 @@ function Database(props: Database2Props) {
     [createRow, getDatabaseId, registerRowSync]
   );
 
-  const populateRowFromCache = useCallback(
+  const loadRowFromSeed = useCallback(
     async (rowId: string): Promise<YDoc | undefined> => {
       if (!rowId) return undefined;
       const existing = rowMapRef.current[rowId];
@@ -254,7 +254,7 @@ function Database(props: Database2Props) {
       if (!seed) return undefined;
 
       const promise = (async () => {
-        const rowDoc = await createRowFast(rowKey, seed);
+        const rowDoc = await openRowDoc(rowKey, seed);
 
         return rowDoc;
       })();
@@ -315,7 +315,7 @@ function Database(props: Database2Props) {
     Promise.all(
       rowsWithSeeds.map(async ({ rowId, rowKey, seed }) => {
         try {
-          const rowDoc = await createRowFast(rowKey, seed ?? undefined);
+          const rowDoc = await openRowDoc(rowKey, seed ?? undefined);
 
           return { rowId, rowKey, rowDoc };
         } catch {
@@ -479,7 +479,7 @@ function Database(props: Database2Props) {
         const seed = takeDatabaseRowDocSeed(rowKey);
 
         try {
-          const rowDoc = await createRowFast(rowKey, seed ?? undefined);
+          const rowDoc = await openRowDoc(rowKey, seed ?? undefined);
 
           // Bind sync for this row - only visible rows call ensureRow
           // Non-visible rows rely on blob diff cached data
@@ -519,7 +519,7 @@ function Database(props: Database2Props) {
       }
     },
     // Omitted deps are stable: setRowMap (useState setter), refs (rowMapRef, pendingRowDocsRef,
-    // localCachePrimedRef), and module-level imports (createRowFast, takeDatabaseRowDocSeed, getRowKey).
+    // localCachePrimedRef), and module-level imports (openRowDoc, takeDatabaseRowDocSeed, getRowKey).
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [createRow, getDatabaseId, ensureBlobPrefetch, registerRowSync]
   );
@@ -659,7 +659,7 @@ function Database(props: Database2Props) {
     () => ({
       readOnly,
       ensureRow,
-      populateRowFromCache,
+      loadRowFromSeed,
       bindRowSync,
       blobPrefetchComplete,
       paddingStart: props.paddingStart,
@@ -692,7 +692,7 @@ function Database(props: Database2Props) {
     [
       readOnly,
       ensureRow,
-      populateRowFromCache,
+      loadRowFromSeed,
       bindRowSync,
       blobPrefetchComplete,
       props.paddingStart,

--- a/src/components/database/Database.tsx
+++ b/src/components/database/Database.tsx
@@ -36,6 +36,13 @@ import { DatabaseContextProvider } from './DatabaseContext';
 
 const PRIORITY_ROW_SEED_LIMIT = 200;
 
+function createDeferredGate() {
+  let resolve!: () => void;
+  const promise = new Promise<void>((r) => { resolve = r; });
+
+  return { promise, resolve };
+}
+
 export interface Database2Props {
   workspaceId: string;
   doc: YDoc;
@@ -156,6 +163,9 @@ function Database(props: Database2Props) {
   const blobPrefetchPromiseRef = useRef<Promise<void> | null>(null);
   const localCachePrimedRef = useRef(false);
   const syncedRowKeysRef = useRef<Set<string>>(new Set());
+  const batchPreloadDoneRef = useRef(false);
+  // Gate that ensureRow awaits. Resolves after batch preload (or immediately in readOnly).
+  const seedsGateRef = useRef(createDeferredGate());
   const [blobPrefetchComplete, setBlobPrefetchComplete] = useState(false);
 
   useEffect(() => {
@@ -269,17 +279,96 @@ function Database(props: Database2Props) {
     [getDatabaseId]
   );
 
+  const runBatchPreload = useCallback(() => {
+    if (batchPreloadDoneRef.current) return;
+    batchPreloadDoneRef.current = true;
+    const gate = seedsGateRef.current;
+    const databaseId = getDatabaseId();
+    const priorityRowIds = getPriorityRowIds();
+
+    if (priorityRowIds.length === 0) {
+      gate.resolve();
+      return;
+    }
+
+    // Collect seeds for the first N priority rows (visible + overscan) in a single pass
+    const BATCH_SIZE = 30;
+    const rowsWithSeeds: { rowId: string; rowKey: string; seed: NonNullable<ReturnType<typeof takeDatabaseRowDocSeed>> }[] = [];
+
+    for (const rowId of priorityRowIds) {
+      if (rowsWithSeeds.length >= BATCH_SIZE) break;
+      if (rowMapRef.current[rowId]) continue;
+
+      const rowKey = getRowKey(databaseId, rowId);
+      const seed = takeDatabaseRowDocSeed(rowKey);
+
+      if (seed) {
+        rowsWithSeeds.push({ rowId, rowKey, seed });
+      }
+    }
+
+    if (rowsWithSeeds.length === 0) {
+      gate.resolve();
+      return;
+    }
+
+    Promise.all(
+      rowsWithSeeds.map(async ({ rowId, rowKey, seed }) => {
+        try {
+          const rowDoc = await createRowFast(rowKey, seed ?? undefined);
+
+          return { rowId, rowKey, rowDoc };
+        } catch {
+          return null;
+        }
+      })
+    ).then((results) => {
+      const newEntries: Record<string, YDoc> = {};
+      const syncKeys: string[] = [];
+
+      for (const result of results) {
+        if (result?.rowDoc && !rowMapRef.current[result.rowId]) {
+          newEntries[result.rowId] = result.rowDoc;
+          syncKeys.push(result.rowKey);
+        }
+      }
+
+      const count = Object.keys(newEntries).length;
+
+      if (count > 0) {
+        // Single setState to add all preloaded rows at once
+        setRowMap((prev) => ({ ...prev, ...newEntries }));
+
+        // Defer sync binding — rows are hydrated from seeds, sync can wait
+        requestAnimationFrame(() => {
+          syncKeys.forEach((rowKey) => registerRowSync(rowKey));
+        });
+      }
+
+      // Open the gate — ensureRow calls can now proceed
+      gate.resolve();
+    }).catch(() => {
+      // Ensure the gate always resolves even on unexpected errors,
+      // otherwise ensureRow calls would be permanently blocked.
+      gate.resolve();
+    });
+  }, [getDatabaseId, getPriorityRowIds, registerRowSync]);
+
   const ensureBlobPrefetch = useCallback(() => {
     // Skip blob prefetch in read-only mode (publish view)
     // The publish API doesn't support blob/diff endpoint
     if (readOnly) {
+      seedsGateRef.current.resolve();
       setBlobPrefetchComplete(true);
       return null;
     }
 
     const databaseId = getDatabaseId();
 
-    if (!workspaceId || !databaseId) return null;
+    if (!workspaceId || !databaseId) {
+      seedsGateRef.current.resolve();
+      return null;
+    }
 
     const existingPromise = prefetchPromisesRef.current.get(databaseId);
 
@@ -289,19 +378,27 @@ function Database(props: Database2Props) {
     }
 
     const priorityRowIds = getPriorityRowIds();
-    const promise = prefetchDatabaseBlobDiff(workspaceId, databaseId, { priorityRowIds })
+    const promise = prefetchDatabaseBlobDiff(workspaceId, databaseId, {
+      priorityRowIds,
+      onSeedsReady: () => {
+        // Seeds are cached — kick off batch preload immediately,
+        // before the slow IndexedDB persist starts
+        runBatchPreload();
+      },
+    })
       .then(() => {
         setBlobPrefetchComplete(true);
       })
       .catch(() => {
         prefetchPromisesRef.current.delete(databaseId);
+        seedsGateRef.current.resolve(); // Unblock ensureRow on failure
         setBlobPrefetchComplete(true);
       });
 
     prefetchPromisesRef.current.set(databaseId, promise);
     blobPrefetchPromiseRef.current = promise;
     return promise;
-  }, [readOnly, workspaceId, getDatabaseId, getPriorityRowIds]);
+  }, [readOnly, workspaceId, getDatabaseId, getPriorityRowIds, runBatchPreload]);
 
   useEffect(() => {
     const databaseId = getDatabaseId();
@@ -343,16 +440,31 @@ function Database(props: Database2Props) {
   const ensureRow = useCallback(
     async (rowId: string) => {
       if (!createRow || !rowId) return;
+
+      // Fast path: row already loaded (e.g. by batch preload or previous call).
+      // Check before awaiting the gate to avoid blocking on already-available rows.
       const existing = rowMapRef.current[rowId];
 
       if (existing) {
-        // Ensure sync is registered even for rows loaded via populateRowFromCache,
-        // which loads from IndexedDB without setting up WebSocket sync.
         const databaseId = getDatabaseId();
         const rowKey = getRowKey(databaseId, rowId);
 
         registerRowSync(rowKey);
         return existing;
+      }
+
+      // Wait for batch preload to finish — it loads visible rows from seeds
+      // in parallel. After it completes, the row may now be in rowMap.
+      await seedsGateRef.current.promise;
+
+      const existingAfterGate = rowMapRef.current[rowId];
+
+      if (existingAfterGate) {
+        const databaseId = getDatabaseId();
+        const rowKey = getRowKey(databaseId, rowId);
+
+        registerRowSync(rowKey);
+        return existingAfterGate;
       }
 
       const pending = pendingRowDocsRef.current.get(rowId);
@@ -418,6 +530,8 @@ function Database(props: Database2Props) {
     blobPrefetchPromiseRef.current = null;
     localCachePrimedRef.current = false;
     syncedRowKeysRef.current.clear();
+    batchPreloadDoneRef.current = false;
+    seedsGateRef.current = createDeferredGate();
     setRowMap({});
     setBlobPrefetchComplete(false);
   }, [doc.guid]);

--- a/src/components/database/components/board/group/Group.tsx
+++ b/src/components/database/components/board/group/Group.tsx
@@ -25,7 +25,7 @@ export const Group = ({ groupId }: GroupProps) => {
   const { columns, groupResult, fieldId, notFound } = useRowsByGroup(groupId);
   const { t } = useTranslation();
   const context = useDatabaseContext();
-  const { paddingStart, paddingEnd, navigateToRow, ensureRow, populateRowFromCache, blobPrefetchComplete } =
+  const { paddingStart, paddingEnd, navigateToRow, ensureRow, loadRowFromSeed, blobPrefetchComplete } =
     context;
   const rowOrders = useRowOrdersSelector();
 
@@ -37,12 +37,12 @@ export const Group = ({ groupId }: GroupProps) => {
 
   // Store callbacks in refs to avoid triggering effect re-runs (advanced-use-latest pattern)
   const ensureRowRef = useRef(ensureRow);
-  const populateRowFromCacheRef = useRef(populateRowFromCache);
+  const loadRowFromSeedRef = useRef(loadRowFromSeed);
   const loadedRowsRef = useRef<Set<string>>(new Set());
 
   useEffect(() => {
     ensureRowRef.current = ensureRow;
-    populateRowFromCacheRef.current = populateRowFromCache;
+    loadRowFromSeedRef.current = loadRowFromSeed;
   });
 
   // Set up intersection observer for lazy loading
@@ -98,10 +98,10 @@ export const Group = ({ groupId }: GroupProps) => {
 
     const loadRows = async () => {
       try {
-        if (blobPrefetchComplete && populateRowFromCacheRef.current) {
+        if (blobPrefetchComplete && loadRowFromSeedRef.current) {
           // Load all rows from cache in parallel
           const results = await Promise.all(
-            rowsToLoad.map((row) => populateRowFromCacheRef.current!(row.id))
+            rowsToLoad.map((row) => loadRowFromSeedRef.current!(row.id))
           );
 
           // Mark rows as loaded

--- a/src/components/database/components/grid/grid-row/GridVirtualRow.tsx
+++ b/src/components/database/components/grid/grid-row/GridVirtualRow.tsx
@@ -57,6 +57,7 @@ function GridVirtualRow({
   const dragHandleRef = useRef<HTMLDivElement | null>(null);
   const [state, setState] = useState<ItemState>(idleState);
   const sorts = useSortsSelector();
+
   const [openClearSortsConfirmed, setOpenClearSortsConfirmed] = useState(false);
 
   const hasSorted = sorts.length > 0;


### PR DESCRIPTION
<!---
Thank you for submitting a pull request to the AppFlowy Web! The team will dedicate their best efforts to reviewing and approving your PR. If you have any questions or feedback, feel free to join our [Discord](https://discord.gg/wdjWUXXhtw).
-->


### **Description**
<!---
Provide a clear and concise description of the changes introduced in this pull request for AppFlowy Web. What problem does it solve? What value does it add?
-->

---

### **Checklist**
<!---
Before marking your pull request as ready for review, ensure the following checklist is complete.
-->

#### **General**
- [ ] I've included relevant documentation or comments for the changes introduced.
- [ ] I've tested the changes in multiple environments (e.g., different browsers, operating systems).

#### **Testing**
- [ ] I've added or updated tests to validate the changes introduced for AppFlowy Web.

#### **Feature-Specific**
- [ ] For feature additions, I've added a preview (video, screenshot, or demo) in the "Feature Preview" section.
- [ ] I've verified that this feature integrates seamlessly with existing functionality.

## Summary by Sourcery

Optimize database row loading and condition-based sorting/filtering by asynchronously preloading seeded row docs and progressively applying filters, while adjusting publish UI elements for database views.

New Features:
- Introduce a batch preload mechanism that uses blob diff seeds to eagerly hydrate priority row documents before user access.
- Add a callback hook to blob prefetch that signals when row doc seeds are ready for consumption by other subsystems.

Enhancements:
- Gate per-row loading on completion of batch preload to reduce redundant work and leverage prehydrated row documents.
- Update the background row document loader to prefer fast in-memory seed application and only fall back to IndexedDB when necessary.
- Change row ordering logic to progressively apply sorts/filters only to rows whose documents are loaded, avoiding full-data blocking behavior.
- Prevent publish icons from showing or toggling publish state on database views within the outline and breadcrumb components.