### PR TITLE
Feat/support pdf

### DIFF
--- a/playwright/e2e/page/export-pdf.spec.ts
+++ b/playwright/e2e/page/export-pdf.spec.ts
@@ -77,13 +77,24 @@ test.describe('Feature: Export to PDF', () => {
   });
 
   test('Scenario: Clicking Export to PDF triggers a download', async ({ page, request }) => {
+    // The PDF endpoint is fully mocked here so the test doesn't depend on the
+    // CI backend having Typst/render configured. We assert the request shape
+    // (URL + query params) and that the client triggers a browser download
+    // from the response blob. Real PDF rendering is verified server-side.
     let exportRequestUrl: string | null = null;
+    const fakePdf = Buffer.from('%PDF-1.4\n%fake\n', 'utf-8');
 
-    await test.step('Given the request to /api/export/view/.../pdf is observable', async () => {
-      page.on('request', (req) => {
-        if (req.url().includes('/api/export/view/') && req.url().includes('/pdf')) {
-          exportRequestUrl = req.url();
-        }
+    await test.step('Given the PDF endpoint is mocked to return a tiny PDF with attachment headers', async () => {
+      await page.route(/\/api\/export\/view\/.*\/pdf(\?|$)/, (route) => {
+        exportRequestUrl = route.request().url();
+        route.fulfill({
+          status: 200,
+          headers: {
+            'Content-Type': 'application/pdf',
+            'Content-Disposition': 'attachment; filename="Getting started.pdf"',
+          },
+          body: fakePdf,
+        });
       });
     });
 
@@ -98,16 +109,15 @@ test.describe('Feature: Export to PDF', () => {
       await openSharePopover(page);
       await switchToExportAsTab(page);
 
-      const downloadPromise = page.waitForEvent('download', { timeout: 60000 });
+      const downloadPromise = page.waitForEvent('download', { timeout: 30000 });
 
       await ExportSelectors.pdfButton(page).click({ force: true });
       const download = await downloadPromise;
 
-      await test.step('Then the browser receives a non-empty PDF download', async () => {
+      await test.step('Then the browser receives a download with the server-suggested filename', async () => {
         const filename = download.suggestedFilename();
 
         expect(filename.length).toBeGreaterThan(0);
-        // Server returns application/pdf or application/zip (multi-page)
         expect(filename).toMatch(/\.(pdf|zip)$/i);
       });
     });

--- a/playwright/e2e/page/export-pdf.spec.ts
+++ b/playwright/e2e/page/export-pdf.spec.ts
@@ -1,0 +1,193 @@
+import { Page, expect, test } from '@playwright/test';
+
+import { signInAndWaitForApp } from '../../support/auth-flow-helpers';
+import { mockBillingEndpoints, setupPageErrorHandling } from '../../support/fixtures';
+import {
+  ExportSelectors,
+  PageSelectors,
+  ShareSelectors,
+  SidebarSelectors,
+} from '../../support/selectors';
+import { generateRandomEmail } from '../../support/test-config';
+
+/**
+ * Export to PDF — BDD scenarios for the Share popover's "Export as" tab.
+ *
+ * The endpoint under test is POST /api/export/view/{ws}/{view}/pdf, which
+ * returns a binary PDF/ZIP. The web client renders a small panel with:
+ *   - "Export to PDF" button (always visible)
+ *   - "Include linked pages" switch (Pro-gated; clicking on Free opens upgrade)
+ *
+ * Self-host (`isAppFlowyHosted()=false`) auto-enables Pro features. To force
+ * "free cloud user" behavior in tests, we keep the default hosted detection and
+ * mock the subscriptions endpoint to return an empty plan list.
+ */
+async function openSharePopover(page: Page): Promise<void> {
+  await expect(ShareSelectors.shareButton(page)).toBeVisible({ timeout: 10000 });
+  // evaluate(click) avoids the sticky header overlay intercepting pointer events
+  await ShareSelectors.shareButton(page).evaluate((el: HTMLElement) => el.click());
+  await page.waitForTimeout(1000);
+}
+
+async function switchToExportAsTab(page: Page): Promise<void> {
+  const popover = ShareSelectors.sharePopover(page);
+
+  await expect(popover.getByText('Export as', { exact: true })).toBeVisible();
+  await popover.getByText('Export as', { exact: true }).click({ force: true });
+  await page.waitForTimeout(500);
+  await expect(ExportSelectors.panel(page)).toBeVisible();
+}
+
+test.describe('Feature: Export to PDF', () => {
+  let testEmail: string;
+
+  test.beforeEach(async ({ page }) => {
+    setupPageErrorHandling(page);
+    testEmail = generateRandomEmail();
+  });
+
+  test('Scenario: Open share popover and switch to Export as tab', async ({ page, request }) => {
+    await test.step('Given a signed-in user with the default workspace loaded', async () => {
+      await signInAndWaitForApp(page, request, testEmail);
+      await expect(SidebarSelectors.pageHeader(page)).toBeVisible({ timeout: 30000 });
+      await expect(PageSelectors.names(page).first()).toBeVisible({ timeout: 30000 });
+    });
+
+    await test.step('When the user opens the Share popover', async () => {
+      await openSharePopover(page);
+    });
+
+    await test.step('Then the Share, Publish, and Export as tabs are visible', async () => {
+      const popover = ShareSelectors.sharePopover(page);
+
+      await expect(popover.getByText('Share', { exact: true })).toBeVisible();
+      await expect(popover.getByText('Publish', { exact: true })).toBeVisible();
+      await expect(popover.getByText('Export as', { exact: true })).toBeVisible();
+    });
+
+    await test.step('When switching to Export as', async () => {
+      await switchToExportAsTab(page);
+    });
+
+    await test.step('Then the Export to PDF button and Include-linked-pages switch are present', async () => {
+      await expect(ExportSelectors.pdfButton(page)).toBeVisible();
+      await expect(ExportSelectors.pdfButton(page)).toBeEnabled();
+      await expect(ExportSelectors.includeLinkedPagesSwitch(page)).toBeVisible();
+    });
+  });
+
+  test('Scenario: Clicking Export to PDF triggers a download', async ({ page, request }) => {
+    let exportRequestUrl: string | null = null;
+
+    await test.step('Given the request to /api/export/view/.../pdf is observable', async () => {
+      page.on('request', (req) => {
+        if (req.url().includes('/api/export/view/') && req.url().includes('/pdf')) {
+          exportRequestUrl = req.url();
+        }
+      });
+    });
+
+    await test.step('And a signed-in user with the default workspace', async () => {
+      await signInAndWaitForApp(page, request, testEmail);
+      await expect(SidebarSelectors.pageHeader(page)).toBeVisible({ timeout: 30000 });
+      await expect(PageSelectors.names(page).first()).toBeVisible({ timeout: 30000 });
+      await page.waitForTimeout(2000);
+    });
+
+    await test.step('When the user opens Export as and clicks Export to PDF', async () => {
+      await openSharePopover(page);
+      await switchToExportAsTab(page);
+
+      const downloadPromise = page.waitForEvent('download', { timeout: 60000 });
+
+      await ExportSelectors.pdfButton(page).click({ force: true });
+      const download = await downloadPromise;
+
+      await test.step('Then the browser receives a non-empty PDF download', async () => {
+        const filename = download.suggestedFilename();
+
+        expect(filename.length).toBeGreaterThan(0);
+        // Server returns application/pdf or application/zip (multi-page)
+        expect(filename).toMatch(/\.(pdf|zip)$/i);
+      });
+    });
+
+    await test.step('And the request hit the view PDF endpoint with default query params', () => {
+      expect(exportRequestUrl).not.toBeNull();
+      expect(exportRequestUrl!).toContain('include_nested=');
+      expect(exportRequestUrl!).toContain('include_database=');
+      expect(exportRequestUrl!).toContain('include_images=true');
+      expect(exportRequestUrl!).toContain('max_depth=2');
+    });
+  });
+
+  test('Scenario: Free cloud user clicking Include-linked-pages opens the upgrade flow', async ({
+    page,
+    request,
+  }) => {
+    let upgradeLinkRequested = false;
+
+    await test.step('Given billing endpoints report no active subscription (Free)', async () => {
+      await mockBillingEndpoints(page);
+      // Match the actual URL — `getSubscriptionLink` hits
+      // /billing/api/v1/subscription-link?workspace_subscription_plan=...&workspace_id=...
+      // (no path segments after `subscription-link`). Use a regex so query string is irrelevant.
+      await page.route(/\/billing\/api\/v1\/subscription-link(\?|$)/, (route) => {
+        upgradeLinkRequested = true;
+        route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            code: 0,
+            data: 'https://example.com/checkout/test-session',
+            message: 'success',
+          }),
+        });
+      });
+    });
+
+    await test.step('And a signed-in user on the share Export-as tab', async () => {
+      await signInAndWaitForApp(page, request, testEmail);
+      await expect(SidebarSelectors.pageHeader(page)).toBeVisible({ timeout: 30000 });
+      await expect(PageSelectors.names(page).first()).toBeVisible({ timeout: 30000 });
+      await openSharePopover(page);
+      await switchToExportAsTab(page);
+    });
+
+    await test.step('When the user clicks the Include-linked-pages switch', async () => {
+      // Stub window.open so the test environment doesn't actually open a tab
+      await page.evaluate(() => {
+        (window as unknown as { __opened: string[] }).__opened = [];
+        const original = window.open;
+
+        window.open = (url?: string | URL) => {
+          (window as unknown as { __opened: string[] }).__opened.push(String(url ?? ''));
+          return null as unknown as Window;
+        };
+        // Keep a reference so a later GC doesn't break the test cleanup
+        (window as unknown as { __originalOpen: typeof original }).__originalOpen = original;
+      });
+
+      await ExportSelectors.includeLinkedPagesSwitch(page).click({ force: true });
+      await page.waitForTimeout(1500);
+    });
+
+    await test.step('Then the subscription-link endpoint is hit and a checkout URL is opened', async () => {
+      expect(upgradeLinkRequested).toBe(true);
+
+      const opened = await page.evaluate(() =>
+        ((window as unknown as { __opened?: string[] }).__opened ?? []).slice()
+      );
+
+      expect(opened.length).toBeGreaterThan(0);
+      expect(opened[0]).toContain('checkout');
+    });
+
+    await test.step('And the toggle did NOT flip to checked (still Free)', async () => {
+      await expect(ExportSelectors.includeLinkedPagesSwitch(page)).toHaveAttribute(
+        'data-state',
+        'unchecked',
+      );
+    });
+  });
+});

--- a/playwright/e2e/page/import-page.spec.ts
+++ b/playwright/e2e/page/import-page.spec.ts
@@ -1,0 +1,213 @@
+import { Page, expect, test } from '@playwright/test';
+
+import { signInAndWaitForApp } from '../../support/auth-flow-helpers';
+import { setupPageErrorHandling } from '../../support/fixtures';
+import {
+  AddPageSelectors,
+  ImportSelectors,
+  PageSelectors,
+  SidebarSelectors,
+} from '../../support/selectors';
+import { generateRandomEmail } from '../../support/test-config';
+
+/**
+ * Import — BDD scenarios for the sidebar "+" → Import flow.
+ *
+ * Two formats are supported:
+ *   - Text & Markdown — fully client-side: parses MD locally, creates an empty
+ *     Document via PageService.add, fetches its collab, mutates the Y.Doc,
+ *     and PUTs the encoded update back.
+ *   - CSV — server flow: createDatabaseCsvImportTask → upload to presigned
+ *     URL → poll status until Completed (mocked here for hermetic tests).
+ *
+ * The dialog is owned by Outline.tsx (a persistent ancestor) so it survives
+ * the dropdown unmount that happens when the Import menu item is clicked.
+ */
+
+const SAMPLE_MARKDOWN = '# Imported Heading\n\nThis is **bold** content from a markdown file.\n';
+
+async function openAddPageMenu(page: Page): Promise<void> {
+  // Hover the first sidebar page so the inline "+" button reveals.
+  const firstPage = PageSelectors.items(page).first();
+
+  await expect(firstPage).toBeVisible({ timeout: 30000 });
+  await firstPage.hover();
+
+  const addButton = AddPageSelectors.inlineAddButton(page).first();
+
+  await expect(addButton).toBeVisible({ timeout: 10000 });
+  await addButton.evaluate((el: HTMLElement) => el.click());
+  await page.waitForTimeout(500);
+}
+
+async function openImportDialogFromAddMenu(page: Page): Promise<void> {
+  await openAddPageMenu(page);
+  await expect(AddPageSelectors.addImportButton(page)).toBeVisible({ timeout: 5000 });
+  await AddPageSelectors.addImportButton(page).click({ force: true });
+  await expect(ImportSelectors.dialog(page)).toBeVisible({ timeout: 5000 });
+}
+
+test.describe('Feature: Import', () => {
+  let testEmail: string;
+
+  test.beforeEach(async ({ page }) => {
+    setupPageErrorHandling(page);
+    testEmail = generateRandomEmail();
+  });
+
+  test('Scenario: Open Import dialog from the sidebar add menu', async ({ page, request }) => {
+    await test.step('Given a signed-in user', async () => {
+      await signInAndWaitForApp(page, request, testEmail);
+      await expect(SidebarSelectors.pageHeader(page)).toBeVisible({ timeout: 30000 });
+      await expect(PageSelectors.names(page).first()).toBeVisible({ timeout: 30000 });
+    });
+
+    await test.step('When the user opens the inline "+" menu and clicks Import', async () => {
+      await openImportDialogFromAddMenu(page);
+    });
+
+    await test.step('Then the Import dialog shows Text & Markdown and CSV options', async () => {
+      await expect(ImportSelectors.markdownButton(page)).toBeVisible();
+      await expect(ImportSelectors.csvButton(page)).toBeVisible();
+    });
+  });
+
+  test('Scenario: Importing a Markdown file creates a Document page with the file content', async ({
+    page,
+    request,
+  }) => {
+    await test.step('Given a signed-in user with the default workspace', async () => {
+      await signInAndWaitForApp(page, request, testEmail);
+      await expect(SidebarSelectors.pageHeader(page)).toBeVisible({ timeout: 30000 });
+      await expect(PageSelectors.names(page).first()).toBeVisible({ timeout: 30000 });
+      await page.waitForTimeout(1500);
+    });
+
+    await test.step('When the user opens Import → Text & Markdown and picks a .md file', async () => {
+      await openImportDialogFromAddMenu(page);
+
+      const filename = `notes-${Date.now()}.md`;
+
+      await ImportSelectors.markdownInput(page).setInputFiles({
+        name: filename,
+        mimeType: 'text/markdown',
+        buffer: Buffer.from(SAMPLE_MARKDOWN, 'utf-8'),
+      });
+    });
+
+    await test.step('Then a new Document with the file basename appears in the sidebar', async () => {
+      await expect(ImportSelectors.dialog(page)).not.toBeVisible({ timeout: 30000 });
+      // Server side: the new view is created via addAppPage, then the doc is
+      // populated via getCollab + updateCollab. Refresh of the outline is
+      // handled by usePageOperations.addPage, which calls loadOutline.
+      await expect(PageSelectors.nameContaining(page, /^notes-\d+$/).first()).toBeVisible({
+        timeout: 30000,
+      });
+    });
+
+    await test.step('And the page modal that auto-opens displays the imported heading and bold text', async () => {
+      // After import, ExportPanel calls openPageModal(viewId) — a [role="dialog"]
+      // overlay that renders the new page's editor. Wait for it and assert content
+      // inside that modal (avoids fighting the overlay with sidebar clicks).
+      const modal = page.locator('[role="dialog"]').last();
+
+      await expect(modal).toBeVisible({ timeout: 15000 });
+      await expect(modal.locator('[data-slate-editor="true"]').first()).toBeVisible({
+        timeout: 15000,
+      });
+      await expect(modal.getByText('Imported Heading').first()).toBeVisible({ timeout: 15000 });
+      await expect(modal.getByText('bold').first()).toBeVisible({ timeout: 5000 });
+    });
+  });
+
+  test('Scenario: Importing a CSV file creates a Grid page (server flow mocked)', async ({
+    page,
+    request,
+  }) => {
+    const taskId = 'test-csv-task-id';
+    const fakeViewId = '00000000-0000-4000-8000-000000000001';
+    let presignedUploadHit = false;
+    let pollCount = 0;
+
+    await test.step('Given the CSV import server endpoints are mocked end-to-end', async () => {
+      // 1) createDatabaseCsvImportTask → returns a presigned URL we control
+      await page.route('**/api/workspace/**/database/import/csv', (route) => {
+        if (route.request().method() !== 'POST') return route.fallback();
+        return route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            code: 0,
+            data: {
+              task_id: taskId,
+              presigned_url: 'https://example.test/csv-upload',
+              expires_in_secs: 1800,
+            },
+            message: 'success',
+          }),
+        });
+      });
+
+      // 2) Upload to presigned URL → 200 OK
+      await page.route('https://example.test/csv-upload', (route) => {
+        presignedUploadHit = true;
+        route.fulfill({ status: 200, body: '' });
+      });
+
+      // 3) Status poll → first response Pending, second Completed.
+      // The client polls every 1.5s; with fake timers the second hit is enough.
+      await page.route(
+        `**/api/workspace/**/database/import/csv/${taskId}`,
+        (route) => {
+          pollCount += 1;
+          const isDone = pollCount >= 2;
+
+          route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify({
+              code: 0,
+              data: {
+                task_id: taskId,
+                status: isDone ? 'Completed' : 'Pending',
+                progress: { rows_processed: isDone ? 1 : 0, rows_total: 1 },
+                ...(isDone ? { view_id: fakeViewId, database_id: fakeViewId } : {}),
+              },
+              message: 'success',
+            }),
+          });
+        },
+      );
+    });
+
+    await test.step('And a signed-in user', async () => {
+      await signInAndWaitForApp(page, request, testEmail);
+      await expect(SidebarSelectors.pageHeader(page)).toBeVisible({ timeout: 30000 });
+      await expect(PageSelectors.names(page).first()).toBeVisible({ timeout: 30000 });
+      await page.waitForTimeout(1500);
+    });
+
+    await test.step('When the user picks a CSV file via Import → CSV', async () => {
+      await openImportDialogFromAddMenu(page);
+
+      const csv = 'name,role\nAlice,Engineer\nBob,Designer\n';
+
+      await ImportSelectors.csvInput(page).setInputFiles({
+        name: `team-${Date.now()}.csv`,
+        mimeType: 'text/csv',
+        buffer: Buffer.from(csv, 'utf-8'),
+      });
+    });
+
+    await test.step('Then the CSV is uploaded and the dialog closes after polling completes', async () => {
+      await expect(ImportSelectors.dialog(page)).not.toBeVisible({ timeout: 15000 });
+      expect(presignedUploadHit).toBe(true);
+      expect(pollCount).toBeGreaterThanOrEqual(2);
+    });
+
+    await test.step('And the client navigates to the new view returned by the server', async () => {
+      // toView() pushes the view_id onto the URL — assert the URL ends with the fake id
+      await expect.poll(() => page.url(), { timeout: 10000 }).toContain(fakeViewId);
+    });
+  });
+});

