### PR TITLE
fix: highlight selected view after creating db

### DIFF
--- a/playwright/e2e/database/board-edit-operations.spec.ts
+++ b/playwright/e2e/database/board-edit-operations.spec.ts
@@ -157,7 +157,7 @@ test.describe('Board Operations', () => {
       await page.waitForTimeout(1500);
 
       // Then: the modal should show the original title
-      const dialog = page.locator('[role="dialog"]');
+      const dialog = page.locator('.MuiDialog-paper').filter({ has: page.getByTestId('row-title-input') }).first();
       await expect(dialog).toBeVisible({ timeout: 10000 });
       await expect(dialog.getByTestId('row-title-input')).toHaveValue(originalName, { timeout: 10000 });
 
@@ -316,7 +316,7 @@ test.describe('Board Operations', () => {
       await BoardSelectors.boardContainer(page).getByText(cardName).click({ force: true });
       await page.waitForTimeout(1500);
 
-      const dialog = page.locator('[role="dialog"]');
+      const dialog = page.locator('.MuiDialog-paper').filter({ has: page.getByTestId('row-title-input') }).first();
       await expect(dialog).toBeVisible({ timeout: 10000 });
 
       await dialog.locator('[data-block-type]').first().click({ force: true });

--- a/playwright/e2e/database/duplicate-row-doc-content.spec.ts
+++ b/playwright/e2e/database/duplicate-row-doc-content.spec.ts
@@ -3,9 +3,9 @@ import { generateRandomEmail, setupPageErrorHandling } from '../../support/test-
 import { signUpAndLoginWithPasswordViaUi } from '../../support/auth-flow-helpers';
 import {
   openRowDetail,
-  closeRowDetailWithEscape,
-  typeInRowDocument,
   duplicateRowFromDetail,
+  getVisibleDataRowIds,
+  openRowDetailByRowId,
 } from '../../support/row-detail-helpers';
 import { createDatabaseView, waitForGridReady } from '../../support/database-ui-helpers';
 import { DatabaseGridSelectors } from '../../support/selectors';
@@ -57,6 +57,8 @@ test.describe('Duplicate row preserves document content', () => {
     await page.waitForTimeout(3000);
 
     // Duplicate the row from row detail
+    const rowIdsBeforeDuplicate = await getVisibleDataRowIds(page);
+
     await openRowDetail(page, 0);
     await duplicateRowFromDetail(page);
     // duplicateRowFromDetail auto-closes the dialog; ensure it's closed
@@ -65,12 +67,16 @@ test.describe('Duplicate row preserves document content', () => {
 
     // Verify 4 rows (3 default + 1 duplicate)
     const rowCount = await DatabaseGridSelectors.dataRows(page).count();
-    expect(rowCount).toBe(4);
+    expect(rowCount).toBe(rowIdsBeforeDuplicate.length + 1);
 
-    // Open the duplicated row (index 1) in full-page mode so the Yjs
+    const rowIdsAfterDuplicate = await getVisibleDataRowIds(page);
+    const duplicatedRowId = rowIdsAfterDuplicate.find((rowId) => !rowIdsBeforeDuplicate.includes(rowId));
+    expect(duplicatedRowId).toBeTruthy();
+
+    // Open the duplicated row in full-page mode so the Yjs
     // provider creates a fresh connection on each attempt.  The dialog's
     // lazy sub-document loading can miss updates; full-page mode is reliable.
-    await openRowDetail(page, 1);
+    await openRowDetailByRowId(page, duplicatedRowId!);
     const dialogTitle2 = page.locator('.MuiDialogTitle-root');
     await dialogTitle2.locator('button').first().click({ force: true });
     await page.waitForTimeout(2000);

--- a/playwright/e2e/database/duplicate-row-inline-db.spec.ts
+++ b/playwright/e2e/database/duplicate-row-inline-db.spec.ts
@@ -5,6 +5,8 @@ import {
   openRowDetail,
   closeRowDetailWithEscape,
   duplicateRowFromDetail,
+  getVisibleDataRowIds,
+  openRowDetailByRowId,
 } from '../../support/row-detail-helpers';
 import { createDatabaseView, waitForGridReady } from '../../support/database-ui-helpers';
 import {
@@ -70,6 +72,8 @@ test.describe('Duplicate row with inline database', () => {
     await page.waitForTimeout(1000);
 
     // Duplicate the row from row detail
+    const rowIdsBeforeDuplicate = await getVisibleDataRowIds(page);
+
     await openRowDetail(page, 0);
     await duplicateRowFromDetail(page);
     await closeRowDetailWithEscape(page);
@@ -85,10 +89,14 @@ test.describe('Duplicate row with inline database', () => {
     await page.waitForTimeout(2000);
 
     // Verify the grid now has 4 rows (3 default + 1 duplicate)
-    expect(await getGridRowCount(page)).toBe(4);
+    expect(await getGridRowCount(page)).toBe(rowIdsBeforeDuplicate.length + 1);
 
-    // Open the duplicated row (index 1) in full page mode to verify
-    await openRowDetail(page, 1);
+    const rowIdsAfterDuplicate = await getVisibleDataRowIds(page);
+    const duplicatedRowId = rowIdsAfterDuplicate.find((rowId) => !rowIdsBeforeDuplicate.includes(rowId));
+    expect(duplicatedRowId).toBeTruthy();
+
+    // Open the duplicated row in full page mode to verify
+    await openRowDetailByRowId(page, duplicatedRowId!);
     const dialogTitle2 = page.locator('.MuiDialogTitle-root');
     await dialogTitle2.locator('button').first().click({ force: true });
     await page.waitForTimeout(2000);
@@ -108,7 +116,7 @@ test.describe('Duplicate row with inline database', () => {
       await page.goBack();
       await page.waitForTimeout(3000);
       await waitForGridReady(page);
-      await openRowDetail(page, 1);
+      await openRowDetailByRowId(page, duplicatedRowId!);
       const dt = page.locator('.MuiDialogTitle-root');
       await dt.locator('button').first().click({ force: true });
       await page.waitForTimeout(2000);

--- a/playwright/e2e/embeded/database/duplicate-doc-inline-and-linked-db.spec.ts
+++ b/playwright/e2e/embeded/database/duplicate-doc-inline-and-linked-db.spec.ts
@@ -39,9 +39,9 @@ test.describe('Duplicate Document Inline And Linked Database', () => {
 
     const docViewId = await createNamedDocumentPage(page, docName);
     const editor = editorForView(page, docViewId);
-    // The linked database picker searches by container name ("New Database"),
-    // not the renamed view name.
-    await insertLinkedGridViaSlash(page, docViewId, 'New Database', 0);
+    // The linked database picker lists databases by the container name.
+    // `createNamedGridPage` renames the container itself, so search by sourceDbName.
+    await insertLinkedGridViaSlash(page, docViewId, sourceDbName, 0);
 
     await expect(databaseBlocks(editor)).toHaveCount(1, { timeout: 30000 });
     await expectNoActiveFilters(databaseBlocks(editor).nth(0));

--- a/playwright/e2e/embeded/database/duplicate-doc-linked-db-filter.spec.ts
+++ b/playwright/e2e/embeded/database/duplicate-doc-linked-db-filter.spec.ts
@@ -37,13 +37,13 @@ test.describe('Duplicate Document Linked Database Filter', () => {
 
     const docViewId = await createNamedDocumentPage(page, docName);
     const editor = editorForView(page, docViewId);
-    // The linked database picker searches by container name ("New Database"),
-    // not the renamed view name. Each test workspace has only one database.
-    await insertLinkedGridViaSlash(page, docViewId, 'New Database', 0);
+    // The linked database picker lists databases by the container name.
+    // `createNamedGridPage` renames the container itself, so search by sourceDbName.
+    await insertLinkedGridViaSlash(page, docViewId, sourceDbName, 0);
     // Wait for the first linked grid to fully render and for any background
     // IndexedDB sync activity to settle before opening the slash menu again.
     await page.waitForTimeout(3000);
-    await insertLinkedGridViaSlash(page, docViewId, 'New Database', 1);
+    await insertLinkedGridViaSlash(page, docViewId, sourceDbName, 1);
 
     await expect(databaseBlocks(editor)).toHaveCount(2, { timeout: 30000 });
     await expectNoActiveFilters(databaseBlocks(editor).nth(0));

--- a/playwright/support/row-detail-helpers.ts
+++ b/playwright/support/row-detail-helpers.ts
@@ -43,6 +43,37 @@ export async function openRowDetail(page: Page, rowIndex: number = 0): Promise<v
 }
 
 /**
+ * Return visible data-row ids in DOM order.
+ */
+export async function getVisibleDataRowIds(page: Page): Promise<string[]> {
+  const testIds = await DatabaseGridSelectors.dataRows(page).evaluateAll((rows) =>
+    rows
+      .map((row) => row.getAttribute('data-testid') || '')
+      .filter(Boolean)
+  );
+
+  return testIds.map((testId) => testId.replace('grid-row-', ''));
+}
+
+/**
+ * Open a specific row detail modal by row id.
+ */
+export async function openRowDetailByRowId(page: Page, rowId: string): Promise<void> {
+  const row = DatabaseGridSelectors.rowById(page, rowId);
+  await expect(row).toBeVisible({ timeout: 10000 });
+  await row.scrollIntoViewIfNeeded();
+  await row.hover();
+  await page.waitForTimeout(500);
+
+  const expandButton = page.getByTestId('row-expand-button').first();
+  await expect(expandButton).toBeVisible({ timeout: 5000 });
+  await expandButton.click({ force: true });
+  await page.waitForTimeout(1000);
+
+  await expect(RowDetailSelectors.modal(page)).toBeVisible();
+}
+
+/**
  * Open row detail by hovering over a cell to reveal the expand button
  */
 export async function openRowDetailViaCell(

--- a/src/application/types.ts
+++ b/src/application/types.ts
@@ -1290,6 +1290,7 @@ export interface ViewMetaProps {
   cover?: ViewMetaCover;
   name?: string;
   viewId?: string;
+  parentViewId?: string;
   workspaceId?: string;
   layout?: ViewLayout;
   visibleViewIds?: string[];

--- a/src/components/app/DatabaseView.tsx
+++ b/src/components/app/DatabaseView.tsx
@@ -37,7 +37,13 @@ function DatabaseView(props: DatabaseViewProps) {
   }, [outline, databasePageId]);
 
   // Use hook to determine container view and visible view IDs
-  const { containerView, visibleViewIds } = useContainerVisibleViewIds({ view, outline });
+  const { containerView, visibleViewIds } = useContainerVisibleViewIds({
+    view,
+    outline,
+    parentViewId: viewMeta.parentViewId,
+    databaseId: viewMeta.extra?.database_id,
+    embedded: viewMeta.extra?.embedded,
+  });
 
   // Use container view (if present) as the "page meta" view for naming/icon operations.
   const pageView = containerView || view;

--- a/src/components/app/app.hooks.tsx
+++ b/src/components/app/app.hooks.tsx
@@ -5,6 +5,7 @@ import LoadingDots from '@/components/_shared/LoadingDots';
 import { findView } from '@/components/_shared/outline/utils';
 import {
   DATABASE_TAB_VIEW_ID_QUERY_PARAM,
+  resolveSidebarHighlightedViewIds,
   resolveSidebarSelectedViewId,
 } from '@/components/app/hooks/resolveSidebarSelectedViewId';
 
@@ -509,5 +510,24 @@ export function useSidebarSelectedViewId() {
         outline,
       }),
     [outline, routeViewId, tabViewId]
+  );
+}
+
+export function useSidebarHighlightedViewIds() {
+  const routeViewId = useAppViewId();
+  const outline = useAppOutline();
+  const breadcrumbs = useBreadcrumb();
+  const [searchParams] = useSearchParams();
+  const tabViewId = searchParams.get(DATABASE_TAB_VIEW_ID_QUERY_PARAM);
+
+  return useMemo(
+    () =>
+      resolveSidebarHighlightedViewIds({
+        routeViewId,
+        tabViewId,
+        outline,
+        breadcrumbs,
+      }),
+    [breadcrumbs, outline, routeViewId, tabViewId]
   );
 }

--- a/src/components/app/hooks/__tests__/ViewItem.databaseContainer.test.tsx
+++ b/src/components/app/hooks/__tests__/ViewItem.databaseContainer.test.tsx
@@ -6,6 +6,8 @@ import ViewItem from '@/components/app/outline/ViewItem';
 declare global {
   // eslint-disable-next-line no-var
   var __selectedViewId: string | undefined;
+  // eslint-disable-next-line no-var
+  var __highlightedViewIds: string[] | undefined;
 }
 
 jest.mock('react-i18next', () => ({
@@ -14,6 +16,7 @@ jest.mock('react-i18next', () => ({
 
 jest.mock('@/components/app/app.hooks', () => ({
   useSidebarSelectedViewId: () => global.__selectedViewId,
+  useSidebarHighlightedViewIds: () => global.__highlightedViewIds || [],
   useAppOperations: () => ({
     updatePage: jest.fn(),
     uploadFile: jest.fn(),
@@ -30,6 +33,7 @@ jest.mock('@/components/_shared/view-icon/PageIcon', () => () => null);
 describe('ViewItem database container', () => {
   beforeEach(() => {
     global.__selectedViewId = undefined;
+    global.__highlightedViewIds = undefined;
   });
 
   it('clicking a container opens its first child', () => {
@@ -111,5 +115,46 @@ describe('ViewItem database container', () => {
     const el = screen.getByTestId(`page-${containerView.view_id}`);
 
     expect(el.getAttribute('data-selected')).toBe('true');
+  });
+
+  it('marks both the database container and active child view as selected', () => {
+    const childView: View = {
+      view_id: 'child-view-id',
+      name: 'Grid',
+      icon: null,
+      layout: ViewLayout.Grid,
+      extra: { is_space: false },
+      children: [],
+      is_published: false,
+      is_private: false,
+      parent_view_id: 'container-view-id',
+    };
+
+    const containerView: View = {
+      view_id: 'container-view-id',
+      name: 'New database',
+      icon: null,
+      layout: ViewLayout.Grid,
+      extra: { is_space: false, is_database_container: true },
+      children: [childView],
+      is_published: false,
+      is_private: false,
+    };
+
+    global.__selectedViewId = childView.view_id;
+    global.__highlightedViewIds = [childView.view_id, containerView.view_id];
+
+    render(
+      <ViewItem
+        view={containerView}
+        width={240}
+        expandIds={[containerView.view_id]}
+        toggleExpand={jest.fn()}
+        onClickView={jest.fn()}
+      />
+    );
+
+    expect(screen.getByTestId(`page-${containerView.view_id}`).getAttribute('data-selected')).toBe('true');
+    expect(screen.getByTestId(`page-${childView.view_id}`).getAttribute('data-selected')).toBe('true');
   });
 });

--- a/src/components/app/hooks/__tests__/databaseTabSidebarSync.test.tsx
+++ b/src/components/app/hooks/__tests__/databaseTabSidebarSync.test.tsx
@@ -21,13 +21,19 @@ declare global {
 }
 
 jest.mock('@/components/app/app.hooks', () => {
-  const { resolveSidebarSelectedViewId } = jest.requireActual(
+  const { resolveSidebarSelectedViewId, resolveSidebarHighlightedViewIds } = jest.requireActual(
     '@/components/app/hooks/resolveSidebarSelectedViewId'
   );
 
   return {
     useSidebarSelectedViewId: () =>
       resolveSidebarSelectedViewId({
+        routeViewId: global.__routeViewId,
+        tabViewId: global.__tabViewId,
+        outline: global.__outline,
+      }),
+    useSidebarHighlightedViewIds: () =>
+      resolveSidebarHighlightedViewIds({
         routeViewId: global.__routeViewId,
         tabViewId: global.__tabViewId,
         outline: global.__outline,

--- a/src/components/app/hooks/__tests__/resolveSidebarSelectedViewId.test.ts
+++ b/src/components/app/hooks/__tests__/resolveSidebarSelectedViewId.test.ts
@@ -1,5 +1,8 @@
 import { View, ViewLayout } from '@/application/types';
-import { resolveSidebarSelectedViewId } from '@/components/app/hooks/resolveSidebarSelectedViewId';
+import {
+  resolveSidebarHighlightedViewIds,
+  resolveSidebarSelectedViewId,
+} from '@/components/app/hooks/resolveSidebarSelectedViewId';
 
 describe('resolveSidebarSelectedViewId', () => {
   const containerViewId = 'container-view-id';
@@ -120,5 +123,61 @@ describe('resolveSidebarSelectedViewId', () => {
       gridViewId
     );
   });
-});
 
+  describe('resolveSidebarHighlightedViewIds', () => {
+    it('highlights the active child and database container when the active route view is a loaded child', () => {
+      expect(resolveSidebarHighlightedViewIds({ routeViewId: gridViewId, tabViewId: null, outline })).toEqual([
+        gridViewId,
+        containerViewId,
+      ]);
+    });
+
+    it('highlights the active child and database container from breadcrumbs when the outline is shallow', () => {
+      const shallowContainer: View = {
+        ...containerView,
+        children: [],
+        has_children: true,
+      };
+
+      const shallowOutline: View[] = [
+        {
+          ...outline[0],
+          children: [shallowContainer, documentView],
+        },
+      ];
+
+      expect(
+        resolveSidebarHighlightedViewIds({
+          routeViewId: gridViewId,
+          tabViewId: null,
+          outline: shallowOutline,
+          breadcrumbs: [outline[0], shallowContainer, gridView],
+        })
+      ).toEqual([gridViewId, containerViewId]);
+    });
+
+    it('highlights the selected tab view and database container', () => {
+      expect(resolveSidebarHighlightedViewIds({ routeViewId: gridViewId, tabViewId: boardViewId, outline })).toEqual([
+        boardViewId,
+        containerViewId,
+      ]);
+    });
+
+    it('keeps non-database child views selected normally', () => {
+      const childDocument: View = {
+        ...documentView,
+        view_id: 'child-doc-id',
+        parent_view_id: 'space',
+      };
+
+      expect(
+        resolveSidebarHighlightedViewIds({
+          routeViewId: childDocument.view_id,
+          tabViewId: null,
+          outline: [{ ...outline[0], children: [childDocument] }],
+          breadcrumbs: [outline[0], childDocument],
+        })
+      ).toEqual([childDocument.view_id]);
+    });
+  });
+});

--- a/src/components/app/hooks/resolveSidebarSelectedViewId.ts
+++ b/src/components/app/hooks/resolveSidebarSelectedViewId.ts
@@ -32,3 +32,33 @@ export function resolveSidebarSelectedViewId(params: {
   return tabView.parent_view_id === containerId || tabView.view_id === containerId ? tabViewId : routeViewId;
 }
 
+export function resolveSidebarHighlightedViewIds(params: {
+  routeViewId?: string;
+  tabViewId?: string | null;
+  outline?: View[];
+  breadcrumbs?: View[];
+}): string[] {
+  const selectedViewId = resolveSidebarSelectedViewId(params);
+
+  if (!selectedViewId) return [];
+
+  const highlightedViewIds = new Set<string>([selectedViewId]);
+
+  const { outline, breadcrumbs } = params;
+  const selectedIndex = breadcrumbs?.findIndex((view) => view.view_id === selectedViewId) ?? -1;
+  const breadcrumbParent = selectedIndex > 0 ? breadcrumbs?.[selectedIndex - 1] : undefined;
+
+  if (breadcrumbParent && isDatabaseContainer(breadcrumbParent)) {
+    highlightedViewIds.add(breadcrumbParent.view_id);
+    return Array.from(highlightedViewIds);
+  }
+
+  const selectedView = outline ? findView(outline, selectedViewId) : undefined;
+  const outlineParent = selectedView?.parent_view_id && outline ? findView(outline, selectedView.parent_view_id) : undefined;
+
+  if (outlineParent && isDatabaseContainer(outlineParent)) {
+    highlightedViewIds.add(outlineParent.view_id);
+  }
+
+  return Array.from(highlightedViewIds);
+}

--- a/src/components/app/outline/ViewItem.tsx
+++ b/src/components/app/outline/ViewItem.tsx
@@ -12,7 +12,7 @@ import {
 import { CustomIconPopover } from '@/components/_shared/cutsom-icon';
 import OutlineIcon from '@/components/_shared/outline/OutlineIcon';
 import PageIcon from '@/components/_shared/view-icon/PageIcon';
-import { useAppOperations, useSidebarSelectedViewId } from '@/components/app/app.hooks';
+import { useAppOperations, useSidebarHighlightedViewIds, useSidebarSelectedViewId } from '@/components/app/app.hooks';
 
 function ViewItem({
   view,
@@ -39,9 +39,10 @@ function ViewItem({
 }) {
   const { t } = useTranslation();
   const selectedViewId = useSidebarSelectedViewId();
+  const highlightedViewIds = useSidebarHighlightedViewIds();
   const viewId = view.view_id;
   const selected =
-    selectedViewId === viewId ||
+    highlightedViewIds.includes(viewId) ||
     (isDatabaseContainer(view) && Boolean(view.children?.some((child) => child.view_id === selectedViewId)));
   const { updatePage, uploadFile } = useAppOperations();
 

--- a/src/components/database/hooks/visibleViewIds/useContainerVisibleViewIds.ts
+++ b/src/components/database/hooks/visibleViewIds/useContainerVisibleViewIds.ts
@@ -13,6 +13,21 @@ interface UseContainerVisibleViewIdsProps {
    * The full outline tree
    */
   outline: View[] | null | undefined;
+  /**
+   * Parent id from the active view metadata. Used when the outline is shallow
+   * and does not currently include the active database child view.
+   */
+  parentViewId?: string;
+  /**
+   * Database id from the active view metadata. Used as a fallback for
+   * container lookup when parent metadata is not enough.
+   */
+  databaseId?: string;
+  /**
+   * Embedded database views should not resolve to another database's sidebar
+   * container just because they share the same database id.
+   */
+  embedded?: boolean;
 }
 
 interface UseContainerVisibleViewIdsResult {
@@ -53,30 +68,52 @@ interface UseContainerVisibleViewIdsResult {
 export function useContainerVisibleViewIds({
   view,
   outline,
+  parentViewId,
+  databaseId,
+  embedded,
 }: UseContainerVisibleViewIdsProps): UseContainerVisibleViewIdsResult {
   const containerView = useMemo((): View | undefined => {
-    if (!outline || !view) return undefined;
+    if (!outline) return undefined;
 
     // Check if current view is a container
-    if (isDatabaseContainer(view)) {
+    if (view && isDatabaseContainer(view)) {
       return view;
     }
 
     // Check if parent is a container
-    const parentId = view.parent_view_id;
+    const parentId = view?.parent_view_id || parentViewId;
 
-    if (!parentId) {
+    if (parentId) {
+      const parent = findView(outline, parentId);
+
+      if (parent && isDatabaseContainer(parent)) {
+        return parent;
+      }
+    }
+
+    if (!databaseId || embedded) {
       return undefined;
     }
 
-    const parent = findView(outline, parentId);
+    const stack = [...outline];
 
-    // Return parent if it's a container, otherwise undefined
-    return parent && isDatabaseContainer(parent) ? parent : undefined;
-  }, [outline, view]);
+    while (stack.length > 0) {
+      const current = stack.shift();
+
+      if (!current) continue;
+      if (isDatabaseContainer(current) && current.extra?.database_id === databaseId) {
+        return current;
+      }
+
+      stack.push(...(current.children || []));
+    }
+
+    return undefined;
+  }, [databaseId, embedded, outline, parentViewId, view]);
 
   const visibleViewIds = useMemo(() => {
     if (!containerView) return undefined;
+    if (containerView.children.length === 0) return undefined;
     return containerView.children.map((child) => child.view_id);
   }, [containerView]);
 

--- a/src/pages/AppPage.tsx
+++ b/src/pages/AppPage.tsx
@@ -430,6 +430,7 @@ function AppPage() {
         layout: view.layout,
         visibleViewIds: [],
         viewId: view.view_id,
+        parentViewId: view.parent_view_id,
         extra: view.extra,
         workspaceId,
       };

--- a/src/pages/__tests__/DatabaseView.databaseContainer.test.tsx
+++ b/src/pages/__tests__/DatabaseView.databaseContainer.test.tsx
@@ -153,4 +153,64 @@ describe('DatabaseView database container', () => {
     expect(metaProps?.viewId).toBe(containerId);
     expect(metaProps?.name).toBe('New Database');
   });
+
+  it('uses parent container metadata when the active child is missing from a shallow outline', () => {
+    const containerId = 'container-id';
+    const gridViewId = 'grid-view-id';
+
+    const containerView: View = {
+      view_id: containerId,
+      name: 'New Database',
+      icon: null,
+      layout: ViewLayout.Grid,
+      extra: { is_space: false, is_database_container: true, database_id: 'db-1' },
+      children: [],
+      has_children: true,
+      is_published: false,
+      is_private: false,
+    };
+
+    global.__databaseViewTestState = { outline: [containerView] };
+
+    const viewMeta: ViewMetaProps = {
+      viewId: gridViewId,
+      parentViewId: containerId,
+      name: 'Grid',
+      layout: ViewLayout.Grid,
+      icon: undefined,
+      extra: { is_space: false, database_id: 'db-1' },
+      workspaceId: 'workspace-id',
+      visibleViewIds: [],
+    };
+
+    render(
+      <MemoryRouter initialEntries={['/app/workspace-id/grid-view-id']}>
+        <DatabaseView
+          doc={createDatabaseDoc('db-1', [gridViewId])}
+          workspaceId={'workspace-id'}
+          readOnly={false}
+          viewMeta={viewMeta}
+          updatePage={jest.fn()}
+          updatePageIcon={jest.fn()}
+          updatePageName={jest.fn()}
+          onRendered={jest.fn()}
+        />
+      </MemoryRouter>
+    );
+
+    const databaseProps = global.__databaseViewTestState?.capturedDatabaseProps as
+      | { visibleViewIds?: string[]; databaseName: string }
+      | undefined;
+    const metaProps = global.__databaseViewTestState?.capturedViewMetaProps as
+      | { viewId?: string; name?: string }
+      | undefined;
+
+    expect(databaseProps).toBeDefined();
+    expect(metaProps).toBeDefined();
+
+    expect(databaseProps?.visibleViewIds).toBeUndefined();
+    expect(databaseProps?.databaseName).toBe('New Database');
+    expect(metaProps?.viewId).toBe(containerId);
+    expect(metaProps?.name).toBe('New Database');
+  });
 });


### PR DESCRIPTION
<!---
Thank you for submitting a pull request to the AppFlowy Web! The team will dedicate their best efforts to reviewing and approving your PR. If you have any questions or feedback, feel free to join our [Discord](https://discord.gg/wdjWUXXhtw).
-->


### **Description**
<!---
Provide a clear and concise description of the changes introduced in this pull request for AppFlowy Web. What problem does it solve? What value does it add?
-->

---

### **Checklist**
<!---
Before marking your pull request as ready for review, ensure the following checklist is complete.
-->

#### **General**
- [ ] I've included relevant documentation or comments for the changes introduced.
- [ ] I've tested the changes in multiple environments (e.g., different browsers, operating systems).

#### **Testing**
- [ ] I've added or updated tests to validate the changes introduced for AppFlowy Web.

#### **Feature-Specific**
- [ ] For feature additions, I've added a preview (video, screenshot, or demo) in the "Feature Preview" section.
- [ ] I've verified that this feature integrates seamlessly with existing functionality.

## Summary by Sourcery

Ensure database containers and their child views are correctly highlighted and selected in the sidebar and metadata when navigating or creating database views, even with shallow outlines.

Bug Fixes:
- Fix sidebar selection so the appropriate database container is used when the active database child view is missing from the outline.
- Fix sidebar highlighting to mark both the active database child view and its container as selected where appropriate, including after creating a database.

Enhancements:
- Enhance database container visible-view resolution to fall back to parent and database metadata and to avoid cross-database resolution for embedded views.

Tests:
- Add tests covering sidebar highlight behavior for database containers and children, including shallow outline and non-database child cases.
- Add tests ensuring database container metadata is used when the active child is missing from the outline.
- Extend ViewItem database container tests to verify both container and active child views are marked selected.