### PR TITLE
Improve shared database row loading

### DIFF
--- a/src/application/database-blob/index.ts
+++ b/src/application/database-blob/index.ts
@@ -1,5 +1,8 @@
 import { stringify as uuidStringify } from 'uuid';
 
+import * as Y from 'yjs';
+
+import { hasRowConditionData, invalidateRowConditionCache } from '@/application/database-yjs/condition-value-cache';
 import { getRowKey } from '@/application/database-yjs/row_meta';
 import { getCachedProviderDoc, openCollabDBWithProvider } from '@/application/db';
 import { getCachedRowDoc } from '@/application/services/js-services/cache';
@@ -25,15 +28,67 @@ type PrefetchOptions = {
   onSeedsReady?: () => void;
 };
 
+type SharedPrefetchEntry = {
+  priorityRowIds: Set<string>;
+  onSeedsReadyCallbacks: Set<() => void>;
+  seedsReady: boolean;
+  settled?: boolean;
+  clearWhenSettled?: boolean;
+  promise?: Promise<database_blob.DatabaseBlobDiffResponse>;
+};
+
 const RID_CACHE_PREFIX = 'af_database_blob_rid:';
 const APPLY_CONCURRENCY = 6;
 const MAX_ROW_DOC_SEEDS = 2000;
 const MAX_ROW_DOC_SEEDS_LOOKUP = 10000;
 
 const readyStatus = database_blob.DiffStatus.READY;