--- a/playwright/support/selectors.ts
+++ b/playwright/support/selectors.ts
@@ -425,6 +425,27 @@ export const AddPageSelectors = {
   addCalendarButton: (page: Page) => page.getByTestId('add-calendar-button'),
   addBoardButton: (page: Page) => page.getByTestId('add-board-button'),
   addAIChatButton: (page: Page) => page.getByTestId('add-ai-chat-button'),
+  addImportButton: (page: Page) => page.getByTestId('add-import-button'),
+};
+
+/**
+ * Export-As (PDF) selectors
+ */
+export const ExportSelectors = {
+  panel: (page: Page) => page.getByTestId('export-panel'),
+  pdfButton: (page: Page) => page.getByTestId('export-pdf-button'),
+  includeLinkedPagesSwitch: (page: Page) => page.getByTestId('export-include-linked-pages-switch'),
+};
+
+/**
+ * Import dialog selectors
+ */
+export const ImportSelectors = {
+  dialog: (page: Page) => page.getByTestId('import-dialog'),
+  markdownButton: (page: Page) => page.getByTestId('import-markdown'),
+  csvButton: (page: Page) => page.getByTestId('import-csv'),
+  markdownInput: (page: Page) => page.getByTestId('import-markdown-input'),
+  csvInput: (page: Page) => page.getByTestId('import-csv-input'),
 };
 
 /**

--- a/src/@types/translations/en.json
+++ b/src/@types/translations/en.json
@@ -165,6 +165,13 @@
     "unPublish": "Unpublish",
     "visitSite": "Visit site",
     "exportAsTab": "Export as",
+    "exportPdf": "Export to PDF",
+    "exportPdfExporting": "Exporting...",
+    "exportPdfDescription": "Download this page as a PDF",
+    "exportPdfIncludeLinkedPages": "Include linked pages",
+    "exportPdfIncludeLinkedPagesPro": "Pro plan required",
+    "exportPdfSuccess": "PDF downloaded",
+    "exportPdfError": "Failed to export PDF",
     "publishTab": "Publish",
     "shareTab": "Share",
     "publishOnAppFlowy": "Publish on AppFlowy",
@@ -239,12 +246,15 @@
     "syncedAtLabel": "Synced: "
   },
   "importPanel": {
+    "title": "Import",
     "textAndMarkdown": "Text & Markdown",
     "documentFromV010": "Document from v0.1.0",
     "databaseFromV010": "Database from v0.1.0",
     "notionZip": "Notion Exported Zip File",
     "csv": "CSV",
-    "database": "Database"
+    "database": "Database",
+    "success": "Imported successfully",
+    "failed": "Import failed"
   },
   "teamSpace": "Team space",
   "share": "Share",

--- a/src/application/services/js-services/http/export-api.ts
+++ b/src/application/services/js-services/http/export-api.ts
@@ -1,0 +1,95 @@
+import { APIError, getAxios, handleAPIError } from './core';
+
+export interface ExportPdfOptions {
+  includeNested?: boolean;
+  includeDatabase?: boolean;
+  includeImages?: boolean;
+  maxDepth?: number;
+}
+
+export interface ExportPdfResult {
+  blob: Blob;
+  filename: string;
+}
+
+const DEFAULT_OPTIONS: Required<ExportPdfOptions> = {
+  includeNested: true,
+  includeDatabase: true,
+  includeImages: true,
+  maxDepth: 2,
+};
+
+export async function getViewPdfBlob(
+  workspaceId: string,
+  viewId: string,
+  opts: ExportPdfOptions = {},
+): Promise<ExportPdfResult> {
+  const url = `/api/export/view/${workspaceId}/${viewId}/pdf`;
+  const merged = { ...DEFAULT_OPTIONS, ...opts };
+
+  try {
+    const axiosInstance = getAxios();
+
+    if (!axiosInstance) {
+      const apiError: APIError = { code: -1, message: 'API service not initialized' };
+
+      throw apiError;
+    }
+
+    const response = await axiosInstance.post<Blob>(url, undefined, {
+      params: {
+        include_nested: merged.includeNested,
+        include_database: merged.includeDatabase,
+        include_images: merged.includeImages,
+        max_depth: merged.maxDepth,
+      },
+      responseType: 'blob',
+      validateStatus: (status) => status < 400,
+    });
+
+    if (!response?.data) {
+      const apiError: APIError = { code: -1, message: 'No response data received' };
+
+      throw apiError;
+    }
+
+    const cd = response.headers?.['content-disposition'] as string | undefined;
+    const fallback = `export-${viewId}.pdf`;
+    const filename = parseFilenameFromContentDisposition(cd) ?? fallback;
+
+    return { blob: response.data, filename };
+  } catch (error) {
+    throw handleAPIError(error);
+  }
+}
+
+/**
+ * Parse RFC 6266 Content-Disposition. Prefers `filename*=UTF-8''...` when present
+ * (handles non-ASCII titles), falls back to plain `filename="..."`.
+ */
+export function parseFilenameFromContentDisposition(header?: string): string | null {
+  if (!header) return null;
+
+  const extMatch = /filename\*\s*=\s*([^;]+)/i.exec(header);
+
+  if (extMatch) {
+    const raw = extMatch[1].trim();
+    const parts = raw.split("''");
+
+    if (parts.length === 2) {
+      try {
+        return decodeURIComponent(parts[1].replace(/^"|"$/g, ''));
+      } catch {
+        // fall through
+      }
+    }
+  }
+
+  const plainMatch = /filename\s*=\s*"?([^";]+)"?/i.exec(header);
+
+  if (plainMatch) {
+    return plainMatch[1].trim();
+  }
+
+  return null;
+}

