### PR TITLE
Fix database collab IndexedDB cache identity

### DIFF
--- a/playwright/e2e/database/database-collab-cache.spec.ts
+++ b/playwright/e2e/database/database-collab-cache.spec.ts
@@ -1,0 +1,445 @@
+/**
+ * Database Collab Cache Identity
+ *
+ * BDD regression coverage for the databaseId/viewId IndexedDB cache split:
+ * - embedded database blocks should load through the canonical databaseId cache;
+ * - legacy viewId IndexedDB updates should be merged into that canonical cache;
+ * - sibling database views should resolve to the same database collab object.
+ */
+import { expect, Page, test } from '@playwright/test';
+import { v4 as uuidv4 } from 'uuid';
+
+import { signInAndWaitForApp } from '../../support/auth-flow-helpers';
+import { createDatabaseView, waitForGridReady } from '../../support/database-ui-helpers';
+import { getSlashMenuItemName } from '../../support/i18n-constants';
+import { createDocumentPageAndNavigate } from '../../support/page-utils';
+import {
+  DatabaseGridSelectors,
+  DatabaseViewSelectors,
+  SlashCommandSelectors,
+} from '../../support/selectors';
+import { generateRandomEmail } from '../../support/test-config';
+import {
+  getCurrentDatabaseInfo,
+  seedPrimaryRows,
+  waitForDatabaseTestContext,
+} from '../../support/relation-test-helpers';
+
+type ActiveDatabaseIdentity = {
+  databaseId: string;
+  docGuid: string;
+  rowOrderIds: string[];
+  viewId: string;
+};
+
+type DatabaseBlockState = {
+  databaseId: string | null;
+  viewIds: string[];
+};
+
+const ignoredPageErrors = [
+  'Minified React error',
+  'View not found',
+  'No workspace or service found',
+  'ResizeObserver loop',
+  'Failed to fetch',
+  'NetworkError',
+];
+
+function ignoreKnownPageErrors(page: Page) {
+  page.on('pageerror', (err) => {
+    if (ignoredPageErrors.some((message) => err.message.includes(message))) {
+      return;
+    }
+  });
+}
+
+async function getActiveDatabaseIdentity(page: Page): Promise<ActiveDatabaseIdentity> {
+  await waitForDatabaseTestContext(page);
+
+  return page.evaluate(() => {
+    const ctx = (window as any).__TEST_DATABASE_CONTEXT__;
+    const doc = ctx.databaseDoc;
+    const database = doc.getMap('data').get('database');
+    const view = database?.get('views')?.get(ctx.activeViewId);
+    const rowOrders = view?.get('row_orders')?.toJSON?.() ?? [];
+
+    return {
+      databaseId: database?.get('id') || doc.guid,
+      docGuid: doc.guid,
+      rowOrderIds: rowOrders.map((row: { id: string }) => row.id),
+      viewId: ctx.activeViewId,
+    };
+  });
+}
+
+async function getDatabaseBlockState(page: Page, docViewId: string): Promise<DatabaseBlockState[]> {
+  return page.evaluate((currentDocViewId) => {
+    const testWindow = window as Window & {
+      __TEST_EDITORS__?: Record<
+        string,
+        {
+          children?: Array<{
+            type?: string;
+            data?: {
+              database_id?: string;
+              view_id?: string;
+              view_ids?: string[];
+            };
+          }>;
+        }
+      >;
+    };
+    const editor = testWindow.__TEST_EDITORS__?.[currentDocViewId];
+
+    return (editor?.children ?? [])
+      .filter((node) => node?.type === 'grid')
+      .map((node) => ({
+        databaseId: node.data?.database_id ?? null,
+        viewIds: Array.isArray(node.data?.view_ids)
+          ? node.data.view_ids
+          : node.data?.view_id
+          ? [node.data.view_id]
+          : [],
+      }));
+  }, docViewId);
+}
+
+async function waitForEmbeddedDatabaseBlockIdentity(page: Page, docViewId: string) {
+  let blockState: DatabaseBlockState | null = null;
+
+  await expect
+    .poll(
+      async () => {
+        const blocks = await getDatabaseBlockState(page, docViewId);
+
+        blockState = blocks[0] ?? null;
+        return Boolean(blockState?.databaseId && blockState.viewIds.length > 0);
+      },
+      { timeout: 15000, message: 'Waiting for embedded database block view_ids and database_id' }
+    )
+    .toBe(true);
+
+  return blockState as DatabaseBlockState;
+}
+
+async function closeViewModalIfOpen(page: Page) {
+  const dialog = page.locator('[role="dialog"]').last();
+
+  if (!(await dialog.isVisible().catch(() => false))) {
+    return;
+  }
+
+  await page.keyboard.press('Escape');
+
+  if (await dialog.isVisible().catch(() => false)) {
+    await page.mouse.click(10, 10);
+  }
+
+  await expect(dialog).toBeHidden({ timeout: 10000 });
+}
+
+async function insertEmbeddedGridDatabase(page: Page, docViewId: string) {
+  const editor = page.locator(`#editor-${docViewId}`);
+
+  await expect(editor).toBeVisible({ timeout: 15000 });
+  await editor.click({ position: { x: 200, y: 100 }, force: true });
+  await editor.pressSequentially('/', { delay: 50 });
+
+  const slashPanel = SlashCommandSelectors.slashPanel(page);
+
+  await expect(slashPanel).toBeVisible({ timeout: 10000 });
+  await SlashCommandSelectors.slashMenuItem(page, getSlashMenuItemName('grid')).first().click({ force: true });
+  await waitForDatabaseTestContext(page);
+  await closeViewModalIfOpen(page);
+
+  const embeddedGrid = editor.locator('[data-testid="database-grid"]').first();
+
+  await expect(embeddedGrid).toBeVisible({ timeout: 30000 });
+  await waitForDatabaseTestContext(page);
+  await waitForEmbeddedDatabaseBlockIdentity(page, docViewId);
+}
+
+async function appendLegacyViewIdCacheRows(page: Page, rowIds: string[]) {
+  return page.evaluate(async (ids) => {
+    const win = window as any;
+    const Y = win.Y;
+    const ctx = win.__TEST_DATABASE_CONTEXT__;
+    const sourceDoc = ctx.databaseDoc;
+    const viewId = ctx.activeViewId;
+    const sourceDatabase = sourceDoc.getMap('data').get('database');
+    const databaseId = sourceDatabase?.get('id') || sourceDoc.guid;
+    const legacyDoc = new Y.Doc({ guid: viewId });
+
+    function openYjsDatabase(name: string, version?: number): Promise<IDBDatabase> {
+      return new Promise((resolve, reject) => {
+        const request = typeof version === 'number' ? indexedDB.open(name, version) : indexedDB.open(name);
+
+        request.onupgradeneeded = () => {
+          const db = request.result;
+
+          if (!db.objectStoreNames.contains('updates')) {
+            db.createObjectStore('updates', { autoIncrement: true });
+          }
+
+          if (!db.objectStoreNames.contains('custom')) {
+            db.createObjectStore('custom');
+          }
+        };
+        request.onsuccess = () => resolve(request.result);
+        request.onerror = () => reject(request.error);
+        request.onblocked = () => reject(new Error(`Opening IndexedDB ${name} was blocked`));
+      });
+    }
+
+    async function ensureYjsDatabase(name: string): Promise<IDBDatabase> {
+      let db = await openYjsDatabase(name);
+
+      if (db.objectStoreNames.contains('updates') && db.objectStoreNames.contains('custom')) {
+        return db;
+      }
+
+      const nextVersion = db.version + 1;
+
+      db.close();
+      db = await openYjsDatabase(name, nextVersion);
+      return db;
+    }
+
+    async function appendUpdate(name: string, update: Uint8Array): Promise<void> {
+      const db = await ensureYjsDatabase(name);
+
+      await new Promise<void>((resolve, reject) => {
+        const tx = db.transaction('updates', 'readwrite');
+
+        tx.objectStore('updates').add(update);
+        tx.oncomplete = () => resolve();
+        tx.onerror = () => reject(tx.error);
+        tx.onabort = () => reject(tx.error);
+      });
+      db.close();
+    }
+
+    Y.applyUpdate(legacyDoc, Y.encodeStateAsUpdate(sourceDoc));
+
+    const legacyDatabase = legacyDoc.getMap('data').get('database');
+    const legacyView = legacyDatabase?.get('views')?.get(viewId);
+    const rowOrders = legacyView?.get('row_orders');
+
+    if (!rowOrders) {
+      throw new Error('Cannot write legacy cache rows: row_orders was not found');
+    }
+
+    legacyDoc.transact(() => {
+      ids.forEach((id) => rowOrders.push([{ id, height: 36 }]));
+    });
+
+    await appendUpdate(viewId, Y.encodeStateAsUpdate(legacyDoc));
+    legacyDoc.destroy();
+
+    return {
+      databaseId,
+      rowOrderCount: rowOrders.length,
+      viewId,
+    };
+  }, rowIds);
+}
+
+async function expectActiveRowsToContain(page: Page, rowIds: string[]) {
+  await expect
+    .poll(
+      () =>
+        page.evaluate((expectedRowIds) => {
+          const ctx = (window as any).__TEST_DATABASE_CONTEXT__;
+          const doc = ctx?.databaseDoc;
+          const database = doc?.getMap('data').get('database');
+          const view = database?.get('views')?.get(ctx.activeViewId);
+          const rowOrders = view?.get('row_orders')?.toJSON?.() ?? [];
+          const actualIds = rowOrders.map((row: { id: string }) => row.id);
+
+          return expectedRowIds.every((rowId) => actualIds.includes(rowId));
+        }, rowIds),
+      { timeout: 30000, message: 'Waiting for legacy row orders to appear in canonical database doc' }
+    )
+    .toBe(true);
+}
+
+async function readYjsUpdateCount(page: Page, dbName: string): Promise<number> {
+  return page.evaluate(async (name) => {
+    function openDatabase(): Promise<IDBDatabase | null> {
+      return new Promise((resolve) => {
+        const request = indexedDB.open(name);
+
+        request.onsuccess = () => resolve(request.result);
+        request.onerror = () => resolve(null);
+        request.onblocked = () => resolve(null);
+      });
+    }
+
+    const databases = await indexedDB.databases?.();
+
+    if (databases && !databases.some((db) => db.name === name)) {
+      return 0;
+    }
+
+    const db = await openDatabase();
+
+    if (!db) {
+      return 0;
+    }
+
+    if (!db.objectStoreNames.contains('updates')) {
+      db.close();
+      return 0;
+    }
+
+    const count = await new Promise<number>((resolve) => {
+      const tx = db.transaction('updates', 'readonly');
+      const request = tx.objectStore('updates').count();
+
+      request.onsuccess = () => resolve(request.result);
+      request.onerror = () => resolve(0);
+      tx.onabort = () => resolve(0);
+    });
+
+    db.close();
+    return count;
+  }, dbName);
+}
+
+async function expectYjsCacheToExist(page: Page, dbName: string) {
+  await expect
+    .poll(() => readYjsUpdateCount(page, dbName), {
+      timeout: 15000,
+      message: `Waiting for IndexedDB Yjs cache ${dbName}`,
+    })
+    .toBeGreaterThan(0);
+}
+
+async function addViewToDatabase(page: Page, viewType: 'Board' | 'Calendar' | 'Grid') {
+  await DatabaseViewSelectors.addViewButton(page).click({ force: true });
+
+  const menu = page.locator('[data-slot="dropdown-menu-content"]');
+
+  await expect(menu).toBeVisible({ timeout: 5000 });
+  await menu.locator('[role="menuitem"]').filter({ hasText: viewType }).click({ force: true });
+}
+
+async function switchToDatabaseView(page: Page, viewType: string) {
+  await DatabaseViewSelectors.viewTab(page).filter({ hasText: viewType }).click({ force: true });
+  await waitForDatabaseTestContext(page);
+}
+
+function escapeRegExp(value: string) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+test.describe('Feature: Database Collab IndexedDB Cache Identity', () => {
+  test.beforeEach(async ({ page }) => {
+    ignoreKnownPageErrors(page);
+    await page.setViewportSize({ width: 1400, height: 900 });
+  });
+
+  test('Scenario: embedded database reload merges legacy viewId cache into the canonical databaseId cache', async ({
+    page,
+    request,
+  }) => {
+    // Given: a signed-in user has a document with an embedded grid database.
+    await signInAndWaitForApp(page, request, generateRandomEmail());
+    await expect(page).toHaveURL(/\/app/, { timeout: 30000 });
+
+    const docViewId = await createDocumentPageAndNavigate(page);
+
+    await insertEmbeddedGridDatabase(page, docViewId);
+
+    const beforeLegacyWrite = await getActiveDatabaseIdentity(page);
+
+    expect(beforeLegacyWrite.databaseId).not.toBe('');
+    expect(beforeLegacyWrite.viewId).not.toBe('');
+    expect(beforeLegacyWrite.docGuid).toBe(beforeLegacyWrite.databaseId);
+    await expectYjsCacheToExist(page, beforeLegacyWrite.databaseId);
+
+    // And: an older client has written local-only row order updates into the legacy viewId cache.
+    const legacyRowIds = Array.from({ length: 8 }, () => uuidv4());
+    const legacyWrite = await appendLegacyViewIdCacheRows(page, legacyRowIds);
+
+    expect(legacyWrite.databaseId).toBe(beforeLegacyWrite.databaseId);
+    expect(legacyWrite.viewId).toBe(beforeLegacyWrite.viewId);
+
+    let staleDatabaseFetchCount = 0;
+
+    // If the canonical cache migration works, reopening the embedded block should not need
+    // a stale page-view fetch for the database view.
+    const databaseViewIdPattern = escapeRegExp(beforeLegacyWrite.viewId);
+
+    await page.route(new RegExp(`/api/workspace/[^/]+/page-view/${databaseViewIdPattern}(?:\\?|$)`), async (route) => {
+      staleDatabaseFetchCount += 1;
+      await route.continue();
+    });
+
+    // When: the user reopens the document page containing the embedded database.
+    await page.reload({ waitUntil: 'domcontentloaded' });
+    await expect(page.locator(`#editor-${docViewId}`)).toBeVisible({ timeout: 30000 });
+    await expect(page.locator(`#editor-${docViewId} [data-testid="database-grid"]`).first()).toBeVisible({
+      timeout: 30000,
+    });
+    await waitForDatabaseTestContext(page);
+
+    const afterReload = await getActiveDatabaseIdentity(page);
+    const blockAfterReload = await waitForEmbeddedDatabaseBlockIdentity(page, docViewId);
+
+    // Then: the embedded database is still attached to the canonical databaseId cache.
+    expect(blockAfterReload.databaseId).toBe(beforeLegacyWrite.databaseId);
+    expect(blockAfterReload.viewIds).toContain(beforeLegacyWrite.viewId);
+    expect(afterReload.databaseId).toBe(beforeLegacyWrite.databaseId);
+    expect(afterReload.viewId).toBe(beforeLegacyWrite.viewId);
+    expect(afterReload.docGuid).toBe(beforeLegacyWrite.databaseId);
+
+    // And: the local-only legacy row orders have been merged instead of being replaced by server state.
+    await expectActiveRowsToContain(page, legacyRowIds);
+    expect(staleDatabaseFetchCount).toBe(0);
+  });
+
+  test('Scenario: sibling database views resolve to the same canonical databaseId cache', async ({
+    page,
+    request,
+  }) => {
+    // Given: a signed-in user has a grid database with persisted rows.
+    await signInAndWaitForApp(page, request, generateRandomEmail());
+    await expect(page).toHaveURL(/\/app/, { timeout: 30000 });
+    await createDatabaseView(page, 'Grid', 7000);
+    await waitForGridReady(page);
+    await seedPrimaryRows(page, ['cache-grid-row-a', 'cache-grid-row-b']);
+
+    const gridInfo = await getCurrentDatabaseInfo(page);
+    const gridIdentity = await getActiveDatabaseIdentity(page);
+
+    expect(gridIdentity.docGuid).toBe(gridInfo.databaseId);
+
+    // When: the user adds and opens another view of the same database.
+    await addViewToDatabase(page, 'Board');
+    await expect(DatabaseViewSelectors.activeViewTab(page)).toContainText('Board', { timeout: 30000 });
+    await waitForDatabaseTestContext(page);
+
+    const boardInfo = await getCurrentDatabaseInfo(page);
+    const boardIdentity = await getActiveDatabaseIdentity(page);
+
+    // Then: both views use the same database collab object and cache key.
+    expect(boardInfo.databaseId).toBe(gridInfo.databaseId);
+    expect(boardInfo.viewId).not.toBe(gridInfo.viewId);
+    expect(boardIdentity.databaseId).toBe(gridInfo.databaseId);
+    expect(boardIdentity.docGuid).toBe(gridInfo.databaseId);
+
+    // When: switching back to the grid view after another view has been opened.
+    await switchToDatabaseView(page, 'Grid');
+    await expect(DatabaseGridSelectors.grid(page)).toBeVisible({ timeout: 30000 });
+    await expect(DatabaseGridSelectors.grid(page)).toContainText('cache-grid-row-a', { timeout: 20000 });
+    await expect(DatabaseGridSelectors.grid(page)).toContainText('cache-grid-row-b', { timeout: 20000 });
+
+    const gridAfterSwitch = await getActiveDatabaseIdentity(page);
+
+    // Then: the grid view is still backed by the same canonical databaseId cache.
+    expect(gridAfterSwitch.databaseId).toBe(gridInfo.databaseId);
+    expect(gridAfterSwitch.docGuid).toBe(gridInfo.databaseId);
+  });
+});

