### PR TITLE
fix: publish database with embeded db

### DIFF
--- a/package.json
+++ b/package.json
@@ -268,6 +268,8 @@
       "@remix-run/router": "^1.23.2",
       "@babel/runtime@<7.26.10": "7.28.4",
       "brace-expansion@<1.1.13": "1.1.13",
+      "browserslist": "4.28.1",
+      "caniuse-lite": "1.0.30001761",
       "diff@>=4.0.0 <4.0.4": "4.0.4",
       "dompurify@<3.4.0": "3.4.0",
       "follow-redirects@<=1.15.11": "1.16.0",
@@ -284,6 +286,7 @@
       "picomatch@<2.3.2": "2.3.2",
       "postcss@<8.5.10": "8.5.10",
       "rollup@>=4.0.0 <4.59.0": "4.59.0",
+      "update-browserslist-db": "1.2.3",
       "yaml@>=1.0.0 <1.10.3": "1.10.3",
       "yaml@>=2.0.0 <2.8.3": "2.8.3"
     }

--- a/playwright/e2e/page/publish-document-embedded-database.spec.ts
+++ b/playwright/e2e/page/publish-document-embedded-database.spec.ts
@@ -1,0 +1,334 @@
+/**
+ * Publish Document with Embedded Database
+ *
+ * Regression coverage for documents that contain inline database views.
+ * Publishing the document must also publish the embedded database view so the
+ * public document can load that database snapshot.
+ */
+import { test, expect, type APIRequestContext, type Page } from '@playwright/test';
+import {
+  ShareSelectors,
+  SidebarSelectors,
+} from '../../support/selectors';
+import { signInAndWaitForApp } from '../../support/auth-flow-helpers';
+import { generateRandomEmail, setupPageErrorHandling, TestConfig } from '../../support/test-config';
+import { testLog } from '../../support/test-helpers';
+
+type ApiResponse<T> = {
+  code: number;
+  data?: T;
+  message: string;
+};
+
+type PublishedInfo = {
+  namespace: string;
+  publish_name: string;
+  view_id: string;
+};
+
+type PublishedSnapshotPayload = {
+  kind: string;
+  view: {
+    viewId: string;
+  };
+};
+
+type WorkspaceView = {
+  view_id: string;
+  name: string;
+  children?: WorkspaceView[];
+};
+
+type CreatePageResponse = {
+  view_id: string;
+  database_id?: string;
+};
+
+const ViewLayout = {
+  Document: 0,
+  Grid: 1,
+} as const;
+
+function apiUrl(path: string): string {
+  return new URL(path, TestConfig.apiUrl).toString();
+}
+
+async function getAccessToken(page: Page): Promise<string> {
+  const token = await page.evaluate(() => localStorage.getItem('af_auth_token'));
+
+  expect(token).toBeTruthy();
+
+  return token!;
+}
+
+async function currentWorkspaceId(page: Page): Promise<string> {
+  for (let attempt = 0; attempt < 60; attempt += 1) {
+    const url = new URL(page.url());
+    const [, workspaceId] = url.pathname.split('/').filter(Boolean);
+
+    if (workspaceId) return workspaceId;
+
+    await page.waitForTimeout(500);
+  }
+
+  throw new Error(`Could not read workspace id from current URL: ${page.url()}`);
+}
+
+async function apiRequest<T>(
+  request: APIRequestContext,
+  token: string,
+  method: 'GET' | 'POST',
+  path: string,
+  data?: unknown
+): Promise<T> {
+  const response = await request.fetch(apiUrl(path), {
+    method,
+    data,
+    failOnStatusCode: false,
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    },
+  });
+  const text = await response.text();
+
+  expect(response.ok(), text).toBeTruthy();
+
+  const body = JSON.parse(text) as ApiResponse<T>;
+
+  expect(body.code, text).toBe(0);
+  expect(body.data, text).toBeTruthy();
+
+  return body.data!;
+}
+
+async function apiVoidRequest(
+  request: APIRequestContext,
+  token: string,
+  method: 'POST',
+  path: string,
+  data?: unknown
+): Promise<void> {
+  const response = await request.fetch(apiUrl(path), {
+    method,
+    data,
+    failOnStatusCode: false,
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    },
+  });
+  const text = await response.text();
+
+  expect(response.ok(), text).toBeTruthy();
+
+  const body = JSON.parse(text) as ApiResponse<unknown>;
+
+  expect(body.code, text).toBe(0);
+}
+
+async function setupDocumentWithEmbeddedDatabase(
+  request: APIRequestContext,
+  token: string,
+  workspaceId: string,
+  documentText: string
+): Promise<{ documentViewId: string; embeddedViewId: string }> {
+  const folder = await apiRequest<WorkspaceView>(
+    request,
+    token,
+    'GET',
+    `/api/workspace/${workspaceId}/folder?depth=2`
+  );
+  const generalSpace = folder.children?.find(view => view.name === 'General') ?? folder.children?.[0];
+
+  expect(generalSpace?.view_id).toBeTruthy();
+
+  const document = await apiRequest<CreatePageResponse>(
+    request,
+    token,
+    'POST',
+    `/api/workspace/${workspaceId}/page-view`,
+    {
+      parent_view_id: generalSpace!.view_id,
+      layout: ViewLayout.Document,
+      name: documentText,
+      page_data: {
+        type: 'page',
+        children: [
+          {
+            type: 'paragraph',
+            data: {
+              delta: [{ insert: documentText }],
+            },
+          },
+        ],
+      },
+    }
+  );
+
+  const embeddedDatabase = await apiRequest<CreatePageResponse>(
+    request,
+    token,
+    'POST',
+    `/api/workspace/${workspaceId}/page-view`,
+    {
+      parent_view_id: document.view_id,
+      layout: ViewLayout.Grid,
+      name: 'Embedded tracker',
+    }
+  );
+
+  expect(embeddedDatabase.database_id).toBeTruthy();
+
+  await apiVoidRequest(
+    request,
+    token,
+    'POST',
+    `/api/workspace/${workspaceId}/page-view/${document.view_id}/append-block`,
+    {
+      blocks: [
+        {
+          type: 'grid',
+          data: {
+            database_id: embeddedDatabase.database_id,
+            parent_id: document.view_id,
+            view_id: embeddedDatabase.view_id,
+            view_ids: [embeddedDatabase.view_id],
+          },
+        },
+      ],
+    }
+  );
+
+  return {
+    documentViewId: document.view_id,
+    embeddedViewId: embeddedDatabase.view_id,
+  };
+}
+
+async function publishCurrentPage(page: Page): Promise<string> {
+  await expect(ShareSelectors.shareButton(page)).toBeVisible({ timeout: 10000 });
+  await ShareSelectors.shareButton(page).click({ force: true });
+  await expect(ShareSelectors.sharePopover(page)).toBeVisible({ timeout: 5000 });
+
+  await ShareSelectors.sharePopover(page).getByText('Publish', { exact: true }).click({ force: true });
+  await expect(ShareSelectors.publishConfirmButton(page)).toBeVisible({ timeout: 10000 });
+  await expect(ShareSelectors.publishConfirmButton(page)).toBeEnabled();
+  await ShareSelectors.publishConfirmButton(page).click({ force: true });
+
+  await expect(ShareSelectors.publishNamespace(page)).toBeVisible({ timeout: 30000 });
+
+  const origin = new URL(page.url()).origin;
+  const namespace = ((await ShareSelectors.publishNamespace(page).textContent()) ?? '').trim();
+  const publishName = (await ShareSelectors.publishNameInput(page).inputValue()).trim();
+
+  await page.keyboard.press('Escape');
+
+  return `${origin}/${namespace}/${publishName}`;
+}
+
+async function expectPublishedInfo(
+  request: APIRequestContext,
+  embeddedViewId: string
+): Promise<PublishedInfo> {
+  let latestBody = '';
+
+  for (let attempt = 0; attempt < 20; attempt += 1) {
+    const response = await request.get(
+      apiUrl(`/api/workspace/v1/published-info/${embeddedViewId}`),
+      { failOnStatusCode: false }
+    );
+
+    latestBody = await response.text();
+
+    if (response.ok()) {
+      const body = JSON.parse(latestBody) as ApiResponse<PublishedInfo>;
+
+      if (body.code === 0 && body.data?.view_id === embeddedViewId) {
+        expect(body.data.publish_name).toBeTruthy();
+        return body.data;
+      }
+    }
+
+    await new Promise(resolve => setTimeout(resolve, 1000));
+  }
+
+  throw new Error(`Embedded database view was not published: ${embeddedViewId}. Last response: ${latestBody}`);
+}
+
+async function expectDatabaseSnapshot(
+  request: APIRequestContext,
+  publishedInfo: PublishedInfo
+): Promise<void> {
+  const response = await request.get(
+    apiUrl(`/api/workspace/v2/published/${publishedInfo.namespace}/${publishedInfo.publish_name}/snapshot`),
+    { failOnStatusCode: false }
+  );
+  const text = await response.text();
+
+  expect(response.ok(), text).toBeTruthy();
+
+  const body = JSON.parse(text) as ApiResponse<PublishedSnapshotPayload>;
+
+  expect(body.code).toBe(0);
+  expect(body.data?.kind).toBe('database');
+  expect(body.data?.view.viewId).toBe(publishedInfo.view_id);
+}
+
+test.describe('Publish Document with Embedded Database', () => {
+  test.setTimeout(180000);
+
+  test.beforeEach(async ({ page }) => {
+    setupPageErrorHandling(page);
+    await page.setViewportSize({ width: 1280, height: 720 });
+  });
+
+  test('publishes embedded database view and renders it on the public document', async ({
+    page,
+    request,
+    browser,
+  }) => {
+    const email = generateRandomEmail();
+
+    await signInAndWaitForApp(page, request, email);
+    await expect(SidebarSelectors.pageHeader(page)).toBeVisible({ timeout: 30000 });
+
+    const documentText = `Document with published embedded database ${Date.now()}`;
+    const token = await getAccessToken(page);
+    const workspaceId = await currentWorkspaceId(page);
+    const { documentViewId, embeddedViewId } = await setupDocumentWithEmbeddedDatabase(
+      request,
+      token,
+      workspaceId,
+      documentText
+    );
+
+    await page.goto(`/app/${workspaceId}/${documentViewId}`, { waitUntil: 'domcontentloaded' });
+    await expect(page.locator('body')).toContainText(documentText, { timeout: 30000 });
+
+    const publishedUrl = await publishCurrentPage(page);
+
+    testLog.info(`Published document URL: ${publishedUrl}`);
+
+    const publishedInfo = await expectPublishedInfo(request, embeddedViewId);
+
+    await expectDatabaseSnapshot(request, publishedInfo);
+
+    const publicContext = await browser.newContext();
+    const publicPage = await publicContext.newPage();
+
+    setupPageErrorHandling(publicPage);
+    await publicPage.goto(publishedUrl, { waitUntil: 'load' });
+
+    await expect(publicPage.locator('body')).toContainText(documentText, { timeout: 30000 });
+    await expect(publicPage.locator('body')).not.toContainText("This page hasn't been published yet");
+
+    const publicDatabase = publicPage.locator('[class*="appflowy-database"]').last();
+
+    await expect(publicDatabase).toBeVisible({ timeout: 30000 });
+    await expect(publicDatabase.locator('[data-testid="database-grid"]')).toBeVisible({ timeout: 30000 });
+    await expect(publicDatabase).toContainText('Name', { timeout: 30000 });
+
+    await publicContext.close();
+  });
+});