--- a/src/application/services/js-services/http/http_api.ts
+++ b/src/application/services/js-services/http/http_api.ts
@@ -193,6 +193,12 @@ export {
   deleteQuickNote,
 } from './misc-api';
 
+// Export
+export {
+  getViewPdfBlob,
+} from './export-api';
+export type { ExportPdfOptions, ExportPdfResult } from './export-api';
+
 // Notification
 export {
   listNotifications,

--- a/src/components/app/import/ImportDialog.tsx
+++ b/src/components/app/import/ImportDialog.tsx
@@ -1,0 +1,210 @@
+import { CircularProgress, Dialog, IconButton } from '@mui/material';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { toast } from 'sonner';
+
+import { ViewLayout } from '@/application/types';
+import { ReactComponent as CloseIcon } from '@/assets/icons/close.svg';
+import { ReactComponent as DatabaseIcon } from '@/assets/icons/database.svg';
+import { ReactComponent as TextIcon } from '@/assets/icons/text.svg';
+import {
+  useAppOperations,
+  useCurrentWorkspaceId,
+  useOpenPageModal,
+  useToView,
+} from '@/components/app/app.hooks';
+import {
+  ImportAbortError,
+  importCsvAsDatabase,
+  populateDocumentWithMarkdown,
+  stripFileExtension,
+} from '@/components/app/import/import-service';
+
+const MARKDOWN_ACCEPT = '.md,.markdown,.txt,text/markdown,text/plain';
+const CSV_ACCEPT = '.csv,text/csv';
+
+type ImportFormat = 'markdown' | 'csv';
+
+interface ImportDialogProps {
+  open: boolean;
+  parentViewId: string;
+  prevViewId?: string;
+  onOpenChange: (open: boolean) => void;
+}
+
+export default function ImportDialog({ open, parentViewId, prevViewId, onOpenChange }: ImportDialogProps) {
+  const { t } = useTranslation();
+  const workspaceId = useCurrentWorkspaceId();
+  const { addPage } = useAppOperations();
+  const openPageModal = useOpenPageModal();
+  const toView = useToView();
+  const [active, setActive] = useState<ImportFormat | null>(null);
+  const markdownInputRef = useRef<HTMLInputElement>(null);
+  const csvInputRef = useRef<HTMLInputElement>(null);
+  const abortRef = useRef<AbortController | null>(null);
+
+  // Abort any in-flight import on unmount so polling doesn't keep running
+  // after the dialog is torn down.
+  useEffect(() => {
+    return () => {
+      abortRef.current?.abort();
+      abortRef.current = null;
+    };
+  }, []);
+
+  const close = useCallback(() => {
+    setActive(null);
+    onOpenChange(false);
+  }, [onOpenChange]);
+
+  const handleClose = useCallback(() => {
+    if (active) return;
+    onOpenChange(false);
+  }, [active, onOpenChange]);
+
+  const handleMarkdown = useCallback(
+    async (file: File) => {
+      if (!workspaceId || !addPage) return;
+      setActive('markdown');
+      try {
+        const created = await addPage(parentViewId, {
+          layout: ViewLayout.Document,
+          name: stripFileExtension(file.name),
+          prev_view_id: prevViewId,
+        });
+
+        await populateDocumentWithMarkdown(workspaceId, created.view_id, file);
+        toast.success(t('importPanel.success'));
+        close();
+        void openPageModal?.(created.view_id);
+        // eslint-disable-next-line
+      } catch (e: any) {
+        toast.error(e?.message ?? t('importPanel.failed'));
+      } finally {
+        setActive(null);
+      }
+    },
+    [workspaceId, addPage, parentViewId, prevViewId, openPageModal, close, t],
+  );
+
+  const handleCsv = useCallback(
+    async (file: File) => {
+      if (!workspaceId) return;
+      const controller = new AbortController();
+
+      abortRef.current?.abort();
+      abortRef.current = controller;
+      setActive('csv');
+      try {
+        const result = await importCsvAsDatabase({
+          workspaceId,
+          parentViewId,
+          file,
+          signal: controller.signal,
+        });
+
+        toast.success(t('importPanel.success'));
+        close();
+        void toView(result.viewId);
+        // eslint-disable-next-line
+      } catch (e: any) {
+        if (e instanceof ImportAbortError) return;
+        toast.error(e?.message ?? t('importPanel.failed'));
+      } finally {
+        if (abortRef.current === controller) abortRef.current = null;
+        setActive(null);
+      }
+    },
+    [workspaceId, parentViewId, toView, close, t],
+  );
+
+  const onMarkdownPicked = useCallback(
+    (event: React.ChangeEvent<HTMLInputElement>) => {
+      const file = event.target.files?.[0];
+
+      event.target.value = '';
+      if (file) void handleMarkdown(file);
+    },
+    [handleMarkdown],
+  );
+
+  const onCsvPicked = useCallback(
+    (event: React.ChangeEvent<HTMLInputElement>) => {
+      const file = event.target.files?.[0];
+
+      event.target.value = '';
+      if (file) void handleCsv(file);
+    },
+    [handleCsv],
+  );
+
+  return (
+    <Dialog
+      open={open}
+      onClose={handleClose}
+      keepMounted={false}
+      PaperProps={{
+        'data-testid': 'import-dialog',
+        className: 'w-[480px] max-w-[90vw] rounded-500',
+      }}
+    >
+      <div className='relative flex flex-col gap-4 p-5'>
+        <div className='flex w-full items-center justify-between text-base font-medium'>
+          <span className='flex-1 truncate font-medium'>{t('importPanel.title')}</span>
+          <IconButton
+            size='small'
+            color='inherit'
+            className='-right-1.5 h-6 w-6'
+            onClick={handleClose}
+            disabled={!!active}
+          >
+            <CloseIcon />
+          </IconButton>
+        </div>
+
+        <div className='grid grid-cols-2 gap-3'>
+          <button
+            type='button'
+            disabled={!!active}
+            onClick={() => markdownInputRef.current?.click()}
+            className='flex items-center gap-3 rounded-300 bg-fill-content px-4 py-3 text-left text-text-primary hover:bg-fill-content-hover disabled:opacity-60'
+            data-testid='import-markdown'
+          >
+            <TextIcon className='h-5 w-5 text-icon-primary' />
+            <span className='text-sm'>{t('importPanel.textAndMarkdown')}</span>
+            {active === 'markdown' && <CircularProgress size={14} className='ml-auto' />}
+          </button>
+
+          <button
+            type='button'
+            disabled={!!active}
+            onClick={() => csvInputRef.current?.click()}
+            className='flex items-center gap-3 rounded-300 bg-fill-content px-4 py-3 text-left text-text-primary hover:bg-fill-content-hover disabled:opacity-60'
+            data-testid='import-csv'
+          >
+            <DatabaseIcon className='h-5 w-5 text-icon-primary' />
+            <span className='text-sm'>{t('importPanel.csv')}</span>
+            {active === 'csv' && <CircularProgress size={14} className='ml-auto' />}
+          </button>
+        </div>
+
+        <input
+          ref={markdownInputRef}
+          type='file'
+          accept={MARKDOWN_ACCEPT}
+          className='hidden'
+          data-testid='import-markdown-input'
+          onChange={onMarkdownPicked}
+        />
+        <input
+          ref={csvInputRef}
+          type='file'
+          accept={CSV_ACCEPT}
+          className='hidden'
+          data-testid='import-csv-input'
+          onChange={onCsvPicked}
+        />
+      </div>
+    </Dialog>
+  );
+}

--- a/src/components/app/import/import-service.ts
+++ b/src/components/app/import/import-service.ts
@@ -1,0 +1,195 @@
+import * as Y from 'yjs';
+
+import { getCollab, updateCollab } from '@/application/services/js-services/http/collab-api';
+import {
+  cancelDatabaseCsvImportTask,
+  createDatabaseCsvImportTask,
+  getDatabaseCsvImportStatus,
+  uploadDatabaseCsvImportFile,
+} from '@/application/services/js-services/http/import-api';
+import { slateContentInsertToYData } from '@/application/slate-yjs/utils/convert';
+import {
+  deleteBlock,
+  getBlock,
+  getChildrenArray,
+  getPageId,
+} from '@/application/slate-yjs/utils/yjs';
+import {
+  DatabaseCsvImportLayout,
+  DatabaseCsvImportMode,
+  Types,
+  YjsEditorKey,
+  YSharedRoot,
+} from '@/application/types';
+import { parsedBlockToSlateElement } from '@/components/app/import/markdown-to-blocks';
+import { parseMarkdown } from '@/components/editor/parsers/markdown-parser';
+import { calculateMd5 } from '@/utils/md5';
+
+const CSV_POLL_INTERVAL_MS = 1500;
+const CSV_POLL_TIMEOUT_MS = 5 * 60 * 1000;
+
+export function stripFileExtension(name: string): string {
+  const dot = name.lastIndexOf('.');
+
+  return dot > 0 ? name.slice(0, dot) : name;
+}
+
+/**
+ * Populate a freshly-created Document page with the contents of a Markdown / plain-text file.
+ *
+ * The server has no single-file MD endpoint, so we fetch the page's empty Y.Doc, mutate it
+ * locally with `slateContentInsertToYData`, and PUT the encoded update back via `updateCollab`.
+ * The page must already exist (created via PageService.add by the caller).
+ */
+export async function populateDocumentWithMarkdown(
+  workspaceId: string,
+  viewId: string,
+  file: File,
+): Promise<void> {
+  // Fetch the file text and the (empty) page collab in parallel — they're independent
+  // and the markdown parse is much cheaper than either round trip.
+  const [text, collab] = await Promise.all([
+    file.text(),
+    getCollab(workspaceId, viewId, Types.Document),
+  ]);
+  const blocks = parseMarkdown(text);
+
+  if (blocks.length === 0) return;
+
+  const docState = collab.data;
+  const doc = new Y.Doc();
+
+  Y.applyUpdate(doc, docState);
+
+  const sharedRoot = doc.getMap(YjsEditorKey.data_section) as YSharedRoot;
+  const pageId = getPageId(sharedRoot);
+  const pageBlock = getBlock(pageId, sharedRoot);
+
+  if (!pageBlock) {
+    throw new Error('Imported document has no root page block');
+  }
+
+  const childrenArray = getChildrenArray(pageBlock.get(YjsEditorKey.block_children), sharedRoot);
+  const existingChildIds = childrenArray ? childrenArray.toArray() : [];
+  const slateNodes = blocks.map(parsedBlockToSlateElement);
+
+  doc.transact(() => {
+    existingChildIds.forEach((id) => deleteBlock(sharedRoot, id));
+    slateContentInsertToYData(pageId, 0, slateNodes, doc);
+  });
+
+  const update = Y.encodeStateAsUpdate(doc);
+
+  await updateCollab(workspaceId, viewId, Types.Document, update, { version_vector: 0 });
+}
+
+export interface ImportCsvInput {
+  workspaceId: string;
+  parentViewId: string;
+  file: File;
+  onProgress?: (fraction: number) => void;
+  signal?: AbortSignal;
+}
+
+export interface ImportCsvResult {
+  viewId: string;
+}
+
+export class ImportAbortError extends Error {
+  constructor() {
+    super('CSV import aborted');
+    this.name = 'ImportAbortError';
+  }
+}
+
+/**
+ * Import a CSV file as a new Grid (database) page. Server handles parsing.
+ *
+ *   1. createDatabaseCsvImportTask → { task_id, presigned_url }
+ *   2. PUT csv to presigned_url
+ *   3. poll getDatabaseCsvImportStatus until 'Completed' (returns view_id) or terminal failure
+ *
+ * If `signal` aborts, polling exits and the server task is cancelled best-effort.
+ */
+export async function importCsvAsDatabase(input: ImportCsvInput): Promise<ImportCsvResult> {
+  const { workspaceId, parentViewId, file, onProgress, signal } = input;
+
+  throwIfAborted(signal);
+  const md5_base64 = await calculateMd5(file);
+
+  throwIfAborted(signal);
+  const baseName = stripFileExtension(file.name);
+
+  const task = await createDatabaseCsvImportTask(workspaceId, {
+    content_length: file.size,
+    md5_base64,
+    mode: DatabaseCsvImportMode.Create,
+    parent_view_id: parentViewId,
+    name: baseName,
+    layout: DatabaseCsvImportLayout.Grid,
+    csv: {
+      has_header: true,
+      delimiter: ',',
+      quote: '"',
+      escape: '\\',
+      encoding: 'utf-8',
+      trim: false,
+    },
+  });
+
+  try {
+    throwIfAborted(signal);
+    await uploadDatabaseCsvImportFile(task.presigned_url, file, onProgress);
+
+    const start = Date.now();
+
+    while (Date.now() - start < CSV_POLL_TIMEOUT_MS) {
+      throwIfAborted(signal);
+      const status = await getDatabaseCsvImportStatus(workspaceId, task.task_id);
+
+      if (status.status === 'Completed' && status.view_id) {
+        return { viewId: status.view_id };
+      }
+
+      if (status.status === 'Failed' || status.status === 'Expire' || status.status === 'Cancel') {
+        throw new Error(status.error || `CSV import ${status.status.toLowerCase()}`);
+      }
+
+      await sleep(CSV_POLL_INTERVAL_MS, signal);
+    }
+
+    throw new Error('CSV import timed out');
+  } catch (err) {
+    // Server task is still running — cancel it whether we aborted, timed out, or hit a hard failure.
+    void cancelDatabaseCsvImportTask(workspaceId, task.task_id).catch(noop);
+    throw err;
+  }
+}
+
+function noop(): void {
+  /* swallow */
+}
+
+function throwIfAborted(signal?: AbortSignal): void {
+  if (signal?.aborted) throw new ImportAbortError();
+}
+
+function sleep(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (signal?.aborted) {
+      reject(new ImportAbortError());
+      return;
+    }
+
+    const timer = setTimeout(() => {
+      signal?.removeEventListener('abort', onAbort);
+      resolve();
+    }, ms);
+    const onAbort = () => {
+      clearTimeout(timer);
+      reject(new ImportAbortError());
+    };
+
+    signal?.addEventListener('abort', onAbort, { once: true });
+  });
+}