--- a/src/application/__tests__/view-loader.test.ts
+++ b/src/application/__tests__/view-loader.test.ts
@@ -1,0 +1,158 @@
+import { expect } from '@jest/globals';
+import * as Y from 'yjs';
+
+import { openCollabDB, openCollabDBWithProvider } from '@/application/db';
+import { fetchPageCollab } from '@/application/services/js-services/fetch';
+import { enqueueOutboxUpdate } from '@/application/sync-outbox';
+import { Types, ViewLayout, YDoc, YjsDatabaseKey, YjsEditorKey } from '@/application/types';
+import { getDatabaseIdFromDoc, openView } from '@/application/view-loader';
+
+jest.mock('@/application/db', () => ({
+  openCollabDB: jest.fn(),
+  openCollabDBWithProvider: jest.fn(),
+}));
+
+jest.mock('@/application/services/js-services/cache', () => ({
+  getOrCreateRowSubDoc: jest.fn(),
+  hasCollabCache: jest.fn((doc: YDoc) => {
+    const root = doc.getMap(YjsEditorKey.data_section);
+
+    return root.has(YjsEditorKey.database) || root.has(YjsEditorKey.document);
+  }),
+}));
+
+jest.mock('@/application/services/js-services/fetch', () => ({
+  fetchPageCollab: jest.fn(),
+}));
+
+jest.mock('@/application/sync-outbox', () => ({
+  enqueueOutboxUpdate: jest.fn(),
+}));
+
+const mockOpenCollabDB = openCollabDB as jest.MockedFunction<typeof openCollabDB>;
+const mockOpenCollabDBWithProvider = openCollabDBWithProvider as jest.MockedFunction<typeof openCollabDBWithProvider>;
+const mockFetchPageCollab = fetchPageCollab as jest.MockedFunction<typeof fetchPageCollab>;
+const mockEnqueueOutboxUpdate = enqueueOutboxUpdate as jest.MockedFunction<typeof enqueueOutboxUpdate>;
+
+function createEmptyDoc(guid: string): YDoc {
+  return new Y.Doc({ guid }) as YDoc;
+}
+
+function createDatabaseDoc(guid: string, databaseId = guid): YDoc {
+  const doc = createEmptyDoc(guid);
+  const root = doc.getMap(YjsEditorKey.data_section);
+  const database = new Y.Map();
+
+  database.set(YjsDatabaseKey.id, databaseId);
+  root.set(YjsEditorKey.database, database);
+  return doc;
+}
+
+function createProvider(doc: YDoc) {
+  return {
+    doc,
+    provider: {
+      destroy: jest.fn().mockResolvedValue(undefined),
+      synced: true,
+    },
+  };
+}
+
+describe('view-loader database cache identity', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('opens database views from the canonical databaseId cache and migrates legacy viewId data', async () => {
+    const viewId = '00000000-0000-4000-8000-000000000001';
+    const databaseId = '00000000-0000-4000-8000-000000000002';
+    const canonicalDoc = createEmptyDoc(databaseId);
+    const legacyDoc = createDatabaseDoc(viewId, databaseId);
+    const docs = new Map([
+      [databaseId, canonicalDoc],
+      [viewId, legacyDoc],
+    ]);
+
+    mockOpenCollabDBWithProvider.mockImplementation(async (name: string) => {
+      const doc = docs.get(name);
+
+      if (!doc) throw new Error(`Unexpected open ${name}`);
+      return createProvider(doc) as never;
+    });
+
+    const result = await openView('workspace-id', viewId, ViewLayout.Grid, { databaseId });
+
+    expect(result.doc).toBe(canonicalDoc);
+    expect(result.fromCache).toBe(true);
+    expect(result.collabType).toBe(Types.Database);
+    expect(getDatabaseIdFromDoc(canonicalDoc)).toBe(databaseId);
+    expect(mockOpenCollabDBWithProvider).toHaveBeenCalledWith(databaseId, { awaitSync: true });
+    expect(mockOpenCollabDBWithProvider).toHaveBeenCalledWith(viewId, { skipCache: true });
+    expect(mockEnqueueOutboxUpdate).toHaveBeenCalledWith(expect.objectContaining({
+      objectId: databaseId,
+      collabType: Types.Database,
+      payload: expect.any(Uint8Array),
+    }));
+    expect(mockFetchPageCollab).not.toHaveBeenCalled();
+  });
+
+  it('fetches by viewId into the canonical databaseId cache when local cache is empty', async () => {
+    const viewId = '00000000-0000-4000-8000-000000000003';
+    const databaseId = '00000000-0000-4000-8000-000000000004';
+    const canonicalDoc = createEmptyDoc(databaseId);
+    const legacyDoc = createEmptyDoc(viewId);
+    const serverDoc = createDatabaseDoc(databaseId);
+    const docs = new Map([
+      [databaseId, canonicalDoc],
+      [viewId, legacyDoc],
+    ]);
+
+    mockOpenCollabDBWithProvider.mockImplementation(async (name: string) => {
+      const doc = docs.get(name);
+
+      if (!doc) throw new Error(`Unexpected open ${name}`);
+      return createProvider(doc) as never;
+    });
+    mockOpenCollabDB.mockImplementation(async (name: string) => {
+      const doc = docs.get(name);
+
+      if (!doc) throw new Error(`Unexpected open ${name}`);
+      return doc;
+    });
+    mockFetchPageCollab.mockResolvedValue({
+      data: Y.encodeStateAsUpdate(serverDoc),
+      rows: {},
+    });
+
+    const result = await openView('workspace-id', viewId, ViewLayout.Grid, { databaseId });
+
+    expect(result.doc).toBe(canonicalDoc);
+    expect(result.fromCache).toBe(false);
+    expect(getDatabaseIdFromDoc(canonicalDoc)).toBe(databaseId);
+    expect(mockFetchPageCollab).toHaveBeenCalledWith('workspace-id', viewId);
+  });
+
+  it('uses the canonical databaseId cache when the database layout was discovered after the first load', async () => {
+    const viewId = '00000000-0000-4000-8000-000000000005';
+    const databaseId = '00000000-0000-4000-8000-000000000006';
+    const canonicalDoc = createEmptyDoc(databaseId);
+    const legacyDoc = createDatabaseDoc(viewId, databaseId);
+    const docs = new Map([
+      [databaseId, canonicalDoc],
+      [viewId, legacyDoc],
+    ]);
+
+    mockOpenCollabDBWithProvider.mockImplementation(async (name: string) => {
+      const doc = docs.get(name);
+
+      if (!doc) throw new Error(`Unexpected open ${name}`);
+      return createProvider(doc) as never;
+    });
+
+    const result = await openView('workspace-id', viewId, undefined, { databaseId });
+
+    expect(result.doc).toBe(canonicalDoc);
+    expect(result.fromCache).toBe(true);
+    expect(getDatabaseIdFromDoc(canonicalDoc)).toBe(databaseId);
+  });
+});