+const sharedPrefetchEntries = new Map<string, SharedPrefetchEntry>();
 
 function ridCacheKey(databaseId: string) {
   return `${RID_CACHE_PREFIX}${databaseId}`;
+}
+
+function sharedPrefetchKey(workspaceId: string, databaseId: string) {
+  return `${workspaceId}:${databaseId}`;
+}
+
+function applyPrefetchOptions(entry: SharedPrefetchEntry, options?: PrefetchOptions) {
+  options?.priorityRowIds?.forEach((rowId) => entry.priorityRowIds.add(rowId));
+
+  if (!options?.onSeedsReady) return;
+
+  if (entry.seedsReady) {
+    void Promise.resolve().then(options.onSeedsReady);
+    return;
+  }
+
+  entry.onSeedsReadyCallbacks.add(options.onSeedsReady);
+}
+
+function notifySeedsReady(entry: SharedPrefetchEntry) {
+  entry.seedsReady = true;
+  const callbacks = Array.from(entry.onSeedsReadyCallbacks);
+
+  entry.onSeedsReadyCallbacks.clear();
+  callbacks.forEach((callback) => callback());
+}
+
+function clearSharedPrefetchEntryAfterSettle(
+  databaseId: string,
+  sharedKey: string,
+  entry: SharedPrefetchEntry
+) {
+  if (entry.clearWhenSettled) return;
+  entry.clearWhenSettled = true;
+
+  entry.promise?.finally(() => {
+    entry.clearWhenSettled = false;
+
+    if ((rowDocSeedCacheRetainCounts.get(databaseId) ?? 0) === 0 && sharedPrefetchEntries.get(sharedKey) === entry) {
+      clearDatabaseRowDocSeedCache(databaseId);
+    }
+  }).catch(() => undefined);
 }
 
 function parseRid(rid?: database_blob.IDatabaseBlobRowRid | null): DatabaseBlobRowRid | null {
@@ -81,6 +136,22 @@ function compareRid(a: DatabaseBlobRowRid, b: DatabaseBlobRowRid) {
 
 const rowDocSeedCache = new Map<string, RowDocSeed>();
 const rowDocSeedLookup = new Map<string, RowDocSeed>();
+const rowDocSeedDocCache = new Map<string, YDoc>();
+const rowDocSeedCacheRetainCounts = new Map<string, number>();
+
+function applySeedToSharedRowDoc(rowKey: string, seed: RowDocSeed) {
+  const doc = rowDocSeedDocCache.get(rowKey);
+
+  if (!doc) return;
+
+  try {
+    applyYDoc(doc, seed.bytes, seed.encoderVersion);
+    invalidateRowConditionCache(doc);
+  } catch {
+    doc.destroy();
+    rowDocSeedDocCache.delete(rowKey);
+  }
+}
 
 function trimRowDocSeedLookup() {
   while (rowDocSeedLookup.size > MAX_ROW_DOC_SEEDS_LOOKUP) {
@@ -92,12 +163,15 @@ function trimRowDocSeedLookup() {
 }
 
 function cacheRowDocSeed(rowKey: string, docState?: database_blob.ICollabDocState | null) {
-  if (getCachedRowDoc(rowKey)) return;
+  const cachedDoc = getCachedRowDoc(rowKey);
+
+  if (hasRowConditionData(cachedDoc)) return;
 
   const seed = getDocState(docState);
 
   if (!seed) return;
 
+  applySeedToSharedRowDoc(rowKey, seed);
   rowDocSeedCache.set(rowKey, seed);
 
   while (rowDocSeedCache.size > MAX_ROW_DOC_SEEDS) {
@@ -144,8 +218,74 @@ export function takeDatabaseRowDocSeed(rowKey: string): RowDocSeed | null {
   return seed;
 }
 
+/**
+ * Non-destructive read of a row doc seed. Multiple database views may need
+ * the same row seed at the same time: one to build an in-memory doc for
+ * filter/sort, another to open the IndexedDB-backed row doc for rendering.
+ */
+export function peekDatabaseRowDocSeed(rowKey: string): RowDocSeed | null {
+  return rowDocSeedCache.get(rowKey) ?? rowDocSeedLookup.get(rowKey) ?? null;
+}
+
+/**
+ * Shared read-only row doc for filter/sort. Reuses an existing live row doc
+ * when one is already cached; otherwise builds one shared in-memory doc from
+ * seed bytes so multiple views of the same database can reuse cell values.
+ */
+export function getDatabaseRowDocFromSeed(rowKey: string): YDoc | null {
+  const liveDoc = getCachedRowDoc(rowKey);
+
+  if (hasRowConditionData(liveDoc)) return liveDoc;
+
+  const cachedDoc = rowDocSeedDocCache.get(rowKey);
+
+  if (cachedDoc) {
+    if (hasRowConditionData(cachedDoc)) return cachedDoc;
+    cachedDoc.destroy();
+    rowDocSeedDocCache.delete(rowKey);
+  }
+
+  const seed = peekDatabaseRowDocSeed(rowKey);
+
+  if (!seed) return null;
+
+  const doc = new Y.Doc({ guid: rowKey }) as YDoc;
+
+  try {
+    applyYDoc(doc, seed.bytes, seed.encoderVersion);
+  } catch {
+    doc.destroy();
+    return null;
+  }
+
+  const dataSection = doc.getMap(YjsEditorKey.data_section);
+
+  if (!dataSection.has(YjsEditorKey.database_row)) {
+    doc.destroy();
+    return null;
+  }
+
+  rowDocSeedDocCache.set(rowKey, doc);
+  return doc;
+}
+
 export function clearDatabaseRowDocSeedCache(databaseId: string) {
   const prefix = `${databaseId}_rows_`;
+  const sharedPrefetchSuffix = `:${databaseId}`;
+  let hasUnsettledPrefetch = false;
+
+  for (const [key, entry] of sharedPrefetchEntries.entries()) {
+    if (key.endsWith(sharedPrefetchSuffix)) {
+      entry.onSeedsReadyCallbacks.clear();
+
+      if (entry.promise && !entry.settled) {
+        clearSharedPrefetchEntryAfterSettle(databaseId, key, entry);
+        hasUnsettledPrefetch = true;
+      }
+    }
+  }
+
+  if (hasUnsettledPrefetch) return;
 
   for (const key of rowDocSeedCache.keys()) {
     if (key.startsWith(prefix)) {
@@ -158,6 +298,36 @@ export function clearDatabaseRowDocSeedCache(databaseId: string) {
       rowDocSeedLookup.delete(key);
     }
   }
+
+  for (const [key, doc] of rowDocSeedDocCache.entries()) {
+    if (key.startsWith(prefix)) {
+      doc.destroy();
+      rowDocSeedDocCache.delete(key);
+    }
+  }
+
+  for (const [key, entry] of sharedPrefetchEntries.entries()) {
+    if (key.endsWith(sharedPrefetchSuffix)) {
+      entry.onSeedsReadyCallbacks.clear();
+      sharedPrefetchEntries.delete(key);
+    }
+  }
+}
+
+export function retainDatabaseRowDocSeedCache(databaseId: string) {
+  rowDocSeedCacheRetainCounts.set(databaseId, (rowDocSeedCacheRetainCounts.get(databaseId) ?? 0) + 1);
+}
+
+export function releaseDatabaseRowDocSeedCache(databaseId: string) {
+  const count = rowDocSeedCacheRetainCounts.get(databaseId) ?? 0;
+
+  if (count > 1) {
+    rowDocSeedCacheRetainCounts.set(databaseId, count - 1);
+    return;
+  }
+
+  rowDocSeedCacheRetainCounts.delete(databaseId);
+  clearDatabaseRowDocSeedCache(databaseId);
 }
 
 function maxRidFromDiff(diff: database_blob.DatabaseBlobDiffResponse): DatabaseBlobRowRid | null {
@@ -231,6 +401,7 @@ function applySeedToCachedDoc(rowKey: string, seed: RowDocSeed) {
   if (!cachedDoc) return false;
 
   applyYDoc(cachedDoc, seed.bytes, seed.encoderVersion);
+  invalidateRowConditionCache(cachedDoc);
   return true;
 }
 
@@ -259,6 +430,7 @@ function seedRowDocCacheFromDiff(databaseId: string, diff: database_blob.Databas
 
     if (!seed) return;
 
+    applySeedToSharedRowDoc(rowKey, seed);
     rowDocSeedLookup.set(rowKey, seed);
     if (rowDocSeedLookup.size > MAX_ROW_DOC_SEEDS_LOOKUP) {
       trimRowDocSeedLookup();
@@ -299,6 +471,7 @@ function seedRowDocCacheFromDiff(databaseId: string, diff: database_blob.Databas
 
     if (!seed) return;
 
+    applySeedToSharedRowDoc(rowKey, seed);
     rowDocSeedLookup.set(rowKey, seed);
     if (rowDocSeedLookup.size > MAX_ROW_DOC_SEEDS_LOOKUP) {
       trimRowDocSeedLookup();
@@ -381,6 +554,7 @@ async function applyCollabUpdate(objectId: string, docState: database_blob.IColl
       ...beforeState,
     });
     applyYDoc(cachedDoc, state.bytes, state.encoderVersion);
+    invalidateRowConditionCache(cachedDoc);
 
     const afterState = inspectDocRowData(cachedDoc, objectId);
 
@@ -609,41 +783,84 @@ export async function prefetchDatabaseBlobDiff(
   databaseId: string,
   options?: PrefetchOptions
 ) {
-  const diff = await fetchReadyDiff(workspaceId, databaseId);
-  const seedSummary = seedRowDocCacheFromDiff(databaseId, diff, options);
+  const sharedKey = sharedPrefetchKey(workspaceId, databaseId);
+  const existingEntry = sharedPrefetchEntries.get(sharedKey);
 
-  Log.debug('[Database] blob seed cache prepared', {
-    databaseId,
-    ...seedSummary,
-    seedCount: rowDocSeedCache.size,
-    lookupCount: rowDocSeedLookup.size,
-  });
-
-  // Signal that seeds are available before the slow IndexedDB persist
-  options?.onSeedsReady?.();
-
-  const applyStartedAt = Date.now();
-
-  try {
-    await applyDiff(databaseId, diff, { seedCache: false });
-    Log.debug('[Database] blob diff persisted to IndexedDB', {
-      databaseId,
-      durationMs: Date.now() - applyStartedAt,
-      ...summarizeDiff(diff),
-    });
-
-    const maxRid = maxRidFromDiff(diff);
-
-    if (maxRid) {
-      writeCachedRid(databaseId, maxRid);
-      Log.debug('[Database] blob updated rid cache', { databaseId, maxRid });
-    }
-  } catch (error) {
-    Log.warn('[Database] blob diff persist failed', {
-      databaseId,
-      error,
-    });
+  if (existingEntry?.promise && !existingEntry.settled) {
+    applyPrefetchOptions(existingEntry, options);
+    return existingEntry.promise;
   }
 
-  return diff;
+  if (existingEntry) {
+    existingEntry.onSeedsReadyCallbacks.clear();
+    sharedPrefetchEntries.delete(sharedKey);
+  }
+
+  const entry: SharedPrefetchEntry = {
+    priorityRowIds: new Set(),
+    onSeedsReadyCallbacks: new Set(),
+    seedsReady: false,
+  };
+
+  applyPrefetchOptions(entry, options);
+
+  const promise = (async () => {
+    const diff = await fetchReadyDiff(workspaceId, databaseId);
+    const seedSummary = seedRowDocCacheFromDiff(databaseId, diff, {
+      priorityRowIds: Array.from(entry.priorityRowIds),
+    });
+
+    Log.debug('[Database] blob seed cache prepared', {
+      databaseId,
+      ...seedSummary,
+      seedCount: rowDocSeedCache.size,
+      lookupCount: rowDocSeedLookup.size,
+    });
+
+    // Signal that seeds are available before the slow IndexedDB persist.
+    notifySeedsReady(entry);
+
+    const applyStartedAt = Date.now();
+
+    try {
+      await applyDiff(databaseId, diff, { seedCache: false });
+      Log.debug('[Database] blob diff persisted to IndexedDB', {
+        databaseId,
+        durationMs: Date.now() - applyStartedAt,
+        ...summarizeDiff(diff),
+      });
+
+      const maxRid = maxRidFromDiff(diff);
+
+      if (maxRid) {
+        writeCachedRid(databaseId, maxRid);
+        Log.debug('[Database] blob updated rid cache', { databaseId, maxRid });
+      }
+    } catch (error) {
+      Log.warn('[Database] blob diff persist failed', {
+        databaseId,
+        error,
+      });
+    }
+
+    return diff;
+  })().finally(() => {
+    entry.settled = true;
+  });
+
+  entry.promise = promise;
+  sharedPrefetchEntries.set(sharedKey, entry);
+
+  try {
+    return await promise;
+  } catch (error) {
+    const currentEntry = sharedPrefetchEntries.get(sharedKey);
+
+    if (currentEntry === entry) {
+      sharedPrefetchEntries.delete(sharedKey);
+    }
+
+    entry.onSeedsReadyCallbacks.clear();
+    throw error;
+  }
 }

--- a/src/application/database-yjs/condition-value-cache.ts
+++ b/src/application/database-yjs/condition-value-cache.ts
@@ -1,0 +1,188 @@
+import { parseYDatabaseDateTimeCellToCell } from '@/application/database-yjs/cell.parse';
+import { DateTimeCell } from '@/application/database-yjs/cell.type';
+import { decodeCellForSort, decodeCellToText } from '@/application/database-yjs/decode';
+import {
+  FieldId,
+  YDatabaseCell,
+  YDatabaseCells,
+  YDatabaseField,
+  YDatabaseRow,
+  YDoc,
+  YjsDatabaseKey,
+  YjsEditorKey,
+} from '@/application/types';
+
+export type ConditionSortValue = string | number | boolean | undefined;
+
+export type RowConditionSnapshot = {
+  row: YDatabaseRow;
+  cells?: YDatabaseCells;
+  cellDataByField: Map<FieldId, CellCacheEntry<unknown>>;
+  dateCellByField: Map<FieldId, CellCacheEntry<DateTimeCell | null>>;
+  filterTextByField: Map<string, string>;
+  sortValueByField: Map<string, ConditionSortValue>;
+};
+
+type CellCacheEntry<T> = {
+  revision: string;
+  value: T;
+};
+
+const rowConditionCache = new WeakMap<YDoc, RowConditionSnapshot | null>();
+const rowConditionMissingObservers = new WeakMap<YDoc, () => void>();
+
+export function hasRowConditionData(rowDoc: YDoc): boolean;
+export function hasRowConditionData(rowDoc?: YDoc | null): rowDoc is YDoc;
+export function hasRowConditionData(rowDoc?: YDoc | null) {
+  return Boolean(rowDoc?.getMap(YjsEditorKey.data_section).has(YjsEditorKey.database_row));
+}
+
+function getFieldCacheKey(fieldId: FieldId, field: YDatabaseField) {
+  return [
+    fieldId,
+    field.get(YjsDatabaseKey.type),
+    field.get(YjsDatabaseKey.last_modified) ?? '',
+  ].join(':');
+}
+
+function getSnapshotCell(snapshot: RowConditionSnapshot, fieldId: FieldId): YDatabaseCell | undefined {
+  return snapshot.cells?.get(fieldId);
+}
+
+function serializeCellRevisionValue(value: unknown) {
+  if (value === undefined) return 'undefined';
+  if (value === null) return 'null';
+  if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') return String(value);
+
+  try {
+    const jsonValue = value as { toJSON?: () => unknown };
+
+    if (typeof jsonValue.toJSON === 'function') {
+      return JSON.stringify(jsonValue.toJSON());
+    }
+
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}
+
+function getCellRevision(cell?: YDatabaseCell) {
+  if (!cell) return 'missing';
+
+  return [
+    cell.get(YjsDatabaseKey.data),
+    cell.get(YjsDatabaseKey.field_type),
+    cell.get(YjsDatabaseKey.source_field_type),
+    cell.get(YjsDatabaseKey.end_timestamp),
+    cell.get(YjsDatabaseKey.include_time),
+    cell.get(YjsDatabaseKey.is_range),
+    cell.get(YjsDatabaseKey.reminder_id),
+    cell.get(YjsDatabaseKey.last_modified),
+  ].map(serializeCellRevisionValue).join('|');
+}
+
+export function getRowConditionSnapshot(rowDoc?: YDoc | null): RowConditionSnapshot | null {
+  if (!rowDoc) return null;
+
+  if (rowConditionCache.has(rowDoc)) {
+    const cached = rowConditionCache.get(rowDoc);
+
+    if (cached) return cached;
+
+    if (!rowDoc.getMap(YjsEditorKey.data_section).has(YjsEditorKey.database_row)) {
+      return null;
+    }
+
+    invalidateRowConditionCache(rowDoc);
+  }
+
+  const dataSection = rowDoc.getMap(YjsEditorKey.data_section);
+  const row = dataSection.get(YjsEditorKey.database_row) as YDatabaseRow | undefined;
+
+  if (!row) {
+    const invalidateMissingSnapshot = () => invalidateRowConditionCache(rowDoc);
+
+    dataSection.observeDeep(invalidateMissingSnapshot);
+    rowConditionMissingObservers.set(rowDoc, () => dataSection.unobserveDeep(invalidateMissingSnapshot));
+    rowConditionCache.set(rowDoc, null);
+    return null;
+  }
+
+  const snapshot: RowConditionSnapshot = {
+    row,
+    cells: row.get(YjsDatabaseKey.cells),
+    cellDataByField: new Map(),
+    dateCellByField: new Map(),
+    filterTextByField: new Map(),
+    sortValueByField: new Map(),
+  };
+
+  rowConditionCache.set(rowDoc, snapshot);
+  return snapshot;
+}
+
+export function invalidateRowConditionCache(rowDoc?: YDoc | null) {
+  if (!rowDoc) return;
+  rowConditionMissingObservers.get(rowDoc)?.();
+  rowConditionMissingObservers.delete(rowDoc);
+  rowConditionCache.delete(rowDoc);
+}
+
+export function getConditionCellData(snapshot: RowConditionSnapshot, fieldId: FieldId) {
+  const cell = getSnapshotCell(snapshot, fieldId);
+  const revision = getCellRevision(cell);
+  const cached = snapshot.cellDataByField.get(fieldId);
+
+  if (cached?.revision === revision) {
+    return cached.value;
+  }
+
+  const data = cell?.get(YjsDatabaseKey.data);
+
+  snapshot.cellDataByField.set(fieldId, { revision, value: data });
+  return data;
+}
+
+export function getConditionCellText(snapshot: RowConditionSnapshot, fieldId: FieldId, field: YDatabaseField) {
+  const cell = getSnapshotCell(snapshot, fieldId);
+  const cacheKey = `${getFieldCacheKey(fieldId, field)}:${getCellRevision(cell)}`;
+
+  if (snapshot.filterTextByField.has(cacheKey)) {
+    return snapshot.filterTextByField.get(cacheKey) ?? '';
+  }
+
+  const text = cell ? decodeCellToText(cell, field) : '';
+
+  snapshot.filterTextByField.set(cacheKey, text);
+  return text;
+}
+
+export function getConditionSortValue(snapshot: RowConditionSnapshot, fieldId: FieldId, field: YDatabaseField) {
+  const cell = getSnapshotCell(snapshot, fieldId);
+  const cacheKey = `${getFieldCacheKey(fieldId, field)}:${getCellRevision(cell)}`;
+
+  if (snapshot.sortValueByField.has(cacheKey)) {
+    return snapshot.sortValueByField.get(cacheKey);
+  }
+
+  const value = cell ? decodeCellForSort(cell, field) : undefined;
+
+  snapshot.sortValueByField.set(cacheKey, value);
+  return value;
+}
+
+export function getConditionDateCell(snapshot: RowConditionSnapshot, fieldId: FieldId) {
+  const cell = getSnapshotCell(snapshot, fieldId);
+  const revision = getCellRevision(cell);
+  const cached = snapshot.dateCellByField.get(fieldId);
+
+  if (cached?.revision === revision) {
+    return cached.value;
+  }
+
+  const value = cell ? parseYDatabaseDateTimeCellToCell(cell) : null;
+
+  snapshot.dateCellByField.set(fieldId, { revision, value });
+  return value;
+}

--- a/src/application/database-yjs/context.ts
+++ b/src/application/database-yjs/context.ts
@@ -51,8 +51,16 @@ export interface DatabaseContextState {
   rowMap: Record<RowId, YDoc> | null;
   ensureRow?: (rowId: string) => Promise<YDoc | undefined> | void;
   loadRowFromSeed?: (rowId: string) => Promise<YDoc | undefined>;
+  /**
+   * Synchronous shared read-only doc for filter/sort. Reuses an existing
+   * row doc when cached; otherwise builds one shared in-memory Y.Doc from
+   * seed bytes without touching IndexedDB or consuming the seed.
+   */
+  peekRowDocFromSeed?: (rowId: string) => YDoc | null;
   bindRowSync?: (rowId: string) => void;
   blobPrefetchComplete?: boolean;
+  /** True as soon as row seeds are cached (before IndexedDB persist completes). */
+  seedsReady?: boolean;
   isDatabaseRowPage?: boolean;
   paddingStart?: number;
   paddingEnd?: number;

--- a/src/application/database-yjs/filter.ts
+++ b/src/application/database-yjs/filter.ts
@@ -1,10 +1,14 @@
 import dayjs from 'dayjs';
 import { every, filter, some } from 'lodash-es';
 
-import { parseYDatabaseDateTimeCellToCell } from '@/application/database-yjs/cell.parse';
 import { DateTimeCell } from '@/application/database-yjs/cell.type';
+import {
+  getConditionCellData,
+  getConditionCellText,
+  getConditionDateCell,
+  getRowConditionSnapshot,
+} from '@/application/database-yjs/condition-value-cache';
 import { FieldType, FilterType } from '@/application/database-yjs/database.type';
-import { decodeCellToText } from '@/application/database-yjs/decode';
 import {
   CheckboxFilter,
   CheckboxFilterCondition,
@@ -32,10 +36,8 @@ import {
   YDatabaseFields,
   YDatabaseFilter,
   YDatabaseFilters,
-  YDatabaseRow,
   YDoc,
   YjsDatabaseKey,
-  YjsEditorKey,
 } from '@/application/types';
 import { isAfterOneDay, isTimestampBefore, isTimestampBetweenRange, isTimestampInSameDay } from '@/utils/time';
 
@@ -462,13 +464,11 @@ export function filterBy(
     if (!rowMeta) return false;
 
     const filterValue = parseFilter(fieldType, node);
-    const meta = rowMeta.getMap(YjsEditorKey.data_section).get(YjsEditorKey.database_row) as YDatabaseRow;
+    const snapshot = getRowConditionSnapshot(rowMeta);
 
-    if (!meta) return false;
+    if (!snapshot) return false;
 
-    const cells = meta.get(YjsDatabaseKey.cells);
-    const cell = cells.get(fieldId);
-    const cellData = cell?.get(YjsDatabaseKey.data);
+    const cellData = getConditionCellData(snapshot, fieldId);
 
     const condition = Number(filterValue.condition);
     const rawContent = filterValue.content;
@@ -479,9 +479,7 @@ export function filterBy(
         ? options?.getRelationCellText?.(rowId, fieldId) ?? ''
         : fieldType === FieldType.Rollup
           ? options?.getRollupCellText?.(rowId, fieldId) ?? ''
-          : cell
-            ? decodeCellToText(cell, field)
-            : '';
+          : getConditionCellText(snapshot, fieldId, field);
 
     if (fieldType === FieldType.Relation) {
       const relationRowIds = parseRelationFilterIds(content);
@@ -509,15 +507,15 @@ export function filterBy(
       case FieldType.Checklist:
         return checklistFilterCheck(cellData as string, content, condition);
       case FieldType.DateTime:
-        return dateFilterCheck(cell ? parseYDatabaseDateTimeCellToCell(cell) : null, filterValue as DateFilter);
+        return dateFilterCheck(getConditionDateCell(snapshot, fieldId), filterValue as DateFilter);
       case FieldType.CreatedTime: {
-        const data = meta.get(YjsDatabaseKey.created_at);
+        const data = snapshot.row.get(YjsDatabaseKey.created_at);
 
         return rowTimeFilterCheck(data, filterValue as DateFilter);
       }
 
       case FieldType.LastEditedTime: {
-        const data = meta.get(YjsDatabaseKey.last_modified);
+        const data = snapshot.row.get(YjsDatabaseKey.last_modified);
 
         return rowTimeFilterCheck(data, filterValue as DateFilter);
       }

--- a/src/application/database-yjs/hooks/useBackgroundRowDocLoader.ts
+++ b/src/application/database-yjs/hooks/useBackgroundRowDocLoader.ts
@@ -1,19 +1,180 @@
-import { useEffect, useRef, useState } from 'react';
+import { startTransition, useCallback, useEffect, useMemo, useSyncExternalStore } from 'react';
 
-import { useDatabaseContext, useDatabaseView, useRowMap } from '@/application/database-yjs/context';
+import { useDatabaseContext, useDatabaseView, useDatabaseViewId, useRowMap } from '@/application/database-yjs/context';
+import { hasRowConditionData } from '@/application/database-yjs/condition-value-cache';
 import { getRowKey } from '@/application/database-yjs/row_meta';
 import { openCollabDBWithProvider } from '@/application/db';
 import { YDoc, YjsDatabaseKey } from '@/application/types';
 
 const BACKGROUND_BATCH_SIZE = 24;
 const BACKGROUND_CONCURRENCY = 12;
+const SEED_HYDRATE_BATCH_SIZE = 32;
+
+type RowDocMap = Record<string, YDoc>;
+
+const pendingEphemeralRowDocs = new Map<string, Promise<YDoc>>();
+const retainedEphemeralRowDocs = new WeakMap<YDoc, number>();
+
+function openEphemeralRowDoc(rowKey: string) {
+  const pending = pendingEphemeralRowDocs.get(rowKey);
+
+  if (pending) return pending;
+
+  const promise = (async () => {
+    const { doc, provider } = await openCollabDBWithProvider(rowKey, { skipCache: true });
+
+    await provider.destroy();
+    return doc;
+  })();
+
+  pendingEphemeralRowDocs.set(rowKey, promise);
+  promise.finally(() => {
+    if (pendingEphemeralRowDocs.get(rowKey) === promise) {
+      pendingEphemeralRowDocs.delete(rowKey);
+    }
+  }).catch(() => undefined);
+
+  return promise;
+}
+
+function retainEphemeralRowDoc(doc: YDoc) {
+  retainedEphemeralRowDocs.set(doc, (retainedEphemeralRowDocs.get(doc) ?? 0) + 1);
+}
+
+function releaseOwnedRowDoc(doc: YDoc) {
+  const retainCount = retainedEphemeralRowDocs.get(doc) ?? 0;
+
+  if (retainCount > 1) {
+    retainedEphemeralRowDocs.set(doc, retainCount - 1);
+    return;
+  }
+
+  if (retainCount === 1) {
+    retainedEphemeralRowDocs.delete(doc);
+  }
+
+  doc.destroy();
+}
+
+type LoaderStore = {
+  key: string;
+  refCount: number;
+  cachedRowDocs: RowDocMap;
+  subscribers: Set<() => void>;
+  sharedCachedRowDocIds: Set<string>;
+  cachedRowDocPending: Map<string, Promise<YDoc | undefined>>;
+  backgroundQueue: Set<string>;
+  backgroundLoading: boolean;
+  backgroundCancelled: boolean;
+  backgroundRun: number;
+  pendingDocs: RowDocMap;
+  flushHandle: number | null;
+  seedHydrateFrame: number | null;
+  seedHydrateRun: number;
+  seedHydrateActive: boolean;
+  rows: RowDocMap | null | undefined;
+};
+
+const loaderStores = new Map<string, LoaderStore>();
+
+function createLoaderStore(key: string): LoaderStore {
+  return {
+    key,
+    refCount: 0,
+    cachedRowDocs: {},
+    subscribers: new Set(),
+    sharedCachedRowDocIds: new Set(),
+    cachedRowDocPending: new Map(),
+    backgroundQueue: new Set(),
+    backgroundLoading: false,
+    backgroundCancelled: false,
+    backgroundRun: 0,
+    pendingDocs: {},
+    flushHandle: null,
+    seedHydrateFrame: null,
+    seedHydrateRun: 0,
+    seedHydrateActive: false,
+    rows: undefined,
+  };
+}
+
+function getLoaderStore(key: string) {
+  let store = loaderStores.get(key);
+
+  if (!store) {
+    store = createLoaderStore(key);
+    loaderStores.set(key, store);
+  }
+
+  return store;
+}
+
+function notifyStore(store: LoaderStore) {
+  store.subscribers.forEach((callback) => callback());
+}
+
+function disposeStoreDoc(store: LoaderStore, rowId: string, doc: YDoc) {
+  if (store.sharedCachedRowDocIds.has(rowId) && store.cachedRowDocs[rowId] === doc) return;
+  releaseOwnedRowDoc(doc);
+}
+
+function setStoreCachedRowDocs(store: LoaderStore, updater: (prev: RowDocMap) => RowDocMap) {
+  const next = updater(store.cachedRowDocs);
+
+  if (next === store.cachedRowDocs) return;
+  store.cachedRowDocs = next;
+  notifyStore(store);
+}
+
+function clearPendingFlush(store: LoaderStore) {
+  if (store.flushHandle !== null) {
+    cancelAnimationFrame(store.flushHandle);
+    store.flushHandle = null;
+  }
+
+  Object.entries(store.pendingDocs).forEach(([rowId, doc]) => {
+    disposeStoreDoc(store, rowId, doc);
+  });
+  store.pendingDocs = {};
+}
+
+function cancelBackgroundRun(store: LoaderStore, runId?: number) {
+  if (runId !== undefined && store.backgroundRun !== runId) return;
+
+  store.backgroundRun += 1;
+  store.backgroundCancelled = true;
+  store.backgroundQueue.clear();
+  store.backgroundLoading = false;
+  clearPendingFlush(store);
+}
+
+function destroyStore(store: LoaderStore) {
+  cancelBackgroundRun(store);
+
+  Object.entries(store.cachedRowDocs).forEach(([rowId, doc]) => {
+    disposeStoreDoc(store, rowId, doc);
+  });
+
+  store.seedHydrateRun += 1;
+  if (store.seedHydrateFrame !== null) {
+    cancelAnimationFrame(store.seedHydrateFrame);
+  }
+
+  store.cachedRowDocs = {};
+  store.sharedCachedRowDocIds.clear();
+  store.cachedRowDocPending.clear();
+  store.seedHydrateFrame = null;
+  store.seedHydrateActive = false;
+  loaderStores.delete(store.key);
+}
 
 /**
  * Hook that handles background loading of row documents for sorting/filtering.
  * When sorts or filters are active, row docs need to be loaded to apply conditions.
  *
- * Uses blob diff seeds (via loadRowFromSeed) when available for fast loading,
- * falling back to IndexedDB for rows without seeds.
+ * The loader state is shared per database view because useRowOrdersSelector is
+ * consumed by several grid subcomponents. Without this store, each consumer
+ * starts its own row hydration pass.
  *
  * @param hasConditions - Whether there are active sorts or filters
  * @returns Object containing cached row docs and merged row docs for conditions
@@ -21,36 +182,84 @@ const BACKGROUND_CONCURRENCY = 12;
 export function useBackgroundRowDocLoader(hasConditions: boolean) {
   const rows = useRowMap();
   const view = useDatabaseView();
-  const { databaseDoc, loadRowFromSeed, blobPrefetchComplete } = useDatabaseContext();
+  const viewId = useDatabaseViewId();
+  const { databaseDoc, loadRowFromSeed, peekRowDocFromSeed, blobPrefetchComplete, seedsReady } = useDatabaseContext();
+  const storeKey = `${databaseDoc.guid}:${viewId ?? 'unknown'}`;
+  const store = useMemo(() => getLoaderStore(storeKey), [storeKey]);
 
-  const [cachedRowDocs, setCachedRowDocs] = useState<Record<string, YDoc>>({});
-  const cachedRowDocsRef = useRef<Record<string, YDoc>>({});
-  const cachedRowDocPendingRef = useRef<Map<string, Promise<YDoc | undefined>>>(new Map());
-  const backgroundQueueRef = useRef<Set<string>>(new Set());
-  const backgroundLoadingRef = useRef(false);
-  const backgroundCancelledRef = useRef(false);
+  store.rows = rows;
 
-  // Keep ref in sync with state
+  const cachedRowDocs = useSyncExternalStore(
+    useCallback(
+      (onStoreChange) => {
+        store.subscribers.add(onStoreChange);
+        return () => {
+          store.subscribers.delete(onStoreChange);
+        };
+      },
+      [store]
+    ),
+    useCallback(() => store.cachedRowDocs, [store]),
+    useCallback(() => store.cachedRowDocs, [store])
+  );
+
+  const scheduleFlush = useCallback(() => {
+    if (store.flushHandle !== null) return;
+    store.flushHandle = requestAnimationFrame(() => {
+      store.flushHandle = null;
+      const pending = store.pendingDocs;
+
+      if (Object.keys(pending).length === 0) return;
+      store.pendingDocs = {};
+
+      startTransition(() => {
+        setStoreCachedRowDocs(store, (prev) => {
+          let changed = false;
+          const next = { ...prev };
+          const currentRows = store.rows;
+
+          Object.entries(pending).forEach(([rowId, doc]) => {
+            if (
+              !hasRowConditionData(doc) ||
+              hasRowConditionData(next[rowId]) ||
+              hasRowConditionData(currentRows?.[rowId])
+            ) {
+              releaseOwnedRowDoc(doc);
+              return;
+            }
+
+            next[rowId] = doc;
+            store.sharedCachedRowDocIds.delete(rowId);
+            changed = true;
+          });
+          return changed ? next : prev;
+        });
+      });
+    });
+  }, [store]);
+
   useEffect(() => {
-    cachedRowDocsRef.current = cachedRowDocs;
-  }, [cachedRowDocs]);
+    store.refCount += 1;
 
-  // Cancel background loading on unmount
-  useEffect(() => {
     return () => {
-      backgroundCancelledRef.current = true;
-    };
-  }, []);
+      store.refCount -= 1;
 
-  // Clean up cached docs that are now in the main rowMap
+      if (store.refCount <= 0) {
+        destroyStore(store);
+      }
+    };
+  }, [store]);
+
+  // Clean up cached docs that are now in the main rowMap.
   useEffect(() => {
-    const cached = cachedRowDocsRef.current;
+    const cached = store.cachedRowDocs;
     let changed = false;
-    const next: Record<string, YDoc> = {};
+    const next: RowDocMap = {};
 
     Object.entries(cached).forEach(([rowId, doc]) => {
-      if (rows?.[rowId]) {
-        doc.destroy();
+      if (hasRowConditionData(rows?.[rowId])) {
+        disposeStoreDoc(store, rowId, doc);
+        store.sharedCachedRowDocIds.delete(rowId);
         changed = true;
         return;
       }
@@ -59,20 +268,105 @@ export function useBackgroundRowDocLoader(hasConditions: boolean) {
     });
 
     if (changed) {
-      setCachedRowDocs(next);
+      setStoreCachedRowDocs(store, () => next);
     }
-  }, [rows]);
+  }, [rows, store]);
 
-  // Clean up all cached docs when database changes
+  // Fast path: as soon as seeds are cached in memory, read shared in-memory
+  // row docs without IndexedDB. Hydrate in frame-sized chunks so large filtered
+  // databases do not spend one long task resolving every row.
   useEffect(() => {
-    const pendingRef = cachedRowDocPendingRef.current;
+    if (!hasConditions || !seedsReady || !peekRowDocFromSeed || store.seedHydrateActive) return;
+
+    const rowOrdersData = view?.get(YjsDatabaseKey.row_orders)?.toJSON() as { id: string }[] | undefined;
+
+    if (!rowOrdersData) return;
+
+    const runId = store.seedHydrateRun + 1;
+    let index = 0;
+    let cancelled = false;
+
+    store.seedHydrateRun = runId;
+    store.seedHydrateActive = true;
+
+    const processBatch = () => {
+      if (cancelled || store.seedHydrateRun !== runId) return;
+
+      const additions: RowDocMap = {};
+      let processed = 0;
+
+      while (index < rowOrdersData.length && processed < SEED_HYDRATE_BATCH_SIZE) {
+        const rowId = rowOrdersData[index]?.id;
+
+        index += 1;
+        processed += 1;
+
+        if (
+          !rowId ||
+          additions[rowId] ||
+          hasRowConditionData(store.rows?.[rowId]) ||
+          hasRowConditionData(store.cachedRowDocs[rowId]) ||
+          hasRowConditionData(store.pendingDocs[rowId])
+        ) {
+          continue;
+        }
+
+        const doc = peekRowDocFromSeed(rowId);
+
+        if (doc) additions[rowId] = doc;
+      }
+
+      if (Object.keys(additions).length > 0) {
+        startTransition(() => {
+          setStoreCachedRowDocs(store, (prev) => {
+            let changed = false;
+            const next = { ...prev };
+            const currentRows = store.rows;
+
+            Object.entries(additions).forEach(([rowId, doc]) => {
+              if (
+                hasRowConditionData(next[rowId]) ||
+                hasRowConditionData(currentRows?.[rowId]) ||
+                hasRowConditionData(store.pendingDocs[rowId])
+              ) {
+                return;
+              }
+
+              next[rowId] = doc;
+              store.sharedCachedRowDocIds.add(rowId);
+              changed = true;
+            });
+            return changed ? next : prev;
+          });
+        });
+      }
+
+      if (index < rowOrdersData.length) {
+        store.seedHydrateFrame = requestAnimationFrame(processBatch);
+      } else {
+        store.seedHydrateFrame = null;
+        store.seedHydrateActive = false;
+      }
+    };
+
+    store.seedHydrateFrame = requestAnimationFrame(processBatch);
 
     return () => {
-      Object.values(cachedRowDocsRef.current).forEach((doc) => doc.destroy());
-      cachedRowDocsRef.current = {};
-      pendingRef.clear();
+      cancelled = true;
+      store.seedHydrateRun += 1;
+      store.seedHydrateActive = false;
+
+      if (store.seedHydrateFrame !== null) {
+        cancelAnimationFrame(store.seedHydrateFrame);
+        store.seedHydrateFrame = null;
+      }
     };
-  }, [databaseDoc.guid]);
+  }, [hasConditions, seedsReady, peekRowDocFromSeed, store, view, viewId]);
+
+  useEffect(() => {
+    if (hasConditions) return;
+    cancelBackgroundRun(store);
+  }, [hasConditions, store]);
 
   // Background loading of row docs for sorting/filtering.
   // Waits for blob prefetch to complete so seeds are available, then uses
@@ -85,46 +379,50 @@ export function useBackgroundRowDocLoader(hasConditions: boolean) {
 
     if (!rowOrdersData) return;
 
-    const rowDocsForConditions = { ...cachedRowDocsRef.current, ...(rows || {}) };
+    const hasReadyRowDoc = (rowId: string) => {
+      return hasRowConditionData(store.cachedRowDocs[rowId]) || hasRowConditionData(store.rows?.[rowId]);
+    };
 
     rowOrdersData.forEach(({ id }) => {
-      if (!rowDocsForConditions[id]) {
-        backgroundQueueRef.current.add(id);
+      if (!hasReadyRowDoc(id)) {
+        store.backgroundQueue.add(id);
       }
     });
 
-    if (backgroundQueueRef.current.size === 0 || backgroundLoadingRef.current) return;
+    if (store.backgroundQueue.size === 0 || store.backgroundLoading) return;
 
-    backgroundLoadingRef.current = true;
-    backgroundCancelledRef.current = false;
+    const runId = store.backgroundRun + 1;
+    const isRunActive = () => store.backgroundRun === runId && !store.backgroundCancelled;
+
+    store.backgroundRun = runId;
+    store.backgroundLoading = true;
+    store.backgroundCancelled = false;
 
     const drainQueue = async () => {
-      while (!backgroundCancelledRef.current) {
-        if (backgroundQueueRef.current.size === 0) {
+      while (isRunActive()) {
+        if (store.backgroundQueue.size === 0) {
           await new Promise((resolve) => setTimeout(resolve, 0));
-          if (backgroundQueueRef.current.size === 0 || backgroundCancelledRef.current) {
+          if (store.backgroundQueue.size === 0 || !isRunActive()) {
             break;
           }
         }
 
-        const batch = Array.from(backgroundQueueRef.current).slice(0, BACKGROUND_BATCH_SIZE);
+        const batch = Array.from(store.backgroundQueue).slice(0, BACKGROUND_BATCH_SIZE);
 
         batch.forEach((rowId) => {
-          backgroundQueueRef.current.delete(rowId);
+          store.backgroundQueue.delete(rowId);
         });
 
         for (let i = 0; i < batch.length; i += BACKGROUND_CONCURRENCY) {
-          if (backgroundCancelledRef.current) break;
+          if (!isRunActive()) break;
           const slice = batch.slice(i, i + BACKGROUND_CONCURRENCY);
 
           await Promise.all(
             slice.map(async (rowId) => {
-              const currentRowDocs = { ...cachedRowDocsRef.current, ...(rows || {}) };
+              if (!isRunActive() || hasReadyRowDoc(rowId)) return;
 
-              if (currentRowDocs[rowId]) return;
-
-              if (cachedRowDocPendingRef.current.has(rowId)) {
-                await cachedRowDocPendingRef.current.get(rowId);
+              if (store.cachedRowDocPending.has(rowId)) {
+                await store.cachedRowDocPending.get(rowId);
                 return;
               }
 
@@ -133,71 +431,75 @@ export function useBackgroundRowDocLoader(hasConditions: boolean) {
               if (loadRowFromSeed) {
                 const pending = loadRowFromSeed(rowId);
 
-                cachedRowDocPendingRef.current.set(rowId, pending);
+                store.cachedRowDocPending.set(rowId, pending);
 
                 try {
                   const doc = await pending;
 
-                  if (doc) return; // Success — doc is now in main rowMap
+                  if (!isRunActive()) return;
+                  if (hasRowConditionData(doc)) return;
                 } finally {
-                  cachedRowDocPendingRef.current.delete(rowId);
+                  store.cachedRowDocPending.delete(rowId);
                 }
               }
 
-              // Fallback: open from IndexedDB for rows without seeds
+              if (!isRunActive()) return;
+
+              // Fallback: open from IndexedDB for rows without seeds. The
+              // module-level pending map dedupes concurrent opens across views
+              // without retaining the doc in the process-wide row cache.
               const rowKey = getRowKey(databaseDoc.guid, rowId);
-              const pending = (async () => {
-                const { doc, provider } = await openCollabDBWithProvider(rowKey, { skipCache: true });
+              const pending = openEphemeralRowDoc(rowKey);
 
-                await provider.destroy();
-                return doc;
-              })();
-
-              cachedRowDocPendingRef.current.set(rowId, pending);
+              store.cachedRowDocPending.set(rowId, pending);
 
               try {
                 const doc = await pending;
 
-                if (backgroundCancelledRef.current) {
-                  doc.destroy();
+                retainEphemeralRowDoc(doc);
+
+                if (!isRunActive()) {
+                  releaseOwnedRowDoc(doc);
                   return;
                 }
 
-                if (rows?.[rowId]) {
-                  doc.destroy();
+                if (!hasRowConditionData(doc)) {
+                  releaseOwnedRowDoc(doc);
                   return;
                 }
 
-                setCachedRowDocs((prev) => {
-                  if (prev[rowId] || rows?.[rowId]) return prev;
-                  return { ...prev, [rowId]: doc };
-                });
+                if (hasReadyRowDoc(rowId) || hasRowConditionData(store.pendingDocs[rowId])) {
+                  releaseOwnedRowDoc(doc);
+                  return;
+                }
+
+                store.pendingDocs[rowId] = doc;
+                scheduleFlush();
               } finally {
-                cachedRowDocPendingRef.current.delete(rowId);
+                store.cachedRowDocPending.delete(rowId);
               }
             })
           );
         }
 
-        if (backgroundCancelledRef.current) break;
+        if (!isRunActive()) break;
 
         await new Promise((resolve) => setTimeout(resolve, 0));
       }
 
-      backgroundLoadingRef.current = false;
+      if (store.backgroundRun === runId) {
+        store.backgroundLoading = false;
+      }
     };
 
     void drainQueue();
 
-    // Capture ref values for cleanup (react-hooks/exhaustive-deps)
-    const queueRef = backgroundQueueRef.current;
-
     return () => {
-      backgroundCancelledRef.current = true;
-      queueRef.clear();
-      backgroundLoadingRef.current = false;
+      if (store.refCount <= 0) {
+        cancelBackgroundRun(store, runId);
+      }
     };
-  }, [databaseDoc.guid, hasConditions, blobPrefetchComplete, rows, view, loadRowFromSeed]);
+  }, [databaseDoc.guid, hasConditions, blobPrefetchComplete, rows, view, viewId, loadRowFromSeed, scheduleFlush, store]);
 
   return {
     cachedRowDocs,

--- a/src/application/database-yjs/selector.ts
+++ b/src/application/database-yjs/selector.ts
@@ -1,9 +1,10 @@
 import dayjs from 'dayjs';
 import { debounce } from 'lodash-es';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useDeferredValue, useEffect, useMemo, useRef, useState } from 'react';
 
 import { parseYDatabaseCellToCell } from '@/application/database-yjs/cell.parse';
 import { DateTimeCell, RollupCell } from '@/application/database-yjs/cell.type';
+import { hasRowConditionData, invalidateRowConditionCache } from '@/application/database-yjs/condition-value-cache';
 import { getCell, MIN_COLUMN_WIDTH } from '@/application/database-yjs/const';
 import {
   useDatabase,
@@ -1096,11 +1097,27 @@ export function useRowOrdersSelector() {
   // Background loading of row docs for sorting/filtering
   const { cachedRowDocs } = useBackgroundRowDocLoader(hasConditions);
 
-  // Merge cached docs with main rowMap
-  const rowDocsForConditions = useMemo(
-    () => ({ ...cachedRowDocs, ...(rows || {}) }),
-    [cachedRowDocs, rows]
-  );
+  // Merge cached docs with main rowMap.
+  // useDeferredValue lets React treat the filter/sort recompute as low-priority
+  // so a burst of cache updates coalesces into fewer renders — React will
+  // abandon in-progress filter work when a newer snapshot arrives.
+  const rowDocsForConditionsRaw = useMemo(() => {
+    const next = { ...cachedRowDocs };
+
+    Object.entries(rows || {}).forEach(([rowId, rowDoc]) => {
+      if (hasRowConditionData(rowDoc) || !next[rowId]) {
+        next[rowId] = rowDoc;
+      }
+    });
+
+    return next;
+  }, [cachedRowDocs, rows]);
+  const rowDocsForConditions = useDeferredValue(rowDocsForConditionsRaw);
+  const rowDocsForConditionsRef = useRef(rowDocsForConditions);
+
+  useEffect(() => {
+    rowDocsForConditionsRef.current = rowDocsForConditions;
+  }, [rowDocsForConditions]);
 
   // Getter for relation cell text (used in sorting/filtering)
   const relationTextGetter = useCallback(
@@ -1182,15 +1199,15 @@ export function useRowOrdersSelector() {
       return;
     }
 
-    // Apply filters/sorts progressively: only include rows whose docs are loaded.
-    // Rows without docs are excluded until their data arrives, at which point
-    // this callback re-runs and they get included if they match.
-    const rowsWithDocs = originalRowOrders.filter((row: Row) => rowDocsForConditions[row.id]);
+    // Apply filters/sorts progressively to the subset whose row docs are ready.
+    // This never renders raw unfiltered rows, but it allows matching rows to
+    // appear as soon as their cells can be evaluated instead of waiting for the
+    // entire database to finish loading.
+    const rowsWithDocs = originalRowOrders.filter((row: Row) => hasRowConditionData(rowDocsForConditions[row.id]));
 
     if (rowsWithDocs.length === 0) {
-      // No docs loaded yet — keep current state (or show empty if first run)
       if (!filtersAppliedRef.current) {
-        setRowOrders(originalRowOrders);
+        setRowOrders(undefined);
       }
 
       return;
@@ -1281,6 +1298,10 @@ export function useRowOrdersSelector() {
     const handleFieldChange = () => {
       refreshConditionFieldIds();
 
+      Object.values(rowDocsForConditionsRef.current).forEach((rowDoc) => {
+        invalidateRowConditionCache(rowDoc);
+      });
+
       if (rows) {
         Object.keys(rows).forEach((rowId) => {
           for (const fieldId of rollupFieldIds) {
@@ -1301,6 +1322,8 @@ export function useRowOrdersSelector() {
 
     Object.entries(rows || {}).forEach(([rowId, rowDoc]) => {
       const observerRowsEvent = () => {
+        invalidateRowConditionCache(rowDoc);
+
         // Only invalidate relation/rollup fields (O(relation+rollup) instead of O(allFields)).
         for (const fieldId of relationFieldIds) {
           invalidateRelationCell(`${rowId}:${fieldId}`);

--- a/src/application/database-yjs/sort.ts
+++ b/src/application/database-yjs/sort.ts
@@ -1,19 +1,21 @@
 import { FieldType, RollupDisplayMode, SortCondition } from '@/application/database-yjs/database.type';
-import { decodeCellForSort } from '@/application/database-yjs/decode';
+import {
+  ConditionSortValue,
+  getConditionSortValue,
+  getRowConditionSnapshot,
+} from '@/application/database-yjs/condition-value-cache';
 import { parseRollupTypeOption } from '@/application/database-yjs/fields';
 import { isNumericRollupField } from '@/application/database-yjs/rollup/utils';
 import { Row } from '@/application/database-yjs/selector';
 import {
   RowId,
   YDatabaseFields,
-  YDatabaseRow,
   YDatabaseSorts,
   YDoc,
   YjsDatabaseKey,
-  YjsEditorKey,
 } from '@/application/types';
 
-type SortableValue = string | number | object | boolean | undefined;
+type SortableValue = ConditionSortValue;
 
 type SortOptions = {
   getRelationCellText?: (rowId: string, fieldId: string) => string;
@@ -82,22 +84,19 @@ export function sortBy(
 
       const rowId = row.id;
       const rowMeta = rowMetas[rowId];
-      const meta = rowMeta?.getMap(YjsEditorKey.data_section).get(YjsEditorKey.database_row) as YDatabaseRow;
+      const snapshot = getRowConditionSnapshot(rowMeta);
 
       const defaultData = defaultValueForSort(fieldType, Number(sort.get(YjsDatabaseKey.condition)), isRollupNumeric);
 
-      if (!meta) return defaultData;
+      if (!snapshot) return defaultData;
 
       if (fieldType === FieldType.LastEditedTime) {
-        return meta.get(YjsDatabaseKey.last_modified);
+        return snapshot.row.get(YjsDatabaseKey.last_modified);
       }
 
       if (fieldType === FieldType.CreatedTime) {
-        return meta.get(YjsDatabaseKey.created_at);
+        return snapshot.row.get(YjsDatabaseKey.created_at);
       }
-
-      const cells = meta.get(YjsDatabaseKey.cells);
-      const cell = cells.get(fieldId);
 
       if (fieldType === FieldType.Relation && options?.getRelationCellText) {
         const relationText = options.getRelationCellText(rowId, fieldId);
@@ -130,8 +129,7 @@ export function sortBy(
         return rollupValue?.value || defaultData;
       }
 
-      if (!cell) return defaultData;
-      const decoded = decodeCellForSort(cell, field);
+      const decoded = getConditionSortValue(snapshot, fieldId, field);
 
       if (decoded === undefined || decoded === null || decoded === '') {
         return defaultData;

--- a/src/application/services/js-services/cache/index.ts
+++ b/src/application/services/js-services/cache/index.ts
@@ -1,5 +1,6 @@
 import * as Y from 'yjs';
 
+import { invalidateRowConditionCache } from '@/application/database-yjs/condition-value-cache';
 import { migrateDatabaseFieldTypes } from '@/application/database-yjs/migrations/rollup_fieldtype';
 import { getRowKey } from '@/application/database-yjs/row_meta';
 import { closeCollabDB, db, evictProviderCache, openCollabDB, openCollabDBWithProvider } from '@/application/db';
@@ -460,6 +461,23 @@ let rowSyncLogCount = 0;
 let rowFastLogCount = 0;
 
 const rowDocs = new Map<string, RowDocEntry>();
+const pendingRowDocEntries = new Map<string, Promise<RowDocEntry>>();
+const appliedSeedBytesByDoc = new WeakMap<YDoc, WeakSet<Uint8Array>>();
+
+function hasAppliedSeed(doc: YDoc, seedBytes: Uint8Array) {
+  return appliedSeedBytesByDoc.get(doc)?.has(seedBytes) ?? false;
+}
+
+function markSeedApplied(doc: YDoc, seedBytes: Uint8Array) {
+  let appliedSeeds = appliedSeedBytesByDoc.get(doc);
+
+  if (!appliedSeeds) {
+    appliedSeeds = new WeakSet();
+    appliedSeedBytesByDoc.set(doc, appliedSeeds);
+  }
+
+  appliedSeeds.add(seedBytes);
+}
 
 async function getOrCreateRowDocEntry(rowKey: string): Promise<RowDocEntry> {
   const existing = rowDocs.get(rowKey);
@@ -468,18 +486,38 @@ async function getOrCreateRowDocEntry(rowKey: string): Promise<RowDocEntry> {
     return existing;
   }
 
-  // providerCache in openCollabDBWithProvider handles concurrent dedup
-  const entry = await _createRowDocEntry(rowKey);
+  const pending = pendingRowDocEntries.get(rowKey);
 
-  // Post-await race check: another caller may have populated rowDocs
-  const raceWinner = rowDocs.get(rowKey);
-
-  if (raceWinner) {
-    return raceWinner;
+  if (pending) {
+    return pending;
   }
 
-  rowDocs.set(rowKey, entry);
-  return entry;
+  const promise = (async () => {
+    // providerCache in openCollabDBWithProvider handles provider-level dedup;
+    // this map prevents duplicate row doc entry creation while the first open
+    // is still awaiting IndexedDB/provider setup.
+    const entry = await _createRowDocEntry(rowKey);
+
+    // Post-await race check: another caller may have populated rowDocs.
+    const raceWinner = rowDocs.get(rowKey);
+
+    if (raceWinner) {
+      return raceWinner;
+    }
+
+    rowDocs.set(rowKey, entry);
+    return entry;
+  })();
+
+  pendingRowDocEntries.set(rowKey, promise);
+
+  try {
+    return await promise;
+  } finally {
+    if (pendingRowDocEntries.get(rowKey) === promise) {
+      pendingRowDocEntries.delete(rowKey);
+    }
+  }
 }
 
 async function _createRowDocEntry(rowKey: string): Promise<RowDocEntry> {
@@ -542,7 +580,7 @@ export async function openRowDoc(rowKey: string, seed?: { bytes: Uint8Array; enc
   const rowSharedRootBefore = entry.doc.getMap(YjsEditorKey.data_section);
   const hasRowDataBefore = rowSharedRootBefore.has(YjsEditorKey.database_row);
 
-  if (seed) {
+  if (seed && !hasAppliedSeed(entry.doc, seed.bytes)) {
     Log.debug('[Database] createRowDocFast applying seed', {
       rowKey,
       seedBytes: seed.bytes.length,
@@ -551,6 +589,8 @@ export async function openRowDoc(rowKey: string, seed?: { bytes: Uint8Array; enc
     });
 
     applyYDoc(entry.doc, seed.bytes, seed.encoderVersion);
+    markSeedApplied(entry.doc, seed.bytes);
+    invalidateRowConditionCache(entry.doc);
   }
 
   const rowSharedRoot = entry.doc.getMap(YjsEditorKey.data_section);

--- a/src/components/database/Database.tsx
+++ b/src/components/database/Database.tsx
@@ -3,12 +3,15 @@ import EventEmitter from 'events';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import {
-  clearDatabaseRowDocSeedCache,
+  getDatabaseRowDocFromSeed,
+  peekDatabaseRowDocSeed,
   prefetchDatabaseBlobDiff,
-  takeDatabaseRowDocSeed,
+  releaseDatabaseRowDocSeedCache,
+  retainDatabaseRowDocSeedCache,
 } from '@/application/database-blob';
+import { hasRowConditionData } from '@/application/database-yjs/condition-value-cache';
 import { getRowKey } from '@/application/database-yjs/row_meta';
-import { openRowDoc } from '@/application/services/js-services/cache';
+import { getCachedRowDoc, openRowDoc } from '@/application/services/js-services/cache';
 import {
   AppendBreadcrumb,
   CreateDatabaseViewPayload,
@@ -175,6 +178,7 @@ function Database(props: Database2Props) {
   // Gate that ensureRow awaits. Resolves after batch preload (or immediately in readOnly).
   const seedsGateRef = useRef(createDeferredGate());
   const [blobPrefetchComplete, setBlobPrefetchComplete] = useState(false);
+  const [seedsReady, setSeedsReady] = useState(false);
 
   useEffect(() => {
     rowMapRef.current = rowMap;
@@ -247,17 +251,26 @@ function Database(props: Database2Props) {
   const loadRowFromSeed = useCallback(
     async (rowId: string): Promise<YDoc | undefined> => {
       if (!rowId) return undefined;
+      const databaseId = getDatabaseId();
+      const rowKey = getRowKey(databaseId, rowId);
       const existing = rowMapRef.current[rowId];
 
-      if (existing) return existing;
+      if (hasRowConditionData(existing)) return existing;
 
       const pending = pendingRowDocsRef.current.get(rowId);
 
       if (pending) return pending;
 
-      const databaseId = getDatabaseId();
-      const rowKey = getRowKey(databaseId, rowId);
-      const seed = takeDatabaseRowDocSeed(rowKey);
+      const cachedRowDoc = getCachedRowDoc(rowKey);
+      const seed = peekDatabaseRowDocSeed(rowKey);
+
+      if (hasRowConditionData(cachedRowDoc)) {
+        setRowMap((prev) => {
+          if (prev[rowId]) return prev;
+          return { ...prev, [rowId]: cachedRowDoc };
+        });
+        return cachedRowDoc;
+      }
 
       if (!seed) return undefined;
 
@@ -287,6 +300,20 @@ function Database(props: Database2Props) {
     [getDatabaseId]
   );
 
+  // Synchronous shared read-only doc for filter/sort. Reuses an existing row
+  // doc when cached, otherwise builds one shared in-memory Y.Doc from seed
+  // bytes without touching IndexedDB or consuming the seed.
+  const peekRowDocFromSeed = useCallback(
+    (rowId: string): YDoc | null => {
+      if (!rowId) return null;
+      const databaseId = getDatabaseId();
+      const rowKey = getRowKey(databaseId, rowId);
+
+      return getDatabaseRowDocFromSeed(rowKey);
+    },
+    [getDatabaseId]
+  );
+
   const runBatchPreload = useCallback(() => {
     if (batchPreloadDoneRef.current) return;
     batchPreloadDoneRef.current = true;
@@ -301,14 +328,14 @@ function Database(props: Database2Props) {
 
     // Collect seeds for the first N priority rows (visible + overscan) in a single pass
     const BATCH_SIZE = 30;
-    const rowsWithSeeds: { rowId: string; rowKey: string; seed: NonNullable<ReturnType<typeof takeDatabaseRowDocSeed>> }[] = [];
+    const rowsWithSeeds: { rowId: string; rowKey: string; seed: NonNullable<ReturnType<typeof peekDatabaseRowDocSeed>> }[] = [];
 
     for (const rowId of priorityRowIds) {
       if (rowsWithSeeds.length >= BATCH_SIZE) break;
-      if (rowMapRef.current[rowId]) continue;
+      if (hasRowConditionData(rowMapRef.current[rowId])) continue;
 
       const rowKey = getRowKey(databaseId, rowId);
-      const seed = takeDatabaseRowDocSeed(rowKey);
+      const seed = peekDatabaseRowDocSeed(rowKey);
 
       if (seed) {
         rowsWithSeeds.push({ rowId, rowKey, seed });
@@ -368,6 +395,7 @@ function Database(props: Database2Props) {
     if (readOnly) {
       seedsGateRef.current.resolve();
       setBlobPrefetchComplete(true);
+      setSeedsReady(true);
       return null;
     }
 
@@ -389,8 +417,10 @@ function Database(props: Database2Props) {
     const promise = prefetchDatabaseBlobDiff(workspaceId, databaseId, {
       priorityRowIds,
       onSeedsReady: () => {
-        // Seeds are cached — kick off batch preload immediately,
-        // before the slow IndexedDB persist starts
+        // Seeds are cached — filter/sort can now build ephemeral docs from them
+        // without waiting for IndexedDB persist.
+        setSeedsReady(true);
+        // Also kick off batch preload for visible rows (heavy IndexedDB path).
         runBatchPreload();
       },
     })
@@ -401,6 +431,7 @@ function Database(props: Database2Props) {
         prefetchPromisesRef.current.delete(databaseId);
         seedsGateRef.current.resolve(); // Unblock ensureRow on failure
         setBlobPrefetchComplete(true);
+        setSeedsReady(true);
       });
 
     prefetchPromisesRef.current.set(databaseId, promise);
@@ -411,8 +442,10 @@ function Database(props: Database2Props) {
   useEffect(() => {
     const databaseId = getDatabaseId();
 
+    retainDatabaseRowDocSeedCache(databaseId);
+
     return () => {
-      clearDatabaseRowDocSeedCache(databaseId);
+      releaseDatabaseRowDocSeedCache(databaseId);
     };
   }, [getDatabaseId]);
 
@@ -453,7 +486,7 @@ function Database(props: Database2Props) {
       // Check before awaiting the gate to avoid blocking on already-available rows.
       const existing = rowMapRef.current[rowId];
 
-      if (existing) {
+      if (hasRowConditionData(existing)) {
         const databaseId = getDatabaseId();
         const rowKey = getRowKey(databaseId, rowId);
 
@@ -467,7 +500,7 @@ function Database(props: Database2Props) {
 
       const existingAfterGate = rowMapRef.current[rowId];
 
-      if (existingAfterGate) {
+      if (hasRowConditionData(existingAfterGate)) {
         const databaseId = getDatabaseId();
         const rowKey = getRowKey(databaseId, rowId);
 
@@ -484,7 +517,13 @@ function Database(props: Database2Props) {
       const promise = (async () => {
         const databaseId = getDatabaseId();
         const rowKey = getRowKey(databaseId, rowId);
-        const seed = takeDatabaseRowDocSeed(rowKey);
+        const cachedRowDoc = getCachedRowDoc(rowKey);
+        const seed = peekDatabaseRowDocSeed(rowKey);
+
+        if (hasRowConditionData(cachedRowDoc)) {
+          registerRowSync(rowKey);
+          return cachedRowDoc;
+        }
 
         try {
           const rowDoc = await openRowDoc(rowKey, seed ?? undefined);
@@ -527,7 +566,7 @@ function Database(props: Database2Props) {
       }
     },
     // Omitted deps are stable: setRowMap (useState setter), refs (rowMapRef, pendingRowDocsRef,
-    // localCachePrimedRef), and module-level imports (openRowDoc, takeDatabaseRowDocSeed, getRowKey).
+    // localCachePrimedRef), and module-level imports (openRowDoc, getCachedRowDoc, peekDatabaseRowDocSeed, getRowKey).
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [createRow, getDatabaseId, ensureBlobPrefetch, registerRowSync]
   );
@@ -542,6 +581,7 @@ function Database(props: Database2Props) {
     seedsGateRef.current = createDeferredGate();
     setRowMap({});
     setBlobPrefetchComplete(false);
+    setSeedsReady(false);
   }, [doc.guid]);
 
   // Trigger blob prefetch when database opens
@@ -668,8 +708,10 @@ function Database(props: Database2Props) {
       readOnly,
       ensureRow,
       loadRowFromSeed,
+      peekRowDocFromSeed,
       bindRowSync,
       blobPrefetchComplete,
+      seedsReady,
       paddingStart: props.paddingStart,
       paddingEnd: props.paddingEnd,
       isDocumentBlock: _isDocumentBlock,
@@ -704,8 +746,10 @@ function Database(props: Database2Props) {
       readOnly,
       ensureRow,
       loadRowFromSeed,
+      peekRowDocFromSeed,
       bindRowSync,
       blobPrefetchComplete,
+      seedsReady,
       props.paddingStart,
       props.paddingEnd,
       _isDocumentBlock,

--- a/src/pages/AppPage.tsx
+++ b/src/pages/AppPage.tsx
@@ -593,17 +593,17 @@ function AppPage() {
     loadDatabaseRelations,
   ]);
 
-  // Keep previous view content visible during transitions to prevent
-  // the old Document from unmounting (which triggers clearAwareness/disconnect).
-  const viewDomRef = useRef<React.ReactNode>(null);
+  // Keep current view content visible during same-view transitions, but do not
+  // show stale content after navigating to a different view.
+  const viewDomRef = useRef<{ viewId: string; node: React.ReactNode } | null>(null);
 
   // Cache the latest non-null viewDom in an effect (not during render)
   // to keep the render function pure per React concurrent mode rules.
   useEffect(() => {
-    if (viewDom !== null) {
-      viewDomRef.current = viewDom;
+    if (viewDom !== null && viewId) {
+      viewDomRef.current = { viewId, node: viewDom };
     }
-  }, [viewDom]);
+  }, [viewDom, viewId]);
 
   // Clear stale content when an error occurs so the error UI shows immediately
   useEffect(() => {
@@ -614,7 +614,9 @@ function AppPage() {
 
   // Show current content, or keep previous content visible during transition.
   // The ref was set by a prior committed effect, so reading it here is safe.
-  const displayDom = viewDom ?? viewDomRef.current;
+  const cachedEntry = viewDomRef.current;
+  const cachedViewDom = cachedEntry && cachedEntry.viewId === viewId ? cachedEntry.node : null;
+  const displayDom = viewDom ?? cachedViewDom;
   const isTransitioning = viewDom === null && displayDom !== null;
 
   useEffect(() => {


### PR DESCRIPTION
<!---
Thank you for submitting a pull request to the AppFlowy Web! The team will dedicate their best efforts to reviewing and approving your PR. If you have any questions or feedback, feel free to join our [Discord](https://discord.gg/wdjWUXXhtw).
-->


### **Description**
<!---
Provide a clear and concise description of the changes introduced in this pull request for AppFlowy Web. What problem does it solve? What value does it add?
-->

---

### **Checklist**
<!---
Before marking your pull request as ready for review, ensure the following checklist is complete.
-->

#### **General**
- [ ] I've included relevant documentation or comments for the changes introduced.
- [ ] I've tested the changes in multiple environments (e.g., different browsers, operating systems).

#### **Testing**
- [ ] I've added or updated tests to validate the changes introduced for AppFlowy Web.

#### **Feature-Specific**
- [ ] For feature additions, I've added a preview (video, screenshot, or demo) in the "Feature Preview" section.
- [ ] I've verified that this feature integrates seamlessly with existing functionality.

## Summary by Sourcery

Improve shared loading and reuse of database row documents and seed caches to make filtering, sorting, and multi-view access more efficient and responsive.

New Features:
- Introduce a shared per-view background row document loader that deduplicates work across consumers and reuses ephemeral docs for sorting and filtering.
- Add shared read-only row documents derived from cached seeds so multiple database views can evaluate conditions without hitting IndexedDB.
- Provide synchronous access to row docs from seeds via a new context hook for fast filter/sort evaluation.

Bug Fixes:
- Prevent use of incomplete row documents for conditions by checking for the presence of row condition data before reusing cached docs.
- Avoid re-applying the same seed bytes to a live row document multiple times, preventing inconsistent state and stale condition results.

Enhancements:
- Optimize database blob prefetching with shared entries, priority row handling, and early seed-availability signaling across callers.
- Add a condition value cache layer to reuse decoded cell data, text, dates, and sort values when applying filters and sorts.
- Improve row doc caching and seed application logic to avoid redundant IndexedDB opens and duplicate seed application, while properly invalidating condition caches on updates.
- Refine filter/sort behavior to progressively show only rows whose condition data is ready and to coalesce recomputations using deferred values.
- Ensure seed caches and shared prefetch entries are reference-counted and cleaned up safely when databases are closed.

Chores:
- Refactor row-loading hooks and database context types to expose new seed-based accessors and readiness flags without changing public UI behavior.