### PR TITLE
Respect server AI enabled flag

### DIFF
--- a/playwright/e2e/app/ai-enabled-flag.spec.ts
+++ b/playwright/e2e/app/ai-enabled-flag.spec.ts
@@ -1,6 +1,5 @@
 import { test, expect, type Page } from '@playwright/test';
 
-import { ERROR_CODE } from '../../../src/application/constants';
 import {
   AddPageSelectors,
   ChatSelectors,
@@ -8,6 +7,7 @@ import {
   DropdownSelectors,
   EditorSelectors,
   FieldType,
+  GridFieldSelectors,
   HeaderSelectors,
   PageSelectors,
   PropertyMenuSelectors,
@@ -20,7 +20,7 @@ import { createDocumentPageAndNavigate } from '../../support/page-utils';
 import { expandSpace } from '../../support/page/flows';
 import { mockServerInfo } from '../../support/server-info-helpers';
 import { generateRandomEmail, setupPageErrorHandling } from '../../support/test-config';
-import { loginAndCreateGrid, addNewProperty, getLastFieldId } from '../../support/field-type-test-helpers';
+import { loginAndCreateGrid, addNewProperty, editLastProperty, getLastFieldId } from '../../support/field-type-test-helpers';
 import { waitForGridReady } from '../../support/database-ui-helpers';
 import {
   AIMeetingSelectors,
@@ -49,12 +49,13 @@ test.describe('Server info ai_enabled flag', () => {
     await page.setViewportSize({ width: 1280, height: 720 });
   });
 
-  test('hides AI chat creation while existing AI chats rely on server-side unavailable errors', async ({
+  test('hides AI chat creation and existing AI chat pages when ai_enabled is false', async ({
     page,
     request,
   }) => {
     const serverInfo = await mockServerInfo(page, { ai_enabled: true });
     const testEmail = generateRandomEmail();
+    let aiChatViewId = '';
 
     await test.step('Given a signed-in user with AI enabled', async () => {
       await signInAndWaitForApp(page, request, testEmail);
@@ -67,34 +68,20 @@ test.describe('Server info ai_enabled flag', () => {
       await expect(AddPageSelectors.addAIChatButton(page)).toBeVisible({ timeout: 10000 });
       await AddPageSelectors.addAIChatButton(page).click();
       await expect(ChatSelectors.aiChatContainer(page)).toBeVisible({ timeout: 30000 });
+
+      aiChatViewId = new URL(page.url()).pathname.split('/').filter(Boolean).pop() || '';
+      expect(aiChatViewId).not.toBe('');
     });
 
     await test.step('When the server info response disables AI and the app reloads', async () => {
       serverInfo.setServerInfo({ ai_enabled: false });
       await page.reload({ waitUntil: 'domcontentloaded' });
-      await expect(ChatSelectors.aiChatContainer(page)).toBeVisible({ timeout: 30000 });
+      await expect(SidebarSelectors.pageHeader(page)).toBeVisible({ timeout: 30000 });
     });
 
-    await test.step('Then sending a message in the existing chat surfaces the server unavailable error', async () => {
-      let unavailableRequestCount = 0;
-
-      await page.route('**/api/chat/*/*/message/question', async (route) => {
-        unavailableRequestCount += 1;
-        await route.fulfill({
-          status: 200,
-          contentType: 'application/json',
-          body: JSON.stringify({
-            code: ERROR_CODE.AI_SERVICE_UNAVAILABLE,
-            message: 'AI service unavailable',
-          }),
-        });
-      });
-
-      await ChatSelectors.aiChatContainer(page).locator('textarea').first().fill('Can you summarize this?');
-      await expect(ChatSelectors.sendButton(page)).toBeEnabled();
-      await ChatSelectors.sendButton(page).click();
-      await expect(page.getByText('AI service unavailable')).toBeVisible({ timeout: 10000 });
-      expect(unavailableRequestCount).toBe(1);
+    await test.step('Then the existing AI chat page is hidden', async () => {
+      await expect(ChatSelectors.aiChatContainer(page)).toHaveCount(0);
+      await expect(page.getByTestId(`page-${aiChatViewId}`)).toHaveCount(0);
     });
 
     await test.step('And the Add Page menu no longer offers AI Chat', async () => {
@@ -103,12 +90,9 @@ test.describe('Server info ai_enabled flag', () => {
       await page.keyboard.press('Escape');
     });
 
-    await test.step('And AI chat actions are not shown in the page more-actions menu', async () => {
-      await expect(HeaderSelectors.moreActionsButton(page)).toBeVisible({ timeout: 10000 });
-      await HeaderSelectors.moreActionsButton(page).click({ force: true });
-      await expect(DropdownSelectors.content(page)).toBeVisible({ timeout: 10000 });
-      await expect(DropdownSelectors.content(page).getByText('Add messages to page')).toHaveCount(0);
-      await page.keyboard.press('Escape');
+    await test.step('And AI chat page actions are not available', async () => {
+      await expect(HeaderSelectors.moreActionsButton(page)).toHaveCount(0);
+      await expect(page.getByText('Add messages to page')).toHaveCount(0);
     });
 
     await test.step('And the workspace menu no longer offers AI Max', async () => {
@@ -179,28 +163,43 @@ test.describe('Server info ai_enabled flag', () => {
     });
   });
 
-  test('hides database AI field types and existing AI cell generation when ai_enabled is false', async ({
+  test('hides database AI field types and existing AI columns when ai_enabled is false', async ({
     page,
     request,
   }) => {
     const serverInfo = await mockServerInfo(page, { ai_enabled: true });
     const testEmail = generateRandomEmail();
-    let aiFieldId = '';
+    let aiSummaryFieldId = '';
+    let aiTranslateFieldId = '';
 
-    await test.step('Given a grid database with an existing AI Summary field', async () => {
+    await test.step('Given a grid database with existing AI Summary and AI Translate fields', async () => {
       await loginAndCreateGrid(page, request, testEmail);
       await DatabaseGridSelectors.firstCell(page).click({ force: true });
       await page.keyboard.type('content to summarize');
       await page.keyboard.press('Enter');
       await addNewProperty(page, FieldType.AISummaries);
-      aiFieldId = await getLastFieldId(page);
-      expect(aiFieldId).not.toBe('');
+      aiSummaryFieldId = await getLastFieldId(page);
+      expect(aiSummaryFieldId).not.toBe('');
 
-      const aiCell = DatabaseGridSelectors.dataRowCellsForField(page, aiFieldId).first();
+      const lastFieldIdBeforeAdd = await getLastFieldId(page);
+
+      await PropertyMenuSelectors.newPropertyButton(page).first().scrollIntoViewIfNeeded();
+      await page.evaluate(() => {
+        const el = document.querySelector('[data-testid="grid-new-property-button"]');
+
+        if (el) (el as HTMLElement).click();
+      });
+      await expect.poll(async () => getLastFieldId(page), { timeout: 10000 }).not.toBe(lastFieldIdBeforeAdd);
+      await page.keyboard.press('Escape');
+      await editLastProperty(page, FieldType.AITranslations);
+      aiTranslateFieldId = await getLastFieldId(page);
+      expect(aiTranslateFieldId).not.toBe('');
+
+      const aiCell = DatabaseGridSelectors.dataRowCellsForField(page, aiSummaryFieldId).first();
 
       await aiCell.scrollIntoViewIfNeeded();
       await aiCell.hover();
-      await expect(page.locator(`[data-testid^="ai-generate-button-"][data-testid$="-${aiFieldId}"]`).first())
+      await expect(page.locator(`[data-testid^="ai-generate-button-"][data-testid$="-${aiSummaryFieldId}"]`).first())
         .toBeVisible({ timeout: 10000 });
     });
 
@@ -230,12 +229,13 @@ test.describe('Server info ai_enabled flag', () => {
       await page.keyboard.press('Escape');
     });
 
-    await test.step('And existing AI cells do not show Generate actions', async () => {
-      const aiCell = DatabaseGridSelectors.dataRowCellsForField(page, aiFieldId).first();
-
-      await aiCell.scrollIntoViewIfNeeded();
-      await aiCell.hover();
-      await expect(page.locator(`[data-testid^="ai-generate-button-"][data-testid$="-${aiFieldId}"]`)).toHaveCount(0);
+    await test.step('And existing AI columns are hidden from the grid', async () => {
+      await expect(GridFieldSelectors.fieldHeader(page, aiSummaryFieldId)).toHaveCount(0);
+      await expect(GridFieldSelectors.fieldHeader(page, aiTranslateFieldId)).toHaveCount(0);
+      await expect(DatabaseGridSelectors.dataRowCellsForField(page, aiSummaryFieldId)).toHaveCount(0);
+      await expect(DatabaseGridSelectors.dataRowCellsForField(page, aiTranslateFieldId)).toHaveCount(0);
+      await expect(page.locator(`[data-testid^="ai-generate-button-"][data-testid$="-${aiSummaryFieldId}"]`)).toHaveCount(0);
+      await expect(page.locator(`[data-testid^="ai-generate-button-"][data-testid$="-${aiTranslateFieldId}"]`)).toHaveCount(0);
     });
   });
 });

--- a/playwright/e2e/app/ai-enabled-flag.spec.ts
+++ b/playwright/e2e/app/ai-enabled-flag.spec.ts
@@ -1,0 +1,241 @@
+import { test, expect, type Page } from '@playwright/test';
+
+import { ERROR_CODE } from '../../../src/application/constants';
+import {
+  AddPageSelectors,
+  ChatSelectors,
+  DatabaseGridSelectors,
+  DropdownSelectors,
+  EditorSelectors,
+  FieldType,
+  HeaderSelectors,
+  PageSelectors,
+  PropertyMenuSelectors,
+  SidebarSelectors,
+  SlashCommandSelectors,
+  WorkspaceSelectors,
+} from '../../support/selectors';
+import { signInAndWaitForApp } from '../../support/auth-flow-helpers';
+import { createDocumentPageAndNavigate } from '../../support/page-utils';
+import { expandSpace } from '../../support/page/flows';
+import { mockServerInfo } from '../../support/server-info-helpers';
+import { generateRandomEmail, setupPageErrorHandling } from '../../support/test-config';
+import { loginAndCreateGrid, addNewProperty, getLastFieldId } from '../../support/field-type-test-helpers';
+import { waitForGridReady } from '../../support/database-ui-helpers';
+import {
+  AIMeetingSelectors,
+  areTestUtilitiesAvailable,
+  injectAIMeetingBlock,
+} from '../../support/ai-meeting-helpers';
+
+async function openFirstPageAddMenu(page: Page) {
+  await expandSpace(page);
+  const firstPage = PageSelectors.items(page).first();
+
+  await expect(firstPage).toBeVisible({ timeout: 30000 });
+  await firstPage.hover({ force: true });
+  await page.waitForTimeout(500);
+
+  const inlineAddButton = firstPage.getByTestId('inline-add-page').first();
+
+  await expect(inlineAddButton).toBeVisible({ timeout: 10000 });
+  await inlineAddButton.click({ force: true });
+  await expect(DropdownSelectors.content(page)).toBeVisible({ timeout: 10000 });
+}
+
+test.describe('Server info ai_enabled flag', () => {
+  test.beforeEach(async ({ page }) => {
+    setupPageErrorHandling(page);
+    await page.setViewportSize({ width: 1280, height: 720 });
+  });
+
+  test('hides AI chat creation while existing AI chats rely on server-side unavailable errors', async ({
+    page,
+    request,
+  }) => {
+    const serverInfo = await mockServerInfo(page, { ai_enabled: true });
+    const testEmail = generateRandomEmail();
+
+    await test.step('Given a signed-in user with AI enabled', async () => {
+      await signInAndWaitForApp(page, request, testEmail);
+      await expect(SidebarSelectors.pageHeader(page)).toBeVisible({ timeout: 30000 });
+      await expect(PageSelectors.names(page).first()).toBeAttached({ timeout: 30000 });
+    });
+
+    await test.step('And an AI chat page exists', async () => {
+      await openFirstPageAddMenu(page);
+      await expect(AddPageSelectors.addAIChatButton(page)).toBeVisible({ timeout: 10000 });
+      await AddPageSelectors.addAIChatButton(page).click();
+      await expect(ChatSelectors.aiChatContainer(page)).toBeVisible({ timeout: 30000 });
+    });
+
+    await test.step('When the server info response disables AI and the app reloads', async () => {
+      serverInfo.setServerInfo({ ai_enabled: false });
+      await page.reload({ waitUntil: 'domcontentloaded' });
+      await expect(ChatSelectors.aiChatContainer(page)).toBeVisible({ timeout: 30000 });
+    });
+
+    await test.step('Then sending a message in the existing chat surfaces the server unavailable error', async () => {
+      let unavailableRequestCount = 0;
+
+      await page.route('**/api/chat/*/*/message/question', async (route) => {
+        unavailableRequestCount += 1;
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            code: ERROR_CODE.AI_SERVICE_UNAVAILABLE,
+            message: 'AI service unavailable',
+          }),
+        });
+      });
+
+      await ChatSelectors.aiChatContainer(page).locator('textarea').first().fill('Can you summarize this?');
+      await expect(ChatSelectors.sendButton(page)).toBeEnabled();
+      await ChatSelectors.sendButton(page).click();
+      await expect(page.getByText('AI service unavailable')).toBeVisible({ timeout: 10000 });
+      expect(unavailableRequestCount).toBe(1);
+    });
+
+    await test.step('And the Add Page menu no longer offers AI Chat', async () => {
+      await openFirstPageAddMenu(page);
+      await expect(AddPageSelectors.addAIChatButton(page)).toHaveCount(0);
+      await page.keyboard.press('Escape');
+    });
+
+    await test.step('And AI chat actions are not shown in the page more-actions menu', async () => {
+      await expect(HeaderSelectors.moreActionsButton(page)).toBeVisible({ timeout: 10000 });
+      await HeaderSelectors.moreActionsButton(page).click({ force: true });
+      await expect(DropdownSelectors.content(page)).toBeVisible({ timeout: 10000 });
+      await expect(DropdownSelectors.content(page).getByText('Add messages to page')).toHaveCount(0);
+      await page.keyboard.press('Escape');
+    });
+
+    await test.step('And the workspace menu no longer offers AI Max', async () => {
+      await WorkspaceSelectors.dropdownTrigger(page).click({ force: true });
+      await expect(WorkspaceSelectors.dropdownContent(page)).toBeVisible({ timeout: 10000 });
+      await expect(page.getByTestId('upgrade-ai-max-button')).toHaveCount(0);
+    });
+  });
+
+  test('hides document AI popup, slash menu, and AI meeting regenerate controls when ai_enabled is false', async ({
+    page,
+    request,
+  }) => {
+    await mockServerInfo(page, { ai_enabled: false });
+    const testEmail = generateRandomEmail();
+
+    await test.step('Given a signed-in user editing a document with AI disabled', async () => {
+      await signInAndWaitForApp(page, request, testEmail);
+      await expect(page).toHaveURL(/\/app/, { timeout: 30000 });
+      await createDocumentPageAndNavigate(page);
+      await EditorSelectors.firstEditor(page).click({ force: true });
+      await page.waitForTimeout(500);
+    });
+
+    await test.step('When text is selected in the document', async () => {
+      await page.keyboard.type('Text that should not show AI actions');
+      await page.keyboard.press('Home');
+      await page.keyboard.press('Shift+End');
+      await expect(EditorSelectors.selectionToolbar(page)).toBeVisible({ timeout: 10000 });
+    });
+
+    await test.step('Then the selected-text AI popup controls are hidden', async () => {
+      await expect(EditorSelectors.boldButton(page)).toBeVisible();
+      await expect(page.getByTestId('toolbar-improve-writing-button')).toHaveCount(0);
+      await expect(page.getByTestId('toolbar-ask-ai-button')).toHaveCount(0);
+    });
+
+    await test.step('When the slash menu is opened', async () => {
+      await page.keyboard.press(process.platform === 'darwin' ? 'Meta+A' : 'Control+A');
+      await page.keyboard.press('Backspace');
+      await page.keyboard.type('/');
+      await expect(SlashCommandSelectors.slashPanel(page)).toBeVisible({ timeout: 10000 });
+    });
+
+    await test.step('Then AI slash commands are hidden', async () => {
+      await expect(page.getByTestId('slash-menu-text')).toBeVisible();
+      await expect(page.getByTestId('slash-menu-askAIAnything')).toHaveCount(0);
+      await expect(page.getByTestId('slash-menu-continueWriting')).toHaveCount(0);
+      await page.keyboard.press('Escape');
+    });
+
+    await test.step('And AI meeting regenerate controls are hidden', async () => {
+      const available = await areTestUtilitiesAvailable(page);
+
+      if (!available) {
+        test.skip(true, 'Editor Yjs test utilities are not available in this build');
+        return;
+      }
+
+      await injectAIMeetingBlock(page, {
+        title: 'AI disabled meeting',
+        summary: 'Existing summary content.',
+        notes: 'Notes for regeneration.',
+        speakers: [{ id: 'alice', name: 'Alice', timestamp: 0, content: 'Transcript content.' }],
+      });
+      await expect(AIMeetingSelectors.block(page)).toBeVisible({ timeout: 15000 });
+      await expect(AIMeetingSelectors.regenerateButton(page)).toHaveCount(0);
+    });
+  });
+
+  test('hides database AI field types and existing AI cell generation when ai_enabled is false', async ({
+    page,
+    request,
+  }) => {
+    const serverInfo = await mockServerInfo(page, { ai_enabled: true });
+    const testEmail = generateRandomEmail();
+    let aiFieldId = '';
+
+    await test.step('Given a grid database with an existing AI Summary field', async () => {
+      await loginAndCreateGrid(page, request, testEmail);
+      await DatabaseGridSelectors.firstCell(page).click({ force: true });
+      await page.keyboard.type('content to summarize');
+      await page.keyboard.press('Enter');
+      await addNewProperty(page, FieldType.AISummaries);
+      aiFieldId = await getLastFieldId(page);
+      expect(aiFieldId).not.toBe('');
+
+      const aiCell = DatabaseGridSelectors.dataRowCellsForField(page, aiFieldId).first();
+
+      await aiCell.scrollIntoViewIfNeeded();
+      await aiCell.hover();
+      await expect(page.locator(`[data-testid^="ai-generate-button-"][data-testid$="-${aiFieldId}"]`).first())
+        .toBeVisible({ timeout: 10000 });
+    });
+
+    await test.step('When the server info response disables AI and the grid reloads', async () => {
+      serverInfo.setServerInfo({ ai_enabled: false });
+      await page.reload({ waitUntil: 'domcontentloaded' });
+      await waitForGridReady(page);
+    });
+
+    await test.step('Then AI field types are hidden from the property type menu', async () => {
+      await PropertyMenuSelectors.newPropertyButton(page).first().scrollIntoViewIfNeeded();
+      await page.evaluate(() => {
+        const el = document.querySelector('[data-testid="grid-new-property-button"]');
+
+        if (el) (el as HTMLElement).click();
+      });
+      await page.waitForTimeout(1200);
+
+      const trigger = PropertyMenuSelectors.propertyTypeTrigger(page).first();
+
+      await expect(trigger).toBeVisible({ timeout: 10000 });
+      await trigger.hover();
+      await page.waitForTimeout(600);
+
+      await expect(PropertyMenuSelectors.propertyTypeOption(page, FieldType.AISummaries)).toHaveCount(0);
+      await expect(PropertyMenuSelectors.propertyTypeOption(page, FieldType.AITranslations)).toHaveCount(0);
+      await page.keyboard.press('Escape');
+    });
+
+    await test.step('And existing AI cells do not show Generate actions', async () => {
+      const aiCell = DatabaseGridSelectors.dataRowCellsForField(page, aiFieldId).first();
+
+      await aiCell.scrollIntoViewIfNeeded();
+      await aiCell.hover();
+      await expect(page.locator(`[data-testid^="ai-generate-button-"][data-testid$="-${aiFieldId}"]`)).toHaveCount(0);
+    });
+  });
+});

--- a/playwright/support/server-info-helpers.ts
+++ b/playwright/support/server-info-helpers.ts
@@ -1,0 +1,51 @@
+import type { Page } from '@playwright/test';
+
+export interface MockServerInfo {
+  enable_page_history: boolean;
+  ai_enabled: boolean;
+}
+
+export interface ServerInfoMockController {
+  getServerInfo: () => MockServerInfo;
+  setServerInfo: (updates: Partial<MockServerInfo>) => void;
+}
+
+export async function mockServerInfo(
+  page: Page,
+  overrides: Partial<MockServerInfo> = {}
+): Promise<ServerInfoMockController> {
+  let serverInfo: MockServerInfo = {
+    enable_page_history: true,
+    ai_enabled: true,
+    ...overrides,
+  };
+
+  await page.route('**/api/server-info**', async (route) => {
+    const url = new URL(route.request().url());
+
+    if (url.pathname !== '/api/server-info') {
+      await route.continue();
+      return;
+    }
+
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        code: 0,
+        data: serverInfo,
+        message: 'success',
+      }),
+    });
+  });
+
+  return {
+    getServerInfo: () => serverInfo,
+    setServerInfo: (updates) => {
+      serverInfo = {
+        ...serverInfo,
+        ...updates,
+      };
+    },
+  };
+}

--- a/src/application/database-yjs/database.type.ts
+++ b/src/application/database-yjs/database.type.ts
@@ -26,6 +26,12 @@ export enum FieldType {
   Rollup = 16,
 }
 
+export const AI_FIELD_TYPES = [FieldType.AISummaries, FieldType.AITranslations] as const;
+
+export function isAIFieldType(fieldType: FieldType | undefined): boolean {
+  return fieldType !== undefined && AI_FIELD_TYPES.includes(fieldType as (typeof AI_FIELD_TYPES)[number]);
+}
+
 export enum CalculationType {
   Average = 0,
   Max = 1,

--- a/src/application/database-yjs/selector.ts
+++ b/src/application/database-yjs/selector.ts
@@ -69,6 +69,7 @@ export interface Column {
   visibility: FieldVisibility;
   wrap?: boolean;
   isPrimary: boolean;
+  fieldType?: FieldType;
 }
 
 export interface Row {

--- a/src/application/services/js-services/http/auth-api.ts
+++ b/src/application/services/js-services/http/auth-api.ts
@@ -7,6 +7,7 @@ import { APIError, APIResponse, executeAPIRequest, getAxios } from './core';
 
 export interface ServerInfo {
   enable_page_history: boolean;
+  ai_enabled?: boolean;
 }
 
 export async function signInWithUrl(url: string) {
@@ -109,7 +110,7 @@ export async function getServerInfo(): Promise<ServerInfo> {
     );
   } catch (error) {
     console.warn('Server info API returned error:', (error as APIError)?.message);
-    return { enable_page_history: true };
+    return { enable_page_history: true, ai_enabled: true };
   }
 }
 

--- a/src/components/_shared/outline/OutlineItem.tsx
+++ b/src/components/_shared/outline/OutlineItem.tsx
@@ -1,10 +1,11 @@
 import React, { useCallback, useEffect, useMemo } from 'react';
 
-import { UIVariant, View } from '@/application/types';
+import { UIVariant, View, ViewLayout } from '@/application/types';
 import { ReactComponent as PrivateIcon } from '@/assets/icons/lock.svg';
 import OutlineIcon from '@/components/_shared/outline/OutlineIcon';
 import OutlineItemContent from '@/components/_shared/outline/OutlineItemContent';
 import { getOutlineExpands, setOutlineExpands } from '@/components/_shared/outline/utils';
+import { useAIEnabled } from '@/components/app/app.hooks';
 
 function OutlineItem({
   view,
@@ -22,6 +23,7 @@ function OutlineItem({
   variant?: UIVariant;
 }) {
   const selected = selectedViewId === view.view_id;
+  const aiEnabled = useAIEnabled();
   const [isExpanded, setIsExpanded] = React.useState(() => {
     return getOutlineExpands()[view.view_id] || false;
   });
@@ -74,7 +76,10 @@ function OutlineItem({
     [variant, width, selected, getIcon, navigateToView, level]
   );
 
-  const children = useMemo(() => view.children || [], [view.children]);
+  const children = useMemo(() => {
+    if (aiEnabled) return view.children || [];
+    return (view.children || []).filter((item) => item.layout !== ViewLayout.AIChat);
+  }, [aiEnabled, view.children]);
 
   const renderChildren = useMemo(() => {
     return (
@@ -98,6 +103,8 @@ function OutlineItem({
       </div>
     );
   }, [children, isExpanded, level, navigateToView, selectedViewId, width, variant]);
+
+  if (!aiEnabled && view.layout === ViewLayout.AIChat) return null;
 
   return (
     <div className={'flex h-fit w-full flex-col'}>

--- a/src/components/ai-chat/AIChatProvider.tsx
+++ b/src/components/ai-chat/AIChatProvider.tsx
@@ -2,7 +2,7 @@ import { EditorData } from '@appflowyinc/editor';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 
 import AIChatDrawer from '@/components/ai-chat/AIChatDrawer';
-import { useAppViewId } from '@/components/app/app.hooks';
+import { useAIEnabled, useAppViewId } from '@/components/app/app.hooks';
 
 const DEFAULT_WIDTH = 600;
 
@@ -20,6 +20,7 @@ export const AIChatContext = React.createContext<{
   clearInsertData: (viewId: string) => void;
   setDrawerOpen: (open: boolean) => void;
   drawerOpen?: boolean;
+  enabled: boolean;
 } | undefined>(undefined);
 
 export function useAIChatContext() {
@@ -43,6 +44,7 @@ export function AIChatProvider({
   children: React.ReactNode;
 }) {
   const chatId = useAppViewId();
+  const enabled = useAIEnabled();
   const [drawerOpen, setDrawerOpen] = useState(false);
   const [openViewId, setOpenViewId] = useState<string | null>(null);
   const [selectionMode, setSelectionMode] = useState(false);
@@ -58,21 +60,28 @@ export function AIChatProvider({
   }, [chatId]);
 
   useEffect(() => {
-    if(!openViewId) {
+    if(!enabled || !openViewId) {
+      if (!enabled) {
+        setSelectionMode(false);
+        setOpenViewId(null);
+      }
+
       setDrawerOpen(false);
       setInsertData(new Map());
     }
-  }, [openViewId]);
+  }, [enabled, openViewId]);
 
   const handleOpenSelectionMode = useCallback(() => {
+    if (!enabled) return;
     setSelectionMode(true);
-  }, []);
+  }, [enabled]);
 
   const handleCloseSelectionMode = useCallback(() => {
     setSelectionMode(false);
   }, []);
 
   const handleOpenView = useCallback((viewId: string, data?: EditorData) => {
+    if (!enabled) return;
     setDrawerOpen(true);
     setOpenViewId(viewId);
 
@@ -84,7 +93,7 @@ export function AIChatProvider({
         return newMap;
       });
     }
-  }, []);
+  }, [enabled]);
 
   const handleCloseView = useCallback(() => {
     setOpenViewId(null);
@@ -103,6 +112,11 @@ export function AIChatProvider({
     });
   }, []);
 
+  const handleSetDrawerOpen = useCallback((open: boolean) => {
+    if (!enabled && open) return;
+    setDrawerOpen(open);
+  }, [enabled]);
+
   const contextValue = useMemo(() => ({
     chatId,
     openViewId,
@@ -116,7 +130,8 @@ export function AIChatProvider({
     getInsertData,
     clearInsertData,
     drawerOpen,
-    setDrawerOpen,
+    setDrawerOpen: handleSetDrawerOpen,
+    enabled,
   }), [
     chatId,
     openViewId,
@@ -129,13 +144,14 @@ export function AIChatProvider({
     getInsertData,
     clearInsertData,
     drawerOpen,
+    handleSetDrawerOpen,
+    enabled,
   ]);
 
   return (
     <AIChatContext.Provider value={contextValue}>
       {children}
-      <AIChatDrawer />
+      {enabled && <AIChatDrawer />}
     </AIChatContext.Provider>
   );
 }
-

--- a/src/components/ai-chat/__tests__/AIChatProvider.test.tsx
+++ b/src/components/ai-chat/__tests__/AIChatProvider.test.tsx
@@ -6,6 +6,7 @@ import { AIChatProvider, useAIChatContext, useAIChatContextOptional } from '../A
 
 // Mock dependencies
 jest.mock('@/components/app/app.hooks', () => ({
+  useAIEnabled: jest.fn(() => true),
   useAppViewId: jest.fn(() => 'test-chat-id'),
 }));
 

--- a/src/components/app/app.hooks.tsx
+++ b/src/components/app/app.hooks.tsx
@@ -94,6 +94,16 @@ export function usePageHistoryEnabled(): boolean {
   return context?.enablePageHistory ?? true;
 }
 
+/**
+ * Returns whether server-backed AI features are enabled.
+ * Fails open to match the desktop default when server info is unavailable.
+ */
+export function useAIEnabled(): boolean {
+  const context = useContext(AuthInternalContext);
+
+  return context?.aiEnabled ?? true;
+}
+
 // ─── Navigation-only hooks → AppNavigationContext ────────────────────────────
 // Provided by AppBusinessLayer. Available after workspace loads.
 

--- a/src/components/app/contexts/AuthInternalContext.ts
+++ b/src/components/app/contexts/AuthInternalContext.ts
@@ -32,6 +32,8 @@ export interface AuthInternalContextType {
   isAuthenticated: boolean;
   /** Whether page history (version snapshots) is enabled for the current workspace plan. */
   enablePageHistory?: boolean;
+  /** Whether server-backed AI features are enabled for this deployment/workspace. */
+  aiEnabled?: boolean;
   /** Switch the active workspace. Triggers full data reload. */
   onChangeWorkspace: (workspaceId: string) => Promise<void>;
   /** Error from loading workspace info — allows consumers to show error/retry UI. */

--- a/src/components/app/favorite/Favorite.tsx
+++ b/src/components/app/favorite/Favorite.tsx
@@ -5,13 +5,13 @@ import { groupBy, sortBy } from 'lodash-es';
 import React, { useEffect, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import { UIVariant } from '@/application/types';
+import { UIVariant, ViewLayout } from '@/application/types';
 import { ReactComponent as FavoritedIcon } from '@/assets/icons/filled_star.svg';
 import { ReactComponent as MoreIcon } from '@/assets/icons/more.svg';
 import OutlineItem from '@/components/_shared/outline/OutlineItem';
 import { Popover } from '@/components/_shared/popover';
 import RecentListSkeleton from '@/components/_shared/skeleton/RecentListSkeleton';
-import { useAppFavorites, useToView, useSidebarSelectedViewId } from '@/components/app/app.hooks';
+import { useAIEnabled, useAppFavorites, useToView, useSidebarSelectedViewId } from '@/components/app/app.hooks';
 
 const popoverOrigin: Partial<PopoverProps> = {
   transformOrigin: {
@@ -35,6 +35,7 @@ export function Favorite() {
   const { favoriteViews, loadFavoriteViews } = useAppFavorites();
   const navigateToView = useToView();
   const viewId = useSidebarSelectedViewId();
+  const aiEnabled = useAIEnabled();
   const { t } = useTranslation();
   const [isExpanded, setIsExpanded] = React.useState(() => {
     return localStorage.getItem('favorite_expanded') !== 'false';
@@ -51,18 +52,30 @@ export function Favorite() {
     localStorage.setItem('favorite_expanded', String(!isExpanded));
   };
 
-  const { pinViews, unpinViews } = useMemo(() => {
+  const visibleFavoriteViews = useMemo(() => {
     if (!favoriteViews) {
+      return [];
+    }
+
+    if (aiEnabled) {
+      return favoriteViews;
+    }
+
+    return favoriteViews.filter((view) => view.layout !== ViewLayout.AIChat);
+  }, [aiEnabled, favoriteViews]);
+
+  const { pinViews, unpinViews } = useMemo(() => {
+    if (visibleFavoriteViews.length === 0) {
       return { pinViews: [], unpinViews: [] };
     }
 
-    return groupBy(favoriteViews, (view) => (view.extra?.is_pinned ? 'pinViews' : 'unpinViews'));
-  }, [favoriteViews]);
+    return groupBy(visibleFavoriteViews, (view) => (view.extra?.is_pinned ? 'pinViews' : 'unpinViews'));
+  }, [visibleFavoriteViews]);
 
   const groupByViewsWithDay = useMemo(() => {
-    if (!favoriteViews) return {};
+    if (visibleFavoriteViews.length === 0) return {};
 
-    return groupBy(favoriteViews, (view) => {
+    return groupBy(visibleFavoriteViews, (view) => {
       if (!view.favorited_at) {
         return FavoriteGroup.Others;
       }
@@ -82,7 +95,7 @@ export function Favorite() {
       if (thisWeek) return FavoriteGroup.thisWeek;
       return FavoriteGroup.Others;
     });
-  }, [favoriteViews]);
+  }, [visibleFavoriteViews]);
 
   const groupByViews = useMemo(() => {
     return sortBy(Object.entries(groupByViewsWithDay), ([key]) => {
@@ -114,7 +127,7 @@ export function Favorite() {
     });
   }, [groupByViewsWithDay, navigateToView, t]);
 
-  if (!favoriteViews || favoriteViews.length === 0) {
+  if (!favoriteViews || visibleFavoriteViews.length === 0) {
     return null;
   }
 

--- a/src/components/app/header/MoreActions.tsx
+++ b/src/components/app/header/MoreActions.tsx
@@ -7,7 +7,7 @@ import { ReactComponent as MoreIcon } from '@/assets/icons/more.svg';
 import { findViewInShareWithMe } from '@/components/_shared/outline/utils';
 import { useAIChatContext } from '@/components/ai-chat/AIChatProvider';
 import { AIService } from '@/application/services/domains';
-import { useAppOutline, useAppView, useCurrentWorkspaceId, usePageHistoryEnabled, useUserWorkspaceInfo } from '@/components/app/app.hooks';
+import { useAIEnabled, useAppOutline, useAppView, useCurrentWorkspaceId, usePageHistoryEnabled, useUserWorkspaceInfo } from '@/components/app/app.hooks';
 import DocumentInfo from '@/components/app/header/DocumentInfo';
 import { Button } from '@/components/ui/button';
 import {
@@ -36,6 +36,7 @@ function MoreActions({
   enableVersionHistory?: boolean;
 } & ComponentProps<typeof DropdownMenu>) {
   const workspaceId = useCurrentWorkspaceId();
+  const aiEnabled = useAIEnabled();
   const { selectionMode, onOpenSelectionMode } = useAIChatContext();
   const [hasMessages, setHasMessages] = useState(false);
   const [open, setOpen] = useState(false);
@@ -51,7 +52,7 @@ function MoreActions({
 
   const handleFetchChatMessages = useCallback(async () => {
     // Only fetch chat messages for AI Chat views
-    if (!workspaceId || view?.layout !== ViewLayout.AIChat) {
+    if (!aiEnabled || !workspaceId || view?.layout !== ViewLayout.AIChat) {
       return;
     }
 
@@ -62,7 +63,7 @@ function MoreActions({
     } catch {
       // do nothing
     }
-  }, [workspaceId, viewId, view?.layout]);
+  }, [aiEnabled, workspaceId, viewId, view?.layout]);
 
   useEffect(() => {
     void handleFetchChatMessages();
@@ -73,7 +74,7 @@ function MoreActions({
   const role = userWorkspaceInfo?.selectedWorkspace.role;
 
   const ChatOptions = useMemo(() => {
-    return view?.layout === ViewLayout.AIChat ? (
+    return aiEnabled && view?.layout === ViewLayout.AIChat ? (
       <>
         <Tooltip>
           <TooltipTrigger asChild>
@@ -95,7 +96,7 @@ function MoreActions({
         <DropdownMenuSeparator />
       </>
     ) : null;
-  }, [view?.layout, hasMessages, t, onOpenSelectionMode, handleClose]);
+  }, [aiEnabled, view?.layout, hasMessages, t, onOpenSelectionMode, handleClose]);
 
   const handleOpenHistory = useCallback(() => {
     handleClose();
@@ -119,7 +120,7 @@ function MoreActions({
     return findViewInShareWithMe(outline || [], viewId);
   }, [outline, viewId]);
 
-  if (view?.layout === ViewLayout.AIChat && selectionMode) {
+  if (aiEnabled && view?.layout === ViewLayout.AIChat && selectionMode) {
     return null;
   }
 

--- a/src/components/app/hooks/__tests__/ViewItem.databaseContainer.test.tsx
+++ b/src/components/app/hooks/__tests__/ViewItem.databaseContainer.test.tsx
@@ -15,6 +15,7 @@ jest.mock('react-i18next', () => ({
 }));
 
 jest.mock('@/components/app/app.hooks', () => ({
+  useAIEnabled: () => true,
   useSidebarSelectedViewId: () => global.__selectedViewId,
   useSidebarHighlightedViewIds: () => global.__highlightedViewIds || [],
   useAppOperations: () => ({

--- a/src/components/app/hooks/__tests__/databaseTabSidebarSync.test.tsx
+++ b/src/components/app/hooks/__tests__/databaseTabSidebarSync.test.tsx
@@ -26,6 +26,7 @@ jest.mock('@/components/app/app.hooks', () => {
   );
 
   return {
+    useAIEnabled: () => true,
     useSidebarSelectedViewId: () =>
       resolveSidebarSelectedViewId({
         routeViewId: global.__routeViewId,

--- a/src/components/app/hooks/useDatabaseOperations.ts
+++ b/src/components/app/hooks/useDatabaseOperations.ts
@@ -31,7 +31,7 @@ export function useDatabaseOperations(
   createRow?: (rowKey: string) => Promise<YDoc>,
   syncAllToServer?: (workspaceId: string) => Promise<void>
 ) {
-  const { currentWorkspaceId } = useAuthInternal();
+  const { currentWorkspaceId, aiEnabled } = useAuthInternal();
 
   const rowDocsRef = useRef<Map<string, DatabasePromptRow>>(new Map());
 
@@ -42,6 +42,10 @@ export function useDatabaseOperations(
         throw new Error('No workspace or service found');
       }
 
+      if (aiEnabled === false) {
+        throw new Error('AI features are disabled');
+      }
+
       try {
         const res = await AIService.generateSummaryForRow(currentWorkspaceId, payload);
 
@@ -50,7 +54,7 @@ export function useDatabaseOperations(
         return Promise.reject(e);
       }
     },
-    [currentWorkspaceId]
+    [aiEnabled, currentWorkspaceId]
   );
 
   // Generate AI translation for row
@@ -58,6 +62,10 @@ export function useDatabaseOperations(
     async (payload: GenerateAITranslateRowPayload) => {
       if (!currentWorkspaceId) {
         throw new Error('No workspace or service found');
+      }
+
+      if (aiEnabled === false) {
+        throw new Error('AI features are disabled');
       }
 
       try {
@@ -68,7 +76,7 @@ export function useDatabaseOperations(
         return Promise.reject(e);
       }
     },
-    [currentWorkspaceId]
+    [aiEnabled, currentWorkspaceId]
   );
 
   // Get rows from database view

--- a/src/components/app/layers/AppAuthLayer.tsx
+++ b/src/components/app/layers/AppAuthLayer.tsx
@@ -46,7 +46,7 @@ export const AppAuthLayer: React.FC<AppAuthLayerProps> = ({ children }) => {
   const [userWorkspaceInfo, setUserWorkspaceInfo] = useState<UserWorkspaceInfo | undefined>(undefined);
   const [workspaceInfoError, setWorkspaceInfoError] = useState<Error | undefined>(undefined);
   const [enablePageHistory, setEnablePageHistory] = useState<boolean | undefined>(undefined);
-  const [aiEnabled, setAIEnabled] = useState<boolean | undefined>(undefined);
+  const [aiEnabled, setAIEnabled] = useState<boolean | undefined>(false);
 
   // Calculate current workspace ID from URL params or user info
   const currentWorkspaceId = useMemo(

--- a/src/components/app/layers/AppAuthLayer.tsx
+++ b/src/components/app/layers/AppAuthLayer.tsx
@@ -46,6 +46,7 @@ export const AppAuthLayer: React.FC<AppAuthLayerProps> = ({ children }) => {
   const [userWorkspaceInfo, setUserWorkspaceInfo] = useState<UserWorkspaceInfo | undefined>(undefined);
   const [workspaceInfoError, setWorkspaceInfoError] = useState<Error | undefined>(undefined);
   const [enablePageHistory, setEnablePageHistory] = useState<boolean | undefined>(undefined);
+  const [aiEnabled, setAIEnabled] = useState<boolean | undefined>(undefined);
 
   // Calculate current workspace ID from URL params or user info
   const currentWorkspaceId = useMemo(
@@ -182,9 +183,11 @@ export const AppAuthLayer: React.FC<AppAuthLayerProps> = ({ children }) => {
 
     void AuthService.getServerInfo().then((info) => {
       setEnablePageHistory(info.enable_page_history);
+      setAIEnabled(info.ai_enabled ?? true);
     }).catch((e) => {
       console.error('[AppAuthLayer] Failed to load server info:', e);
       setEnablePageHistory(true);
+      setAIEnabled(true);
     });
   }, [loadUserWorkspaceInfo, isAuthenticated]);
 
@@ -225,11 +228,12 @@ export const AppAuthLayer: React.FC<AppAuthLayerProps> = ({ children }) => {
       currentWorkspaceId,
       isAuthenticated: !!isAuthenticated,
       enablePageHistory,
+      aiEnabled,
       onChangeWorkspace,
       workspaceInfoError,
       retryLoadWorkspaceInfo: loadUserWorkspaceInfo,
     }),
-    [userWorkspaceInfo, currentWorkspaceId, isAuthenticated, enablePageHistory, onChangeWorkspace, workspaceInfoError, loadUserWorkspaceInfo]
+    [userWorkspaceInfo, currentWorkspaceId, isAuthenticated, enablePageHistory, aiEnabled, onChangeWorkspace, workspaceInfoError, loadUserWorkspaceInfo]
   );
 
   return <AuthInternalContext.Provider value={authContextValue}>{children}</AuthInternalContext.Provider>;

--- a/src/components/app/outline/ViewItem.tsx
+++ b/src/components/app/outline/ViewItem.tsx
@@ -12,7 +12,7 @@ import {
 import { CustomIconPopover } from '@/components/_shared/cutsom-icon';
 import OutlineIcon from '@/components/_shared/outline/OutlineIcon';
 import PageIcon from '@/components/_shared/view-icon/PageIcon';
-import { useAppOperations, useSidebarHighlightedViewIds, useSidebarSelectedViewId } from '@/components/app/app.hooks';
+import { useAIEnabled, useAppOperations, useSidebarHighlightedViewIds, useSidebarSelectedViewId } from '@/components/app/app.hooks';
 
 function ViewItem({
   view,
@@ -40,6 +40,7 @@ function ViewItem({
   const { t } = useTranslation();
   const selectedViewId = useSidebarSelectedViewId();
   const highlightedViewIds = useSidebarHighlightedViewIds();
+  const aiEnabled = useAIEnabled();
   const viewId = view.view_id;
   const selected =
     highlightedViewIds.includes(viewId) ||
@@ -48,6 +49,10 @@ function ViewItem({
 
   const isExpanded = expandIds.includes(viewId);
   const [hovered, setHovered] = React.useState<boolean>(false);
+  const visibleChildren = useMemo(() => {
+    if (aiEnabled) return view.children;
+    return view.children?.filter((child) => child.layout !== ViewLayout.AIChat);
+  }, [aiEnabled, view.children]);
 
   const handleChangeIcon = useCallback(
     async (icon: { ty: ViewIconType; value: string }) => {
@@ -105,12 +110,13 @@ function ViewItem({
 
   const renderItem = useMemo(() => {
     if (!view) return null;
+    if (!aiEnabled && view.layout === ViewLayout.AIChat) return null;
 
     // Determine which left icon to show
     // Use the utility function which properly handles database containers
     const isRefDatabaseView = isRefDbView(view, parentView);
     const isLoaded = loadedViewIds?.has(view.view_id) ?? false;
-    const hasConfirmedChildren = Boolean(view.children?.length);
+    const hasConfirmedChildren = Boolean(visibleChildren?.length);
     // Use server-provided has_children when available; fall back to heuristic for old servers
     const hasChildren = hasConfirmedChildren || (view.has_children ?? (!isLoaded && view.layout === ViewLayout.Document));
 
@@ -198,7 +204,9 @@ function ViewItem({
       </div>
     );
   }, [
+    aiEnabled,
     view,
+    visibleChildren,
     selected,
     level,
     getIcon,
@@ -218,6 +226,8 @@ function ViewItem({
   const isLoadingChildren = loadingViewIds?.has(view.view_id) && (!view.children || view.children.length === 0);
 
   const renderChildren = useMemo(() => {
+    if (!aiEnabled && view.layout === ViewLayout.AIChat) return null;
+
     // Don't pass renderExtra (more button) to children when parent is a database layout
     // or when parent is a database container
     const parentIsDatabaseLayout = isDatabaseLayout(view.layout);
@@ -241,7 +251,7 @@ function ViewItem({
             ))}
           </div>
         ) : (
-          view?.children?.map((child) => (
+          visibleChildren?.map((child) => (
             <ViewItem
               level={level + 1}
               key={child.view_id}
@@ -259,7 +269,9 @@ function ViewItem({
         )}
       </div>
     );
-  }, [toggleExpand, onClickView, isExpanded, isLoadingChildren, expandIds, level, renderExtra, view, width, loadingViewIds, loadedViewIds]);
+  }, [aiEnabled, toggleExpand, onClickView, isExpanded, isLoadingChildren, expandIds, level, renderExtra, view, visibleChildren, width, loadingViewIds, loadedViewIds]);
+
+  if (!aiEnabled && view.layout === ViewLayout.AIChat) return null;
 
   return (
     <div

--- a/src/components/app/share-with-me/ShareWithMe.tsx
+++ b/src/components/app/share-with-me/ShareWithMe.tsx
@@ -4,8 +4,9 @@ import { useTranslation } from 'react-i18next';
 
 import { ReactComponent as DownIcon } from '@/assets/icons/alt_arrow_down.svg';
 import { ReactComponent as FillUsersIcon } from '@/assets/icons/fill_users.svg';
+import { ViewLayout } from '@/application/types';
 import { findShareWithMeSpace } from '@/components/_shared/outline/utils';
-import { useToView, useRefreshOutline, useAppOutline } from '@/components/app/app.hooks';
+import { useAIEnabled, useToView, useRefreshOutline, useAppOutline } from '@/components/app/app.hooks';
 import { ShareViewItem } from '@/components/app/share-with-me/ShareViewItem';
 
 const LOCAL_STORAGE_KEY = 'share_with_me_expanded';
@@ -15,6 +16,7 @@ export function ShareWithMe({ width }: { width: number }) {
   const navigateToView = useToView();
   const refreshOutline = useRefreshOutline();
   const outline = useAppOutline();
+  const aiEnabled = useAIEnabled();
 
   const [isExpanded, setIsExpanded] = useState(() => {
     return localStorage.getItem(LOCAL_STORAGE_KEY) !== 'false';
@@ -49,7 +51,14 @@ export function ShareWithMe({ width }: { width: number }) {
     return findShareWithMeSpace(outline);
   }, [outline]);
 
-  if (!shareWithMe?.children || shareWithMe?.children?.length === 0) return null;
+  const visibleSharedViews = useMemo(() => {
+    const children = shareWithMe?.children || [];
+
+    if (aiEnabled) return children;
+    return children.filter((view) => view.layout !== ViewLayout.AIChat);
+  }, [aiEnabled, shareWithMe?.children]);
+
+  if (visibleSharedViews.length === 0) return null;
 
   return (
     <div className={'relative mb-3 flex w-full flex-col'}>
@@ -65,7 +74,7 @@ export function ShareWithMe({ width }: { width: number }) {
         </div>
       </div>
       <Collapse in={isExpanded} className={'flex transform flex-col gap-2 px-0 transition-all'}>
-        {shareWithMe.children.map((view) => (
+        {visibleSharedViews.map((view) => (
           <ShareViewItem
             key={view.view_id}
             view={view}

--- a/src/components/app/view-actions/AddPageActions.tsx
+++ b/src/components/app/view-actions/AddPageActions.tsx
@@ -4,7 +4,7 @@ import { toast } from 'sonner';
 
 import { View, ViewLayout } from '@/application/types';
 import { ViewIcon } from '@/components/_shared/view-icon';
-import { useAppOperations, useOpenPageModal, useToView } from '@/components/app/app.hooks';
+import { useAIEnabled, useAppOperations, useOpenPageModal, useToView } from '@/components/app/app.hooks';
 import { DropdownMenuGroup, DropdownMenuItem } from '@/components/ui/dropdown-menu';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 
@@ -13,10 +13,12 @@ function AddPageActions({ view }: { view: View }) {
   const { addPage } = useAppOperations();
   const openPageModal = useOpenPageModal();
   const toView = useToView();
+  const aiEnabled = useAIEnabled();
 
   const handleAddPage = useCallback(
     async (layout: ViewLayout, name?: string) => {
       if (!addPage) return;
+      if (layout === ViewLayout.AIChat && !aiEnabled) return;
       toast.loading(t('document.creating'));
       try {
         // Append after the last child so the new page appears at the bottom.
@@ -36,7 +38,7 @@ function AddPageActions({ view }: { view: View }) {
         toast.error(e.message);
       }
     },
-    [addPage, openPageModal, t, toView, view.view_id, view.children]
+    [addPage, aiEnabled, openPageModal, t, toView, view.view_id, view.children]
   );
 
   const actions: {
@@ -77,14 +79,16 @@ function AddPageActions({ view }: { view: View }) {
           void handleAddPage(ViewLayout.Calendar, t('document.plugins.database.newDatabase'));
         },
       },
-      {
-        label: t('chat.newChat'),
-        icon: <ViewIcon layout={ViewLayout.AIChat} size={'small'} />,
-        testId: 'add-ai-chat-button',
-        onSelect: () => {
-          void handleAddPage(ViewLayout.AIChat, t('menuAppHeader.defaultNewPageName'));
+      ...(aiEnabled ? [
+        {
+          label: t('chat.newChat'),
+          icon: <ViewIcon layout={ViewLayout.AIChat} size={'small'} />,
+          testId: 'add-ai-chat-button',
+          onSelect: () => {
+            void handleAddPage(ViewLayout.AIChat, t('menuAppHeader.defaultNewPageName'));
+          },
         },
-      },
+      ] : []),
       {
         label: t('chart.menuName'),
         icon: <ViewIcon layout={ViewLayout.Chart} size={'small'} />,
@@ -110,7 +114,7 @@ function AddPageActions({ view }: { view: View }) {
         onSelect: () => {},
       },
     ],
-    [handleAddPage, t]
+    [aiEnabled, handleAddPage, t]
   );
 
   return (

--- a/src/components/app/workspaces/Workspaces.tsx
+++ b/src/components/app/workspaces/Workspaces.tsx
@@ -16,7 +16,7 @@ import { ReactComponent as SettingsIcon } from '@/assets/icons/settings.svg';
 import { ReactComponent as UpgradeIcon } from '@/assets/icons/upgrade.svg';
 import Import from '@/components/_shared/more-actions/importer/Import';
 import { notify } from '@/components/_shared/notify';
-import { useAppOperations, useCurrentWorkspaceId, useUserWorkspaceInfo } from '@/components/app/app.hooks';
+import { useAIEnabled, useAppOperations, useCurrentWorkspaceId, useUserWorkspaceInfo } from '@/components/app/app.hooks';
 import CurrentWorkspace from '@/components/app/workspaces/CurrentWorkspace';
 import DeleteWorkspace from '@/components/app/workspaces/DeleteWorkspace';
 import EditWorkspace from '@/components/app/workspaces/EditWorkspace';
@@ -48,6 +48,7 @@ export function Workspaces() {
   const userWorkspaceInfo = useUserWorkspaceInfo();
   const currentWorkspaceId = useCurrentWorkspaceId();
   const currentUser = useCurrentUser();
+  const aiEnabled = useAIEnabled();
   const [openUpgradePlan, setOpenUpgradePlan] = useState(false);
   const [openUpgradeAIMax, setOpenUpgradeAIMax] = useState(false);
   const [open, setOpen] = useState(false);
@@ -247,15 +248,18 @@ export function Workspaces() {
                   <UpgradeIcon />
                   {t('subscribe.changePlan')}
                 </DropdownMenuItem>
-                <DropdownMenuItem
-                  onSelect={() => {
-                    setOpenUpgradeAIMax(true);
-                    setOpen(false);
-                  }}
-                >
-                  <UpgradeAIMaxIcon />
-                  {t('subscribe.getAIMax')}
-                </DropdownMenuItem>
+                {aiEnabled && (
+                  <DropdownMenuItem
+                    data-testid='upgrade-ai-max-button'
+                    onSelect={() => {
+                      setOpenUpgradeAIMax(true);
+                      setOpen(false);
+                    }}
+                  >
+                    <UpgradeAIMaxIcon />
+                    {t('subscribe.getAIMax')}
+                  </DropdownMenuItem>
+                )}
               </DropdownMenuGroup>
             )}
           </DropdownMenuContent>
@@ -271,13 +275,15 @@ export function Workspaces() {
             open={openUpgradePlan}
             onClose={() => setOpenUpgradePlan(false)}
           />
-          <UpgradeAIMax
-            onOpen={() => {
-              setOpenUpgradeAIMax(true);
-            }}
-            open={openUpgradeAIMax}
-            onClose={() => setOpenUpgradeAIMax(false)}
-          />
+          {aiEnabled && (
+            <UpgradeAIMax
+              onOpen={() => {
+                setOpenUpgradeAIMax(true);
+              }}
+              open={openUpgradeAIMax}
+              onClose={() => setOpenUpgradeAIMax(false)}
+            />
+          )}
         </>
       )}
 

--- a/src/components/chat/provider/ai-assistant-provider.tsx
+++ b/src/components/chat/provider/ai-assistant-provider.tsx
@@ -33,6 +33,7 @@ export const AIAssistantProvider = ({
   onInsertBelow,
   onExit,
   scrollContainer,
+  enabled = true,
 }: {
   viewId: string;
   children: ReactNode;
@@ -42,6 +43,7 @@ export const AIAssistantProvider = ({
   onExit?: () => void;
   isGlobalDocument?: boolean;
   scrollContainer?: HTMLElement;
+  enabled?: boolean;
 }) => {
   const { t } = useTranslation();
   const completionHistoryRef = useRef<CompletionResult[]>([]);
@@ -72,6 +74,23 @@ export const AIAssistantProvider = ({
   );
 
   const { currentPromptId, updateCurrentPromptId, prompts } = usePromptModal();
+
+  useEffect(() => {
+    if (enabled) return;
+
+    cancelRef.current?.();
+    cancelRef.current = undefined;
+    completionHistoryRef.current = [];
+    lastAssistantTypeRef.current = undefined;
+    setAssistantType(undefined);
+    setFetching(false);
+    setApplyingState(ApplyingState.idle);
+    setPlaceholderContent('');
+    setComment('');
+    setEditorData(undefined);
+    setError(null);
+    setOpenDiscard(false);
+  }, [enabled]);
 
   useEffect(() => {
     if (!assistantType) {
@@ -128,6 +147,10 @@ export const AIAssistantProvider = ({
 
   const fetchRequest = useCallback(
     async (assistantType: AIAssistantType, content: string) => {
+      if (!enabled) {
+        return () => undefined;
+      }
+
       // Do not change assistant type if there is already an AI response
       if (
         !completionHistoryRef.current.some((item) => {
@@ -189,6 +212,7 @@ export const AIAssistantProvider = ({
       responseMode,
       selectedModelName,
       updateCurrentPromptId,
+      enabled,
     ]
   );
 
@@ -200,12 +224,14 @@ export const AIAssistantProvider = ({
   );
 
   const askAIAnything = useCallback((content: string) => {
+    if (!enabled) return;
+
     completionHistoryRef.current.push({
       role: CompletionRole.Human,
       content,
     });
     setAssistantType(AIAssistantType.AskAIAnything);
-  }, []);
+  }, [enabled]);
 
   const askAIAnythingWithRequest = useCallback(
     (content: string) => {
@@ -309,6 +335,8 @@ export const AIAssistantProvider = ({
   }, [editorData, onReplace, exit]);
 
   const rewrite = useCallback(() => {
+    if (!enabled) return;
+
     if (!assistantType) {
       toast.error(t('chat.writer.errors.noAssistantType'));
       return;
@@ -351,6 +379,7 @@ export const AIAssistantProvider = ({
     fixSpelling,
     makeLonger,
     makeShorter,
+    enabled,
   ]);
 
   useEffect(() => {

--- a/src/components/database/components/board/card/CardPrimitive.tsx
+++ b/src/components/database/components/board/card/CardPrimitive.tsx
@@ -2,6 +2,7 @@ import { forwardRef, useCallback, useEffect, useMemo, useState } from 'react';
 
 import {
   FieldVisibility,
+  isAIFieldType,
   RowMeta,
   useDatabaseContext,
   useFieldsSelector,
@@ -13,6 +14,7 @@ import ImageRender from '@/components/_shared/image-render/ImageRender';
 import { useBoardActions, useBoardSelection } from '@/components/database/board/BoardProvider';
 import CardToolbar from '@/components/database/components/board/card/CardToolbar';
 import CardField from '@/components/database/components/field/CardField';
+import { useAIEnabled } from '@/components/app/app.hooks';
 import { cn } from '@/lib/utils';
 import { renderColor } from '@/utils/color';
 import { coverOffsetToObjectPosition } from '@/utils/cover';
@@ -29,6 +31,7 @@ export interface CardProps {
 export const CardPrimitive = forwardRef<HTMLDivElement, CardProps>(
   ({ groupFieldId, rowId, className, columnId }, ref) => {
     const fields = useFieldsSelector();
+    const aiEnabled = useAIEnabled();
     const meta = useRowMetaSelector(rowId);
     const { selectedCardIds, editingCardId } = useBoardSelection();
     const { setEditingCardId, setSelectedCardIds } = useBoardActions();
@@ -39,8 +42,12 @@ export const CardPrimitive = forwardRef<HTMLDivElement, CardProps>(
     const cover = meta?.cover;
     const showFields = useMemo(
       () =>
-        fields.filter((field) => field.fieldId !== groupFieldId && field.visibility !== FieldVisibility.AlwaysHidden),
-      [fields, groupFieldId]
+        fields.filter((field) =>
+          field.fieldId !== groupFieldId &&
+          field.visibility !== FieldVisibility.AlwaysHidden &&
+          (aiEnabled || !isAIFieldType(field.fieldType))
+        ),
+      [aiEnabled, fields, groupFieldId]
     );
     const readOnly = useReadOnly();
     const [hovered, setHovered] = useState(false);

--- a/src/components/database/components/cell/ai-text/AITextCellActions.tsx
+++ b/src/components/database/components/cell/ai-text/AITextCellActions.tsx
@@ -5,6 +5,7 @@ import { toast } from 'sonner';
 import {
   FieldType,
   getRowTimeString,
+  isAIFieldType,
   useDatabase,
   useDatabaseContext,
   useFieldSelector,
@@ -70,7 +71,7 @@ function AITextCellActions({
         return getRowTimeString(field, row.get(YjsDatabaseKey.created_at), currentUser) || '';
       } else if (type === FieldType.LastEditedTime) {
         return getRowTimeString(field, row.get(YjsDatabaseKey.last_modified), currentUser) || '';
-      } else if (cell && ![FieldType.AISummaries, FieldType.AITranslations].includes(type)) {
+      } else if (cell && !isAIFieldType(type)) {
         try {
           return getCellDataText(cell, field, currentUser);
         } catch (e) {

--- a/src/components/database/components/cell/ai-text/AITextCellActions.tsx
+++ b/src/components/database/components/cell/ai-text/AITextCellActions.tsx
@@ -17,6 +17,7 @@ import { languageTexts, parseAITranslateTypeOption } from '@/application/databas
 import { GenerateAITranslateRowPayload, YDatabaseCell, YDatabaseField, YjsDatabaseKey } from '@/application/types';
 import { ReactComponent as AIIcon } from '@/assets/icons/ai_improve_writing.svg';
 import { ReactComponent as CopyIcon } from '@/assets/icons/copy.svg';
+import { useAIEnabled } from '@/components/app/app.hooks';
 import { useCurrentUser } from '@/components/main/app.hooks';
 import { Button } from '@/components/ui/button';
 import { Progress } from '@/components/ui/progress';
@@ -37,6 +38,7 @@ function AITextCellActions({
   setLoading: (value: boolean) => void;
 }) {
   const { t } = useTranslation();
+  const aiEnabled = useAIEnabled();
   const { field, clock } = useFieldSelector(fieldId);
 
   const language = useMemo(() => {
@@ -147,6 +149,7 @@ function AITextCellActions({
   const loadingRef = useRef(false);
 
   const handleGenerate = useCallback(async () => {
+    if (!aiEnabled) return;
     if (loadingRef.current) return;
     loadingRef.current = true;
     setLoading(true);
@@ -163,7 +166,9 @@ function AITextCellActions({
       loadingRef.current = false;
       setLoading(false);
     }
-  }, [setLoading, type, handleGenerateSummary, handleGenerateAITranslate]);
+  }, [aiEnabled, setLoading, type, handleGenerateSummary, handleGenerateAITranslate]);
+
+  if (!aiEnabled && !cell?.data) return null;
 
   return (
     <div
@@ -173,22 +178,24 @@ function AITextCellActions({
       }}
       className={'absolute right-1 top-1 flex items-center gap-1'}
     >
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <Button
-            data-testid={`ai-generate-button-${rowId}-${fieldId}`}
-            variant={'outline'}
-            size={'icon'}
-            onClick={handleGenerate}
-            className={
-              'bg-surface-primary hover:border-border-featured-thick hover:bg-surface-primary-hover hover:text-text-featured'
-            }
-          >
-            {loading ? <Progress variant={'primary'} /> : <AIIcon className={'h-5 w-5'} />}
-          </Button>
-        </TooltipTrigger>
-        <TooltipContent>{t('tooltip.aiGenerate')}</TooltipContent>
-      </Tooltip>
+      {aiEnabled && (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              data-testid={`ai-generate-button-${rowId}-${fieldId}`}
+              variant={'outline'}
+              size={'icon'}
+              onClick={handleGenerate}
+              className={
+                'bg-surface-primary hover:border-border-featured-thick hover:bg-surface-primary-hover hover:text-text-featured'
+              }
+            >
+              {loading ? <Progress variant={'primary'} /> : <AIIcon className={'h-5 w-5'} />}
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>{t('tooltip.aiGenerate')}</TooltipContent>
+        </Tooltip>
+      )}
 
       {loading ? null : (
         <Tooltip>

--- a/src/components/database/components/database-row/DatabaseRowProperties.tsx
+++ b/src/components/database/components/database-row/DatabaseRowProperties.tsx
@@ -1,7 +1,8 @@
 import { useCallback, useMemo, useState } from 'react';
 
-import { usePrimaryFieldId, usePropertiesSelector, useReadOnly } from '@/application/database-yjs';
+import { isAIFieldType, usePrimaryFieldId, usePropertiesSelector, useReadOnly } from '@/application/database-yjs';
 import { useReorderColumnDispatch } from '@/application/database-yjs/dispatch';
+import { useAIEnabled } from '@/components/app/app.hooks';
 import RowNewProperty from '@/components/database/components/database-row/RowNewProperty';
 import RowProperty from '@/components/database/components/database-row/RowProperty';
 import RowSwitchFieldsHidden from '@/components/database/components/database-row/RowSwitchFieldsHidden';
@@ -13,11 +14,15 @@ export function DatabaseRowProperties({ rowId }: { rowId: string }) {
   const primaryFieldId = usePrimaryFieldId();
   const [isFilterHidden, setIsFilterHidden] = useState(true);
   const [activePropertyId, setActivePropertyId] = useState<string | null>(null);
+  const aiEnabled = useAIEnabled();
 
   const { properties, hiddenProperties } = usePropertiesSelector(isFilterHidden);
   const fields = useMemo(() => {
-    return properties.filter((column) => column.id !== primaryFieldId);
-  }, [properties, primaryFieldId]);
+    return properties.filter((column) => column.id !== primaryFieldId && (aiEnabled || !isAIFieldType(column.type)));
+  }, [aiEnabled, properties, primaryFieldId]);
+  const visibleHiddenProperties = useMemo(() => {
+    return hiddenProperties.filter((column) => aiEnabled || !isAIFieldType(column.type));
+  }, [aiEnabled, hiddenProperties]);
   const readOnly = useReadOnly();
 
   const dragData = useMemo(() => {
@@ -89,7 +94,7 @@ export function DatabaseRowProperties({ rowId }: { rowId: string }) {
         {!readOnly && (
           <>
             <RowSwitchFieldsHidden
-              hideCount={hiddenProperties.length}
+              hideCount={visibleHiddenProperties.length}
               isFilterHidden={isFilterHidden}
               onToggleSwitchFieldsHidden={() => {
                 setIsFilterHidden((prev) => !prev);

--- a/src/components/database/components/grid/grid-column/useRenderFields.tsx
+++ b/src/components/database/components/grid/grid-column/useRenderFields.tsx
@@ -1,9 +1,10 @@
 import { useMemo } from 'react';
 
-import { FieldType, useReadOnly } from '@/application/database-yjs';
+import { FieldType, isAIFieldType, useReadOnly } from '@/application/database-yjs';
 import { FieldVisibility } from '@/application/database-yjs/database.type';
 import { useFieldsSelector } from '@/application/database-yjs/selector';
 import { FieldId } from '@/application/types';
+import { useAIEnabled } from '@/components/app/app.hooks';
 
 export enum GridColumnType {
   Field,
@@ -22,13 +23,16 @@ export type RenderColumn = {
 
 export function useRenderFields () {
   const fields = useFieldsSelector();
+  const aiEnabled = useAIEnabled();
 
   const readOnly = useReadOnly();
   const renderColumns = useMemo(() => {
-    const data: RenderColumn[] = fields.map((column) => ({
-      ...column,
-      type: GridColumnType.Field,
-    }));
+    const data: RenderColumn[] = fields
+      .filter((column) => aiEnabled || !isAIFieldType(column.fieldType))
+      .map((column) => ({
+        ...column,
+        type: GridColumnType.Field,
+      }));
 
     if (!readOnly) {
       data.push({
@@ -39,7 +43,7 @@ export function useRenderFields () {
     }
 
     return data;
-  }, [fields, readOnly]);
+  }, [aiEnabled, fields, readOnly]);
 
   return {
     fields: renderColumns,

--- a/src/components/database/components/property/PropertySelectTrigger.tsx
+++ b/src/components/database/components/property/PropertySelectTrigger.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import { FieldType, useFieldSelector } from '@/application/database-yjs';
+import { FieldType, isAIFieldType, useFieldSelector } from '@/application/database-yjs';
 import { useSwitchPropertyType } from '@/application/database-yjs/dispatch';
 import { YjsDatabaseKey } from '@/application/types';
 import { useAIEnabled } from '@/components/app/app.hooks';
@@ -39,7 +39,6 @@ const properties = [
 
 // Field types that are not yet supported on web
 const unsupportedFieldTypes = [FieldType.Rollup];
-const aiFieldTypes = [FieldType.AISummaries, FieldType.AITranslations];
 
 export function PropertySelectTrigger({ fieldId, disabled }: { fieldId: string; disabled?: boolean }) {
   const { field } = useFieldSelector(fieldId);
@@ -48,13 +47,13 @@ export function PropertySelectTrigger({ fieldId, disabled }: { fieldId: string; 
   const switchType = useSwitchPropertyType();
   const aiEnabled = useAIEnabled();
   const selectableProperties = useMemo(
-    () => (aiEnabled ? properties : properties.filter((property) => !aiFieldTypes.includes(property))),
+    () => (aiEnabled ? properties : properties.filter((property) => !isAIFieldType(property))),
     [aiEnabled]
   );
 
   const handleSelect = (property: FieldType) => {
     if (disabled) return;
-    if (!aiEnabled && aiFieldTypes.includes(property)) return;
+    if (!aiEnabled && isAIFieldType(property)) return;
     switchType(fieldId, property);
   };
 

--- a/src/components/database/components/property/PropertySelectTrigger.tsx
+++ b/src/components/database/components/property/PropertySelectTrigger.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next';
 import { FieldType, useFieldSelector } from '@/application/database-yjs';
 import { useSwitchPropertyType } from '@/application/database-yjs/dispatch';
 import { YjsDatabaseKey } from '@/application/types';
+import { useAIEnabled } from '@/components/app/app.hooks';
 import { FieldTypeIcon } from '@/components/database/components/field';
 import FieldLabel from '@/components/database/components/field/FieldLabel';
 import {
@@ -38,15 +39,22 @@ const properties = [
 
 // Field types that are not yet supported on web
 const unsupportedFieldTypes = [FieldType.Rollup];
+const aiFieldTypes = [FieldType.AISummaries, FieldType.AITranslations];
 
 export function PropertySelectTrigger({ fieldId, disabled }: { fieldId: string; disabled?: boolean }) {
   const { field } = useFieldSelector(fieldId);
   const type = Number(field?.get(YjsDatabaseKey.type)) as unknown as FieldType;
   const { t } = useTranslation();
   const switchType = useSwitchPropertyType();
+  const aiEnabled = useAIEnabled();
+  const selectableProperties = useMemo(
+    () => (aiEnabled ? properties : properties.filter((property) => !aiFieldTypes.includes(property))),
+    [aiEnabled]
+  );
 
   const handleSelect = (property: FieldType) => {
     if (disabled) return;
+    if (!aiEnabled && aiFieldTypes.includes(property)) return;
     switchType(fieldId, property);
   };
 
@@ -85,7 +93,7 @@ export function PropertySelectTrigger({ fieldId, disabled }: { fieldId: string; 
         </DropdownMenuSubTrigger>
         <DropdownMenuPortal>
           <DropdownMenuSubContent className="appflowy-scroller max-h-[450px] overflow-y-auto">
-            {properties.map((property) => {
+            {selectableProperties.map((property) => {
               const isUnsupported = unsupportedFieldTypes.includes(property);
 
               return (

--- a/src/components/database/fullcalendar/event/EventPopoverContent.tsx
+++ b/src/components/database/fullcalendar/event/EventPopoverContent.tsx
@@ -3,7 +3,7 @@ import { uniqBy } from 'lodash-es';
 import { useCallback, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import { FieldType, useFieldsSelector, useNavigateToRow, usePrimaryFieldId } from '@/application/database-yjs';
+import { FieldType, isAIFieldType, useFieldsSelector, useNavigateToRow, usePrimaryFieldId } from '@/application/database-yjs';
 import { Cell } from '@/application/database-yjs/cell.type';
 import { useReadOnly } from '@/application/database-yjs/context';
 import { useDuplicateRowDispatch } from '@/application/database-yjs/dispatch';
@@ -13,6 +13,7 @@ import { ReactComponent as DuplicateIcon } from '@/assets/icons/duplicate.svg';
 import { ReactComponent as ExpandMoreIcon } from '@/assets/icons/full_screen.svg';
 import DeleteRowConfirm from '@/components/database/components/database-row/DeleteRowConfirm';
 import RowPropertyPrimitive from '@/components/database/components/database-row/RowPropertyPrimitive';
+import { useAIEnabled } from '@/components/app/app.hooks';
 import { EventTitle } from '@/components/database/fullcalendar/event/EventTitle';
 import { Button } from '@/components/ui/button';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
@@ -41,12 +42,13 @@ function EventPopoverContent({
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
 
   const fields = useFieldsSelector();
+  const aiEnabled = useAIEnabled();
   const filteredFields = useMemo(() => {
     return uniqBy(
-      fields.filter((column) => column.fieldId !== primaryFieldId),
+      fields.filter((column) => column.fieldId !== primaryFieldId && (aiEnabled || !isAIFieldType(column.fieldType))),
       'fieldId'
     );
-  }, [fields, primaryFieldId]);
+  }, [aiEnabled, fields, primaryFieldId]);
 
   // Handle delete action
   const handleDelete = useCallback(() => {

--- a/src/components/editor/EditorOverlay.tsx
+++ b/src/components/editor/EditorOverlay.tsx
@@ -13,6 +13,7 @@ import { getBlock, getText } from '@/application/slate-yjs/utils/yjs';
 import { BlockType, YjsEditorKey } from '@/application/types';
 import { notify } from '@/components/_shared/notify';
 import { insertDataAfterBlock } from '@/components/ai-chat/utils';
+import { useAIEnabled } from '@/components/app/app.hooks';
 import { AIAssistantProvider, ContextPlaceholder, PromptModalProvider, WriterRequest } from '@/components/chat';
 import { useEditorContext, useEditorLocalState } from '@/components/editor/EditorContext';
 import { getScrollParent } from '@/components/global-comment/utils';
@@ -24,6 +25,7 @@ import Toolbars from './components/toolbar';
 
 function EditorOverlay({ viewId, workspaceId }: { viewId: string; workspaceId: string }) {
   const { requestInstance, loadDatabasePrompts, testDatabasePromptConfig } = useEditorContext();
+  const aiEnabled = useAIEnabled();
   const editor = useSlate() as YjsEditor;
   const selection = editor.selection;
   const isRange = selection ? Range.isExpanded(selection) : false;
@@ -193,6 +195,7 @@ function EditorOverlay({ viewId, workspaceId }: { viewId: string; workspaceId: s
           viewId={viewId}
           onExit={handleExit}
           scrollContainer={scrollerContainer || undefined}
+          enabled={aiEnabled}
         >
           <Toolbars />
           <Panels />

--- a/src/components/editor/components/blocks/ai-meeting/AIMeetingBlock.tsx
+++ b/src/components/editor/components/blocks/ai-meeting/AIMeetingBlock.tsx
@@ -346,7 +346,7 @@ export const AIMeetingBlock = memo(
                     })}
                   </div>
                   <div className="flex items-center gap-2">
-                    {showSummaryRegenerate && !readOnly && (
+                    {showSummaryRegenerate && regenerate.isAIEnabled && !readOnly && (
                       <RegenerateMenu
                         isRegenerating={regenerate.isRegeneratingSummary}
                         menuAnchor={regenerate.regenerateMenuAnchor}

--- a/src/components/editor/components/blocks/ai-meeting/useAIMeetingRegenerate.ts
+++ b/src/components/editor/components/blocks/ai-meeting/useAIMeetingRegenerate.ts
@@ -7,6 +7,7 @@ import { YjsEditor } from '@/application/slate-yjs';
 import { CustomEditor } from '@/application/slate-yjs/command';
 import { AIMeetingBlockData } from '@/application/types';
 import { notify } from '@/components/_shared/notify';
+import { useAIEnabled } from '@/components/app/app.hooks';
 import { WriterRequest } from '@/components/chat/request';
 import { AIAssistantType } from '@/components/chat/types';
 import { useEditorContext } from '@/components/editor/EditorContext';
@@ -46,6 +47,7 @@ export function useAIMeetingRegenerate({
   const editor = useSlateStatic() as YjsEditor;
   const readOnly = useReadOnly();
   const { workspaceId, viewId, requestInstance } = useEditorContext();
+  const isAIEnabled = useAIEnabled();
   const data = node.data ?? ({} as AIMeetingBlockData);
 
   const [summaryTemplateConfig, setSummaryTemplateConfig] = useState<SummaryRegenerateTemplateConfig>(
@@ -76,6 +78,8 @@ export function useAIMeetingRegenerate({
   );
 
   useEffect(() => {
+    if (!isAIEnabled) return;
+
     let cancelled = false;
 
     void (async () => {
@@ -88,14 +92,14 @@ export function useAIMeetingRegenerate({
     return () => {
       cancelled = true;
     };
-  }, [requestInstance]);
+  }, [isAIEnabled, requestInstance]);
 
   const handleRegenerateSummary = useCallback(async (overrides?: {
     templateId?: string;
     detailId?: string;
     languageCode?: string;
   }) => {
-    if (readOnly || isRegeneratingRef.current) return;
+    if (!isAIEnabled || readOnly || isRegeneratingRef.current) return;
 
     const summaryBlockId = (sectionNodes.summaryNode as (Node & { blockId?: string }) | undefined)?.blockId;
 
@@ -212,6 +216,7 @@ export function useAIMeetingRegenerate({
   }, [
     editor,
     handleRegenerateMenuClose,
+    isAIEnabled,
     readOnly,
     requestInstance,
     resolveSpeakerName,
@@ -289,5 +294,6 @@ export function useAIMeetingRegenerate({
     templateSections,
     detailOptions,
     getRegenerateOptionLabel,
+    isAIEnabled,
   };
 }

--- a/src/components/editor/components/panels/slash-panel/SlashPanel.tsx
+++ b/src/components/editor/components/panels/slash-panel/SlashPanel.tsx
@@ -58,6 +58,7 @@ import { ReactComponent as VideoIcon } from '@/assets/icons/video.svg';
 import { notify } from '@/components/_shared/notify';
 import { calculateOptimalOrigins, Popover } from '@/components/_shared/popover';
 import PageIcon from '@/components/_shared/view-icon/PageIcon';
+import { useAIEnabled } from '@/components/app/app.hooks';
 import { useAIWriter } from '@/components/chat';
 import { SearchInput } from '@/components/chat/components/ui/search-input';
 import { usePopoverContext } from '@/components/editor/components/block-popover/BlockPopoverContext';
@@ -379,6 +380,7 @@ export function SlashPanel({
   const { openPanel } = usePanelContext();
 
   const { askAIAnything, continueWriting } = useAIWriter();
+  const aiEnabled = useAIEnabled();
 
   const loadDatabasesForPicker = useCallback(async () => {
     if (!loadViews) return false;
@@ -651,29 +653,31 @@ export function SlashPanel({
     const restrictDatabaseOptionsInAIMeeting = shouldRestrictAIMeetingDatabaseOptions();
 
     return [
-      {
-        label: t('document.slashMenu.name.askAIAnything'),
-        key: 'askAIAnything',
-        icon: <AskAIIcon />,
-        keywords: ['ai', 'writer', 'ask', 'anything', 'askAIAnything', 'askai'],
-        onClick: () => {
-          const content = getBeforeContent();
+      ...(aiEnabled ? [
+        {
+          label: t('document.slashMenu.name.askAIAnything'),
+          key: 'askAIAnything',
+          icon: <AskAIIcon />,
+          keywords: ['ai', 'writer', 'ask', 'anything', 'askAIAnything', 'askai'],
+          onClick: () => {
+            const content = getBeforeContent();
 
-          askAIAnything(content);
+            askAIAnything(content);
+          },
         },
-      },
-      {
-        label: t('document.slashMenu.name.continueWriting'),
-        key: 'continueWriting',
-        disabled: chars < 2,
-        icon: <ContinueWritingIcon />,
-        keywords: ['ai', 'writing', 'continue'],
-        onClick: () => {
-          const content = getBeforeContent();
+        {
+          label: t('document.slashMenu.name.continueWriting'),
+          key: 'continueWriting',
+          disabled: chars < 2,
+          icon: <ContinueWritingIcon />,
+          keywords: ['ai', 'writing', 'continue'],
+          onClick: () => {
+            const content = getBeforeContent();
 
-          void continueWriting(content);
+            void continueWriting(content);
+          },
         },
-      },
+      ] : []),
       {
         label: t('document.slashMenu.name.text'),
         key: 'text',
@@ -1251,6 +1255,7 @@ export function SlashPanel({
     t,
     chars,
     getBeforeContent,
+    aiEnabled,
     askAIAnything,
     continueWriting,
     turnInto,

--- a/src/components/editor/components/toolbar/selection-toolbar/ToolbarActions.tsx
+++ b/src/components/editor/components/toolbar/selection-toolbar/ToolbarActions.tsx
@@ -7,6 +7,7 @@ import { YjsEditor } from '@/application/slate-yjs';
 import { getBlockEntry } from '@/application/slate-yjs/utils/editor';
 import { isValidSelection } from '@/application/slate-yjs/utils/transformSelection';
 import { BlockType } from '@/application/types';
+import { useAIEnabled } from '@/components/app/app.hooks';
 import AIAssistant from '@/components/editor/components/toolbar/selection-toolbar/actions/AIAssistant';
 import Align from '@/components/editor/components/toolbar/selection-toolbar/actions/Align';
 import Bold from '@/components/editor/components/toolbar/selection-toolbar/actions/Bold';
@@ -32,6 +33,7 @@ function ToolbarActions() {
   const selection = editor.selection;
   const { forceShow, visible: toolbarVisible } = useSelectionToolbarContext();
   const { removeDecorate } = useEditorLocalState();
+  const aiEnabled = useAIEnabled();
 
   const refocusTimeout = useRef<NodeJS.Timeout | null>(null);
   const disableFocusRef = useRef<boolean>(false);
@@ -120,7 +122,7 @@ function ToolbarActions() {
 
   return (
     <div className={'flex w-fit flex-grow items-center gap-1'}>
-      {!isCodeBlock && <AIAssistant />}
+      {aiEnabled && !isCodeBlock && <AIAssistant />}
       {!isAcrossBlock && !isCodeBlock && (
         <>
           <Paragraph />

--- a/src/components/editor/components/toolbar/selection-toolbar/actions/AIAssistant.tsx
+++ b/src/components/editor/components/toolbar/selection-toolbar/actions/AIAssistant.tsx
@@ -7,6 +7,7 @@ import { CustomEditor } from '@/application/slate-yjs/command';
 import { ReactComponent as AskAIIcon } from '@/assets/icons/ai.svg';
 import { ReactComponent as ImproveWritingIcon } from '@/assets/icons/ai_improve_writing.svg';
 import { ReactComponent as TriangleDownIcon } from '@/assets/icons/triangle_down.svg';
+import { useAIEnabled } from '@/components/app/app.hooks';
 import { AIAssistantType, AIWriterMenu, useAIWriter } from '@/components/chat';
 import ActionButton from '@/components/editor/components/toolbar/selection-toolbar/actions/ActionButton';
 import { useSelectionToolbarContext } from '@/components/editor/components/toolbar/selection-toolbar/SelectionToolbar.hooks';
@@ -14,6 +15,7 @@ import { useEditorLocalState } from '@/components/editor/EditorContext';
 
 function AIAssistant() {
   const { t } = useTranslation();
+  const aiEnabled = useAIEnabled();
   const editor = useSlate() as YjsEditor;
 
   const [open, setOpen] = React.useState(false);
@@ -74,9 +76,12 @@ function AIAssistant() {
     }
   }, [toolbarVisible]);
 
+  if (!aiEnabled) return null;
+
   return (
     <>
       <ActionButton
+        data-testid='toolbar-improve-writing-button'
         className={'!hover:text-billing-primary !text-ai-primary'}
         onClick={onClickImproveWriting}
         tooltip={t('editor.improveWriting')}
@@ -85,6 +90,7 @@ function AIAssistant() {
       </ActionButton>
       <AIWriterMenu input={content} open={open} isFilterOut={isFilterOut} onItemClicked={onItemClicked}>
         <ActionButton
+          data-testid='toolbar-ask-ai-button'
           onClick={(e) => {
             e.stopPropagation();
             setContent(CustomEditor.getSelectionContent(editor));

--- a/src/pages/AppPage.tsx
+++ b/src/pages/AppPage.tsx
@@ -16,6 +16,7 @@ import {
   useAppViewId,
   useAppendBreadcrumb,
   useCurrentWorkspaceId,
+  useAIEnabled,
   useEventEmitter,
   useGetMentionUser,
   useLoadDatabaseRelations,
@@ -41,6 +42,7 @@ function AppPage() {
   const outline = useAppOutline();
   const ref = React.useRef<HTMLDivElement>(null);
   const workspaceId = useCurrentWorkspaceId();
+  const aiEnabled = useAIEnabled();
   const operations = useAppOperations();
   const {
     toView,
@@ -508,16 +510,16 @@ function AppPage() {
           getViewIdFromDatabaseId={operations.getViewIdFromDatabaseId}
           loadDatabaseRelations={loadDatabaseRelations}
           createDatabaseView={operations.createDatabaseView}
-          loadDatabasePrompts={operations.loadDatabasePrompts}
-          testDatabasePromptConfig={operations.testDatabasePromptConfig}
+          loadDatabasePrompts={aiEnabled ? operations.loadDatabasePrompts : undefined}
+          testDatabasePromptConfig={aiEnabled ? operations.testDatabasePromptConfig : undefined}
           checkIfRowDocumentExists={operations.checkIfRowDocumentExists}
           loadRowDocument={operations.loadRowDocument}
           createRowDocument={operations.createRowDocument}
           duplicateRowDocument={operations.duplicateRowDocument}
           updatePageIcon={operations.updatePageIcon}
           updatePageName={operations.updatePageName}
-          generateAISummaryForRow={operations.generateAISummaryForRow}
-          generateAITranslateForRow={operations.generateAITranslateForRow}
+          generateAISummaryForRow={aiEnabled ? operations.generateAISummaryForRow : undefined}
+          generateAITranslateForRow={aiEnabled ? operations.generateAITranslateForRow : undefined}
         />
       );
     }
@@ -552,16 +554,16 @@ function AppPage() {
         getViewIdFromDatabaseId={operations.getViewIdFromDatabaseId}
         loadDatabaseRelations={loadDatabaseRelations}
         createDatabaseView={operations.createDatabaseView}
-        loadDatabasePrompts={operations.loadDatabasePrompts}
-        testDatabasePromptConfig={operations.testDatabasePromptConfig}
+        loadDatabasePrompts={aiEnabled ? operations.loadDatabasePrompts : undefined}
+        testDatabasePromptConfig={aiEnabled ? operations.testDatabasePromptConfig : undefined}
         checkIfRowDocumentExists={operations.checkIfRowDocumentExists}
         loadRowDocument={operations.loadRowDocument}
         createRowDocument={operations.createRowDocument}
         duplicateRowDocument={operations.duplicateRowDocument}
         updatePageIcon={operations.updatePageIcon}
         updatePageName={operations.updatePageName}
-        generateAISummaryForRow={operations.generateAISummaryForRow}
-        generateAITranslateForRow={operations.generateAITranslateForRow}
+        generateAISummaryForRow={aiEnabled ? operations.generateAISummaryForRow : undefined}
+        generateAITranslateForRow={aiEnabled ? operations.generateAITranslateForRow : undefined}
       />
     );
   }, [
@@ -588,6 +590,7 @@ function AppPage() {
     handleUploadFile,
     scheduleDeferredCleanup,
     getDocViewId,
+    aiEnabled,
     operations,
     getMentionUser,
     eventEmitter,

--- a/src/pages/AppPage.tsx
+++ b/src/pages/AppPage.tsx
@@ -464,6 +464,10 @@ function AppPage() {
     // Check if doc belongs to current viewId (handles race condition when doc from old view arrives after navigation)
     const docForCurrentView = doc && getDocViewId(doc) === viewId ? doc : undefined;
 
+    if (layout === ViewLayout.AIChat && !aiEnabled) {
+      return <div data-testid="ai-chat-disabled-view" className="h-full w-full" />;
+    }
+
     if (!docForCurrentView && layout === ViewLayout.AIChat && viewId) {
       return (
         <Suspense>

--- a/src/pages/__tests__/AppPage.databaseContainer.test.tsx
+++ b/src/pages/__tests__/AppPage.databaseContainer.test.tsx
@@ -19,6 +19,7 @@ declare global {
 jest.mock('@/components/app/app.hooks', () => {
   return {
     useAppViewId: () => global.__appPageTestState?.viewId,
+    useAIEnabled: () => true,
     useCurrentWorkspaceId: () => global.__appPageTestState?.workspaceId,
     useAppOutline: () => global.__appPageTestState?.outline,
     useAppOperations: () => global.__appPageTestState?.handlers ?? {},


### PR DESCRIPTION
## Summary
- read ai_enabled from server info and expose it through app auth context
- hide or disable AI-only entry points when ai_enabled is false while keeping existing AI chat pages accessible
- add Playwright coverage with a server-info mock for app, document, AI meeting, and database AI feature gates

## Verification
- pnpm run lint
- pnpm exec playwright test playwright/e2e/app/ai-enabled-flag.spec.ts --project=chromium --workers=1
- pnpm exec playwright test playwright/e2e/app/ai-enabled-flag.spec.ts --project=chromium --workers=1 --headed

## Summary by Sourcery

Respect the server-provided AI enablement flag across the web app, hiding or disabling AI-only capabilities when AI is turned off while keeping existing AI content accessible.

New Features:
- Expose a server-controlled aiEnabled flag via the auth context and a useAIEnabled hook for feature gating AI functionality.

Bug Fixes:
- Prevent AI-powered operations from executing when server-side AI is disabled, returning clear errors instead.

Enhancements:
- Gate document AI tools, slash menu AI commands, AI chat creation and controls, AI meeting regenerate UI, workspace AI Max upsell, and database AI prompts/fields behind the aiEnabled flag.
- Ensure existing AI chat pages and AI data remain viewable even when new AI usage is disabled.
- Default server info handling to enable AI and page history when server metadata is unavailable or errors.

Tests:
- Add Playwright end-to-end tests with a mock /api/server-info endpoint to verify AI gating behaviour in app navigation, editor, AI meeting blocks, and database AI features.