### PR TITLE
chore: show no access for relation field

### DIFF
--- a/src/components/database/components/cell/relation/RelationItems.tsx
+++ b/src/components/database/components/cell/relation/RelationItems.tsx
@@ -66,21 +66,33 @@ function RelationItems({
       return;
     }
 
+    let cancelled = false;
+
     void (async () => {
       try {
         const viewId = await getViewIdFromDatabaseId?.(relatedDatabaseId);
 
+        if (cancelled) return;
+
         if (!viewId) {
           setRelatedViewId(null);
+          setNoAccess(true);
           return;
         }
 
+        setNoAccess(false);
         setRelatedViewId(viewId);
       } catch (e) {
+        if (cancelled) return;
         console.error(e);
         setRelatedViewId(null);
+        setNoAccess(true);
       }
     })();
+
+    return () => {
+      cancelled = true;
+    };
   }, [getViewIdFromDatabaseId, relatedDatabaseId]);
 
   useEffect(() => {


### PR DESCRIPTION
<!---
Thank you for submitting a pull request to the AppFlowy Web! The team will dedicate their best efforts to reviewing and approving your PR. If you have any questions or feedback, feel free to join our [Discord](https://discord.gg/wdjWUXXhtw).
-->


### **Description**
<!---
Provide a clear and concise description of the changes introduced in this pull request for AppFlowy Web. What problem does it solve? What value does it add?
-->

---

### **Checklist**
<!---
Before marking your pull request as ready for review, ensure the following checklist is complete.
-->

#### **General**
- [ ] I've included relevant documentation or comments for the changes introduced.
- [ ] I've tested the changes in multiple environments (e.g., different browsers, operating systems).

#### **Testing**
- [ ] I've added or updated tests to validate the changes introduced for AppFlowy Web.

#### **Feature-Specific**
- [ ] For feature additions, I've added a preview (video, screenshot, or demo) in the "Feature Preview" section.
- [ ] I've verified that this feature integrates seamlessly with existing functionality.

## Summary by Sourcery

Handle relation field access resolution more safely when loading related database views.

Bug Fixes:
- Set relation field to a no-access state when the related view cannot be resolved or an error occurs, preventing ambiguous UI states.

Enhancements:
- Add cancellation logic to avoid updating relation field state after the component effect is cleaned up.