### PR TITLE
Fix database view ordering and board rendering

### DIFF
--- a/playwright/e2e/database/database-collab-cache.spec.ts
+++ b/playwright/e2e/database/database-collab-cache.spec.ts
@@ -11,12 +11,11 @@ import { v4 as uuidv4 } from 'uuid';
 
 import { signInAndWaitForApp } from '../../support/auth-flow-helpers';
 import { createDatabaseView, waitForGridReady } from '../../support/database-ui-helpers';
-import { getSlashMenuItemName } from '../../support/i18n-constants';
+import { insertInlineGridViaSlash } from '../../support/duplicate-test-helpers';
 import { createDocumentPageAndNavigate } from '../../support/page-utils';
 import {
   DatabaseGridSelectors,
   DatabaseViewSelectors,
-  SlashCommandSelectors,
 } from '../../support/selectors';
 import { generateRandomEmail } from '../../support/test-config';
 import {
@@ -143,13 +142,7 @@ async function insertEmbeddedGridDatabase(page: Page, docViewId: string) {
   const editor = page.locator(`#editor-${docViewId}`);
 
   await expect(editor).toBeVisible({ timeout: 15000 });
-  await editor.click({ position: { x: 200, y: 100 }, force: true });
-  await editor.pressSequentially('/', { delay: 50 });
-
-  const slashPanel = SlashCommandSelectors.slashPanel(page);
-
-  await expect(slashPanel).toBeVisible({ timeout: 10000 });
-  await SlashCommandSelectors.slashMenuItem(page, getSlashMenuItemName('grid')).first().click({ force: true });
+  await insertInlineGridViaSlash(page, docViewId);
   await waitForDatabaseTestContext(page);
   await closeViewModalIfOpen(page);
 

--- a/src/application/database-yjs/__tests__/useAddDatabaseView.test.tsx
+++ b/src/application/database-yjs/__tests__/useAddDatabaseView.test.tsx
@@ -34,10 +34,11 @@ function createView(overrides: Partial<View>): View {
 }
 
 describe('useAddDatabaseView', () => {
-  it('creates linked view under database container when parent is container', async () => {
+  it('appends linked view under database container when parent is container', async () => {
     const databaseId = 'db-1';
     const baseViewId = 'base-view-id';
     const activeViewId = 'active-view-id';
+    const lastChildId = 'last-child-id';
     const containerId = 'container-view-id';
 
     const createDatabaseView = jest.fn().mockResolvedValue({
@@ -61,6 +62,8 @@ describe('useAddDatabaseView', () => {
           extra: { is_space: false, is_database_container: true },
           children: [
             createView({ view_id: baseViewId, layout: ViewLayout.Grid, parent_view_id: containerId }),
+            createView({ view_id: activeViewId, layout: ViewLayout.Board, parent_view_id: containerId }),
+            createView({ view_id: lastChildId, layout: ViewLayout.Calendar, parent_view_id: containerId }),
           ],
         });
       }
@@ -92,7 +95,7 @@ describe('useAddDatabaseView', () => {
       activeViewId,
       expect.objectContaining({
         parent_view_id: containerId,
-        prev_view_id: activeViewId,
+        prev_view_id: lastChildId,
         database_id: databaseId,
         layout: ViewLayout.Calendar,
         name: 'Calendar',
@@ -104,6 +107,7 @@ describe('useAddDatabaseView', () => {
   it('creates embedded linked view under document when no container exists', async () => {
     const databaseId = 'db-1';
     const baseViewId = 'linked-view-id';
+    const lastChildId = 'last-document-child-id';
     const documentId = 'document-id';
 
     const createDatabaseView = jest.fn().mockResolvedValue({
@@ -125,6 +129,10 @@ describe('useAddDatabaseView', () => {
         return createView({
           view_id: documentId,
           layout: ViewLayout.Document,
+          children: [
+            createView({ view_id: baseViewId, layout: ViewLayout.Grid, parent_view_id: documentId }),
+            createView({ view_id: lastChildId, layout: ViewLayout.Document, parent_view_id: documentId }),
+          ],
         });
       }
 
@@ -155,7 +163,7 @@ describe('useAddDatabaseView', () => {
       baseViewId,
       expect.objectContaining({
         parent_view_id: documentId,
-        prev_view_id: baseViewId,
+        prev_view_id: lastChildId,
         database_id: databaseId,
         layout: ViewLayout.Board,
         name: 'Board',

--- a/src/application/database-yjs/dispatch.ts
+++ b/src/application/database-yjs/dispatch.ts
@@ -2114,7 +2114,7 @@ export function useAddDatabaseView() {
         if (isDatabaseContainer(parentMeta)) {
           return {
             tabsParentViewId: parentId,
-            prevViewId: currentMeta?.view_id,
+            prevViewId: getLastChildViewId(parentMeta),
           };
         }
 
@@ -2122,7 +2122,7 @@ export function useAddDatabaseView() {
         if (isDocumentBlock) {
           return {
             tabsParentViewId: parentId,
-            prevViewId: currentMeta?.view_id,
+            prevViewId: getLastChildViewId(parentMeta) ?? currentMeta?.view_id,
           };
         }
 

--- a/src/components/database/Database.tsx
+++ b/src/components/database/Database.tsx
@@ -900,7 +900,7 @@ function Database(props: Database2Props) {
   }
 
   return (
-    <div className={'flex w-full flex-1 justify-center'}>
+    <div className={'flex min-h-0 w-full flex-1 justify-center'}>
       <DatabaseContextProvider value={mainContextValue}>
         {rowId ? (
           <DatabaseRow appendBreadcrumb={appendBreadcrumb} rowId={rowId} />
@@ -908,7 +908,7 @@ function Database(props: Database2Props) {
           <div
             className={cn(
               'appflowy-database relative flex w-full select-text flex-col',
-              shouldUseFixedViewport ? 'flex-1 overflow-hidden' : 'overflow-visible'
+              shouldUseFixedViewport ? 'min-h-0 flex-1 overflow-hidden' : 'overflow-visible'
             )}
           >
             <DatabaseViews

--- a/src/components/database/DatabaseContext.tsx
+++ b/src/components/database/DatabaseContext.tsx
@@ -32,6 +32,11 @@ export const DatabaseContextProvider = ({ children, value }: DatabaseContextProv
       __TEST_DATABASE_CONTEXT__?: DatabaseContextState;
       Y?: typeof Y;
     };
+    const previousTestContext = {
+      databaseDoc: testWindow.__TEST_DATABASE_DOC__,
+      viewId: testWindow.__TEST_DATABASE_VIEW_ID__,
+      context: testWindow.__TEST_DATABASE_CONTEXT__,
+    };
 
     testWindow.__TEST_DATABASE_DOC__ = value.databaseDoc;
     testWindow.__TEST_DATABASE_VIEW_ID__ = value.activeViewId;
@@ -40,9 +45,15 @@ export const DatabaseContextProvider = ({ children, value }: DatabaseContextProv
 
     return () => {
       if (testWindow.__TEST_DATABASE_CONTEXT__ === value) {
-        delete testWindow.__TEST_DATABASE_DOC__;
-        delete testWindow.__TEST_DATABASE_VIEW_ID__;
-        delete testWindow.__TEST_DATABASE_CONTEXT__;
+        if (previousTestContext.context) {
+          testWindow.__TEST_DATABASE_DOC__ = previousTestContext.databaseDoc;
+          testWindow.__TEST_DATABASE_VIEW_ID__ = previousTestContext.viewId;
+          testWindow.__TEST_DATABASE_CONTEXT__ = previousTestContext.context;
+        } else {
+          delete testWindow.__TEST_DATABASE_DOC__;
+          delete testWindow.__TEST_DATABASE_VIEW_ID__;
+          delete testWindow.__TEST_DATABASE_CONTEXT__;
+        }
       }
 
       // Keep Y exposed — it may be needed by other editors

--- a/src/components/database/DatabaseViews.tsx
+++ b/src/components/database/DatabaseViews.tsx
@@ -16,7 +16,7 @@ import { shouldUseFixedDatabaseViewport } from '@/components/database/layout';
 import { ElementFallbackRender } from '@/components/error/ElementFallbackRender';
 import { cn } from '@/lib/utils';
 import {
-  insertViewIdAfter,
+  appendViewId,
   readStoredViewOrder,
   reconcileOrderedViewIds,
   selectHydratingViewOrder,
@@ -71,14 +71,15 @@ function DatabaseViews({
   const orderedDatabaseIdRef = useRef<string | undefined>();
   const pendingViewCreationRef = useRef(false);
   const pendingExpectedViewIdsRef = useRef<string[] | null>(null);
-  const pendingViewInsertionRef = useRef<{ anchorViewId: string; baseViewIds: string[] } | null>(null);
+  const pendingViewAppendBaseRef = useRef<string[] | null>(null);
+  const hasAuthoritativeVisibleOrder = Boolean(visibleViewIds && visibleViewIds.length > 0);
 
   const [layout, setLayout] = useState<DatabaseViewLayout | null>(null);
   // Track the previous valid layout to prevent flash when switching to a new view
   const prevLayoutRef = useRef<DatabaseViewLayout | null>(null);
 
   const fallbackViewIds = useMemo(() => {
-    if (!visibleViewIds || visibleViewIds.length === 0) {
+    if (hasAuthoritativeVisibleOrder) {
       return viewIds;
     }
 
@@ -101,7 +102,7 @@ function DatabaseViews({
     };
 
     return [...viewIds].sort((left, right) => getCreatedAtSortValue(left) - getCreatedAtSortValue(right));
-  }, [viewIds, views, visibleViewIds]);
+  }, [hasAuthoritativeVisibleOrder, viewIds, views]);
 
   useEffect(() => {
     const isNewDatabase = orderedDatabaseIdRef.current !== databaseId;
@@ -132,6 +133,8 @@ function DatabaseViews({
     const baseViewIds =
       pendingExpectedViewIds && pendingExpectedViewIds.every((viewId) => viewIds.includes(viewId))
         ? pendingExpectedViewIds
+        : hasAuthoritativeVisibleOrder
+        ? fallbackViewIds
         : storedViewIds && storedViewIds.length > 0
         ? storedViewIds
         : isNewDatabase
@@ -153,7 +156,7 @@ function DatabaseViews({
     orderedViewIdsRef.current = nextViewIds;
     writeStoredViewOrder(databaseId, nextViewIds);
     setOrderedViewIds(nextViewIds);
-  }, [databaseId, fallbackViewIds, viewIds]);
+  }, [databaseId, fallbackViewIds, hasAuthoritativeVisibleOrder, viewIds]);
 
   const [conditionsExpanded, setConditionsExpanded] = useState<boolean>(false);
   const toggleExpanded = useCallback(() => {
@@ -253,36 +256,33 @@ function DatabaseViews({
     const baseViewIds =
       orderedViewIdsRef.current.length > 0
         ? orderedViewIdsRef.current
+        : hasAuthoritativeVisibleOrder
+        ? fallbackViewIds
         : storedViewIds && storedViewIds.length > 0
         ? storedViewIds
         : fallbackViewIds;
 
     pendingViewCreationRef.current = true;
-    pendingViewInsertionRef.current = {
-      anchorViewId: activeViewId,
-      baseViewIds,
-    };
-  }, [activeViewId, databaseId, fallbackViewIds]);
+    pendingViewAppendBaseRef.current = baseViewIds;
+  }, [databaseId, fallbackViewIds, hasAuthoritativeVisibleOrder]);
 
   const handleAfterViewAddedToDatabase = useCallback(() => {
     pendingViewCreationRef.current = false;
-    pendingViewInsertionRef.current = null;
+    pendingViewAppendBaseRef.current = null;
   }, []);
 
   const handleViewAddedToDatabase = useCallback(
     (newViewId: string) => {
       const storedViewIds = readStoredViewOrder(databaseId);
-      const pendingViewInsertion = pendingViewInsertionRef.current;
       const baseViewIds =
-        pendingViewInsertion?.baseViewIds ??
+        pendingViewAppendBaseRef.current ??
         selectStableViewOrder({
           previousViewIds: orderedViewIdsRef.current,
           storedViewIds,
           fallbackViewIds,
           pendingViewId: newViewId,
         });
-      const anchorViewId = pendingViewInsertion?.anchorViewId ?? activeViewId;
-      const nextViewIds = insertViewIdAfter(baseViewIds, anchorViewId, newViewId);
+      const nextViewIds = appendViewId(baseViewIds, newViewId);
 
       pendingExpectedViewIdsRef.current = nextViewIds;
       orderedViewIdsRef.current = nextViewIds;
@@ -292,7 +292,7 @@ function DatabaseViews({
       });
       onViewAdded?.(newViewId);
     },
-    [activeViewId, databaseId, fallbackViewIds, onViewAdded]
+    [databaseId, fallbackViewIds, onViewAdded]
   );
 
   const displayedViewIds = orderedViewIds.length > 0 ? orderedViewIds : viewIds;
@@ -364,7 +364,7 @@ function DatabaseViews({
         <div
           className={cn(
             'relative flex w-full flex-col',
-            shouldUseFixedViewport ? 'h-full flex-1 overflow-hidden' : 'overflow-visible'
+            shouldUseFixedViewport ? 'h-full min-h-0 flex-1 overflow-hidden' : 'overflow-visible'
           )}
           style={
             fixedHeight !== undefined
@@ -373,7 +373,7 @@ function DatabaseViews({
           }
         >
           <div
-            className={cn('w-full', shouldUseFixedViewport && 'h-full')}
+            className={cn('w-full', shouldUseFixedViewport && 'flex h-full min-h-0 flex-col')}
             style={
               fixedHeight !== undefined
                 ? { height: `${fixedHeight}px`, maxHeight: `${fixedHeight}px` }

--- a/src/components/database/__tests__/DatabaseViews.order.test.tsx
+++ b/src/components/database/__tests__/DatabaseViews.order.test.tsx
@@ -1,0 +1,176 @@
+import { expect } from '@jest/globals';
+import { act, render, waitFor } from '@testing-library/react';
+import * as Y from 'yjs';
+
+import { DatabaseContext, DatabaseContextState } from '@/application/database-yjs';
+import { DatabaseViewLayout, YDoc, YjsDatabaseKey, YjsEditorKey } from '@/application/types';
+import DatabaseViews from '@/components/database/DatabaseViews';
+
+type CapturedDatabaseTabsProps = {
+  viewIds: string[];
+  onBeforeViewAddedToDatabase?: () => void;
+  onViewAddedToDatabase?: (viewId: string) => void;
+  onAfterViewAddedToDatabase?: () => void;
+};
+
+declare global {
+  // eslint-disable-next-line no-var
+  var __databaseViewsOrderTestState:
+    | {
+        renderedViewIds: string[][];
+        latestTabsProps?: CapturedDatabaseTabsProps;
+      }
+    | undefined;
+}
+
+jest.mock('@/utils/runtime-config', () => ({
+  getConfigValue: (_key: string, fallback: string) => fallback,
+}));
+
+jest.mock('@/components/database/components/tabs', () => ({
+  DatabaseTabs: (props: CapturedDatabaseTabsProps) => {
+    global.__databaseViewsOrderTestState = {
+      renderedViewIds: [...(global.__databaseViewsOrderTestState?.renderedViewIds ?? []), props.viewIds],
+      latestTabsProps: props,
+    };
+
+    return null;
+  },
+}));
+
+jest.mock('@/components/database/grid', () => ({
+  Grid: () => null,
+}));
+
+jest.mock('@/components/database/board', () => ({
+  Board: () => null,
+}));
+
+jest.mock('@/components/database/chart', () => ({
+  Chart: () => null,
+}));
+
+jest.mock('@/components/database/fullcalendar', () => ({
+  Calendar: () => null,
+}));
+
+jest.mock('@/components/database/components/UnsupportedView', () => () => null);
+jest.mock('src/components/database/components/conditions/DatabaseConditions', () => () => null);
+
+function createDatabaseDoc(
+  databaseId: string,
+  viewsInInsertionOrder: Array<{ viewId: string; name: string; createdAt: string }>
+): YDoc {
+  const doc = new Y.Doc() as unknown as YDoc;
+  const sharedRoot = doc.getMap(YjsEditorKey.data_section);
+  const database = new Y.Map();
+  const views = new Y.Map();
+
+  database.set(YjsDatabaseKey.id, databaseId);
+
+  viewsInInsertionOrder.forEach(({ viewId, name, createdAt }) => {
+    const view = new Y.Map();
+
+    view.set(YjsDatabaseKey.id, viewId);
+    view.set(YjsDatabaseKey.name, name);
+    view.set(YjsDatabaseKey.layout, DatabaseViewLayout.Grid);
+    view.set(YjsDatabaseKey.created_at, createdAt);
+    view.set(YjsDatabaseKey.is_inline, false);
+    view.set(YjsDatabaseKey.embedded, false);
+    views.set(viewId, view);
+  });
+
+  database.set(YjsDatabaseKey.views, views);
+  sharedRoot.set(YjsEditorKey.database, database);
+
+  return doc;
+}
+
+function renderDatabaseViews({
+  databaseId = 'db-1',
+  visibleViewIds,
+  activeViewId = visibleViewIds[0],
+}: {
+  databaseId?: string;
+  visibleViewIds: string[];
+  activeViewId?: string;
+}) {
+  const doc = createDatabaseDoc(databaseId, [
+    { viewId: visibleViewIds[0], name: 'Launch Review Log', createdAt: '300' },
+    { viewId: visibleViewIds[1], name: 'Grid', createdAt: '200' },
+    { viewId: visibleViewIds[2], name: 'Grid2', createdAt: '100' },
+  ]);
+  const contextValue: DatabaseContextState = {
+    readOnly: true,
+    databaseDoc: doc,
+    databasePageId: visibleViewIds[0],
+    activeViewId,
+    rowDocMap: {},
+    workspaceId: 'workspace-id',
+  };
+
+  render(
+    <DatabaseContext.Provider value={contextValue}>
+      <DatabaseViews
+        onChangeView={jest.fn()}
+        activeViewId={activeViewId}
+        databasePageId={visibleViewIds[0]}
+        visibleViewIds={visibleViewIds}
+      />
+    </DatabaseContext.Provider>
+  );
+}
+
+describe('DatabaseViews order', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    global.__databaseViewsOrderTestState = undefined;
+  });
+
+  it('preserves visible view order instead of sorting container tabs by created_at', async () => {
+    const visibleViewIds = ['launch-review-log', 'grid', 'grid2'];
+
+    renderDatabaseViews({ visibleViewIds });
+
+    await waitFor(() => {
+      expect(global.__databaseViewsOrderTestState?.renderedViewIds.length).toBeGreaterThanOrEqual(2);
+    });
+
+    expect(global.__databaseViewsOrderTestState?.renderedViewIds.at(-1)).toEqual(visibleViewIds);
+  });
+
+  it('overwrites stale stored order when visible view order is authoritative', async () => {
+    const databaseId = 'db-1';
+    const visibleViewIds = ['launch-review-log', 'grid', 'grid2'];
+
+    window.localStorage.setItem('database_view_order:db-1', JSON.stringify(['grid2', 'launch-review-log', 'grid']));
+
+    renderDatabaseViews({ databaseId, visibleViewIds });
+
+    await waitFor(() => {
+      expect(global.__databaseViewsOrderTestState?.renderedViewIds.length).toBeGreaterThanOrEqual(2);
+    });
+
+    expect(global.__databaseViewsOrderTestState?.renderedViewIds.at(-1)).toEqual(visibleViewIds);
+    expect(JSON.parse(window.localStorage.getItem(`database_view_order:${databaseId}`) || '[]')).toEqual(visibleViewIds);
+  });
+
+  it('optimistically appends a newly created view to the end', async () => {
+    const visibleViewIds = ['launch-review-log', 'grid', 'grid2'];
+    const newViewId = 'new-grid';
+
+    renderDatabaseViews({ visibleViewIds, activeViewId: 'grid' });
+
+    await waitFor(() => {
+      expect(global.__databaseViewsOrderTestState?.latestTabsProps).toBeDefined();
+    });
+
+    act(() => {
+      global.__databaseViewsOrderTestState?.latestTabsProps?.onBeforeViewAddedToDatabase?.();
+      global.__databaseViewsOrderTestState?.latestTabsProps?.onViewAddedToDatabase?.(newViewId);
+      global.__databaseViewsOrderTestState?.latestTabsProps?.onAfterViewAddedToDatabase?.();
+    });
+
+    expect(global.__databaseViewsOrderTestState?.renderedViewIds.at(-1)).toEqual([...visibleViewIds, newViewId]);
+  });
+});

--- a/src/components/database/__tests__/view-order.test.ts
+++ b/src/components/database/__tests__/view-order.test.ts
@@ -1,4 +1,5 @@
 import {
+  appendViewId,
   insertViewIdAfter,
   readStoredViewOrder,
   reconcileOrderedViewIds,
@@ -22,6 +23,14 @@ describe('database view ordering helpers', () => {
 
   it('inserts a new view immediately after the active tab', () => {
     expect(insertViewIdAfter(['grid', 'board'], 'grid', 'calendar')).toEqual(['grid', 'calendar', 'board']);
+  });
+
+  it('appends a new view to the end', () => {
+    expect(appendViewId(['grid', 'board'], 'calendar')).toEqual(['grid', 'board', 'calendar']);
+  });
+
+  it('moves an existing view to the end when appending', () => {
+    expect(appendViewId(['grid', 'calendar', 'board'], 'calendar')).toEqual(['grid', 'board', 'calendar']);
   });
 
   it('persists and restores stored view order', () => {

--- a/src/components/database/board/Board.tsx
+++ b/src/components/database/board/Board.tsx
@@ -23,7 +23,7 @@ export function Board() {
 
   return (
     <BoardProvider>
-      <div className={'database-board flex w-full flex-1 flex-col'}>
+      <div className={'database-board flex h-full min-h-0 w-full flex-1 flex-col'}>
         <Group groupId={group} key={group} />
       </div>
     </BoardProvider>

--- a/src/components/database/components/board/column/CardList.tsx
+++ b/src/components/database/components/board/column/CardList.tsx
@@ -16,6 +16,8 @@ export interface RenderCard {
   id: string;
 }
 
+const CARD_LIST_MAX_HEIGHT = 2000;
+
 function CardList({
   data,
   fieldId,
@@ -71,13 +73,28 @@ function CardList({
     getItemKey: (index) => data[index].id || String(index),
   });
 
-  const items = virtualizer.getVirtualItems();
+  const virtualItems = virtualizer.getVirtualItems();
+  const viewportHeight = Math.min(
+    parentRef.current?.clientHeight || CARD_LIST_MAX_HEIGHT,
+    CARD_LIST_MAX_HEIGHT
+  );
+  const scrollTop = parentRef.current?.scrollTop ?? 0;
+  const renderStart = Math.max(0, scrollTop - 5 * 36);
+  const renderEnd = scrollTop + viewportHeight + 5 * 36;
+  const maxRenderedItems = Math.ceil(viewportHeight / 36) + 12;
+  const items = virtualItems.length > maxRenderedItems
+    ? virtualItems
+      .filter((item) => item.end >= renderStart && item.start <= renderEnd)
+      .slice(0, maxRenderedItems)
+    : virtualItems;
 
   return (
     <div
       ref={parentRef}
-      className='appflowy-custom-scroller w-full'
+      className='appflowy-custom-scroller w-full shrink-0'
       style={{
+        height: CARD_LIST_MAX_HEIGHT,
+        maxHeight: CARD_LIST_MAX_HEIGHT,
         overflowY: 'auto',
       }}
     >

--- a/src/components/database/components/board/column/Column.tsx
+++ b/src/components/database/components/board/column/Column.tsx
@@ -17,6 +17,32 @@ export interface ColumnProps {
   groupId: string;
 }
 
+function areRowsEqual(prevRows: Row[], nextRows: Row[]) {
+  if (prevRows === nextRows) return true;
+  if (prevRows.length !== nextRows.length) return false;
+
+  for (let index = 0; index < prevRows.length; index += 1) {
+    const prevRow = prevRows[index];
+    const nextRow = nextRows[index];
+
+    if (prevRow.id !== nextRow.id || prevRow.height !== nextRow.height) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+function areColumnPropsEqual(prev: ColumnProps, next: ColumnProps) {
+  return (
+    prev.id === next.id &&
+    prev.fieldId === next.fieldId &&
+    prev.groupId === next.groupId &&
+    prev.addCardBefore === next.addCardBefore &&
+    areRowsEqual(prev.rows, next.rows)
+  );
+}
+
 export const Column = memo(
   ({ id, rows, fieldId, addCardBefore, groupId }: ColumnProps) => {
     const readOnly = useReadOnly();
@@ -49,14 +75,14 @@ export const Column = memo(
 
     return (
       <ColumnDragContext.Provider value={contextValue}>
-        <div data-column-id={id} className={'relative h-full w-[256px]'} ref={columnInnerRef}>
+        <div data-column-id={id} className={'relative flex h-full min-h-0 w-[256px]'} ref={columnInnerRef}>
           <div
             style={{
               opacity: isDragging ? 0.4 : 1,
               pointerEvents: isDragging ? 'none' : undefined,
             }}
             ref={columnRef}
-            className={'flex w-[256px] min-w-[256px] flex-col items-center pt-2'}
+            className={'flex h-full min-h-0 w-[256px] min-w-[256px] flex-col items-center pt-2'}
           >
             <ColumnHeaderPrimitive
               rowCount={rows.length}
@@ -84,5 +110,5 @@ export const Column = memo(
       </ColumnDragContext.Provider>
     );
   },
-  (prev, next) => JSON.stringify(prev) === JSON.stringify(next)
+  areColumnPropsEqual
 );

--- a/src/components/database/components/board/group/Columns.tsx
+++ b/src/components/database/components/board/group/Columns.tsx
@@ -47,7 +47,7 @@ const Columns = forwardRef<
   const readOnly = useReadOnly();
 
   return (
-    <div ref={ref} className={'columns flex w-fit min-w-full flex-1 gap-2'}>
+    <div ref={ref} className={'columns flex h-full min-h-0 w-fit min-w-full flex-1 gap-2'}>
       {!readOnly && <HiddenGroupColumn fieldId={fieldId} groupId={props.groupId} getRows={getRows} />}
 
       {columnsWithRows.map((data) => (

--- a/src/components/database/components/board/group/Group.tsx
+++ b/src/components/database/components/board/group/Group.tsx
@@ -2,7 +2,7 @@ import { autoScrollForElements } from '@atlaskit/pragmatic-drag-and-drop-auto-sc
 import React, { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import { PADDING_END, useDatabaseContext, useReadOnly, useRowOrdersSelector, useRowsByGroup } from '@/application/database-yjs';
+import { PADDING_END, useDatabaseContext, useReadOnly, useRowsByGroup } from '@/application/database-yjs';
 import { useNewRowDispatch } from '@/application/database-yjs/dispatch';
 import { useBoardActions } from '@/components/database/board/BoardProvider';
 import { BoardDragContext } from '@/components/database/components/board/drag-and-drop/board-context';
@@ -25,112 +25,7 @@ export const Group = ({ groupId }: GroupProps) => {
   const { columns, groupResult, fieldId, notFound } = useRowsByGroup(groupId);
   const { t } = useTranslation();
   const context = useDatabaseContext();
-  const { paddingStart, paddingEnd, navigateToRow, ensureRow, loadRowFromSeed, blobPrefetchComplete } =
-    context;
-  const rowOrders = useRowOrdersSelector();
-
-  // Track visibility for lazy loading (rerender-move-effect-to-event pattern)
-  const [isVisible, setIsVisible] = useState(false);
-  const observerRef = useRef<IntersectionObserver | null>(null);
-  const containerRef = useRef<HTMLDivElement | null>(null);
-  const observedContainerRef = useRef<HTMLDivElement | null>(null);
-
-  // Store callbacks in refs to avoid triggering effect re-runs (advanced-use-latest pattern)
-  const ensureRowRef = useRef(ensureRow);
-  const loadRowFromSeedRef = useRef(loadRowFromSeed);
-  const loadedRowsRef = useRef<Set<string>>(new Set());
-
-  useEffect(() => {
-    ensureRowRef.current = ensureRow;
-    loadRowFromSeedRef.current = loadRowFromSeed;
-  });
-
-  // Set up intersection observer for lazy loading
-  useEffect(() => {
-    if (typeof IntersectionObserver === 'undefined') {
-      setIsVisible(true);
-      return;
-    }
-
-    observerRef.current = new IntersectionObserver(
-      (entries) => {
-        // Once visible, stay visible (no need to unload)
-        if (entries[0]?.isIntersecting) {
-          setIsVisible(true);
-        }
-      },
-      {
-        // Load slightly before entering viewport for smoother UX
-        rootMargin: '100px',
-        threshold: 0,
-      }
-    );
-
-    const container = containerRef.current;
-
-    if (container) {
-      observerRef.current.observe(container);
-      observedContainerRef.current = container;
-    }
-
-    return () => {
-      observerRef.current?.disconnect();
-    };
-  }, []);
-
-  // Reset loaded rows and visibility when group changes
-  useEffect(() => {
-    loadedRowsRef.current.clear();
-    setIsVisible(false);
-  }, [groupId]);
-
-  // Load row documents only when group becomes visible.
-  // Try cached data first (fast), then fall back to ensureRow (WebSocket sync).
-  // Uses Promise.all for parallel loading to avoid request waterfalls.
-  useEffect(() => {
-    // Only load when visible (lazy loading for off-screen groups)
-    if (!isVisible || !rowOrders || rowOrders.length === 0) return;
-
-    // Only load rows we haven't loaded yet (avoid re-loading on sort/filter changes)
-    const rowsToLoad = rowOrders.filter((row) => !loadedRowsRef.current.has(row.id));
-
-    if (rowsToLoad.length === 0) return;
-
-    const loadRows = async () => {
-      try {
-        if (blobPrefetchComplete && loadRowFromSeedRef.current) {
-          // Load all rows from cache in parallel
-          const results = await Promise.all(
-            rowsToLoad.map((row) => loadRowFromSeedRef.current!(row.id))
-          );
-
-          // Mark rows as loaded
-          rowsToLoad.forEach((row) => loadedRowsRef.current.add(row.id));
-
-          // Fall back to ensureRow for any rows not in cache
-          if (ensureRowRef.current) {
-            results.forEach((doc, index) => {
-              if (!doc) {
-                // Ignore errors - WebSocket sync provides fallback
-                ensureRowRef.current!(rowsToLoad[index].id)?.catch(() => undefined);
-              }
-            });
-          }
-        } else if (ensureRowRef.current) {
-          // No cache available, use ensureRow directly
-          rowsToLoad.forEach((row) => {
-            // Ignore errors - WebSocket sync provides fallback
-            ensureRowRef.current!(row.id)?.catch(() => undefined);
-            loadedRowsRef.current.add(row.id);
-          });
-        }
-      } catch {
-        // Silently handle errors - WebSocket sync will provide data as fallback
-      }
-    };
-
-    void loadRows();
-  }, [isVisible, blobPrefetchComplete, rowOrders]);
+  const { paddingStart, paddingEnd, navigateToRow } = context;
 
   const readOnly = useReadOnly();
   const getCards = useCallback(
@@ -199,16 +94,6 @@ export const Group = ({ groupId }: GroupProps) => {
 
   const handleRefCallback = useCallback((el: HTMLDivElement | null) => {
     ref.current = el;
-    containerRef.current = el;
-    if (observedContainerRef.current && observerRef.current) {
-      observerRef.current.unobserve(observedContainerRef.current);
-    }
-
-    observedContainerRef.current = el;
-    if (el && observerRef.current) {
-      observerRef.current.observe(el);
-    }
-
     if (!el) return;
     const container = getVerticalScrollContainer(el);
 
@@ -343,7 +228,7 @@ export const Group = ({ groupId }: GroupProps) => {
         tabIndex={0}
         onMouseLeave={handleMouseLeave}
         ref={handleRefCallback}
-        className={'appflowy-custom-scroller h-full overflow-x-auto px-24 focus:outline-none max-sm:!px-6'}
+        className={'appflowy-custom-scroller h-full min-h-0 overflow-x-auto px-24 focus:outline-none max-sm:!px-6'}
         style={{
           paddingLeft: paddingStart,
           paddingRight: paddingEnd,
@@ -351,7 +236,7 @@ export const Group = ({ groupId }: GroupProps) => {
         }}
         onScroll={handleScroll}
       >
-        <div className='flex h-full w-fit min-w-full flex-col'>
+        <div className='flex h-full min-h-0 w-fit min-w-full flex-col'>
           <Columns
             groupId={groupId}
             fieldId={fieldId}

--- a/src/utils/database-view-order.ts
+++ b/src/utils/database-view-order.ts
@@ -56,6 +56,12 @@ export function insertViewIdAfter(viewIds: string[], anchorViewId: string, newVi
   ];
 }
 
+export function appendViewId(viewIds: string[], newViewId: string): string[] {
+  const dedupedViewIds = viewIds.filter((viewId) => viewId !== newViewId);
+
+  return [...dedupedViewIds, newViewId];
+}
+
 export function selectStableViewOrder(params: {
   previousViewIds: string[];
   storedViewIds?: string[];


### PR DESCRIPTION
## Summary
- append newly created database views to the end of the tab order and preserve authoritative embedded view order
- avoid loading every board row document when opening a board view
- bound and virtualize board card lists so large board columns stay responsive

## Tests
- pnpm exec tsc --noEmit --project tsconfig.web.json --pretty false
- pnpm jest src/application/database-yjs/__tests__/useAddDatabaseView.test.tsx src/application/database-yjs/__tests__/useDatabaseViewsSelector.test.tsx src/components/database/__tests__/DatabaseViews.order.test.tsx src/components/database/__tests__/view-order.test.ts --runInBand --no-coverage
- git diff --check

## Summary by Sourcery

Adjust database view ordering logic and optimize board rendering performance for large datasets.

Bug Fixes:
- Ensure newly created database views are appended to the end of the tab order while preserving embedded view order.
- Respect authoritative visible view order over stored or created_at-based ordering, overwriting stale persisted orders when necessary.

Enhancements:
- Optimize board columns by bounding and virtualizing card lists so large columns remain responsive.
- Avoid eagerly loading all board row documents when opening a board, relying instead on existing data flows.
- Improve memoization and layout structure of board columns and containers to reduce unnecessary renders and layout issues.

Tests:
- Add and update tests covering database view ordering, append behavior for new views, and authoritative visible order handling.