### PR TITLE
fix: create db view order

### DIFF
--- a/src/application/database-yjs/__tests__/useAddDatabaseView.test.tsx
+++ b/src/application/database-yjs/__tests__/useAddDatabaseView.test.tsx
@@ -92,6 +92,7 @@ describe('useAddDatabaseView', () => {
       activeViewId,
       expect.objectContaining({
         parent_view_id: containerId,
+        prev_view_id: activeViewId,
         database_id: databaseId,
         layout: ViewLayout.Calendar,
         name: 'Calendar',
@@ -154,6 +155,7 @@ describe('useAddDatabaseView', () => {
       baseViewId,
       expect.objectContaining({
         parent_view_id: documentId,
+        prev_view_id: baseViewId,
         database_id: databaseId,
         layout: ViewLayout.Board,
         name: 'Board',
@@ -218,6 +220,70 @@ describe('useAddDatabaseView', () => {
         database_id: databaseId,
         layout: ViewLayout.Grid,
         name: 'Grid',
+        embedded: false,
+      })
+    );
+
+    const [, payload] = createDatabaseView.mock.calls[0];
+
+    expect(payload.prev_view_id).toBeUndefined();
+  });
+
+  it('uses the container last child as prev_view_id when the current route is the container itself', async () => {
+    const databaseId = 'db-1';
+    const containerId = 'container-view-id';
+    const firstChildId = 'grid-view-id';
+    const secondChildId = 'board-view-id';
+
+    const createDatabaseView = jest.fn().mockResolvedValue({
+      view_id: 'new-view-id',
+      database_id: databaseId,
+    });
+
+    const loadViewMeta = jest.fn(async (viewId: string) => {
+      if (viewId === containerId) {
+        return createView({
+          view_id: containerId,
+          layout: ViewLayout.Grid,
+          extra: { is_space: false, is_database_container: true },
+          children: [
+            createView({ view_id: firstChildId, layout: ViewLayout.Grid, parent_view_id: containerId }),
+            createView({ view_id: secondChildId, layout: ViewLayout.Board, parent_view_id: containerId }),
+          ],
+        });
+      }
+
+      return null;
+    });
+
+    const contextValue: DatabaseContextState = {
+      readOnly: false,
+      databaseDoc: createDatabaseDoc(databaseId),
+      databasePageId: containerId,
+      activeViewId: containerId,
+      rowDocMap: {},
+      workspaceId: 'workspace-id',
+      createDatabaseView,
+      loadViewMeta,
+      isDocumentBlock: false,
+    };
+
+    const { result } = renderHook(() => useAddDatabaseView(), {
+      wrapper: ({ children }) => <DatabaseContext.Provider value={contextValue}>{children}</DatabaseContext.Provider>,
+    });
+
+    await act(async () => {
+      await result.current(DatabaseViewLayout.Calendar, 'Calendar');
+    });
+
+    expect(createDatabaseView).toHaveBeenCalledWith(
+      containerId,
+      expect.objectContaining({
+        parent_view_id: containerId,
+        prev_view_id: secondChildId,
+        database_id: databaseId,
+        layout: ViewLayout.Calendar,
+        name: 'Calendar',
         embedded: false,
       })
     );

--- a/src/application/database-yjs/__tests__/useDatabaseViewsSelector.test.tsx
+++ b/src/application/database-yjs/__tests__/useDatabaseViewsSelector.test.tsx
@@ -10,16 +10,21 @@ jest.mock('@/utils/runtime-config', () => ({
   getConfigValue: (_key: string, fallback: string) => fallback,
 }));
 
-function createDatabaseDocWithViews(viewIdsInInsertionOrder: string[]): YDoc {
+function createDatabaseDocWithViews(
+  viewIdsInInsertionOrder: Array<string | { viewId: string; createdAt?: string }>
+): YDoc {
   const doc = new Y.Doc() as unknown as YDoc;
   const sharedRoot = doc.getMap(YjsEditorKey.data_section);
   const database = new Y.Map();
   const views = new Y.Map();
 
-  viewIdsInInsertionOrder.forEach((viewId) => {
+  viewIdsInInsertionOrder.forEach((input, index) => {
+    const viewId = typeof input === 'string' ? input : input.viewId;
+    const createdAt =
+      typeof input === 'string' ? new Date(Date.UTC(2024, 0, index + 1)).toISOString() : input.createdAt;
     const view = new Y.Map();
 
-    view.set('created_at', new Date().toISOString());
+    view.set(YjsDatabaseKey.created_at, createdAt);
     views.set(viewId, view);
   });
 
@@ -29,6 +34,40 @@ function createDatabaseDocWithViews(viewIdsInInsertionOrder: string[]): YDoc {
 }
 
 describe('useDatabaseViewsSelector', () => {
+  it('sorts standalone database views by created_at instead of raw Yjs insertion order', () => {
+    const gridId = 'grid-id';
+    const boardId = 'board-id';
+    const calendarId = 'calendar-id';
+
+    const databaseDoc = createDatabaseDocWithViews([
+      { viewId: boardId, createdAt: '2024-01-02T00:00:00.000Z' },
+      { viewId: gridId, createdAt: '2024-01-01T00:00:00.000Z' },
+      { viewId: calendarId, createdAt: '2024-01-03T00:00:00.000Z' },
+    ]);
+
+    const contextValue: DatabaseContextState = {
+      readOnly: true,
+      databaseDoc,
+      databasePageId: gridId,
+      activeViewId: gridId,
+      rowDocMap: null,
+      workspaceId: 'workspace-id',
+    };
+
+    const { result } = renderHook(
+      () => useDatabaseViewsSelector(gridId),
+      {
+        wrapper: ({ children }) => (
+          <DatabaseContext.Provider value={contextValue}>
+            {children}
+          </DatabaseContext.Provider>
+        ),
+      }
+    );
+
+    expect(result.current.viewIds).toEqual([gridId, boardId, calendarId]);
+  });
+
   it('preserves visibleViewIds ordering (folder/outline order)', () => {
     const gridId = 'grid-id';
     const boardId = 'board-id';

--- a/src/application/database-yjs/dispatch.ts
+++ b/src/application/database-yjs/dispatch.ts
@@ -2220,10 +2220,19 @@ export function useAddDatabaseView() {
       const viewLayout = layoutToViewLayout[layout];
       const name = layoutToName[layout];
 
-      const tabsParentViewId = await (async (): Promise<string> => {
+      const getLastChildViewId = (view: View | null | undefined): string | undefined => {
+        const children = view?.children ?? [];
+
+        return children.length > 0 ? children[children.length - 1].view_id : undefined;
+      };
+
+      const { tabsParentViewId, prevViewId } = await (async (): Promise<{
+        tabsParentViewId: string;
+        prevViewId?: string;
+      }> => {
         // Best-effort: fall back to previous behavior if meta lookup isn't available.
         if (!loadViewMeta) {
-          return databasePageId;
+          return { tabsParentViewId: databasePageId };
         }
 
         const safeLoadViewMeta = async (viewId: string): Promise<View | null> => {
@@ -2238,34 +2247,47 @@ export function useAddDatabaseView() {
 
         // If the current view itself is a container, attach under it.
         if (currentMeta && isDatabaseContainer(currentMeta)) {
-          return currentMeta.view_id;
+          return {
+            tabsParentViewId: currentMeta.view_id,
+            prevViewId: getLastChildViewId(currentMeta),
+          };
         }
 
         const parentId = currentMeta?.parent_view_id;
 
         if (!parentId) {
-          return databasePageId;
+          return { tabsParentViewId: databasePageId };
         }
 
         // If parent is a database container, attach under the container (Scenario 4).
         const parentMeta = await safeLoadViewMeta(parentId);
 
         if (isDatabaseContainer(parentMeta)) {
-          return parentId;
+          return {
+            tabsParentViewId: parentId,
+            prevViewId: currentMeta?.view_id,
+          };
         }
 
         // Embedded databases without a container attach under the document (Scenario 3).
         if (isDocumentBlock) {
-          return parentId;
+          return {
+            tabsParentViewId: parentId,
+            prevViewId: currentMeta?.view_id,
+          };
         }
 
         // Backward-compatible fallback: attach under the current database view.
-        return databasePageId;
+        return {
+          tabsParentViewId: databasePageId,
+          prevViewId: getLastChildViewId(currentMeta),
+        };
       })();
 
       // Create new view as a child of the database container (or document for embedded linked views).
       const response = await createDatabaseView(requestViewId, {
         parent_view_id: tabsParentViewId,
+        prev_view_id: prevViewId,
         database_id: databaseId,
         layout: viewLayout,
         name: nameOverride ?? name,

--- a/src/application/database-yjs/selector.ts
+++ b/src/application/database-yjs/selector.ts
@@ -107,6 +107,26 @@ export function useDatabaseViewsSelector(databasePageId: string, visibleViewIds?
         }
       >;
 
+      const insertionOrder = new Map<string, number>();
+
+      const getCreatedAtSortValue = (viewId: string): number => {
+        const createdAt = views.get(viewId)?.get(YjsDatabaseKey.created_at);
+
+        if (!createdAt) {
+          return Number.POSITIVE_INFINITY;
+        }
+
+        const numericValue = Number(createdAt);
+
+        if (Number.isFinite(numericValue)) {
+          return numericValue;
+        }
+
+        const timestampValue = Date.parse(createdAt);
+
+        return Number.isFinite(timestampValue) ? timestampValue : Number.POSITIVE_INFINITY;
+      };
+
       // Step 1: Get all non-inline views from Yjs (don't filter by embedded yet)
       // See: flowy-database2/src/services/database/database_editor.rs:get_database_view_ids()
       let allViewIds = Object.keys(viewsObj).filter((viewId) => {
@@ -117,6 +137,10 @@ export function useDatabaseViewsSelector(databasePageId: string, visibleViewIds?
         const isInline = view.get(YjsDatabaseKey.is_inline);
 
         return !isInline;
+      });
+
+      allViewIds.forEach((viewId, index) => {
+        insertionOrder.set(viewId, index);
       });
 
       // Step 2: Apply context-specific filtering (separate concerns)
@@ -135,6 +159,16 @@ export function useDatabaseViewsSelector(databasePageId: string, visibleViewIds?
           const isEmbedded = view?.get(YjsDatabaseKey.embedded) === true;
 
           return !isEmbedded;
+        });
+
+        allViewIds.sort((left, right) => {
+          const createdAtDiff = getCreatedAtSortValue(left) - getCreatedAtSortValue(right);
+
+          if (createdAtDiff !== 0) {
+            return createdAtDiff;
+          }
+
+          return (insertionOrder.get(left) ?? 0) - (insertionOrder.get(right) ?? 0);
         });
       }
 

--- a/src/application/services/js-services/http/page-api.ts
+++ b/src/application/services/js-services/http/page-api.ts
@@ -136,6 +136,7 @@ export async function createDatabaseView(workspaceId: string, viewId: string, pa
   return executeAPIRequest<CreateDatabaseViewResponse>(() =>
     getAxios()?.post<APIResponse<CreateDatabaseViewResponse>>(url, {
       parent_view_id: payload.parent_view_id,
+      prev_view_id: payload.prev_view_id,
       database_id: payload.database_id,
       layout: payload.layout,
       name: payload.name,

--- a/src/application/types.ts
+++ b/src/application/types.ts
@@ -1391,6 +1391,8 @@ export interface DuplicatePageOptions {
 
 export interface CreateDatabaseViewPayload {
   parent_view_id: string;
+  /** Insert the new database view after this sibling. When omitted the backend prepends. */
+  prev_view_id?: string;
   database_id: string;
   layout: ViewLayout;
   name?: string;

--- a/src/components/database/DatabaseViews.tsx
+++ b/src/components/database/DatabaseViews.tsx
@@ -208,14 +208,15 @@ function DatabaseViews({
 
     if (fromYjs) return fromYjs;
 
-    const fromSelector = childViews.find((view) => view?.get(YjsDatabaseKey.id) === activeViewId);
+    const selectorIndex = viewIds.indexOf(activeViewId);
+    const fromSelector = selectorIndex === -1 ? undefined : childViews[selectorIndex];
 
     if (fromSelector) return fromSelector;
 
     // Fallback: try to get view directly from Yjs map
     // This handles newly created views before useDatabaseViewsSelector updates
     return views?.get(activeViewId);
-  }, [activeViewId, childViews, views]);
+  }, [activeViewId, childViews, viewIds, views]);
 
   // Update layout when active view changes
   useEffect(() => {

--- a/src/components/database/DatabaseViews.tsx
+++ b/src/components/database/DatabaseViews.tsx
@@ -1,4 +1,5 @@
 import { Suspense, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { flushSync } from 'react-dom';
 import { ErrorBoundary } from 'react-error-boundary';
 
 import { useDatabase, useDatabaseViewsSelector } from '@/application/database-yjs';
@@ -11,6 +12,14 @@ import UnsupportedView from '@/components/database/components/UnsupportedView';
 import { Calendar } from '@/components/database/fullcalendar';
 import { Grid } from '@/components/database/grid';
 import { ElementFallbackRender } from '@/components/error/ElementFallbackRender';
+import {
+  insertViewIdAfter,
+  readStoredViewOrder,
+  reconcileOrderedViewIds,
+  selectHydratingViewOrder,
+  selectStableViewOrder,
+  writeStoredViewOrder,
+} from '@/utils/database-view-order';
 
 import DatabaseConditions from 'src/components/database/components/conditions/DatabaseConditions';
 
@@ -24,7 +33,6 @@ function DatabaseViews({
   fixedHeight,
   onViewIdsChanged,
 }: {
-  // Debug logging will be added inside the component
   onChangeView: (viewId: string) => void;
   /**
    * Called when a new view is added via the + button.
@@ -52,18 +60,96 @@ function DatabaseViews({
 }) {
   const { childViews, viewIds } = useDatabaseViewsSelector(databasePageId, visibleViewIds);
   const database = useDatabase();
+  const databaseId = database?.get(YjsDatabaseKey.id) as string | undefined;
   const views = database?.get(YjsDatabaseKey.views);
+  const [orderedViewIds, setOrderedViewIds] = useState<string[]>([]);
+  const orderedViewIdsRef = useRef<string[]>([]);
+  const orderedDatabaseIdRef = useRef<string | undefined>();
+  const pendingViewCreationRef = useRef(false);
+  const pendingExpectedViewIdsRef = useRef<string[] | null>(null);
+  const pendingViewInsertionRef = useRef<{ anchorViewId: string; baseViewIds: string[] } | null>(null);
 
   const [layout, setLayout] = useState<DatabaseViewLayout | null>(null);
   // Track the previous valid layout to prevent flash when switching to a new view
   const prevLayoutRef = useRef<DatabaseViewLayout | null>(null);
 
-  const value = useMemo(() => {
-    return Math.max(
-      0,
-      viewIds.findIndex((id) => id === activeViewId)
-    );
-  }, [activeViewId, viewIds]);
+  const fallbackViewIds = useMemo(() => {
+    if (!visibleViewIds || visibleViewIds.length === 0) {
+      return viewIds;
+    }
+
+    const getCreatedAtSortValue = (viewId: string): number => {
+      const createdAt = views?.get(viewId)?.get(YjsDatabaseKey.created_at);
+
+      if (!createdAt) {
+        return Number.POSITIVE_INFINITY;
+      }
+
+      const numericValue = Number(createdAt);
+
+      if (Number.isFinite(numericValue)) {
+        return numericValue;
+      }
+
+      const timestampValue = Date.parse(createdAt);
+
+      return Number.isFinite(timestampValue) ? timestampValue : Number.POSITIVE_INFINITY;
+    };
+
+    return [...viewIds].sort((left, right) => getCreatedAtSortValue(left) - getCreatedAtSortValue(right));
+  }, [viewIds, views, visibleViewIds]);
+
+  useEffect(() => {
+    const isNewDatabase = orderedDatabaseIdRef.current !== databaseId;
+    const storedViewIds = readStoredViewOrder(databaseId);
+    const previousViewIds = orderedViewIdsRef.current;
+
+    orderedDatabaseIdRef.current = databaseId;
+
+    const hydratingViewIds = selectHydratingViewOrder({
+      incomingViewIds: viewIds,
+      previousViewIds,
+      storedViewIds,
+      isNewDatabase,
+    });
+
+    if (hydratingViewIds) {
+      orderedViewIdsRef.current = hydratingViewIds;
+      setOrderedViewIds(hydratingViewIds);
+      return;
+    }
+
+    const pendingExpectedViewIds = pendingExpectedViewIdsRef.current;
+
+    if (pendingViewCreationRef.current) {
+      return;
+    }
+
+    const baseViewIds =
+      pendingExpectedViewIds && pendingExpectedViewIds.every((viewId) => viewIds.includes(viewId))
+        ? pendingExpectedViewIds
+        : storedViewIds && storedViewIds.length > 0
+        ? storedViewIds
+        : isNewDatabase
+        ? fallbackViewIds
+        : previousViewIds.length > 0
+        ? previousViewIds
+        : fallbackViewIds;
+
+    if (pendingExpectedViewIds && pendingExpectedViewIds.some((viewId) => !viewIds.includes(viewId))) {
+      return;
+    }
+
+    const nextViewIds = reconcileOrderedViewIds(baseViewIds, viewIds);
+
+    if (pendingExpectedViewIds && pendingExpectedViewIds.every((viewId) => nextViewIds.includes(viewId))) {
+      pendingExpectedViewIdsRef.current = null;
+    }
+
+    orderedViewIdsRef.current = nextViewIds;
+    writeStoredViewOrder(databaseId, nextViewIds);
+    setOrderedViewIds(nextViewIds);
+  }, [databaseId, fallbackViewIds, viewIds]);
 
   const [conditionsExpanded, setConditionsExpanded] = useState<boolean>(false);
   const toggleExpanded = useCallback(() => {
@@ -118,14 +204,18 @@ function DatabaseViews({
   // Get active view from selector state, or directly from Yjs if not yet in state
   // This handles the race condition when a new view is created but selector hasn't updated yet
   const activeView = useMemo(() => {
-    const fromSelector = childViews[value];
+    const fromYjs = views?.get(activeViewId);
+
+    if (fromYjs) return fromYjs;
+
+    const fromSelector = childViews.find((view) => view?.get(YjsDatabaseKey.id) === activeViewId);
 
     if (fromSelector) return fromSelector;
 
     // Fallback: try to get view directly from Yjs map
     // This handles newly created views before useDatabaseViewsSelector updates
     return views?.get(activeViewId);
-  }, [childViews, value, views, activeViewId]);
+  }, [activeViewId, childViews, views]);
 
   // Update layout when active view changes
   useEffect(() => {
@@ -152,6 +242,55 @@ function DatabaseViews({
     },
     [onChangeView]
   );
+
+  const handleBeforeViewAddedToDatabase = useCallback(() => {
+    const storedViewIds = readStoredViewOrder(databaseId);
+    const baseViewIds =
+      orderedViewIdsRef.current.length > 0
+        ? orderedViewIdsRef.current
+        : storedViewIds && storedViewIds.length > 0
+        ? storedViewIds
+        : fallbackViewIds;
+
+    pendingViewCreationRef.current = true;
+    pendingViewInsertionRef.current = {
+      anchorViewId: activeViewId,
+      baseViewIds,
+    };
+  }, [activeViewId, databaseId, fallbackViewIds]);
+
+  const handleAfterViewAddedToDatabase = useCallback(() => {
+    pendingViewCreationRef.current = false;
+    pendingViewInsertionRef.current = null;
+  }, []);
+
+  const handleViewAddedToDatabase = useCallback(
+    (newViewId: string) => {
+      const storedViewIds = readStoredViewOrder(databaseId);
+      const pendingViewInsertion = pendingViewInsertionRef.current;
+      const baseViewIds =
+        pendingViewInsertion?.baseViewIds ??
+        selectStableViewOrder({
+          previousViewIds: orderedViewIdsRef.current,
+          storedViewIds,
+          fallbackViewIds,
+          pendingViewId: newViewId,
+        });
+      const anchorViewId = pendingViewInsertion?.anchorViewId ?? activeViewId;
+      const nextViewIds = insertViewIdAfter(baseViewIds, anchorViewId, newViewId);
+
+      pendingExpectedViewIdsRef.current = nextViewIds;
+      orderedViewIdsRef.current = nextViewIds;
+      writeStoredViewOrder(databaseId, nextViewIds);
+      flushSync(() => {
+        setOrderedViewIds(nextViewIds);
+      });
+      onViewAdded?.(newViewId);
+    },
+    [activeViewId, databaseId, fallbackViewIds, onViewAdded]
+  );
+
+  const displayedViewIds = orderedViewIds.length > 0 ? orderedViewIds : viewIds;
 
   // Render the appropriate view component based on layout
   // Use previous layout as fallback to prevent flash during view transitions
@@ -202,8 +341,10 @@ function DatabaseViews({
           databasePageId={databasePageId}
           selectedViewId={activeViewId}
           setSelectedViewId={handleViewChange}
-          viewIds={viewIds}
-          onViewAddedToDatabase={onViewAdded}
+          viewIds={displayedViewIds}
+          onViewAddedToDatabase={handleViewAddedToDatabase}
+          onBeforeViewAddedToDatabase={handleBeforeViewAddedToDatabase}
+          onAfterViewAddedToDatabase={handleAfterViewAddedToDatabase}
           onViewIdsChanged={onViewIdsChanged}
         />
 

--- a/src/components/database/__tests__/view-order.test.ts
+++ b/src/components/database/__tests__/view-order.test.ts
@@ -1,0 +1,80 @@
+import {
+  insertViewIdAfter,
+  readStoredViewOrder,
+  reconcileOrderedViewIds,
+  selectHydratingViewOrder,
+  selectStableViewOrder,
+  writeStoredViewOrder,
+} from '@/utils/database-view-order';
+
+describe('database view ordering helpers', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('preserves previous tab order and appends unseen ids', () => {
+    expect(reconcileOrderedViewIds(['grid', 'board'], ['calendar', 'grid', 'board'])).toEqual([
+      'grid',
+      'board',
+      'calendar',
+    ]);
+  });
+
+  it('inserts a new view immediately after the active tab', () => {
+    expect(insertViewIdAfter(['grid', 'board'], 'grid', 'calendar')).toEqual(['grid', 'calendar', 'board']);
+  });
+
+  it('persists and restores stored view order', () => {
+    writeStoredViewOrder('db-1', ['grid', 'calendar', 'board']);
+
+    expect(readStoredViewOrder('db-1')).toEqual(['grid', 'calendar', 'board']);
+  });
+
+  it('falls back to the stable order when previous and stored orders collapse to the new view', () => {
+    expect(
+      selectStableViewOrder({
+        previousViewIds: ['new-board'],
+        storedViewIds: ['new-board'],
+        fallbackViewIds: ['grid', 'board', 'calendar'],
+        pendingViewId: 'new-board',
+      })
+    ).toEqual(['grid', 'board', 'calendar']);
+  });
+
+  it('preserves stored order while view ids are still hydrating', () => {
+    expect(
+      selectHydratingViewOrder({
+        incomingViewIds: [],
+        previousViewIds: [],
+        storedViewIds: ['grid', 'board'],
+        isNewDatabase: true,
+      })
+    ).toEqual(['grid', 'board']);
+  });
+
+  it('keeps previous order during same-database hydration without leaking it to a new database', () => {
+    expect(
+      selectHydratingViewOrder({
+        incomingViewIds: [],
+        previousViewIds: ['grid', 'board'],
+        storedViewIds: undefined,
+        isNewDatabase: false,
+      })
+    ).toEqual(['grid', 'board']);
+
+    expect(
+      selectHydratingViewOrder({
+        incomingViewIds: [],
+        previousViewIds: ['grid', 'board'],
+        storedViewIds: undefined,
+        isNewDatabase: true,
+      })
+    ).toBeUndefined();
+  });
+
+  it('ignores invalid stored data', () => {
+    window.localStorage.setItem('database_view_order:db-1', JSON.stringify({ order: ['grid'] }));
+
+    expect(readStoredViewOrder('db-1')).toBeUndefined();
+  });
+});

--- a/src/components/database/components/tabs/AddViewButton.tsx
+++ b/src/components/database/components/tabs/AddViewButton.tsx
@@ -17,15 +17,18 @@ import { Progress } from '@/components/ui/progress';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 
 interface AddViewButtonProps {
+  onBeforeAddView?: () => void;
+  onAfterAddView?: () => void;
   onViewAdded: (viewId: string) => void;
 }
 
-export function AddViewButton({ onViewAdded }: AddViewButtonProps) {
+export function AddViewButton({ onBeforeAddView, onAfterAddView, onViewAdded }: AddViewButtonProps) {
   const { t } = useTranslation();
   const onAddView = useAddDatabaseView();
   const [addLoading, setAddLoading] = useState(false);
 
   const handleAddView = async (layout: DatabaseViewLayout, name: string) => {
+    onBeforeAddView?.();
     setAddLoading(true);
     const startTime = Date.now();
     const MIN_LOADING_TIME = 300; // Minimum time to show spinner for smooth UX
@@ -38,6 +41,7 @@ export function AddViewButton({ onViewAdded }: AddViewButtonProps) {
       console.error('[AddViewButton] Error adding view:', e);
       toast.error(e instanceof Error ? e.message : 'Failed to add view');
     } finally {
+      onAfterAddView?.();
       // Ensure minimum loading time to prevent jarring UI flicker
       const elapsed = Date.now() - startTime;
       const remaining = MIN_LOADING_TIME - elapsed;

--- a/src/components/database/components/tabs/DatabaseTabs.tsx
+++ b/src/components/database/components/tabs/DatabaseTabs.tsx
@@ -27,6 +27,8 @@ export interface DatabaseTabBarProps {
    * Used by embedded databases to update state immediately before Yjs sync.
    */
   onViewAddedToDatabase?: (viewId: string) => void;
+  onBeforeViewAddedToDatabase?: () => void;
+  onAfterViewAddedToDatabase?: () => void;
   /**
    * Callback when view IDs change (views added or removed).
    * Used to update the block data in embedded database blocks.
@@ -36,7 +38,17 @@ export interface DatabaseTabBarProps {
 
 export const DatabaseTabs = forwardRef<HTMLDivElement, DatabaseTabBarProps>(
   (
-    { viewIds, databasePageId, selectedViewId, setSelectedViewId, viewName: _viewName, onViewAddedToDatabase, onViewIdsChanged },
+    {
+      viewIds,
+      databasePageId,
+      selectedViewId,
+      setSelectedViewId,
+      viewName: _viewName,
+      onViewAddedToDatabase,
+      onBeforeViewAddedToDatabase,
+      onAfterViewAddedToDatabase,
+      onViewIdsChanged,
+    },
     ref
   ) => {
     const views = useDatabase()?.get(YjsDatabaseKey.views);
@@ -233,6 +245,8 @@ export const DatabaseTabs = forwardRef<HTMLDivElement, DatabaseTabBarProps>(
             setRenameViewId={setRenameViewId}
             pendingScrollToViewId={pendingScrollToViewId}
             setPendingScrollToViewId={setPendingScrollToViewId}
+            onBeforeViewAdded={onBeforeViewAddedToDatabase}
+            onAfterViewAdded={onAfterViewAddedToDatabase}
             onViewAdded={(viewId) => {
               // For embedded databases, notify parent immediately
               if (onViewAddedToDatabase) {

--- a/src/components/database/components/tabs/DatabaseViewTabs.tsx
+++ b/src/components/database/components/tabs/DatabaseViewTabs.tsx
@@ -32,6 +32,8 @@ export interface DatabaseViewTabsProps {
   setRenameViewId: (id: string | null) => void;
   pendingScrollToViewId?: string | null;
   setPendingScrollToViewId?: (id: string | null) => void;
+  onBeforeViewAdded?: () => void;
+  onAfterViewAdded?: () => void;
   onViewAdded?: (viewId: string) => void;
 }
 
@@ -50,6 +52,8 @@ export function DatabaseViewTabs({
   setRenameViewId,
   pendingScrollToViewId,
   setPendingScrollToViewId,
+  onBeforeViewAdded,
+  onAfterViewAdded,
   onViewAdded
 }: DatabaseViewTabsProps) {
   const [tabsWidth, setTabsWidth] = useState<number | null>(null);
@@ -225,7 +229,11 @@ export function DatabaseViewTabs({
       </AFScroller>
 
       {!readOnly && onViewAdded && (
-        <AddViewButton onViewAdded={onViewAdded} />
+        <AddViewButton
+          onBeforeAddView={onBeforeViewAdded}
+          onAfterAddView={onAfterViewAdded}
+          onViewAdded={onViewAdded}
+        />
       )}
     </div>
   );

--- a/src/utils/database-view-order.ts
+++ b/src/utils/database-view-order.ts
@@ -1,0 +1,117 @@
+const DATABASE_VIEW_ORDER_STORAGE_KEY_PREFIX = 'database_view_order:';
+
+function getDatabaseViewOrderStorageKey(databaseId: string) {
+  return `${DATABASE_VIEW_ORDER_STORAGE_KEY_PREFIX}${databaseId}`;
+}
+
+export function reconcileOrderedViewIds(previousViewIds: string[], incomingViewIds: string[]): string[] {
+  if (previousViewIds.length === 0) {
+    return incomingViewIds;
+  }
+
+  const incomingViewIdSet = new Set(incomingViewIds);
+  const previousViewIdSet = new Set(previousViewIds);
+
+  const retainedViewIds = previousViewIds.filter((viewId) => incomingViewIdSet.has(viewId));
+  const appendedViewIds = incomingViewIds.filter((viewId) => !previousViewIdSet.has(viewId));
+
+  return [...retainedViewIds, ...appendedViewIds];
+}
+
+export function selectHydratingViewOrder(params: {
+  incomingViewIds: string[];
+  previousViewIds: string[];
+  storedViewIds?: string[];
+  isNewDatabase: boolean;
+}): string[] | undefined {
+  const { incomingViewIds, previousViewIds, storedViewIds, isNewDatabase } = params;
+
+  if (incomingViewIds.length > 0) {
+    return undefined;
+  }
+
+  if (storedViewIds && storedViewIds.length > 0) {
+    return storedViewIds;
+  }
+
+  if (!isNewDatabase && previousViewIds.length > 0) {
+    return previousViewIds;
+  }
+
+  return undefined;
+}
+
+export function insertViewIdAfter(viewIds: string[], anchorViewId: string, newViewId: string): string[] {
+  const dedupedViewIds = viewIds.filter((viewId) => viewId !== newViewId);
+  const anchorIndex = dedupedViewIds.indexOf(anchorViewId);
+
+  if (anchorIndex === -1) {
+    return [...dedupedViewIds, newViewId];
+  }
+
+  return [
+    ...dedupedViewIds.slice(0, anchorIndex + 1),
+    newViewId,
+    ...dedupedViewIds.slice(anchorIndex + 1),
+  ];
+}
+
+export function selectStableViewOrder(params: {
+  previousViewIds: string[];
+  storedViewIds?: string[];
+  fallbackViewIds: string[];
+  pendingViewId: string;
+}): string[] {
+  const { previousViewIds, storedViewIds, fallbackViewIds, pendingViewId } = params;
+
+  const isCollapsedOrder = (viewIds?: string[]) =>
+    Boolean(viewIds && viewIds.length === 1 && viewIds[0] === pendingViewId && fallbackViewIds.length > 1);
+
+  if (previousViewIds.length > 0 && !isCollapsedOrder(previousViewIds)) {
+    return previousViewIds;
+  }
+
+  if (storedViewIds && storedViewIds.length > 0 && !isCollapsedOrder(storedViewIds)) {
+    return storedViewIds;
+  }
+
+  return fallbackViewIds;
+}
+
+export function readStoredViewOrder(databaseId?: string): string[] | undefined {
+  if (!databaseId || typeof window === 'undefined') {
+    return undefined;
+  }
+
+  try {
+    const rawValue = window.localStorage.getItem(getDatabaseViewOrderStorageKey(databaseId));
+
+    if (!rawValue) {
+      return undefined;
+    }
+
+    const parsedValue = JSON.parse(rawValue);
+
+    if (!Array.isArray(parsedValue) || parsedValue.some((value) => typeof value !== 'string')) {
+      return undefined;
+    }
+
+    return parsedValue;
+  } catch {
+    return undefined;
+  }
+}
+
+export function writeStoredViewOrder(databaseId: string | undefined, viewIds: string[]) {
+  if (!databaseId || typeof window === 'undefined') {
+    return;
+  }
+
+  try {
+    const dedupedViewIds = Array.from(new Set(viewIds));
+
+    window.localStorage.setItem(getDatabaseViewOrderStorageKey(databaseId), JSON.stringify(dedupedViewIds));
+  } catch {
+    // Ignore storage failures (private mode/quota).
+  }
+}


### PR DESCRIPTION
<!---
Thank you for submitting a pull request to the AppFlowy Web! The team will dedicate their best efforts to reviewing and approving your PR. If you have any questions or feedback, feel free to join our [Discord](https://discord.gg/wdjWUXXhtw).
-->


### **Description**
<!---
Provide a clear and concise description of the changes introduced in this pull request for AppFlowy Web. What problem does it solve? What value does it add?
-->

---

### **Checklist**
<!---
Before marking your pull request as ready for review, ensure the following checklist is complete.
-->

#### **General**
- [ ] I've included relevant documentation or comments for the changes introduced.
- [ ] I've tested the changes in multiple environments (e.g., different browsers, operating systems).

#### **Testing**
- [ ] I've added or updated tests to validate the changes introduced for AppFlowy Web.

#### **Feature-Specific**
- [ ] For feature additions, I've added a preview (video, screenshot, or demo) in the "Feature Preview" section.
- [ ] I've verified that this feature integrates seamlessly with existing functionality.

## Summary by Sourcery

Persist and stabilize database view tab ordering, and create new views in a predictable position relative to existing views.

New Features:
- Remember database view ordering per database in local storage and reuse it when rendering view tabs.

Bug Fixes:
- Ensure newly created database views are inserted after the expected sibling based on the current container and route, instead of relying on backend defaults.
- Sort standalone database views by creation time rather than raw Yjs insertion order for more intuitive tab ordering.
- Stabilize tab ordering during view creation to avoid flicker and unexpected reordering when views are added.

Enhancements:
- Propagate explicit prev_view_id when creating database views via the HTTP API to align server-side insertion with client expectations.
- Add lifecycle hooks around adding a database view to coordinate optimistic UI updates in the tabs component.

Tests:
- Add tests covering createDatabaseView payload prev_view_id selection for various container/route scenarios.
- Add selector tests validating created_at-based sorting for standalone databases and view ordering behavior.