### PR TITLE
fix: prevent title input remount on outline update in view modal

### DIFF
--- a/src/components/app/ViewModal.tsx
+++ b/src/components/app/ViewModal.tsx
@@ -163,11 +163,17 @@ function ViewModal({ viewId, open, onClose }: { viewId?: string; open: boolean; 
   // and the correct layout is known for the page-view API call.
   const resolvedView = effectiveOutlineView || fallbackMeta;
 
+  // Gate on metadata availability via a boolean so outline updates (e.g. a
+  // title edit propagating through the outline tree) don't churn the dep
+  // array and re-trigger loadPageDoc — which would setDoc(undefined) and
+  // remount the editor mid-keystroke.
+  const hasResolvedView = !!resolvedView;
+
   useEffect(() => {
-    if (open && effectiveViewId && resolvedView) {
+    if (open && effectiveViewId && hasResolvedView) {
       void loadPageDoc(effectiveViewId);
     }
-  }, [open, effectiveViewId, loadPageDoc, resolvedView]);
+  }, [open, effectiveViewId, loadPageDoc, hasResolvedView]);
 
   const layout = resolvedView?.layout ?? ViewLayout.Document;
 


### PR DESCRIPTION
## Summary
- The `loadPageDoc` effect in `ViewModal` depended on the `resolvedView` object reference. Every title edit propagates through the outline tree, which produces a fresh `outlineView` → `effectiveOutlineView` → `resolvedView` object (same view, new reference), re-fired the effect, and called `setDoc(undefined)` — unmounting `Document` → `ViewMetaPreview` → `TitleEditable` mid-keystroke. On remount, `TitleEditable` reset its `contentEditable` text to the server-side name, so any character typed in the 300 ms debounce window (or during the async reload) was lost.
- Gate the effect on a stable `hasResolvedView` boolean derived during render, so it only fires on the genuine "metadata absent → present" transition. No reload is triggered when the metadata object reference churns due to outline updates.

## Test plan
- [ ] Open the center page modal for a brand-new page and type continuously in the title — characters should stick, no flicker/reload mid-keystroke.
- [ ] Edit the title of an existing page in the center modal — title persists, no editor remount.
- [ ] Open a database container in the center modal (verifies the `effectiveViewId` first-child resolution path still works) and edit a row's title.
- [ ] Reopen the modal for a different view — the new doc loads (`effectiveViewId` change still triggers `loadPageDoc`).
- [ ] Close the modal and reopen for the same view — fresh load happens (`open` flips false → true → loadPageDoc fires).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bug Fixes:
- Ensure the view modal no longer remounts the document and title editor mid-keystroke due to outline-driven metadata reference changes.