--- a/src/components/app/import/markdown-to-blocks.ts
+++ b/src/components/app/import/markdown-to-blocks.ts
@@ -1,0 +1,66 @@
+import { Element, Text } from 'slate';
+
+import { YjsEditorKey } from '@/application/types';
+import { ParsedBlock, InlineFormat } from '@/components/editor/parsers/types';
+
+/**
+ * Convert a ParsedBlock to a Slate Element compatible with `slateContentInsertToYData`.
+ * Mirrors the (unexported) pair in `withPasted.ts` and `ai-meeting.summary-regenerate.ts`.
+ */
+export function parsedBlockToSlateElement(block: ParsedBlock): Element {
+  const textNodes = parsedBlockToTextNodes(block);
+  const slateChildren: (Element | Text)[] = [
+    { type: YjsEditorKey.text, children: textNodes } as unknown as Element,
+    ...block.children.map(parsedBlockToSlateElement),
+  ];
+
+  return {
+    type: block.type,
+    data: block.data,
+    children: slateChildren,
+  } as unknown as Element;
+}
+
+function parsedBlockToTextNodes(block: ParsedBlock): Text[] {
+  const { text, formats } = block;
+
+  if (formats.length === 0) return [{ text }];
+
+  const boundaries = new Set<number>([0, text.length]);
+
+  formats.forEach((f: InlineFormat) => {
+    boundaries.add(f.start);
+    boundaries.add(f.end);
+  });
+
+  const positions = Array.from(boundaries).sort((a, b) => a - b);
+  const nodes: Text[] = [];
+
+  for (let i = 0; i < positions.length - 1; i++) {
+    const start = positions[i];
+    const end = positions[i + 1];
+    const segment = text.slice(start, end);
+
+    if (segment.length === 0) continue;
+
+    const active = formats.filter((f) => f.start <= start && f.end >= end);
+    const attributes: Record<string, unknown> = {};
+
+    active.forEach((f) => {
+      switch (f.type) {
+        case 'bold': attributes.bold = true; break;
+        case 'italic': attributes.italic = true; break;
+        case 'underline': attributes.underline = true; break;
+        case 'strikethrough': attributes.strikethrough = true; break;
+        case 'code': attributes.code = true; break;
+        case 'link': attributes.href = f.data?.href; break;
+        case 'color': attributes.font_color = f.data?.color; break;
+        case 'bgColor': attributes.bg_color = f.data?.bgColor; break;
+      }
+    });
+
+    nodes.push({ text: segment, ...attributes } as Text);
+  }
+
+  return nodes;
+}