--- a/playwright/e2e/page/publish-existing-document-embedded-database.spec.ts
+++ b/playwright/e2e/page/publish-existing-document-embedded-database.spec.ts
@@ -1,0 +1,479 @@
+/**
+ * Publish Existing Document with Embedded Database
+ *
+ * Regression coverage for a real seeded workspace page. The synthetic publish
+ * fixture proves the happy path; this spec targets the existing Project Tracker
+ * page shape so embedded database extraction matches production document data.
+ */
+import { test, expect, type APIRequestContext, type Page } from '@playwright/test';
+
+import { signInWithPasswordViaUi } from '../../support/auth-flow-helpers';
+import { setupPageErrorHandling, TestConfig } from '../../support/test-config';
+import { testLog } from '../../support/test-helpers';
+import {
+  DatabaseGridSelectors,
+  SidebarSelectors,
+} from '../../support/selectors';
+
+type ApiResponse<T> = {
+  code: number;
+  data?: T;
+  message: string;
+};
+
+type WorkspaceView = {
+  view_id: string;
+  name: string;
+  children?: WorkspaceView[];
+};
+
+type PublishedInfo = {
+  namespace: string;
+  publish_name: string;
+  view_id: string;
+};
+
+type PublishedSnapshotPayload = {
+  kind: string;
+  view: {
+    viewId: string;
+  };
+};
+
+const existingEmail = process.env.APPFLOWY_E2E_EXISTING_EMAIL ?? 'nathan@appflowy.io';
+const existingPassword = process.env.APPFLOWY_E2E_EXISTING_PASSWORD;
+const targetPageName = process.env.APPFLOWY_E2E_EXISTING_PUBLISH_PAGE ?? 'Project Tracker 2';
+
+function apiUrl(path: string): string {
+  return new URL(path, TestConfig.apiUrl).toString();
+}
+
+async function getAccessToken(page: Page): Promise<string> {
+  const token = await page.evaluate(() => {
+    const directToken = localStorage.getItem('af_auth_token');
+
+    if (directToken) return directToken;
+
+    const tokenJson = localStorage.getItem('token');
+
+    if (!tokenJson) return null;
+
+    try {
+      return (JSON.parse(tokenJson) as { access_token?: string }).access_token ?? null;
+    } catch {
+      return null;
+    }
+  });
+
+  expect(token).toBeTruthy();
+
+  return token!;
+}
+
+async function currentWorkspaceId(page: Page): Promise<string> {
+  for (let attempt = 0; attempt < 60; attempt += 1) {
+    const url = new URL(page.url());
+    const [, workspaceId] = url.pathname.split('/').filter(Boolean);
+
+    if (workspaceId) return workspaceId;
+
+    await page.waitForTimeout(500);
+  }
+
+  throw new Error(`Could not read workspace id from current URL: ${page.url()}`);
+}
+
+async function apiRequest<T>(
+  request: APIRequestContext,
+  token: string,
+  method: 'GET' | 'POST',
+  path: string,
+  data?: unknown
+): Promise<T> {
+  const response = await request.fetch(apiUrl(path), {
+    method,
+    data,
+    failOnStatusCode: false,
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    },
+  });
+  const text = await response.text();
+
+  expect(response.ok(), text).toBeTruthy();
+
+  const body = JSON.parse(text) as ApiResponse<T>;
+
+  expect(body.code, text).toBe(0);
+  expect(body.data, text).toBeTruthy();
+
+  return body.data!;
+}
+
+async function apiVoidRequest(
+  request: APIRequestContext,
+  token: string,
+  method: 'POST',
+  path: string,
+  data?: unknown
+): Promise<void> {
+  const response = await request.fetch(apiUrl(path), {
+    method,
+    data,
+    failOnStatusCode: false,
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    },
+  });
+  const text = await response.text();
+
+  expect(response.ok(), text).toBeTruthy();
+
+  const body = JSON.parse(text) as ApiResponse<unknown>;
+
+  expect(body.code, text).toBe(0);
+}
+
+function findViewByName(view: WorkspaceView, name: string): WorkspaceView | undefined {
+  if (view.name === name) return view;
+
+  for (const child of view.children ?? []) {
+    const match = findViewByName(child, name);
+
+    if (match) return match;
+  }
+
+  return undefined;
+}
+
+async function findExistingPage(
+  request: APIRequestContext,
+  token: string,
+  workspaceId: string,
+  name: string
+): Promise<WorkspaceView> {
+  const folder = await apiRequest<WorkspaceView>(
+    request,
+    token,
+    'GET',
+    `/api/workspace/${workspaceId}/folder?depth=20`
+  );
+  const view = findViewByName(folder, name);
+
+  expect(view?.view_id, `Expected to find existing page named "${name}"`).toBeTruthy();
+
+  return view!;
+}
+
+async function embeddedDatabaseViewIdsFromEditor(page: Page, documentViewId: string): Promise<string[]> {
+  return page.evaluate((currentDocumentViewId) => {
+    const uuidPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+    const testWindow = window as Window & {
+      __TEST_EDITORS__?: Record<
+        string,
+        {
+          children?: unknown[];
+        }
+      >;
+    };
+    const editor = testWindow.__TEST_EDITORS__?.[currentDocumentViewId];
+    const ids = new Set<string>();
+
+    const addId = (value: unknown) => {
+      if (typeof value === 'string' && uuidPattern.test(value)) {
+        ids.add(value);
+      }
+    };
+
+    const visit = (value: unknown) => {
+      if (!value || typeof value !== 'object') return;
+      if (Array.isArray(value)) {
+        value.forEach(visit);
+        return;
+      }
+
+      const node = value as {
+        type?: string;
+        data?: {
+          view_id?: unknown;
+          viewId?: unknown;
+          database_view_id?: unknown;
+          view_ids?: unknown;
+          viewIds?: unknown;
+          database_view_ids?: unknown;
+        };
+      };
+      const type = node.type;
+
+      if (['grid', 'board', 'calendar', 'list', 'gallery', 'chart'].includes(type ?? '')) {
+        addId(node.data?.view_id);
+        addId(node.data?.viewId);
+        addId(node.data?.database_view_id);
+
+        for (const values of [node.data?.view_ids, node.data?.viewIds, node.data?.database_view_ids]) {
+          if (Array.isArray(values)) values.forEach(addId);
+        }
+      }
+
+      Object.values(value).forEach(visit);
+    };
+
+    visit(editor?.children ?? []);
+
+    return Array.from(ids);
+  }, documentViewId);
+}
+
+async function embeddedDatabaseViewIdsFromTabs(page: Page): Promise<string[]> {
+  const testIds = await page.locator('[data-testid^="view-tab-"]').evaluateAll((nodes) =>
+    nodes
+      .map((node) => node.getAttribute('data-testid') ?? '')
+      .filter((testId) => testId.startsWith('view-tab-'))
+  );
+
+  return Array.from(new Set(testIds.map((testId) => testId.replace(/^view-tab-/, '')).filter(Boolean)));
+}
+
+async function waitForEmbeddedDatabaseViewIds(page: Page, documentViewId: string): Promise<string[]> {
+  await expect
+    .poll(
+      async () => {
+        const editorIds = await embeddedDatabaseViewIdsFromEditor(page, documentViewId);
+
+        if (editorIds.length > 0) return editorIds;
+
+        return embeddedDatabaseViewIdsFromTabs(page);
+      },
+      { timeout: 30000 }
+    )
+    .not.toEqual([]);
+
+  const editorIds = await embeddedDatabaseViewIdsFromEditor(page, documentViewId);
+
+  return editorIds.length > 0 ? editorIds : embeddedDatabaseViewIdsFromTabs(page);
+}
+
+async function maybePublishedInfo(
+  request: APIRequestContext,
+  viewId: string
+): Promise<PublishedInfo | undefined> {
+  const response = await request.get(apiUrl(`/api/workspace/v1/published-info/${viewId}`), {
+    failOnStatusCode: false,
+  });
+  const text = await response.text();
+
+  if (!response.ok()) return undefined;
+
+  const body = JSON.parse(text) as ApiResponse<PublishedInfo>;
+
+  if (body.code !== 0 || body.data?.view_id !== viewId) return undefined;
+
+  return body.data;
+}
+
+async function expectPublishedInfo(
+  request: APIRequestContext,
+  viewId: string
+): Promise<PublishedInfo> {
+  let latestBody = '';
+
+  for (let attempt = 0; attempt < 20; attempt += 1) {
+    const response = await request.get(apiUrl(`/api/workspace/v1/published-info/${viewId}`), {
+      failOnStatusCode: false,
+    });
+
+    latestBody = await response.text();
+
+    if (response.ok()) {
+      const body = JSON.parse(latestBody) as ApiResponse<PublishedInfo>;
+
+      if (body.code === 0 && body.data?.view_id === viewId) {
+        expect(body.data.publish_name).toBeTruthy();
+        return body.data;
+      }
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+  }
+
+  throw new Error(`View was not published: ${viewId}. Last response: ${latestBody}`);
+}
+
+async function expectDatabaseSnapshot(
+  request: APIRequestContext,
+  publishedInfo: PublishedInfo
+): Promise<void> {
+  const response = await request.get(
+    apiUrl(`/api/workspace/v2/published/${publishedInfo.namespace}/${publishedInfo.publish_name}/snapshot`),
+    { failOnStatusCode: false }
+  );
+  const text = await response.text();
+
+  expect(response.ok(), text).toBeTruthy();
+
+  const body = JSON.parse(text) as ApiResponse<PublishedSnapshotPayload>;
+
+  expect(body.code, text).toBe(0);
+  expect(body.data?.kind, text).toBe('database');
+  expect(body.data?.view.viewId, text).toBe(publishedInfo.view_id);
+}
+
+async function expectCommentsDoNotOverlapDatabase(page: Page): Promise<void> {
+  const comments = page.getByTestId('global-comment');
+
+  await expect(comments).toBeVisible({ timeout: 30000 });
+  await comments.scrollIntoViewIfNeeded();
+  await page.waitForTimeout(500);
+
+  await expect
+    .poll(
+      async () =>
+        page.evaluate(() => {
+          const comment = document.querySelector('[data-testid="global-comment"]');
+          const database = document.querySelector('[class*="appflowy-database"]');
+
+          if (!comment || !database) return false;
+
+          const commentRect = comment.getBoundingClientRect();
+          const rows = Array.from(database.querySelectorAll('[data-row-id]'));
+
+          return rows.every((row) => {
+            const rowRect = row.getBoundingClientRect();
+
+            return rowRect.bottom <= commentRect.top || rowRect.top >= commentRect.bottom;
+          });
+        }),
+      { timeout: 10000 }
+    )
+    .toBe(true);
+}
+
+async function publishExistingPage(
+  request: APIRequestContext,
+  token: string,
+  workspaceId: string,
+  viewId: string,
+  publishName?: string
+): Promise<PublishedInfo> {
+  const existingInfo = await maybePublishedInfo(request, viewId);
+
+  await apiVoidRequest(
+    request,
+    token,
+    'POST',
+    `/api/workspace/${workspaceId}/page-view/${viewId}/publish`,
+    publishName || existingInfo?.publish_name
+      ? { publish_name: publishName || existingInfo?.publish_name }
+      : {}
+  );
+
+  return expectPublishedInfo(request, viewId);
+}
+
+async function unpublishIfPublished(
+  request: APIRequestContext,
+  token: string,
+  workspaceId: string,
+  viewId: string
+): Promise<void> {
+  const existingInfo = await maybePublishedInfo(request, viewId);
+
+  if (!existingInfo) return;
+
+  await apiVoidRequest(
+    request,
+    token,
+    'POST',
+    `/api/workspace/${workspaceId}/page-view/${viewId}/unpublish`
+  );
+}
+
+async function expectNotPublished(
+  request: APIRequestContext,
+  viewId: string
+): Promise<void> {
+  await expect
+    .poll(
+      async () => {
+        return (await maybePublishedInfo(request, viewId)) ? 'published' : 'unpublished';
+      },
+      { timeout: 30000 }
+    )
+    .toBe('unpublished');
+}
+
+test.describe('Publish existing document with embedded database', () => {
+  test.skip(!existingPassword, 'Set APPFLOWY_E2E_EXISTING_PASSWORD to run this seeded-workspace regression test.');
+  test.setTimeout(180000);
+
+  test.beforeEach(async ({ page }) => {
+    setupPageErrorHandling(page);
+    await page.setViewportSize({ width: 1440, height: 900 });
+  });
+
+  test('publishes embedded databases for Project Tracker 2', async ({
+    page,
+    request,
+    browser,
+  }) => {
+    await signInWithPasswordViaUi(page, existingEmail, existingPassword!, 3000);
+    await expect(SidebarSelectors.pageHeader(page)).toBeVisible({ timeout: 30000 });
+
+    const token = await getAccessToken(page);
+    const workspaceId = await currentWorkspaceId(page);
+    const targetPage = await findExistingPage(request, token, workspaceId, targetPageName);
+
+    await page.goto(`/app/${workspaceId}/${targetPage.view_id}`, { waitUntil: 'domcontentloaded' });
+    await expect(page.locator('body')).toContainText(targetPageName, { timeout: 30000 });
+    await expect(DatabaseGridSelectors.grid(page)).toBeVisible({ timeout: 30000 });
+
+    const embeddedViewIds = await waitForEmbeddedDatabaseViewIds(page, targetPage.view_id);
+
+    expect(embeddedViewIds.length, 'Expected the target document to contain at least one embedded database view').toBeGreaterThan(0);
+    testLog.info(`Embedded database view IDs: ${embeddedViewIds.join(', ')}`);
+
+    const previousParentPublishInfo = await maybePublishedInfo(request, targetPage.view_id);
+
+    await unpublishIfPublished(request, token, workspaceId, targetPage.view_id);
+    await expectNotPublished(request, targetPage.view_id);
+
+    for (const embeddedViewId of embeddedViewIds) {
+      await unpublishIfPublished(request, token, workspaceId, embeddedViewId);
+      await expectNotPublished(request, embeddedViewId);
+    }
+
+    const parentPublishInfo = await publishExistingPage(
+      request,
+      token,
+      workspaceId,
+      targetPage.view_id,
+      previousParentPublishInfo?.publish_name
+    );
+    const publishedUrl = new URL(
+      `/${parentPublishInfo.namespace}/${parentPublishInfo.publish_name}`,
+      TestConfig.baseUrl
+    ).toString();
+
+    for (const embeddedViewId of embeddedViewIds) {
+      const publishedInfo = await expectPublishedInfo(request, embeddedViewId);
+
+      await expectDatabaseSnapshot(request, publishedInfo);
+    }
+
+    const publicContext = await browser.newContext();
+    const publicPage = await publicContext.newPage();
+
+    setupPageErrorHandling(publicPage);
+    await publicPage.goto(publishedUrl, { waitUntil: 'load' });
+
+    await expect(publicPage.locator('body')).toContainText(targetPageName, { timeout: 30000 });
+    await expect(publicPage.locator('body')).not.toContainText("This page hasn't been published yet");
+    await expect(publicPage.locator('[class*="appflowy-database"]').last()).toBeVisible({ timeout: 30000 });
+    await expect(publicPage.locator('[data-testid="database-grid"]').last()).toBeVisible({ timeout: 30000 });
+    await expectCommentsDoNotOverlapDatabase(publicPage);
+
+    await publicContext.close();
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,8 @@ overrides:
   '@remix-run/router': ^1.23.2
   '@babel/runtime@<7.26.10': 7.28.4
   brace-expansion@<1.1.13: 1.1.13
+  browserslist: 4.28.1
+  caniuse-lite: 1.0.30001761
   diff@>=4.0.0 <4.0.4: 4.0.4
   dompurify@<3.4.0: 3.4.0
   follow-redirects@<=1.15.11: 1.16.0
@@ -24,6 +26,7 @@ overrides:
   picomatch@<2.3.2: 2.3.2
   postcss@<8.5.10: 8.5.10
   rollup@>=4.0.0 <4.59.0: 4.59.0
+  update-browserslist-db: 1.2.3
   yaml@>=1.0.0 <1.10.3: 1.10.3
   yaml@>=2.0.0 <2.8.3: 2.8.3
 
@@ -4318,11 +4321,6 @@ packages:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
 
-  browserslist@4.24.5:
-    resolution: {integrity: sha512-FDToo4Wo82hIdgc1CQ+NQD0hEhmpPjrZ3hiUgwgOG6IuTdlpr8jdjyG24P6cNP1yJpTLzS5OcGgSw0xmDU1/Tw==}
-    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
-    hasBin: true
-
   browserslist@4.28.1:
     resolution: {integrity: sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
@@ -4371,9 +4369,6 @@ packages:
   camelcase@6.3.0:
     resolution: {integrity: sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==}
     engines: {node: '>=10'}
-
-  caniuse-lite@1.0.30001718:
-    resolution: {integrity: sha512-AflseV1ahcSunK53NfEs9gFWgOEmzr0f+kaMFA4xiLZlr9Hzt7HxcSpIFcnNCUkz6R6dWKa54rUz3HUmI3nVcw==}
 
   caniuse-lite@1.0.30001761:
     resolution: {integrity: sha512-JF9ptu1vP2coz98+5051jZ4PwQgd2ni8A+gYSN7EA7dPKIMf0pDlSUxhdmVOaV3/fYK5uWBkgSXJaRLr4+3A6g==}
@@ -5025,9 +5020,6 @@ packages:
     resolution: {integrity: sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==}
     engines: {node: '>=0.10.0'}
     hasBin: true
-
-  electron-to-chromium@1.5.155:
-    resolution: {integrity: sha512-ps5KcGGmwL8VaeJlvlDlu4fORQpv3+GIcF5I3f9tUKUlJ/wsysh6HU8P5L1XWRYeXfA0oJd4PyM8ds8zTFf6Ng==}
 
   electron-to-chromium@1.5.267:
     resolution: {integrity: sha512-0Drusm6MVRXSOJpGbaSVgcQsuB4hEkMpHXaVstcPmhu5LIedxs1xNK/nIxmQIU/RPC0+1/o0AVZfBTkTNJOdUw==}
@@ -6622,9 +6614,6 @@ packages:
   node-int64@0.4.0:
     resolution: {integrity: sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==}
 
-  node-releases@2.0.19:
-    resolution: {integrity: sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==}
-
   node-releases@2.0.27:
     resolution: {integrity: sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==}
 
@@ -8216,17 +8205,11 @@ packages:
     resolution: {integrity: sha512-j6qT2floy5Q2g2d939FJpwey1yw/GpQecFiSouyJtsHQPj3oqmqq3K4rI+GF8vU1zwGCT7ZwIGQd2dtCQLjYJw==}
     engines: {node: '>=10'}
 
-  update-browserslist-db@1.1.3:
-    resolution: {integrity: sha512-UxhIZQ+QInVdunkDAaiazvvT/+fXL5Osr0JZlJulepYu6Jd7qJtDZjlur0emRlT71EN3ScPoE7gvsuIKKNavKw==}
-    hasBin: true
-    peerDependencies:
-      browserslist: '>= 4.21.0'
-
   update-browserslist-db@1.2.3:
     resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
     hasBin: true
     peerDependencies:
-      browserslist: '>= 4.21.0'
+      browserslist: 4.28.1
 
   upper-case-first@2.0.2:
     resolution: {integrity: sha512-514ppYHBaKwfJRK/pNC6c/OxfGa0obSnAl106u97Ed0I625Nin96KAjttZF6ZL3e1XLtphxnqrOi9iWgm+u+bg==}
@@ -9043,7 +9026,7 @@ snapshots:
     dependencies:
       '@babel/compat-data': 7.27.2
       '@babel/helper-validator-option': 7.27.1
-      browserslist: 4.24.5
+      browserslist: 4.28.1
       lru-cache: 5.1.1
       semver: 6.3.1
 
@@ -12541,8 +12524,8 @@ snapshots:
 
   autoprefixer@10.4.21(postcss@8.5.10):
     dependencies:
-      browserslist: 4.24.5
-      caniuse-lite: 1.0.30001718
+      browserslist: 4.28.1
+      caniuse-lite: 1.0.30001761
       fraction.js: 4.3.7
       normalize-range: 0.1.2
       picocolors: 1.1.1
@@ -12662,8 +12645,7 @@ snapshots:
 
   base64-js@1.5.1: {}
 
-  baseline-browser-mapping@2.9.11:
-    optional: true
+  baseline-browser-mapping@2.9.11: {}
 
   bidi-js@1.0.3:
     dependencies:
@@ -12696,13 +12678,6 @@ snapshots:
     dependencies:
       fill-range: 7.1.1
 
-  browserslist@4.24.5:
-    dependencies:
-      caniuse-lite: 1.0.30001718
-      electron-to-chromium: 1.5.155
-      node-releases: 2.0.19
-      update-browserslist-db: 1.1.3(browserslist@4.24.5)
-
   browserslist@4.28.1:
     dependencies:
       baseline-browser-mapping: 2.9.11
@@ -12710,7 +12685,6 @@ snapshots:
       electron-to-chromium: 1.5.267
       node-releases: 2.0.27
       update-browserslist-db: 1.2.3(browserslist@4.28.1)
-    optional: true
 
   bs-logger@0.2.6:
     dependencies:
@@ -12757,10 +12731,7 @@ snapshots:
 
   camelcase@6.3.0: {}
 
-  caniuse-lite@1.0.30001718: {}
-
-  caniuse-lite@1.0.30001761:
-    optional: true
+  caniuse-lite@1.0.30001761: {}
 
   capital-case@1.0.4:
     dependencies:
@@ -12940,7 +12911,7 @@ snapshots:
 
   core-js-compat@3.42.0:
     dependencies:
-      browserslist: 4.24.5
+      browserslist: 4.28.1
 
   cose-base@1.0.3:
     dependencies:
@@ -13437,10 +13408,7 @@ snapshots:
     dependencies:
       jake: 10.9.2
 
-  electron-to-chromium@1.5.155: {}
-
-  electron-to-chromium@1.5.267:
-    optional: true
+  electron-to-chromium@1.5.267: {}
 
   emittery@0.13.1: {}
 
@@ -15676,10 +15644,7 @@ snapshots:
 
   node-int64@0.4.0: {}
 
-  node-releases@2.0.19: {}
-
-  node-releases@2.0.27:
-    optional: true
+  node-releases@2.0.27: {}
 
   normalize-path@3.0.0: {}
 
@@ -17436,18 +17401,11 @@ snapshots:
 
   unsplash-js@7.0.19: {}
 
-  update-browserslist-db@1.1.3(browserslist@4.24.5):
-    dependencies:
-      browserslist: 4.24.5
-      escalade: 3.2.0
-      picocolors: 1.1.1
-
   update-browserslist-db@1.2.3(browserslist@4.28.1):
     dependencies:
       browserslist: 4.28.1
       escalade: 3.2.0
       picocolors: 1.1.1
-    optional: true
 
   upper-case-first@2.0.2:
     dependencies:

--- a/src/application/database-yjs/selector.ts
+++ b/src/application/database-yjs/selector.ts
@@ -1230,6 +1230,7 @@ export function useRowOrdersSelector() {
     if (!currentHasConditions) {
       filtersAppliedRef.current = false;
       setRowOrders(originalRowOrders);
+
       return;
     }
 

--- a/src/application/publish-snapshot/__fixtures__/published-page-snapshots.ts
+++ b/src/application/publish-snapshot/__fixtures__/published-page-snapshots.ts
@@ -1,0 +1,213 @@
+import {
+  BlockType,
+  CoverType,
+  DatabaseViewLayout,
+  ViewIconType,
+  ViewLayout,
+  YjsDatabaseKey,
+  YjsEditorKey,
+} from '@/application/types';
+import type {
+  PublishedDatabaseSnapshotPayload,
+  PublishedDocumentSnapshotPayload,
+} from '@/application/publish-snapshot/types';
+
+export const publishedDocumentPayload: PublishedDocumentSnapshotPayload = {
+  schemaVersion: 1,
+  kind: 'document',
+  namespace: 'published-namespace',
+  publishName: 'published-document',
+  view: {
+    viewId: 'published-document-view-id',
+    name: 'Published document',
+    icon: {
+      ty: ViewIconType.Icon,
+      value: 'document',
+    },
+    extra: JSON.stringify({
+      cover: {
+        type: CoverType.NormalColor,
+        value: '#F3E8D0',
+        offset: 0,
+      },
+    }),
+    layout: ViewLayout.Document,
+    databaseRelations: {
+      'related-database-id': 'related-database-view-id',
+    },
+  },
+  document: {
+    children: [
+      {
+        type: BlockType.Paragraph,
+        blockId: 'published-document-block-id',
+        data: {},
+        children: [
+          {
+            type: YjsEditorKey.text,
+            textId: 'published-document-text-id',
+            children: [{ text: 'Published document body' }],
+          },
+        ],
+      },
+    ],
+  },
+};
+
+const databaseId = 'published-database-id';
+const databaseViewId = 'published-database-view-id';
+const rowId = 'published-row-id';
+
+export const publishedRowDocumentId = 'published-row-document-id';
+const fieldId = 'published-name-field-id';
+
+export const publishedDatabasePayload: PublishedDatabaseSnapshotPayload = {
+  schemaVersion: 1,
+  kind: 'database',
+  namespace: 'published-namespace',
+  publishName: 'published-database',
+  view: {
+    viewId: databaseViewId,
+    name: 'Published database',
+    icon: {
+      ty: ViewIconType.Icon,
+      value: 'database',
+    },
+    extra: JSON.stringify({
+      cover: {
+        type: CoverType.NormalColor,
+        value: '#DDEBFF',
+        offset: 0,
+      },
+    }),
+    layout: ViewLayout.Grid,
+  },
+  database: {
+    databaseId,
+    activeViewId: databaseViewId,
+    visibleViewIds: [databaseViewId],
+    fields: [
+      {
+        fieldId,
+        name: 'Name',
+        fieldType: 0,
+        isPrimary: true,
+        width: 180,
+      },
+    ],
+    views: [
+      {
+        viewId: databaseViewId,
+        name: 'Grid',
+        layout: DatabaseViewLayout.Grid,
+        fieldIds: [fieldId],
+        rowIds: [rowId],
+      },
+    ],
+    rows: [
+      {
+        rowId,
+        cells: {
+          [fieldId]: 'First published row',
+        },
+      },
+    ],
+    raw: {
+      database: {
+        [YjsDatabaseKey.id]: databaseId,
+        [YjsDatabaseKey.fields]: {
+          [fieldId]: {
+            [YjsDatabaseKey.id]: fieldId,
+            [YjsDatabaseKey.name]: 'Name',
+            [YjsDatabaseKey.type]: 0,
+            [YjsDatabaseKey.is_primary]: true,
+            [YjsDatabaseKey.type_option]: {},
+          },
+        },
+        [YjsDatabaseKey.views]: {
+          [databaseViewId]: {
+            [YjsDatabaseKey.database_id]: databaseId,
+            [YjsDatabaseKey.name]: 'Grid',
+            [YjsDatabaseKey.layout]: DatabaseViewLayout.Grid,
+            [YjsDatabaseKey.created_at]: '1',
+            [YjsDatabaseKey.modified_at]: '1',
+            [YjsDatabaseKey.is_inline]: false,
+            [YjsDatabaseKey.embedded]: false,
+            [YjsDatabaseKey.field_orders]: [{ id: fieldId }],
+            [YjsDatabaseKey.row_orders]: [{ id: rowId, height: 36 }],
+            [YjsDatabaseKey.field_settings]: {
+              [fieldId]: {
+                [YjsDatabaseKey.width]: '180',
+                [YjsDatabaseKey.visibility]: '0',
+                [YjsDatabaseKey.wrap]: true,
+              },
+            },
+            [YjsDatabaseKey.filters]: [],
+            [YjsDatabaseKey.groups]: [],
+            [YjsDatabaseKey.sorts]: [],
+            [YjsDatabaseKey.calculations]: [],
+            [YjsDatabaseKey.layout_settings]: {},
+          },
+        },
+        [YjsDatabaseKey.metas]: {},
+      },
+      rows: {
+        [rowId]: {
+          [YjsEditorKey.database_row]: {
+            [YjsDatabaseKey.id]: rowId,
+            [YjsDatabaseKey.database_id]: databaseId,
+            [YjsDatabaseKey.visibility]: true,
+            [YjsDatabaseKey.height]: 36,
+            [YjsDatabaseKey.created_at]: '1',
+            [YjsDatabaseKey.last_modified]: '1',
+            [YjsDatabaseKey.cells]: {
+              [fieldId]: {
+                [YjsDatabaseKey.field_type]: 0,
+                [YjsDatabaseKey.data]: 'First published row',
+                [YjsDatabaseKey.created_at]: '1',
+                [YjsDatabaseKey.last_modified]: '1',
+              },
+            },
+          },
+          [YjsEditorKey.meta]: {},
+        },
+      },
+      row_documents: {
+        [publishedRowDocumentId]: {
+          data: {
+            page_id: 'published-row-document-page-id',
+            blocks: {
+              'published-row-document-page-id': {
+                id: 'published-row-document-page-id',
+                ty: BlockType.Page,
+                parent: '',
+                children: 'published-row-document-page-id',
+                external_id: 'published-row-document-page-id',
+                external_type: YjsEditorKey.text,
+                data: {},
+              },
+              'published-row-document-block-id': {
+                id: 'published-row-document-block-id',
+                ty: BlockType.Paragraph,
+                parent: 'published-row-document-page-id',
+                children: 'published-row-document-block-id',
+                external_id: 'published-row-document-text-id',
+                external_type: YjsEditorKey.text,
+                data: {},
+              },
+            },
+            meta: {
+              children_map: {
+                'published-row-document-page-id': ['published-row-document-block-id'],
+                'published-row-document-block-id': [],
+              },
+              text_map: {
+                'published-row-document-text-id': JSON.stringify([{ insert: 'Published row document body' }]),
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+};

--- a/src/application/publish-snapshot/__tests__/data-source.test.ts
+++ b/src/application/publish-snapshot/__tests__/data-source.test.ts
@@ -1,0 +1,10 @@
+import { createPublishSnapshotDataSource } from '@/application/publish-snapshot/data-source';
+import { JsonPublishSnapshotDataSource } from '@/application/publish-snapshot/json-api-adapter';
+
+describe('createPublishSnapshotDataSource', () => {
+  it('uses the v2 JSON snapshot API data source', () => {
+    const dataSource = createPublishSnapshotDataSource();
+
+    expect(dataSource).toBeInstanceOf(JsonPublishSnapshotDataSource);
+  });
+});

--- a/src/application/publish-snapshot/__tests__/database-yjs-render-bridge.test.ts
+++ b/src/application/publish-snapshot/__tests__/database-yjs-render-bridge.test.ts
@@ -1,0 +1,174 @@
+import * as Y from 'yjs';
+
+import { DatabaseViewLayout, ViewLayout, YDatabase, YDatabaseRow, YjsDatabaseKey, YjsEditorKey } from '@/application/types';
+import {
+  createDatabaseYjsRenderDocsFromSnapshot,
+  getPublishedDatabaseRenderRowMap,
+} from '@/application/publish-snapshot/database-yjs-render-bridge';
+import type { PublishedDatabaseSnapshot } from '@/application/publish-snapshot/types';
+
+describe('createDatabaseYjsRenderDocsFromSnapshot', () => {
+  it('hydrates database and row snapshot JSON into the Yjs shape expected by database UI hooks', () => {
+    const databaseId = 'database-id';
+    const viewId = 'view-id';
+    const rowId = 'row-id';
+    const fieldId = 'field-id';
+    const filterId = 'filter-id';
+    const childFilterId = 'child-filter-id';
+    const groupId = 'group-id';
+    const snapshot: PublishedDatabaseSnapshot = {
+      schemaVersion: 1,
+      kind: 'database',
+      namespace: 'namespace',
+      publishName: 'publish-name',
+      view: {
+        viewId,
+        name: 'Published database',
+        icon: null,
+        extra: null,
+        layout: ViewLayout.Grid,
+        childViews: [],
+        ancestorViews: [],
+        visibleViewIds: [viewId],
+        databaseRelations: {},
+      },
+      database: {
+        databaseId,
+        activeViewId: viewId,
+        visibleViewIds: [viewId],
+        fields: [
+          {
+            fieldId,
+            name: 'Name',
+            fieldType: 0,
+            isPrimary: true,
+          },
+        ],
+        views: [
+          {
+            viewId,
+            name: 'Grid',
+            layout: DatabaseViewLayout.Grid,
+            fieldIds: [fieldId],
+            rowIds: [rowId],
+          },
+        ],
+        rows: [
+          {
+            rowId,
+            cells: {
+              [fieldId]: 'Hello',
+            },
+          },
+        ],
+        raw: {
+          database: {
+            [YjsDatabaseKey.id]: databaseId,
+            [YjsDatabaseKey.fields]: {
+              [fieldId]: {
+                [YjsDatabaseKey.id]: fieldId,
+                [YjsDatabaseKey.name]: 'Name',
+                [YjsDatabaseKey.type]: 0,
+                [YjsDatabaseKey.is_primary]: true,
+                [YjsDatabaseKey.type_option]: {},
+              },
+            },
+            [YjsDatabaseKey.views]: {
+              [viewId]: {
+                [YjsDatabaseKey.database_id]: databaseId,
+                [YjsDatabaseKey.name]: 'Grid',
+                [YjsDatabaseKey.layout]: DatabaseViewLayout.Grid,
+                [YjsDatabaseKey.created_at]: '1',
+                [YjsDatabaseKey.modified_at]: '1',
+                [YjsDatabaseKey.is_inline]: false,
+                [YjsDatabaseKey.embedded]: false,
+                [YjsDatabaseKey.field_orders]: [{ id: fieldId }],
+                [YjsDatabaseKey.row_orders]: [{ id: rowId, height: 36 }],
+                [YjsDatabaseKey.field_settings]: {
+                  [fieldId]: {
+                    [YjsDatabaseKey.width]: '180',
+                    [YjsDatabaseKey.visibility]: '0',
+                    [YjsDatabaseKey.wrap]: true,
+                  },
+                },
+                [YjsDatabaseKey.filters]: [
+                  {
+                    [YjsDatabaseKey.id]: filterId,
+                    [YjsDatabaseKey.filter_type]: 0,
+                    [YjsDatabaseKey.children]: [
+                      {
+                        [YjsDatabaseKey.id]: childFilterId,
+                        [YjsDatabaseKey.field_id]: fieldId,
+                        [YjsDatabaseKey.condition]: '0',
+                        [YjsDatabaseKey.content]: '',
+                      },
+                    ],
+                  },
+                ],
+                [YjsDatabaseKey.groups]: [
+                  {
+                    [YjsDatabaseKey.id]: groupId,
+                    [YjsDatabaseKey.field_id]: fieldId,
+                    [YjsDatabaseKey.groups]: [{ id: 'ungrouped', visible: true }],
+                  },
+                ],
+                [YjsDatabaseKey.sorts]: [],
+                [YjsDatabaseKey.calculations]: [],
+                [YjsDatabaseKey.layout_settings]: {},
+              },
+            },
+            [YjsDatabaseKey.metas]: {},
+          },
+          rows: {
+            [rowId]: {
+              [YjsEditorKey.database_row]: {
+                [YjsDatabaseKey.id]: rowId,
+                [YjsDatabaseKey.database_id]: databaseId,
+                [YjsDatabaseKey.visibility]: true,
+                [YjsDatabaseKey.height]: 36,
+                [YjsDatabaseKey.created_at]: '1',
+                [YjsDatabaseKey.last_modified]: '1',
+                [YjsDatabaseKey.cells]: {
+                  [fieldId]: {
+                    [YjsDatabaseKey.field_type]: 0,
+                    [YjsDatabaseKey.data]: 'Hello',
+                    [YjsDatabaseKey.created_at]: '1',
+                    [YjsDatabaseKey.last_modified]: '1',
+                  },
+                },
+              },
+              [YjsEditorKey.meta]: {},
+            },
+          },
+          row_documents: {},
+        },
+      },
+    };
+
+    const { doc, rowMap } = createDatabaseYjsRenderDocsFromSnapshot(snapshot);
+    const database = doc.getMap(YjsEditorKey.data_section).get(YjsEditorKey.database) as YDatabase;
+    const view = database.get(YjsDatabaseKey.views).get(viewId);
+    const filters = view.get(YjsDatabaseKey.filters);
+    const groups = view.get(YjsDatabaseKey.groups);
+    const row = rowMap[rowId]
+      .getMap(YjsEditorKey.data_section)
+      .get(YjsEditorKey.database_row) as YDatabaseRow;
+    const cell = row.get(YjsDatabaseKey.cells).get(fieldId);
+
+    expect(doc.guid).toBe(databaseId);
+    expect(doc.object_id).toBe(databaseId);
+    expect(doc.view_id).toBe(viewId);
+    expect(database.get(YjsDatabaseKey.id)).toBe(databaseId);
+    expect(view.get(YjsDatabaseKey.row_orders)).toBeInstanceOf(Y.Array);
+    expect(view.get(YjsDatabaseKey.row_orders).toJSON()).toEqual([{ id: rowId, height: 36 }]);
+    expect(filters).toBeInstanceOf(Y.Array);
+    expect(filters.get(0).get(YjsDatabaseKey.children)).toBeInstanceOf(Y.Array);
+    expect(filters.get(0).get(YjsDatabaseKey.children)?.get(0).get(YjsDatabaseKey.id)).toBe(childFilterId);
+    expect(groups).toBeInstanceOf(Y.Array);
+    expect(groups.get(0).get(YjsDatabaseKey.groups)).toBeInstanceOf(Y.Array);
+    expect(rowMap[rowId].guid).toBe(`${databaseId}_rows_${rowId}`);
+    expect(getPublishedDatabaseRenderRowMap(doc)?.[rowId]).toBe(rowMap[rowId]);
+    expect(row.get(YjsDatabaseKey.id)).toBe(rowId);
+    expect(cell.get(YjsDatabaseKey.data)).toBe('Hello');
+  });
+});

--- a/src/application/publish-snapshot/__tests__/document-yjs-render-bridge.test.ts
+++ b/src/application/publish-snapshot/__tests__/document-yjs-render-bridge.test.ts
@@ -1,0 +1,58 @@
+import { normalizePublishedPageSnapshot } from '@/application/publish-snapshot/normalize';
+import {
+  publishedDatabasePayload,
+  publishedDocumentPayload,
+  publishedRowDocumentId,
+} from '@/application/publish-snapshot/__fixtures__/published-page-snapshots';
+import {
+  createDocumentYjsRenderDocFromRawData,
+  createDocumentYjsRenderDocFromSnapshot,
+} from '@/application/publish-snapshot/document-yjs-render-bridge';
+import { yDocToSlateContent } from '@/application/slate-yjs/utils/convert';
+
+describe('createDocumentYjsRenderDocFromSnapshot', () => {
+  it('builds a Yjs document for legacy render consumers from the published document JSON', () => {
+    const snapshot = normalizePublishedPageSnapshot(publishedDocumentPayload);
+
+    if (snapshot.kind !== 'document') {
+      throw new Error('Expected document snapshot fixture');
+    }
+
+    const doc = createDocumentYjsRenderDocFromSnapshot(snapshot);
+    const slateContent = yDocToSlateContent(doc);
+    const firstBlock = slateContent?.children[0] as {
+      blockId?: string;
+      children?: Array<{ children?: Array<{ text?: string }> }>;
+    } | undefined;
+
+    expect(doc.guid).toBe(snapshot.view.viewId);
+    expect(doc.object_id).toBe(snapshot.view.viewId);
+    expect(doc.view_id).toBe(snapshot.view.viewId);
+    expect(firstBlock?.blockId).toBe('published-document-block-id');
+    expect(firstBlock?.children?.[0]?.children?.[0]?.text).toBe('Published document body');
+  });
+
+  it('builds a Yjs document from published raw document JSON', () => {
+    const snapshot = normalizePublishedPageSnapshot(publishedDatabasePayload);
+
+    if (snapshot.kind !== 'database') {
+      throw new Error('Expected database snapshot fixture');
+    }
+
+    const doc = createDocumentYjsRenderDocFromRawData(
+      publishedRowDocumentId,
+      snapshot.database.raw.row_documents[publishedRowDocumentId]
+    );
+    const slateContent = yDocToSlateContent(doc);
+    const firstBlock = slateContent?.children[0] as {
+      blockId?: string;
+      children?: Array<{ children?: Array<{ text?: string }> }>;
+    } | undefined;
+
+    expect(doc.guid).toBe(publishedRowDocumentId);
+    expect(doc.object_id).toBe(publishedRowDocumentId);
+    expect(doc.view_id).toBe(publishedRowDocumentId);
+    expect(firstBlock?.blockId).toBe('published-row-document-block-id');
+    expect(firstBlock?.children?.[0]?.children?.[0]?.text).toBe('Published row document body');
+  });
+});

--- a/src/application/publish-snapshot/__tests__/http-json-adapter.test.ts
+++ b/src/application/publish-snapshot/__tests__/http-json-adapter.test.ts
@@ -1,0 +1,77 @@
+import { ViewLayout } from '@/application/types';
+import { executeAPIRequest, getAxios } from '@/application/services/js-services/http/core';
+import {
+  createHttpJsonPublishSnapshotDataSource,
+  fetchPublishedPageSnapshot,
+  getPublishedPageSnapshotEndpoint,
+} from '@/application/publish-snapshot/http-json-adapter';
+import { publishedDocumentPayload } from '@/application/publish-snapshot/__fixtures__/published-page-snapshots';
+
+jest.mock('@/application/services/js-services/http/core', () => ({
+  executeAPIRequest: jest.fn(),
+  getAxios: jest.fn(),
+}));
+
+const mockExecuteAPIRequest = executeAPIRequest as unknown as jest.Mock;
+const mockGetAxios = getAxios as unknown as jest.Mock;
+const mockGet = jest.fn();
+
+describe('http JSON publish snapshot adapter', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGet.mockResolvedValue({
+      data: {
+        code: 0,
+        message: '',
+        data: publishedDocumentPayload,
+      },
+    });
+    mockGetAxios.mockReturnValue({ get: mockGet });
+    mockExecuteAPIRequest.mockImplementation(async (request: () => Promise<{ data: { data: unknown } }>) => {
+      const response = await request();
+
+      return response.data.data;
+    });
+  });
+
+  it('builds the future JSON snapshot endpoint with encoded path segments', () => {
+    expect(getPublishedPageSnapshotEndpoint('team space', 'document/page')).toBe(
+      '/api/workspace/v2/published/team%20space/document%2Fpage/snapshot'
+    );
+  });
+
+  it('fetches a publish snapshot payload through the standard API envelope', async () => {
+    await expect(fetchPublishedPageSnapshot('team space', 'document/page')).resolves.toBe(publishedDocumentPayload);
+
+    expect(mockExecuteAPIRequest).toHaveBeenCalledTimes(1);
+    expect(mockGet).toHaveBeenCalledWith('/api/workspace/v2/published/team%20space/document%2Fpage/snapshot');
+  });
+
+  it('creates a data source that normalizes sparse JSON payloads', async () => {
+    const dataSource = createHttpJsonPublishSnapshotDataSource(async () => ({
+      schemaVersion: 1,
+      kind: 'document',
+      namespace: 'namespace',
+      publishName: 'publish-name',
+      view: {
+        viewId: 'view-id',
+        name: 'Document',
+        icon: null,
+        extra: null,
+        layout: ViewLayout.Document,
+      },
+    }));
+
+    await expect(dataSource.getPage('namespace', 'publish-name')).resolves.toMatchObject({
+      view: {
+        childViews: [],
+        ancestorViews: [],
+        visibleViewIds: [],
+        databaseRelations: {},
+      },
+      document: {
+        children: [],
+      },
+    });
+  });
+});

--- a/src/application/publish-snapshot/__tests__/json-api-adapter.test.ts
+++ b/src/application/publish-snapshot/__tests__/json-api-adapter.test.ts
@@ -1,0 +1,79 @@
+import { ViewLayout } from '@/application/types';
+import { createJsonPublishSnapshotDataSource } from '@/application/publish-snapshot/json-api-adapter';
+import type {
+  PublishedDatabaseSnapshotPayload,
+  PublishedDocumentSnapshotPayload,
+} from '@/application/publish-snapshot/types';
+
+describe('JsonPublishSnapshotDataSource', () => {
+  it('normalizes optional view and document collections from the fetched snapshot', async () => {
+    const snapshot: PublishedDocumentSnapshotPayload = {
+      schemaVersion: 1,
+      kind: 'document',
+      namespace: 'namespace',
+      publishName: 'publish-name',
+      view: {
+        viewId: 'view-id',
+        name: 'Published document',
+        icon: null,
+        extra: null,
+        layout: ViewLayout.Document,
+      },
+      document: {},
+    };
+    const dataSource = createJsonPublishSnapshotDataSource(async () => snapshot);
+
+    await expect(dataSource.getPage('namespace', 'publish-name')).resolves.toMatchObject({
+      view: {
+        childViews: [],
+        ancestorViews: [],
+        visibleViewIds: [],
+        databaseRelations: {},
+      },
+      document: {
+        children: [],
+      },
+    });
+  });
+
+  it('normalizes optional database collections from the fetched snapshot', async () => {
+    const snapshot: PublishedDatabaseSnapshotPayload = {
+      schemaVersion: 1,
+      kind: 'database',
+      namespace: 'namespace',
+      publishName: 'publish-name',
+      view: {
+        viewId: 'view-id',
+        name: 'Published database',
+        icon: null,
+        extra: null,
+        layout: ViewLayout.Grid,
+      },
+      database: {
+        databaseId: 'database-id',
+        activeViewId: 'view-id',
+      },
+    };
+    const dataSource = createJsonPublishSnapshotDataSource(async () => snapshot);
+
+    await expect(dataSource.getPage('namespace', 'publish-name')).resolves.toMatchObject({
+      view: {
+        childViews: [],
+        ancestorViews: [],
+        visibleViewIds: [],
+        databaseRelations: {},
+      },
+      database: {
+        visibleViewIds: [],
+        fields: [],
+        views: [],
+        rows: [],
+        raw: {
+          database: {},
+          rows: {},
+          row_documents: {},
+        },
+      },
+    });
+  });
+});

--- a/src/application/publish-snapshot/data-source.ts
+++ b/src/application/publish-snapshot/data-source.ts
@@ -1,0 +1,6 @@
+import { createHttpJsonPublishSnapshotDataSource } from './http-json-adapter';
+import type { PublishSnapshotDataSource } from './types';
+
+export function createPublishSnapshotDataSource(): PublishSnapshotDataSource {
+  return createHttpJsonPublishSnapshotDataSource();
+}

--- a/src/application/publish-snapshot/database-yjs-render-bridge.ts
+++ b/src/application/publish-snapshot/database-yjs-render-bridge.ts
@@ -1,0 +1,272 @@
+import * as Y from 'yjs';
+
+import { getRowKey } from '@/application/database-yjs/row_meta';
+import {
+  RowId,
+  YDatabase,
+  YDatabaseRow,
+  YDoc,
+  YSharedRoot,
+  YjsDatabaseKey,
+  YjsEditorKey,
+} from '@/application/types';
+import type {
+  PublishedDatabaseSnapshot,
+  PublishedJsonObject,
+  PublishedJsonValue,
+} from './types';
+
+export interface PublishedDatabaseRenderDocs {
+  doc: YDoc;
+  rowMap: Record<RowId, YDoc>;
+}
+
+const PUBLISHED_DATABASE_RENDER_ROW_MAP_KEY = '__appflowyPublishedDatabaseRenderRowMap';
+
+type YDocWithPublishedDatabaseRowMap = YDoc & {
+  [PUBLISHED_DATABASE_RENDER_ROW_MAP_KEY]?: Record<RowId, YDoc>;
+};
+
+function attachPublishedDatabaseRenderRowMap(doc: YDoc, rowMap: Record<RowId, YDoc>) {
+  (doc as YDocWithPublishedDatabaseRowMap)[PUBLISHED_DATABASE_RENDER_ROW_MAP_KEY] = rowMap;
+}
+
+export function getPublishedDatabaseRenderRowMap(doc: YDoc | null | undefined): Record<RowId, YDoc> | undefined {
+  return (doc as YDocWithPublishedDatabaseRowMap | null | undefined)?.[PUBLISHED_DATABASE_RENDER_ROW_MAP_KEY];
+}
+
+function isJsonObject(value: PublishedJsonValue | undefined): value is PublishedJsonObject {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function toPlainJson(value: PublishedJsonValue): unknown {
+  if (Array.isArray(value)) {
+    return value.map(toPlainJson);
+  }
+
+  if (isJsonObject(value)) {
+    return Object.fromEntries(Object.entries(value).map(([key, child]) => [key, toPlainJson(child)]));
+  }
+
+  return value;
+}
+
+function createYArray(
+  values: PublishedJsonValue[],
+  mapItem: (value: PublishedJsonValue) => unknown = toPlainJson
+): Y.Array<unknown> {
+  const array = new Y.Array<unknown>();
+
+  if (values.length > 0) {
+    array.push(values.map(mapItem));
+  }
+
+  return array;
+}
+
+function createYMap(
+  value: PublishedJsonObject,
+  mapValue: (key: string, value: PublishedJsonValue) => unknown = hydrateGenericValue
+): Y.Map<unknown> {
+  const map = new Y.Map<unknown>();
+
+  Object.entries(value).forEach(([key, child]) => {
+    map.set(key, mapValue(key, child));
+  });
+
+  return map;
+}
+
+function createYMapOfObjects(
+  value: PublishedJsonObject,
+  hydrateValue: (value: PublishedJsonObject) => Y.Map<unknown> = createYMap
+): Y.Map<unknown> {
+  const map = new Y.Map<unknown>();
+
+  Object.entries(value).forEach(([key, child]) => {
+    map.set(key, isJsonObject(child) ? hydrateValue(child) : toPlainJson(child));
+  });
+
+  return map;
+}
+
+function hydrateGenericValue(_key: string, value: PublishedJsonValue): unknown {
+  if (Array.isArray(value)) {
+    return createYArray(value);
+  }
+
+  if (isJsonObject(value)) {
+    return createYMap(value);
+  }
+
+  return value;
+}
+
+function hydrateFilter(value: PublishedJsonObject): Y.Map<unknown> {
+  return createYMap(value, (key, child) => {
+    if (key === YjsDatabaseKey.children && Array.isArray(child)) {
+      return createYArray(child, (item) => isJsonObject(item) ? hydrateFilter(item) : toPlainJson(item));
+    }
+
+    return hydrateGenericValue(key, child);
+  });
+}
+
+function hydrateGroup(value: PublishedJsonObject): Y.Map<unknown> {
+  return createYMap(value, (key, child) => {
+    if (key === YjsDatabaseKey.groups && Array.isArray(child)) {
+      return createYArray(child);
+    }
+
+    return hydrateGenericValue(key, child);
+  });
+}
+
+function hydrateView(value: PublishedJsonObject): Y.Map<unknown> {
+  return createYMap(value, (key, child) => {
+    if ((key === YjsDatabaseKey.field_orders || key === YjsDatabaseKey.row_orders) && Array.isArray(child)) {
+      return createYArray(child);
+    }
+
+    if (key === YjsDatabaseKey.groups && Array.isArray(child)) {
+      return createYArray(child, (item) => isJsonObject(item) ? hydrateGroup(item) : toPlainJson(item));
+    }
+
+    if (key === YjsDatabaseKey.filters && Array.isArray(child)) {
+      return createYArray(child, (item) => isJsonObject(item) ? hydrateFilter(item) : toPlainJson(item));
+    }
+
+    if ((key === YjsDatabaseKey.sorts || key === YjsDatabaseKey.calculations) && Array.isArray(child)) {
+      return createYArray(child, (item) => isJsonObject(item) ? createYMap(item) : toPlainJson(item));
+    }
+
+    if ((key === YjsDatabaseKey.field_settings || key === YjsDatabaseKey.layout_settings) && isJsonObject(child)) {
+      return createYMapOfObjects(child);
+    }
+
+    return hydrateGenericValue(key, child);
+  });
+}
+
+function hydrateField(value: PublishedJsonObject): Y.Map<unknown> {
+  return createYMap(value, (key, child) => {
+    if (key === YjsDatabaseKey.type_option && isJsonObject(child)) {
+      return createYMapOfObjects(child);
+    }
+
+    return hydrateGenericValue(key, child);
+  });
+}
+
+function hydrateDatabase(value: PublishedJsonObject): YDatabase {
+  return createYMap(value, (key, child) => {
+    if (key === YjsDatabaseKey.views && isJsonObject(child)) {
+      return createYMapOfObjects(child, hydrateView);
+    }
+
+    if (key === YjsDatabaseKey.fields && isJsonObject(child)) {
+      return createYMapOfObjects(child, hydrateField);
+    }
+
+    if (key === YjsDatabaseKey.metas && isJsonObject(child)) {
+      return createYMap(child);
+    }
+
+    return hydrateGenericValue(key, child);
+  }) as YDatabase;
+}
+
+function hydrateCell(value: PublishedJsonObject): Y.Map<unknown> {
+  return createYMap(value, (key, child) => {
+    if (key === YjsDatabaseKey.data && Array.isArray(child)) {
+      return createYArray(child);
+    }
+
+    return hydrateGenericValue(key, child);
+  });
+}
+
+function hydrateDatabaseRow(value: PublishedJsonObject): YDatabaseRow {
+  return createYMap(value, (key, child) => {
+    if (key === YjsDatabaseKey.cells && isJsonObject(child)) {
+      return createYMapOfObjects(child, hydrateCell);
+    }
+
+    return hydrateGenericValue(key, child);
+  }) as YDatabaseRow;
+}
+
+function hydrateSharedRootValue(key: string, value: PublishedJsonValue): unknown {
+  if (key === YjsEditorKey.database && isJsonObject(value)) {
+    return hydrateDatabase(value);
+  }
+
+  if (key === YjsEditorKey.database_row && isJsonObject(value)) {
+    return hydrateDatabaseRow(value);
+  }
+
+  return hydrateGenericValue(key, value);
+}
+
+function populateSharedRoot(root: YSharedRoot, value: PublishedJsonObject) {
+  Object.entries(value).forEach(([key, child]) => {
+    root.set(key, hydrateSharedRootValue(key, child));
+  });
+}
+
+function createDatabaseDoc(snapshot: PublishedDatabaseSnapshot): YDoc {
+  const doc = new Y.Doc({
+    guid: snapshot.database.databaseId,
+  }) as YDoc;
+  const root = doc.getMap(YjsEditorKey.data_section) as YSharedRoot;
+  const database = hydrateDatabase(snapshot.database.raw.database);
+
+  doc.object_id = snapshot.database.databaseId;
+  doc.view_id = snapshot.view.viewId;
+  root.set(YjsEditorKey.database, database);
+  return doc;
+}
+
+function createRowDoc({
+  databaseId,
+  rowId,
+  raw,
+}: {
+  databaseId: string;
+  rowId: RowId;
+  raw: PublishedJsonObject;
+}): YDoc {
+  const rowKey = getRowKey(databaseId, rowId);
+  const doc = new Y.Doc({
+    guid: rowKey,
+  }) as YDoc;
+  const root = doc.getMap(YjsEditorKey.data_section) as YSharedRoot;
+
+  doc.object_id = rowKey;
+  doc.view_id = rowId;
+  populateSharedRoot(root, raw);
+
+  return doc;
+}
+
+export function createDatabaseYjsRenderDocsFromSnapshot(snapshot: PublishedDatabaseSnapshot): PublishedDatabaseRenderDocs {
+  const databaseId = snapshot.database.databaseId;
+  const doc = createDatabaseDoc(snapshot);
+  const rowMap = Object.fromEntries(
+    Object.entries(snapshot.database.raw.rows).map(([rowId, raw]) => [
+      rowId,
+      createRowDoc({
+        databaseId,
+        rowId,
+        raw,
+      }),
+    ])
+  );
+
+  attachPublishedDatabaseRenderRowMap(doc, rowMap);
+
+  return {
+    doc,
+    rowMap,
+  };
+}

--- a/src/application/publish-snapshot/document-yjs-render-bridge.ts
+++ b/src/application/publish-snapshot/document-yjs-render-bridge.ts
@@ -1,0 +1,217 @@
+import { Descendant, Element, Text } from 'slate';
+import * as Y from 'yjs';
+
+import { slateNodeToDeltaInsert } from '@/application/slate-yjs/utils/convert';
+import {
+  generateBlockId,
+  getChildrenArray,
+  getDocument,
+  getPageId,
+  getTextMap,
+  initializeDocumentStructure,
+} from '@/application/slate-yjs/utils/yjs';
+import {
+  BlockType,
+  YBlock,
+  YBlocks,
+  YChildrenMap,
+  YDoc,
+  YjsEditorKey,
+  YMeta,
+  YSharedRoot,
+  YTextMap,
+} from '@/application/types';
+
+import type { PublishedDocumentRaw, PublishedDocumentSnapshot } from './types';
+
+type PublishedSlateElement = Element & {
+  blockId?: string;
+  relationId?: string;
+  data?: object;
+};
+
+type PublishedTextElement = Element & {
+  textId?: string;
+  children: Text[];
+};
+
+type TextDeltaInsert = {
+  insert: string;
+  attributes?: Record<string, unknown>;
+};
+
+function isPublishedTextElement(node: Descendant): node is PublishedTextElement {
+  return Element.isElement(node) && node.type === YjsEditorKey.text;
+}
+
+function yTextFromSerializedDelta(serializedDelta: string): Y.Text {
+  const text = new Y.Text();
+
+  try {
+    const delta = JSON.parse(serializedDelta) as Array<Partial<TextDeltaInsert>>;
+    const validDelta = delta
+      .filter((op): op is TextDeltaInsert => typeof op.insert === 'string')
+      .map((op) => ({
+        insert: op.insert,
+        attributes: op.attributes,
+      }));
+
+    if (validDelta.length > 0) {
+      text.applyDelta(validDelta);
+    }
+  } catch {
+    // Invalid text deltas are treated as empty text so publish rendering can continue.
+  }
+
+  return text;
+}
+
+function createBlockFromSlateElement({
+  element,
+  parentId,
+  sharedRoot,
+}: {
+  element: PublishedSlateElement;
+  parentId: string;
+  sharedRoot: YSharedRoot;
+}): string {
+  const document = getDocument(sharedRoot);
+  const blocks = document.get(YjsEditorKey.blocks) as YBlocks;
+  const meta = document.get(YjsEditorKey.meta) as Y.Map<unknown>;
+  const childrenMap = meta.get(YjsEditorKey.children_map) as YChildrenMap;
+  const textMap = getTextMap(sharedRoot);
+  const blockId = element.blockId || generateBlockId();
+  const relationId = element.relationId || blockId;
+  const textElement = element.children.find(isPublishedTextElement);
+  const childBlocks = element.children.filter((child): child is PublishedSlateElement => (
+    Element.isElement(child) && child.type !== YjsEditorKey.text
+  ));
+  const block = new Y.Map() as YBlock;
+
+  block.set(YjsEditorKey.block_id, blockId);
+  block.set(YjsEditorKey.block_type, element.type as BlockType);
+  block.set(YjsEditorKey.block_children, relationId);
+  block.set(YjsEditorKey.block_data, JSON.stringify(element.data || {}));
+  block.set(YjsEditorKey.block_parent, parentId);
+
+  if (textElement) {
+    const textId = textElement.textId || blockId;
+    const yText = new Y.Text();
+    const delta = textElement.children.filter(Text.isText).map(slateNodeToDeltaInsert);
+
+    if (delta.length > 0) {
+      yText.applyDelta(delta);
+    }
+
+    block.set(YjsEditorKey.block_external_id, textId);
+    block.set(YjsEditorKey.block_external_type, YjsEditorKey.text);
+    textMap.set(textId, yText);
+  }
+
+  blocks.set(blockId, block);
+  childrenMap.set(relationId, new Y.Array());
+
+  const childIds = childBlocks.map((child) =>
+    createBlockFromSlateElement({
+      element: child,
+      parentId: blockId,
+      sharedRoot,
+    })
+  );
+
+  if (childIds.length > 0) {
+    childrenMap.get(relationId)?.push(childIds);
+  }
+
+  return blockId;
+}
+
+export function createDocumentYjsRenderDocFromSnapshot(snapshot: PublishedDocumentSnapshot): YDoc {
+  const doc = new Y.Doc({
+    guid: snapshot.view.viewId,
+  }) as YDoc;
+
+  doc.object_id = snapshot.view.viewId;
+  doc.view_id = snapshot.view.viewId;
+
+  initializeDocumentStructure(doc, false, snapshot.view.viewId);
+
+  const sharedRoot = doc.getMap(YjsEditorKey.data_section) as YSharedRoot;
+  const pageId = getPageId(sharedRoot);
+  const childIds = snapshot.document.children
+    .filter((child): child is PublishedSlateElement => Element.isElement(child))
+    .map((element) =>
+      createBlockFromSlateElement({
+        element,
+        parentId: pageId,
+        sharedRoot,
+      })
+    );
+
+  if (childIds.length > 0) {
+    getChildrenArray(pageId, sharedRoot)?.push(childIds);
+  }
+
+  return doc;
+}
+
+export function createDocumentYjsRenderDocFromRawData(documentId: string, raw: PublishedDocumentRaw): YDoc {
+  const doc = new Y.Doc({
+    guid: documentId,
+  }) as YDoc;
+  const sharedRoot = doc.getMap(YjsEditorKey.data_section) as YSharedRoot;
+  const document = new Y.Map<unknown>();
+  const blocks = new Y.Map() as YBlocks;
+  const meta = new Y.Map() as YMeta;
+  const childrenMap = new Y.Map() as YChildrenMap;
+  const textMap = new Y.Map() as YTextMap;
+
+  doc.object_id = documentId;
+  doc.view_id = documentId;
+
+  Object.entries(raw.data.blocks).forEach(([blockId, rawBlock]) => {
+    const block = new Y.Map() as YBlock;
+
+    block.set(YjsEditorKey.block_id, rawBlock.id || blockId);
+    block.set(YjsEditorKey.block_type, rawBlock.ty as BlockType);
+    block.set(YjsEditorKey.block_children, rawBlock.children);
+    block.set(YjsEditorKey.block_data, JSON.stringify(rawBlock.data || {}));
+
+    if (rawBlock.parent !== undefined) {
+      block.set(YjsEditorKey.block_parent, rawBlock.parent);
+    }
+
+    if (rawBlock.external_id) {
+      block.set(YjsEditorKey.block_external_id, rawBlock.external_id);
+    }
+
+    if (rawBlock.external_type) {
+      block.set(YjsEditorKey.block_external_type, rawBlock.external_type);
+    }
+
+    blocks.set(blockId, block);
+  });
+
+  Object.entries(raw.data.meta.children_map ?? {}).forEach(([childrenId, childIds]) => {
+    const children = new Y.Array<string>();
+
+    if (childIds.length > 0) {
+      children.push(childIds);
+    }
+
+    childrenMap.set(childrenId, children);
+  });
+
+  Object.entries(raw.data.meta.text_map ?? {}).forEach(([textId, delta]) => {
+    textMap.set(textId, yTextFromSerializedDelta(delta));
+  });
+
+  document.set(YjsEditorKey.page_id, raw.data.page_id);
+  document.set(YjsEditorKey.blocks, blocks);
+  document.set(YjsEditorKey.meta, meta);
+  meta.set(YjsEditorKey.children_map, childrenMap);
+  meta.set(YjsEditorKey.text_map, textMap);
+  sharedRoot.set(YjsEditorKey.document, document);
+
+  return doc;
+}

--- a/src/application/publish-snapshot/http-json-adapter.ts
+++ b/src/application/publish-snapshot/http-json-adapter.ts
@@ -1,0 +1,29 @@
+import { APIResponse, executeAPIRequest, getAxios } from '@/application/services/js-services/http/core';
+
+import {
+  createJsonPublishSnapshotDataSource,
+  JsonPublishSnapshotDataSource,
+  type FetchPublishedPageSnapshot,
+} from './json-api-adapter';
+import type { PublishedPageSnapshotPayload } from './types';
+
+export function getPublishedPageSnapshotEndpoint(namespace: string, publishName: string): string {
+  return `/api/workspace/v2/published/${encodeURIComponent(namespace)}/${encodeURIComponent(publishName)}/snapshot`;
+}
+
+export async function fetchPublishedPageSnapshot(
+  namespace: string,
+  publishName: string
+): Promise<PublishedPageSnapshotPayload> {
+  const url = getPublishedPageSnapshotEndpoint(namespace, publishName);
+
+  return executeAPIRequest<PublishedPageSnapshotPayload>(() =>
+    getAxios()?.get<APIResponse<PublishedPageSnapshotPayload>>(url)
+  );
+}
+
+export function createHttpJsonPublishSnapshotDataSource(
+  fetchPage: FetchPublishedPageSnapshot = fetchPublishedPageSnapshot
+): JsonPublishSnapshotDataSource {
+  return createJsonPublishSnapshotDataSource(fetchPage);
+}

--- a/src/application/publish-snapshot/index.ts
+++ b/src/application/publish-snapshot/index.ts
@@ -1,0 +1,6 @@
+export * from './types';
+export * from './data-source';
+export * from './http-json-adapter';
+export * from './json-api-adapter';
+export * from './normalize';
+export * from './database-yjs-render-bridge';

--- a/src/application/publish-snapshot/json-api-adapter.ts
+++ b/src/application/publish-snapshot/json-api-adapter.ts
@@ -1,0 +1,23 @@
+import type { PublishedPageSnapshot, PublishedPageSnapshotPayload, PublishSnapshotDataSource } from './types';
+import { normalizePublishedPageSnapshot } from './normalize';
+
+export type FetchPublishedPageSnapshot = (
+  namespace: string,
+  publishName: string
+) => Promise<PublishedPageSnapshotPayload>;
+
+export class JsonPublishSnapshotDataSource implements PublishSnapshotDataSource {
+  constructor(private readonly fetchPage: FetchPublishedPageSnapshot) {}
+
+  async getPage(namespace: string, publishName: string): Promise<PublishedPageSnapshot> {
+    const snapshot = await this.fetchPage(namespace, publishName);
+
+    return normalizePublishedPageSnapshot(snapshot);
+  }
+}
+
+export function createJsonPublishSnapshotDataSource(
+  fetchPage: FetchPublishedPageSnapshot
+): JsonPublishSnapshotDataSource {
+  return new JsonPublishSnapshotDataSource(fetchPage);
+}

--- a/src/application/publish-snapshot/normalize.ts
+++ b/src/application/publish-snapshot/normalize.ts
@@ -1,0 +1,67 @@
+import type {
+  PublishedDatabaseSnapshot,
+  PublishedDatabaseSnapshotPayload,
+  PublishedDocumentSnapshot,
+  PublishedDocumentSnapshotPayload,
+  PublishedJsonObject,
+  PublishedPageSnapshot,
+  PublishedPageSnapshotPayload,
+  PublishedView,
+  PublishedViewPayload,
+} from './types';
+
+function normalizeView(view: PublishedViewPayload): PublishedView {
+  return {
+    ...view,
+    childViews: view.childViews ?? [],
+    ancestorViews: view.ancestorViews ?? [],
+    visibleViewIds: view.visibleViewIds ?? [],
+    databaseRelations: view.databaseRelations ?? {},
+  };
+}
+
+function normalizeDocumentSnapshot(snapshot: PublishedDocumentSnapshotPayload): PublishedDocumentSnapshot {
+  const document = snapshot.document ?? {};
+
+  return {
+    ...snapshot,
+    view: normalizeView(snapshot.view),
+    document: {
+      ...document,
+      children: document.children ?? [],
+    },
+  };
+}
+
+function normalizeDatabaseSnapshot(snapshot: PublishedDatabaseSnapshotPayload): PublishedDatabaseSnapshot {
+  const raw = snapshot.database.raw ?? {
+    database: {} as PublishedJsonObject,
+    rows: {},
+    row_documents: {},
+  };
+
+  return {
+    ...snapshot,
+    view: normalizeView(snapshot.view),
+    database: {
+      ...snapshot.database,
+      visibleViewIds: snapshot.database.visibleViewIds ?? [],
+      fields: snapshot.database.fields ?? [],
+      views: snapshot.database.views ?? [],
+      rows: snapshot.database.rows ?? [],
+      raw: {
+        database: raw.database ?? {},
+        rows: raw.rows ?? {},
+        row_documents: raw.row_documents ?? {},
+      },
+    },
+  };
+}
+
+export function normalizePublishedPageSnapshot(snapshot: PublishedPageSnapshotPayload): PublishedPageSnapshot {
+  if (snapshot.kind === 'document') {
+    return normalizeDocumentSnapshot(snapshot);
+  }
+
+  return normalizeDatabaseSnapshot(snapshot);
+}

--- a/src/application/publish-snapshot/types.ts
+++ b/src/application/publish-snapshot/types.ts
@@ -1,0 +1,160 @@
+import type { Descendant } from 'slate';
+
+import { DatabaseViewLayout, FieldId, RowId, ViewId, ViewInfo, ViewLayout, ViewMetaIcon } from '@/application/types';
+
+export type PublishedSnapshotKind = 'document' | 'database';
+
+export interface PublishedView {
+  viewId: ViewId;
+  name: string;
+  icon: ViewMetaIcon | null;
+  extra: string | null;
+  layout: ViewLayout;
+  childViews: ViewInfo[];
+  ancestorViews: ViewInfo[];
+  visibleViewIds: ViewId[];
+  databaseRelations: Record<string, ViewId>;
+}
+
+export interface PublishedViewPayload {
+  viewId: ViewId;
+  name: string;
+  icon: ViewMetaIcon | null;
+  extra: string | null;
+  layout: ViewLayout;
+  childViews?: ViewInfo[];
+  ancestorViews?: ViewInfo[];
+  visibleViewIds?: ViewId[];
+  databaseRelations?: Record<string, ViewId>;
+}
+
+export interface PublishedSnapshotBase {
+  schemaVersion: 1;
+  kind: PublishedSnapshotKind;
+  namespace: string;
+  publishName: string;
+  view: PublishedView;
+}
+
+export interface PublishedSnapshotPayloadBase {
+  schemaVersion: 1;
+  kind: PublishedSnapshotKind;
+  namespace: string;
+  publishName: string;
+  view: PublishedViewPayload;
+}
+
+export type PublishedJsonValue =
+  | string
+  | number
+  | boolean
+  | null
+  | PublishedJsonObject
+  | PublishedJsonValue[];
+
+export interface PublishedJsonObject {
+  [key: string]: PublishedJsonValue;
+}
+
+export interface PublishedDocumentBlock {
+  id: string;
+  ty: string;
+  parent?: string;
+  children: string;
+  external_id?: string | null;
+  external_type?: string | null;
+  data?: PublishedJsonObject | null;
+}
+
+export interface PublishedDocumentRaw {
+  data: {
+    page_id: string;
+    blocks: Record<string, PublishedDocumentBlock>;
+    meta: {
+      children_map?: Record<string, string[]>;
+      text_map?: Record<string, string> | null;
+    };
+  };
+}
+
+export interface PublishedDocumentSnapshot extends PublishedSnapshotBase {
+  kind: 'document';
+  document: {
+    children: Descendant[];
+    raw?: PublishedDocumentRaw;
+  };
+}
+
+// Server-facing payloads may omit collections that the UI expects to be present.
+// Normalize them before passing data into publish renderers.
+export interface PublishedDocumentSnapshotPayload extends PublishedSnapshotPayloadBase {
+  kind: 'document';
+  document?: {
+    children?: Descendant[];
+    raw?: PublishedDocumentRaw;
+  };
+}
+
+export interface PublishedDatabaseField {
+  fieldId: FieldId;
+  name: string;
+  fieldType: number;
+  isPrimary: boolean;
+  width?: number;
+}
+
+export interface PublishedDatabaseRow {
+  rowId: RowId;
+  cells: Record<FieldId, unknown>;
+}
+
+export interface PublishedDatabaseView {
+  viewId: ViewId;
+  name: string;
+  layout: DatabaseViewLayout;
+  fieldIds: FieldId[];
+  rowIds: RowId[];
+}
+
+export interface PublishedDatabaseSnapshot extends PublishedSnapshotBase {
+  kind: 'database';
+  database: {
+    databaseId: string;
+    activeViewId: ViewId;
+    visibleViewIds: ViewId[];
+    fields: PublishedDatabaseField[];
+    views: PublishedDatabaseView[];
+    rows: PublishedDatabaseRow[];
+    raw: {
+      database: PublishedJsonObject;
+      rows: Record<RowId, PublishedJsonObject>;
+      row_documents: Record<string, PublishedDocumentRaw>;
+    };
+  };
+}
+
+// Server-facing payloads may omit collections that the UI expects to be present.
+// Normalize them before passing data into publish renderers.
+export interface PublishedDatabaseSnapshotPayload extends PublishedSnapshotPayloadBase {
+  kind: 'database';
+  database: {
+    databaseId: string;
+    activeViewId: ViewId;
+    visibleViewIds?: ViewId[];
+    fields?: PublishedDatabaseField[];
+    views?: PublishedDatabaseView[];
+    rows?: PublishedDatabaseRow[];
+    raw?: {
+      database?: PublishedJsonObject;
+      rows?: Record<RowId, PublishedJsonObject>;
+      row_documents?: Record<string, PublishedDocumentRaw>;
+    };
+  };
+}
+
+export type PublishedPageSnapshot = PublishedDocumentSnapshot | PublishedDatabaseSnapshot;
+export type PublishedPageSnapshotPayload = PublishedDocumentSnapshotPayload | PublishedDatabaseSnapshotPayload;
+
+export interface PublishSnapshotDataSource {
+  getPage(namespace: string, publishName: string): Promise<PublishedPageSnapshot>;
+}

--- a/src/application/publish/__tests__/context.test.tsx
+++ b/src/application/publish/__tests__/context.test.tsx
@@ -1,0 +1,235 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { useEffect } from 'react';
+
+import { normalizePublishedPageSnapshot } from '@/application/publish-snapshot/normalize';
+import { getPublishedDatabaseRenderRowMap } from '@/application/publish-snapshot/database-yjs-render-bridge';
+import {
+  publishedDatabasePayload,
+  publishedDocumentPayload,
+  publishedRowDocumentId,
+} from '@/application/publish-snapshot/__fixtures__/published-page-snapshots';
+import { PublishContextType, PublishProvider, usePublishContext } from '@/application/publish';
+import { YjsEditorKey } from '@/application/types';
+import { yDocToSlateContent } from '@/application/slate-yjs/utils/convert';
+
+const mockNavigate = jest.fn();
+const mockGetPage = jest.fn();
+const mockGetView = jest.fn();
+const mockGetViewInfo = jest.fn();
+const mockGetViewMeta = jest.fn();
+const mockGetRowDocument = jest.fn();
+
+jest.mock('dexie-react-hooks', () => ({
+  useLiveQuery: jest.fn(() => undefined),
+}));
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useNavigate: () => mockNavigate,
+}));
+
+jest.mock('@/application/db', () => {
+  const hookSubscribers: Record<string, Set<(...args: unknown[]) => unknown>> = {};
+  const hook = jest.fn((eventName: string, subscriber?: (...args: unknown[]) => unknown) => {
+    hookSubscribers[eventName] = hookSubscribers[eventName] ?? new Set();
+
+    if (subscriber) {
+      hookSubscribers[eventName].add(subscriber);
+      return;
+    }
+
+    return {
+      unsubscribe: (fn: (...args: unknown[]) => unknown) => {
+        hookSubscribers[eventName]?.delete(fn);
+      },
+    };
+  });
+
+  return {
+    db: {
+      view_metas: {
+        get: jest.fn(),
+        hook,
+      },
+    },
+  };
+});
+
+jest.mock('@/application/publish-snapshot/data-source', () => ({
+  createPublishSnapshotDataSource: jest.fn(() => ({
+    getPage: (...args: unknown[]) => mockGetPage(...args),
+  })),
+}));
+
+jest.mock('@/application/services/domains', () => ({
+  PublishService: {
+    getOutline: jest.fn(async () => []),
+    getView: (...args: unknown[]) => mockGetView(...args),
+    getViewInfo: (...args: unknown[]) => mockGetViewInfo(...args),
+    getViewMeta: (...args: unknown[]) => mockGetViewMeta(...args),
+    getRowDocument: (...args: unknown[]) => mockGetRowDocument(...args),
+  },
+  RowService: {
+    create: jest.fn(),
+    remove: jest.fn(),
+  },
+}));
+
+function ContextProbe({ onContext }: { onContext: (context: PublishContextType) => void }) {
+  const context = usePublishContext();
+
+  useEffect(() => {
+    if (context) {
+      onContext(context);
+    }
+  }, [context, onContext]);
+
+  return (
+    <>
+      <div data-testid="view-id">{context?.viewMeta?.view_id}</div>
+      <div data-testid="breadcrumbs">{context?.breadcrumbs.map((crumb) => crumb.name).join('/')}</div>
+    </>
+  );
+}
+
+describe('PublishProvider', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetViewInfo.mockResolvedValue({
+      namespace: 'published-namespace',
+      publishName: 'published-document',
+      commentEnabled: true,
+      duplicateEnabled: true,
+    });
+  });
+
+  it('uses the published JSON snapshot as the publish metadata source', async () => {
+    const snapshot = normalizePublishedPageSnapshot(publishedDocumentPayload);
+    let latestContext: PublishContextType | undefined;
+
+    render(
+      <PublishProvider
+        namespace={snapshot.namespace}
+        publishName={snapshot.publishName}
+        snapshot={snapshot}
+      >
+        <ContextProbe onContext={(context) => {
+          latestContext = context;
+        }} />
+      </PublishProvider>
+    );
+
+    expect(screen.getByTestId('view-id').textContent).toBe(snapshot.view.viewId);
+    await waitFor(() => {
+      expect(screen.getByTestId('breadcrumbs').textContent).toBe(snapshot.view.name);
+    });
+    await waitFor(() => {
+      expect(latestContext?.duplicateEnabled).toBe(true);
+    });
+
+    await expect(latestContext?.getViewIdFromDatabaseId?.('related-database-id')).resolves.toBe(
+      'related-database-view-id'
+    );
+    expect(mockGetViewInfo).toHaveBeenCalledWith(snapshot.view.viewId);
+    expect(mockGetViewMeta).not.toHaveBeenCalled();
+  });
+
+  it('loads related published pages through the JSON snapshot data source', async () => {
+    const currentSnapshot = normalizePublishedPageSnapshot(publishedDocumentPayload);
+    const relatedSnapshot = normalizePublishedPageSnapshot(publishedDatabasePayload);
+    let latestContext: PublishContextType | undefined;
+
+    if (relatedSnapshot.kind !== 'database') {
+      throw new Error('Expected database snapshot fixture');
+    }
+
+    mockGetViewInfo.mockImplementation(async (viewId: string) => {
+      if (viewId === relatedSnapshot.view.viewId) {
+        return {
+          namespace: relatedSnapshot.namespace,
+          publishName: relatedSnapshot.publishName,
+          commentEnabled: true,
+          duplicateEnabled: true,
+        };
+      }
+
+      return {
+        namespace: currentSnapshot.namespace,
+        publishName: currentSnapshot.publishName,
+        commentEnabled: true,
+        duplicateEnabled: true,
+      };
+    });
+    mockGetPage.mockResolvedValue(relatedSnapshot);
+
+    render(
+      <PublishProvider
+        namespace={currentSnapshot.namespace}
+        publishName={currentSnapshot.publishName}
+        snapshot={currentSnapshot}
+      >
+        <ContextProbe onContext={(context) => {
+          latestContext = context;
+        }} />
+      </PublishProvider>
+    );
+
+    await waitFor(() => {
+      expect(latestContext).toBeDefined();
+    });
+
+    const doc = await latestContext?.loadView(relatedSnapshot.view.viewId);
+    const database = doc?.getMap(YjsEditorKey.data_section).get(YjsEditorKey.database);
+
+    expect(mockGetPage).toHaveBeenCalledWith(relatedSnapshot.namespace, relatedSnapshot.publishName);
+    expect(mockGetView).not.toHaveBeenCalled();
+    expect(doc?.guid).toBe(relatedSnapshot.database.databaseId);
+    expect(database).toBeDefined();
+    expect(Object.keys(getPublishedDatabaseRenderRowMap(doc) ?? {})).toEqual(['published-row-id']);
+  });
+
+  it('loads published row documents from the related database JSON snapshot', async () => {
+    const currentSnapshot = normalizePublishedPageSnapshot(publishedDocumentPayload);
+    const relatedSnapshot = normalizePublishedPageSnapshot(publishedDatabasePayload);
+    let latestContext: PublishContextType | undefined;
+
+    if (relatedSnapshot.kind !== 'database') {
+      throw new Error('Expected database snapshot fixture');
+    }
+
+    mockGetViewInfo.mockResolvedValue({
+      namespace: relatedSnapshot.namespace,
+      publishName: relatedSnapshot.publishName,
+      commentEnabled: true,
+      duplicateEnabled: true,
+    });
+    mockGetPage.mockResolvedValue(relatedSnapshot);
+
+    render(
+      <PublishProvider
+        namespace={currentSnapshot.namespace}
+        publishName={currentSnapshot.publishName}
+        snapshot={currentSnapshot}
+      >
+        <ContextProbe onContext={(context) => {
+          latestContext = context;
+        }} />
+      </PublishProvider>
+    );
+
+    await waitFor(() => {
+      expect(latestContext).toBeDefined();
+    });
+
+    await latestContext?.loadView(relatedSnapshot.view.viewId);
+
+    const rowDocument = await latestContext?.loadRowDocument?.(publishedRowDocumentId);
+    const rowDocumentContent = rowDocument ? yDocToSlateContent(rowDocument) : undefined;
+    const firstRowDocumentBlock = rowDocumentContent?.children[0] as {
+      children?: Array<{ children?: Array<{ text?: string }> }>;
+    } | undefined;
+
+    expect(firstRowDocumentBlock?.children?.[0]?.children?.[0]?.text).toBe('Published row document body');
+    expect(mockGetRowDocument).not.toHaveBeenCalled();
+  });
+});

--- a/src/application/publish/context.tsx
+++ b/src/application/publish/context.tsx
@@ -4,10 +4,93 @@ import { useNavigate } from 'react-router-dom';
 
 import { db } from '@/application/db';
 import { ViewMeta } from '@/application/db/tables/view_metas';
-import { AppendBreadcrumb, CreateRow, LoadView, LoadViewMeta, View, ViewInfo, ViewLayout } from '@/application/types';
+import { createDatabaseYjsRenderDocsFromSnapshot } from '@/application/publish-snapshot/database-yjs-render-bridge';
+import { createPublishSnapshotDataSource } from '@/application/publish-snapshot/data-source';
+import {
+  createDocumentYjsRenderDocFromRawData,
+  createDocumentYjsRenderDocFromSnapshot,
+} from '@/application/publish-snapshot/document-yjs-render-bridge';
+import type { PublishedDocumentRaw, PublishedPageSnapshot, PublishedView } from '@/application/publish-snapshot/types';
+import { AppendBreadcrumb, CreateRow, LoadView, LoadViewMeta, View, ViewInfo, ViewLayout, YDoc } from '@/application/types';
 import { notify } from '@/components/_shared/notify';
 import { findAncestors, findView } from '@/components/_shared/outline/utils';
 import { PublishService, RowService } from '@/application/services/domains';
+
+function publishedViewToViewInfo(view: PublishedView): ViewInfo {
+  return {
+    view_id: view.viewId,
+    name: view.name,
+    icon: view.icon,
+    extra: view.extra,
+    layout: view.layout,
+    created_at: '',
+    created_by: '',
+    last_edited_time: '',
+    last_edited_by: '',
+    child_views: view.childViews,
+  };
+}
+
+function publishedSnapshotToViewMeta(snapshot: PublishedPageSnapshot): ViewMeta {
+  const viewInfo = publishedViewToViewInfo(snapshot.view);
+
+  return {
+    ...viewInfo,
+    publish_name: `${snapshot.namespace}_${snapshot.publishName}`,
+    child_views: snapshot.view.childViews,
+    ancestor_views: snapshot.view.ancestorViews,
+    visible_view_ids: snapshot.view.visibleViewIds,
+    database_relations: snapshot.view.databaseRelations,
+  };
+}
+
+function parseViewInfoToView(meta: ViewInfo | ViewMeta): View {
+  let extra = null;
+
+  try {
+    extra = meta.extra ? JSON.parse(meta.extra) : null;
+  } catch (e) {
+    // do nothing
+  }
+
+  return {
+    is_private: false,
+    view_id: meta.view_id,
+    name: meta.name,
+    layout: meta.layout,
+    extra,
+    icon: meta.icon,
+    children: meta.child_views?.map(parseViewInfoToView) || [],
+    is_published: true,
+    database_relations: 'database_relations' in meta ? meta.database_relations : undefined,
+  };
+}
+
+function findViewInfoById(views: ViewInfo[] | null | undefined, viewId: string): ViewInfo | undefined {
+  if (!views) return;
+
+  for (const view of views) {
+    if (view.view_id === viewId) return view;
+
+    const child = findViewInfoById(view.child_views, viewId);
+
+    if (child) return child;
+  }
+}
+
+function snapshotToRenderDoc(snapshot: PublishedPageSnapshot) {
+  if (snapshot.kind === 'database') {
+    return createDatabaseYjsRenderDocsFromSnapshot(snapshot).doc;
+  }
+
+  return createDocumentYjsRenderDocFromSnapshot(snapshot);
+}
+
+function rowDocumentsFromSnapshot(snapshot: PublishedPageSnapshot): Record<string, PublishedDocumentRaw> {
+  if (snapshot.kind !== 'database') return {};
+
+  return snapshot.database.raw.row_documents;
+}
 
 export interface PublishContextType {
   namespace: string;
@@ -19,6 +102,7 @@ export interface PublishContextType {
   loadViewMeta: LoadViewMeta;
   createRow?: CreateRow;
   loadView: LoadView;
+  loadRowDocument?: (documentId: string) => Promise<YDoc | null>;
   outline?: View[];
   appendBreadcrumb?: AppendBreadcrumb;
   breadcrumbs: View[];
@@ -37,29 +121,39 @@ export const PublishProvider = ({
   publishName,
   isTemplateThumb,
   isTemplate,
+  snapshot,
 }: {
   children: React.ReactNode;
   namespace: string;
   publishName: string;
   isTemplateThumb?: boolean;
   isTemplate?: boolean;
+  snapshot?: PublishedPageSnapshot;
 }) => {
   const [outline, setOutline] = useState<View[]>([]);
   const createdRowKeys = useRef<string[]>([]);
   const [rendered, setRendered] = useState(false);
+  const [snapshotDataSource] = useState(() => createPublishSnapshotDataSource());
+  const rowDocumentSnapshotsRef = useRef<Record<string, PublishedDocumentRaw>>({});
+  const rowDocumentDocsRef = useRef<Map<string, YDoc>>(new Map());
+  const viewMetaSubscribersRef = useRef<Map<string, (meta: ViewMeta) => void>>(new Map());
 
-  const [subscribers, setSubscribers] = useState<Map<string, (meta: ViewMeta) => void>>(new Map());
-
-  useEffect(() => {
-    return () => {
-      setSubscribers(new Map());
-    };
+  const registerSnapshotRowDocuments = useCallback((snapshot: PublishedPageSnapshot) => {
+    Object.assign(rowDocumentSnapshotsRef.current, rowDocumentsFromSnapshot(snapshot));
   }, []);
 
-  const viewMeta = useLiveQuery(async () => {
+  const snapshotViewMeta = useMemo(() => {
+    return snapshot ? publishedSnapshotToViewMeta(snapshot) : undefined;
+  }, [snapshot]);
+
+  const cachedViewMeta = useLiveQuery(async () => {
     const name = `${namespace}_${publishName}`;
 
-    const view = await db.view_metas.get(name);
+    return db.view_metas.get(name);
+  }, [namespace, publishName]);
+
+  const viewMeta = useMemo(() => {
+    const view = snapshotViewMeta ?? cachedViewMeta;
 
     if (!view) return;
 
@@ -67,7 +161,7 @@ export const PublishProvider = ({
       ...view,
       name: findView(outline, view.view_id)?.name || view.name,
     };
-  }, [namespace, publishName, outline]);
+  }, [cachedViewMeta, outline, snapshotViewMeta]);
 
   const viewId = viewMeta?.view_id;
 
@@ -80,39 +174,18 @@ export const PublishProvider = ({
   >();
 
   const originalCrumbs = useMemo(() => {
-    if (!viewMeta || !outline) return [];
-    const ancestors = findAncestors(outline, viewMeta?.view_id);
+    if (!viewMeta) return [];
+    const ancestors = outline.length > 0 ? findAncestors(outline, viewMeta.view_id) : undefined;
 
     if (ancestors) return ancestors;
     if (!viewMeta?.ancestor_views) return [];
-    const parseToView = (ancestor: ViewInfo): View => {
-      let extra = null;
 
-      try {
-        extra = ancestor.extra ? JSON.parse(ancestor.extra) : null;
-      } catch (e) {
-        // do nothing
-      }
+    const currentView = parseViewInfoToView(viewMeta);
+    const crumbs = viewMeta.ancestor_views
+      .slice(1)
+      .map((item) => findView(outline, item.view_id) || parseViewInfoToView(item));
 
-      return {
-        view_id: ancestor.view_id,
-        name: ancestor.name,
-        icon: ancestor.icon,
-        layout: ancestor.layout,
-        extra,
-        is_published: true,
-        children: [],
-        is_private: false,
-      };
-    };
-
-    const currentView = parseToView(viewMeta);
-
-    return (
-      viewMeta?.ancestor_views.slice(1).map((item) => findView(outline, item.view_id) || parseToView(item)) || [
-        currentView,
-      ]
-    );
+    return crumbs.length > 0 ? crumbs : [currentView];
   }, [viewMeta, outline]);
 
   const [breadcrumbs, setBreadcrumbs] = useState<View[]>([]);
@@ -140,22 +213,34 @@ export const PublishProvider = ({
   }, []);
 
   useEffect(() => {
-    db.view_metas.hook('creating', (primaryKey, obj) => {
-      const subscriber = subscribers.get(primaryKey);
+    rowDocumentSnapshotsRef.current = {};
+    rowDocumentDocsRef.current.clear();
+
+    if (snapshot) {
+      registerSnapshotRowDocuments(snapshot);
+    }
+  }, [namespace, publishName, registerSnapshotRowDocuments, snapshot]);
+
+  useEffect(() => {
+    const subscribers = viewMetaSubscribersRef.current;
+    const handleCreating = (primaryKey: string, obj: ViewMeta) => {
+      const subscriber = subscribers.get(String(primaryKey));
 
       subscriber?.(obj);
 
       return obj;
-    });
-    db.view_metas.hook('deleting', (primaryKey, obj) => {
-      const subscriber = subscribers.get(primaryKey);
+    };
+
+    const handleDeleting = (primaryKey: string, obj: ViewMeta) => {
+      const subscriber = subscribers.get(String(primaryKey));
 
       subscriber?.(obj);
 
       return;
-    });
-    db.view_metas.hook('updating', (modifications, primaryKey, obj) => {
-      const subscriber = subscribers.get(primaryKey);
+    };
+
+    const handleUpdating = (modifications: Partial<ViewMeta>, primaryKey: string, obj: ViewMeta) => {
+      const subscriber = subscribers.get(String(primaryKey));
 
       subscriber?.({
         ...obj,
@@ -163,8 +248,19 @@ export const PublishProvider = ({
       });
 
       return modifications;
-    });
-  }, [subscribers]);
+    };
+
+    db.view_metas.hook('creating', handleCreating);
+    db.view_metas.hook('deleting', handleDeleting);
+    db.view_metas.hook('updating', handleUpdating);
+
+    return () => {
+      db.view_metas.hook('creating').unsubscribe(handleCreating);
+      db.view_metas.hook('deleting').unsubscribe(handleDeleting);
+      db.view_metas.hook('updating').unsubscribe(handleUpdating);
+      subscribers.clear();
+    };
+  }, []);
 
   const prevViewMeta = useRef(viewMeta);
 
@@ -203,8 +299,21 @@ export const PublishProvider = ({
   const navigate = useNavigate();
 
   const loadViewMeta = useCallback(
-    async (viewId: string, callback?: (meta: View) => void) => {
+    async (viewId: string, callback?: (meta: View | null) => void) => {
       try {
+        const snapshotMeta =
+          viewMeta?.view_id === viewId
+            ? viewMeta
+            : findViewInfoById(snapshotViewMeta?.child_views, viewId) ||
+              findViewInfoById(snapshotViewMeta?.ancestor_views, viewId);
+
+        if (snapshotMeta) {
+          const view = parseViewInfoToView(snapshotMeta);
+
+          callback?.(view);
+          return view;
+        }
+
         const info = await PublishService.getViewInfo(viewId);
 
         if (!info) {
@@ -212,40 +321,20 @@ export const PublishProvider = ({
         }
 
         const { namespace, publishName } = info;
-
         const name = `${namespace}_${publishName}`;
-
         const meta = await PublishService.getViewMeta(namespace, publishName);
 
         if (!meta) {
           return Promise.reject(new Error('View meta has not been published yet'));
         }
 
-        const parseMetaToView = (meta: ViewInfo | ViewMeta): View => {
-          return {
-            is_private: false,
-            view_id: meta.view_id,
-            name: meta.name,
-            layout: meta.layout,
-            extra: meta.extra ? JSON.parse(meta.extra) : undefined,
-            icon: meta.icon,
-            children: meta.child_views?.map(parseMetaToView) || [],
-            is_published: true,
-            database_relations: 'database_relations' in meta ? meta.database_relations : undefined,
-          };
-        };
-
-        const res = parseMetaToView(meta);
+        const res = parseViewInfoToView(meta);
 
         callback?.(res);
 
         if (callback) {
-          setSubscribers((prev) => {
-            prev.set(name, (meta) => {
-              return callback?.(parseMetaToView(meta));
-            });
-
-            return prev;
+          viewMetaSubscribersRef.current.set(name, (meta) => {
+            return callback?.(parseViewInfoToView(meta));
           });
         }
 
@@ -254,7 +343,7 @@ export const PublishProvider = ({
         return Promise.reject(e);
       }
     },
-    []
+    [snapshotViewMeta, viewMeta]
   );
 
   const toView = useCallback(
@@ -352,10 +441,25 @@ export const PublishProvider = ({
     []
   );
 
+  const loadRowDocument = useCallback(async (documentId: string): Promise<YDoc | null> => {
+    const cachedDoc = rowDocumentDocsRef.current.get(documentId);
+
+    if (cachedDoc) return cachedDoc;
+
+    const rawDocument = rowDocumentSnapshotsRef.current[documentId];
+
+    if (!rawDocument) return null;
+
+    const doc = createDocumentYjsRenderDocFromRawData(documentId, rawDocument);
+
+    rowDocumentDocsRef.current.set(documentId, doc);
+    return doc;
+  }, []);
+
   const loadView = useCallback(
     async (viewId: string, isSubDocument?: boolean) => {
       if (isSubDocument) {
-        const data = await PublishService.getRowDocument(viewId);
+        const data = await loadRowDocument(viewId);
 
         if (!data) {
           return Promise.reject(new Error('View has not been published yet'));
@@ -365,6 +469,10 @@ export const PublishProvider = ({
       }
 
       try {
+        if (snapshot?.view.viewId === viewId) {
+          return snapshotToRenderDoc(snapshot);
+        }
+
         const res = await PublishService.getViewInfo(viewId);
 
         if (!res) {
@@ -373,18 +481,20 @@ export const PublishProvider = ({
 
         const { namespace, publishName } = res;
 
-        const data = PublishService.getView(namespace, publishName);
+        const data = await snapshotDataSource.getPage(namespace, publishName);
 
         if (!data) {
           throw new Error('View has not been published yet');
         }
 
-        return data;
+        registerSnapshotRowDocuments(data);
+
+        return snapshotToRenderDoc(data);
       } catch (e) {
         return Promise.reject(e);
       }
     },
-    []
+    [loadRowDocument, registerSnapshotRowDocuments, snapshot, snapshotDataSource]
   );
 
   const onRendered = useCallback(() => {
@@ -402,11 +512,7 @@ export const PublishProvider = ({
 
   const getViewIdFromDatabaseId = useCallback(
     async (databaseId: string) => {
-      if (!viewId) return null;
-      const currentView = await loadViewMeta(viewId);
-
-      if (!currentView) return null;
-      const databaseRelations = Object.entries(currentView.database_relations || {});
+      const databaseRelations = Object.entries(viewMeta?.database_relations || {});
 
       for (const [relationDatabaseId, relationViewId] of databaseRelations) {
         if (relationDatabaseId === databaseId) {
@@ -414,9 +520,20 @@ export const PublishProvider = ({
         }
       }
 
+      if (!viewId) return null;
+      const currentView = await loadViewMeta(viewId);
+
+      if (!currentView) return null;
+
+      for (const [relationDatabaseId, relationViewId] of Object.entries(currentView.database_relations || {})) {
+        if (relationDatabaseId === databaseId) {
+          return relationViewId;
+        }
+      }
+
       return null;
     },
-    [viewId, loadViewMeta]
+    [loadViewMeta, viewId, viewMeta]
   );
 
   useEffect(() => {
@@ -442,6 +559,7 @@ export const PublishProvider = ({
       commentEnabled,
       duplicateEnabled,
       getViewIdFromDatabaseId,
+      loadRowDocument,
     }),
     [
       loadView,
@@ -460,6 +578,7 @@ export const PublishProvider = ({
       commentEnabled,
       duplicateEnabled,
       getViewIdFromDatabaseId,
+      loadRowDocument,
     ]
   );
 

--- a/src/components/database/Database.tsx
+++ b/src/components/database/Database.tsx
@@ -36,6 +36,8 @@ import { DatabaseRow } from '@/components/database/DatabaseRow';
 import DatabaseRowModal from '@/components/database/DatabaseRowModal';
 import DatabaseViews from '@/components/database/DatabaseViews';
 import { CalendarViewType } from '@/components/database/fullcalendar/types';
+import { shouldUseFixedDatabaseViewport } from '@/components/database/layout';
+import { cn } from '@/lib/utils';
 
 import { DatabaseContextProvider } from './DatabaseContext';
 
@@ -51,6 +53,7 @@ function createDeferredGate() {
 export interface Database2Props {
   workspaceId: string;
   doc: YDoc;
+  initialRowMap?: Record<RowId, YDoc>;
   readOnly?: boolean;
   createRow?: CreateRow;
   loadView?: LoadView;
@@ -166,8 +169,13 @@ function Database(props: Database2Props) {
     generateAISummaryForRow,
     generateAITranslateForRow,
   } = props;
+  const shouldUseFixedViewport = shouldUseFixedDatabaseViewport({
+    embeddedHeight,
+    isDocumentBlock: _isDocumentBlock,
+    variant: props.variant,
+  });
 
-  const [rowMap, setRowMap] = useState<Record<RowId, YDoc>>({});
+  const [rowMap, setRowMap] = useState<Record<RowId, YDoc>>(() => props.initialRowMap ?? {});
   const rowMapRef = useRef(rowMap);
   const pendingRowDocsRef = useRef<Map<RowId, Promise<YDoc | undefined>>>(new Map());
   const prefetchPromisesRef = useRef<Map<string, Promise<void>>>(new Map());
@@ -572,6 +580,8 @@ function Database(props: Database2Props) {
   );
 
   useEffect(() => {
+    const initialRowMap = props.initialRowMap ?? {};
+
     rowMapRef.current = {};
     pendingRowDocsRef.current.clear();
     blobPrefetchPromiseRef.current = null;
@@ -579,10 +589,11 @@ function Database(props: Database2Props) {
     syncedRowKeysRef.current.clear();
     batchPreloadDoneRef.current = false;
     seedsGateRef.current = createDeferredGate();
-    setRowMap({});
+    rowMapRef.current = initialRowMap;
+    setRowMap(initialRowMap);
     setBlobPrefetchComplete(false);
     setSeedsReady(false);
-  }, [doc.guid]);
+  }, [doc.guid, props.initialRowMap]);
 
   // Trigger blob prefetch when database opens
   useEffect(() => {
@@ -832,7 +843,12 @@ function Database(props: Database2Props) {
         {rowId ? (
           <DatabaseRow appendBreadcrumb={appendBreadcrumb} rowId={rowId} />
         ) : (
-          <div className='appflowy-database relative flex w-full flex-1 select-text flex-col overflow-hidden'>
+          <div
+            className={cn(
+              'appflowy-database relative flex w-full select-text flex-col',
+              shouldUseFixedViewport ? 'flex-1 overflow-hidden' : 'overflow-visible'
+            )}
+          >
             <DatabaseViews
               visibleViewIds={visibleViewIds}
               databasePageId={databasePageId}

--- a/src/components/database/DatabaseViews.tsx
+++ b/src/components/database/DatabaseViews.tsx
@@ -2,7 +2,7 @@ import { Suspense, useCallback, useEffect, useMemo, useRef, useState } from 'rea
 import { flushSync } from 'react-dom';
 import { ErrorBoundary } from 'react-error-boundary';
 
-import { useDatabase, useDatabaseViewsSelector } from '@/application/database-yjs';
+import { useDatabase, useDatabaseContext, useDatabaseViewsSelector } from '@/application/database-yjs';
 import { FilterType } from '@/application/database-yjs/database.type';
 import { DatabaseViewLayout, YjsDatabaseKey } from '@/application/types';
 import { Board } from '@/components/database/board';
@@ -11,7 +11,9 @@ import { DatabaseTabs } from '@/components/database/components/tabs';
 import UnsupportedView from '@/components/database/components/UnsupportedView';
 import { Calendar } from '@/components/database/fullcalendar';
 import { Grid } from '@/components/database/grid';
+import { shouldUseFixedDatabaseViewport } from '@/components/database/layout';
 import { ElementFallbackRender } from '@/components/error/ElementFallbackRender';
+import { cn } from '@/lib/utils';
 import {
   insertViewIdAfter,
   readStoredViewOrder,
@@ -59,6 +61,7 @@ function DatabaseViews({
   onViewIdsChanged?: (viewIds: string[]) => void;
 }) {
   const { childViews, viewIds } = useDatabaseViewsSelector(databasePageId, visibleViewIds);
+  const { isDocumentBlock, variant } = useDatabaseContext();
   const database = useDatabase();
   const databaseId = database?.get(YjsDatabaseKey.id) as string | undefined;
   const views = database?.get(YjsDatabaseKey.views);
@@ -313,6 +316,11 @@ function DatabaseViews({
         return null;
     }
   }, [effectiveLayout]);
+  const shouldUseFixedViewport = shouldUseFixedDatabaseViewport({
+    embeddedHeight: fixedHeight,
+    isDocumentBlock,
+    variant,
+  });
   const databaseConditionsValue = useMemo(
     () => ({
       expanded: conditionsExpanded,
@@ -352,7 +360,10 @@ function DatabaseViews({
         <DatabaseConditions />
 
         <div
-          className={'relative flex h-full w-full flex-1 flex-col overflow-hidden'}
+          className={cn(
+            'relative flex w-full flex-col',
+            shouldUseFixedViewport ? 'h-full flex-1 overflow-hidden' : 'overflow-visible'
+          )}
           style={
             fixedHeight !== undefined
               ? { height: `${fixedHeight}px`, maxHeight: `${fixedHeight}px` }
@@ -360,7 +371,7 @@ function DatabaseViews({
           }
         >
           <div
-            className='h-full w-full'
+            className={cn('w-full', shouldUseFixedViewport && 'h-full')}
             style={
               fixedHeight !== undefined
                 ? { height: `${fixedHeight}px`, maxHeight: `${fixedHeight}px` }

--- a/src/components/database/__tests__/layout.test.ts
+++ b/src/components/database/__tests__/layout.test.ts
@@ -1,0 +1,32 @@
+import { UIVariant } from '@/application/types';
+import { shouldUseFixedDatabaseViewport } from '@/components/database/layout';
+
+describe('shouldUseFixedDatabaseViewport', () => {
+  it('keeps app standalone databases in a fixed viewport', () => {
+    expect(shouldUseFixedDatabaseViewport({ variant: UIVariant.App })).toBe(true);
+    expect(shouldUseFixedDatabaseViewport({})).toBe(true);
+  });
+
+  it('lets published standalone databases flow with the page', () => {
+    expect(shouldUseFixedDatabaseViewport({ variant: UIVariant.Publish })).toBe(false);
+  });
+
+  it('lets document block databases flow with the document', () => {
+    expect(
+      shouldUseFixedDatabaseViewport({
+        isDocumentBlock: true,
+        variant: UIVariant.Publish,
+      })
+    ).toBe(false);
+  });
+
+  it('uses a fixed viewport when an embedded height is provided', () => {
+    expect(
+      shouldUseFixedDatabaseViewport({
+        embeddedHeight: 420,
+        isDocumentBlock: true,
+        variant: UIVariant.Publish,
+      })
+    ).toBe(true);
+  });
+});

--- a/src/components/database/components/filters/overview/FilterContentOverview.tsx
+++ b/src/components/database/components/filters/overview/FilterContentOverview.tsx
@@ -7,6 +7,7 @@ import {
   FieldType,
   Filter,
   PersonFilterCondition,
+  RelationFilterCondition,
   SelectOptionFilter,
   useFieldSelector,
 } from '@/application/database-yjs';
@@ -26,9 +27,25 @@ export function FilterContentOverview({ filter }: { filter: Filter }) {
     switch (fieldType) {
       case FieldType.RichText:
       case FieldType.URL:
-      case FieldType.Relation:
       case FieldType.Rollup:
         return <TextFilterContentOverview filter={filter} />;
+      case FieldType.Relation:
+        return (
+          <>
+            :{' '}
+            {filter.condition === RelationFilterCondition.RelationContains
+              ? t('grid.personFilter.contains')
+              : filter.condition === RelationFilterCondition.RelationDoesNotContain
+              ? t('grid.personFilter.doesNotContain')
+              : filter.condition === RelationFilterCondition.RelationIsEmpty ||
+                filter.condition === RelationFilterCondition.RelationLegacyTextIsEmpty
+              ? t('grid.personFilter.isEmpty')
+              : filter.condition === RelationFilterCondition.RelationIsNotEmpty ||
+                filter.condition === RelationFilterCondition.RelationLegacyTextIsNotEmpty
+              ? t('grid.personFilter.isNotEmpty')
+              : ''}
+          </>
+        );
       case FieldType.Number:
         return <NumberFilterContentOverview filter={filter} />;
       case FieldType.DateTime:

--- a/src/components/database/components/grid/grid-row/useRenderRows.tsx
+++ b/src/components/database/components/grid/grid-row/useRenderRows.tsx
@@ -2,7 +2,6 @@ import { useMemo } from 'react';
 
 import { useReadOnly, useRowOrdersSelector } from '@/application/database-yjs';
 
-
 export enum RenderRowType {
   Header = 'header',
   Row = 'row',

--- a/src/components/database/layout.ts
+++ b/src/components/database/layout.ts
@@ -1,0 +1,15 @@
+import { UIVariant } from '@/application/types';
+
+export interface DatabaseViewportLayoutInput {
+  embeddedHeight?: number;
+  isDocumentBlock?: boolean;
+  variant?: UIVariant;
+}
+
+export function shouldUseFixedDatabaseViewport({
+  embeddedHeight,
+  isDocumentBlock,
+  variant,
+}: DatabaseViewportLayoutInput) {
+  return embeddedHeight !== undefined || (!isDocumentBlock && variant !== UIVariant.Publish);
+}

--- a/src/components/editor/Editable.tsx
+++ b/src/components/editor/Editable.tsx
@@ -201,10 +201,10 @@ const EditorEditable = () => {
               autoCorrect={'off'}
               autoComplete={'off'}
               scrollSelectionIntoView={scrollSelectionIntoView}
-              onCompositionStart={onCompositionStart}
-              onKeyDown={onKeyDown}
+              onCompositionStart={readOnly ? undefined : onCompositionStart}
+              onKeyDown={readOnly ? undefined : onKeyDown}
               onMouseDown={handleMouseDown}
-              onClick={handleClick}
+              onClick={readOnly ? undefined : handleClick}
             />
           </ErrorBoundary>
 

--- a/src/components/editor/EditorContext.tsx
+++ b/src/components/editor/EditorContext.tsx
@@ -75,6 +75,7 @@ export interface EditorContextState {
   navigateToView?: (viewId: string, blockOrRowId?: string) => Promise<void>;
   loadViewMeta?: LoadViewMeta;
   loadView?: LoadView;
+  loadRowDocument?: (documentId: string) => Promise<YDoc | null>;
   createRow?: CreateRow;
   bindViewSync?: (doc: YDoc) => SyncContext | null;
   readSummary?: boolean;
@@ -119,6 +120,7 @@ export const EditorContextProvider = ({
   navigateToView,
   loadViewMeta,
   loadView,
+  loadRowDocument,
   createRow,
   bindViewSync,
   readSummary,
@@ -201,6 +203,7 @@ export const EditorContextProvider = ({
       navigateToView,
       loadViewMeta,
       loadView,
+      loadRowDocument,
       createRow,
       bindViewSync,
       readSummary,
@@ -240,6 +243,7 @@ export const EditorContextProvider = ({
       navigateToView,
       loadViewMeta,
       loadView,
+      loadRowDocument,
       createRow,
       bindViewSync,
       readSummary,

--- a/src/components/editor/StaticEditor.tsx
+++ b/src/components/editor/StaticEditor.tsx
@@ -1,0 +1,62 @@
+import { memo, useCallback, useMemo, useState } from 'react';
+import { createEditor } from 'slate';
+import type { Descendant } from 'slate';
+import { Slate, withReact } from 'slate-react';
+
+import { BlockType, YjsEditorKey } from '@/application/types';
+import EditorEditable from '@/components/editor/Editable';
+import { defaultLayoutStyle, EditorContextProvider, EditorContextState } from '@/components/editor/EditorContext';
+import { withPlugins } from '@/components/editor/plugins';
+import './editor.scss';
+
+const emptyValue: Descendant[] = [
+  {
+    type: BlockType.Paragraph,
+    blockId: 'published-empty-paragraph',
+    data: {},
+    children: [
+      {
+        type: YjsEditorKey.text,
+        textId: 'published-empty-text',
+        children: [{ text: '' }],
+      },
+    ],
+  },
+] as Descendant[];
+
+export interface StaticEditorProps extends Omit<EditorContextState, 'readOnly'> {
+  value: Descendant[];
+}
+
+export const StaticEditor = memo(({ value, layoutStyle = defaultLayoutStyle, ...props }: StaticEditorProps) => {
+  const [codeGrammars, setCodeGrammars] = useState<Record<string, string>>({});
+  const handleAddCodeGrammars = useCallback((blockId: string, grammar: string) => {
+    setCodeGrammars((prev) => ({ ...prev, [blockId]: grammar }));
+  }, []);
+  const editor = useMemo(() => {
+    const nextEditor = withPlugins(withReact(createEditor()));
+
+    Object.assign(nextEditor, {
+      readOnly: true,
+    });
+
+    return nextEditor;
+  }, []);
+  const initialValue = value.length > 0 ? value : emptyValue;
+
+  return (
+    <EditorContextProvider
+      {...props}
+      readOnly
+      layoutStyle={layoutStyle}
+      codeGrammars={codeGrammars}
+      addCodeGrammars={handleAddCodeGrammars}
+    >
+      <Slate key={props.viewId} editor={editor} initialValue={initialValue}>
+        <EditorEditable />
+      </Slate>
+    </EditorContextProvider>
+  );
+});
+
+export default StaticEditor;

--- a/src/components/editor/components/blocks/database/DatabaseBlock.tsx
+++ b/src/components/editor/components/blocks/database/DatabaseBlock.tsx
@@ -5,7 +5,7 @@ import { ReactEditor, useReadOnly, useSlateStatic } from 'slate-react';
 import { APP_EVENTS } from '@/application/constants';
 import { DatabaseContextState } from '@/application/database-yjs';
 import { ViewService } from '@/application/services/domains';
-import { YjsEditorKey, YSharedRoot } from '@/application/types';
+import { UIVariant, YjsEditorKey, YSharedRoot } from '@/application/types';
 import { useEmbeddedVisibleViewIds } from '@/components/database/hooks';
 import { DatabaseNode, EditorElementProps } from '@/components/editor/editor.type';
 import { useEditorContext } from '@/components/editor/EditorContext';
@@ -33,6 +33,8 @@ export const DatabaseBlock = memo(
 
     const [hasDatabase, setHasDatabase] = useState(false);
     const [deletionStatus, setDeletionStatus] = useState<'none' | 'inTrash' | 'deleted' | null>(null);
+    const effectiveDeletionStatus =
+      context.variant === UIVariant.Publish && deletionStatus === null ? 'none' : deletionStatus;
     const containerRef = useRef<HTMLDivElement | null>(null);
     const editor = useSlateStatic();
     const readOnly = useReadOnly() || editor.isElementReadOnly(node as unknown as Element);
@@ -339,7 +341,7 @@ export const DatabaseBlock = memo(
             selectedViewId={selectedViewId}
             hasDatabase={hasDatabase}
             notFound={notFound}
-            deletionStatus={deletionStatus}
+            deletionStatus={effectiveDeletionStatus}
             paddingStart={paddingStart}
             paddingEnd={paddingEnd}
             width={width}

--- a/src/components/editor/components/blocks/database/components/DatabaseContent.tsx
+++ b/src/components/editor/components/blocks/database/components/DatabaseContent.tsx
@@ -2,6 +2,7 @@ import CircularProgress from '@mui/material/CircularProgress';
 import { useTranslation } from 'react-i18next';
 
 import { DatabaseContextState } from '@/application/database-yjs';
+import { getPublishedDatabaseRenderRowMap } from '@/application/publish-snapshot/database-yjs-render-bridge';
 import { LoadView, LoadViewMeta, UIVariant, YDoc } from '@/application/types';
 import { Database } from '@/components/database';
 
@@ -66,6 +67,7 @@ export const DatabaseContent = ({
 }: DatabaseContentProps) => {
   const { t } = useTranslation();
   const isPublishVariant = context?.variant === UIVariant.Publish;
+  const initialRowMap = isPublishVariant ? getPublishedDatabaseRenderRowMap(doc) : undefined;
 
   if (selectedViewId && doc && hasDatabase && !notFound && deletionStatus === 'none') {
     return (
@@ -76,29 +78,30 @@ export const DatabaseContent = ({
           width,
         }}
       >
-          <Database
-            {...context}
-            workspaceId={workspaceId}
-            doc={doc}
-            databasePageId={baseViewId}
-            activeViewId={selectedViewId}
-            createRow={createRow}
-            loadView={loadView}
-            navigateToView={navigateToView}
-            onOpenRowPage={onOpenRowPage}
-            loadViewMeta={loadViewMeta}
-            databaseName={databaseName}
-            visibleViewIds={visibleViewIds}
-            onChangeView={onChangeView}
-            onViewAdded={onViewAdded}
-            onViewIdsChanged={onViewIdsChanged}
-            showActions={true}
-            paddingStart={paddingStart}
-            paddingEnd={paddingEnd}
-            isDocumentBlock={true}
-            embeddedHeight={fixedHeight}
-            onRendered={onRendered}
-          />
+        <Database
+          {...context}
+          workspaceId={workspaceId}
+          doc={doc}
+          initialRowMap={initialRowMap}
+          databasePageId={baseViewId}
+          activeViewId={selectedViewId}
+          createRow={createRow}
+          loadView={loadView}
+          navigateToView={navigateToView}
+          onOpenRowPage={onOpenRowPage}
+          loadViewMeta={loadViewMeta}
+          databaseName={databaseName}
+          visibleViewIds={visibleViewIds}
+          onChangeView={onChangeView}
+          onViewAdded={onViewAdded}
+          onViewIdsChanged={onViewIdsChanged}
+          showActions={true}
+          paddingStart={paddingStart}
+          paddingEnd={paddingEnd}
+          isDocumentBlock={true}
+          embeddedHeight={fixedHeight}
+          onRendered={onRendered}
+        />
       </div>
     );
   }

--- a/src/components/editor/components/blocks/database/components/__tests__/DatabaseContent.test.tsx
+++ b/src/components/editor/components/blocks/database/components/__tests__/DatabaseContent.test.tsx
@@ -1,0 +1,76 @@
+import { render } from '@testing-library/react';
+
+import { DatabaseContextState } from '@/application/database-yjs';
+import { createDatabaseYjsRenderDocsFromSnapshot } from '@/application/publish-snapshot/database-yjs-render-bridge';
+import { normalizePublishedPageSnapshot } from '@/application/publish-snapshot/normalize';
+import { publishedDatabasePayload } from '@/application/publish-snapshot/__fixtures__/published-page-snapshots';
+import { UIVariant } from '@/application/types';
+import { Database } from '@/components/database';
+
+import { DatabaseContent } from '../DatabaseContent';
+
+jest.mock('@/components/database', () => ({
+  Database: jest.fn(() => <div data-testid="database" />),
+}));
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (_key: string, fallback?: string) => fallback ?? _key,
+  }),
+}));
+
+describe('DatabaseContent', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('passes published database row docs into embedded publish databases', () => {
+    const snapshot = normalizePublishedPageSnapshot(publishedDatabasePayload);
+
+    if (snapshot.kind !== 'database') {
+      throw new Error('Expected database snapshot fixture');
+    }
+
+    const { doc, rowMap } = createDatabaseYjsRenderDocsFromSnapshot(snapshot);
+    const context = {
+      readOnly: true,
+      databaseDoc: doc,
+      databasePageId: snapshot.view.viewId,
+      activeViewId: snapshot.database.activeViewId,
+      rowMap: null,
+      workspaceId: 'publish',
+      variant: UIVariant.Publish,
+    } as DatabaseContextState;
+
+    render(
+      <DatabaseContent
+        baseViewId={snapshot.view.viewId}
+        selectedViewId={snapshot.database.activeViewId}
+        hasDatabase={true}
+        notFound={false}
+        deletionStatus="none"
+        paddingStart={0}
+        paddingEnd={0}
+        width={800}
+        doc={doc}
+        workspaceId="publish"
+        onOpenRowPage={jest.fn()}
+        loadViewMeta={jest.fn()}
+        databaseName={snapshot.view.name}
+        visibleViewIds={snapshot.database.visibleViewIds}
+        onChangeView={jest.fn()}
+        context={context}
+      />
+    );
+
+    expect(Database).toHaveBeenCalled();
+    expect((Database as jest.Mock).mock.calls[0][0]).toEqual(
+      expect.objectContaining({
+        doc,
+        initialRowMap: rowMap,
+        activeViewId: snapshot.database.activeViewId,
+        variant: UIVariant.Publish,
+      })
+    );
+  });
+});

--- a/src/components/editor/components/element/Element.tsx
+++ b/src/components/editor/components/element/Element.tsx
@@ -54,6 +54,7 @@ export const Element = ({
   const {
     jumpBlockId,
     onJumpedBlockId,
+    readOnly,
   } = useEditorContext();
   const { selectedBlockIds } = useEditorLocalState();
 
@@ -82,14 +83,14 @@ export const Element = ({
   const highlightTimeoutRef = React.useRef<NodeJS.Timeout>();
   const [blockElement, setBlockElement] = React.useState<HTMLElement | null>(null);
   const allowBlockDrop = useMemo(() => {
-    if (type === YjsEditorKey.text) {
+    if (readOnly || type === YjsEditorKey.text) {
       return false;
     }
 
     const blockType = node.type as BlockType;
 
     return ![BlockType.SimpleTableRowBlock, BlockType.SimpleTableCellBlock].includes(blockType);
-  }, [node.type, type]);
+  }, [node.type, readOnly, type]);
 
   const scrollAndHighlight = useCallback(async (element: HTMLElement) => {
     element.scrollIntoView({ block: 'start' });

--- a/src/components/editor/index.ts
+++ b/src/components/editor/index.ts
@@ -1,3 +1,4 @@
 import { lazy } from 'react';
 
 export const Editor = lazy(() => import('./Editor'));
+export const StaticEditor = lazy(() => import('./StaticEditor'));

--- a/src/components/global-comment/GlobalComment.tsx
+++ b/src/components/global-comment/GlobalComment.tsx
@@ -6,12 +6,15 @@ import { AddCommentWrapper } from '@/components/global-comment/add-comment';
 import CommentList from '@/components/global-comment/CommentList';
 import { useGlobalCommentContext } from '@/components/global-comment/GlobalComment.hooks';
 
-function GlobalComment() {
+function GlobalComment({ disableFixedAddComment }: { disableFixedAddComment?: boolean }) {
   const { t } = useTranslation();
   const { loading, comments } = useGlobalCommentContext();
 
   return (
-    <div className={'mb-[480px] mt-16 flex h-fit w-full justify-center max-md:mb-[100px]'}>
+    <div
+      data-testid="global-comment"
+      className={'mb-[480px] mt-16 flex h-fit w-full justify-center max-md:mb-[100px]'}
+    >
       <div
         className={
           'flex w-[952px] min-w-0 max-w-full transform flex-col gap-2 px-24 transition-all duration-300 ease-in-out max-sm:px-6'
@@ -19,7 +22,7 @@ function GlobalComment() {
       >
         <div className={'text-[24px]'}>{t('globalComment.comments')}</div>
         <Divider />
-        <AddCommentWrapper />
+        <AddCommentWrapper disableFixedAddComment={disableFixedAddComment} />
 
         {loading && !comments?.length ? (
           <div className={'flex h-[200px] w-full items-center justify-center'}>

--- a/src/components/global-comment/GlobalCommentProvider.tsx
+++ b/src/components/global-comment/GlobalCommentProvider.tsx
@@ -8,7 +8,7 @@ import {
   useLoadReactions,
 } from '@/components/global-comment/GlobalComment.hooks';
 
-export function GlobalCommentProvider() {
+export function GlobalCommentProvider({ disableFixedAddComment }: { disableFixedAddComment?: boolean }) {
   const { comments, loading, reload } = useLoadComments();
   const { reactions, toggleReaction } = useLoadReactions();
   const [replyCommentId, setReplyCommentId] = useState<string | null>(null);
@@ -66,7 +66,7 @@ export function GlobalCommentProvider() {
 
   return (
     <GlobalCommentContext.Provider value={contextValue}>
-      <GlobalComment />
+      <GlobalComment disableFixedAddComment={disableFixedAddComment} />
     </GlobalCommentContext.Provider>
   );
 }

--- a/src/components/global-comment/add-comment/AddCommentWrapper.tsx
+++ b/src/components/global-comment/add-comment/AddCommentWrapper.tsx
@@ -2,13 +2,18 @@ import { Portal } from '@mui/material';
 import { useEffect, useRef, useState } from 'react';
 
 import { HEADER_HEIGHT } from '@/application/constants';
+import { usePublishContext } from '@/application/publish';
 import { useGlobalCommentContext } from '@/components/global-comment/GlobalComment.hooks';
 import { getScrollParent } from '@/components/global-comment/utils';
 
 import AddComment from './AddComment';
+import { shouldUseFixedGlobalCommentInput } from './layout';
 
-export function AddCommentWrapper() {
+export function AddCommentWrapper({ disableFixedAddComment }: { disableFixedAddComment?: boolean }) {
   const { replyCommentId } = useGlobalCommentContext();
+  const publishContext = usePublishContext();
+  const useFixedAddComment =
+    !disableFixedAddComment && shouldUseFixedGlobalCommentInput(publishContext?.viewMeta?.layout);
   const addCommentRef = useRef<HTMLDivElement>(null);
   const [showFixedAddComment, setShowFixedAddComment] = useState(false);
   const [offsetLeft, setOffsetLeft] = useState(0);
@@ -22,6 +27,11 @@ export function AddCommentWrapper() {
   }, [replyCommentId]);
 
   useEffect(() => {
+    if (!useFixedAddComment) {
+      setShowFixedAddComment(false);
+      return;
+    }
+
     const element = addCommentRef.current;
 
     if (!element) return;
@@ -45,7 +55,7 @@ export function AddCommentWrapper() {
     return () => {
       scrollContainer.removeEventListener('scroll', handleScroll);
     };
-  }, []);
+  }, [useFixedAddComment]);
 
   useEffect(() => {
     const element = addCommentRef.current;
@@ -72,7 +82,7 @@ export function AddCommentWrapper() {
           fixed={false}
         />
       </div>
-      {showFixedAddComment && (
+      {useFixedAddComment && showFixedAddComment && (
         <Portal container={document.body}>
           <div
             style={{

--- a/src/components/global-comment/add-comment/__tests__/layout.test.ts
+++ b/src/components/global-comment/add-comment/__tests__/layout.test.ts
@@ -1,0 +1,20 @@
+import { ViewLayout } from '@/application/types';
+
+import { shouldUseFixedGlobalCommentInput } from '../layout';
+
+describe('shouldUseFixedGlobalCommentInput', () => {
+  it('allows the sticky comment input on document publish pages', () => {
+    expect(shouldUseFixedGlobalCommentInput(ViewLayout.Document)).toBe(true);
+  });
+
+  it('disables the sticky comment input on database publish pages', () => {
+    expect(shouldUseFixedGlobalCommentInput(ViewLayout.Grid)).toBe(false);
+    expect(shouldUseFixedGlobalCommentInput(ViewLayout.Board)).toBe(false);
+    expect(shouldUseFixedGlobalCommentInput(ViewLayout.Calendar)).toBe(false);
+  });
+
+  it('keeps the sticky comment input when the view layout is not loaded yet', () => {
+    expect(shouldUseFixedGlobalCommentInput(undefined)).toBe(true);
+    expect(shouldUseFixedGlobalCommentInput(null)).toBe(true);
+  });
+});

--- a/src/components/global-comment/add-comment/layout.ts
+++ b/src/components/global-comment/add-comment/layout.ts
@@ -1,0 +1,8 @@
+import { ViewLayout } from '@/application/types';
+import { isDatabaseLayout } from '@/application/view-utils';
+
+export function shouldUseFixedGlobalCommentInput(viewLayout?: ViewLayout | null) {
+  if (viewLayout === undefined || viewLayout === null) return true;
+
+  return !isDatabaseLayout(viewLayout);
+}

--- a/src/components/publish-render/PublishSnapshotView.tsx
+++ b/src/components/publish-render/PublishSnapshotView.tsx
@@ -1,0 +1,29 @@
+import React, { Suspense } from 'react';
+
+import PublishedDocumentRenderer from '@/components/publish-render/document/PublishedDocumentRenderer';
+import PublishedDatabaseRenderer from '@/components/publish-render/database/PublishedDatabaseRenderer';
+import type { PublishedPageSnapshot } from '@/application/publish-snapshot/types';
+import { usePublishContext } from '@/application/publish';
+
+const ViewHelmet = React.lazy(() => import('@/components/_shared/helmet/ViewHelmet'));
+
+export function PublishSnapshotView({ snapshot }: { snapshot: PublishedPageSnapshot }) {
+  const rendered = usePublishContext()?.rendered;
+
+  return (
+    <>
+      {rendered && (
+        <Suspense>
+          <ViewHelmet icon={snapshot.view.icon || undefined} name={snapshot.view.name} />
+        </Suspense>
+      )}
+      {snapshot.kind === 'document' ? (
+        <PublishedDocumentRenderer snapshot={snapshot} />
+      ) : (
+        <PublishedDatabaseRenderer snapshot={snapshot} />
+      )}
+    </>
+  );
+}
+
+export default PublishSnapshotView;

--- a/src/components/publish-render/__tests__/PublishSnapshotView.test.tsx
+++ b/src/components/publish-render/__tests__/PublishSnapshotView.test.tsx
@@ -1,0 +1,135 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+
+import { UIVariant, YjsDatabaseKey, YjsEditorKey } from '@/application/types';
+import { normalizePublishedPageSnapshot } from '@/application/publish-snapshot/normalize';
+import {
+  publishedDatabasePayload,
+  publishedDocumentPayload,
+  publishedRowDocumentId,
+} from '@/application/publish-snapshot/__fixtures__/published-page-snapshots';
+import { yDocToSlateContent } from '@/application/slate-yjs/utils/convert';
+import type { StaticEditorProps } from '@/components/editor/StaticEditor';
+import StaticEditor from '@/components/editor/StaticEditor';
+import type { DatabaseProps } from '@/components/publish/DatabaseView';
+import DatabaseView from '@/components/publish/DatabaseView';
+import PublishSnapshotView from '@/components/publish-render/PublishSnapshotView';
+
+jest.mock('@/components/editor/StaticEditor', () => {
+  const React = jest.requireActual('react') as typeof import('react');
+
+  return {
+    __esModule: true,
+    default: jest.fn((props: StaticEditorProps) => {
+      const firstBlock = props.value[0] as { children?: { children?: { text?: string }[] }[] } | undefined;
+      const firstText = firstBlock?.children?.[0]?.children?.[0]?.text ?? '';
+
+      return React.createElement('div', { 'data-testid': 'static-editor' }, firstText);
+    }),
+  };
+});
+
+jest.mock('@/components/publish/DatabaseView', () => {
+  const React = jest.requireActual('react') as typeof import('react');
+
+  return {
+    __esModule: true,
+    default: jest.fn((props: DatabaseProps) =>
+      React.createElement('div', { 'data-testid': 'database-view' }, props.viewMeta.name)
+    ),
+  };
+});
+
+jest.mock('@/components/view-meta/ViewMetaPreview', () => {
+  const React = jest.requireActual('react') as typeof import('react');
+
+  return {
+    __esModule: true,
+    default: jest.fn((props: { name?: string }) =>
+      React.createElement('div', { 'data-testid': 'view-meta-preview' }, props.name)
+    ),
+  };
+});
+
+const mockStaticEditor = StaticEditor as unknown as jest.Mock;
+const mockDatabaseView = DatabaseView as unknown as jest.Mock;
+
+describe('PublishSnapshotView', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders a normalized document JSON snapshot through the shared static editor UI', () => {
+    const snapshot = normalizePublishedPageSnapshot(publishedDocumentPayload);
+
+    if (snapshot.kind !== 'document') {
+      throw new Error('Expected document snapshot fixture');
+    }
+
+    render(
+      <MemoryRouter>
+        <PublishSnapshotView snapshot={snapshot} />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByTestId('view-meta-preview').parentElement?.className).toContain('min-h-[calc(100vh-48px)]');
+    expect(screen.getByTestId('view-meta-preview').parentElement?.className).not.toContain('h-full');
+    expect(screen.getByTestId('view-meta-preview').textContent).toBe('Published document');
+    expect(screen.getByTestId('static-editor').textContent).toBe('Published document body');
+    expect(mockStaticEditor).toHaveBeenCalledTimes(1);
+
+    const staticEditorProps = mockStaticEditor.mock.calls[0][0] as StaticEditorProps;
+
+    expect(staticEditorProps.workspaceId).toBe('publish');
+    expect(staticEditorProps.viewId).toBe(snapshot.view.viewId);
+    expect(staticEditorProps.value).toBe(snapshot.document.children);
+    expect(staticEditorProps.databaseRelations).toEqual({
+      'related-database-id': 'related-database-view-id',
+    });
+  });
+
+  it('renders a normalized database JSON snapshot through the shared database UI bridge', async () => {
+    const snapshot = normalizePublishedPageSnapshot(publishedDatabasePayload);
+
+    if (snapshot.kind !== 'database') {
+      throw new Error('Expected database snapshot fixture');
+    }
+
+    render(
+      <MemoryRouter>
+        <PublishSnapshotView snapshot={snapshot} />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByTestId('database-view').textContent).toBe('Published database');
+    expect(mockDatabaseView).toHaveBeenCalledTimes(1);
+
+    const databaseProps = mockDatabaseView.mock.calls[0][0] as DatabaseProps;
+    const database = databaseProps.doc
+      .getMap(YjsEditorKey.data_section)
+      .get(YjsEditorKey.database);
+
+    expect(databaseProps.workspaceId).toBe('publish');
+    expect(databaseProps.variant).toBe(UIVariant.Publish);
+    expect(databaseProps.doc.guid).toBe(snapshot.database.databaseId);
+    expect(databaseProps.doc.object_id).toBe(snapshot.database.databaseId);
+    expect(databaseProps.doc.view_id).toBe(snapshot.view.viewId);
+    expect(databaseProps.viewMeta).toMatchObject({
+      name: snapshot.view.name,
+      viewId: snapshot.view.viewId,
+      layout: snapshot.view.layout,
+      visibleViewIds: snapshot.database.visibleViewIds,
+      database_relations: {},
+    });
+    expect(database?.get(YjsDatabaseKey.id)).toBe(snapshot.database.databaseId);
+    expect(Object.keys(databaseProps.initialRowMap ?? {})).toEqual(['published-row-id']);
+
+    const rowDocument = await databaseProps.loadRowDocument?.(publishedRowDocumentId);
+    const rowDocumentContent = rowDocument ? yDocToSlateContent(rowDocument) : undefined;
+    const firstRowDocumentBlock = rowDocumentContent?.children[0] as {
+      children?: Array<{ children?: Array<{ text?: string }> }>;
+    } | undefined;
+
+    expect(firstRowDocumentBlock?.children?.[0]?.children?.[0]?.text).toBe('Published row document body');
+  });
+});

--- a/src/components/publish-render/database/PublishedDatabaseRenderer.tsx
+++ b/src/components/publish-render/database/PublishedDatabaseRenderer.tsx
@@ -1,0 +1,78 @@
+import { useCallback, useMemo } from 'react';
+
+import { createDatabaseYjsRenderDocsFromSnapshot } from '@/application/publish-snapshot/database-yjs-render-bridge';
+import { createDocumentYjsRenderDocFromRawData } from '@/application/publish-snapshot/document-yjs-render-bridge';
+import type { PublishedDatabaseSnapshot } from '@/application/publish-snapshot/types';
+import { UIVariant, type ViewMetaProps, type YDoc } from '@/application/types';
+import DatabaseView from '@/components/publish/DatabaseView';
+import { usePublishContext } from '@/application/publish';
+import {
+  getPublishedViewCover,
+  parsePublishedViewExtra,
+} from '@/components/publish-render/shared/PublishedPageMeta';
+
+export function PublishedDatabaseRenderer({ snapshot }: { snapshot: PublishedDatabaseSnapshot }) {
+  const publishContext = usePublishContext();
+  const { database, view } = snapshot;
+  const { doc, rowMap } = useMemo(() => createDatabaseYjsRenderDocsFromSnapshot(snapshot), [snapshot]);
+  const rowDocumentMap = useMemo(
+    () =>
+      Object.fromEntries(
+        Object.entries(database.raw.row_documents).map(([documentId, raw]) => [
+          documentId,
+          createDocumentYjsRenderDocFromRawData(documentId, raw),
+        ])
+      ),
+    [database.raw.row_documents]
+  );
+  const extra = useMemo(() => parsePublishedViewExtra(view.extra), [view.extra]);
+  const loadView = publishContext?.loadView;
+  const contextLoadRowDocument = publishContext?.loadRowDocument;
+  const loadRowDocument = useCallback(
+    async (documentId: string): Promise<YDoc | null> => {
+      return rowDocumentMap[documentId] ?? (await contextLoadRowDocument?.(documentId)) ?? null;
+    },
+    [contextLoadRowDocument, rowDocumentMap]
+  );
+  const viewMeta = useMemo<ViewMetaProps>(
+    () => ({
+      icon: view.icon || undefined,
+      cover: getPublishedViewCover(extra),
+      name: view.name,
+      viewId: view.viewId,
+      layout: view.layout,
+      visibleViewIds: database.visibleViewIds,
+      database_relations: view.databaseRelations,
+      extra: extra as ViewMetaProps['extra'],
+    }),
+    [
+      database.visibleViewIds,
+      extra,
+      view.databaseRelations,
+      view.icon,
+      view.layout,
+      view.name,
+      view.viewId,
+    ]
+  );
+
+  return (
+    <DatabaseView
+      workspaceId="publish"
+      doc={doc}
+      initialRowMap={rowMap}
+      viewMeta={viewMeta}
+      createRow={publishContext?.createRow}
+      loadView={loadView}
+      loadRowDocument={loadRowDocument}
+      navigateToView={publishContext?.toView}
+      loadViewMeta={publishContext?.loadViewMeta}
+      appendBreadcrumb={publishContext?.appendBreadcrumb}
+      onRendered={publishContext?.onRendered}
+      variant={UIVariant.Publish}
+      getViewIdFromDatabaseId={publishContext?.getViewIdFromDatabaseId}
+    />
+  );
+}
+
+export default PublishedDatabaseRenderer;

--- a/src/components/publish-render/document/PublishedDocumentRenderer.tsx
+++ b/src/components/publish-render/document/PublishedDocumentRenderer.tsx
@@ -1,0 +1,113 @@
+import { useEffect, useMemo } from 'react';
+import { useSearchParams } from 'react-router-dom';
+
+import type { PublishedDocumentSnapshot } from '@/application/publish-snapshot/types';
+import { FontLayout, LineHeightLayout, UIVariant } from '@/application/types';
+import StaticEditor from '@/components/editor/StaticEditor';
+import PublishedPageMeta from '@/components/publish-render/shared/PublishedPageMeta';
+import { usePublishContext } from '@/application/publish';
+import { getFontFamily } from '@/utils/font';
+
+const FONT_SIZE_MAP: Record<FontLayout, string | undefined> = {
+  [FontLayout.small]: '14px',
+  [FontLayout.normal]: '16px',
+  [FontLayout.large]: '20px',
+};
+
+const THUMBNAIL_BLOCK_LIMIT = 10;
+
+interface PublishedViewExtra {
+  font?: string;
+  fontLayout?: FontLayout;
+  lineHeightLayout?: LineHeightLayout;
+}
+
+function parseViewExtra(extra: string | null): PublishedViewExtra {
+  if (!extra) return {};
+  try {
+    const parsed = JSON.parse(extra);
+
+    return parsed && typeof parsed === 'object' ? parsed as PublishedViewExtra : {};
+  } catch {
+    return {};
+  }
+}
+
+export function PublishedDocumentRenderer({ snapshot }: { snapshot: PublishedDocumentSnapshot }) {
+  const publishContext = usePublishContext();
+  const onRendered = publishContext?.onRendered;
+  const isTemplateThumb = publishContext?.isTemplateThumb ?? false;
+  const [search] = useSearchParams();
+  const jumpBlockId = search.get('blockId') || undefined;
+
+  const extra = useMemo(() => parseViewExtra(snapshot.view.extra), [snapshot.view.extra]);
+  const font = extra.font || '';
+  const fontLayout = extra.fontLayout;
+  const lineHeightLayout = extra.lineHeightLayout;
+
+  const editorValue = useMemo(() => {
+    if (!isTemplateThumb) return snapshot.document.children;
+
+    return snapshot.document.children.slice(0, THUMBNAIL_BLOCK_LIMIT);
+  }, [isTemplateThumb, snapshot.document.children]);
+
+  const wrapperStyle = useMemo(() => {
+    const style: React.CSSProperties = {};
+
+    if (font) style.fontFamily = font;
+    if (fontLayout) {
+      const fontSize = FONT_SIZE_MAP[fontLayout];
+
+      if (fontSize) style.fontSize = fontSize;
+    }
+
+    return style;
+  }, [font, fontLayout]);
+
+  const wrapperClassName = useMemo(() => {
+    const classes = ['flex min-h-[calc(100vh-48px)] w-full flex-col items-center'];
+
+    if (fontLayout === FontLayout.large) classes.push('font-large');
+    else if (fontLayout === FontLayout.small) classes.push('font-small');
+
+    if (lineHeightLayout === LineHeightLayout.large) classes.push('line-height-large');
+    else if (lineHeightLayout === LineHeightLayout.small) classes.push('line-height-small');
+
+    return classes.join(' ');
+  }, [fontLayout, lineHeightLayout]);
+
+  useEffect(() => {
+    onRendered?.();
+  }, [onRendered]);
+
+  useEffect(() => {
+    if (!font) return;
+    void getFontFamily(font);
+  }, [font]);
+
+  return (
+    <div className={wrapperClassName} style={wrapperStyle}>
+      <PublishedPageMeta view={snapshot.view} />
+      <div className="relative flex w-full justify-center">
+        <StaticEditor
+          workspaceId="publish"
+          viewId={snapshot.view.viewId}
+          value={editorValue}
+          navigateToView={publishContext?.toView}
+          loadViewMeta={publishContext?.loadViewMeta}
+          loadView={publishContext?.loadView}
+          loadRowDocument={publishContext?.loadRowDocument}
+          createRow={publishContext?.createRow}
+          onRendered={onRendered}
+          variant={UIVariant.Publish}
+          databaseRelations={snapshot.view.databaseRelations}
+          getViewIdFromDatabaseId={publishContext?.getViewIdFromDatabaseId}
+          jumpBlockId={jumpBlockId}
+          readSummary={isTemplateThumb}
+        />
+      </div>
+    </div>
+  );
+}
+
+export default PublishedDocumentRenderer;

--- a/src/components/publish-render/index.ts
+++ b/src/components/publish-render/index.ts
@@ -1,0 +1,1 @@
+export * from './PublishSnapshotView';

--- a/src/components/publish-render/shared/PublishedPageMeta.tsx
+++ b/src/components/publish-render/shared/PublishedPageMeta.tsx
@@ -1,0 +1,57 @@
+import { useMemo } from 'react';
+
+import { ViewExtra, ViewLayout, ViewMetaCover } from '@/application/types';
+import type { PublishedView } from '@/application/publish-snapshot/types';
+import ViewMetaPreview from '@/components/view-meta/ViewMetaPreview';
+import { clampCoverOffset } from '@/utils/cover';
+
+export function parsePublishedViewExtra(extra?: string | null): Record<string, unknown> | null {
+  if (!extra) return null;
+
+  try {
+    const value = JSON.parse(extra);
+
+    return value && typeof value === 'object' ? value as Record<string, unknown> : null;
+  } catch {
+    return null;
+  }
+}
+
+export function getPublishedViewCover(extra: Record<string, unknown> | null): ViewMetaCover | undefined {
+  const rawCover = extra?.cover as ViewMetaCover | undefined;
+
+  if (!rawCover) return undefined;
+
+  return {
+    ...rawCover,
+    offset: clampCoverOffset(rawCover.offset),
+  };
+}
+
+export function PublishedPageMeta({
+  view,
+  layout = view.layout,
+  maxWidth = 952,
+}: {
+  view: PublishedView;
+  layout?: ViewLayout;
+  maxWidth?: number;
+}) {
+  const extra = useMemo(() => parsePublishedViewExtra(view.extra), [view.extra]);
+  const cover = useMemo(() => getPublishedViewCover(extra), [extra]);
+
+  return (
+    <ViewMetaPreview
+      readOnly
+      icon={view.icon || undefined}
+      cover={cover}
+      name={view.name}
+      viewId={view.viewId}
+      layout={layout}
+      maxWidth={maxWidth}
+      extra={extra as ViewExtra | null}
+    />
+  );
+}
+
+export default PublishedPageMeta;

--- a/src/components/publish/DatabaseView.tsx
+++ b/src/components/publish/DatabaseView.tsx
@@ -2,17 +2,17 @@ import { Suspense, useCallback, useMemo } from 'react';
 import { useSearchParams } from 'react-router-dom';
 
 import { usePublishContext } from '@/application/publish';
-import {
+import { UIVariant, ViewLayout, YjsEditorKey } from '@/application/types';
+import type {
   AppendBreadcrumb,
   CreateRow,
   LoadView,
   LoadViewMeta,
+  RowId,
   View,
-  ViewLayout,
   ViewMetaProps,
   YDatabase,
   YDoc,
-  YjsEditorKey,
 } from '@/application/types';
 import ComponentLoading from '@/components/_shared/progress/ComponentLoading';
 import CalendarSkeleton from '@/components/_shared/skeleton/CalendarSkeleton';
@@ -21,12 +21,14 @@ import GridSkeleton from '@/components/_shared/skeleton/GridSkeleton';
 import KanbanSkeleton from '@/components/_shared/skeleton/KanbanSkeleton';
 import { Database } from '@/components/database';
 import { findParentView } from '@/components/_shared/outline/utils';
+import { cn } from '@/lib/utils';
 
 import ViewMetaPreview from 'src/components/view-meta/ViewMetaPreview';
 
 export interface DatabaseProps {
   workspaceId: string;
   doc: YDoc;
+  initialRowMap?: Record<RowId, YDoc>;
   createRow?: CreateRow;
   loadView?: LoadView;
   /**
@@ -39,6 +41,7 @@ export interface DatabaseProps {
   appendBreadcrumb?: AppendBreadcrumb;
   onRendered?: () => void;
   getViewIdFromDatabaseId?: (databaseId: string) => Promise<string | null>;
+  variant?: UIVariant;
 }
 
 function DatabaseView({ viewMeta, navigateToView, ...props }: DatabaseProps) {
@@ -136,6 +139,7 @@ function DatabaseView({ viewMeta, navigateToView, ...props }: DatabaseProps) {
   const rowId = search.get('r') || undefined;
   const doc = props.doc;
   const database = doc?.getMap(YjsEditorKey.data_section)?.get(YjsEditorKey.database) as YDatabase;
+  const isPublishVariant = props.variant === UIVariant.Publish;
 
   const skeleton = useMemo(() => {
     if (rowId) {
@@ -162,7 +166,7 @@ function DatabaseView({ viewMeta, navigateToView, ...props }: DatabaseProps) {
         minHeight: 'calc(100vh - 48px)',
         maxWidth: isTemplateThumb ? '964px' : undefined,
       }}
-      className={'relative flex h-full w-full flex-col'}
+      className={cn('relative flex w-full flex-col', !isPublishVariant && 'h-full')}
     >
       {rowId ? null : <ViewMetaPreview {...viewMeta} readOnly={true} />}
 

--- a/src/components/publish/PublishLayout.tsx
+++ b/src/components/publish/PublishLayout.tsx
@@ -1,4 +1,4 @@
-import { YDoc } from '@/application/types';
+import type { PublishedPageSnapshot } from '@/application/publish-snapshot/types';
 import { useOutlineDrawer } from '@/components/_shared/outline/outline.hooks';
 import { AFScroller } from '@/components/_shared/scroller';
 import { PublishViewHeader } from '@/components/publish/header';
@@ -8,11 +8,11 @@ import SideBar from '@/components/publish/SideBar';
 function PublishLayout({
   isTemplateThumb,
   isTemplate,
-  doc,
+  snapshot,
 }: {
   isTemplateThumb: boolean;
   isTemplate: boolean;
-  doc?: YDoc;
+  snapshot?: PublishedPageSnapshot;
 }) {
   const { drawerOpened, drawerWidth, setDrawerWidth, toggleOpenDrawer } = useOutlineDrawer();
 
@@ -68,7 +68,7 @@ function PublishLayout({
           />
         )}
 
-        <PublishMain doc={doc} isTemplate={isTemplate} />
+        <PublishMain snapshot={snapshot} isTemplate={isTemplate} />
       </AFScroller>
       {drawerOpened && (
         <SideBar

--- a/src/components/publish/PublishMain.tsx
+++ b/src/components/publish/PublishMain.tsx
@@ -1,23 +1,25 @@
 import { Suspense } from 'react';
 
 import { usePublishContext } from '@/application/publish';
-import { YDoc } from '@/application/types';
+import type { PublishedPageSnapshot } from '@/application/publish-snapshot/types';
 import ComponentLoading from '@/components/_shared/progress/ComponentLoading';
 import { GlobalCommentProvider } from '@/components/global-comment';
-import CollabView from '@/components/publish/CollabView';
+import { shouldDisableFixedGlobalCommentInput } from '@/components/publish/comment';
+import { PublishSnapshotView } from '@/components/publish-render/PublishSnapshotView';
 
-function PublishMain ({ doc, isTemplate }: {
-  doc?: YDoc;
+function PublishMain ({ snapshot, isTemplate }: {
+  snapshot?: PublishedPageSnapshot;
   isTemplate: boolean;
 }) {
   const commentEnabled = usePublishContext()?.commentEnabled;
+  const content = snapshot ? <PublishSnapshotView snapshot={snapshot} /> : <ComponentLoading />;
 
   return (
     <>
-      <CollabView doc={doc} />
-      {doc && !isTemplate && commentEnabled && (
+      {content}
+      {snapshot && !isTemplate && commentEnabled && (
         <Suspense fallback={<ComponentLoading />}>
-          <GlobalCommentProvider />
+          <GlobalCommentProvider disableFixedAddComment={shouldDisableFixedGlobalCommentInput(snapshot)} />
         </Suspense>
       )}
     </>

--- a/src/components/publish/PublishMobileLayout.tsx
+++ b/src/components/publish/PublishMobileLayout.tsx
@@ -1,15 +1,16 @@
 import React, { Suspense } from 'react';
 
-import { UIVariant, YDoc } from '@/application/types';
+import type { PublishedPageSnapshot } from '@/application/publish-snapshot/types';
+import { UIVariant } from '@/application/types';
 import { AFScroller } from '@/components/_shared/scroller';
 import PublishMain from '@/components/publish/PublishMain';
 
 const MobileTopBar = React.lazy(() => import('@/components/_shared/mobile-topbar/MobileTopBar'));
 
 function PublishMobileLayout ({
-  doc,
+  snapshot,
 }: {
-  doc?: YDoc;
+  snapshot?: PublishedPageSnapshot;
 }) {
   return (
     <div
@@ -26,7 +27,7 @@ function PublishMobileLayout ({
           <MobileTopBar variant={UIVariant.Publish} />
         </Suspense>
         <PublishMain
-          doc={doc}
+          snapshot={snapshot}
           isTemplate={false}
         />
       </AFScroller>

--- a/src/components/publish/PublishView.tsx
+++ b/src/components/publish/PublishView.tsx
@@ -1,9 +1,9 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
 
 import { PublishProvider } from '@/application/publish';
-import { PublishService } from '@/application/services/domains';
-import { YDoc } from '@/application/types';
+import { createPublishSnapshotDataSource } from '@/application/publish-snapshot/data-source';
+import type { PublishedPageSnapshot, PublishSnapshotDataSource } from '@/application/publish-snapshot/types';
 import NotFound from '@/components/error/NotFound';
 import PublishLayout from '@/components/publish/PublishLayout';
 import PublishMobileLayout from '@/components/publish/PublishMobileLayout';
@@ -15,26 +15,32 @@ export interface PublishViewProps {
 }
 
 export function PublishView({ namespace, publishName }: PublishViewProps) {
-  const [doc, setDoc] = useState<YDoc | undefined>();
+  const [snapshot, setSnapshot] = useState<PublishedPageSnapshot | undefined>();
   const [notFound, setNotFound] = useState<boolean>(false);
-  const openPublishView = useCallback(async() => {
-    let doc;
-
-    setNotFound(false);
-    setDoc(undefined);
-    try {
-      doc = await PublishService.getView(namespace, publishName);
-    } catch(e) {
-      setNotFound(true);
-      return;
-    }
-
-    setDoc(doc);
-  }, [namespace, publishName]);
+  const [dataSource] = useState<PublishSnapshotDataSource>(() => createPublishSnapshotDataSource());
 
   useEffect(() => {
-    void openPublishView();
-  }, [openPublishView]);
+    let cancelled = false;
+
+    setNotFound(false);
+    setSnapshot(undefined);
+
+    void dataSource.getPage(namespace, publishName)
+      .then((data) => {
+        if (cancelled) return;
+
+        setSnapshot(data);
+      })
+      .catch(() => {
+        if (cancelled) return;
+
+        setNotFound(true);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [dataSource, namespace, publishName]);
 
   const [search] = useSearchParams();
 
@@ -54,7 +60,7 @@ export function PublishView({ namespace, publishName }: PublishViewProps) {
     };
   }, [isTemplateThumb]);
 
-  if (notFound && !doc) {
+  if (notFound && !snapshot) {
     return <NotFound />;
   }
 
@@ -64,11 +70,12 @@ export function PublishView({ namespace, publishName }: PublishViewProps) {
       isTemplate={isTemplate}
       namespace={namespace}
       publishName={publishName}
+      snapshot={snapshot}
     >
-      {getPlatform().isMobile ? <PublishMobileLayout doc={doc} /> : <PublishLayout
+      {getPlatform().isMobile ? <PublishMobileLayout snapshot={snapshot} /> : <PublishLayout
         isTemplateThumb={isTemplateThumb}
         isTemplate={isTemplate}
-        doc={doc}
+        snapshot={snapshot}
       />}
 
     </PublishProvider>

--- a/src/components/publish/__tests__/comment.test.ts
+++ b/src/components/publish/__tests__/comment.test.ts
@@ -1,0 +1,66 @@
+import { normalizePublishedPageSnapshot } from '@/application/publish-snapshot/normalize';
+import {
+  publishedDatabasePayload,
+  publishedDocumentPayload,
+} from '@/application/publish-snapshot/__fixtures__/published-page-snapshots';
+import { BlockType } from '@/application/types';
+
+import { shouldDisableFixedGlobalCommentInput } from '../comment';
+
+describe('shouldDisableFixedGlobalCommentInput', () => {
+  it('disables fixed comments for published database pages', () => {
+    expect(shouldDisableFixedGlobalCommentInput(normalizePublishedPageSnapshot(publishedDatabasePayload))).toBe(true);
+  });
+
+  it('keeps fixed comments for normal published documents', () => {
+    expect(shouldDisableFixedGlobalCommentInput(normalizePublishedPageSnapshot(publishedDocumentPayload))).toBe(false);
+  });
+
+  it('disables fixed comments for published documents with database blocks in raw data', () => {
+    const snapshot = normalizePublishedPageSnapshot({
+      ...publishedDocumentPayload,
+      document: {
+        ...publishedDocumentPayload.document,
+        raw: {
+          data: {
+            page_id: 'page-id',
+            blocks: {
+              'page-id': {
+                id: 'page-id',
+                ty: BlockType.Page,
+                children: 'page-id',
+              },
+              'database-block-id': {
+                id: 'database-block-id',
+                ty: BlockType.GridBlock,
+                parent: 'page-id',
+                children: 'database-block-id',
+              },
+            },
+            meta: {},
+          },
+        },
+      },
+    });
+
+    expect(shouldDisableFixedGlobalCommentInput(snapshot)).toBe(true);
+  });
+
+  it('disables fixed comments for published documents with database blocks in slate children', () => {
+    const snapshot = normalizePublishedPageSnapshot({
+      ...publishedDocumentPayload,
+      document: {
+        children: [
+          {
+            type: BlockType.GridBlock,
+            blockId: 'database-block-id',
+            data: {},
+            children: [{ text: '' }],
+          },
+        ],
+      },
+    });
+
+    expect(shouldDisableFixedGlobalCommentInput(snapshot)).toBe(true);
+  });
+});

--- a/src/components/publish/comment.ts
+++ b/src/components/publish/comment.ts
@@ -1,0 +1,43 @@
+import type { PublishedPageSnapshot } from '@/application/publish-snapshot/types';
+import { BlockType } from '@/application/types';
+
+const DATABASE_BLOCK_TYPES = new Set<string>([
+  BlockType.GridBlock,
+  BlockType.BoardBlock,
+  BlockType.CalendarBlock,
+]);
+
+function nodeHasDatabaseBlock(node: unknown): boolean {
+  if (!node || typeof node !== 'object') return false;
+
+  const element = node as { type?: unknown; children?: unknown };
+
+  if (typeof element.type === 'string' && DATABASE_BLOCK_TYPES.has(element.type)) {
+    return true;
+  }
+
+  return Array.isArray(element.children) && element.children.some(nodeHasDatabaseBlock);
+}
+
+function documentRawHasDatabaseBlock(snapshot: PublishedPageSnapshot) {
+  if (snapshot.kind !== 'document') return false;
+
+  const blocks = snapshot.document.raw?.data.blocks;
+
+  if (!blocks) return false;
+
+  return Object.values(blocks).some((block) => DATABASE_BLOCK_TYPES.has(block.ty));
+}
+
+function documentChildrenHaveDatabaseBlock(snapshot: PublishedPageSnapshot) {
+  if (snapshot.kind !== 'document') return false;
+
+  return snapshot.document.children.some(nodeHasDatabaseBlock);
+}
+
+export function shouldDisableFixedGlobalCommentInput(snapshot?: PublishedPageSnapshot) {
+  if (!snapshot) return false;
+  if (snapshot.kind === 'database') return true;
+
+  return documentRawHasDatabaseBlock(snapshot) || documentChildrenHaveDatabaseBlock(snapshot);
+}

--- a/src/shims/protobufjs-inquire.cjs
+++ b/src/shims/protobufjs-inquire.cjs
@@ -1,0 +1,6 @@
+'use strict';
+
+// Browser bundles cannot load optional Node modules through protobufjs' dynamic require.
+module.exports = function inquire() {
+  return null;
+};

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -209,6 +209,7 @@ export default defineConfig({
   },
   resolve: {
     alias: [
+      { find: '@protobufjs/inquire', replacement: path.resolve(__dirname, 'src/shims/protobufjs-inquire.cjs') },
       { find: 'src/', replacement: `${__dirname}/src/` },
       { find: '@/', replacement: `${__dirname}/src/` },
     ],


### PR DESCRIPTION
<!---
Thank you for submitting a pull request to the AppFlowy Web! The team will dedicate their best efforts to reviewing and approving your PR. If you have any questions or feedback, feel free to join our [Discord](https://discord.gg/wdjWUXXhtw).
-->


### **Description**
<!---
Provide a clear and concise description of the changes introduced in this pull request for AppFlowy Web. What problem does it solve? What value does it add?
-->

---

### **Checklist**
<!---
Before marking your pull request as ready for review, ensure the following checklist is complete.
-->

#### **General**
- [ ] I've included relevant documentation or comments for the changes introduced.
- [ ] I've tested the changes in multiple environments (e.g., different browsers, operating systems).

#### **Testing**
- [ ] I've added or updated tests to validate the changes introduced for AppFlowy Web.

#### **Feature-Specific**
- [ ] For feature additions, I've added a preview (video, screenshot, or demo) in the "Feature Preview" section.
- [ ] I've verified that this feature integrates seamlessly with existing functionality.

## Summary by Sourcery

Ensure published pages render from JSON snapshots, including embedded databases and row documents, and adjust publish/database/comment layouts for better UX.

New Features:
- Render published documents and databases from normalized JSON snapshots via a dedicated publish snapshot data source and renderer.
- Support static, read-only document rendering for published content through a shared StaticEditor component.
- Enable loading of embedded database row documents from publish snapshots for row page rendering on public pages.

Bug Fixes:
- Fix publishing of documents with embedded databases so their database views and row documents are also published and can be rendered on public pages.
- Prevent fixed global comment input and database viewport layouts from overlapping or clipping published database content.
- Respect read-only mode in the editor by disabling input-related handlers to avoid unintended interactions on published pages.

Enhancements:
- Reuse shared database and editor UI for publish rendering while decoupling it from live Yjs collaboration state.
- Improve breadcrumb, outline, and database relation handling in publish context when snapshot metadata is available.
- Refine layout behavior for embedded and published databases to avoid unnecessary fixed-height viewports and improve scrolling.
- Stabilize view meta subscription lifecycle to avoid stale subscribers when publish metadata updates.

Build:
- Shim protobufjs inquire for browser builds to avoid optional Node module resolution issues.
- Pin browserslist, caniuse-lite, and update-browserslist-db versions to satisfy tooling and vulnerability requirements.

Tests:
- Add Playwright end-to-end coverage for publishing documents and existing seeded pages with embedded databases and verifying public rendering and comments positioning.
- Add unit tests for publish snapshot adapters, normalization, Yjs render bridges, publish context, and publish renderers.
- Add layout tests for database viewport and global comment placement to guard against regressions around published database rendering.