--- a/src/application/database-yjs/__tests__/useGroup.test.tsx
+++ b/src/application/database-yjs/__tests__/useGroup.test.tsx
@@ -1,0 +1,121 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import type React from 'react';
+import * as Y from 'yjs';
+
+import { DatabaseContext, DatabaseContextState, FieldType, useGroup } from '@/application/database-yjs';
+import { YDoc, YjsDatabaseKey, YjsEditorKey } from '@/application/types';
+
+jest.mock('@/utils/runtime-config', () => ({
+  getConfigValue: (_key: string, fallback: string) => fallback,
+}));
+
+function createDatabaseDoc({
+  fieldId,
+  groupId,
+  groupColumns,
+  viewId,
+}: {
+  fieldId: string;
+  groupId: string;
+  groupColumns: unknown[];
+  viewId: string;
+}): YDoc {
+  const doc = new Y.Doc() as unknown as YDoc;
+  const sharedRoot = doc.getMap(YjsEditorKey.data_section);
+  const database = new Y.Map();
+  const fields = new Y.Map();
+  const field = new Y.Map();
+  const views = new Y.Map();
+  const view = new Y.Map();
+  const groups = new Y.Array();
+  const group = new Y.Map();
+  const columns = new Y.Array();
+
+  field.set(YjsDatabaseKey.id, fieldId);
+  field.set(YjsDatabaseKey.type, FieldType.SingleSelect);
+  fields.set(fieldId, field);
+
+  columns.push(groupColumns);
+  group.set(YjsDatabaseKey.id, groupId);
+  group.set(YjsDatabaseKey.field_id, fieldId);
+  group.set(YjsDatabaseKey.type, FieldType.SingleSelect);
+  group.set(YjsDatabaseKey.groups, columns);
+  groups.push([group]);
+
+  view.set(YjsDatabaseKey.groups, groups);
+  views.set(viewId, view);
+
+  database.set(YjsDatabaseKey.id, 'database-id');
+  database.set(YjsDatabaseKey.fields, fields);
+  database.set(YjsDatabaseKey.views, views);
+  sharedRoot.set(YjsEditorKey.database, database);
+
+  return doc;
+}
+
+function createWrapper(databaseDoc: YDoc, activeViewId: string) {
+  const contextValue: DatabaseContextState = {
+    readOnly: false,
+    databaseDoc,
+    databasePageId: activeViewId,
+    activeViewId,
+    rowMap: null,
+    workspaceId: 'workspace-id',
+  };
+
+  return ({ children }: { children: React.ReactNode }) => (
+    <DatabaseContext.Provider value={contextValue}>{children}</DatabaseContext.Provider>
+  );
+}
+
+describe('useGroup', () => {
+  it('falls back to default group columns when persisted board columns are empty', async () => {
+    const fieldId = 'field-id';
+    const groupId = 'group-id';
+    const viewId = 'board-view-id';
+    const databaseDoc = createDatabaseDoc({
+      fieldId,
+      groupId,
+      groupColumns: [],
+      viewId,
+    });
+
+    const { result } = renderHook(() => useGroup(groupId), {
+      wrapper: createWrapper(databaseDoc, viewId),
+    });
+
+    await waitFor(() => {
+      expect(result.current.fieldId).toBe(fieldId);
+    });
+
+    expect(result.current.columns).toEqual([{ id: fieldId, visible: true }]);
+  });
+
+  it('normalizes Y.Map group columns from persisted collab data', async () => {
+    const fieldId = 'field-id';
+    const groupId = 'group-id';
+    const optionId = 'option-id';
+    const viewId = 'board-view-id';
+    const column = new Y.Map();
+
+    column.set(YjsDatabaseKey.id, optionId);
+    column.set(YjsDatabaseKey.visible, false);
+
+    const databaseDoc = createDatabaseDoc({
+      fieldId,
+      groupId,
+      groupColumns: [column],
+      viewId,
+    });
+
+    const { result } = renderHook(() => useGroup(groupId), {
+      wrapper: createWrapper(databaseDoc, viewId),
+    });
+
+    await waitFor(() => {
+      expect(result.current.fieldId).toBe(fieldId);
+    });
+
+    expect(result.current.columns).toEqual([{ id: optionId, visible: false }]);
+  });
+});