--- a/src/components/app/outline/Outline.tsx
+++ b/src/components/app/outline/Outline.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import React, { lazy, Suspense, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { useTranslation } from 'react-i18next';
 
@@ -23,6 +23,9 @@ import ViewActionsPopover from '@/components/app/view-actions/ViewActionsPopover
 import { Button } from '@/components/ui/button';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { Log } from '@/utils/log';
+
+// Lazy: MUI Dialog + import-service (yjs / md parser) shouldn't sit in the Outline bundle.
+const ImportDialog = lazy(() => import('@/components/app/import/ImportDialog'));
 
 const AUTO_LOAD_RETRY_DELAY_MS = 15000;
 
@@ -64,6 +67,19 @@ export function Outline({ width }: { width: number }) {
       }
     | undefined
   >(undefined);
+  // Import dialog state lives here (not in ViewActionsPopover) because the
+  // popover is unmounted as soon as the dropdown closes — clicking the Import
+  // menu item closes the dropdown, which would otherwise tear down the dialog
+  // before it can render.
+  const [importTarget, setImportTarget] = useState<View | undefined>(undefined);
+  const handleImportClick = useCallback((view: View) => {
+    setImportTarget(view);
+  }, []);
+  const importLastChildId = importTarget?.children?.[importTarget.children.length - 1]?.view_id;
+  const handleImportOpenChange = useCallback((open: boolean) => {
+    if (!open) setImportTarget(undefined);
+  }, []);
+
   const loadingViewIdsRef = useRef<Set<string>>(new Set());
   const autoLoadRetryAfterRef = useRef<Map<string, number>>(new Map());
   const validatingRestoreIdsRef = useRef<Set<string>>(new Set());
@@ -420,6 +436,7 @@ export function Outline({ width }: { width: number }) {
                 setMenuProps(undefined);
               }
             }}
