### PR TITLE
feat: add relative date filters (Today/Yesterday/Tomorrow/This-Last-N…

### DIFF
--- a/playwright/e2e/database/row-document.spec.ts
+++ b/playwright/e2e/database/row-document.spec.ts
@@ -193,6 +193,73 @@ test.describe('Row Document Test', () => {
     await expect(page.locator('[role="dialog"]')).toContainText(longText);
   });
 
+  /**
+   * Repro: pasting a URL as a bookmark in a row's document, then closing
+   * the card immediately, used to lose the bookmark. The LinkPreview block
+   * was inserted via Slate's Transforms.insertNodes, but the slate-yjs
+   * binding's applyInsertNode bails out for non-text nodes — so the block
+   * rendered in Slate's local state but never persisted to the Y.Doc, and
+   * was discarded as soon as the editor unmounted. The fix writes the
+   * block directly to Yjs (matching the markdown-paste path).
+   */
+  test('persists pasted bookmark when card is closed immediately after paste', async ({
+    page,
+    request,
+  }) => {
+    const testEmail = generateRandomEmail();
+    const cardName = `Bookmark-${uuidv4().substring(0, 6)}`;
+    const bookmarkUrl = `https://appflowy.io/bookmark-test-${uuidv4().substring(0, 8)}`;
+
+    // Given: a board with a new card and the row document editor focused
+    await createBoardAndWait(page, request, testEmail);
+    await addNewCard(page, cardName);
+    await openCard(page, cardName);
+    await clickIntoEditor(page);
+
+    // When: pasting a URL into the row document editor
+    await page.evaluate((url) => {
+      const editors = Array.from(document.querySelectorAll('[data-slate-editor="true"]')) as HTMLElement[];
+      // The dialog's row sub-document editor is the last/innermost slate editor
+      const target = editors[editors.length - 1];
+
+      if (!target) throw new Error('No slate editor found in dialog');
+
+      const clipboardData = new DataTransfer();
+
+      clipboardData.setData('text/plain', url);
+      const event = new ClipboardEvent('paste', {
+        clipboardData,
+        bubbles: true,
+        cancelable: true,
+      });
+
+      target.dispatchEvent(event);
+    }, bookmarkUrl);
+
+    const dialog = page.locator('[role="dialog"]');
+
+    await expect(dialog.locator('.link-preview-block')).toBeVisible({ timeout: 5000 });
+
+    // When: closing the modal IMMEDIATELY after paste — no debounce window.
+    await closeRowDetailWithEscape(page);
+    await page.waitForTimeout(3000);
+
+    // And: reopening the same card
+    await openCard(page, cardName);
+    await page.waitForTimeout(2000);
+
+    const scrollContainer = dialog.locator('.appflowy-scroll-container');
+
+    if ((await scrollContainer.count()) > 0) {
+      await scrollContainer.evaluate((el) => el.scrollTo(0, 9999));
+      await page.waitForTimeout(500);
+    }
+
+    // Then: the bookmark must still be present in the row document
+    await expect(dialog.locator('.link-preview-block')).toBeVisible({ timeout: 10000 });
+    await expect(dialog).toContainText(bookmarkUrl);
+  });
+
   test('shows row document indicator after editing row document', async ({ page, request }) => {
     const testEmail = generateRandomEmail();
     const cardName = `RowDoc-${uuidv4().substring(0, 6)}`;

--- a/playwright/e2e/database2/filter-date-relative.spec.ts
+++ b/playwright/e2e/database2/filter-date-relative.spec.ts
@@ -1,0 +1,253 @@
+/**
+ * Database Relative Date Filter Tests
+ *
+ * Mirrors the desktop BDD scenario from AppFlowy-Premium PR #965:
+ *   AppFlowy-Premium/frontend/appflowy_flutter/integration_test/desktop/
+ *     bdd/database/grid/relative_date_filter.feature
+ *
+ * Both tests use the same row names, date arithmetic, and assertion order
+ * (see playwright/support/relative-date-anchors.ts).
+ */
+import { test, expect, Page, Locator } from '@playwright/test';
+
+import { addFieldWithType, addRows } from '../../support/field-type-helpers';
+import {
+  addFilterByFieldName,
+  assertRowCount,
+  clickFilterChip,
+  generateRandomEmail,
+  getPrimaryFieldId,
+  loginAndCreateGrid,
+  setupFilterTest,
+  typeTextIntoCell,
+} from '../../support/filter-test-helpers';
+import {
+  getRelativeDateAnchors,
+  RELATIVE_DATE_FIELD_NAME,
+} from '../../support/relative-date-anchors';
+import { DatabaseGridSelectors, FieldType, GridFieldSelectors, PropertyMenuSelectors } from '../../support/selectors';
+
+// Mirrors src/application/database-yjs/fields/date/date.type.ts.
+enum DateFilterCondition {
+  DateStartsToday = 16,
+  DateStartsYesterday = 17,
+  DateStartsTomorrow = 18,
+  DateStartsThisWeek = 19,
+  DateStartsLastWeek = 20,
+  DateStartsNextWeek = 21,
+}
+
+async function getDateFieldId(page: Page): Promise<string> {
+  const lastHeader = page.locator('[data-testid^="grid-field-header-"]').last();
+  const testId = await lastHeader.getAttribute('data-testid');
+  return testId?.replace('grid-field-header-', '') || '';
+}
+
+async function renameField(page: Page, fieldId: string, newName: string): Promise<void> {
+  await GridFieldSelectors.fieldHeader(page, fieldId).last().click({ force: true });
+  await page.waitForTimeout(400);
+  await PropertyMenuSelectors.editPropertyMenuItem(page).first().click({ force: true });
+  await page.waitForTimeout(400);
+
+  const nameInput = page.locator('[data-radix-popper-content-wrapper]').last().locator('input').first();
+  await expect(nameInput).toBeVisible({ timeout: 5000 });
+  await nameInput.clear();
+  await nameInput.fill(newName);
+  await page.keyboard.press('Escape');
+  await page.waitForTimeout(400);
+}
+
+async function clickDateCell(page: Page, fieldId: string, rowIndex: number): Promise<void> {
+  const cell = DatabaseGridSelectors.dataRowCellsForField(page, fieldId).nth(rowIndex);
+  await cell.scrollIntoViewIfNeeded();
+  await cell.dispatchEvent('click', { bubbles: true });
+  await expect(page.locator('[data-radix-popper-content-wrapper]').last()).toBeVisible({
+    timeout: 5000,
+  });
+  await page.waitForTimeout(250);
+}
+
+// Navigate the open react-day-picker popover to the target month, then click the day.
+// Robust to dates in adjacent months (e.g. last/next week crossing a month boundary).
+async function setDateInOpenPicker(page: Page, target: Date): Promise<void> {
+  const popover = page.locator('[data-radix-popper-content-wrapper]').last();
+  await expect(popover).toBeVisible({ timeout: 5000 });
+  await page.waitForTimeout(150);
+
+  const targetLabel = target.toLocaleString('en-US', { month: 'long', year: 'numeric' });
+
+  for (let i = 0; i < 24; i++) {
+    const caption = popover.locator('text=/^[A-Z][a-z]+ \\d{4}$/').first();
+    await expect(caption).toBeVisible({ timeout: 5000 });
+    const currentText = ((await caption.textContent()) ?? '').trim();
+    if (currentText === targetLabel) break;
+
+    const [monthName, yearStr] = currentText.split(' ');
+    const currentMonthDate = new Date(`${monthName} 1, ${yearStr}`);
+    const dir = currentMonthDate.getTime() < target.getTime() ? 'next-month' : 'previous-month';
+    await popover.locator(`button[name="${dir}"]`).click();
+    await page.waitForTimeout(150);
+  }
+
+  // Click the day — skip "day-outside" buttons so we land on the target month's day.
+  const dayButtons = popover.locator('button');
+  const count = await dayButtons.count();
+  let clicked = false;
+  for (let i = 0; i < count; i++) {
+    const btn = dayButtons.nth(i);
+    const text = (await btn.textContent())?.trim();
+    if (text !== String(target.getDate())) continue;
+    const cls = (await btn.getAttribute('class')) || '';
+    if (cls.includes('day-outside')) continue;
+    await btn.evaluate((el) => (el as HTMLElement).click());
+    clicked = true;
+    break;
+  }
+  if (!clicked) {
+    throw new Error(`setDateInOpenPicker: could not click day ${target.getDate()} in ${targetLabel}`);
+  }
+  await page.waitForTimeout(300);
+}
+
+async function setCellDate(page: Page, dateFieldId: string, rowIndex: number, target: Date): Promise<void> {
+  await clickDateCell(page, dateFieldId, rowIndex);
+  await setDateInOpenPicker(page, target);
+  await page.keyboard.press('Escape');
+  await page.waitForTimeout(250);
+}
+
+async function changeDateFilterCondition(page: Page, condition: DateFilterCondition): Promise<void> {
+  const trigger = page.getByTestId('filter-condition-trigger');
+  await expect(trigger).toBeVisible({ timeout: 5000 });
+  await trigger.click({ force: true });
+  await page.waitForTimeout(300);
+  const item = page.getByTestId(`filter-condition-${condition}`);
+  await expect(item).toBeVisible({ timeout: 5000 });
+  await item.click({ force: true });
+  await page.waitForTimeout(300);
+}
+
+async function expectVisibleRowNames(cells: Locator, names: string[]): Promise<void> {
+  for (const name of names) {
+    await expect(cells).toContainText([name]);
+  }
+}
+
+async function expectHiddenRowNames(cells: Locator, names: string[]): Promise<void> {
+  for (const name of names) {
+    await expect(cells).not.toContainText([name]);
+  }
+}
+
+test.describe('Database Relative Date Filter Tests', () => {
+  test('relative date filters return the correct rows', async ({ page, request }) => {
+    test.setTimeout(180_000); // 9-row seed + 6 filter switches takes a while.
+
+    setupFilterTest(page);
+    const email = generateRandomEmail();
+    await loginAndCreateGrid(page, request, email);
+
+    // Given: a grid with a "Due Date" date field (matches desktop scenario field name).
+    const primaryFieldId = await getPrimaryFieldId(page);
+    await addFieldWithType(page, FieldType.DateTime);
+    await page.waitForTimeout(800);
+    const dateFieldId = await getDateFieldId(page);
+    await renameField(page, dateFieldId, RELATIVE_DATE_FIELD_NAME);
+
+    // And: the grid has the nine relative-date anchor rows.
+    const anchors = getRelativeDateAnchors();
+    // Grid starts with 3 rows; add 6 more to reach 9.
+    await addRows(page, anchors.length - 3);
+    await page.waitForTimeout(500);
+
+    for (let i = 0; i < anchors.length; i++) {
+      await typeTextIntoCell(page, primaryFieldId, i, anchors[i].name);
+    }
+    for (let i = 0; i < anchors.length; i++) {
+      await setCellDate(page, dateFieldId, i, anchors[i].date);
+    }
+    await assertRowCount(page, anchors.length);
+
+    // When: the user adds a today date filter on field 'Due Date'.
+    await addFilterByFieldName(page, RELATIVE_DATE_FIELD_NAME);
+    await page.waitForTimeout(500);
+    await changeDateFilterCondition(page, DateFilterCondition.DateStartsToday);
+    await page.keyboard.press('Escape');
+    await page.waitForTimeout(500);
+
+    let cells = DatabaseGridSelectors.dataRowCellsForField(page, primaryFieldId);
+
+    // Then: the today row is shown; yesterday/tomorrow rows are hidden.
+    await expectVisibleRowNames(cells, ['Today task']);
+    await expectHiddenRowNames(cells, ['Yesterday task', 'Tomorrow task']);
+
+    // When: condition → Yesterday.
+    await clickFilterChip(page);
+    await changeDateFilterCondition(page, DateFilterCondition.DateStartsYesterday);
+    await page.keyboard.press('Escape');
+    await page.waitForTimeout(500);
+    cells = DatabaseGridSelectors.dataRowCellsForField(page, primaryFieldId);
+    await expectVisibleRowNames(cells, ['Yesterday task']);
+    await expectHiddenRowNames(cells, ['Today task', 'Tomorrow task']);
+
+    // When: condition → Tomorrow.
+    await clickFilterChip(page);
+    await changeDateFilterCondition(page, DateFilterCondition.DateStartsTomorrow);
+    await page.keyboard.press('Escape');
+    await page.waitForTimeout(500);
+    cells = DatabaseGridSelectors.dataRowCellsForField(page, primaryFieldId);
+    await expectVisibleRowNames(cells, ['Tomorrow task']);
+    await expectHiddenRowNames(cells, ['Today task', 'Yesterday task']);
+
+    // When: condition → This week.
+    await clickFilterChip(page);
+    await changeDateFilterCondition(page, DateFilterCondition.DateStartsThisWeek);
+    await page.keyboard.press('Escape');
+    await page.waitForTimeout(500);
+    cells = DatabaseGridSelectors.dataRowCellsForField(page, primaryFieldId);
+    await expectVisibleRowNames(cells, ['ThisMon task', 'ThisSun task']);
+    await expectHiddenRowNames(cells, ['LastMon task', 'NextMon task']);
+
+    // When: condition → Last week.
+    await clickFilterChip(page);
+    await changeDateFilterCondition(page, DateFilterCondition.DateStartsLastWeek);
+    await page.keyboard.press('Escape');
+    await page.waitForTimeout(500);
+    cells = DatabaseGridSelectors.dataRowCellsForField(page, primaryFieldId);
+    await expectVisibleRowNames(cells, ['LastMon task', 'LastSun task']);
+    await expectHiddenRowNames(cells, ['ThisMon task', 'NextMon task']);
+
+    // When: condition → Next week.
+    await clickFilterChip(page);
+    await changeDateFilterCondition(page, DateFilterCondition.DateStartsNextWeek);
+    await page.keyboard.press('Escape');
+    await page.waitForTimeout(500);
+    cells = DatabaseGridSelectors.dataRowCellsForField(page, primaryFieldId);
+    await expectVisibleRowNames(cells, ['NextMon task', 'NextSun task']);
+    await expectHiddenRowNames(cells, ['ThisMon task', 'LastMon task']);
+  });
+
+  // Web-only UX assertion: the date input disappears for relative conditions.
+  test('relative date filter hides the date input', async ({ page, request }) => {
+    setupFilterTest(page);
+    const email = generateRandomEmail();
+    await loginAndCreateGrid(page, request, email);
+
+    await addFieldWithType(page, FieldType.DateTime);
+    await page.waitForTimeout(1000);
+
+    await addFilterByFieldName(page, 'Date');
+    await page.waitForTimeout(500);
+
+    // Default condition is "DateStartsOn" (0) — date picker is shown.
+    await expect(page.getByTestId('date-filter-date-picker')).toBeVisible({ timeout: 5000 });
+
+    await changeDateFilterCondition(page, DateFilterCondition.DateStartsToday);
+    await page.waitForTimeout(500);
+    await expect(page.getByTestId('date-filter-date-picker')).toHaveCount(0);
+
+    await changeDateFilterCondition(page, 0 as DateFilterCondition); // DateStartsOn
+    await page.waitForTimeout(500);
+    await expect(page.getByTestId('date-filter-date-picker')).toBeVisible({ timeout: 5000 });
+  });
+});

--- a/playwright/e2e/database2/filter-new-row-opens-detail.spec.ts
+++ b/playwright/e2e/database2/filter-new-row-opens-detail.spec.ts
@@ -1,0 +1,53 @@
+/**
+ * When filters are active, clicking "+ New row" should open the row detail
+ * modal so the user can complete the row (its primary cell is empty and may
+ * need to be filled to satisfy the filter or just to be useful).
+ */
+import { test, expect } from '@playwright/test';
+
+import { addRows } from '../../support/field-type-helpers';
+import {
+  addFilterByFieldName,
+  generateRandomEmail,
+  loginAndCreateGrid,
+  setupFilterTest,
+} from '../../support/filter-test-helpers';
+import { DatabaseGridSelectors } from '../../support/selectors';
+
+test.describe('New row opens detail when filter is active', () => {
+  test('clicking new row with filter opens row detail modal', async ({ page, request }) => {
+    setupFilterTest(page);
+    const email = generateRandomEmail();
+    await loginAndCreateGrid(page, request, email);
+
+    // Add a Name filter (works without typing content — empty filter still counts).
+    await addFilterByFieldName(page, 'Name');
+
+    // Dismiss the filter chip popover by clicking the grid area (avoid Escape — it
+    // closes the chip popover but can also dispatch to other listeners).
+    await page.locator('main').click({ position: { x: 5, y: 5 }, force: true });
+    await page.waitForTimeout(500);
+
+    // Verify the filter persists.
+    await expect(page.getByTestId('database-filter-condition')).toHaveCount(1);
+
+    // Click "+ New row".
+    await DatabaseGridSelectors.newRowButton(page).click();
+
+    // The row detail modal should appear (MUI Dialog renders [role="dialog"]).
+    await expect(page.locator('[role="dialog"]').last()).toBeVisible({ timeout: 8000 });
+  });
+
+  test('clicking new row without filter does NOT open detail modal', async ({ page, request }) => {
+    setupFilterTest(page);
+    const email = generateRandomEmail();
+    await loginAndCreateGrid(page, request, email);
+
+    const dialogsBefore = await page.locator('[role="dialog"]').count();
+    await addRows(page, 1);
+    await page.waitForTimeout(1500);
+    const dialogsAfter = await page.locator('[role="dialog"]').count();
+
+    expect(dialogsAfter).toBe(dialogsBefore);
+  });
+});

--- a/playwright/support/relative-date-anchors.ts
+++ b/playwright/support/relative-date-anchors.ts
@@ -1,0 +1,58 @@
+/**
+ * Shared data config for the "relative date filter" feature, kept in lock-step
+ * with the desktop integration test fixture:
+ *
+ *   AppFlowy-Premium/frontend/appflowy_flutter/test/step/
+ *     the_current_grid_has_relative_date_anchor_rows_in_date_field.dart
+ *
+ * If you change row names or date arithmetic here, mirror the change there
+ * (and vice versa) so both platforms run the same scenario.
+ */
+
+export const RELATIVE_DATE_FIELD_NAME = 'Due Date';
+
+export interface RelativeDateAnchor {
+  readonly name: string;
+  readonly date: Date;
+}
+
+function startOfDay(d: Date): Date {
+  const x = new Date(d);
+  x.setHours(0, 0, 0, 0);
+  return x;
+}
+
+function addDays(d: Date, days: number): Date {
+  const x = new Date(d);
+  x.setDate(x.getDate() + days);
+  return x;
+}
+
+// Monday-based week start (ISO 8601), matching the source's
+// dateRangeForRelative() and the desktop fixture's `monday`.
+function mondayOf(d: Date): Date {
+  const day = startOfDay(d);
+  const monBased = (day.getDay() + 6) % 7;
+  return addDays(day, -monBased);
+}
+
+/**
+ * Returns the nine anchor rows used by both the web and desktop scenarios.
+ * Order matters: the test fills row[i] from anchors[i].
+ */
+export function getRelativeDateAnchors(today: Date = new Date()): RelativeDateAnchor[] {
+  const todayDate = startOfDay(today);
+  const monday = mondayOf(todayDate);
+
+  return [
+    { name: 'Today task', date: todayDate },
+    { name: 'Yesterday task', date: addDays(todayDate, -1) },
+    { name: 'Tomorrow task', date: addDays(todayDate, 1) },
+    { name: 'ThisMon task', date: monday },
+    { name: 'ThisSun task', date: addDays(monday, 6) },
+    { name: 'LastMon task', date: addDays(monday, -7) },
+    { name: 'LastSun task', date: addDays(monday, -1) },
+    { name: 'NextMon task', date: addDays(monday, 7) },
+    { name: 'NextSun task', date: addDays(monday, 13) },
+  ];
+}

--- a/src/@types/translations/en.json
+++ b/src/@types/translations/en.json
@@ -2725,6 +2725,9 @@
     "yesterday": "Yesterday",
     "today": "Today",
     "tomorrow": "Tomorrow",
+    "thisWeek": "This week",
+    "lastWeek": "Last week",
+    "nextWeek": "Next week",
     "oneWeek": "1 week"
   },
   "notificationHub": {

--- a/src/application/database-yjs/__tests__/pre-fill.test.ts
+++ b/src/application/database-yjs/__tests__/pre-fill.test.ts
@@ -101,4 +101,38 @@ describe('pre-fill cell tests', () => {
 
     expect(dateFilterFillData(filter)).toEqual({ data: start, endTimestamp: end, isRange: true });
   });
+
+  it('pre-fills DateStartsToday with today midnight', () => {
+    const filter = createFilter(DateFilterCondition.DateStartsToday, '');
+    const today = dayjs().startOf('day').unix().toString();
+
+    expect(dateFilterFillData(filter)).toEqual({ data: today, isRange: false });
+  });
+
+  it('pre-fills DateStartsYesterday with yesterday midnight', () => {
+    const filter = createFilter(DateFilterCondition.DateStartsYesterday, '');
+    const yesterday = dayjs().startOf('day').subtract(1, 'day').unix().toString();
+
+    expect(dateFilterFillData(filter)).toEqual({ data: yesterday, isRange: false });
+  });
+
+  it('pre-fills DateStartsThisWeek with this Monday midnight', () => {
+    const filter = createFilter(DateFilterCondition.DateStartsThisWeek, '');
+    const today = dayjs().startOf('day');
+    const monBased = (today.day() + 6) % 7;
+    const monday = today.subtract(monBased, 'day').unix().toString();
+
+    expect(dateFilterFillData(filter)).toEqual({ data: monday, isRange: false });
+  });
+
+  it('pre-fills DateEndsToday with today midnight as a range', () => {
+    const filter = createFilter(DateFilterCondition.DateEndsToday, '');
+    const today = dayjs().startOf('day').unix().toString();
+
+    expect(dateFilterFillData(filter)).toEqual({
+      data: today,
+      endTimestamp: today,
+      isRange: true,
+    });
+  });
 });

--- a/src/application/database-yjs/dispatch.ts
+++ b/src/application/database-yjs/dispatch.ts
@@ -1,19 +1,16 @@
 import dayjs from 'dayjs';
 import { nanoid } from 'nanoid';
 import { useCallback, useMemo } from 'react';
-import { v4 as uuidv4 } from 'uuid';
 import * as Y from 'yjs';
 
 import { calculateFieldValue } from '@/application/database-yjs/calculation';
 import {
-  useCreateRow,
   useDatabase,
   useDatabaseContext,
   useDatabaseFields,
   useDatabaseView,
   useDatabaseViewId,
   useDefaultTimeSetting,
-  useDocGuid,
   useRowMap,
   useSharedRoot,
 } from '@/application/database-yjs/context';
@@ -30,16 +27,17 @@ import {
   RollupDisplayMode,
   SortCondition,
 } from '@/application/database-yjs/database.type';
+import { useNewRowDispatch } from '@/application/database-yjs/dispatch/row';
 import { getFieldName, NumberFormat, parseSelectOptionTypeOptions, SelectOption, SelectOptionColor, SelectTypeOption } from '@/application/database-yjs/fields';
 import { createCheckboxCell } from '@/application/database-yjs/fields/checkbox/utils';
 import { createRelationField } from '@/application/database-yjs/fields/relation/utils';
 import { createRollupField } from '@/application/database-yjs/fields/rollup/utils';
 import { createSelectOptionCell } from '@/application/database-yjs/fields/select-option/utils';
 import { createDateTimeField } from '@/application/database-yjs/fields/text/utils';
-import { dateFilterFillData, filterFillData, getDefaultFilterCondition } from '@/application/database-yjs/filter';
-import { getOptionsFromRow, initialDatabaseRow } from '@/application/database-yjs/row';
-import { generateRowMeta, getMetaIdMap, getRowKey } from '@/application/database-yjs/row_meta';
-import { useBoardLayoutSettings, useCalendarLayoutSetting, useDatabaseViewLayout, useFieldSelector, useFieldType } from '@/application/database-yjs/selector';
+import { getDefaultFilterCondition } from '@/application/database-yjs/filter';
+import { getOptionsFromRow } from '@/application/database-yjs/row';
+import { getMetaIdMap } from '@/application/database-yjs/row_meta';
+import { useBoardLayoutSettings, useCalendarLayoutSetting, useFieldSelector, useFieldType } from '@/application/database-yjs/selector';
 import { executeOperations } from '@/application/slate-yjs/utils/yjs';
 import {
   DatabaseViewLayout,
@@ -1193,189 +1191,6 @@ export function useDeletePropertyDispatch() {
   );
 }
 
-export function useNewRowDispatch() {
-  const database = useDatabase();
-  const sharedRoot = useSharedRoot();
-  const createRow = useCreateRow();
-  const guid = useDocGuid();
-  const viewId = useDatabaseViewId();
-  const currentView = useDatabaseView();
-  const layout = useDatabaseViewLayout();
-  const isCalendar = layout === DatabaseViewLayout.Calendar;
-  const calendarSetting = useCalendarLayoutSetting();
-  const filters = currentView?.get(YjsDatabaseKey.filters);
-  const { navigateToRow } = useDatabaseContext();
-
-  return useCallback(
-    async ({
-      beforeRowId,
-      cellsData,
-      tailing = false,
-    }: {
-      beforeRowId?: string;
-      cellsData?: Record<
-        FieldId,
-        | string
-        | {
-          data: string;
-          endTimestamp?: string;
-          isRange?: boolean;
-          includeTime?: boolean;
-          reminderId?: string;
-        }
-      >;
-      tailing?: boolean;
-    }) => {
-      if (!currentView) {
-        throw new Error('Current view not found');
-      }
-
-      if (!createRow) {
-        throw new Error('No createRow function');
-      }
-
-      const rowId = uuidv4();
-      const rowKey = getRowKey(guid, rowId);
-      const rowDoc = await createRow(rowKey);
-      let shouldOpenRowModal = false;
-
-      rowDoc.transact(() => {
-        initialDatabaseRow(rowId, database.get(YjsDatabaseKey.id), rowDoc);
-        const rowSharedRoot = rowDoc.getMap(YjsEditorKey.data_section) as YSharedRoot;
-        const row = rowSharedRoot.get(YjsEditorKey.database_row);
-        const meta = rowSharedRoot.get(YjsEditorKey.meta);
-
-        const cells = row.get(YjsDatabaseKey.cells);
-
-        if (filters) {
-          filters.toArray().forEach((filter) => {
-            const cell = new Y.Map() as YDatabaseCell;
-            const fieldId = filter.get(YjsDatabaseKey.field_id);
-            const field = database.get(YjsDatabaseKey.fields)?.get(fieldId);
-
-            if (!field) {
-              return;
-            }
-
-            if (isCalendar && calendarSetting?.fieldId === fieldId) {
-              shouldOpenRowModal = true;
-            }
-
-            const type = Number(field.get(YjsDatabaseKey.type));
-
-            if (type === FieldType.DateTime) {
-              const { data, endTimestamp, isRange } = dateFilterFillData(filter);
-
-              if (data !== null) {
-                cell.set(YjsDatabaseKey.data, data);
-              }
-
-              if (endTimestamp) {
-                cell.set(YjsDatabaseKey.end_timestamp, endTimestamp);
-              }
-
-              if (isRange) {
-                cell.set(YjsDatabaseKey.is_range, isRange);
-              }
-            } else if ([FieldType.CreatedTime, FieldType.LastEditedTime].includes(type)) {
-              shouldOpenRowModal = true;
-              return;
-            } else {
-              const data = filterFillData(filter, field);
-
-              if (data === null) {
-                return;
-              }
-
-              cell.set(YjsDatabaseKey.data, data);
-            }
-
-            cell.set(YjsDatabaseKey.created_at, String(dayjs().unix()));
-            cell.set(YjsDatabaseKey.field_type, type);
-
-            cells.set(fieldId, cell);
-          });
-        }
-
-        if (cellsData) {
-          Object.entries(cellsData).forEach(([fieldId, data]) => {
-            const cell = new Y.Map() as YDatabaseCell;
-            const field = database.get(YjsDatabaseKey.fields)?.get(fieldId);
-
-            const type = Number(field.get(YjsDatabaseKey.type));
-
-            cell.set(YjsDatabaseKey.created_at, String(dayjs().unix()));
-            cell.set(YjsDatabaseKey.field_type, type);
-
-            if (typeof data === 'object') {
-              cell.set(YjsDatabaseKey.data, data.data);
-              cell.set(YjsDatabaseKey.end_timestamp, data.endTimestamp);
-              cell.set(YjsDatabaseKey.is_range, data.isRange);
-              cell.set(YjsDatabaseKey.include_time, data.includeTime);
-              cell.set(YjsDatabaseKey.reminder_id, data.reminderId);
-            } else {
-              cell.set(YjsDatabaseKey.data, data);
-            }
-
-            cells.set(fieldId, cell);
-          });
-        }
-
-        row.set(YjsDatabaseKey.last_modified, String(dayjs().unix()));
-
-        const newMeta = generateRowMeta(rowId, {
-          [RowMetaKey.IsDocumentEmpty]: true,
-        });
-
-        Object.keys(newMeta).forEach((key) => {
-          const value = newMeta[key];
-
-          if (value) {
-            meta.set(key, value);
-          }
-        });
-
-        if (shouldOpenRowModal) {
-          navigateToRow?.(rowId);
-        }
-      });
-
-      executeOperationWithAllViews(
-        sharedRoot,
-        database,
-        (view, id) => {
-          const rowOrders = view.get(YjsDatabaseKey.row_orders);
-
-          if (!rowOrders) {
-            throw new Error(`Row orders not found`);
-          }
-
-          const row = {
-            id: rowId,
-            height: 36,
-          };
-
-          const index = beforeRowId ? rowOrders.toArray().findIndex((row) => row.id === beforeRowId) + 1 : 0;
-
-          if ((viewId !== id && index === -1) || tailing) {
-            rowOrders.push([row]);
-          } else {
-            rowOrders.insert(index, [row]);
-          }
-        },
-        'newRowDispatch'
-      );
-
-      if (isCalendar && shouldOpenRowModal) {
-        return null;
-      }
-
-      return rowId;
-    },
-    [calendarSetting, createRow, currentView, database, filters, guid, isCalendar, navigateToRow, sharedRoot, viewId]
-  );
-}
-
 export function useCreateCalendarEvent() {
   const newRowDispatch = useNewRowDispatch();
   const currentView = useDatabaseView();
@@ -1469,8 +1284,12 @@ function cloneCell(fieldType: FieldType, referenceCell?: YDatabaseCell) {
   return cell;
 }
 
-// Re-export from the extracted dispatch module
-export { useDuplicateRowDispatch } from './dispatch/row';
+// Re-export from the extracted dispatch module.
+// Note: re-exporting useNewRowDispatch is necessary because Vite's module
+// resolver picks this file (dispatch.ts) over dispatch/index.ts when both
+// exist as siblings, while TS picks the folder. Without this re-export the
+// two paths resolve to different implementations and silently drift.
+export { useDuplicateRowDispatch, useNewRowDispatch } from './dispatch/row';
 
 export function useClearSortingDispatch() {
   const sharedRoot = useSharedRoot();

--- a/src/application/database-yjs/dispatch/row.ts
+++ b/src/application/database-yjs/dispatch/row.ts
@@ -328,64 +328,69 @@ export function useNewRowDispatch() {
       const rowId = uuidv4();
       const rowKey = getRowKey(guid, rowId);
       const rowDoc = await createRow(rowKey);
-      let shouldOpenRowModal = false;
+      // Snapshot the filter array once: Y.Array.toArray() allocates a fresh
+      // JS array on each call, and we read it twice (length check + forEach).
+      const filterArray = filters?.toArray() ?? [];
+      // Open the row detail page whenever filters are active so the user can
+      // see and complete the new row (its primary "Name" cell is always empty,
+      // and other cells get pre-filled from filters but still need user input).
+      let shouldOpenRowModal = filterArray.length > 0;
 
       rowDoc.transact(() => {
         initialDatabaseRow(rowId, database.get(YjsDatabaseKey.id), rowDoc);
         const rowSharedRoot = rowDoc.getMap(YjsEditorKey.data_section) as YSharedRoot;
         const row = rowSharedRoot.get(YjsEditorKey.database_row);
+        const meta = rowSharedRoot.get(YjsEditorKey.meta);
 
         const cells = row.get(YjsDatabaseKey.cells);
 
-        if (filters) {
-          filters.toArray().forEach((filter) => {
-            const cell = new Y.Map() as YDatabaseCell;
-            const fieldId = filter.get(YjsDatabaseKey.field_id);
-            const field = database.get(YjsDatabaseKey.fields)?.get(fieldId);
+        filterArray.forEach((filter) => {
+          const cell = new Y.Map() as YDatabaseCell;
+          const fieldId = filter.get(YjsDatabaseKey.field_id);
+          const field = database.get(YjsDatabaseKey.fields)?.get(fieldId);
 
-            if (!field) {
-              return;
-            }
+          if (!field) {
+            return;
+          }
 
-            if (isCalendar && calendarSetting?.fieldId === fieldId) {
-              shouldOpenRowModal = true;
-            }
+          if (isCalendar && calendarSetting?.fieldId === fieldId) {
+            shouldOpenRowModal = true;
+          }
 
-            const type = Number(field.get(YjsDatabaseKey.type));
+          const type = Number(field.get(YjsDatabaseKey.type));
 
-            if (type === FieldType.DateTime) {
-              const { data, endTimestamp, isRange } = dateFilterFillData(filter);
+          if (type === FieldType.DateTime) {
+            const { data, endTimestamp, isRange } = dateFilterFillData(filter);
 
-              if (data !== null) {
-                cell.set(YjsDatabaseKey.data, data);
-              }
-
-              if (endTimestamp) {
-                cell.set(YjsDatabaseKey.end_timestamp, endTimestamp);
-              }
-
-              if (isRange) {
-                cell.set(YjsDatabaseKey.is_range, isRange);
-              }
-            } else if ([FieldType.CreatedTime, FieldType.LastEditedTime].includes(type)) {
-              shouldOpenRowModal = true;
-              return;
-            } else {
-              const data = filterFillData(filter, field);
-
-              if (data === null) {
-                return;
-              }
-
+            if (data !== null) {
               cell.set(YjsDatabaseKey.data, data);
             }
 
-            cell.set(YjsDatabaseKey.created_at, String(dayjs().unix()));
-            cell.set(YjsDatabaseKey.field_type, type);
+            if (endTimestamp) {
+              cell.set(YjsDatabaseKey.end_timestamp, endTimestamp);
+            }
 
-            cells.set(fieldId, cell);
-          });
-        }
+            if (isRange) {
+              cell.set(YjsDatabaseKey.is_range, isRange);
+            }
+          } else if ([FieldType.CreatedTime, FieldType.LastEditedTime].includes(type)) {
+            shouldOpenRowModal = true;
+            return;
+          } else {
+            const data = filterFillData(filter, field);
+
+            if (data === null) {
+              return;
+            }
+
+            cell.set(YjsDatabaseKey.data, data);
+          }
+
+          cell.set(YjsDatabaseKey.created_at, String(dayjs().unix()));
+          cell.set(YjsDatabaseKey.field_type, type);
+
+          cells.set(fieldId, cell);
+        });
 
         if (cellsData) {
           Object.entries(cellsData).forEach(([fieldId, data]) => {
@@ -412,6 +417,18 @@ export function useNewRowDispatch() {
         }
 
         row.set(YjsDatabaseKey.last_modified, String(dayjs().unix()));
+
+        const newMeta = generateRowMeta(rowId, {
+          [RowMetaKey.IsDocumentEmpty]: true,
+        });
+
+        Object.keys(newMeta).forEach((key) => {
+          const value = newMeta[key];
+
+          if (value) {
+            meta.set(key, value);
+          }
+        });
 
         if (shouldOpenRowModal) {
           navigateToRow?.(rowId);

--- a/src/application/database-yjs/fields/date/date.type.ts
+++ b/src/application/database-yjs/fields/date/date.type.ts
@@ -17,6 +17,27 @@ export enum DateFilterCondition {
   DateEndsBetween = 13,
   DateEndIsEmpty = 14,
   DateEndIsNotEmpty = 15,
+  DateStartsToday = 16,
+  DateStartsYesterday = 17,
+  DateStartsTomorrow = 18,
+  DateStartsThisWeek = 19,
+  DateStartsLastWeek = 20,
+  DateStartsNextWeek = 21,
+  DateEndsToday = 22,
+  DateEndsYesterday = 23,
+  DateEndsTomorrow = 24,
+  DateEndsThisWeek = 25,
+  DateEndsLastWeek = 26,
+  DateEndsNextWeek = 27,
+}
+
+export enum DateFilterRelativeCondition {
+  Today = 'today',
+  Yesterday = 'yesterday',
+  Tomorrow = 'tomorrow',
+  ThisWeek = 'thisWeek',
+  LastWeek = 'lastWeek',
+  NextWeek = 'nextWeek',
 }
 
 export interface DateFilter extends Filter {

--- a/src/application/database-yjs/fields/date/index.ts
+++ b/src/application/database-yjs/fields/date/index.ts
@@ -1,2 +1,3 @@
 export * from './date.type';
+export * from './relativeDate';
 export * from './utils';

--- a/src/application/database-yjs/fields/date/relativeDate.test.ts
+++ b/src/application/database-yjs/fields/date/relativeDate.test.ts
@@ -1,0 +1,105 @@
+import dayjs from 'dayjs';
+import { expect } from '@jest/globals';
+
+import {
+  DateFilterCondition,
+  DateFilterRelativeCondition,
+  dateRangeForRelative,
+  isRelativeDateCondition,
+  isStartDateCondition,
+  resolveRelativeDates,
+  toEndDateCondition,
+  toStartDateCondition,
+} from './';
+
+// Deterministic anchor (Wed 2024-06-12) — matches desktop test fixture.
+const TEST_TODAY = dayjs('2024-06-12');
+
+describe('relativeDate', () => {
+  it('detects relative conditions', () => {
+    expect(isRelativeDateCondition(DateFilterCondition.DateStartsToday)).toBe(true);
+    expect(isRelativeDateCondition(DateFilterCondition.DateEndsNextWeek)).toBe(true);
+    expect(isRelativeDateCondition(DateFilterCondition.DateStartsOn)).toBe(false);
+  });
+
+  it('classifies start vs end conditions', () => {
+    expect(isStartDateCondition(DateFilterCondition.DateStartsToday)).toBe(true);
+    expect(isStartDateCondition(DateFilterCondition.DateEndsToday)).toBe(false);
+    expect(toEndDateCondition(DateFilterCondition.DateStartsThisWeek)).toBe(
+      DateFilterCondition.DateEndsThisWeek
+    );
+    expect(toStartDateCondition(DateFilterCondition.DateEndsLastWeek)).toBe(
+      DateFilterCondition.DateStartsLastWeek
+    );
+  });
+
+  it('Today resolves to single-day range', () => {
+    const range = dateRangeForRelative(DateFilterRelativeCondition.Today, TEST_TODAY);
+
+    expect(range.start.format('YYYY-MM-DD')).toBe('2024-06-12');
+    expect(range.end.format('YYYY-MM-DD')).toBe('2024-06-12');
+  });
+
+  it('ThisWeek resolves to Mon-Sun for a Wednesday', () => {
+    const range = dateRangeForRelative(DateFilterRelativeCondition.ThisWeek, TEST_TODAY);
+
+    expect(range.start.format('YYYY-MM-DD')).toBe('2024-06-10');
+    expect(range.end.format('YYYY-MM-DD')).toBe('2024-06-16');
+  });
+
+  it('LastWeek and NextWeek shift by 7 days', () => {
+    const last = dateRangeForRelative(DateFilterRelativeCondition.LastWeek, TEST_TODAY);
+
+    expect(last.start.format('YYYY-MM-DD')).toBe('2024-06-03');
+    expect(last.end.format('YYYY-MM-DD')).toBe('2024-06-09');
+
+    const next = dateRangeForRelative(DateFilterRelativeCondition.NextWeek, TEST_TODAY);
+
+    expect(next.start.format('YYYY-MM-DD')).toBe('2024-06-17');
+    expect(next.end.format('YYYY-MM-DD')).toBe('2024-06-23');
+  });
+
+  it('resolveRelativeDates clears unused fields and sets timestamp for single-day', () => {
+    const resolved = resolveRelativeDates(
+      {
+        id: 'f',
+        fieldId: 'date',
+        filterType: 0,
+        condition: DateFilterCondition.DateStartsToday,
+      } as any,
+      TEST_TODAY
+    );
+
+    expect(resolved.timestamp).toBe(TEST_TODAY.startOf('day').unix());
+    expect(resolved.start).toBeUndefined();
+    expect(resolved.end).toBeUndefined();
+  });
+
+  it('resolveRelativeDates sets start/end for week range', () => {
+    const resolved = resolveRelativeDates(
+      {
+        id: 'f',
+        fieldId: 'date',
+        filterType: 0,
+        condition: DateFilterCondition.DateStartsThisWeek,
+      } as any,
+      TEST_TODAY
+    );
+
+    expect(resolved.start).toBe(dayjs('2024-06-10').startOf('day').unix());
+    expect(resolved.end).toBe(dayjs('2024-06-16').startOf('day').unix());
+    expect(resolved.timestamp).toBeUndefined();
+  });
+
+  it('resolveRelativeDates is identity for non-relative conditions', () => {
+    const filter = {
+      id: 'f',
+      fieldId: 'date',
+      filterType: 0,
+      condition: DateFilterCondition.DateStartsOn,
+      timestamp: 1668387885,
+    } as any;
+
+    expect(resolveRelativeDates(filter, TEST_TODAY)).toBe(filter);
+  });
+});

--- a/src/application/database-yjs/fields/date/relativeDate.ts
+++ b/src/application/database-yjs/fields/date/relativeDate.ts
@@ -1,0 +1,141 @@
+import dayjs, { Dayjs } from 'dayjs';
+
+import {
+  DateFilter,
+  DateFilterCondition,
+  DateFilterRelativeCondition,
+} from './date.type';
+
+export function relativeConditionFor(condition: DateFilterCondition): DateFilterRelativeCondition | null {
+  switch (condition) {
+    case DateFilterCondition.DateStartsToday:
+    case DateFilterCondition.DateEndsToday:
+      return DateFilterRelativeCondition.Today;
+    case DateFilterCondition.DateStartsYesterday:
+    case DateFilterCondition.DateEndsYesterday:
+      return DateFilterRelativeCondition.Yesterday;
+    case DateFilterCondition.DateStartsTomorrow:
+    case DateFilterCondition.DateEndsTomorrow:
+      return DateFilterRelativeCondition.Tomorrow;
+    case DateFilterCondition.DateStartsThisWeek:
+    case DateFilterCondition.DateEndsThisWeek:
+      return DateFilterRelativeCondition.ThisWeek;
+    case DateFilterCondition.DateStartsLastWeek:
+    case DateFilterCondition.DateEndsLastWeek:
+      return DateFilterRelativeCondition.LastWeek;
+    case DateFilterCondition.DateStartsNextWeek:
+    case DateFilterCondition.DateEndsNextWeek:
+      return DateFilterRelativeCondition.NextWeek;
+    default:
+      return null;
+  }
+}
+
+export function isRelativeDateCondition(condition: DateFilterCondition): boolean {
+  return relativeConditionFor(condition) !== null;
+}
+
+const START_END_PAIRS: ReadonlyArray<readonly [DateFilterCondition, DateFilterCondition]> = [
+  [DateFilterCondition.DateStartsOn, DateFilterCondition.DateEndsOn],
+  [DateFilterCondition.DateStartsBefore, DateFilterCondition.DateEndsAfter],
+  [DateFilterCondition.DateStartsAfter, DateFilterCondition.DateEndsBefore],
+  [DateFilterCondition.DateStartsOnOrBefore, DateFilterCondition.DateEndsOnOrAfter],
+  [DateFilterCondition.DateStartsOnOrAfter, DateFilterCondition.DateEndsOnOrBefore],
+  [DateFilterCondition.DateStartsBetween, DateFilterCondition.DateEndsBetween],
+  [DateFilterCondition.DateStartIsEmpty, DateFilterCondition.DateEndIsEmpty],
+  [DateFilterCondition.DateStartIsNotEmpty, DateFilterCondition.DateEndIsNotEmpty],
+  [DateFilterCondition.DateStartsToday, DateFilterCondition.DateEndsToday],
+  [DateFilterCondition.DateStartsYesterday, DateFilterCondition.DateEndsYesterday],
+  [DateFilterCondition.DateStartsTomorrow, DateFilterCondition.DateEndsTomorrow],
+  [DateFilterCondition.DateStartsThisWeek, DateFilterCondition.DateEndsThisWeek],
+  [DateFilterCondition.DateStartsLastWeek, DateFilterCondition.DateEndsLastWeek],
+  [DateFilterCondition.DateStartsNextWeek, DateFilterCondition.DateEndsNextWeek],
+];
+
+export function isStartDateCondition(condition: DateFilterCondition): boolean {
+  return START_END_PAIRS.some(([start]) => start === condition);
+}
+
+export function toStartDateCondition(condition: DateFilterCondition): DateFilterCondition {
+  for (const [start, end] of START_END_PAIRS) {
+    if (start === condition || end === condition) return start;
+  }
+
+  return condition;
+}
+
+export function toEndDateCondition(condition: DateFilterCondition): DateFilterCondition {
+  for (const [start, end] of START_END_PAIRS) {
+    if (start === condition || end === condition) return end;
+  }
+
+  return condition;
+}
+
+// Mirrors desktop: week starts on Monday (ISO 8601). Returns inclusive [start, end] dates.
+export function dateRangeForRelative(
+  relative: DateFilterRelativeCondition,
+  today: Dayjs = dayjs(),
+): { start: Dayjs; end: Dayjs } {
+  const startOfToday = today.startOf('day');
+
+  switch (relative) {
+    case DateFilterRelativeCondition.Today:
+      return { start: startOfToday, end: startOfToday };
+    case DateFilterRelativeCondition.Yesterday: {
+      const day = startOfToday.subtract(1, 'day');
+
+      return { start: day, end: day };
+    }
+
+    case DateFilterRelativeCondition.Tomorrow: {
+      const day = startOfToday.add(1, 'day');
+
+      return { start: day, end: day };
+    }
+
+    case DateFilterRelativeCondition.ThisWeek:
+      return weekRange(startOfToday, 0);
+    case DateFilterRelativeCondition.LastWeek:
+      return weekRange(startOfToday, -7);
+    case DateFilterRelativeCondition.NextWeek:
+      return weekRange(startOfToday, 7);
+  }
+}
+
+function weekRange(today: Dayjs, offsetDays: number): { start: Dayjs; end: Dayjs } {
+  // dayjs().day() returns 0 (Sunday) - 6 (Saturday); convert to Monday-based 0-6.
+  const mondayBased = (today.day() + 6) % 7;
+  const start = today.subtract(mondayBased, 'day').add(offsetDays, 'day');
+  const end = start.add(6, 'day');
+
+  return { start, end };
+}
+
+// Returns a filter copy with relative-date conditions resolved into start/end timestamps
+// anchored at today's local date. For non-relative conditions this returns the filter as-is.
+export function resolveRelativeDates(filter: DateFilter, today: Dayjs = dayjs()): DateFilter {
+  const relative = relativeConditionFor(filter.condition);
+
+  if (!relative) return filter;
+
+  const { start, end } = dateRangeForRelative(relative, today);
+  const startUnix = start.unix();
+  const endUnix = end.unix();
+
+  if (startUnix === endUnix) {
+    return {
+      ...filter,
+      timestamp: startUnix,
+      start: undefined,
+      end: undefined,
+    };
+  }
+
+  return {
+    ...filter,
+    timestamp: undefined,
+    start: startUnix,
+    end: endUnix,
+  };
+}

--- a/src/application/database-yjs/filter.ts
+++ b/src/application/database-yjs/filter.ts
@@ -16,12 +16,14 @@ import {
   ChecklistFilterCondition,
   DateFilter,
   DateFilterCondition,
+  isRelativeDateCondition,
   NumberFilter,
   NumberFilterCondition,
   parseChecklistFlexible,
   parseSelectOptionTypeOptions,
   PersonFilterCondition,
   RelationFilterCondition,
+  resolveRelativeDates,
   SelectOptionFilter,
   SelectOptionFilterCondition,
   TextFilter,
@@ -615,6 +617,10 @@ export function checklistFilterCheck(data: unknown, content: string, condition: 
 }
 
 export function rowTimeFilterCheck(data: string, filter: DateFilter) {
+  if (isRelativeDateCondition(filter.condition)) {
+    return relativeDateRangeMatches(data, filter);
+  }
+
   const { condition, end = '', start = '', timestamp = '' } = filter;
 
   switch (condition) {
@@ -644,10 +650,40 @@ export function rowTimeFilterCheck(data: string, filter: DateFilter) {
   }
 }
 
+// Resolves a relative-date filter to a concrete [start, end] range and tests whether
+// the cell's relevant timestamp (start for "DateStarts*", end for "DateEnds*") falls in it.
+function relativeDateRangeMatches(data: string, filter: DateFilter, endTimestamp?: string): boolean {
+  // Mirrors desktop: DateStarts* relatives match against cell.start; DateEnds* match against cell.end.
+  const isEndCondition = filter.condition >= DateFilterCondition.DateEndsToday;
+  const target = isEndCondition ? endTimestamp ?? '' : data;
+
+  if (!target) return false;
+
+  const resolved = resolveRelativeDates(filter);
+
+  // Single-day relatives (Today/Yesterday/Tomorrow) → same-day check.
+  if (resolved.timestamp !== undefined) {
+    return isTimestampInSameDay(target, resolved.timestamp.toString());
+  }
+
+  if (resolved.start !== undefined && resolved.end !== undefined) {
+    // resolved.end is local midnight of the last day; extend to end-of-day for inclusive matching.
+    const endInclusive = resolved.end + 24 * 60 * 60 - 1;
+
+    return isTimestampBetweenRange(target, resolved.start.toString(), endInclusive.toString());
+  }
+
+  return false;
+}
+
 export function dateFilterCheck(cell: DateTimeCell | null, filter: DateFilter) {
   const { condition, end = '', start = '', timestamp = '' } = filter;
 
   const { data = '', endTimestamp = '' } = cell || {};
+
+  if (isRelativeDateCondition(condition)) {
+    return relativeDateRangeMatches(data, filter, endTimestamp);
+  }
 
   switch (condition) {
     case DateFilterCondition.DateEndIsEmpty:
@@ -905,6 +941,22 @@ export function dateFilterFillData(filter: YDatabaseFilter): {
   const content = filter.get(YjsDatabaseKey.content);
   const condition = Number(filter.get(YjsDatabaseKey.condition));
   const today = dayjs().startOf('day').unix().toString();
+
+  // Relative-date conditions (Today / This week / etc.) ignore the stored
+  // timestamp and always pre-fill from the resolved range so the new row
+  // satisfies the filter.
+  if (isRelativeDateCondition(condition)) {
+    const resolved = resolveRelativeDates({
+      condition,
+      timestamp: undefined,
+      start: undefined,
+      end: undefined,
+    } as DateFilter);
+    const isEnd = condition >= DateFilterCondition.DateEndsToday;
+    const fill = (resolved.timestamp ?? resolved.start ?? Number(today)).toString();
+
+    return isEnd ? { data: fill, endTimestamp: fill, isRange: true } : { data: fill, isRange: false };
+  }
 
   try {
     const {

--- a/src/components/database/components/database-row/DatabaseRowSubDocument.tsx
+++ b/src/components/database/components/database-row/DatabaseRowSubDocument.tsx
@@ -875,6 +875,74 @@ export const DatabaseRowSubDocument = memo(({ rowId }: { rowId: string }) => {
   useEffect(() => {
     if (!doc) return;
 
+    // Body of the debounced meta update. Extracted so the unmount cleanup can
+    // flush it synchronously instead of cancelling pending work — otherwise a
+    // paste-then-close-card sequence loses the just-pasted content because
+    // ensureRowDocumentExists() never registers the orphan collab on the
+    // server, and the local outbox update has no doc to drain into.
+    const flushPendingMetaUpdate = () => {
+      if (!pendingMetaUpdateRef.current) return;
+      clearTimeout(pendingMetaUpdateRef.current);
+      pendingMetaUpdateRef.current = null;
+
+      const editor = editorRef.current;
+
+      if (!editor) {
+        return;
+      }
+
+      const isEmpty = isDocumentEmpty(editor);
+
+      if (lastIsEmptyRef.current === isEmpty) {
+        return;
+      }
+
+      if (shouldSkipIsDocumentEmptyUpdate(isEmpty)) {
+        return;
+      }
+
+      if (isEmpty) {
+        lastIsEmptyRef.current = isEmpty;
+        pendingNonEmptyRef.current = false;
+        Log.debug('[DatabaseRowSubDocument] row document empty -> update meta', {
+          rowId,
+          documentId,
+        });
+        updateRowMeta(RowMetaKey.IsDocumentEmpty, isEmpty);
+        return;
+      }
+
+      void (async () => {
+        lastIsEmptyRef.current = isEmpty;
+        pendingNonEmptyRef.current = false;
+        Log.debug('[DatabaseRowSubDocument] row document edited', {
+          rowId,
+          documentId,
+        });
+        Log.debug('[DatabaseRowSubDocument] row document non-empty -> update meta immediately', {
+          rowId,
+          documentId,
+        });
+        updateRowMeta(RowMetaKey.IsDocumentEmpty, isEmpty);
+
+        const ensurePromise = ensureRowDocumentExists();
+
+        // Track the in-flight creation so syncAllToServer can await it
+        // before batch-syncing. Without this, a page duplicate that runs
+        // before the server-side collab is created will silently lose the
+        // row sub-document content.
+        if (documentId) {
+          trackRowDocEnsure(documentId, ensurePromise);
+        }
+
+        const ensured = await ensurePromise;
+
+        if (!ensured) {
+          scheduleEnsureRowDocumentExists();
+        }
+      })();
+    };
+
     const handleDocUpdate = (_update: Uint8Array, origin: unknown) => {
       if (origin !== CollabOrigin.Local && origin !== CollabOrigin.LocalManual) {
         return;
@@ -884,75 +952,16 @@ export const DatabaseRowSubDocument = memo(({ rowId }: { rowId: string }) => {
         clearTimeout(pendingMetaUpdateRef.current);
       }
 
-      pendingMetaUpdateRef.current = setTimeout(() => {
-        pendingMetaUpdateRef.current = null;
-        const editor = editorRef.current;
-
-        if (!editor) {
-          return;
-        }
-
-        const isEmpty = isDocumentEmpty(editor);
-
-        if (lastIsEmptyRef.current === isEmpty) {
-          return;
-        }
-
-        if (shouldSkipIsDocumentEmptyUpdate(isEmpty)) {
-          return;
-        }
-
-        if (isEmpty) {
-          lastIsEmptyRef.current = isEmpty;
-          pendingNonEmptyRef.current = false;
-          Log.debug('[DatabaseRowSubDocument] row document empty -> update meta', {
-            rowId,
-            documentId,
-          });
-          updateRowMeta(RowMetaKey.IsDocumentEmpty, isEmpty);
-          return;
-        }
-
-        void (async () => {
-          lastIsEmptyRef.current = isEmpty;
-          pendingNonEmptyRef.current = false;
-          Log.debug('[DatabaseRowSubDocument] row document edited', {
-            rowId,
-            documentId,
-          });
-          Log.debug('[DatabaseRowSubDocument] row document non-empty -> update meta immediately', {
-            rowId,
-            documentId,
-          });
-          updateRowMeta(RowMetaKey.IsDocumentEmpty, isEmpty);
-
-          const ensurePromise = ensureRowDocumentExists();
-
-          // Track the in-flight creation so syncAllToServer can await it
-          // before batch-syncing. Without this, a page duplicate that runs
-          // before the server-side collab is created will silently lose the
-          // row sub-document content.
-          if (documentId) {
-            trackRowDocEnsure(documentId, ensurePromise);
-          }
-
-          const ensured = await ensurePromise;
-
-          if (!ensured) {
-            scheduleEnsureRowDocumentExists();
-          }
-        })();
-      }, 0);
+      pendingMetaUpdateRef.current = setTimeout(flushPendingMetaUpdate, 0);
     };
 
     doc.on('update', handleDocUpdate);
 
     return () => {
       doc.off('update', handleDocUpdate);
-      if (pendingMetaUpdateRef.current) {
-        clearTimeout(pendingMetaUpdateRef.current);
-        pendingMetaUpdateRef.current = null;
-      }
+      // Flush — not cancel — so a close-card immediately after paste still
+      // marks the row non-empty and registers the orphan collab on the server.
+      flushPendingMetaUpdate();
     };
   }, [
     doc,

--- a/src/components/database/components/filters/advanced/FilterPanelRow.tsx
+++ b/src/components/database/components/filters/advanced/FilterPanelRow.tsx
@@ -9,6 +9,7 @@ import {
   DateFilterCondition,
   FieldType,
   Filter,
+  isRelativeDateCondition,
   NumberFilter,
   NumberFilterCondition,
   parseSelectOptionTypeOptions,
@@ -276,6 +277,12 @@ function useConditionsForFieldType(
         { value: DateFilterCondition.DateStartsOnOrBefore, text: t('grid.dateFilter.onOrBefore') },
         { value: DateFilterCondition.DateStartsOnOrAfter, text: t('grid.dateFilter.onOrAfter') },
         { value: DateFilterCondition.DateStartsBetween, text: t('grid.dateFilter.between') },
+        { value: DateFilterCondition.DateStartsToday, text: t('relativeDates.today') },
+        { value: DateFilterCondition.DateStartsYesterday, text: t('relativeDates.yesterday') },
+        { value: DateFilterCondition.DateStartsTomorrow, text: t('relativeDates.tomorrow') },
+        { value: DateFilterCondition.DateStartsThisWeek, text: t('relativeDates.thisWeek') },
+        { value: DateFilterCondition.DateStartsLastWeek, text: t('relativeDates.lastWeek') },
+        { value: DateFilterCondition.DateStartsNextWeek, text: t('relativeDates.nextWeek') },
         { value: DateFilterCondition.DateStartIsEmpty, text: t('grid.dateFilter.empty') },
         { value: DateFilterCondition.DateStartIsNotEmpty, text: t('grid.dateFilter.notEmpty') },
       ];
@@ -460,8 +467,10 @@ function NumberValueInput({ filter, disabled }: { filter: NumberFilter; disabled
 
 // Date Value Input - uses the existing DateTimeFilterDatePicker
 function DateValueInput({ filter, disabled }: { filter: DateFilter; disabled?: boolean }) {
-  // Don't show input for isEmpty/isNotEmpty conditions
+  // Don't show input for isEmpty/isNotEmpty or relative date conditions (Today, This week, …)
   const showInput = useMemo(() => {
+    if (isRelativeDateCondition(filter.condition)) return false;
+
     return ![
       DateFilterCondition.DateStartIsEmpty,
       DateFilterCondition.DateStartIsNotEmpty,

--- a/src/components/database/components/filters/filter-menu/DateTimeFilterMenu.tsx
+++ b/src/components/database/components/filters/filter-menu/DateTimeFilterMenu.tsx
@@ -1,7 +1,16 @@
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import { DateFilter, DateFilterCondition, FieldType, useFieldType } from '@/application/database-yjs';
+import {
+  DateFilter,
+  DateFilterCondition,
+  FieldType,
+  isRelativeDateCondition,
+  isStartDateCondition,
+  toEndDateCondition,
+  toStartDateCondition,
+  useFieldType,
+} from '@/application/database-yjs';
 import { useRemoveFilter, useUpdateFilter } from '@/application/database-yjs/dispatch';
 import { ReactComponent as DeleteIcon } from '@/assets/icons/delete.svg';
 import DateTimeFilterDatePicker from '@/components/database/components/filters/filter-menu/DateTimeFilterDatePicker';
@@ -16,84 +25,62 @@ function TextFilterMenu ({ filter }: { filter: DateFilter }) {
   const updateFilter = useUpdateFilter();
   const fieldType = useFieldType(filter.fieldId);
 
-  const [selectedStart, setSelectedStart] = useState<boolean>(() => {
-    return filter.condition < 8;
-  });
+  // Derived from filter.condition so it stays in sync if the condition is changed
+  // by Yjs sync (e.g., a collaborator editing the same filter).
+  const selectedStart = isStartDateCondition(filter.condition);
 
-  const conditions = useMemo(
-    () => [
-      {
-        value: selectedStart ? DateFilterCondition.DateStartsOn : DateFilterCondition.DateEndsOn,
-        text: t('grid.dateFilter.is'),
-      },
-      {
-        value: selectedStart ? DateFilterCondition.DateStartsBefore : DateFilterCondition.DateEndsAfter,
-        text: t('grid.dateFilter.before'),
-      },
-      {
-        value: selectedStart ? DateFilterCondition.DateStartsAfter : DateFilterCondition.DateEndsBefore,
-        text: t('grid.dateFilter.after'),
-      },
-      {
-        value: selectedStart ? DateFilterCondition.DateStartsOnOrBefore : DateFilterCondition.DateEndsOnOrAfter,
-        text: t('grid.dateFilter.onOrBefore'),
-      },
-      {
-        value: selectedStart ? DateFilterCondition.DateStartsOnOrAfter : DateFilterCondition.DateEndsOnOrBefore,
-        text: t('grid.dateFilter.onOrAfter'),
-      },
-      {
-        value: selectedStart ? DateFilterCondition.DateStartsBetween : DateFilterCondition.DateEndsBetween,
-        text: t('grid.dateFilter.between'),
-      },
-      ![
-        FieldType.CreatedTime,
-        FieldType.LastEditedTime,
-      ].includes(fieldType) && {
-        value: selectedStart ? DateFilterCondition.DateStartIsEmpty : DateFilterCondition.DateEndIsEmpty,
-        text: t('grid.dateFilter.empty'),
-      },
-      ![
-        FieldType.CreatedTime,
-        FieldType.LastEditedTime,
-      ].includes(fieldType) && {
-        value: selectedStart ? DateFilterCondition.DateStartIsNotEmpty : DateFilterCondition.DateEndIsNotEmpty,
-        text: t('grid.dateFilter.notEmpty'),
-      },
-    ].filter(Boolean) as {
-      value: DateFilterCondition;
-      text: string;
-    }[],
-    [fieldType, selectedStart, t],
-  );
+  const conditions = useMemo(() => {
+    const pick = (start: DateFilterCondition): DateFilterCondition =>
+      selectedStart ? start : toEndDateCondition(start);
+    const isRowTime = fieldType === FieldType.CreatedTime || fieldType === FieldType.LastEditedTime;
 
-  const displayTextField = useMemo(() => {
-    return ![
+    return [
+      { value: pick(DateFilterCondition.DateStartsOn), text: t('grid.dateFilter.is') },
+      { value: pick(DateFilterCondition.DateStartsBefore), text: t('grid.dateFilter.before') },
+      { value: pick(DateFilterCondition.DateStartsAfter), text: t('grid.dateFilter.after') },
+      { value: pick(DateFilterCondition.DateStartsOnOrBefore), text: t('grid.dateFilter.onOrBefore') },
+      { value: pick(DateFilterCondition.DateStartsOnOrAfter), text: t('grid.dateFilter.onOrAfter') },
+      { value: pick(DateFilterCondition.DateStartsBetween), text: t('grid.dateFilter.between') },
+      { value: pick(DateFilterCondition.DateStartsToday), text: t('relativeDates.today') },
+      { value: pick(DateFilterCondition.DateStartsYesterday), text: t('relativeDates.yesterday') },
+      { value: pick(DateFilterCondition.DateStartsTomorrow), text: t('relativeDates.tomorrow') },
+      { value: pick(DateFilterCondition.DateStartsThisWeek), text: t('relativeDates.thisWeek') },
+      { value: pick(DateFilterCondition.DateStartsLastWeek), text: t('relativeDates.lastWeek') },
+      { value: pick(DateFilterCondition.DateStartsNextWeek), text: t('relativeDates.nextWeek') },
+      !isRowTime && { value: pick(DateFilterCondition.DateStartIsEmpty), text: t('grid.dateFilter.empty') },
+      !isRowTime && { value: pick(DateFilterCondition.DateStartIsNotEmpty), text: t('grid.dateFilter.notEmpty') },
+    ].filter(Boolean) as { value: DateFilterCondition; text: string }[];
+  }, [fieldType, selectedStart, t]);
+
+  const displayTextField =
+    !isRelativeDateCondition(filter.condition) &&
+    ![
       DateFilterCondition.DateEndIsEmpty,
       DateFilterCondition.DateEndIsNotEmpty,
       DateFilterCondition.DateStartIsEmpty,
       DateFilterCondition.DateStartIsNotEmpty,
     ].includes(filter.condition);
-  }, [filter.condition]);
+
   const deleteFilter = useRemoveFilter();
 
-  const handleSelectStartOrEnd = useCallback((isStart: boolean) => {
-    setSelectedStart(isStart);
-    // Update the filter condition based on the selected start or end
-    // If the condition is already in the correct range, do nothing
-    if (isStart && filter.condition < 8) return;
-    if (!isStart && filter.condition >= 8) return;
+  const handleSelectStartOrEnd = useCallback(
+    (isStart: boolean) => {
+      if (isStart === isStartDateCondition(filter.condition)) return;
 
-    const newCondition = conditions.find((c) => c.value === filter.condition);
+      const newCondition = isStart
+        ? toStartDateCondition(filter.condition)
+        : toEndDateCondition(filter.condition);
 
-    if (newCondition) {
-      updateFilter({
-        filterId: filter.id,
-        fieldId: filter.fieldId,
-        condition: isStart ? newCondition.value - 8 : newCondition.value + 8,
-      });
-    }
-  }, [conditions, filter.condition, filter.id, filter.fieldId, updateFilter]);
+      if (newCondition !== filter.condition) {
+        updateFilter({
+          filterId: filter.id,
+          fieldId: filter.fieldId,
+          condition: newCondition,
+        });
+      }
+    },
+    [filter.condition, filter.id, filter.fieldId, updateFilter],
+  );
 
   return (
     <div

--- a/src/components/database/components/filters/overview/DateFilterContentOverview.tsx
+++ b/src/components/database/components/filters/overview/DateFilterContentOverview.tsx
@@ -52,6 +52,24 @@ function DateFilterContentOverview({ filter }: { filter: DateFilter }) {
       case DateFilterCondition.DateStartIsNotEmpty:
       case DateFilterCondition.DateEndIsNotEmpty:
         return `: ${t('grid.dateFilter.choicechipPrefix.isNotEmpty')}`;
+      case DateFilterCondition.DateStartsToday:
+      case DateFilterCondition.DateEndsToday:
+        return `: ${t('relativeDates.today')}`;
+      case DateFilterCondition.DateStartsYesterday:
+      case DateFilterCondition.DateEndsYesterday:
+        return `: ${t('relativeDates.yesterday')}`;
+      case DateFilterCondition.DateStartsTomorrow:
+      case DateFilterCondition.DateEndsTomorrow:
+        return `: ${t('relativeDates.tomorrow')}`;
+      case DateFilterCondition.DateStartsThisWeek:
+      case DateFilterCondition.DateEndsThisWeek:
+        return `: ${t('relativeDates.thisWeek')}`;
+      case DateFilterCondition.DateStartsLastWeek:
+      case DateFilterCondition.DateEndsLastWeek:
+        return `: ${t('relativeDates.lastWeek')}`;
+      case DateFilterCondition.DateStartsNextWeek:
+      case DateFilterCondition.DateEndsNextWeek:
+        return `: ${t('relativeDates.nextWeek')}`;
       default:
         return '';
     }

--- a/src/components/editor/plugins/withPasted.ts
+++ b/src/components/editor/plugins/withPasted.ts
@@ -409,7 +409,6 @@ function handleURLPaste(editor: ReactEditor, url: string): boolean {
     return insertBlock(editor, {
       type: BlockType.VideoBlock,
       data: { url: processUrl(url) || url, ...videoTypeData(VideoType.External) } as VideoBlockData,
-      children: [{ text: '' }],
     });
   }
 
@@ -417,7 +416,6 @@ function handleURLPaste(editor: ReactEditor, url: string): boolean {
   return insertBlock(editor, {
     type: BlockType.LinkPreview,
     data: { url } as LinkPreviewBlockData,
-    children: [{ text: '' }],
   });
 }
 
@@ -439,17 +437,48 @@ function handleMultiLinePlainText(editor: ReactEditor, lines: string[]): boolean
 }
 
 /**
- * Helper to insert a single block (for URL handlers)
+ * Helper to insert a single block (for URL handlers).
+ *
+ * Writes directly to Yjs via slateContentInsertToYData rather than going
+ * through Transforms.insertNodes — Slate's applyInsertNode binding short-
+ * circuits for non-text nodes (see applyToYjs.ts), so embed blocks like
+ * LinkPreview/VideoBlock would render in Slate's local state but never
+ * persist to the Y.Doc. The block was lost as soon as the editor unmounted
+ * (e.g. closing a database row card right after pasting a URL).
  */
-function insertBlock(editor: ReactEditor, block: unknown): boolean {
-  const point = editor.selection?.anchor as BasePoint;
+function insertBlock(editor: ReactEditor, block: { type: BlockType; data: object }): boolean {
+  const point = editor.selection?.anchor;
 
   if (!point) return false;
 
   try {
-    Transforms.insertNodes(editor, block as import('slate').Node, {
-      at: point,
-      select: true,
+    const entry = getBlockEntry(editor as YjsEditor, point);
+
+    if (!entry) return false;
+
+    const [node] = entry;
+    const blockId = (node as { blockId?: string }).blockId;
+
+    if (!blockId) return false;
+
+    const sharedRoot = getSharedRoot(editor as YjsEditor);
+    const currentBlock = getBlock(blockId, sharedRoot);
+    const parentId = currentBlock.get(YjsEditorKey.block_parent);
+    const parent = getBlock(parentId, sharedRoot);
+    const parentChildren = getChildrenArray(parent.get(YjsEditorKey.block_children), sharedRoot);
+    const index = parentChildren.toArray().findIndex((id) => id === blockId);
+    const doc = assertDocExists(sharedRoot);
+
+    // slateContentInsertToYData expects Slate Element shape; the data
+    // payload becomes the Yjs block's `data` field as-is.
+    const slateNode: Element = {
+      type: block.type,
+      data: block.data,
+      children: [{ text: '' }],
+    } as unknown as Element;
+
+    doc.transact(() => {
+      slateContentInsertToYData(parentId, index + 1, [slateNode], doc);
     });
 
     return true;


### PR DESCRIPTION
…ext week)

Mirrors AppFlowy-Premium PR #965 for the web client.

- Add 12 DateFilterCondition variants (16-27) for start/end relative dates, matching the desktop enum numbering exactly so YJS sync is compatible.
- Resolve relative conditions to a [start, end] window at evaluation time via a new resolveRelativeDates() helper (Monday-based ISO 8601 weeks).
- Surface the new conditions in the simple and advanced filter menus, hide the date input when a relative condition is active, and render the relative label on the choice chip.
- Pre-fill new-row date cells with the resolved range so rows created under a relative filter satisfy it (extends dateFilterFillData).
- Open the row detail modal whenever any filter is active so the user can see and complete the new row whose primary cell is necessarily empty.
- Consolidate the duplicate useNewRowDispatch (dispatch.ts now re-exports from dispatch/row.ts; both Vite and TS module-resolution paths now converge to a single implementation).
- Refactor DateTimeFilterMenu's start/end pairing from fragile +/-8 arithmetic to a START_END_PAIRS lookup; derive selectedStart from filter.condition (was duplicated state with drift risk).

Tests:
- 8 unit tests for relative-date resolution (relativeDate.test.ts).
- 4 unit tests for pre-fill behavior on relative conditions (extending pre-fill.test.ts).
- 2 Playwright e2e specs sharing data config with the desktop BDD scenario (filter-date-relative.spec.ts uses the same 9 anchor rows and condition sequence as relative_date_filter.feature).
- 2 Playwright e2e specs for the new-row-opens-detail behavior (filter-new-row-opens-detail.spec.ts).

<!---
Thank you for submitting a pull request to the AppFlowy Web! The team will dedicate their best efforts to reviewing and approving your PR. If you have any questions or feedback, feel free to join our [Discord](https://discord.gg/wdjWUXXhtw).
-->


### **Description**
<!---
Provide a clear and concise description of the changes introduced in this pull request for AppFlowy Web. What problem does it solve? What value does it add?
-->

---

### **Checklist**
<!---
Before marking your pull request as ready for review, ensure the following checklist is complete.
-->

#### **General**
- [ ] I've included relevant documentation or comments for the changes introduced.
- [ ] I've tested the changes in multiple environments (e.g., different browsers, operating systems).

#### **Testing**
- [ ] I've added or updated tests to validate the changes introduced for AppFlowy Web.

#### **Feature-Specific**
- [ ] For feature additions, I've added a preview (video, screenshot, or demo) in the "Feature Preview" section.
- [ ] I've verified that this feature integrates seamlessly with existing functionality.

## Summary by Sourcery

Add support for relative date filters in database views and ensure new rows created under active filters are pre-filled and opened in a detail modal for completion.

New Features:
- Introduce relative date filter conditions (Today/Yesterday/Tomorrow/This week/Last week/Next week) for start and end dates and surface them in simple and advanced date filter menus and overviews.

Enhancements:
- Resolve relative date conditions into concrete start/end ranges at evaluation and pre-fill time, aligning behavior with the desktop client and using Monday-based ISO weeks.
- Refine date filter UI so start/end selection derives from the condition mapping, avoid duplicated state, and hide date inputs when relative conditions are selected.
- Ensure new rows respect active filters by pre-filling date cells from resolved filter ranges and always opening the row detail modal when any filter is applied.
- Unify the new-row dispatch hook export so all import paths share a single implementation, preventing divergence between build systems.

Tests:
- Add unit tests for relative date range resolution and pre-fill behavior for relative date conditions.
- Add Playwright end-to-end tests to verify relative date filter results, date-input visibility, and that creating a new row under filters opens the detail view.