--- a/src/application/database-yjs/selector.ts
+++ b/src/application/database-yjs/selector.ts
@@ -25,7 +25,7 @@ import {
   SelectOption,
 } from '@/application/database-yjs/fields';
 import { filterBy, flattenFilterTree, parseFilter } from '@/application/database-yjs/filter';
-import { groupByField } from '@/application/database-yjs/group';
+import { getGroupColumns, groupByField } from '@/application/database-yjs/group';
 import { useBackgroundRowDocLoader, useRollupFieldObservers } from '@/application/database-yjs/hooks';
 import {
   invalidateRelationCell,
@@ -890,10 +890,47 @@ export interface GroupColumn {
   visible: boolean;
 }
 
+function normalizeGroupColumn(column: unknown): GroupColumn | null {
+  const parseVisible = (value: unknown) => value !== false && value !== 'false';
+
+  if (!column || typeof column !== 'object') return null;
+
+  if ('get' in column && typeof column.get === 'function') {
+    const mapColumn = column as { get: (key: YjsDatabaseKey) => unknown };
+    const id = mapColumn.get(YjsDatabaseKey.id);
+
+    if (typeof id !== 'string' || !id) return null;
+
+    return {
+      id,
+      visible: parseVisible(mapColumn.get(YjsDatabaseKey.visible)),
+    };
+  }
+
+  const plainColumn = column as Partial<GroupColumn>;
+
+  if (typeof plainColumn.id !== 'string' || !plainColumn.id) return null;
+
+  return {
+    id: plainColumn.id,
+    visible: parseVisible(plainColumn.visible),
+  };
+}
+
+function getFallbackGroupColumns(field?: YDatabaseField): GroupColumn[] {
+  if (!field) return [];
+
+  return (getGroupColumns(field) ?? []).map((column) => ({
+    id: column.id,
+    visible: true,
+  }));
+}
+
 export function useGroup(groupId: string) {
   const database = useDatabase();
   const viewId = useDatabaseViewId();
   const view = database?.get(YjsDatabaseKey.views)?.get(viewId);
+  const fields = database?.get(YjsDatabaseKey.fields);
   const group = view
     ?.get(YjsDatabaseKey.groups)
     ?.toArray()
@@ -909,18 +946,24 @@ export function useGroup(groupId: string) {
 
       setFieldId(groupFieldId);
       const groupColumnsVisible = group.get(YjsDatabaseKey.groups);
-      const visibleArray = groupColumnsVisible?.toArray() || [];
+      const persistedColumns = (groupColumnsVisible?.toArray() ?? [])
+        .map(normalizeGroupColumn)
+        .filter((column): column is GroupColumn => Boolean(column));
 
-      setColumns(visibleArray);
+      setColumns(
+        persistedColumns.length > 0 ? persistedColumns : getFallbackGroupColumns(fields?.get(groupFieldId))
+      );
     };
 
     observerEvent();
     group?.observeDeep(observerEvent);
+    fields?.observeDeep(observerEvent);
 
     return () => {
       group?.unobserveDeep(observerEvent);
+      fields?.unobserveDeep(observerEvent);
     };
-  }, [database, viewId, groupId, group]);
+  }, [viewId, groupId, group, fields]);
 
   return {
     columns,

--- a/src/application/services/js-services/publish-database-data.ts
+++ b/src/application/services/js-services/publish-database-data.ts
@@ -26,21 +26,27 @@ import { Log } from '@/utils/log';
  */
 export async function gatherDatabasePublishData(
   viewId: string,
-  visibleViewIds?: string[]
+  visibleViewIds?: string[],
+  databaseIdHint?: string | null
 ): Promise<Uint8Array> {
-  // 1. Open the database doc from cache (opened when user navigated to the view).
-  //    The doc is cached under the viewId key in the provider cache.
-  //    Its guid may have been changed to databaseId by resolveCollabObjectId,
-  //    but the data is in the doc opened via viewId.
-  const dbDoc = await openCollabDB(viewId);
-  const dbSharedRoot = dbDoc.getMap(YjsEditorKey.data_section);
-  const db = dbSharedRoot?.get(YjsEditorKey.database) as YDatabase | undefined;
+  // 1. Open the database doc from cache. New database views use the canonical
+  //    databaseId cache key; fall back to the legacy viewId cache for users who
+  //    have not reopened/migrated this database yet.
+  let dbDoc = await openCollabDB(databaseIdHint || viewId);
+  let dbSharedRoot = dbDoc.getMap(YjsEditorKey.data_section);
+  let db = dbSharedRoot?.get(YjsEditorKey.database) as YDatabase | undefined;
+
+  if (!db && databaseIdHint && databaseIdHint !== viewId) {
+    dbDoc = await openCollabDB(viewId);
+    dbSharedRoot = dbDoc.getMap(YjsEditorKey.data_section);
+    db = dbSharedRoot?.get(YjsEditorKey.database) as YDatabase | undefined;
+  }
 
   if (!db) {
     throw new Error(`Database not found in doc for view ${viewId}`);
   }
 
-  const actualDatabaseId = db.get(YjsDatabaseKey.id) || dbDoc.guid || viewId;
+  const actualDatabaseId = databaseIdHint || db.get(YjsDatabaseKey.id) || dbDoc.guid || viewId;
 
   // 2. Collect all unique row IDs from all views
   const rowIdSet = new Set<string>();

--- a/src/application/types.ts
+++ b/src/application/types.ts
@@ -956,7 +956,16 @@ export interface PublishViewMetaData {
 export type AppendBreadcrumb = (view?: View) => void;
 
 export type CreateRow = (rowKey: string) => Promise<YDoc>;
-export type LoadView = (viewId: string, isSubDocument?: boolean, loadAwareness?: boolean) => Promise<YDoc>;
+export interface LoadViewOptions {
+  databaseId?: string | null;
+}
+
+export type LoadView = (
+  viewId: string,
+  isSubDocument?: boolean,
+  loadAwareness?: boolean,
+  options?: LoadViewOptions
+) => Promise<YDoc>;
 
 export type LoadViewMeta = (viewId: string, onChange?: (meta: View | null) => void) => Promise<View | null>;
 

--- a/src/application/view-loader/index.ts
+++ b/src/application/view-loader/index.ts
@@ -10,9 +10,10 @@
  * before the component finishes rendering.
  */
 
-import { openCollabDB } from '@/application/db';
+import { openCollabDB, openCollabDBWithProvider } from '@/application/db';
 import { getOrCreateRowSubDoc, hasCollabCache } from '@/application/services/js-services/cache';
 import { fetchPageCollab } from '@/application/services/js-services/fetch';
+import { enqueueOutboxUpdate } from '@/application/sync-outbox';
 import { Types, ViewLayout, YDoc, YjsDatabaseKey, YjsEditorKey, YSharedRoot } from '@/application/types';
 import { applyYDoc } from '@/application/ydoc/apply';
 import { Log } from '@/utils/log';
@@ -26,6 +27,10 @@ export interface ViewLoaderResult {
   doc: YDoc;
   fromCache: boolean;
   collabType: Types;
+}
+
+export interface OpenViewOptions {
+  databaseId?: string | null;
 }
 
 // ============================================================================
@@ -82,6 +87,87 @@ function detectFromDocStructure(doc: YDoc): Types | null {
  */
 function detectCollabType(doc: YDoc, layout?: ViewLayout): Types {
   return detectFromLayout(layout) ?? detectFromDocStructure(doc) ?? Types.Document;
+}
+
+function isDatabaseLayout(layout?: ViewLayout): boolean {
+  return (
+    layout === ViewLayout.Grid ||
+    layout === ViewLayout.Board ||
+    layout === ViewLayout.Calendar
+  );
+}
+
+async function mergeLegacyDatabaseViewCache(viewId: string, databaseId: string, targetDoc: YDoc): Promise<boolean> {
+  if (viewId === databaseId) {
+    return false;
+  }
+
+  const { doc: legacyDoc, provider } = await openCollabDBWithProvider(viewId, { skipCache: true });
+
+  try {
+    if (!hasCollabCache(legacyDoc)) {
+      return false;
+    }
+
+    const legacyDatabaseId = getDatabaseIdFromDoc(legacyDoc);
+
+    if (legacyDatabaseId && legacyDatabaseId !== databaseId) {
+      Log.warn('[ViewLoader] skipped legacy database cache merge due to databaseId mismatch', {
+        viewId,
+        databaseId,
+        legacyDatabaseId,
+      });
+      return false;
+    }
+
+    const missingUpdate = Y.encodeStateAsUpdate(legacyDoc, Y.encodeStateVector(targetDoc));
+
+    // Yjs encodes an empty v1 update as two bytes. Nothing to merge.
+    if (missingUpdate.byteLength <= 2) {
+      return false;
+    }
+
+    applyYDoc(targetDoc, missingUpdate);
+    enqueueOutboxUpdate({
+      objectId: databaseId,
+      collabType: Types.Database,
+      version: targetDoc.version ?? null,
+      payload: missingUpdate,
+    });
+
+    Log.debug('[ViewLoader] merged legacy database view cache into canonical database cache', {
+      viewId,
+      databaseId,
+      updateBytes: missingUpdate.byteLength,
+    });
+
+    return true;
+  } finally {
+    await provider.destroy();
+    legacyDoc.destroy();
+  }
+}
+
+async function openCollabDocForView(viewId: string, layout?: ViewLayout, options: OpenViewOptions = {}): Promise<YDoc> {
+  const databaseId = (layout === undefined || isDatabaseLayout(layout)) ? options.databaseId ?? undefined : undefined;
+
+  if (!databaseId) {
+    return openCollabDB(viewId);
+  }
+
+  const { doc } = await openCollabDBWithProvider(databaseId, { awaitSync: true });
+
+  try {
+    await mergeLegacyDatabaseViewCache(viewId, databaseId, doc);
+  } catch (error) {
+    Log.warn('[ViewLoader] failed to merge legacy database view cache', {
+      viewId,
+      databaseId,
+      error,
+    });
+  }
+
+  return doc;
 }
 
 // ============================================================================
@@ -145,14 +231,15 @@ async function fetchAndApply(workspaceId: string, viewId: string, doc: YDoc): Pr
 export async function openView(
   workspaceId: string,
   viewId: string,
-  layout?: ViewLayout
+  layout?: ViewLayout,
+  options: OpenViewOptions = {}
 ): Promise<ViewLoaderResult> {
   const startedAt = Date.now();
 
-  Log.debug('[ViewLoader] openView start', { workspaceId, viewId, layout });
+  Log.debug('[ViewLoader] openView start', { workspaceId, viewId, layout, databaseId: options.databaseId });
 
   // Step 1: Open from IndexedDB
-  const doc = await openCollabDB(viewId);
+  const doc = await openCollabDocForView(viewId, layout, options);
 
   // Step 2: Check cache — also detect empty-shell documents that were cached
   // during a previous load when the server hadn't finished duplication yet.

--- a/src/components/app/hooks/__tests__/usePageOperations.publish.test.tsx
+++ b/src/components/app/hooks/__tests__/usePageOperations.publish.test.tsx
@@ -1,0 +1,137 @@
+import { act, renderHook } from '@testing-library/react';
+import type { MutableRefObject } from 'react';
+
+import { PublishService } from '@/application/services/domains';
+import { clearPublishViewInfoCache } from '@/application/services/js-services/cached-api';
+import { gatherDatabasePublishData } from '@/application/services/js-services/publish-database-data';
+import { publishCollabs } from '@/application/services/js-services/http/publish-api';
+import { View, ViewLayout } from '@/application/types';
+import { AuthInternalContext, AuthInternalContextType } from '@/components/app/contexts/AuthInternalContext';
+
+import { usePageOperations } from '../usePageOperations';
+
+jest.mock('@/application/services/domains', () => ({
+  BillingService: {},
+  FileService: {},
+  PageService: {},
+  PublishService: {
+    publish: jest.fn(),
+    unpublish: jest.fn(),
+  },
+  ViewService: {},
+}));
+
+jest.mock('@/application/services/js-services/cached-api', () => ({
+  clearPublishViewInfoCache: jest.fn(),
+}));
+
+jest.mock('@/application/services/js-services/publish-database-data', () => ({
+  gatherDatabasePublishData: jest.fn(async () => new Uint8Array([1, 2, 3])),
+}));
+
+jest.mock('@/application/services/js-services/http/publish-api', () => ({
+  publishCollabs: jest.fn(async () => undefined),
+}));
+
+jest.mock('@/utils/runtime-config', () => ({
+  getConfigValue: (_key: string, fallback: string) => fallback,
+}));
+
+function createView(overrides: Partial<View>): View {
+  return {
+    view_id: 'view-id',
+    name: 'View',
+    icon: null,
+    layout: ViewLayout.Document,
+    extra: { is_space: false },
+    children: [],
+    is_published: false,
+    is_private: false,
+    ...overrides,
+  };
+}
+
+function renderUsePageOperations(options?: {
+  outlineRef?: MutableRefObject<View[] | undefined>;
+  getDatabaseIdForViewId?: (viewId: string) => Promise<string | null | undefined>;
+}) {
+  const workspaceId = 'workspace-id';
+  const authContextValue: AuthInternalContextType = {
+    currentWorkspaceId: workspaceId,
+    isAuthenticated: true,
+    onChangeWorkspace: () => Promise.resolve(),
+  };
+  const loadOutline = jest.fn(async () => undefined);
+  const outlineRef = options?.outlineRef ?? { current: undefined };
+
+  const rendered = renderHook(
+    () =>
+      usePageOperations({
+        outlineRef,
+        loadOutline,
+        getDatabaseIdForViewId: options?.getDatabaseIdForViewId,
+      }),
+    {
+      wrapper: ({ children }) => (
+        <AuthInternalContext.Provider value={authContextValue}>{children}</AuthInternalContext.Provider>
+      ),
+    }
+  );
+
+  return {
+    ...rendered,
+    loadOutline,
+    workspaceId,
+  };
+}
+
+describe('usePageOperations publish', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('resolves canonical database id before publishing legacy database views', async () => {
+    const viewId = 'grid-view-id';
+    const databaseId = 'canonical-database-id';
+    const getDatabaseIdForViewId = jest.fn(async () => databaseId);
+    const { result } = renderUsePageOperations({ getDatabaseIdForViewId });
+
+    await act(async () => {
+      await result.current.publish(
+        createView({
+          view_id: viewId,
+          name: 'Legacy Grid',
+          layout: ViewLayout.Grid,
+          extra: { is_space: false },
+        })
+      );
+    });
+
+    expect(getDatabaseIdForViewId).toHaveBeenCalledWith(viewId);
+    expect(gatherDatabasePublishData).toHaveBeenCalledWith(viewId, undefined, databaseId);
+    expect(publishCollabs).toHaveBeenCalledTimes(1);
+    expect(clearPublishViewInfoCache).toHaveBeenCalledWith(viewId);
+    expect(PublishService.publish).not.toHaveBeenCalled();
+  });
+
+  it('uses database id from view metadata without workspace mapping lookup', async () => {
+    const viewId = 'grid-view-id';
+    const databaseId = 'metadata-database-id';
+    const getDatabaseIdForViewId = jest.fn(async () => 'mapping-database-id');
+    const { result } = renderUsePageOperations({ getDatabaseIdForViewId });
+
+    await act(async () => {
+      await result.current.publish(
+        createView({
+          view_id: viewId,
+          name: 'Grid',
+          layout: ViewLayout.Grid,
+          extra: { is_space: false, database_id: databaseId },
+        })
+      );
+    });
+
+    expect(getDatabaseIdForViewId).not.toHaveBeenCalled();
+    expect(gatherDatabasePublishData).toHaveBeenCalledWith(viewId, undefined, databaseId);
+  });
+});

--- a/src/components/app/hooks/useDatabaseIdentity.ts
+++ b/src/components/app/hooks/useDatabaseIdentity.ts
@@ -271,19 +271,27 @@ export function useDatabaseIdentity({
   );
 
   const resolveCollabObjectId = useCallback(
-    async (doc: YDoc, viewId: string, collabType: Types): Promise<string> => {
+    async (
+      doc: YDoc,
+      viewId: string,
+      collabType: Types,
+      options?: { databaseIdHint?: string | null; updateDocGuid?: boolean }
+    ): Promise<string> => {
       if (collabType !== Types.Database) {
         return viewId;
       }
 
+      const databaseIdHint = options?.databaseIdHint;
+
       // First try getting databaseId directly from the doc (fast, synchronous).
       // This works for newly created embedded databases where the doc already has the ID.
-      let databaseId = getDatabaseIdFromDoc(doc);
+      let databaseId = databaseIdHint || getDatabaseIdFromDoc(doc);
 
       if (databaseId) {
-        Log.debug('[useDatabaseIdentity] databaseId loaded from Yjs document', {
+        Log.debug('[useDatabaseIdentity] databaseId resolved for view', {
           viewId,
           databaseId,
+          source: databaseIdHint ? 'hint' : 'doc',
         });
       } else {
         // Fallback to workspace database mapping lookup (async, may timeout).
@@ -298,13 +306,17 @@ export function useDatabaseIdentity({
 
       // Database views (grid/board/calendar, etc.) share one underlying database collab object.
       // Use databaseId as guid so all layouts attach to the same sync channel and cache entry.
-      doc.guid = databaseId;
+      if (options?.updateDocGuid !== false) {
+        doc.guid = databaseId;
+      }
+
       return databaseId;
     },
     [getDatabaseIdForViewId]
   );
 
   return {
+    getDatabaseIdForViewId,
     resolveCollabObjectId,
     getViewIdFromDatabaseId,
   };

--- a/src/components/app/hooks/usePageOperations.ts
+++ b/src/components/app/hooks/usePageOperations.ts
@@ -35,12 +35,14 @@ export function usePageOperations({
   flushAllSync,
   syncAllToServer,
   loadViewChildren,
+  getDatabaseIdForViewId,
 }: {
   outlineRef: MutableRefObject<View[] | undefined>;
   loadOutline?: (workspaceId: string, force?: boolean) => Promise<void>;
   flushAllSync?: () => Promise<boolean>;
   syncAllToServer?: (workspaceId: string) => Promise<void>;
   loadViewChildren?: (viewId: string) => Promise<View[]>;
+  getDatabaseIdForViewId?: (viewId: string) => Promise<string | null | undefined>;
 }) {
   const { currentWorkspaceId, userWorkspaceInfo } = useAuthInternal();
   const role = userWorkspaceInfo?.selectedWorkspace.role;
@@ -394,7 +396,8 @@ export function usePageOperations({
           }
         }
 
-        const data = await gatherDatabasePublishData(viewId, resolvedVisibleViewIds, view.extra?.database_id);
+        const databaseId = view.extra?.database_id ?? (await getDatabaseIdForViewId?.(viewId));
+        const data = await gatherDatabasePublishData(viewId, resolvedVisibleViewIds, databaseId);
 
         const toTimestamp = (s?: string) => {
           if (!s) return 0;
@@ -436,7 +439,7 @@ export function usePageOperations({
 
       await loadOutline?.(currentWorkspaceId, false);
     },
-    [currentWorkspaceId, loadOutline, flushAllSync, outlineRef]
+    [currentWorkspaceId, loadOutline, flushAllSync, outlineRef, getDatabaseIdForViewId]
   );
 
   // Unpublish view

--- a/src/components/app/hooks/usePageOperations.ts
+++ b/src/components/app/hooks/usePageOperations.ts
@@ -394,7 +394,7 @@ export function usePageOperations({
           }
         }
 
-        const data = await gatherDatabasePublishData(viewId, resolvedVisibleViewIds);
+        const data = await gatherDatabasePublishData(viewId, resolvedVisibleViewIds, view.extra?.database_id);
 
         const toTimestamp = (s?: string) => {
           if (!s) return 0;

--- a/src/components/app/hooks/useViewOperations.ts
+++ b/src/components/app/hooks/useViewOperations.ts
@@ -82,7 +82,7 @@ export function useViewOperations() {
     };
   }, [eventEmitter]);
 
-  const { resolveCollabObjectId, getViewIdFromDatabaseId } = useDatabaseIdentity({
+  const { resolveCollabObjectId, getDatabaseIdForViewId, getViewIdFromDatabaseId } = useDatabaseIdentity({
     currentWorkspaceId,
     databaseStorageId,
     registerSyncContext,
@@ -458,6 +458,7 @@ export function useViewOperations() {
     bindViewSync,
     toView,
     awarenessMap,
+    getDatabaseIdForViewId,
     getViewIdFromDatabaseId,
     getViewReadOnlyStatus: getViewReadOnlyStatusFromOutline,
     getCollabHistory,

--- a/src/components/app/hooks/useViewOperations.ts
+++ b/src/components/app/hooks/useViewOperations.ts
@@ -7,6 +7,7 @@ import { APP_EVENTS } from '@/application/constants';
 import { CollabService, ViewService, WorkspaceService } from '@/application/services/domains';
 import {
   AccessLevel,
+  LoadViewOptions,
   Types,
   View,
   ViewLayout,
@@ -14,7 +15,7 @@ import {
   YDocWithMeta,
 } from '@/application/types';
 import { openView } from '@/application/view-loader';
-import { getFirstChildView, isDatabaseContainer } from '@/application/view-utils';
+import { getDatabaseIdFromExtra, getFirstChildView, isDatabaseContainer, isDatabaseLayout } from '@/application/view-utils';
 import { findView, findViewInShareWithMe } from '@/components/_shared/outline/utils';
 import { CollabDocResetPayload } from '@/components/ws/sync/types';
 import { Log } from '@/utils/log';
@@ -103,13 +104,30 @@ export function useViewOperations() {
    * Call bindViewSync() AFTER render to start WebSocket sync.
    */
   const loadView = useCallback(
-    async (viewId: string, isSubDocument = false, loadAwareness = false, outline?: View[]) => {
+    async (
+      viewId: string,
+      isSubDocument = false,
+      loadAwareness = false,
+      outline?: View[],
+      options?: LoadViewOptions
+    ) => {
       try {
         if (!currentWorkspaceId) {
           throw new Error('Workspace not found');
         }
 
-        const view = findView(outline || [], viewId);
+        let view = findView(outline || [], viewId);
+
+        if (!view && !isSubDocument && !options?.databaseId) {
+          try {
+            view = await ViewService.get(currentWorkspaceId, viewId);
+          } catch (e) {
+            Log.debug('[useViewOperations] failed to fetch view metadata before load', {
+              viewId,
+              error: e,
+            });
+          }
+        }
 
         // Check for AIChat early
         if (view?.layout === ViewLayout.AIChat) {
@@ -127,24 +145,50 @@ export function useViewOperations() {
           })();
         }
 
+        const layout = isSubDocument ? ViewLayout.Document : view?.layout;
+        const databaseIdHint = !isSubDocument
+          ? options?.databaseId ??
+            (
+              layout !== undefined && isDatabaseLayout(layout)
+                ? getDatabaseIdFromExtra(view)
+                : undefined
+            )
+          : undefined;
+
         // Use view-loader to open document (handles cache vs fetch)
-        const { doc, collabType: detectedCollabType } = await openView(
+        let { doc, collabType: detectedCollabType } = await openView(
           currentWorkspaceId,
           viewId,
-          isSubDocument ? ViewLayout.Document : view?.layout
+          layout,
+          { databaseId: databaseIdHint }
         );
 
         // Use detected collab type, or override for sub-documents
-        const collabType = isSubDocument ? Types.Document : detectedCollabType;
+        let collabType = isSubDocument ? Types.Document : detectedCollabType;
 
         Log.debug('[useViewOperations] loadView complete (sync not bound)', {
           viewId,
           layout: view?.layout,
           collabType,
+          databaseIdHint,
           isSubDocument,
         });
 
-        const collabObjectId = await resolveCollabObjectId(doc, viewId, collabType);
+        let collabObjectId = await resolveCollabObjectId(doc, viewId, collabType, {
+          databaseIdHint,
+          updateDocGuid: !!databaseIdHint,
+        });
+
+        if (collabType === Types.Database && !databaseIdHint && collabObjectId !== viewId) {
+          const canonical = await openView(currentWorkspaceId, viewId, layout, { databaseId: collabObjectId });
+
+          doc = canonical.doc;
+          detectedCollabType = canonical.collabType;
+          collabType = isSubDocument ? Types.Document : detectedCollabType;
+          collabObjectId = await resolveCollabObjectId(doc, viewId, collabType, {
+            databaseIdHint: collabObjectId,
+          });
+        }
 
         // Store metadata on doc for deferred sync binding
         const docWithMeta = doc as YDocWithMeta;

--- a/src/components/app/layers/AppBusinessLayer.tsx
+++ b/src/components/app/layers/AppBusinessLayer.tsx
@@ -3,7 +3,7 @@ import { useParams, useSearchParams } from 'react-router-dom';
 import { validate as uuidValidate } from 'uuid';
 
 import { ViewService } from '@/application/services/domains';
-import { TextCount, View } from '@/application/types';
+import { LoadViewOptions, TextCount, View } from '@/application/types';
 import { findAncestors, findView } from '@/components/_shared/outline/utils';
 import { AppEventEmitterContext } from '@/components/app/contexts/AppEventEmitterContext';
 import { AppNavigationContext, AppNavigationContextType } from '@/components/app/contexts/AppNavigationContext';
@@ -435,8 +435,8 @@ export const AppBusinessLayer: FC<AppBusinessLayerProps> = ({ children }) => {
 
   // Enhanced loadView with outline context
   const enhancedLoadView = useCallback(
-    async (viewId: string, isSubDocument = false, loadAwareness = false) => {
-      return loadView(viewId, isSubDocument, loadAwareness, stableOutlineRef.current);
+    async (viewId: string, isSubDocument = false, loadAwareness = false, options?: LoadViewOptions) => {
+      return loadView(viewId, isSubDocument, loadAwareness, stableOutlineRef.current, options);
     },
     [loadView, stableOutlineRef]
   );

--- a/src/components/app/layers/AppBusinessLayer.tsx
+++ b/src/components/app/layers/AppBusinessLayer.tsx
@@ -117,7 +117,16 @@ export const AppBusinessLayer: FC<AppBusinessLayerProps> = ({ children }) => {
   }, [outline, tabViewId, viewId]);
 
   // Initialize view operations
-  const { loadView, toView, awarenessMap, getViewIdFromDatabaseId, bindViewSync, getCollabHistory, previewCollabVersion } = useViewOperations();
+  const {
+    loadView,
+    toView,
+    awarenessMap,
+    getDatabaseIdForViewId,
+    getViewIdFromDatabaseId,
+    bindViewSync,
+    getCollabHistory,
+    previewCollabVersion,
+  } = useViewOperations();
 
   // Initialize row operations
   const { createRow } = useRowOperations();
@@ -147,6 +156,7 @@ export const AppBusinessLayer: FC<AppBusinessLayerProps> = ({ children }) => {
     flushAllSync: syncContext.flushAllSync,
     syncAllToServer: syncContext.syncAllToServer,
     loadViewChildren,
+    getDatabaseIdForViewId,
   });
 
   // Check if current view has been deleted

--- a/src/components/editor/components/blocks/database/DatabaseBlock.tsx
+++ b/src/components/editor/components/blocks/database/DatabaseBlock.tsx
@@ -23,6 +23,7 @@ export const DatabaseBlock = memo(
     const viewIds = getViewIds(node.data);
     const viewId = viewIds.length > 0 ? viewIds[0] : '';
     const allowedViewIds = Array.isArray(node.data?.view_ids) ? node.data.view_ids : undefined;
+    const databaseId = typeof node.data?.database_id === 'string' ? node.data.database_id : undefined;
     const context = useEditorContext();
     const workspaceId = context.workspaceId;
 
@@ -43,8 +44,10 @@ export const DatabaseBlock = memo(
     // 1. Document loading
     const { doc, notFound, setNotFound } = useDocumentLoader({
       viewId,
+      databaseId,
       loadView,
       bindViewSync,
+      eventEmitter: context.eventEmitter,
     });
 
     // 2. Visible view IDs from block data

--- a/src/components/editor/components/blocks/database/hooks/__tests__/useDocumentLoader.test.ts
+++ b/src/components/editor/components/blocks/database/hooks/__tests__/useDocumentLoader.test.ts
@@ -1,0 +1,118 @@
+import EventEmitter from 'events';
+
+import { act, renderHook, waitFor } from '@testing-library/react';
+import * as Y from 'yjs';
+
+import { APP_EVENTS } from '@/application/constants';
+import { YDoc } from '@/application/types';
+
+import { useDocumentLoader } from '../useDocumentLoader';
+
+function createDoc(guid: string): YDoc {
+  return new Y.Doc({ guid }) as YDoc;
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+
+  return { promise, resolve };
+}
+
+describe('useDocumentLoader', () => {
+  it('passes databaseId hint into loadView', async () => {
+    const doc = createDoc('database-id');
+    const loadView = jest.fn(async () => doc);
+
+    renderHook(() => useDocumentLoader({
+      viewId: 'view-id',
+      databaseId: 'database-id',
+      loadView,
+    }));
+
+    await waitFor(() => {
+      expect(loadView).toHaveBeenCalledWith('view-id', false, false, { databaseId: 'database-id' });
+    });
+  });
+
+  it('shares one reset event listener across loader instances for the same emitter', async () => {
+    const eventEmitter = new EventEmitter();
+    const loadView = jest.fn(async (viewId: string) => createDoc(viewId));
+
+    const first = renderHook(() => useDocumentLoader({
+      viewId: 'view-a',
+      loadView,
+      eventEmitter,
+    }));
+    const second = renderHook(() => useDocumentLoader({
+      viewId: 'view-b',
+      loadView,
+      eventEmitter,
+    }));
+
+    await waitFor(() => {
+      expect(eventEmitter.listenerCount(APP_EVENTS.COLLAB_DOC_RESET)).toBe(1);
+    });
+
+    first.unmount();
+    expect(eventEmitter.listenerCount(APP_EVENTS.COLLAB_DOC_RESET)).toBe(1);
+
+    second.unmount();
+    expect(eventEmitter.listenerCount(APP_EVENTS.COLLAB_DOC_RESET)).toBe(0);
+  });
+
+  it('ignores stale load results after viewId changes', async () => {
+    const oldLoad = deferred<YDoc>();
+    const newLoad = deferred<YDoc>();
+    const oldDoc = createDoc('old-database-id');
+    const newDoc = createDoc('new-database-id');
+    const loadView = jest.fn((viewId: string) => {
+      return viewId === 'old-view-id' ? oldLoad.promise : newLoad.promise;
+    });
+
+    const { result, rerender } = renderHook(
+      ({ databaseId, viewId }) => useDocumentLoader({
+        viewId,
+        databaseId,
+        loadView,
+      }),
+      {
+        initialProps: {
+          viewId: 'old-view-id',
+          databaseId: 'old-database-id',
+        },
+      }
+    );
+
+    await waitFor(() => {
+      expect(loadView).toHaveBeenCalledWith('old-view-id', false, false, { databaseId: 'old-database-id' });
+    });
+
+    rerender({
+      viewId: 'new-view-id',
+      databaseId: 'new-database-id',
+    });
+
+    await waitFor(() => {
+      expect(loadView).toHaveBeenCalledWith('new-view-id', false, false, { databaseId: 'new-database-id' });
+    });
+
+    await act(async () => {
+      newLoad.resolve(newDoc);
+      await newLoad.promise;
+    });
+
+    await waitFor(() => {
+      expect(result.current.doc).toBe(newDoc);
+    });
+
+    await act(async () => {
+      oldLoad.resolve(oldDoc);
+      await oldLoad.promise;
+    });
+
+    expect(result.current.doc).toBe(newDoc);
+  });
+});

--- a/src/components/editor/components/blocks/database/hooks/useDocumentLoader.ts
+++ b/src/components/editor/components/blocks/database/hooks/useDocumentLoader.ts
@@ -1,13 +1,56 @@
+import EventEmitter from 'events';
 import { useCallback, useEffect, useState } from 'react';
 
-import { YDoc, YDocWithMeta } from '@/application/types';
+import { APP_EVENTS } from '@/application/constants';
+import { LoadView, YDoc, YDocWithMeta } from '@/application/types';
 import { SyncContext } from '@/application/services/js-services/sync-protocol';
+import { CollabDocResetPayload } from '@/components/ws/sync/types';
 import { Log } from '@/utils/log';
+
+type ResetCallback = (payload: CollabDocResetPayload) => void;
+type ResetSubscriptionEntry = {
+  callbacks: Set<ResetCallback>;
+  handler: (payload: CollabDocResetPayload) => void;
+};
+
+const resetSubscriptions = new WeakMap<EventEmitter, ResetSubscriptionEntry>();
+
+function subscribeCollabDocReset(eventEmitter: EventEmitter, callback: ResetCallback) {
+  let entry = resetSubscriptions.get(eventEmitter);
+
+  if (!entry) {
+    entry = {
+      callbacks: new Set(),
+      handler: (payload) => {
+        entry?.callbacks.forEach((cb) => cb(payload));
+      },
+    };
+    resetSubscriptions.set(eventEmitter, entry);
+    eventEmitter.on(APP_EVENTS.COLLAB_DOC_RESET, entry.handler);
+  }
+
+  entry.callbacks.add(callback);
+
+  return () => {
+    const current = resetSubscriptions.get(eventEmitter);
+
+    if (!current) return;
+
+    current.callbacks.delete(callback);
+
+    if (current.callbacks.size === 0) {
+      eventEmitter.off(APP_EVENTS.COLLAB_DOC_RESET, current.handler);
+      resetSubscriptions.delete(eventEmitter);
+    }
+  };
+}
 
 interface UseDocumentLoaderProps {
   viewId: string;
-  loadView?: (viewId: string) => Promise<YDoc | null>;
+  databaseId?: string | null;
+  loadView?: LoadView;
   bindViewSync?: (doc: YDoc) => SyncContext | null;
+  eventEmitter?: EventEmitter;
 }
 
 interface UseDocumentLoaderResult {
@@ -26,8 +69,10 @@ interface UseDocumentLoaderResult {
  */
 export function useDocumentLoader({
   viewId,
+  databaseId,
   loadView,
   bindViewSync,
+  eventEmitter,
 }: UseDocumentLoaderProps): UseDocumentLoaderResult {
   const [doc, setDoc] = useState<YDoc | null>(null);
   const [notFound, setNotFound] = useState(false);
@@ -43,7 +88,7 @@ export function useDocumentLoader({
       for (let attempt = 1; attempt <= retries; attempt++) {
         try {
           Log.debug('[useDocumentLoader] attempt', { viewIdToLoad, attempt, retries });
-          const result = await loadView(viewIdToLoad);
+          const result = await loadView(viewIdToLoad, false, false, { databaseId });
 
           if (result) {
             Log.debug('[useDocumentLoader] loadView returned doc', { viewIdToLoad, attempt });
@@ -68,22 +113,28 @@ export function useDocumentLoader({
 
       return null;
     },
-    [loadView]
+    [databaseId, loadView]
   );
 
   useEffect(() => {
     if (!viewId) return;
+
+    let cancelled = false;
 
     const loadDocument = async () => {
       try {
         Log.debug('[useDocumentLoader] loading doc for viewId', { viewId });
         const loadedDoc = await loadWithRetry(viewId);
 
+        if (cancelled) return;
+
         Log.debug('[useDocumentLoader] loaded doc', { viewId, hasDoc: !!loadedDoc });
         setDoc(loadedDoc);
         setNotFound(false);
         setSyncBound(false);
       } catch (error) {
+        if (cancelled) return;
+
         Log.error('[useDocumentLoader] failed to load doc', {
           viewId,
           error: error instanceof Error ? error.message : String(error),
@@ -93,6 +144,10 @@ export function useDocumentLoader({
     };
 
     void loadDocument();
+
+    return () => {
+      cancelled = true;
+    };
   }, [viewId, loadWithRetry]);
 
   useEffect(() => {
@@ -114,6 +169,39 @@ export function useDocumentLoader({
       setSyncBound(true);
     }
   }, [doc, bindViewSync, syncBound, viewId]);
+
+  useEffect(() => {
+    if (!eventEmitter) return;
+
+    const handleCollabDocReset = ({ objectId, viewId: resetViewId, doc: nextDoc }: CollabDocResetPayload) => {
+      setDoc((currentDoc) => {
+        if (!currentDoc) {
+          return currentDoc;
+        }
+
+        const currentDocWithMeta = currentDoc as YDocWithMeta;
+        const currentObjectId = currentDocWithMeta.object_id ?? currentDoc.guid;
+        const currentViewId = currentDocWithMeta.view_id ?? currentObjectId;
+        const matchesObject = objectId === currentObjectId || objectId === currentDoc.guid;
+        const matchesView = resetViewId === viewId || resetViewId === currentViewId;
+
+        if (!matchesObject && !matchesView) {
+          return currentDoc;
+        }
+
+        const nextDocWithMeta = nextDoc as YDocWithMeta;
+
+        nextDocWithMeta.object_id = nextDocWithMeta.object_id ?? currentObjectId;
+        nextDocWithMeta.view_id = nextDocWithMeta.view_id ?? currentViewId;
+        nextDocWithMeta._collabType = nextDocWithMeta._collabType ?? currentDocWithMeta._collabType;
+        nextDocWithMeta._syncBound = true;
+
+        return nextDoc;
+      });
+    };
+
+    return subscribeCollabDocReset(eventEmitter, handleCollabDocReset);
+  }, [eventEmitter, viewId]);
 
   return { doc, notFound, setNotFound };
 }


### PR DESCRIPTION
## Summary
- use databaseId as the canonical IndexedDB/provider cache key for database collabs, including embedded database blocks
- migrate legacy viewId database caches into the canonical databaseId cache and enqueue the merged update for sync
- pass databaseId hints through loadView, avoid blocking cache open on workspace mapping lookup, and ignore stale embedded DB load completions
- render Board fallback group columns when persisted board group columns are missing, so rows grouped under the default field column are not hidden
- add focused unit coverage and Playwright BDD scenarios for legacy cache migration, multi-view cache identity, and missing board group columns

## Tests
- pnpm exec jest src/application/__tests__/view-loader.test.ts src/application/__tests__/view-utils.test.ts src/components/editor/components/blocks/database/components/__tests__/DatabaseContent.test.tsx src/components/editor/components/blocks/database/hooks/__tests__/useDocumentLoader.test.ts --no-coverage --runInBand
- pnpm exec jest src/application/database-yjs/__tests__/group.test.ts src/application/database-yjs/__tests__/useGroup.test.tsx --no-coverage --runInBand
- pnpm exec tsc --noEmit --project tsconfig.web.json
- pnpm exec eslint --quiet src/application/types.ts src/application/view-loader/index.ts src/application/__tests__/view-loader.test.ts src/components/app/layers/AppBusinessLayer.tsx src/components/app/hooks/useDatabaseIdentity.ts src/components/app/hooks/useViewOperations.ts src/application/services/js-services/publish-database-data.ts src/components/app/hooks/usePageOperations.ts src/components/editor/components/blocks/database/DatabaseBlock.tsx src/components/editor/components/blocks/database/hooks/useDocumentLoader.ts src/components/editor/components/blocks/database/hooks/__tests__/useDocumentLoader.test.ts
- pnpm exec eslint --quiet src/application/database-yjs/selector.ts src/application/database-yjs/__tests__/useGroup.test.tsx src/components/database/components/board/group/Columns.tsx
- pnpm exec playwright test playwright/e2e/database/database-collab-cache.spec.ts --project=chromium passed once locally; latest rerun was blocked because localhost:8000 was down, and restarting AppFlowy-Cloud-Premium failed with an unrelated DatabaseLayout::Form compile error in services/appflowy-worker/src/import_worker/csv_util.rs:1745

## Chrome Debug Note
Investigating http://localhost:3000/app/997c87ed-1667-4a62-8c0a-a74ee1aadb4b/6a8aec32-5f59-43fe-b981-3537710dbd08?v=6a8aec32-5f59-43fe-b981-3537710dbd08 showed Grid rows existed and Board groupResult contained 3 rows under field Z_W0UQ, but the persisted Board group column list was empty, so Columns rendered no visible columns. The new fallback derives columns from the grouped field in that case.