+            onImportClick={handleImportClick}
           >
             <div
               style={{
@@ -435,6 +452,16 @@ export function Outline({ width }: { width: number }) {
           </ViewActionsPopover>,
           document.body
         )}
+      {importTarget && (
+        <Suspense fallback={null}>
+          <ImportDialog
+            open={Boolean(importTarget)}
+            parentViewId={importTarget.view_id}
+            prevViewId={importLastChildId}
+            onOpenChange={handleImportOpenChange}
+          />
+        </Suspense>
+      )}
     </>
   );
 }

--- a/src/components/app/share/ExportPanel.tsx
+++ b/src/components/app/share/ExportPanel.tsx
@@ -1,0 +1,124 @@
+import { useCallback, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { toast } from 'sonner';
+
+import { BillingService } from '@/application/services/domains';
+import { getViewPdfBlob } from '@/application/services/js-services/http/export-api';
+import { SubscriptionInterval, SubscriptionPlan } from '@/application/types';
+import { ReactComponent as PDFIcon } from '@/assets/icons/pdf.svg';
+import { useAppOverlayContext } from '@/components/app/app-overlay/AppOverlayContext';
+import { useAppView, useCurrentWorkspaceId, useGetSubscriptions } from '@/components/app/app.hooks';
+import { useSubscriptionPlan } from '@/components/app/hooks/useSubscriptionPlan';
+import { Button } from '@/components/ui/button';
+import { Switch } from '@/components/ui/switch';
+import { downloadBlob } from '@/utils/download';
+
+function ExportPanel({ viewId }: { viewId: string }) {
+  const { t } = useTranslation();
+  const view = useAppView(viewId);
+  const viewIdResolved = view?.view_id;
+  const workspaceId = useCurrentWorkspaceId();
+  const getSubscriptions = useGetSubscriptions();
+  const { isPro } = useSubscriptionPlan(getSubscriptions);
+  const { showBlockingLoader, hideBlockingLoader } = useAppOverlayContext();
+  const [linkedPagesOverride, setLinkedPagesOverride] = useState<boolean | null>(null);
+  const includeLinkedPages = linkedPagesOverride ?? isPro;
+  const [exporting, setExporting] = useState<boolean>(false);
+  const exportingRef = useRef<boolean>(false);
+
+  const handleExportPdf = useCallback(async () => {
+    if (!workspaceId || !viewIdResolved || exportingRef.current) return;
+
+    exportingRef.current = true;
+    setExporting(true);
+    showBlockingLoader(`${t('shareAction.exportPdfExporting')}...`);
+    try {
+      const { blob, filename } = await getViewPdfBlob(workspaceId, viewIdResolved, {
+        includeNested: isPro ? includeLinkedPages : false,
+        // Mirror desktop: embedded databases are a Pro feature
+        // (share_bloc.dart:447 shouldIncludeEmbeddedDatabases = isProPlan).
+        // Self-host users have isPro=true via useSubscriptionPlan.
+        includeDatabase: isPro,
+      });
+
+      downloadBlob(blob, filename);
+      toast.success(t('shareAction.exportPdfSuccess'));
+    } catch (e) {
+      const message = (e as { message?: string })?.message ?? t('shareAction.exportPdfError');
+
+      toast.error(message);
+    } finally {
+      exportingRef.current = false;
+      setExporting(false);
+      hideBlockingLoader();
+    }
+  }, [workspaceId, viewIdResolved, isPro, includeLinkedPages, t, showBlockingLoader, hideBlockingLoader]);
+
+  // Free users on AppFlowy Cloud get redirected to the Pro upgrade flow when they
+  // try to enable "Include linked pages". Self-hosted users have isPro=true (set
+  // by useSubscriptionPlan) so the toggle works normally without a billing check.
+  const handleLinkedPagesChange = useCallback(
+    async (checked: boolean) => {
+      if (checked && !isPro) {
+        if (!workspaceId) return;
+        try {
+          const link = await BillingService.getSubscriptionLink(
+            workspaceId,
+            SubscriptionPlan.Pro,
+            SubscriptionInterval.Month,
+          );
+
+          window.open(link, '_blank');
+          // eslint-disable-next-line
+        } catch (e: any) {
+          toast.error(e?.message ?? t('shareAction.exportPdfError'));
+        }
+
+        return;
+      }
+
+      setLinkedPagesOverride(checked);
+    },
+    [isPro, workspaceId, t],
+  );
+
+  return (
+    <div className='flex flex-col items-stretch gap-3 px-4 py-4' data-testid='export-panel'>
+      <div className='flex items-center justify-between gap-4'>
+        <div className='flex items-center gap-2'>
+          <PDFIcon className='h-5 w-5' />
+          <div className='flex flex-col'>
+            <span className='text-sm text-text-primary'>{t('shareAction.exportPdf')}</span>
+            <span className='text-xs text-text-tertiary'>{t('shareAction.exportPdfDescription')}</span>
+          </div>
+        </div>
+        <Button
+          size='sm'
+          data-testid='export-pdf-button'
+          onClick={handleExportPdf}
+          disabled={exporting || !workspaceId || !view}
+          loading={exporting}
+        >
+          {exporting ? t('shareAction.exportPdfExporting') : t('shareAction.exportPdf')}
+        </Button>
+      </div>
+
+      <div className='flex items-center justify-between gap-4'>
+        <div className='flex flex-col'>
+          <span className='text-sm text-text-primary'>{t('shareAction.exportPdfIncludeLinkedPages')}</span>
+          {!isPro && (
+            <span className='text-xs text-text-tertiary'>{t('shareAction.exportPdfIncludeLinkedPagesPro')}</span>
+          )}
+        </div>
+        <Switch
+          data-testid='export-include-linked-pages-switch'
+          checked={includeLinkedPages}
+          onCheckedChange={handleLinkedPagesChange}
+          disabled={exporting}
+        />
+      </div>
+    </div>
+  );
+}
+
+export default ExportPanel;

--- a/src/components/app/share/ShareTabs.tsx
+++ b/src/components/app/share/ShareTabs.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo } from 'react';
+import React, { lazy, Suspense, useEffect, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { ReactComponent as SuccessIcon } from '@/assets/icons/success.svg';
@@ -11,9 +11,13 @@ import { useCurrentUser } from '@/components/main/app.hooks';
 import { Separator } from '@/components/ui/separator';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 
+// Lazy: only loaded when the user opens the Export tab.
+const ExportPanel = lazy(() => import('@/components/app/share/ExportPanel'));
+
 enum TabKey {
   SHARE = 'share',
   PUBLISH = 'publish',
+  EXPORT_AS = 'export_as',
   TEMPLATE = 'template',
 }
 
@@ -45,6 +49,11 @@ function ShareTabs({
         label: t('shareAction.publish'),
         icon: view?.is_published ? <SuccessIcon className={'mb-0 h-5 w-5 text-text-action'} /> : undefined,
         Panel: PublishPanel,
+      },
+      {
+        value: TabKey.EXPORT_AS,
+        label: t('shareAction.exportAsTab'),
+        Panel: ExportPanel,
       },
       currentUser?.email?.endsWith('appflowy.io') &&
         view?.is_published && {
@@ -93,12 +102,14 @@ function ShareTabs({
       <Separator className='my-0' />
       {options.map((option) => (
         <TabsContent key={option.value} value={option.value}>
-          <option.Panel
-            viewId={viewId}
-            onClose={onClose}
-            opened={opened}
-            onOpenPublishManage={onOpenPublishManage}
-          />
+          <Suspense fallback={null}>
+            <option.Panel
+              viewId={viewId}
+              onClose={onClose}
+              opened={opened}
+              onOpenPublishManage={onOpenPublishManage}
+            />
+          </Suspense>
         </TabsContent>
       ))}
     </Tabs>

--- a/src/components/app/view-actions/AddPageActions.tsx
+++ b/src/components/app/view-actions/AddPageActions.tsx
@@ -1,19 +1,21 @@
-import React, { useCallback, useMemo } from 'react';
+import { ReactNode, useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { toast } from 'sonner';
 
 import { View, ViewLayout } from '@/application/types';
+import { ReactComponent as UploadIcon } from '@/assets/icons/upload.svg';
 import { ViewIcon } from '@/components/_shared/view-icon';
 import { useAIEnabled, useAppOperations, useOpenPageModal, useToView } from '@/components/app/app.hooks';
 import { DropdownMenuGroup, DropdownMenuItem } from '@/components/ui/dropdown-menu';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 
-function AddPageActions({ view }: { view: View }) {
+function AddPageActions({ view, onImportClick }: { view: View; onImportClick?: (view: View) => void }) {
   const { t } = useTranslation();
   const { addPage } = useAppOperations();
   const openPageModal = useOpenPageModal();
   const toView = useToView();
   const aiEnabled = useAIEnabled();
+  const lastChildViewId = view.children?.[view.children.length - 1]?.view_id;
 
   const handleAddPage = useCallback(
     async (layout: ViewLayout, name?: string) => {
@@ -23,8 +25,7 @@ function AddPageActions({ view }: { view: View }) {
       try {
         // Append after the last child so the new page appears at the bottom.
         // When prev_view_id is omitted the backend prepends (inserts at index 0).
-        const lastChild = view.children?.[view.children.length - 1];
-        const response = await addPage(view.view_id, { layout, name, prev_view_id: lastChild?.view_id });
+        const response = await addPage(view.view_id, { layout, name, prev_view_id: lastChildViewId });
 
         if (layout === ViewLayout.Document) {
           void openPageModal?.(response.view_id);
@@ -38,12 +39,12 @@ function AddPageActions({ view }: { view: View }) {
         toast.error(e.message);
       }
     },
-    [addPage, aiEnabled, openPageModal, t, toView, view.view_id, view.children]
+    [addPage, aiEnabled, openPageModal, t, toView, view.view_id, lastChildViewId]
   );
 
   const actions: {
     label: string;
-    icon: React.ReactNode;
+    icon: ReactNode;
     testId?: string;
     disabled?: boolean;
     tooltip?: string;
@@ -113,8 +114,16 @@ function AddPageActions({ view }: { view: View }) {
         // eslint-disable-next-line @typescript-eslint/no-empty-function
         onSelect: () => {},
       },
+      {
+        label: t('moreAction.import'),
+        icon: <UploadIcon className='h-5 w-5 text-icon-primary' />,
+        testId: 'add-import-button',
+        onSelect: () => {
+          onImportClick?.(view);
+        },
+      },
     ],
-    [aiEnabled, handleAddPage, t]
+    [aiEnabled, handleAddPage, t, onImportClick, view]
   );
 
   return (
@@ -137,9 +146,7 @@ function AddPageActions({ view }: { view: View }) {
             key={action.label}
             data-testid={action.testId}
             disabled={action.disabled}
-            onClick={() => {
-              action.onSelect();
-            }}
+            onClick={action.onSelect}
           >
             {action.icon}
             {action.label}

--- a/src/components/app/view-actions/ViewActionsPopover.tsx
+++ b/src/components/app/view-actions/ViewActionsPopover.tsx
@@ -12,6 +12,7 @@ function ViewActionsPopover ({
   children,
   open,
   onOpenChange,
+  onImportClick,
 }: {
   view?: View;
   popoverType?: {
@@ -19,6 +20,10 @@ function ViewActionsPopover ({
     type: 'more' | 'add';
   },
   children: React.ReactNode;
+  // Forwarded to AddPageActions. The dialog itself must live in a persistent
+  // ancestor (e.g. Outline) since this popover is unmounted as soon as the
+  // dropdown closes.
+  onImportClick?: (view: View) => void;
 } & React.ComponentProps<typeof DropdownMenu>) {
 
   const onClose = useCallback(() => {
@@ -31,6 +36,7 @@ function ViewActionsPopover ({
     if (popoverType.type === 'add') {
       return <AddPageActions
         view={view}
+        onImportClick={onImportClick}
       />;
     }
 
@@ -45,7 +51,7 @@ function ViewActionsPopover ({
         onClose={onClose}
       />;
     }
-  }, [onClose, popoverType, view]);
+  }, [onClose, popoverType, view, onImportClick]);
 
   return (
     <DropdownMenu

--- a/src/utils/download.ts
+++ b/src/utils/download.ts
@@ -3,6 +3,10 @@ import download from 'downloadjs';
 import { getTokenParsed } from '@/application/session/token';
 import { isAppFlowyFileStorageUrl } from '@/utils/file-storage-url';
 
+export function downloadBlob(blob: Blob, filename: string): void {
+  download(blob, filename);
+}
+
 export async function downloadFile(url: string, filename?: string): Promise<void> {
   try {
     let response: Response;


### PR DESCRIPTION
<!---
Thank you for submitting a pull request to the AppFlowy Web! The team will dedicate their best efforts to reviewing and approving your PR. If you have any questions or feedback, feel free to join our [Discord](https://discord.gg/wdjWUXXhtw).
-->


### **Description**
<!---
Provide a clear and concise description of the changes introduced in this pull request for AppFlowy Web. What problem does it solve? What value does it add?
-->

---

### **Checklist**
<!---
Before marking your pull request as ready for review, ensure the following checklist is complete.
-->

#### **General**
- [ ] I've included relevant documentation or comments for the changes introduced.
- [ ] I've tested the changes in multiple environments (e.g., different browsers, operating systems).

#### **Testing**
- [ ] I've added or updated tests to validate the changes introduced for AppFlowy Web.

#### **Feature-Specific**
- [ ] For feature additions, I've added a preview (video, screenshot, or demo) in the "Feature Preview" section.
- [ ] I've verified that this feature integrates seamlessly with existing functionality.

## Summary by Sourcery

Add workspace import/export capabilities for pages, including PDF export and Markdown/CSV import, with corresponding UI, services, and tests.

New Features:
- Introduce an Export panel in the Share popover to export a view as a PDF, with an option to include linked pages that is gated by the Pro subscription plan.
- Add an Import dialog accessible from the sidebar add-page menu to create new pages from Markdown/text files or CSV files imported as databases.

Enhancements:
- Lazy‑load the import dialog and export panel so heavy dependencies are only loaded when those features are opened.
- Add shared helpers and HTTP APIs for downloading blobs and exporting PDFs, and utilities for populating documents from Markdown and importing CSVs via server-side tasks.

Tests:
- Add end-to-end Playwright tests covering the sidebar import flow for Markdown and CSV files and the Share popover PDF export, including Pro-gated linked-page exports.

Chores:
- Extend Playwright selector helpers to cover the new import dialog and export-as PDF panel elements.