### PR TITLE
Scale row collab IndexedDB cache

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -9,3 +9,4 @@ vite.config.ts
 coverage/
 src/proto/**/*
 cypress/e2e/**
+scripts/export-indexeddb-to-zip.js

--- a/.eslintignore.web
+++ b/.eslintignore.web
@@ -14,3 +14,4 @@ playwright.config.ts
 playwright-snapshot.config.ts
 deploy/*.test.ts
 deploy/*.integration.test.ts
+scripts/export-indexeddb-to-zip.js

--- a/src/application/database-blob/index.ts
+++ b/src/application/database-blob/index.ts
@@ -4,7 +4,7 @@ import * as Y from 'yjs';
 
 import { hasRowConditionData, invalidateRowConditionCache } from '@/application/database-yjs/condition-value-cache';
 import { getRowKey } from '@/application/database-yjs/row_meta';
-import { getCachedProviderDoc, openCollabDBWithProvider } from '@/application/db';
+import { getCachedProviderDoc, openCollabDBWithProvider, openRowCollabDBWithProvider } from '@/application/db';
 import { getCachedRowDoc } from '@/application/services/js-services/cache';
 import { databaseBlobDiff } from '@/application/services/js-services/http/http_api';
 import { YDoc, YjsEditorKey } from '@/application/types';
@@ -550,7 +550,11 @@ function inspectDocRowData(doc: YDoc, objectId: string): {
   }
 }
 
-async function applyCollabUpdate(objectId: string, docState: database_blob.ICollabDocState) {
+async function applyCollabUpdate(
+  objectId: string,
+  docState: database_blob.ICollabDocState,
+  options?: { useSharedRowStorage?: boolean }
+) {
   const state = getDocState(docState);
 
   if (!state) {
@@ -589,7 +593,9 @@ async function applyCollabUpdate(objectId: string, docState: database_blob.IColl
   });
 
   const openStartedAt = Date.now();
-  const { doc, provider } = await openCollabDBWithProvider(objectId, { skipCache: true });
+  const { doc, provider } = options?.useSharedRowStorage
+    ? await openRowCollabDBWithProvider(objectId, { skipCache: true })
+    : await openCollabDBWithProvider(objectId, { skipCache: true });
 
   const beforeState = inspectDocRowData(doc, objectId);
 
@@ -658,7 +664,7 @@ async function applyRowUpdate(
       cacheRowDocSeed(rowKey, rowDocState);
     }
 
-    await applyCollabUpdate(rowKey, rowDocState);
+    await applyCollabUpdate(rowId, rowDocState, { useSharedRowStorage: true });
   }
 
   const doc = update.document;

--- a/src/application/database-yjs/__tests__/field-wrap-default.test.tsx
+++ b/src/application/database-yjs/__tests__/field-wrap-default.test.tsx
@@ -1,0 +1,131 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import * as Y from 'yjs';
+
+import {
+  DatabaseContext,
+  DatabaseContextState,
+  FieldType,
+  useFieldsSelector,
+  useFieldWrap,
+  useTogglePropertyWrapDispatch,
+} from '@/application/database-yjs';
+import {
+  YDatabase,
+  YDatabaseField,
+  YDatabaseFieldSetting,
+  YDatabaseFieldSettings,
+  YDatabaseView,
+  YDoc,
+  YjsDatabaseKey,
+  YjsEditorKey,
+} from '@/application/types';
+
+jest.mock('@/utils/runtime-config', () => ({
+  getConfigValue: (_key: string, fallback: string) => fallback,
+}));
+
+const fieldId = 'field-id';
+const viewId = 'view-id';
+
+function createDatabaseDoc(wrap?: boolean): {
+  databaseDoc: YDoc;
+  fieldSettings: YDatabaseFieldSettings;
+} {
+  const databaseDoc = new Y.Doc() as unknown as YDoc;
+  const sharedRoot = databaseDoc.getMap(YjsEditorKey.data_section);
+  const database = new Y.Map() as YDatabase;
+  const fields = new Y.Map() as Y.Map<YDatabaseField>;
+  const field = new Y.Map() as YDatabaseField;
+  const views = new Y.Map() as Y.Map<YDatabaseView>;
+  const view = new Y.Map() as YDatabaseView;
+  const fieldOrders = new Y.Array<{ id: string }>();
+  const fieldSettings = new Y.Map() as YDatabaseFieldSettings;
+  const fieldSetting = new Y.Map() as YDatabaseFieldSetting;
+
+  field.set(YjsDatabaseKey.id, fieldId);
+  field.set(YjsDatabaseKey.is_primary, true);
+  field.set(YjsDatabaseKey.type, FieldType.RichText);
+  fields.set(fieldId, field);
+
+  if (wrap !== undefined) {
+    fieldSetting.set(YjsDatabaseKey.wrap, wrap);
+  }
+
+  fieldSettings.set(fieldId, fieldSetting);
+  fieldOrders.push([{ id: fieldId }]);
+  view.set(YjsDatabaseKey.field_orders, fieldOrders);
+  view.set(YjsDatabaseKey.field_settings, fieldSettings);
+  views.set(viewId, view);
+
+  database.set(YjsDatabaseKey.fields, fields);
+  database.set(YjsDatabaseKey.views, views);
+  sharedRoot.set(YjsEditorKey.database, database);
+
+  return {
+    databaseDoc,
+    fieldSettings,
+  };
+}
+
+function createContextValue(databaseDoc: YDoc): DatabaseContextState {
+  return {
+    readOnly: false,
+    databaseDoc,
+    databasePageId: viewId,
+    activeViewId: viewId,
+    rowMap: null,
+    workspaceId: 'workspace-id',
+  };
+}
+
+describe('field wrap default', () => {
+  it('defaults selector columns to nowrap when wrap is missing', async () => {
+    const { databaseDoc } = createDatabaseDoc();
+    const contextValue = createContextValue(databaseDoc);
+
+    const { result } = renderHook(() => useFieldsSelector(), {
+      wrapper: ({ children }) => <DatabaseContext.Provider value={contextValue}>{children}</DatabaseContext.Provider>,
+    });
+
+    await waitFor(() => expect(result.current).toHaveLength(1));
+    expect(result.current[0].wrap).toBe(false);
+  });
+
+  it('defaults field wrap state to false when wrap is missing', () => {
+    const { databaseDoc } = createDatabaseDoc();
+    const contextValue = createContextValue(databaseDoc);
+
+    const { result } = renderHook(() => useFieldWrap(fieldId), {
+      wrapper: ({ children }) => <DatabaseContext.Provider value={contextValue}>{children}</DatabaseContext.Provider>,
+    });
+
+    expect(result.current).toBe(false);
+  });
+
+  it('toggles a missing wrap setting from false to true', () => {
+    const { databaseDoc, fieldSettings } = createDatabaseDoc();
+    const contextValue = createContextValue(databaseDoc);
+
+    const { result } = renderHook(() => useTogglePropertyWrapDispatch(), {
+      wrapper: ({ children }) => <DatabaseContext.Provider value={contextValue}>{children}</DatabaseContext.Provider>,
+    });
+
+    act(() => {
+      result.current(fieldId);
+    });
+
+    expect(fieldSettings.get(fieldId)?.get(YjsDatabaseKey.wrap)).toBe(true);
+  });
+
+  it('preserves an explicit wrap setting', async () => {
+    const { databaseDoc } = createDatabaseDoc(true);
+    const contextValue = createContextValue(databaseDoc);
+
+    const { result } = renderHook(() => useFieldsSelector(), {
+      wrapper: ({ children }) => <DatabaseContext.Provider value={contextValue}>{children}</DatabaseContext.Provider>,
+    });
+
+    await waitFor(() => expect(result.current).toHaveLength(1));
+    expect(result.current[0].wrap).toBe(true);
+  });
+});

--- a/src/application/database-yjs/__tests__/field-wrap-default.test.tsx
+++ b/src/application/database-yjs/__tests__/field-wrap-default.test.tsx
@@ -34,9 +34,9 @@ function createDatabaseDoc(wrap?: boolean): {
   const databaseDoc = new Y.Doc() as unknown as YDoc;
   const sharedRoot = databaseDoc.getMap(YjsEditorKey.data_section);
   const database = new Y.Map() as YDatabase;
-  const fields = new Y.Map() as Y.Map<YDatabaseField>;
+  const fields = new Y.Map<YDatabaseField>();
   const field = new Y.Map() as YDatabaseField;
-  const views = new Y.Map() as Y.Map<YDatabaseView>;
+  const views = new Y.Map<YDatabaseView>();
   const view = new Y.Map() as YDatabaseView;
   const fieldOrders = new Y.Array<{ id: string }>();
   const fieldSettings = new Y.Map() as YDatabaseFieldSettings;

--- a/src/application/database-yjs/const.ts
+++ b/src/application/database-yjs/const.ts
@@ -6,6 +6,7 @@ import { RowId, YDatabaseRow, YDoc, YjsDatabaseKey, YjsEditorKey } from '@/appli
 export const DEFAULT_ROW_HEIGHT = 36;
 export const MIN_COLUMN_WIDTH = 150;
 export const PADDING_END = 220;
+export const DEFAULT_FIELD_WRAP = false;
 
 export const getCell = (rowId: string, fieldId: string, rowMetas: Record<RowId, YDoc>) => {
   const rowMeta = rowMetas[rowId];

--- a/src/application/database-yjs/dispatch.ts
+++ b/src/application/database-yjs/dispatch.ts
@@ -40,6 +40,8 @@ import { getDefaultFilterCondition } from '@/application/database-yjs/filter';
 import { getOptionsFromRow } from '@/application/database-yjs/row';
 import { getMetaIdMap } from '@/application/database-yjs/row_meta';
 import { useBoardLayoutSettings, useCalendarLayoutSetting, useFieldSelector, useFieldType } from '@/application/database-yjs/selector';
+import { deleteCollabDB } from '@/application/db';
+import { deleteOutboxByObjectId } from '@/application/sync-outbox';
 import { executeOperations } from '@/application/slate-yjs/utils/yjs';
 import {
   DatabaseViewLayout,
@@ -693,6 +695,8 @@ export function useDeleteRowDispatch() {
         },
         'deleteRowDispatch'
       );
+      void deleteOutboxByObjectId(rowId);
+      void deleteCollabDB(rowId, { destroyDoc: false });
     },
     [sharedRoot, database]
   );
@@ -729,6 +733,10 @@ export function useBulkDeleteRowDispatch() {
         },
         'bulkDeleteRowDispatch'
       );
+      rowIds.forEach((rowId) => {
+        void deleteOutboxByObjectId(rowId);
+        void deleteCollabDB(rowId, { destroyDoc: false });
+      });
     },
     [sharedRoot, database]
   );

--- a/src/application/database-yjs/dispatch.ts
+++ b/src/application/database-yjs/dispatch.ts
@@ -37,6 +37,7 @@ import { createRollupField } from '@/application/database-yjs/fields/rollup/util
 import { createSelectOptionCell } from '@/application/database-yjs/fields/select-option/utils';
 import { createDateTimeField } from '@/application/database-yjs/fields/text/utils';
 import { getDefaultFilterCondition } from '@/application/database-yjs/filter';
+import { DEFAULT_FIELD_WRAP } from '@/application/database-yjs/const';
 import { getOptionsFromRow } from '@/application/database-yjs/row';
 import { getMetaIdMap } from '@/application/database-yjs/row_meta';
 import { useBoardLayoutSettings, useCalendarLayoutSetting, useFieldSelector, useFieldType } from '@/application/database-yjs/selector';
@@ -1011,6 +1012,7 @@ export function useNewPropertyDispatch() {
           const setting = new Y.Map() as YDatabaseFieldSetting;
 
           setting.set(YjsDatabaseKey.visibility, FieldVisibility.AlwaysShown);
+          setting.set(YjsDatabaseKey.wrap, DEFAULT_FIELD_WRAP);
           fieldSettings.set(fieldId, setting);
 
           fieldOrders.push([
@@ -1054,6 +1056,7 @@ export function useAddPropertyLeftDispatch() {
           const setting = new Y.Map() as YDatabaseFieldSetting;
 
           setting.set(YjsDatabaseKey.visibility, FieldVisibility.AlwaysShown);
+          setting.set(YjsDatabaseKey.wrap, DEFAULT_FIELD_WRAP);
           fieldSettings.set(newId, setting);
 
           const index = fieldOrders.toArray().findIndex((field) => field.id === fieldId);
@@ -1100,6 +1103,7 @@ export function useAddPropertyRightDispatch() {
           const setting = new Y.Map() as YDatabaseFieldSetting;
 
           setting.set(YjsDatabaseKey.visibility, FieldVisibility.AlwaysShown);
+          setting.set(YjsDatabaseKey.wrap, DEFAULT_FIELD_WRAP);
           fieldSettings.set(newId, setting);
 
           const index = fieldOrders.toArray().findIndex((field) => field.id === fieldId);
@@ -1424,7 +1428,7 @@ export function useTogglePropertyWrapDispatch() {
               fieldSettings.set(fieldId, setting);
             }
 
-            const wrap = setting.get(YjsDatabaseKey.wrap) ?? true;
+            const wrap = setting.get(YjsDatabaseKey.wrap) ?? DEFAULT_FIELD_WRAP;
 
             if (checked !== undefined) {
               setting.set(YjsDatabaseKey.wrap, checked);
@@ -1889,6 +1893,7 @@ function generateBoardSetting(database: YDatabase): YDatabaseFieldSettings {
     const setting = new Y.Map() as YDatabaseFieldSetting;
 
     setting.set(YjsDatabaseKey.visibility, FieldVisibility.HideWhenEmpty);
+    setting.set(YjsDatabaseKey.wrap, DEFAULT_FIELD_WRAP);
 
     fieldSettingsMap.set(id, setting);
   });
@@ -2011,6 +2016,7 @@ function useEnhanceCalendarLayoutByFieldExists() {
           const setting = new Y.Map() as YDatabaseFieldSetting;
 
           setting.set(YjsDatabaseKey.visibility, FieldVisibility.AlwaysShown);
+          setting.set(YjsDatabaseKey.wrap, DEFAULT_FIELD_WRAP);
           fieldSettings.set(fieldId, setting);
         },
         'newDateTimeField'

--- a/src/application/database-yjs/dispatch/row.ts
+++ b/src/application/database-yjs/dispatch/row.ts
@@ -28,7 +28,8 @@ import {
 } from '@/application/database-yjs/context';
 import { FieldType, RowMetaKey } from '@/application/database-yjs/database.type';
 import { getCachedRowSubDoc } from '@/application/services/js-services/cache';
-import { getCachedProviderDoc, openCollabDB } from '@/application/db';
+import { deleteCollabDB, getCachedProviderDoc, openCollabDB } from '@/application/db';
+import { deleteOutboxByObjectId } from '@/application/sync-outbox';
 import { Log } from '@/utils/log';
 import { createCheckboxCell } from '@/application/database-yjs/fields/checkbox/utils';
 import { createSelectOptionCell } from '@/application/database-yjs/fields/select-option/utils';
@@ -246,6 +247,8 @@ export function useDeleteRowDispatch() {
         },
         'deleteRowDispatch'
       );
+      void deleteOutboxByObjectId(rowId);
+      void deleteCollabDB(rowId, { destroyDoc: false });
     },
     [sharedRoot, database]
   );
@@ -282,6 +285,10 @@ export function useBulkDeleteRowDispatch() {
         },
         'bulkDeleteRowDispatch'
       );
+      rowIds.forEach((rowId) => {
+        void deleteOutboxByObjectId(rowId);
+        void deleteCollabDB(rowId, { destroyDoc: false });
+      });
     },
     [sharedRoot, database]
   );

--- a/src/application/database-yjs/selector.ts
+++ b/src/application/database-yjs/selector.ts
@@ -5,7 +5,7 @@ import { useCallback, useDeferredValue, useEffect, useMemo, useRef, useState } f
 import { parseYDatabaseCellToCell } from '@/application/database-yjs/cell.parse';
 import { DateTimeCell, RollupCell } from '@/application/database-yjs/cell.type';
 import { hasRowConditionData, invalidateRowConditionCache } from '@/application/database-yjs/condition-value-cache';
-import { getCell, MIN_COLUMN_WIDTH } from '@/application/database-yjs/const';
+import { DEFAULT_FIELD_WRAP, getCell, MIN_COLUMN_WIDTH } from '@/application/database-yjs/const';
 import {
   useDatabase,
   useDatabaseContext,
@@ -270,7 +270,7 @@ export function useFieldsSelector(visibilitys: FieldVisibility[] = defaultVisibl
             visibility: Number(
               setting?.get(YjsDatabaseKey.visibility) || FieldVisibility.AlwaysShown
             ) as FieldVisibility,
-            wrap: setting?.get(YjsDatabaseKey.wrap) ?? true,
+            wrap: setting?.get(YjsDatabaseKey.wrap) ?? DEFAULT_FIELD_WRAP,
             fieldType: Number(field?.get(YjsDatabaseKey.type)) as FieldType,
           };
         })
@@ -355,13 +355,13 @@ export function useFieldWrap(fieldId: string) {
   const fieldSettings = view?.get(YjsDatabaseKey.field_settings);
   const fieldSetting = fieldSettings?.get(fieldId);
 
-  const [wrap, setWrap] = useState(fieldSetting?.get(YjsDatabaseKey.wrap) ?? true);
+  const [wrap, setWrap] = useState(fieldSetting?.get(YjsDatabaseKey.wrap) ?? DEFAULT_FIELD_WRAP);
 
   useEffect(() => {
     if (!view) return;
 
     const observerEvent = () => {
-      setWrap(fieldSetting?.get(YjsDatabaseKey.wrap) ?? true);
+      setWrap(fieldSetting?.get(YjsDatabaseKey.wrap) ?? DEFAULT_FIELD_WRAP);
     };
 
     observerEvent();

--- a/src/application/database-yjs/selector.ts
+++ b/src/application/database-yjs/selector.ts
@@ -86,12 +86,16 @@ function shouldLogDatabaseConditionPerformance() {
   return typeof window !== 'undefined' && window.location.hostname === 'localhost';
 }
 
+function stringifyConditionSignature(value: unknown) {
+  return JSON.stringify(value, (_key, item) => (typeof item === 'bigint' ? item.toString() : item));
+}
+
 function getConditionSignature(sorts?: YDatabaseSorts, filters?: YDatabaseFilters) {
   const hasConditions = (sorts?.length ?? 0) > 0 || (filters?.length ?? 0) > 0;
 
   if (!hasConditions) return '';
 
-  return JSON.stringify({
+  return stringifyConditionSignature({
     filters: filters?.toJSON?.() ?? [],
     sorts: sorts?.toJSON?.() ?? [],
   });

--- a/src/application/db/__tests__/index.test.ts
+++ b/src/application/db/__tests__/index.test.ts
@@ -1,0 +1,95 @@
+import * as Y from 'yjs';
+
+import { __dbTestUtils, db } from '@/application/db';
+import { type CollabSnapshotRecord, type CollabUpdateRecord } from '@/application/db/tables/collab_storage';
+import { type YDoc } from '@/application/types';
+
+class FakeProvider {
+  synced = false;
+  destroy = jest.fn().mockResolvedValue(undefined);
+
+  private listeners = new Map<string, Set<(...args: unknown[]) => void>>();
+
+  on(event: string, listener: (...args: unknown[]) => void) {
+    const listeners = this.listeners.get(event) ?? new Set<(...args: unknown[]) => void>();
+
+    listeners.add(listener);
+    this.listeners.set(event, listeners);
+  }
+
+  off(event: string, listener: (...args: unknown[]) => void) {
+    this.listeners.get(event)?.delete(listener);
+  }
+
+  emit(event: string, args: unknown[] = []) {
+    this.listeners.get(event)?.forEach((listener) => listener(...args));
+  }
+}
+
+describe('collab IndexedDB persistence internals', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+    localStorage.clear();
+  });
+
+  it('settles waiters when a pending provider is destroyed before synced', async () => {
+    const provider = new FakeProvider();
+    const doc = new Y.Doc({ guid: 'pending-object' }) as YDoc;
+    const entry = __dbTestUtils.createCachedProviderEntry('pending-object', Date.now(), doc, provider as never);
+
+    const waitPromise = __dbTestUtils.waitForProviderEntry('pending-object', entry);
+
+    await __dbTestUtils.destroyProviderEntry(entry, { destroyDoc: false });
+
+    await expect(waitPromise).rejects.toThrow('Collab provider was disposed while opening: pending-object');
+    expect(provider.destroy).toHaveBeenCalledTimes(1);
+  });
+
+  it('reads shared snapshots and update tails in one transaction', async () => {
+    const snapshot: CollabSnapshotRecord = {
+      objectId: 'row-1',
+      update: new Uint8Array([1]),
+      stateVector: new Uint8Array([2]),
+      updatedAt: 1,
+      byteLength: 1,
+    };
+    const updateRecord: CollabUpdateRecord = {
+      id: 1,
+      objectId: 'row-1',
+      update: new Uint8Array([3]),
+      createdAt: 2,
+      byteLength: 1,
+    };
+    const toArray = jest.fn().mockResolvedValue([updateRecord]);
+    const between = jest.fn().mockReturnValue({ toArray });
+    const transactionSpy = jest.spyOn(db, 'transaction').mockImplementation((async (...args: unknown[]) => {
+      const callback = args[args.length - 1] as () => Promise<unknown>;
+
+      return callback();
+    }) as never);
+    const snapshotGetSpy = jest.spyOn(db.collab_snapshots, 'get').mockResolvedValue(snapshot);
+    const updatesWhereSpy = jest.spyOn(db.collab_updates, 'where').mockReturnValue({ between } as never);
+
+    const result = await __dbTestUtils.readSharedCollabRecordsForSync('row-1');
+
+    expect(transactionSpy).toHaveBeenCalledWith('r', db.collab_snapshots, db.collab_updates, expect.any(Function));
+    expect(snapshotGetSpy).toHaveBeenCalledWith('row-1');
+    expect(updatesWhereSpy).toHaveBeenCalledWith('[objectId+id]');
+    expect(between).toHaveBeenCalledTimes(1);
+    expect(between.mock.calls[0][0][0]).toBe('row-1');
+    expect(between.mock.calls[0][1][0]).toBe('row-1');
+    expect(result).toEqual({ snapshot, updates: [updateRecord] });
+  });
+
+  it('clears all blob RID checkpoints when the shared collab cache database is deleted', () => {
+    localStorage.setItem('af_database_blob_rid:database-1', JSON.stringify({ timestamp: 1, seqNo: 2 }));
+    localStorage.setItem('af_database_blob_rid:database-2', JSON.stringify({ timestamp: 3, seqNo: 4 }));
+    localStorage.setItem('unrelated-key', 'keep');
+
+    __dbTestUtils.clearBlobRidCheckpointsForDeletedDatabases([{ name: db.name, deleted: true }]);
+
+    expect(localStorage.getItem('af_database_blob_rid:database-1')).toBeNull();
+    expect(localStorage.getItem('af_database_blob_rid:database-2')).toBeNull();
+    expect(localStorage.getItem('unrelated-key')).toBe('keep');
+  });
+});

--- a/src/application/db/__tests__/indexeddb-exists.test.ts
+++ b/src/application/db/__tests__/indexeddb-exists.test.ts
@@ -1,0 +1,96 @@
+import { collabIndexedDBExists } from '@/application/db';
+
+const originalIndexedDB = globalThis.indexedDB;
+
+function installIndexedDBMock(indexedDBMock: Partial<IDBFactory>) {
+  Object.defineProperty(globalThis, 'indexedDB', {
+    configurable: true,
+    value: indexedDBMock,
+  });
+}
+
+function createSuccessfulOpenRequest(database: IDBDatabase) {
+  const request = { result: database } as IDBOpenDBRequest;
+
+  Promise.resolve().then(() => {
+    request.onsuccess?.({} as Event);
+  });
+
+  return request;
+}
+
+function createNewDatabaseOpenRequest(database: IDBDatabase) {
+  const request = { result: database } as IDBOpenDBRequest;
+
+  Promise.resolve().then(() => {
+    request.onupgradeneeded?.({} as IDBVersionChangeEvent);
+    request.onsuccess?.({} as Event);
+  });
+
+  return request;
+}
+
+function createSuccessfulDeleteRequest() {
+  const request = {} as IDBOpenDBRequest;
+
+  Promise.resolve().then(() => {
+    request.onsuccess?.({} as Event);
+  });
+
+  return request;
+}
+
+describe('collabIndexedDBExists', () => {
+  beforeEach(() => {
+    jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    Object.defineProperty(globalThis, 'indexedDB', {
+      configurable: true,
+      value: originalIndexedDB,
+    });
+    jest.restoreAllMocks();
+  });
+
+  it('probes the named IndexedDB when database enumeration is unavailable', async () => {
+    const database = { close: jest.fn() } as unknown as IDBDatabase;
+    const open = jest.fn(() => createSuccessfulOpenRequest(database));
+    const deleteDatabase = jest.fn();
+
+    installIndexedDBMock({ open, deleteDatabase });
+
+    await expect(collabIndexedDBExists('legacy-row-db')).resolves.toBe(true);
+
+    expect(open).toHaveBeenCalledWith('legacy-row-db');
+    expect(database.close).toHaveBeenCalledTimes(1);
+    expect(deleteDatabase).not.toHaveBeenCalled();
+  });
+
+  it('deletes an empty IndexedDB created while probing a missing name', async () => {
+    const database = { close: jest.fn() } as unknown as IDBDatabase;
+    const open = jest.fn(() => createNewDatabaseOpenRequest(database));
+    const deleteDatabase = jest.fn(() => createSuccessfulDeleteRequest());
+
+    installIndexedDBMock({ open, deleteDatabase });
+
+    await expect(collabIndexedDBExists('missing-row-db')).resolves.toBe(false);
+
+    expect(open).toHaveBeenCalledWith('missing-row-db');
+    expect(database.close).toHaveBeenCalledTimes(1);
+    expect(deleteDatabase).toHaveBeenCalledWith('missing-row-db');
+  });
+
+  it('falls back to probing when database enumeration fails', async () => {
+    const database = { close: jest.fn() } as unknown as IDBDatabase;
+    const open = jest.fn(() => createSuccessfulOpenRequest(database));
+    const databases = jest.fn().mockRejectedValue(new Error('blocked'));
+
+    installIndexedDBMock({ open, databases });
+
+    await expect(collabIndexedDBExists('blocked-enumeration-row-db')).resolves.toBe(true);
+
+    expect(databases).toHaveBeenCalledTimes(1);
+    expect(open).toHaveBeenCalledWith('blocked-enumeration-row-db');
+  });
+});

--- a/src/application/db/index.ts
+++ b/src/application/db/index.ts
@@ -3,6 +3,12 @@ import { IndexeddbPersistence } from 'y-indexeddb';
 import * as Y from 'yjs';
 
 import { databasePrefix } from '@/application/constants';
+import {
+  collabStorageSchema,
+  type CollabSnapshotRecord,
+  type CollabStorageTable,
+  type CollabUpdateRecord,
+} from '@/application/db/tables/collab_storage';
 import { rowSchema, rowTable } from '@/application/db/tables/rows';
 import { syncOutboxSchema, SyncOutboxTable } from '@/application/db/tables/sync_outbox';
 import { userSchema, UserTable } from '@/application/db/tables/users';
@@ -15,12 +21,21 @@ import {
 import { YDoc } from '@/application/types';
 import { Log } from '@/utils/log';
 
-type DexieTables = ViewMetasTable & UserTable & rowTable & WorkspaceMemberProfileTable & VersionsTable & SyncOutboxTable;
+type DexieTables = ViewMetasTable &
+  UserTable &
+  rowTable &
+  WorkspaceMemberProfileTable &
+  VersionsTable &
+  SyncOutboxTable &
+  CollabStorageTable;
 
 export type Dexie<T = DexieTables> = BaseDexie & T;
 
 export const db = new BaseDexie(`${databasePrefix}_cache`) as Dexie;
-const _schema = Object.assign({}, { ...viewMetasSchema, ...userSchema, ...rowSchema, ...versionSchema, ...syncOutboxSchema });
+const _schema = Object.assign(
+  {},
+  { ...viewMetasSchema, ...userSchema, ...rowSchema, ...versionSchema, ...syncOutboxSchema, ...collabStorageSchema }
+);
 
 // Version 1: Initial schema with view_metas, users, and rows
 db.version(1).stores({
@@ -120,6 +135,18 @@ db.version(6)
     }
   });
 
+// Version 7: Shared collab storage for high-cardinality objects such as
+// database rows. This avoids creating one browser IndexedDB database per row.
+db.version(7).stores({
+  ...viewMetasSchema,
+  ...userSchema,
+  ...rowSchema,
+  ...workspaceMemberProfileSchema,
+  ...versionSchema,
+  ...syncOutboxSchema,
+  ...collabStorageSchema,
+});
+
 const openedSet = new Set<string>();
 const ensuredStores = new Map<string, Promise<void>>();
 
@@ -127,6 +154,10 @@ const yjsStoreDefinitions = [
   { name: 'updates', options: { autoIncrement: true } },
   { name: 'custom' },
 ];
+
+type IndexedDBFactoryWithDatabases = IDBFactory & {
+  databases?: () => Promise<Array<{ name?: string | null }>>;
+};
 
 function createYjsStores(db: IDBDatabase) {
   yjsStoreDefinitions.forEach((store) => {
@@ -187,6 +218,31 @@ async function ensureYjsStores(name: string) {
   ensuredStores.delete(name);
 }
 
+export async function listCollabIndexedDBNames() {
+  if (typeof indexedDB === 'undefined') return new Set<string>();
+
+  const indexedDBWithDatabases = indexedDB as IndexedDBFactoryWithDatabases;
+
+  if (typeof indexedDBWithDatabases.databases !== 'function') {
+    return new Set<string>();
+  }
+
+  try {
+    const databases = await indexedDBWithDatabases.databases();
+
+    return new Set(databases.flatMap((database) => (database.name ? [database.name] : [])));
+  } catch (error) {
+    Log.warn('[DB] failed to list IndexedDB databases', { error });
+    return new Set<string>();
+  }
+}
+
+export async function collabIndexedDBExists(name: string) {
+  if (!name) return false;
+
+  return (await listCollabIndexedDBNames()).has(name);
+}
+
 export interface OpenCollabOptions {
   /**
    * Define what version collab should have when loaded from IndexedDB.
@@ -214,12 +270,461 @@ export interface OpenCollabOptions {
  */
 interface CachedProviderEntry {
   doc: YDoc;
-  provider: IndexeddbPersistence;
+  provider: CollabPersistenceProvider;
   whenSynced: Promise<void>;
+  disposed: boolean;
+  settleWhenDisposed: () => void;
 }
 
 const providerCache = new Map<string, CachedProviderEntry>();
 const pendingOpens = new Map<string, Promise<CachedProviderEntry>>();
+const rowProviderCache = new Map<string, CachedProviderEntry>();
+const pendingRowOpens = new Map<string, Promise<CachedProviderEntry>>();
+const DATABASE_BLOB_RID_PREFIX = 'af_database_blob_rid:';
+const SHARED_COLLAB_COMPACT_UPDATE_THRESHOLD = 200;
+const SHARED_COLLAB_COMPACT_MAX_RETRIES = 3;
+
+type CollabPersistenceProvider = IndexeddbPersistence | SharedIndexeddbPersistence;
+type SharedCollabOpenOptions = { awaitSync?: boolean; expectedVersion?: string; forceReset?: boolean; skipCache?: boolean };
+
+class SharedCollabCompactionRetry extends Error {
+  constructor() {
+    super('Shared collab snapshot changed during compaction');
+    this.name = 'SharedCollabCompactionRetry';
+  }
+}
+
+function shouldRetrySharedCollabCompaction(error: unknown) {
+  return error instanceof SharedCollabCompactionRetry || (error as Error)?.name === 'SharedCollabCompactionRetry';
+}
+
+function getSharedCollabSnapshotToken(snapshot: CollabSnapshotRecord | undefined) {
+  return `${snapshot?.compactionId ?? ''}:${snapshot?.updatedAt ?? 0}:${snapshot?.byteLength ?? 0}:${
+    snapshot?.stateVector.byteLength ?? 0
+  }`;
+}
+
+function createSharedCollabSnapshotId() {
+  return globalThis.crypto?.randomUUID?.() ?? `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+}
+
+async function readSharedCollabRecordsForSync(name: string): Promise<{
+  snapshot: CollabSnapshotRecord | undefined;
+  updates: CollabUpdateRecord[];
+}> {
+  return db.transaction('r', db.collab_snapshots, db.collab_updates, async () => {
+    const snapshot = await db.collab_snapshots.get(name);
+    const updates = await db.collab_updates
+      .where('[objectId+id]')
+      .between([name, BaseDexie.minKey], [name, BaseDexie.maxKey])
+      .toArray();
+
+    return { snapshot, updates };
+  });
+}
+
+class CollabProviderDisposedError extends Error {
+  constructor(name: string) {
+    super(`Collab provider was disposed while opening: ${name}`);
+    this.name = 'CollabProviderDisposedError';
+  }
+}
+
+function createCachedProviderEntry(
+  name: string,
+  startedAt: number,
+  doc: YDoc,
+  provider: CollabPersistenceProvider
+): CachedProviderEntry {
+  let settled = false;
+  let resolveWhenSynced!: () => void;
+
+  const entry: CachedProviderEntry = {
+    doc,
+    provider,
+    disposed: false,
+    whenSynced: new Promise<void>((resolve) => {
+      resolveWhenSynced = resolve;
+    }),
+    settleWhenDisposed: () => {
+      entry.disposed = true;
+
+      if (settled) return;
+
+      settled = true;
+      (provider as { off?: (event: string, listener: (...args: unknown[]) => void) => void }).off?.('synced', handleSync);
+      resolveWhenSynced();
+    },
+  };
+
+  const handleSync = () => {
+    if (settled) return;
+
+    settled = true;
+    (provider as { off?: (event: string, listener: (...args: unknown[]) => void) => void }).off?.('synced', handleSync);
+
+    Log.debug('[DB] collab provider synced', {
+      name,
+      syncDurationMs: Date.now() - startedAt,
+      wasOpened: openedSet.has(name),
+    });
+
+    if (!openedSet.has(name)) {
+      openedSet.add(name);
+    }
+
+    resolveWhenSynced();
+  };
+
+  provider.on('synced', handleSync);
+
+  if ((provider as { synced?: boolean }).synced) {
+    handleSync();
+  }
+
+  return entry;
+}
+
+async function waitForProviderEntry(name: string, entry: CachedProviderEntry) {
+  await entry.whenSynced;
+
+  if (entry.disposed) {
+    throw new CollabProviderDisposedError(name);
+  }
+}
+
+class SharedIndexeddbPersistence {
+  doc: YDoc;
+  name: string;
+  synced = false;
+  whenSynced: Promise<SharedIndexeddbPersistence>;
+
+  private _destroyed = false;
+  private _listeners = new Map<string, Set<(...args: unknown[]) => void>>();
+  private _pendingWrite: Promise<void> = Promise.resolve();
+  private _updatesSinceCompact = 0;
+
+  constructor(name: string, doc: YDoc) {
+    this.name = name;
+    this.doc = doc;
+    this.whenSynced = this.sync();
+    this.destroy = this.destroy.bind(this);
+
+    doc.on('update', this._storeUpdate);
+    doc.on('destroy', this.destroy);
+  }
+
+  on(event: string, listener: (...args: unknown[]) => void) {
+    const listeners = this._listeners.get(event) ?? new Set<(...args: unknown[]) => void>();
+
+    listeners.add(listener);
+    this._listeners.set(event, listeners);
+  }
+
+  off(event: string, listener: (...args: unknown[]) => void) {
+    this._listeners.get(event)?.delete(listener);
+  }
+
+  emit(event: string, args: unknown[] = []) {
+    this._listeners.get(event)?.forEach((listener) => {
+      listener(...args);
+    });
+  }
+
+  private async sync() {
+    try {
+      const { snapshot, updates } = await readSharedCollabRecordsForSync(this.name);
+
+      if (this._destroyed) return this;
+
+      if (snapshot?.update) {
+        Y.applyUpdate(this.doc, snapshot.update, this);
+      }
+
+      if (updates.length > 0) {
+        Y.transact(
+          this.doc,
+          () => {
+            updates.forEach((record) => {
+              Y.applyUpdate(this.doc, record.update, this);
+            });
+          },
+          this
+        );
+      }
+
+      this._updatesSinceCompact = updates.length;
+    } catch (error) {
+      Log.warn('[DB] failed to sync shared collab IndexedDB data', { name: this.name, error });
+    } finally {
+      if (!this._destroyed) {
+        this.synced = true;
+        this.emit('synced', [this]);
+
+        if (this._updatesSinceCompact >= SHARED_COLLAB_COMPACT_UPDATE_THRESHOLD) {
+          this.queueCompact();
+        }
+      }
+    }
+
+    return this;
+  }
+
+  private _storeUpdate = (update: Uint8Array, origin: unknown) => {
+    if (this._destroyed || origin === this) {
+      return;
+    }
+
+    const persistedUpdate = new Uint8Array(update);
+
+    this._pendingWrite = this._pendingWrite
+      .then(async () => {
+        await db.collab_updates.add({
+          objectId: this.name,
+          update: persistedUpdate,
+          createdAt: Date.now(),
+          byteLength: persistedUpdate.byteLength,
+        });
+        this._updatesSinceCompact += 1;
+
+        if (this._updatesSinceCompact >= SHARED_COLLAB_COMPACT_UPDATE_THRESHOLD) {
+          await this.compact();
+        }
+      })
+      .catch((error) => {
+        Log.warn('[DB] failed to persist shared collab update', { name: this.name, error });
+      });
+  };
+
+  private queueCompact() {
+    this._pendingWrite = this._pendingWrite.then(() => this.compact()).catch((error) => {
+      Log.warn('[DB] failed to compact shared collab updates', { name: this.name, error });
+    });
+  }
+
+  private async compact() {
+    if (this._destroyed) return;
+
+    for (let attempt = 0; attempt < SHARED_COLLAB_COMPACT_MAX_RETRIES; attempt += 1) {
+      const baseSnapshot = await db.collab_snapshots.get(this.name);
+      const baseSnapshotToken = getSharedCollabSnapshotToken(baseSnapshot);
+      const compactedRecords = await db.collab_updates
+        .where('[objectId+id]')
+        .between([this.name, BaseDexie.minKey], [this.name, BaseDexie.maxKey])
+        .toArray();
+
+      if (this._destroyed) return;
+
+      if (baseSnapshot?.update) {
+        Y.applyUpdate(this.doc, baseSnapshot.update, this);
+      }
+
+      if (compactedRecords.length > 0) {
+        Y.transact(
+          this.doc,
+          () => {
+            compactedRecords.forEach((record) => {
+              Y.applyUpdate(this.doc, record.update, this);
+            });
+          },
+          this
+        );
+      }
+
+      const update = Y.encodeStateAsUpdate(this.doc);
+      const stateVector = Y.encodeStateVector(this.doc);
+      const compactedIds = compactedRecords.flatMap((record) => (typeof record.id === 'number' ? [record.id] : []));
+      const compactionId = createSharedCollabSnapshotId();
+      let remainingUpdateCount = 0;
+
+      try {
+        await db.transaction('rw', db.collab_snapshots, db.collab_updates, async () => {
+          const currentSnapshot = await db.collab_snapshots.get(this.name);
+
+          if (getSharedCollabSnapshotToken(currentSnapshot) !== baseSnapshotToken) {
+            throw new SharedCollabCompactionRetry();
+          }
+
+          await db.collab_snapshots.put({
+            objectId: this.name,
+            update,
+            stateVector,
+            version: this.doc.version ?? null,
+            compactionId,
+            updatedAt: Date.now(),
+            byteLength: update.byteLength,
+          });
+
+          if (compactedIds.length > 0) {
+            await db.collab_updates.bulkDelete(compactedIds);
+          }
+
+          remainingUpdateCount = await db.collab_updates.where('objectId').equals(this.name).count();
+        });
+
+        this._updatesSinceCompact = remainingUpdateCount;
+        return;
+      } catch (error) {
+        if (shouldRetrySharedCollabCompaction(error)) {
+          continue;
+        }
+
+        throw error;
+      }
+    }
+
+    this._updatesSinceCompact = await db.collab_updates.where('objectId').equals(this.name).count();
+  }
+
+  async destroy() {
+    if (this._destroyed) {
+      await this._pendingWrite.catch(() => undefined);
+      return;
+    }
+
+    this.doc.off('update', this._storeUpdate);
+    this.doc.off('destroy', this.destroy);
+    this._destroyed = true;
+    this._listeners.clear();
+    await this._pendingWrite.catch(() => undefined);
+  }
+
+  async clearData() {
+    await this.destroy();
+    await deleteSharedCollabData(this.name);
+  }
+
+  async get(key: IDBValidKey) {
+    return db.collab_custom.get([this.name, String(key)]).then((record) => record?.value);
+  }
+
+  async set(key: IDBValidKey, value: unknown) {
+    await db.collab_custom.put({
+      objectId: this.name,
+      key: String(key),
+      value,
+    });
+
+    return value;
+  }
+
+  async del(key: IDBValidKey) {
+    await db.collab_custom.delete([this.name, String(key)]);
+  }
+}
+
+async function destroyProviderEntry(entry: CachedProviderEntry, options: { destroyDoc?: boolean } = {}) {
+  entry.settleWhenDisposed();
+  await entry.provider.destroy();
+
+  if (options.destroyDoc !== false) {
+    entry.doc.destroy();
+  }
+}
+
+async function disposeCachedProvider(name: string, options: { destroyDoc?: boolean } = {}) {
+  let disposed = false;
+  const pending = pendingOpens.get(name);
+
+  if (pending) {
+    pendingOpens.delete(name);
+
+    try {
+      const entry = await pending;
+
+      if (providerCache.get(name) === entry) {
+        providerCache.delete(name);
+      }
+
+      await destroyProviderEntry(entry, options);
+      disposed = true;
+    } catch (error) {
+      Log.warn('[DB] failed to dispose pending collab provider', { name, error });
+    }
+  }
+
+  const cached = providerCache.get(name);
+
+  providerCache.delete(name);
+  pendingOpens.delete(name);
+
+  if (cached) {
+    await destroyProviderEntry(cached, options);
+    disposed = true;
+  }
+
+  return disposed;
+}
+
+async function disposeRowProvider(name: string, options: { destroyDoc?: boolean } = {}) {
+  let disposed = false;
+  const pending = pendingRowOpens.get(name);
+
+  if (pending) {
+    pendingRowOpens.delete(name);
+
+    try {
+      const entry = await pending;
+
+      if (rowProviderCache.get(name) === entry) {
+        rowProviderCache.delete(name);
+      }
+
+      await destroyProviderEntry(entry, options);
+      disposed = true;
+    } catch (error) {
+      Log.warn('[DB] failed to dispose pending shared row provider', { name, error });
+    }
+  }
+
+  const cached = rowProviderCache.get(name);
+
+  rowProviderCache.delete(name);
+  pendingRowOpens.delete(name);
+
+  if (cached) {
+    await destroyProviderEntry(cached, options);
+    disposed = true;
+  }
+
+  return disposed;
+}
+
+async function deleteIndexedDBDatabase(name: string) {
+  if (typeof indexedDB === 'undefined') return true;
+
+  return new Promise<boolean>((resolve) => {
+    const request = indexedDB.deleteDatabase(name);
+
+    request.onsuccess = () => resolve(true);
+    request.onerror = () => {
+      Log.warn('[DB] failed to delete collab IndexedDB database', { name, error: request.error });
+      resolve(false);
+    };
+
+    request.onblocked = () => {
+      Log.warn('[DB] delete collab IndexedDB database blocked', { name });
+      resolve(false);
+    };
+  });
+}
+
+async function deleteSharedCollabData(name: string) {
+  if (typeof indexedDB === 'undefined') return true;
+
+  try {
+    await db.transaction('rw', db.collab_snapshots, db.collab_updates, db.collab_custom, async () => {
+      await db.collab_snapshots.delete(name);
+      await db.collab_updates.where('objectId').equals(name).delete();
+      await db.collab_custom.where('objectId').equals(name).delete();
+    });
+
+    return true;
+  } catch (error) {
+    Log.warn('[DB] failed to delete shared collab data', { name, error });
+    return false;
+  }
+}
 
 /**
  * Open the collaboration database, and return a function to close it
@@ -243,28 +748,36 @@ export async function openCollabDBWithProvider(
     const entry = await _openCollabDBWithProviderInternal(name, options);
 
     if (options.awaitSync !== false) {
-      await entry.whenSynced;
+      await waitForProviderEntry(name, entry);
     }
 
-    return { doc: entry.doc, provider: entry.provider };
+    if (entry.disposed) {
+      throw new CollabProviderDisposedError(name);
+    }
+
+    return { doc: entry.doc, provider: entry.provider as IndexeddbPersistence };
   }
 
   const needsReset = options?.forceReset || options?.expectedVersion;
 
   if (needsReset) {
-    // Evict stale entry so a fresh one is created below
-    providerCache.delete(name);
-    pendingOpens.delete(name);
+    // Close stale connections before deleting/reopening this object's IndexedDB.
+    await disposeCachedProvider(name);
   } else {
     // Check providerCache for a resolved entry
     const cached = providerCache.get(name);
 
     if (cached) {
       if (options?.awaitSync !== false) {
-        await cached.whenSynced;
+        await waitForProviderEntry(name, cached);
       }
 
-      return { doc: cached.doc, provider: cached.provider };
+      if (cached.disposed) {
+        providerCache.delete(name);
+        throw new CollabProviderDisposedError(name);
+      }
+
+      return { doc: cached.doc, provider: cached.provider as IndexeddbPersistence };
     }
 
     // Join an in-flight open for the same name
@@ -274,10 +787,14 @@ export async function openCollabDBWithProvider(
       const entry = await pending;
 
       if (options?.awaitSync !== false) {
-        await entry.whenSynced;
+        await waitForProviderEntry(name, entry);
       }
 
-      return { doc: entry.doc, provider: entry.provider };
+      if (entry.disposed) {
+        throw new CollabProviderDisposedError(name);
+      }
+
+      return { doc: entry.doc, provider: entry.provider as IndexeddbPersistence };
     }
   }
 
@@ -289,25 +806,159 @@ export async function openCollabDBWithProvider(
   try {
     const entry = await promise;
 
-    providerCache.set(name, entry);
+    if (pendingOpens.get(name) === promise) {
+      providerCache.set(name, entry);
 
-    // Auto-evict if the doc is destroyed via an external path
-    // (e.g., handleAccessChanged, version revert) so subsequent
-    // callers don't receive a stale, destroyed Y.Doc.
-    entry.doc.on('destroy', () => {
-      if (providerCache.get(name) === entry) {
-        providerCache.delete(name);
-      }
-    });
-
-    if (options?.awaitSync !== false) {
-      await entry.whenSynced;
+      // Auto-evict if the doc is destroyed via an external path
+      // (e.g., handleAccessChanged, version revert) so subsequent
+      // callers don't receive a stale, destroyed Y.Doc.
+      entry.doc.on('destroy', () => {
+        if (providerCache.get(name) === entry) {
+          providerCache.delete(name);
+        }
+      });
     }
 
-    return { doc: entry.doc, provider: entry.provider };
+    if (options?.awaitSync !== false) {
+      await waitForProviderEntry(name, entry);
+    }
+
+    if (entry.disposed) {
+      throw new CollabProviderDisposedError(name);
+    }
+
+    return { doc: entry.doc, provider: entry.provider as IndexeddbPersistence };
   } finally {
-    pendingOpens.delete(name);
+    if (pendingOpens.get(name) === promise) {
+      pendingOpens.delete(name);
+    }
   }
+}
+
+export async function openRowCollabDBWithProvider(
+  name: string,
+  options?: SharedCollabOpenOptions
+): Promise<{ doc: YDoc; provider: SharedIndexeddbPersistence }> {
+  if (options?.skipCache) {
+    const entry = await _openRowCollabDBWithProviderInternal(name, options);
+
+    if (options.awaitSync !== false) {
+      await waitForProviderEntry(name, entry);
+    }
+
+    if (entry.disposed) {
+      throw new CollabProviderDisposedError(name);
+    }
+
+    return { doc: entry.doc, provider: entry.provider as SharedIndexeddbPersistence };
+  }
+
+  const needsReset = options?.forceReset || options?.expectedVersion;
+
+  if (needsReset) {
+    await disposeRowProvider(name);
+  } else {
+    const cached = rowProviderCache.get(name);
+
+    if (cached) {
+      if (options?.awaitSync !== false) {
+        await waitForProviderEntry(name, cached);
+      }
+
+      if (cached.disposed) {
+        rowProviderCache.delete(name);
+        throw new CollabProviderDisposedError(name);
+      }
+
+      return { doc: cached.doc, provider: cached.provider as SharedIndexeddbPersistence };
+    }
+
+    const pending = pendingRowOpens.get(name);
+
+    if (pending) {
+      const entry = await pending;
+
+      if (options?.awaitSync !== false) {
+        await waitForProviderEntry(name, entry);
+      }
+
+      if (entry.disposed) {
+        throw new CollabProviderDisposedError(name);
+      }
+
+      return { doc: entry.doc, provider: entry.provider as SharedIndexeddbPersistence };
+    }
+  }
+
+  const promise = _openRowCollabDBWithProviderInternal(name, options);
+
+  pendingRowOpens.set(name, promise);
+
+  try {
+    const entry = await promise;
+
+    if (pendingRowOpens.get(name) === promise) {
+      rowProviderCache.set(name, entry);
+      entry.doc.on('destroy', () => {
+        if (rowProviderCache.get(name) === entry) {
+          rowProviderCache.delete(name);
+        }
+      });
+    }
+
+    if (options?.awaitSync !== false) {
+      await waitForProviderEntry(name, entry);
+    }
+
+    if (entry.disposed) {
+      throw new CollabProviderDisposedError(name);
+    }
+
+    return { doc: entry.doc, provider: entry.provider as SharedIndexeddbPersistence };
+  } finally {
+    if (pendingRowOpens.get(name) === promise) {
+      pendingRowOpens.delete(name);
+    }
+  }
+}
+
+async function _openRowCollabDBWithProviderInternal(
+  name: string,
+  options?: { expectedVersion?: string; forceReset?: boolean }
+): Promise<CachedProviderEntry> {
+  const startedAt = Date.now();
+  let doc = new Y.Doc({
+    guid: name,
+  }) as YDoc;
+  let provider = new SharedIndexeddbPersistence(name, doc);
+  let version = await provider.get(name + '/version') as string | undefined;
+
+  if (options?.forceReset || (options?.expectedVersion && version !== options.expectedVersion)) {
+    await provider.destroy();
+    doc.destroy();
+
+    const deleted = await deleteSharedCollabData(name);
+
+    if (!deleted) {
+      throw new Error(`Failed to delete shared IndexedDB data for collab ${name}`);
+    }
+
+    doc = new Y.Doc({
+      guid: name,
+    }) as YDoc;
+    provider = new SharedIndexeddbPersistence(name, doc);
+
+    if (options?.expectedVersion) {
+      await provider.set(name + '/version', options.expectedVersion);
+      version = options.expectedVersion;
+    } else {
+      version = undefined;
+    }
+  }
+
+  doc.version = version;
+
+  return createCachedProviderEntry(name, startedAt, doc, provider);
 }
 
 async function _openCollabDBWithProviderInternal(
@@ -331,7 +982,16 @@ async function _openCollabDBWithProviderInternal(
   let version = await provider.get(name + '/version');
 
   if (options?.forceReset || (options?.expectedVersion && version !== options.expectedVersion)) {
-    await provider.clearData();
+    await provider.destroy();
+    doc.destroy();
+
+    const deleted = await deleteIndexedDBDatabase(name);
+
+    if (!deleted) {
+      throw new Error(`Failed to delete IndexedDB database for collab ${name}`);
+    }
+
+    await ensureYjsStores(name);
     doc = new Y.Doc({
       guid: name,
     }) as YDoc;
@@ -347,30 +1007,7 @@ async function _openCollabDBWithProviderInternal(
 
   doc.version = version;
 
-  const whenSynced = new Promise<void>((resolve) => {
-    const handleSync = () => {
-      Log.debug('[DB] openCollabDBWithProvider synced', {
-        name,
-        syncDurationMs: Date.now() - startedAt,
-        wasOpened: openedSet.has(name),
-      });
-
-      if (!openedSet.has(name)) {
-        openedSet.add(name);
-      }
-
-      resolve();
-    };
-
-    provider.on('synced', handleSync);
-
-    // If provider already synced before listener was attached
-    if ((provider as unknown as { synced?: boolean }).synced) {
-      handleSync();
-    }
-  });
-
-  return { doc, provider, whenSynced };
+  return createCachedProviderEntry(name, startedAt, doc, provider);
 }
 
 export async function closeCollabDB(name: string) {
@@ -378,18 +1015,14 @@ export async function closeCollabDB(name: string) {
     openedSet.delete(name);
   }
 
-  const cached = providerCache.get(name);
+  const disposed = await disposeCachedProvider(name);
+  const rowDisposed = await disposeRowProvider(name);
 
-  providerCache.delete(name);
-  pendingOpens.delete(name);
-
-  if (cached) {
-    await cached.provider.destroy();
-    cached.doc.destroy();
+  if (disposed || rowDisposed) {
     return;
   }
 
-  // No cached entry — create a temp provider to destroy the IndexedDB store
+  // No cached entry — create a temp provider so y-indexeddb has no live connection.
   const doc = new Y.Doc({
     guid: name,
   });
@@ -401,19 +1034,100 @@ export async function closeCollabDB(name: string) {
 }
 
 /**
+ * Destroy any in-memory provider/doc for the object and delete its y-indexeddb
+ * database. Call this only for authoritative invalidations: access revoked,
+ * object deleted, version reset/force reset, or row deleted.
+ */
+export async function deleteCollabDB(name: string, options: { destroyDoc?: boolean } = {}) {
+  if (!name) return false;
+
+  if (openedSet.has(name)) {
+    openedSet.delete(name);
+  }
+
+  ensuredStores.delete(name);
+  await disposeCachedProvider(name, options);
+  await disposeRowProvider(name, options);
+
+  const [indexedDbDeleted, sharedDataDeleted] = await Promise.all([
+    deleteIndexedDBDatabase(name),
+    deleteSharedCollabData(name),
+  ]);
+
+  if (indexedDbDeleted && sharedDataDeleted) {
+    Log.debug('[DB] deleted collab IndexedDB database', { name });
+  }
+
+  return indexedDbDeleted && sharedDataDeleted;
+}
+
+/**
  * Synchronously evict an entry from the provider cache.
  * Used by deleteRow / deleteRowSubDoc after they destroy the Y.Doc themselves.
  */
 export function evictProviderCache(name: string) {
   providerCache.delete(name);
   pendingOpens.delete(name);
+  rowProviderCache.delete(name);
+  pendingRowOpens.delete(name);
 }
 
 /**
  * Return the cached Y.Doc for a given name, if one exists in the provider cache.
  */
 export function getCachedProviderDoc(name: string): YDoc | undefined {
-  return providerCache.get(name)?.doc;
+  return providerCache.get(name)?.doc ?? rowProviderCache.get(name)?.doc;
+}
+
+function removeLocalStorageKeysByPrefix(prefix: string) {
+  if (typeof localStorage === 'undefined') return;
+
+  const keysToRemove: string[] = [];
+
+  for (let i = 0; i < localStorage.length; i += 1) {
+    const key = localStorage.key(i);
+
+    if (key?.startsWith(prefix)) {
+      keysToRemove.push(key);
+    }
+  }
+
+  keysToRemove.forEach((key) => localStorage.removeItem(key));
+}
+
+function clearBlobRidCheckpointsForDeletedDatabases(results: Array<{ name: string; deleted: boolean }>) {
+  if (typeof localStorage === 'undefined') return;
+
+  const sharedCacheDeleted = results.some(({ name, deleted }) => deleted && name === db.name);
+  const allDatabasesDeleted = results.every((result) => result.deleted);
+
+  if (sharedCacheDeleted || allDatabasesDeleted) {
+    removeLocalStorageKeysByPrefix(DATABASE_BLOB_RID_PREFIX);
+    return;
+  }
+
+  const deletedDatabaseIds = new Set<string>();
+  const blockedDatabaseIds = new Set<string>();
+
+  results.forEach(({ name, deleted }) => {
+    if (!name) return;
+    const markerIndex = name.indexOf('_rows_');
+
+    if (markerIndex <= 0) return;
+    const databaseId = name.slice(0, markerIndex);
+
+    if (!databaseId) return;
+    if (deleted) {
+      deletedDatabaseIds.add(databaseId);
+    } else {
+      blockedDatabaseIds.add(databaseId);
+    }
+  });
+
+  deletedDatabaseIds.forEach((databaseId) => {
+    if (blockedDatabaseIds.has(databaseId)) return;
+    localStorage.removeItem(`${DATABASE_BLOB_RID_PREFIX}${databaseId}`);
+  });
 }
 
 export async function clearData() {
@@ -461,28 +1175,7 @@ export async function clearData() {
     const results = await Promise.all(databases.map(deleteDatabase));
 
     try {
-      const deletedDatabaseIds = new Set<string>();
-      const blockedDatabaseIds = new Set<string>();
-
-      results.forEach(({ name, deleted }) => {
-        if (!name) return;
-        const markerIndex = name.indexOf('_rows_');
-
-        if (markerIndex <= 0) return;
-        const databaseId = name.slice(0, markerIndex);
-
-        if (!databaseId) return;
-        if (deleted) {
-          deletedDatabaseIds.add(databaseId);
-        } else {
-          blockedDatabaseIds.add(databaseId);
-        }
-      });
-
-      deletedDatabaseIds.forEach((databaseId) => {
-        if (blockedDatabaseIds.has(databaseId)) return;
-        localStorage.removeItem(`af_database_blob_rid:${databaseId}`);
-      });
+      clearBlobRidCheckpointsForDeletedDatabases(results);
     } catch {
       // Ignore localStorage failures (private mode/quota).
     }
@@ -493,3 +1186,11 @@ export async function clearData() {
     return false;
   }
 }
+
+export const __dbTestUtils = {
+  createCachedProviderEntry,
+  clearBlobRidCheckpointsForDeletedDatabases,
+  destroyProviderEntry,
+  readSharedCollabRecordsForSync,
+  waitForProviderEntry,
+};

--- a/src/application/db/index.ts
+++ b/src/application/db/index.ts
@@ -237,10 +237,79 @@ export async function listCollabIndexedDBNames() {
   }
 }
 
+async function probeCollabIndexedDBExists(name: string) {
+  if (typeof indexedDB === 'undefined') return false;
+
+  return new Promise<boolean>((resolve) => {
+    let createdDuringProbe = false;
+    let settled = false;
+    const resolveOnce = (exists: boolean) => {
+      if (settled) return;
+
+      settled = true;
+      resolve(exists);
+    };
+
+    try {
+      const request = indexedDB.open(name);
+
+      request.onupgradeneeded = () => {
+        createdDuringProbe = true;
+      };
+
+      request.onsuccess = async () => {
+        const database = request.result;
+
+        database.close();
+
+        if (createdDuringProbe) {
+          const deleted = await deleteIndexedDBDatabase(name);
+
+          if (!deleted) {
+            Log.warn('[DB] failed to delete empty IndexedDB database created while probing existence', { name });
+          }
+
+          resolveOnce(false);
+          return;
+        }
+
+        resolveOnce(true);
+      };
+
+      request.onerror = () => {
+        Log.warn('[DB] failed to probe collab IndexedDB database', { name, error: request.error });
+        resolveOnce(false);
+      };
+
+      request.onblocked = () => {
+        Log.warn('[DB] collab IndexedDB existence probe blocked', { name });
+        resolveOnce(false);
+      };
+    } catch (error) {
+      Log.warn('[DB] failed to probe collab IndexedDB database', { name, error });
+      resolveOnce(false);
+    }
+  });
+}
+
 export async function collabIndexedDBExists(name: string) {
   if (!name) return false;
 
-  return (await listCollabIndexedDBNames()).has(name);
+  if (typeof indexedDB === 'undefined') return false;
+
+  const indexedDBWithDatabases = indexedDB as IndexedDBFactoryWithDatabases;
+
+  if (typeof indexedDBWithDatabases.databases === 'function') {
+    try {
+      const databases = await indexedDBWithDatabases.databases();
+
+      return databases.some((database) => database.name === name);
+    } catch (error) {
+      Log.warn('[DB] failed to list IndexedDB databases while checking collab existence', { name, error });
+    }
+  }
+
+  return probeCollabIndexedDBExists(name);
 }
 
 export interface OpenCollabOptions {

--- a/src/application/db/tables/collab_storage.ts
+++ b/src/application/db/tables/collab_storage.ts
@@ -1,0 +1,37 @@
+import { Table } from 'dexie';
+
+export interface CollabSnapshotRecord {
+  objectId: string;
+  update: Uint8Array;
+  stateVector: Uint8Array;
+  version?: string | null;
+  compactionId?: string;
+  updatedAt: number;
+  byteLength: number;
+}
+
+export interface CollabUpdateRecord {
+  id?: number;
+  objectId: string;
+  update: Uint8Array;
+  createdAt: number;
+  byteLength: number;
+}
+
+export interface CollabCustomRecord {
+  objectId: string;
+  key: string;
+  value: unknown;
+}
+
+export type CollabStorageTable = {
+  collab_snapshots: Table<CollabSnapshotRecord, string>;
+  collab_updates: Table<CollabUpdateRecord, number>;
+  collab_custom: Table<CollabCustomRecord, [string, string]>;
+};
+
+export const collabStorageSchema = {
+  collab_snapshots: 'objectId, updatedAt',
+  collab_updates: '++id, objectId, [objectId+id]',
+  collab_custom: '[objectId+key], objectId',
+};

--- a/src/application/services/js-services/cache/__tests__/cache.test.ts
+++ b/src/application/services/js-services/cache/__tests__/cache.test.ts
@@ -1,8 +1,15 @@
-import { Types } from '@/application/types';
+import * as Y from 'yjs';
+import { Types, YDoc, YjsDatabaseKey, YjsEditorKey } from '@/application/types';
 import { withTestingYDoc } from '@/application/slate-yjs/__tests__/withTestingYjsEditor';
 import { expect } from '@jest/globals';
-import { collabTypeToDBType, getPublishView, getPublishViewMeta } from '@/application/services/js-services/cache';
-import { openCollabDB, db } from '@/application/db';
+import {
+  collabTypeToDBType,
+  getPublishView,
+  getPublishViewMeta,
+  mergeLegacyRowDocIfExists,
+} from '@/application/services/js-services/cache';
+import { applyYDoc } from '@/application/ydoc/apply';
+import { openCollabDB, openCollabDBWithProvider, collabIndexedDBExists, db } from '@/application/db';
 import { StrategyType } from '@/application/services/js-services/cache/types';
 
 jest.mock('@/application/ydoc/apply', () => ({
@@ -11,6 +18,11 @@ jest.mock('@/application/ydoc/apply', () => ({
 
 jest.mock('@/application/db', () => ({
   openCollabDB: jest.fn(),
+  openCollabDBWithProvider: jest.fn(),
+  openRowCollabDBWithProvider: jest.fn(),
+  collabIndexedDBExists: jest.fn(),
+  closeCollabDB: jest.fn(),
+  evictProviderCache: jest.fn(),
   db: {
     view_metas: {
       get: jest.fn(),
@@ -21,6 +33,37 @@ jest.mock('@/application/db', () => ({
 
 const normalDoc = withTestingYDoc('1');
 const mockFetcher = jest.fn();
+const mockedApplyYDoc = applyYDoc as jest.MockedFunction<typeof applyYDoc>;
+const mockedOpenCollabDBWithProvider = openCollabDBWithProvider as jest.MockedFunction<typeof openCollabDBWithProvider>;
+const mockedCollabIndexedDBExists = collabIndexedDBExists as jest.MockedFunction<typeof collabIndexedDBExists>;
+
+function createRowDoc(rowId: string, databaseId: string, cells: Record<string, unknown>) {
+  const doc = new Y.Doc() as YDoc;
+  const sharedRoot = doc.getMap(YjsEditorKey.data_section);
+  const row = new Y.Map();
+  const cellMap = new Y.Map();
+
+  sharedRoot.set(YjsEditorKey.database_row, row);
+  row.set(YjsDatabaseKey.id, rowId);
+  row.set(YjsDatabaseKey.database_id, databaseId);
+  row.set(YjsDatabaseKey.cells, cellMap);
+
+  Object.entries(cells).forEach(([fieldId, data]) => {
+    const cell = new Y.Map();
+
+    cell.set(YjsDatabaseKey.data, data);
+    cellMap.set(fieldId, cell);
+  });
+
+  return doc;
+}
+
+function getCellData(doc: YDoc, fieldId: string) {
+  const row = doc.getMap(YjsEditorKey.data_section).get(YjsEditorKey.database_row) as Y.Map<unknown> | undefined;
+  const cells = row?.get(YjsDatabaseKey.cells) as Y.Map<Y.Map<unknown>> | undefined;
+
+  return cells?.get(fieldId)?.get(YjsDatabaseKey.data);
+}
 
 async function runTestWithStrategy (strategy: StrategyType) {
   return getPublishView(
@@ -110,6 +153,37 @@ describe('Cache functions', () => {
       expect(openCollabDB).toBeCalledTimes(0);
       expect(mockFetcher).toBeCalledTimes(1);
     });
+  });
+});
+
+describe('database row legacy cache migration', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedApplyYDoc.mockImplementation((doc, state) => {
+      Y.applyUpdate(doc, state);
+    });
+  });
+
+  it('merges legacy row updates even when shared row storage already has row data', async () => {
+    const rowId = 'row-legacy-merge';
+    const databaseId = 'database-legacy-merge';
+    const rowKey = `${databaseId}_rows_${rowId}`;
+    const sharedDoc = createRowDoc(rowId, databaseId, { 'server-field': 'server-value' });
+    const legacyDoc = createRowDoc(rowId, databaseId, { 'legacy-field': 'legacy-value' });
+    const legacyProvider = { destroy: jest.fn().mockResolvedValue(undefined) };
+
+    mockedCollabIndexedDBExists.mockResolvedValue(true);
+    mockedOpenCollabDBWithProvider.mockResolvedValue({
+      doc: legacyDoc,
+      provider: legacyProvider,
+    } as never);
+
+    await expect(mergeLegacyRowDocIfExists(rowKey, rowId, sharedDoc)).resolves.toBe(true);
+
+    expect(mockedCollabIndexedDBExists).toHaveBeenCalledWith(rowKey);
+    expect(getCellData(sharedDoc, 'server-field')).toBe('server-value');
+    expect(getCellData(sharedDoc, 'legacy-field')).toBe('legacy-value');
+    expect(legacyProvider.destroy).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/src/application/services/js-services/cache/__tests__/cache.test.ts
+++ b/src/application/services/js-services/cache/__tests__/cache.test.ts
@@ -9,7 +9,7 @@ import {
   mergeLegacyRowDocIfExists,
 } from '@/application/services/js-services/cache';
 import { applyYDoc } from '@/application/ydoc/apply';
-import { openCollabDB, openCollabDBWithProvider, collabIndexedDBExists, db } from '@/application/db';
+import { openCollabDB, openCollabDBWithProvider, collabIndexedDBExists, db, deleteCollabDB } from '@/application/db';
 import { StrategyType } from '@/application/services/js-services/cache/types';
 
 jest.mock('@/application/ydoc/apply', () => ({
@@ -22,9 +22,14 @@ jest.mock('@/application/db', () => ({
   openRowCollabDBWithProvider: jest.fn(),
   collabIndexedDBExists: jest.fn(),
   closeCollabDB: jest.fn(),
+  deleteCollabDB: jest.fn(),
   evictProviderCache: jest.fn(),
   db: {
     view_metas: {
+      get: jest.fn(),
+      put: jest.fn(),
+    },
+    collab_custom: {
       get: jest.fn(),
       put: jest.fn(),
     },
@@ -36,6 +41,7 @@ const mockFetcher = jest.fn();
 const mockedApplyYDoc = applyYDoc as jest.MockedFunction<typeof applyYDoc>;
 const mockedOpenCollabDBWithProvider = openCollabDBWithProvider as jest.MockedFunction<typeof openCollabDBWithProvider>;
 const mockedCollabIndexedDBExists = collabIndexedDBExists as jest.MockedFunction<typeof collabIndexedDBExists>;
+const mockedDeleteCollabDB = deleteCollabDB as jest.MockedFunction<typeof deleteCollabDB>;
 
 function createRowDoc(rowId: string, databaseId: string, cells: Record<string, unknown>) {
   const doc = new Y.Doc() as YDoc;
@@ -159,6 +165,9 @@ describe('Cache functions', () => {
 describe('database row legacy cache migration', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    (db.collab_custom.get as jest.Mock).mockResolvedValue(undefined);
+    (db.collab_custom.put as jest.Mock).mockResolvedValue(undefined);
+    mockedDeleteCollabDB.mockResolvedValue(true);
     mockedApplyYDoc.mockImplementation((doc, state) => {
       Y.applyUpdate(doc, state);
     });
@@ -183,7 +192,93 @@ describe('database row legacy cache migration', () => {
     expect(mockedCollabIndexedDBExists).toHaveBeenCalledWith(rowKey);
     expect(getCellData(sharedDoc, 'server-field')).toBe('server-value');
     expect(getCellData(sharedDoc, 'legacy-field')).toBe('legacy-value');
+    expect(db.collab_custom.put).toHaveBeenCalledWith(
+      expect.objectContaining({
+        objectId: rowId,
+        key: `legacy-row-backfill:${rowKey}`,
+      })
+    );
+    expect(mockedDeleteCollabDB).toHaveBeenCalledWith(rowKey);
     expect(legacyProvider.destroy).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not overwrite existing shared row cells with stale legacy data', async () => {
+    const rowId = 'row-legacy-stale';
+    const databaseId = 'database-legacy-stale';
+    const rowKey = `${databaseId}_rows_${rowId}`;
+    const sharedDoc = createRowDoc(rowId, databaseId, {
+      'same-field': 'current-value',
+      'server-field': 'server-value',
+    });
+    const legacyDoc = createRowDoc(rowId, databaseId, {
+      'same-field': 'stale-value',
+      'legacy-field': 'legacy-value',
+    });
+    const legacyProvider = { destroy: jest.fn().mockResolvedValue(undefined) };
+
+    mockedCollabIndexedDBExists.mockResolvedValue(true);
+    mockedOpenCollabDBWithProvider.mockResolvedValue({
+      doc: legacyDoc,
+      provider: legacyProvider,
+    } as never);
+
+    await expect(mergeLegacyRowDocIfExists(rowKey, rowId, sharedDoc)).resolves.toBe(true);
+
+    expect(getCellData(sharedDoc, 'same-field')).toBe('current-value');
+    expect(getCellData(sharedDoc, 'server-field')).toBe('server-value');
+    expect(getCellData(sharedDoc, 'legacy-field')).toBe('legacy-value');
+    expect(db.collab_custom.put).toHaveBeenCalledWith(
+      expect.objectContaining({
+        objectId: rowId,
+        key: `legacy-row-backfill:${rowKey}`,
+      })
+    );
+    expect(mockedDeleteCollabDB).toHaveBeenCalledWith(rowKey);
+    expect(legacyProvider.destroy).toHaveBeenCalledTimes(1);
+  });
+
+  it('marks the legacy row cache consumed even when it has no missing data to merge', async () => {
+    const rowId = 'row-legacy-noop';
+    const databaseId = 'database-legacy-noop';
+    const rowKey = `${databaseId}_rows_${rowId}`;
+    const sharedDoc = createRowDoc(rowId, databaseId, { 'same-field': 'current-value' });
+    const legacyDoc = createRowDoc(rowId, databaseId, { 'same-field': 'stale-value' });
+    const legacyProvider = { destroy: jest.fn().mockResolvedValue(undefined) };
+
+    mockedCollabIndexedDBExists.mockResolvedValue(true);
+    mockedOpenCollabDBWithProvider.mockResolvedValue({
+      doc: legacyDoc,
+      provider: legacyProvider,
+    } as never);
+
+    await expect(mergeLegacyRowDocIfExists(rowKey, rowId, sharedDoc)).resolves.toBe(false);
+
+    expect(getCellData(sharedDoc, 'same-field')).toBe('current-value');
+    expect(db.collab_custom.put).toHaveBeenCalledWith(
+      expect.objectContaining({
+        objectId: rowId,
+        key: `legacy-row-backfill:${rowKey}`,
+      })
+    );
+    expect(mockedDeleteCollabDB).toHaveBeenCalledWith(rowKey);
+    expect(legacyProvider.destroy).toHaveBeenCalledTimes(1);
+  });
+
+  it('skips legacy row migration after the one-time backfill marker exists', async () => {
+    const rowId = 'row-legacy-marked';
+    const databaseId = 'database-legacy-marked';
+    const rowKey = `${databaseId}_rows_${rowId}`;
+    const sharedDoc = createRowDoc(rowId, databaseId, { 'same-field': 'current-value' });
+
+    (db.collab_custom.get as jest.Mock).mockResolvedValue({ rowKey, migratedAt: Date.now() });
+
+    await expect(mergeLegacyRowDocIfExists(rowKey, rowId, sharedDoc)).resolves.toBe(false);
+
+    expect(mockedCollabIndexedDBExists).not.toHaveBeenCalled();
+    expect(mockedOpenCollabDBWithProvider).not.toHaveBeenCalled();
+    expect(db.collab_custom.put).not.toHaveBeenCalled();
+    expect(mockedDeleteCollabDB).not.toHaveBeenCalled();
+    expect(getCellData(sharedDoc, 'same-field')).toBe('current-value');
   });
 });
 

--- a/src/application/services/js-services/cache/__tests__/cache.test.ts
+++ b/src/application/services/js-services/cache/__tests__/cache.test.ts
@@ -202,16 +202,16 @@ describe('database row legacy cache migration', () => {
     expect(legacyProvider.destroy).toHaveBeenCalledTimes(1);
   });
 
-  it('does not overwrite existing shared row cells with stale legacy data', async () => {
-    const rowId = 'row-legacy-stale';
-    const databaseId = 'database-legacy-stale';
+  it('preserves target-only cells while importing legacy edits for existing cells', async () => {
+    const rowId = 'row-legacy-existing-cell';
+    const databaseId = 'database-legacy-existing-cell';
     const rowKey = `${databaseId}_rows_${rowId}`;
     const sharedDoc = createRowDoc(rowId, databaseId, {
-      'same-field': 'current-value',
+      'same-field': 'server-value',
       'server-field': 'server-value',
     });
     const legacyDoc = createRowDoc(rowId, databaseId, {
-      'same-field': 'stale-value',
+      'same-field': 'legacy-local-value',
       'legacy-field': 'legacy-value',
     });
     const legacyProvider = { destroy: jest.fn().mockResolvedValue(undefined) };
@@ -224,7 +224,7 @@ describe('database row legacy cache migration', () => {
 
     await expect(mergeLegacyRowDocIfExists(rowKey, rowId, sharedDoc)).resolves.toBe(true);
 
-    expect(getCellData(sharedDoc, 'same-field')).toBe('current-value');
+    expect(getCellData(sharedDoc, 'same-field')).toBe('legacy-local-value');
     expect(getCellData(sharedDoc, 'server-field')).toBe('server-value');
     expect(getCellData(sharedDoc, 'legacy-field')).toBe('legacy-value');
     expect(db.collab_custom.put).toHaveBeenCalledWith(
@@ -237,12 +237,12 @@ describe('database row legacy cache migration', () => {
     expect(legacyProvider.destroy).toHaveBeenCalledTimes(1);
   });
 
-  it('marks the legacy row cache consumed even when it has no missing data to merge', async () => {
+  it('marks the legacy row cache consumed when only existing cells were migrated', async () => {
     const rowId = 'row-legacy-noop';
     const databaseId = 'database-legacy-noop';
     const rowKey = `${databaseId}_rows_${rowId}`;
     const sharedDoc = createRowDoc(rowId, databaseId, { 'same-field': 'current-value' });
-    const legacyDoc = createRowDoc(rowId, databaseId, { 'same-field': 'stale-value' });
+    const legacyDoc = createRowDoc(rowId, databaseId, { 'same-field': 'legacy-local-value' });
     const legacyProvider = { destroy: jest.fn().mockResolvedValue(undefined) };
 
     mockedCollabIndexedDBExists.mockResolvedValue(true);
@@ -251,9 +251,9 @@ describe('database row legacy cache migration', () => {
       provider: legacyProvider,
     } as never);
 
-    await expect(mergeLegacyRowDocIfExists(rowKey, rowId, sharedDoc)).resolves.toBe(false);
+    await expect(mergeLegacyRowDocIfExists(rowKey, rowId, sharedDoc)).resolves.toBe(true);
 
-    expect(getCellData(sharedDoc, 'same-field')).toBe('current-value');
+    expect(getCellData(sharedDoc, 'same-field')).toBe('legacy-local-value');
     expect(db.collab_custom.put).toHaveBeenCalledWith(
       expect.objectContaining({
         objectId: rowId,

--- a/src/application/services/js-services/cache/index.ts
+++ b/src/application/services/js-services/cache/index.ts
@@ -3,7 +3,15 @@ import * as Y from 'yjs';
 import { invalidateRowConditionCache } from '@/application/database-yjs/condition-value-cache';
 import { migrateDatabaseFieldTypes } from '@/application/database-yjs/migrations/rollup_fieldtype';
 import { getRowKey } from '@/application/database-yjs/row_meta';
-import { closeCollabDB, db, evictProviderCache, openCollabDB, openCollabDBWithProvider } from '@/application/db';
+import {
+  closeCollabDB,
+  collabIndexedDBExists,
+  db,
+  evictProviderCache,
+  openCollabDB,
+  openCollabDBWithProvider,
+  openRowCollabDBWithProvider,
+} from '@/application/db';
 import { Fetcher, StrategyType } from '@/application/services/js-services/cache/types';
 import {
   DatabaseId,
@@ -463,6 +471,91 @@ let rowFastLogCount = 0;
 const rowDocs = new Map<string, RowDocEntry>();
 const pendingRowDocEntries = new Map<string, Promise<RowDocEntry>>();
 const appliedSeedBytesByDoc = new WeakMap<YDoc, WeakSet<Uint8Array>>();
+const ROW_KEY_SEPARATOR = '_rows_';
+
+function getRowObjectId(rowKey: string) {
+  const separatorIndex = rowKey.lastIndexOf(ROW_KEY_SEPARATOR);
+
+  if (separatorIndex < 0) {
+    return rowKey;
+  }
+
+  const rowObjectId = rowKey.slice(separatorIndex + ROW_KEY_SEPARATOR.length);
+
+  return rowObjectId || rowKey;
+}
+
+function hasDatabaseRow(doc: YDoc) {
+  return doc.getMap(YjsEditorKey.data_section).has(YjsEditorKey.database_row);
+}
+
+function cloneLegacyYjsValue(value: unknown): unknown {
+  if (value instanceof Uint8Array) {
+    return new Uint8Array(value);
+  }
+
+  if (value instanceof Y.Map) {
+    const clonedMap = new Y.Map<unknown>();
+
+    value.forEach((childValue, key) => {
+      clonedMap.set(key, cloneLegacyYjsValue(childValue));
+    });
+
+    return clonedMap;
+  }
+
+  if (value instanceof Y.Array) {
+    const clonedArray = new Y.Array<unknown>();
+
+    clonedArray.push(value.toArray().map(cloneLegacyYjsValue));
+    return clonedArray;
+  }
+
+  if (Array.isArray(value)) {
+    return value.map(cloneLegacyYjsValue);
+  }
+
+  if (value && typeof value === 'object') {
+    try {
+      return structuredClone(value);
+    } catch {
+      return JSON.parse(JSON.stringify(value));
+    }
+  }
+
+  return value;
+}
+
+function mergeLegacyYMapIntoTarget(target: Y.Map<unknown>, legacy: Y.Map<unknown>, overwriteExisting: boolean): boolean {
+  let merged = false;
+
+  legacy.forEach((legacyValue, key) => {
+    const targetValue = target.get(key);
+
+    if (targetValue instanceof Y.Map && legacyValue instanceof Y.Map) {
+      merged = mergeLegacyYMapIntoTarget(targetValue, legacyValue, true) || merged;
+      return;
+    }
+
+    if (!target.has(key) || overwriteExisting) {
+      target.set(key, cloneLegacyYjsValue(legacyValue));
+      merged = true;
+    }
+  });
+
+  return merged;
+}
+
+function mergeLegacyRowDataIntoExistingDoc(doc: YDoc, legacyDoc: YDoc): boolean {
+  const row = doc.getMap(YjsEditorKey.data_section).get(YjsEditorKey.database_row);
+  const legacyRow = legacyDoc.getMap(YjsEditorKey.data_section).get(YjsEditorKey.database_row);
+
+  if (!(row instanceof Y.Map) || !(legacyRow instanceof Y.Map)) {
+    return false;
+  }
+
+  return mergeLegacyYMapIntoTarget(row, legacyRow, true);
+}
 
 function hasAppliedSeed(doc: YDoc, seedBytes: Uint8Array) {
   return appliedSeedBytesByDoc.get(doc)?.has(seedBytes) ?? false;
@@ -479,14 +572,74 @@ function markSeedApplied(doc: YDoc, seedBytes: Uint8Array) {
   appliedSeeds.add(seedBytes);
 }
 
+export async function mergeLegacyRowDocIfExists(
+  rowKey: string,
+  rowObjectId: string,
+  doc: YDoc,
+  options: { legacyExists?: boolean } = {}
+) {
+  if (rowKey === rowObjectId) {
+    return false;
+  }
+
+  const legacyExists = options.legacyExists ?? (await collabIndexedDBExists(rowKey));
+
+  if (!legacyExists) {
+    return false;
+  }
+
+  const { doc: legacyDoc, provider } = await openCollabDBWithProvider(rowKey, { skipCache: true });
+
+  try {
+    if (!hasDatabaseRow(legacyDoc)) {
+      return false;
+    }
+
+    if (hasDatabaseRow(doc)) {
+      const merged = mergeLegacyRowDataIntoExistingDoc(doc, legacyDoc);
+
+      if (merged) {
+        invalidateRowConditionCache(doc);
+        Log.debug('[Database] merged legacy row IndexedDB cache into existing shared row', {
+          rowKey,
+          rowObjectId,
+        });
+      }
+
+      return merged;
+    }
+
+    const legacyUpdate = Y.encodeStateAsUpdate(legacyDoc, Y.encodeStateVector(doc));
+
+    // Yjs encodes an empty v1 update as two bytes. Nothing to merge.
+    if (legacyUpdate.byteLength <= 2) {
+      return false;
+    }
+
+    applyYDoc(doc, legacyUpdate);
+    invalidateRowConditionCache(doc);
+    Log.debug('[Database] migrated legacy row IndexedDB cache', {
+      rowKey,
+      rowObjectId,
+      bytes: legacyUpdate.byteLength,
+    });
+
+    return true;
+  } finally {
+    await provider.destroy();
+    legacyDoc.destroy();
+  }
+}
+
 async function getOrCreateRowDocEntry(rowKey: string): Promise<RowDocEntry> {
-  const existing = rowDocs.get(rowKey);
+  const rowObjectId = getRowObjectId(rowKey);
+  const existing = rowDocs.get(rowObjectId);
 
   if (existing) {
     return existing;
   }
 
-  const pending = pendingRowDocEntries.get(rowKey);
+  const pending = pendingRowDocEntries.get(rowObjectId);
 
   if (pending) {
     return pending;
@@ -496,33 +649,33 @@ async function getOrCreateRowDocEntry(rowKey: string): Promise<RowDocEntry> {
     // providerCache in openCollabDBWithProvider handles provider-level dedup;
     // this map prevents duplicate row doc entry creation while the first open
     // is still awaiting IndexedDB/provider setup.
-    const entry = await _createRowDocEntry(rowKey);
+    const entry = await _createRowDocEntry(rowKey, rowObjectId);
 
     // Post-await race check: another caller may have populated rowDocs.
-    const raceWinner = rowDocs.get(rowKey);
+    const raceWinner = rowDocs.get(rowObjectId);
 
     if (raceWinner) {
       return raceWinner;
     }
 
-    rowDocs.set(rowKey, entry);
+    rowDocs.set(rowObjectId, entry);
     return entry;
   })();
 
-  pendingRowDocEntries.set(rowKey, promise);
+  pendingRowDocEntries.set(rowObjectId, promise);
 
   try {
     return await promise;
   } finally {
-    if (pendingRowDocEntries.get(rowKey) === promise) {
-      pendingRowDocEntries.delete(rowKey);
+    if (pendingRowDocEntries.get(rowObjectId) === promise) {
+      pendingRowDocEntries.delete(rowObjectId);
     }
   }
 }
 
-async function _createRowDocEntry(rowKey: string): Promise<RowDocEntry> {
+async function _createRowDocEntry(rowKey: string, rowObjectId: string): Promise<RowDocEntry> {
   const startedAt = Date.now();
-  const { doc, provider } = await openCollabDBWithProvider(rowKey, { awaitSync: false });
+  const { doc, provider } = await openRowCollabDBWithProvider(rowObjectId, { awaitSync: false });
 
   // Check initial state immediately after opening
   const initialSharedRoot = doc.getMap(YjsEditorKey.data_section);
@@ -530,12 +683,13 @@ async function _createRowDocEntry(rowKey: string): Promise<RowDocEntry> {
 
   Log.debug('[Database] getOrCreateRowDocEntry opened (before sync)', {
     rowKey,
+    rowObjectId,
     openDurationMs: Date.now() - startedAt,
     providerSynced: provider.synced,
     hasRowDataBeforeSync: initialHasRowData,
   });
 
-  const whenSynced = provider.synced
+  const syncedPromise = provider.synced
     ? Promise.resolve()
     : new Promise<void>((resolve) => {
         provider.on('synced', () => {
@@ -546,6 +700,7 @@ async function _createRowDocEntry(rowKey: string): Promise<RowDocEntry> {
 
             Log.debug('[Database] row doc IndexedDB synced', {
               rowKey,
+              rowObjectId,
               durationMs: Date.now() - startedAt,
               hasRowDataAfterSync: hasRowData,
               hadRowDataBeforeSync: initialHasRowData,
@@ -555,6 +710,13 @@ async function _createRowDocEntry(rowKey: string): Promise<RowDocEntry> {
           resolve();
         });
       });
+  const whenSynced = syncedPromise
+    .then(async () => {
+      await mergeLegacyRowDocIfExists(rowKey, rowObjectId, doc);
+    })
+    .catch((error) => {
+      Log.warn('[Database] row doc IndexedDB sync failed', { rowKey, rowObjectId, error });
+    });
 
   return { doc, whenSynced };
 }
@@ -612,18 +774,20 @@ export async function openRowDoc(rowKey: string, seed?: { bytes: Uint8Array; enc
 }
 
 export function getCachedRowDoc(rowKey: string): YDoc | undefined {
-  return rowDocs.get(rowKey)?.doc;
+  return rowDocs.get(getRowObjectId(rowKey))?.doc;
 }
 
 export function deleteRow(rowKey: string) {
-  const entry = rowDocs.get(rowKey);
+  const rowObjectId = getRowObjectId(rowKey);
+  const entry = rowDocs.get(rowObjectId);
+
+  rowDocs.delete(rowObjectId);
 
   if (entry) {
     entry.doc.destroy();
   }
 
-  rowDocs.delete(rowKey);
-  evictProviderCache(rowKey);
+  evictProviderCache(rowObjectId);
 }
 
 // ============================================================================

--- a/src/application/services/js-services/cache/index.ts
+++ b/src/application/services/js-services/cache/index.ts
@@ -7,6 +7,7 @@ import {
   closeCollabDB,
   collabIndexedDBExists,
   db,
+  deleteCollabDB,
   evictProviderCache,
   openCollabDB,
   openCollabDBWithProvider,
@@ -472,6 +473,7 @@ const rowDocs = new Map<string, RowDocEntry>();
 const pendingRowDocEntries = new Map<string, Promise<RowDocEntry>>();
 const appliedSeedBytesByDoc = new WeakMap<YDoc, WeakSet<Uint8Array>>();
 const ROW_KEY_SEPARATOR = '_rows_';
+const LEGACY_ROW_BACKFILL_MARKER_PREFIX = 'legacy-row-backfill:';
 
 function getRowObjectId(rowKey: string) {
   const separatorIndex = rowKey.lastIndexOf(ROW_KEY_SEPARATOR);
@@ -533,7 +535,7 @@ function mergeLegacyYMapIntoTarget(target: Y.Map<unknown>, legacy: Y.Map<unknown
     const targetValue = target.get(key);
 
     if (targetValue instanceof Y.Map && legacyValue instanceof Y.Map) {
-      merged = mergeLegacyYMapIntoTarget(targetValue, legacyValue, true) || merged;
+      merged = mergeLegacyYMapIntoTarget(targetValue, legacyValue, overwriteExisting) || merged;
       return;
     }
 
@@ -554,7 +556,47 @@ function mergeLegacyRowDataIntoExistingDoc(doc: YDoc, legacyDoc: YDoc): boolean 
     return false;
   }
 
-  return mergeLegacyYMapIntoTarget(row, legacyRow, true);
+  return mergeLegacyYMapIntoTarget(row, legacyRow, false);
+}
+
+function getLegacyRowBackfillMarkerKey(rowKey: string) {
+  return `${LEGACY_ROW_BACKFILL_MARKER_PREFIX}${rowKey}`;
+}
+
+async function hasLegacyRowBackfillCompleted(rowObjectId: string, rowKey: string) {
+  try {
+    return Boolean(await db.collab_custom.get([rowObjectId, getLegacyRowBackfillMarkerKey(rowKey)]));
+  } catch (error) {
+    Log.warn('[Database] failed to read legacy row backfill marker', { rowKey, rowObjectId, error });
+    return false;
+  }
+}
+
+async function markLegacyRowBackfillCompleted(rowObjectId: string, rowKey: string) {
+  try {
+    await db.collab_custom.put({
+      objectId: rowObjectId,
+      key: getLegacyRowBackfillMarkerKey(rowKey),
+      value: {
+        rowKey,
+        migratedAt: Date.now(),
+      },
+    });
+  } catch (error) {
+    Log.warn('[Database] failed to write legacy row backfill marker', { rowKey, rowObjectId, error });
+  }
+}
+
+async function deleteLegacyRowCache(rowKey: string, rowObjectId: string) {
+  try {
+    const deleted = await deleteCollabDB(rowKey);
+
+    if (!deleted) {
+      Log.warn('[Database] failed to delete legacy row IndexedDB cache after backfill', { rowKey, rowObjectId });
+    }
+  } catch (error) {
+    Log.warn('[Database] failed to delete legacy row IndexedDB cache after backfill', { rowKey, rowObjectId, error });
+  }
 }
 
 function hasAppliedSeed(doc: YDoc, seedBytes: Uint8Array) {
@@ -582,6 +624,10 @@ export async function mergeLegacyRowDocIfExists(
     return false;
   }
 
+  if (await hasLegacyRowBackfillCompleted(rowObjectId, rowKey)) {
+    return false;
+  }
+
   const legacyExists = options.legacyExists ?? (await collabIndexedDBExists(rowKey));
 
   if (!legacyExists) {
@@ -589,14 +635,18 @@ export async function mergeLegacyRowDocIfExists(
   }
 
   const { doc: legacyDoc, provider } = await openCollabDBWithProvider(rowKey, { skipCache: true });
+  let merged = false;
+  let consumedLegacyCache = false;
 
   try {
     if (!hasDatabaseRow(legacyDoc)) {
-      return false;
+      return merged;
     }
 
+    consumedLegacyCache = true;
+
     if (hasDatabaseRow(doc)) {
-      const merged = mergeLegacyRowDataIntoExistingDoc(doc, legacyDoc);
+      merged = mergeLegacyRowDataIntoExistingDoc(doc, legacyDoc);
 
       if (merged) {
         invalidateRowConditionCache(doc);
@@ -612,22 +662,29 @@ export async function mergeLegacyRowDocIfExists(
     const legacyUpdate = Y.encodeStateAsUpdate(legacyDoc, Y.encodeStateVector(doc));
 
     // Yjs encodes an empty v1 update as two bytes. Nothing to merge.
-    if (legacyUpdate.byteLength <= 2) {
-      return false;
+    if (legacyUpdate.byteLength > 2) {
+      applyYDoc(doc, legacyUpdate);
+      invalidateRowConditionCache(doc);
+      Log.debug('[Database] migrated legacy row IndexedDB cache', {
+        rowKey,
+        rowObjectId,
+        bytes: legacyUpdate.byteLength,
+      });
+      merged = true;
     }
 
-    applyYDoc(doc, legacyUpdate);
-    invalidateRowConditionCache(doc);
-    Log.debug('[Database] migrated legacy row IndexedDB cache', {
-      rowKey,
-      rowObjectId,
-      bytes: legacyUpdate.byteLength,
-    });
-
-    return true;
+    return merged;
   } finally {
+    if (consumedLegacyCache) {
+      await markLegacyRowBackfillCompleted(rowObjectId, rowKey);
+    }
+
     await provider.destroy();
     legacyDoc.destroy();
+
+    if (consumedLegacyCache) {
+      await deleteLegacyRowCache(rowKey, rowObjectId);
+    }
   }
 }
 

--- a/src/application/services/js-services/cache/index.ts
+++ b/src/application/services/js-services/cache/index.ts
@@ -548,6 +548,24 @@ function mergeLegacyYMapIntoTarget(target: Y.Map<unknown>, legacy: Y.Map<unknown
   return merged;
 }
 
+function mergeLegacyCellsIntoTarget(target: Y.Map<unknown>, legacy: Y.Map<unknown>) {
+  let merged = false;
+
+  legacy.forEach((legacyCell, fieldId) => {
+    const targetCell = target.get(fieldId);
+
+    if (targetCell instanceof Y.Map && legacyCell instanceof Y.Map) {
+      merged = mergeLegacyYMapIntoTarget(targetCell, legacyCell, true) || merged;
+      return;
+    }
+
+    target.set(fieldId, cloneLegacyYjsValue(legacyCell));
+    merged = true;
+  });
+
+  return merged;
+}
+
 function mergeLegacyRowDataIntoExistingDoc(doc: YDoc, legacyDoc: YDoc): boolean {
   const row = doc.getMap(YjsEditorKey.data_section).get(YjsEditorKey.database_row);
   const legacyRow = legacyDoc.getMap(YjsEditorKey.data_section).get(YjsEditorKey.database_row);
@@ -556,7 +574,30 @@ function mergeLegacyRowDataIntoExistingDoc(doc: YDoc, legacyDoc: YDoc): boolean 
     return false;
   }
 
-  return mergeLegacyYMapIntoTarget(row, legacyRow, false);
+  let merged = false;
+
+  legacyRow.forEach((legacyValue, key) => {
+    const targetValue = row.get(key);
+
+    if (key === YjsDatabaseKey.cells && targetValue instanceof Y.Map && legacyValue instanceof Y.Map) {
+      merged = mergeLegacyCellsIntoTarget(targetValue, legacyValue) || merged;
+      return;
+    }
+
+    if (key === YjsDatabaseKey.id || key === YjsDatabaseKey.database_id) {
+      if (!row.has(key)) {
+        row.set(key, cloneLegacyYjsValue(legacyValue));
+        merged = true;
+      }
+
+      return;
+    }
+
+    row.set(key, cloneLegacyYjsValue(legacyValue));
+    merged = true;
+  });
+
+  return merged;
 }
 
 function getLegacyRowBackfillMarkerKey(rowKey: string) {
@@ -597,6 +638,27 @@ async function deleteLegacyRowCache(rowKey: string, rowObjectId: string) {
   } catch (error) {
     Log.warn('[Database] failed to delete legacy row IndexedDB cache after backfill', { rowKey, rowObjectId, error });
   }
+}
+
+function applyLegacyRowUpdate(doc: YDoc, legacyDoc: YDoc, rowKey: string, rowObjectId: string) {
+  const hadSharedRowData = hasDatabaseRow(doc);
+  const legacyUpdate = Y.encodeStateAsUpdate(legacyDoc, Y.encodeStateVector(doc));
+
+  // Yjs encodes an empty v1 update as two bytes. Nothing to merge.
+  if (legacyUpdate.byteLength <= 2) {
+    return false;
+  }
+
+  applyYDoc(doc, legacyUpdate);
+  invalidateRowConditionCache(doc);
+  Log.debug('[Database] migrated legacy row IndexedDB cache', {
+    rowKey,
+    rowObjectId,
+    bytes: legacyUpdate.byteLength,
+    hadSharedRowData,
+  });
+
+  return true;
 }
 
 function hasAppliedSeed(doc: YDoc, seedBytes: Uint8Array) {
@@ -659,19 +721,7 @@ export async function mergeLegacyRowDocIfExists(
       return merged;
     }
 
-    const legacyUpdate = Y.encodeStateAsUpdate(legacyDoc, Y.encodeStateVector(doc));
-
-    // Yjs encodes an empty v1 update as two bytes. Nothing to merge.
-    if (legacyUpdate.byteLength > 2) {
-      applyYDoc(doc, legacyUpdate);
-      invalidateRowConditionCache(doc);
-      Log.debug('[Database] migrated legacy row IndexedDB cache', {
-        rowKey,
-        rowObjectId,
-        bytes: legacyUpdate.byteLength,
-      });
-      merged = true;
-    }
+    merged = applyLegacyRowUpdate(doc, legacyDoc, rowKey, rowObjectId);
 
     return merged;
   } finally {

--- a/src/application/services/js-services/sync-protocol.ts
+++ b/src/application/services/js-services/sync-protocol.ts
@@ -1,6 +1,7 @@
 import * as awarenessProtocol from 'y-protocols/awareness';
 import * as Y from 'yjs';
 
+import { deleteCollabDB } from '@/application/db';
 import {
   deleteOutboxByObjectId,
   enqueueOutboxUpdate,
@@ -97,6 +98,7 @@ const handleAccessChanged = (ctx: SyncContext, message: collab.IAccessChanged): 
     void ctx.discardPendingUpdates?.();
     ctx.flush = undefined;
     ctx.discardPendingUpdates = undefined;
+    void deleteCollabDB(ctx.doc.guid, { destroyDoc: false });
     ctx.doc.destroy();
   }
 };

--- a/src/components/app/app.hooks.tsx
+++ b/src/components/app/app.hooks.tsx
@@ -1,8 +1,12 @@
-import { useContext, useMemo, type ReactNode } from 'react';
+import { useContext, useMemo, useState, type ReactNode } from 'react';
 import { useSearchParams } from 'react-router-dom';
 
+import { determineErrorType, ErrorType } from '@/application/utils/error-utils';
+import { ReactComponent as ErrorIcon } from '@/assets/icons/error.svg';
 import LoadingDots from '@/components/_shared/LoadingDots';
 import { findView } from '@/components/_shared/outline/utils';
+import { Button } from '@/components/ui/button';
+import { Progress } from '@/components/ui/progress';
 import {
   DATABASE_TAB_VIEW_ID_QUERY_PARAM,
   resolveSidebarHighlightedViewIds,
@@ -19,13 +23,71 @@ import { AppAuthLayer } from './layers/AppAuthLayer';
 import { AppBusinessLayer } from './layers/AppBusinessLayer';
 import { AppSyncLayer } from './layers/AppSyncLayer';
 
+function WorkspaceBootstrapError({
+  error,
+  onRetry,
+}: {
+  error: Error;
+  onRetry?: () => void | Promise<unknown>;
+}) {
+  const [retrying, setRetrying] = useState(false);
+  const appError = determineErrorType(error);
+  const isNetworkError = appError.type === ErrorType.NetworkError;
+
+  const handleRetry = async () => {
+    if (!onRetry) {
+      window.location.reload();
+      return;
+    }
+
+    setRetrying(true);
+    try {
+      await onRetry();
+    } finally {
+      setRetrying(false);
+    }
+  };
+
+  return (
+    <div className='fixed inset-0 flex items-center justify-center bg-background-primary px-6'>
+      <div role='alert' className='flex max-w-md flex-col items-center gap-5 text-center'>
+        <ErrorIcon className='h-14 w-14 text-function-error' />
+        <div className='flex flex-col gap-2'>
+          <h1 className='text-xl font-semibold text-text-primary'>
+            {isNetworkError ? 'Unable to reach the server' : 'Unable to load workspace'}
+          </h1>
+          <p className='text-sm text-text-secondary'>
+            {isNetworkError
+              ? 'The app will retry automatically when the connection comes back.'
+              : appError.message || 'The app could not load your workspace data.'}
+          </p>
+        </div>
+        <Button onClick={handleRetry} disabled={retrying}>
+          {retrying ? (
+            <span className='flex items-center gap-2'>
+              <Progress variant='inherit' />
+              Retrying
+            </span>
+          ) : (
+            'Retry'
+          )}
+        </Button>
+      </div>
+    </div>
+  );
+}
+
 // Internal component to conditionally render sync and business layers only when workspace ID exists
 const ConditionalWorkspaceLayers = ({ children }: { children: ReactNode }) => {
   const authContext = useContext(AuthInternalContext);
-  const { userWorkspaceInfo } = authContext || {};
+  const { userWorkspaceInfo, workspaceInfoError, retryLoadWorkspaceInfo } = authContext || {};
 
   // Show loading animation while workspace ID is being loaded
   if (!userWorkspaceInfo) {
+    if (workspaceInfoError) {
+      return <WorkspaceBootstrapError error={workspaceInfoError} onRetry={retryLoadWorkspaceInfo} />;
+    }
+
     return (
       <div className='fixed inset-0 flex items-center justify-center bg-background-primary'>
         <LoadingDots className='flex items-center justify-center' />

--- a/src/components/app/contexts/AuthInternalContext.ts
+++ b/src/components/app/contexts/AuthInternalContext.ts
@@ -39,7 +39,7 @@ export interface AuthInternalContextType {
   /** Error from loading workspace info — allows consumers to show error/retry UI. */
   workspaceInfoError?: Error;
   /** Retry loading workspace info after a failure. */
-  retryLoadWorkspaceInfo?: () => void;
+  retryLoadWorkspaceInfo?: () => Promise<UserWorkspaceInfo | undefined>;
 }
 
 export const AuthInternalContext = createContext<AuthInternalContextType | null>(null);

--- a/src/components/app/layers/AppAuthLayer.tsx
+++ b/src/components/app/layers/AppAuthLayer.tsx
@@ -4,6 +4,7 @@ import { useLocation, useNavigate, useParams } from 'react-router-dom';
 import { invalidToken, isTokenValid } from '@/application/session/token';
 import { AuthService, UserService, WorkspaceService } from '@/application/services/domains';
 import { UserWorkspaceInfo } from '@/application/types';
+import { determineErrorType, ErrorType } from '@/application/utils/error-utils';
 import { AFConfigContext } from '@/components/main/app.hooks';
 import { Log } from '@/utils/log';
 
@@ -11,6 +12,21 @@ import { AuthInternalContext, AuthInternalContextType } from '../contexts/AuthIn
 
 interface AppAuthLayerProps {
   children: React.ReactNode;
+}
+
+const RETRY_WORKSPACE_INFO_DELAY_MS = 5000;
+
+type LoadWorkspaceInfoOptions = { force?: boolean };
+
+function isRetryableWorkspaceInfoError(error: Error): boolean {
+  const appError = determineErrorType(error);
+
+  return (
+    appError.type === ErrorType.NetworkError ||
+    appError.type === ErrorType.ServerError ||
+    appError.type === ErrorType.Timeout ||
+    appError.type === ErrorType.Unknown
+  );
 }
 
 /**
@@ -47,6 +63,8 @@ export const AppAuthLayer: React.FC<AppAuthLayerProps> = ({ children }) => {
   const [workspaceInfoError, setWorkspaceInfoError] = useState<Error | undefined>(undefined);
   const [enablePageHistory, setEnablePageHistory] = useState<boolean | undefined>(undefined);
   const [aiEnabled, setAIEnabled] = useState<boolean | undefined>(false);
+  const workspaceInfoPromiseRef = useRef<Promise<UserWorkspaceInfo | undefined> | null>(null);
+  const workspaceInfoRequestIdRef = useRef(0);
 
   // Calculate current workspace ID from URL params or user info
   const currentWorkspaceId = useMemo(
@@ -61,17 +79,42 @@ export const AppAuthLayer: React.FC<AppAuthLayerProps> = ({ children }) => {
   }, [navigate]);
 
   // Load user workspace information
-  const loadUserWorkspaceInfo = useCallback(async () => {
-    setWorkspaceInfoError(undefined);
-    try {
-      const res = await UserService.getWorkspaceInfo();
-
-      setUserWorkspaceInfo(res);
-      return res;
-    } catch (e) {
-      Log.error('[AppAuthLayer] Failed to load workspace info:', e);
-      setWorkspaceInfoError(e instanceof Error ? e : new Error(String(e)));
+  const loadUserWorkspaceInfo = useCallback(async (options?: LoadWorkspaceInfoOptions) => {
+    if (!options?.force && workspaceInfoPromiseRef.current) {
+      return workspaceInfoPromiseRef.current;
     }
+
+    const requestId = workspaceInfoRequestIdRef.current + 1;
+
+    workspaceInfoRequestIdRef.current = requestId;
+    setWorkspaceInfoError(undefined);
+
+    const promise = Promise.resolve()
+      .then(() => UserService.getWorkspaceInfo())
+      .then((res) => {
+        if (workspaceInfoRequestIdRef.current === requestId) {
+          setUserWorkspaceInfo(res);
+        }
+
+        return res;
+      })
+      .catch((e) => {
+        Log.error('[AppAuthLayer] Failed to load workspace info:', e);
+
+        if (workspaceInfoRequestIdRef.current === requestId) {
+          setWorkspaceInfoError(e instanceof Error ? e : new Error(String(e)));
+        }
+
+        return undefined;
+      })
+      .finally(() => {
+        if (workspaceInfoPromiseRef.current === promise && workspaceInfoRequestIdRef.current === requestId) {
+          workspaceInfoPromiseRef.current = null;
+        }
+      });
+
+    workspaceInfoPromiseRef.current = promise;
+    return promise;
   }, []);
 
   // Handle workspace change
@@ -84,7 +127,7 @@ export const AppAuthLayer: React.FC<AppAuthLayerProps> = ({ children }) => {
 
       await WorkspaceService.open(workspaceId);
 
-      await loadUserWorkspaceInfo();
+      await loadUserWorkspaceInfo({ force: true });
 
       // Clean up old global key for backward compatibility
       // New per-workspace-per-user keys don't need to be removed on workspace change
@@ -191,6 +234,42 @@ export const AppAuthLayer: React.FC<AppAuthLayerProps> = ({ children }) => {
     });
   }, [loadUserWorkspaceInfo, isAuthenticated]);
 
+  // If the app boots while the server is down, the first workspace-info request
+  // can fail before the workspace layers mount. Keep retrying transient failures
+  // so returning services can recover without a manual page refresh.
+  useEffect(() => {
+    if (!isAuthenticated || userWorkspaceInfo || !workspaceInfoError) return;
+    if (!isRetryableWorkspaceInfoError(workspaceInfoError)) return;
+
+    let cancelled = false;
+
+    const retry = () => {
+      if (cancelled) return;
+      void loadUserWorkspaceInfo();
+    };
+
+    const retryTimeoutId = window.setTimeout(retry, RETRY_WORKSPACE_INFO_DELAY_MS);
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === 'visible') {
+        retry();
+      }
+    };
+
+    window.addEventListener('online', retry);
+    window.addEventListener('focus', retry);
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+
+    return () => {
+      cancelled = true;
+      window.clearTimeout(retryTimeoutId);
+      window.removeEventListener('online', retry);
+      window.removeEventListener('focus', retry);
+      document.removeEventListener('visibilitychange', handleVisibilityChange);
+    };
+  }, [isAuthenticated, userWorkspaceInfo, workspaceInfoError, loadUserWorkspaceInfo]);
+
+  const retryLoadWorkspaceInfo = useCallback(() => loadUserWorkspaceInfo({ force: true }), [loadUserWorkspaceInfo]);
+
   // Auto-switch workspace when the URL points to a different workspace than
   // the currently selected one (e.g. guest opening a shared direct link).
   // Directly call WorkspaceService.open — the server is the authority on
@@ -216,7 +295,7 @@ export const AppAuthLayer: React.FC<AppAuthLayerProps> = ({ children }) => {
 
     Log.debug('[AppAuthLayer] auto-switching to URL workspace', { urlWorkspaceId, selectedId });
     void WorkspaceService.open(urlWorkspaceId)
-      .then(() => loadUserWorkspaceInfo())
+      .then(() => loadUserWorkspaceInfo({ force: true }))
       .catch((e) => Log.warn('[AppAuthLayer] failed to open URL workspace', e));
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isAuthenticated, params.workspaceId, userWorkspaceInfo?.selectedWorkspace.id, loadUserWorkspaceInfo]);
@@ -231,9 +310,9 @@ export const AppAuthLayer: React.FC<AppAuthLayerProps> = ({ children }) => {
       aiEnabled,
       onChangeWorkspace,
       workspaceInfoError,
-      retryLoadWorkspaceInfo: loadUserWorkspaceInfo,
+      retryLoadWorkspaceInfo,
     }),
-    [userWorkspaceInfo, currentWorkspaceId, isAuthenticated, enablePageHistory, aiEnabled, onChangeWorkspace, workspaceInfoError, loadUserWorkspaceInfo]
+    [userWorkspaceInfo, currentWorkspaceId, isAuthenticated, enablePageHistory, aiEnabled, onChangeWorkspace, workspaceInfoError, retryLoadWorkspaceInfo]
   );
 
   return <AuthInternalContext.Provider value={authContextValue}>{children}</AuthInternalContext.Provider>;

--- a/src/components/app/layers/__tests__/AppAuthLayer.test.tsx
+++ b/src/components/app/layers/__tests__/AppAuthLayer.test.tsx
@@ -1,0 +1,126 @@
+import { act, render, screen, waitFor } from '@testing-library/react';
+import { useContext } from 'react';
+
+import { UserService, WorkspaceService, AuthService } from '@/application/services/domains';
+import { type UserWorkspaceInfo } from '@/application/types';
+import { AuthInternalContext, type AuthInternalContextType } from '@/components/app/contexts/AuthInternalContext';
+import { AppAuthLayer } from '@/components/app/layers/AppAuthLayer';
+import { AFConfigContext } from '@/components/main/app.hooks';
+
+const mockNavigate = jest.fn();
+
+jest.mock('react-router-dom', () => ({
+  useLocation: () => ({ pathname: '/login' }),
+  useNavigate: () => mockNavigate,
+  useParams: () => ({}),
+}));
+
+jest.mock('@/application/session/token', () => ({
+  invalidToken: jest.fn(),
+  isTokenValid: jest.fn(() => true),
+}));
+
+jest.mock('@/application/services/domains', () => ({
+  AuthService: {
+    getServerInfo: jest.fn(),
+  },
+  UserService: {
+    getWorkspaceInfo: jest.fn(),
+  },
+  WorkspaceService: {
+    open: jest.fn(),
+  },
+}));
+
+function createDeferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((promiseResolve, promiseReject) => {
+    resolve = promiseResolve;
+    reject = promiseReject;
+  });
+
+  return { promise, resolve, reject };
+}
+
+function createWorkspaceInfo(selectedWorkspaceId: string): UserWorkspaceInfo {
+  return {
+    selectedWorkspace: { id: selectedWorkspaceId },
+    workspaces: [{ id: 'workspace-old' }, { id: 'workspace-new' }],
+  } as UserWorkspaceInfo;
+}
+
+describe('AppAuthLayer workspace info loading', () => {
+  const mockGetWorkspaceInfo = UserService.getWorkspaceInfo as jest.MockedFunction<typeof UserService.getWorkspaceInfo>;
+  const mockOpenWorkspace = WorkspaceService.open as jest.MockedFunction<typeof WorkspaceService.open>;
+  const mockGetServerInfo = AuthService.getServerInfo as jest.MockedFunction<typeof AuthService.getServerInfo>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetServerInfo.mockResolvedValue({
+      enable_page_history: true,
+      ai_enabled: true,
+    } as never);
+    mockOpenWorkspace.mockResolvedValue(undefined as never);
+  });
+
+  it('forces a fresh workspace-info request after switching workspace and ignores stale responses', async () => {
+    const staleWorkspaceInfo = createDeferred<UserWorkspaceInfo>();
+    const freshWorkspaceInfo = createDeferred<UserWorkspaceInfo>();
+    let latestAuthContext: AuthInternalContextType | null = null;
+
+    mockGetWorkspaceInfo
+      .mockReturnValueOnce(staleWorkspaceInfo.promise as never)
+      .mockReturnValueOnce(freshWorkspaceInfo.promise as never);
+
+    function CaptureAuthContext() {
+      latestAuthContext = useContext(AuthInternalContext);
+
+      return (
+        <div data-testid='selected-workspace'>
+          {latestAuthContext?.userWorkspaceInfo?.selectedWorkspace.id ?? 'none'}
+        </div>
+      );
+    }
+
+    render(
+      <AFConfigContext.Provider
+        value={{
+          isAuthenticated: true,
+          updateCurrentUser: jest.fn(),
+          openLoginModal: jest.fn(),
+        }}
+      >
+        <AppAuthLayer>
+          <CaptureAuthContext />
+        </AppAuthLayer>
+      </AFConfigContext.Provider>
+    );
+
+    await waitFor(() => expect(mockGetWorkspaceInfo).toHaveBeenCalledTimes(1));
+
+    let switchPromise!: Promise<void>;
+
+    act(() => {
+      switchPromise = latestAuthContext!.onChangeWorkspace('workspace-new');
+    });
+
+    await waitFor(() => expect(mockOpenWorkspace).toHaveBeenCalledWith('workspace-new'));
+    await waitFor(() => expect(mockGetWorkspaceInfo).toHaveBeenCalledTimes(2));
+
+    await act(async () => {
+      freshWorkspaceInfo.resolve(createWorkspaceInfo('workspace-new'));
+      await switchPromise;
+    });
+
+    expect(screen.getByTestId('selected-workspace').textContent).toBe('workspace-new');
+    expect(mockNavigate).toHaveBeenCalledWith('/app/workspace-new');
+
+    await act(async () => {
+      staleWorkspaceInfo.resolve(createWorkspaceInfo('workspace-old'));
+      await staleWorkspaceInfo.promise;
+    });
+
+    expect(screen.getByTestId('selected-workspace').textContent).toBe('workspace-new');
+  });
+});

--- a/src/components/database/components/grid/grid-row/GridLoadMoreRow.tsx
+++ b/src/components/database/components/grid/grid-row/GridLoadMoreRow.tsx
@@ -1,0 +1,25 @@
+import { useTranslation } from 'react-i18next';
+
+import { ReactComponent as PlusIcon } from '@/assets/icons/plus.svg';
+import { useGridContext } from '@/components/database/grid/useGridContext';
+
+function GridLoadMoreRow({ remainingCount }: { remainingCount: number }) {
+  const { t } = useTranslation();
+  const { loadMoreRows } = useGridContext();
+
+  return (
+    <button
+      type='button'
+      data-testid='grid-load-more-row'
+      onClick={loadMoreRows}
+      className={
+        'flex h-[36px] w-full flex-1 cursor-pointer items-center gap-1.5 border-t border-border-primary bg-fill-content px-3 py-2 text-left text-sm font-medium text-text-secondary hover:bg-fill-content-hover'
+      }
+    >
+      <PlusIcon className={'h-5 w-5'} />
+      {t('grid.row.loadMore')} ({remainingCount})
+    </button>
+  );
+}
+
+export default GridLoadMoreRow;

--- a/src/components/database/components/grid/grid-row/GridNewRow.tsx
+++ b/src/components/database/components/grid/grid-row/GridNewRow.tsx
@@ -1,17 +1,30 @@
 import { useTranslation } from 'react-i18next';
 
+import { useDatabaseContext } from '@/application/database-yjs';
 import { useNewRowDispatch } from '@/application/database-yjs/dispatch';
 import { ReactComponent as PlusIcon } from '@/assets/icons/plus.svg';
+import { useGridContext } from '@/components/database/grid/useGridContext';
 
 function GridNewRow() {
   const { t } = useTranslation();
   const onNewRow = useNewRowDispatch();
+  const { isDocumentBlock } = useDatabaseContext();
+  const { lastVisibleRowId, revealCreatedRow } = useGridContext();
 
   return (
     <div
       data-testid="grid-new-row"
       onClick={() => {
-        void onNewRow({ tailing: true });
+        void onNewRow(
+          isDocumentBlock
+            ? {
+                beforeRowId: lastVisibleRowId,
+                tailing: !lastVisibleRowId,
+              }
+            : { tailing: true }
+        ).then(() => {
+          revealCreatedRow();
+        });
       }}
       className={
         'flex h-[36px] flex-1 cursor-pointer items-center gap-1.5 border-b border-t border-border-primary bg-fill-content px-3 py-2 text-sm font-medium text-text-secondary hover:bg-fill-content-hover'

--- a/src/components/database/components/grid/grid-row/__tests__/useRenderRows.test.tsx
+++ b/src/components/database/components/grid/grid-row/__tests__/useRenderRows.test.tsx
@@ -46,4 +46,57 @@ describe('useRenderRows', () => {
       RenderRowType.CalculateRow,
     ]);
   });
+
+  it('does not limit rows when no visible row limit is provided', () => {
+    const rows = [{ id: 'row-1' }, { id: 'row-2' }, { id: 'row-3' }];
+    const { result } = renderHook(() => useRenderRows(rows), {
+      wrapper: createWrapper(),
+    });
+
+    expect(result.current.rows.map((row) => row.type)).toEqual([
+      RenderRowType.Header,
+      RenderRowType.Row,
+      RenderRowType.Row,
+      RenderRowType.Row,
+      RenderRowType.NewRow,
+      RenderRowType.CalculateRow,
+    ]);
+    expect(result.current.remainingRowCount).toBe(0);
+    expect(result.current.lastVisibleRowId).toBe('row-3');
+  });
+
+  it('adds a load-more row when a visible row limit hides rows', () => {
+    const rows = [{ id: 'row-1' }, { id: 'row-2' }, { id: 'row-3' }, { id: 'row-4' }];
+    const { result } = renderHook(() => useRenderRows(rows, { visibleRowLimit: 2 }), {
+      wrapper: createWrapper(),
+    });
+
+    expect(result.current.rows.map((row) => row.type)).toEqual([
+      RenderRowType.Header,
+      RenderRowType.Row,
+      RenderRowType.Row,
+      RenderRowType.LoadMoreRow,
+      RenderRowType.NewRow,
+      RenderRowType.CalculateRow,
+    ]);
+    expect(result.current.remainingRowCount).toBe(2);
+    expect(result.current.lastVisibleRowId).toBe('row-2');
+  });
+
+  it('does not add a load-more row when the limit covers every row', () => {
+    const rows = [{ id: 'row-1' }, { id: 'row-2' }];
+    const { result } = renderHook(() => useRenderRows(rows, { visibleRowLimit: 25 }), {
+      wrapper: createWrapper(),
+    });
+
+    expect(result.current.rows.map((row) => row.type)).toEqual([
+      RenderRowType.Header,
+      RenderRowType.Row,
+      RenderRowType.Row,
+      RenderRowType.NewRow,
+      RenderRowType.CalculateRow,
+    ]);
+    expect(result.current.remainingRowCount).toBe(0);
+    expect(result.current.lastVisibleRowId).toBe('row-2');
+  });
 });

--- a/src/components/database/components/grid/grid-row/useRenderRows.tsx
+++ b/src/components/database/components/grid/grid-row/useRenderRows.tsx
@@ -5,6 +5,7 @@ import { Row, useReadOnly } from '@/application/database-yjs';
 export enum RenderRowType {
   Header = 'header',
   Row = 'row',
+  LoadMoreRow = 'load-more-row',
   NewRow = 'new-row',
   CalculateRow = 'calculate-row',
   PlaceholderRow = 'placeholder-row',
@@ -13,10 +14,15 @@ export enum RenderRowType {
 export type RenderRow = {
   type: RenderRowType;
   rowId?: string;
+  remainingRowCount?: number;
 };
 
-export function useRenderRows (rows?: Row[]) {
+export const EMBEDDED_GRID_INITIAL_ROW_LIMIT = 25;
+export const EMBEDDED_GRID_LOAD_MORE_INCREMENT = 25;
+
+export function useRenderRows(rows?: Row[], options?: { visibleRowLimit?: number }) {
   const readOnly = useReadOnly();
+  const visibleRowLimit = options?.visibleRowLimit;
 
   const renderRows = useMemo(() => {
     const placeholderRows = [
@@ -41,12 +47,20 @@ export function useRenderRows (rows?: Row[]) {
         type: RenderRowType.Row,
         rowId: row.id,
       })) ?? [];
+    const visibleRowItems = visibleRowLimit === undefined ? rowItems : rowItems.slice(0, visibleRowLimit);
+    const remainingRowCount =
+      visibleRowLimit === undefined ? 0 : Math.max(rowItems.length - visibleRowItems.length, 0);
 
     return [
       {
         type: RenderRowType.Header,
       },
-      ...rowItems,
+      ...visibleRowItems,
+
+      remainingRowCount > 0 && {
+        type: RenderRowType.LoadMoreRow,
+        remainingRowCount,
+      },
 
       !readOnly && {
         type: RenderRowType.NewRow,
@@ -55,9 +69,17 @@ export function useRenderRows (rows?: Row[]) {
         type: RenderRowType.CalculateRow,
       },
     ].filter(Boolean) as RenderRow[];
-  }, [readOnly, rows]);
+  }, [readOnly, rows, visibleRowLimit]);
+
+  const visibleDataRows = useMemo(() => renderRows.filter((row) => row.type === RenderRowType.Row), [renderRows]);
+  const loadMoreRow = useMemo(
+    () => renderRows.find((row) => row.type === RenderRowType.LoadMoreRow),
+    [renderRows]
+  );
 
   return {
     rows: renderRows,
+    remainingRowCount: loadMoreRow?.remainingRowCount ?? 0,
+    lastVisibleRowId: visibleDataRows[visibleDataRows.length - 1]?.rowId,
   };
 }

--- a/src/components/database/components/grid/grid-table/GridVirtualizer.tsx
+++ b/src/components/database/components/grid/grid-table/GridVirtualizer.tsx
@@ -4,6 +4,7 @@ import { PADDING_END, useDatabaseContext } from '@/application/database-yjs';
 import { GridDragContext } from '@/components/database/components/grid/drag-and-drop/GridDragContext';
 import { RenderColumn } from '@/components/database/components/grid/grid-column/useRenderFields';
 import { RenderRowType } from '@/components/database/components/grid/grid-row';
+import GridLoadMoreRow from '@/components/database/components/grid/grid-row/GridLoadMoreRow';
 import GridNewRow from '@/components/database/components/grid/grid-row/GridNewRow';
 import GridVirtualRow from '@/components/database/components/grid/grid-row/GridVirtualRow';
 import GridStickyHeader from '@/components/database/components/grid/grid-table/GridStickyHeader';
@@ -193,6 +194,8 @@ function GridVirtualizer({ columns }: { columns: RenderColumn[] }) {
             const rowData = data[row.index];
             const rowId = rowData.rowId;
             const isPlaceholderRow = rowData.type === RenderRowType.PlaceholderRow;
+            const isFullWidthControlRow =
+              rowData.type === RenderRowType.NewRow || rowData.type === RenderRowType.LoadMoreRow;
 
             return (
               <div
@@ -220,7 +223,7 @@ function GridVirtualizer({ columns }: { columns: RenderColumn[] }) {
                   >
                     {gridLoadingDots}
                   </div>
-                ) : rowData.type === RenderRowType.NewRow ? (
+                ) : isFullWidthControlRow ? (
                   <div
                     style={{
                       paddingLeft: columnItems[0]?.start,
@@ -228,7 +231,11 @@ function GridVirtualizer({ columns }: { columns: RenderColumn[] }) {
                       width: totalSize - (paddingEnd ?? 0),
                     }}
                   >
-                    <GridNewRow />
+                    {rowData.type === RenderRowType.LoadMoreRow ? (
+                      <GridLoadMoreRow remainingCount={rowData.remainingRowCount ?? 0} />
+                    ) : (
+                      <GridNewRow />
+                    )}
                   </div>
                 ) : (
                   <GridVirtualRow

--- a/src/components/database/grid/GridProvider.tsx
+++ b/src/components/database/grid/GridProvider.tsx
@@ -1,18 +1,32 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
-import { Row } from '@/application/database-yjs';
-import { RenderRow, useRenderRows } from '@/components/database/components/grid/grid-row';
+import { Row, useDatabaseContext } from '@/application/database-yjs';
+import {
+  EMBEDDED_GRID_INITIAL_ROW_LIMIT,
+  EMBEDDED_GRID_LOAD_MORE_INCREMENT,
+  RenderRow,
+  useRenderRows,
+} from '@/components/database/components/grid/grid-row';
 import { GridContext } from '@/components/database/grid/useGridContext';
 
 export const GridProvider = ({ children, rowOrders }: { children: React.ReactNode; rowOrders?: Row[] }) => {
   const [hoverRowId, setHoverRowId] = useState<string | undefined>();
   const [activePropertyId, setActivePropertyId] = useState<string | undefined>();
-  const { rows: initialRows } = useRenderRows(rowOrders);
+  const { isDocumentBlock, activeViewId } = useDatabaseContext();
+  const [visibleRowLimit, setVisibleRowLimit] = useState(EMBEDDED_GRID_INITIAL_ROW_LIMIT);
+  const embeddedVisibleRowLimit = isDocumentBlock ? visibleRowLimit : undefined;
+  const { rows: initialRows, remainingRowCount, lastVisibleRowId } = useRenderRows(rowOrders, {
+    visibleRowLimit: embeddedVisibleRowLimit,
+  });
   const [rows, setRows] = useState<RenderRow[]>(initialRows);
   const [resizeRows, setResizeRows] = useState<Map<string, number>>(new Map());
 
   const isWheelingRef = useRef(false);
   const ref = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    setVisibleRowLimit(EMBEDDED_GRID_INITIAL_ROW_LIMIT);
+  }, [activeViewId, isDocumentBlock]);
 
   useEffect(() => {
     setRows(initialRows);
@@ -64,6 +78,16 @@ export const GridProvider = ({ children, rowOrders }: { children: React.ReactNod
     });
   }, []);
 
+  const loadMoreRows = useCallback(() => {
+    setVisibleRowLimit((prev) => prev + EMBEDDED_GRID_LOAD_MORE_INCREMENT);
+  }, []);
+
+  const revealCreatedRow = useCallback(() => {
+    if (!isDocumentBlock) return;
+
+    setVisibleRowLimit((prev) => prev + 1);
+  }, [isDocumentBlock]);
+
   const [showStickyHeader, setShowStickyHeader] = useState(false);
   const contextValue = useMemo(
     () => ({
@@ -78,6 +102,10 @@ export const GridProvider = ({ children, rowOrders }: { children: React.ReactNod
       resizeRows,
       setResizeRow: onResizeRow,
       onResizeRowEnd,
+      remainingRowCount,
+      lastVisibleRowId,
+      loadMoreRows,
+      revealCreatedRow,
       showStickyHeader,
       setShowStickyHeader,
     }),
@@ -90,6 +118,10 @@ export const GridProvider = ({ children, rowOrders }: { children: React.ReactNod
       resizeRows,
       onResizeRow,
       onResizeRowEnd,
+      remainingRowCount,
+      lastVisibleRowId,
+      loadMoreRows,
+      revealCreatedRow,
       showStickyHeader,
     ]
   );

--- a/src/components/database/grid/useGridContext.ts
+++ b/src/components/database/grid/useGridContext.ts
@@ -17,6 +17,10 @@ type GridContextType = {
   resizeRows?: Map<string, number>;
   setResizeRow: (resizeRow: { rowId: string; maxCellHeight: number }) => void;
   onResizeRowEnd: (id: string) => void;
+  remainingRowCount: number;
+  lastVisibleRowId?: string;
+  loadMoreRows: () => void;
+  revealCreatedRow: () => void;
   showStickyHeader: boolean;
   setShowStickyHeader: (show: boolean) => void;
 };

--- a/src/components/error/RecordNotFound.tsx
+++ b/src/components/error/RecordNotFound.tsx
@@ -22,7 +22,7 @@ function RecordNotFound({
   noContent?: boolean;
   isViewNotFound?: boolean;
   error?: AppError;
-  onRetry?: () => void | Promise<void>;
+  onRetry?: () => void | Promise<unknown>;
 }) {
   const { t } = useTranslation();
   const currentWorkspaceId = useCurrentWorkspaceId();

--- a/src/components/ws/__tests__/useSync.test.ts
+++ b/src/components/ws/__tests__/useSync.test.ts
@@ -4,10 +4,15 @@ import { act, renderHook, waitFor } from '@testing-library/react';
 import * as Y from 'yjs';
 
 import { APP_EVENTS } from '@/application/constants';
-import { openCollabDB } from '@/application/db';
+import {
+  openCollabDB,
+  openCollabDBWithProvider,
+  openRowCollabDBWithProvider,
+  listCollabIndexedDBNames,
+} from '@/application/db';
 import * as httpApi from '@/application/services/js-services/http/http_api';
 import { handleMessage } from '@/application/services/js-services/sync-protocol';
-import { Types, User } from '@/application/types';
+import { Types, User, YDoc, YjsDatabaseKey, YjsEditorKey } from '@/application/types';
 import { Log } from '@/utils/log';
 import { useCurrentUserOptional } from '@/components/main/app.hooks';
 
@@ -19,6 +24,9 @@ jest.mock('@/application/db', () => {
   return {
     ...jest.requireActual('@/application/db'),
     openCollabDB: jest.fn(),
+    openCollabDBWithProvider: jest.fn(),
+    openRowCollabDBWithProvider: jest.fn(),
+    listCollabIndexedDBNames: jest.fn(),
   };
 });
 
@@ -142,6 +150,52 @@ const createDoc = (guid: string): Y.Doc => {
   return doc;
 };
 
+const createDatabaseDocWithRows = (databaseId: string, rowIds: string[]): Y.Doc => {
+  const doc = createDoc(databaseId);
+  const sharedRoot = doc.getMap(YjsEditorKey.data_section);
+  const database = new Y.Map();
+  const views = new Y.Map();
+  const view = new Y.Map();
+  const rowOrders = new Y.Array<{ id: string; height: number }>();
+
+  rowOrders.push(rowIds.map((id) => ({ id, height: 44 })));
+  view.set(YjsDatabaseKey.row_orders, rowOrders);
+  views.set('view-id', view);
+  database.set(YjsDatabaseKey.id, databaseId);
+  database.set(YjsDatabaseKey.views, views);
+  sharedRoot.set(YjsEditorKey.database, database);
+
+  return doc;
+};
+
+const createDatabaseRowDoc = (rowId: string, databaseId: string, cells: Record<string, unknown>): YDoc => {
+  const doc = createDoc(rowId) as YDoc;
+  const sharedRoot = doc.getMap(YjsEditorKey.data_section);
+  const row = new Y.Map();
+  const cellMap = new Y.Map();
+
+  sharedRoot.set(YjsEditorKey.database_row, row);
+  row.set(YjsDatabaseKey.id, rowId);
+  row.set(YjsDatabaseKey.database_id, databaseId);
+  row.set(YjsDatabaseKey.cells, cellMap);
+
+  Object.entries(cells).forEach(([fieldId, data]) => {
+    const cell = new Y.Map();
+
+    cell.set(YjsDatabaseKey.data, data);
+    cellMap.set(fieldId, cell);
+  });
+
+  return doc;
+};
+
+const getRowCellData = (doc: Y.Doc, fieldId: string) => {
+  const row = doc.getMap(YjsEditorKey.data_section).get(YjsEditorKey.database_row) as Y.Map<unknown> | undefined;
+  const cells = row?.get(YjsDatabaseKey.cells) as Y.Map<Y.Map<unknown>> | undefined;
+
+  return cells?.get(fieldId)?.get(YjsDatabaseKey.data);
+};
+
 type Deferred<T> = {
   promise: Promise<T>;
   resolve: (value: T) => void;
@@ -160,6 +214,9 @@ const createDeferred = <T>(): Deferred<T> => {
 };
 
 const mockedOpenCollabDB = openCollabDB as jest.MockedFunction<typeof openCollabDB>;
+const mockedOpenCollabDBWithProvider = openCollabDBWithProvider as jest.MockedFunction<typeof openCollabDBWithProvider>;
+const mockedOpenRowCollabDBWithProvider = openRowCollabDBWithProvider as jest.MockedFunction<typeof openRowCollabDBWithProvider>;
+const mockedListCollabIndexedDBNames = listCollabIndexedDBNames as jest.MockedFunction<typeof listCollabIndexedDBNames>;
 const mockedHandleMessage = handleMessage as jest.MockedFunction<typeof handleMessage>;
 const mockedCollabFullSyncBatch = httpApi.collabFullSyncBatch as jest.MockedFunction<typeof httpApi.collabFullSyncBatch>;
 const mockedRevertCollabVersion = httpApi.revertCollabVersion as jest.MockedFunction<typeof httpApi.revertCollabVersion>;
@@ -180,6 +237,10 @@ const defaultWorkspaceId = 'test-workspace';
 const resetCommonMocks = () => {
   mockedUseCurrentUserOptional.mockReturnValue(undefined);
   mockedOpenCollabDB.mockReset();
+  mockedOpenCollabDBWithProvider.mockReset();
+  mockedOpenRowCollabDBWithProvider.mockReset();
+  mockedListCollabIndexedDBNames.mockReset();
+  mockedListCollabIndexedDBNames.mockResolvedValue(new Set());
   mockedHandleMessage.mockReset();
   mockedCollabFullSyncBatch.mockReset();
   mockedRevertCollabVersion.mockReset();
@@ -827,6 +888,50 @@ describe('useSync public API', () => {
     expect(items.map((item) => item.objectId).sort()).toEqual([docA.guid, docB.guid].sort());
     expect(items.every((item) => item.stateVector instanceof Uint8Array)).toBe(true);
     expect(items.every((item) => item.docState instanceof Uint8Array)).toBe(true);
+  });
+
+  it('syncAllToServer merges legacy row updates before encoding unregistered shared rows', async () => {
+    mockedCollabFullSyncBatch.mockResolvedValueOnce(undefined);
+    const ws = createWs();
+    const bc = createBroadcastChannel();
+    const databaseId = 'abcabcab-1111-4111-8111-abcabcabcabc';
+    const rowId = 'defdefde-2222-4222-8222-defdefdefdef';
+    const rowKey = `${databaseId}_rows_${rowId}`;
+    const databaseDoc = createDatabaseDocWithRows(databaseId, [rowId]);
+    const sharedRowDoc = createDatabaseRowDoc(rowId, databaseId, { 'server-field': 'server-value' });
+    const legacyRowDoc = createDatabaseRowDoc(rowId, databaseId, { 'legacy-field': 'legacy-value' });
+    const sharedProvider = { destroy: jest.fn().mockResolvedValue(undefined) };
+    const legacyProvider = { destroy: jest.fn().mockResolvedValue(undefined) };
+    const { result } = renderHook(() => useSync(ws, bc, defaultEventEmitter, defaultWorkspaceId));
+
+    mockedListCollabIndexedDBNames.mockResolvedValueOnce(new Set([rowKey]));
+    mockedOpenRowCollabDBWithProvider.mockResolvedValueOnce({
+      doc: sharedRowDoc,
+      provider: sharedProvider,
+    } as never);
+    mockedOpenCollabDBWithProvider.mockResolvedValueOnce({
+      doc: legacyRowDoc,
+      provider: legacyProvider,
+    } as never);
+
+    act(() => {
+      result.current.registerSyncContext({ doc: databaseDoc, collabType: Types.Database });
+    });
+
+    await act(async () => {
+      await result.current.syncAllToServer('workspace-sync');
+    });
+
+    const [, items] = mockedCollabFullSyncBatch.mock.calls[0]!;
+    const rowItem = items.find((item) => item.objectId === rowId);
+    const encodedRowDoc = createDoc(rowId);
+
+    expect(rowItem).toBeDefined();
+    Y.applyUpdate(encodedRowDoc, rowItem!.docState);
+    expect(getRowCellData(encodedRowDoc, 'server-field')).toBe('server-value');
+    expect(getRowCellData(encodedRowDoc, 'legacy-field')).toBe('legacy-value');
+    expect(sharedProvider.destroy).toHaveBeenCalledTimes(1);
+    expect(legacyProvider.destroy).toHaveBeenCalledTimes(1);
   });
 
   it('syncAllToServer tolerates batch API errors', async () => {

--- a/src/components/ws/__tests__/useSync.test.ts
+++ b/src/components/ws/__tests__/useSync.test.ts
@@ -9,6 +9,7 @@ import {
   openCollabDBWithProvider,
   openRowCollabDBWithProvider,
   listCollabIndexedDBNames,
+  collabIndexedDBExists,
 } from '@/application/db';
 import * as httpApi from '@/application/services/js-services/http/http_api';
 import { handleMessage } from '@/application/services/js-services/sync-protocol';
@@ -27,6 +28,7 @@ jest.mock('@/application/db', () => {
     openCollabDBWithProvider: jest.fn(),
     openRowCollabDBWithProvider: jest.fn(),
     listCollabIndexedDBNames: jest.fn(),
+    collabIndexedDBExists: jest.fn(),
   };
 });
 
@@ -217,6 +219,7 @@ const mockedOpenCollabDB = openCollabDB as jest.MockedFunction<typeof openCollab
 const mockedOpenCollabDBWithProvider = openCollabDBWithProvider as jest.MockedFunction<typeof openCollabDBWithProvider>;
 const mockedOpenRowCollabDBWithProvider = openRowCollabDBWithProvider as jest.MockedFunction<typeof openRowCollabDBWithProvider>;
 const mockedListCollabIndexedDBNames = listCollabIndexedDBNames as jest.MockedFunction<typeof listCollabIndexedDBNames>;
+const mockedCollabIndexedDBExists = collabIndexedDBExists as jest.MockedFunction<typeof collabIndexedDBExists>;
 const mockedHandleMessage = handleMessage as jest.MockedFunction<typeof handleMessage>;
 const mockedCollabFullSyncBatch = httpApi.collabFullSyncBatch as jest.MockedFunction<typeof httpApi.collabFullSyncBatch>;
 const mockedRevertCollabVersion = httpApi.revertCollabVersion as jest.MockedFunction<typeof httpApi.revertCollabVersion>;
@@ -241,6 +244,8 @@ const resetCommonMocks = () => {
   mockedOpenRowCollabDBWithProvider.mockReset();
   mockedListCollabIndexedDBNames.mockReset();
   mockedListCollabIndexedDBNames.mockResolvedValue(new Set());
+  mockedCollabIndexedDBExists.mockReset();
+  mockedCollabIndexedDBExists.mockResolvedValue(false);
   mockedHandleMessage.mockReset();
   mockedCollabFullSyncBatch.mockReset();
   mockedRevertCollabVersion.mockReset();
@@ -932,6 +937,57 @@ describe('useSync public API', () => {
     expect(getRowCellData(encodedRowDoc, 'legacy-field')).toBe('legacy-value');
     expect(sharedProvider.destroy).toHaveBeenCalledTimes(1);
     expect(legacyProvider.destroy).toHaveBeenCalledTimes(1);
+    expect(sharedProvider.destroy.mock.invocationCallOrder[0]!).toBeGreaterThan(
+      legacyProvider.destroy.mock.invocationCallOrder[0]!
+    );
+    expect(mockedCollabIndexedDBExists).not.toHaveBeenCalled();
+  });
+
+  it('syncAllToServer probes legacy row cache when IndexedDB enumeration is empty', async () => {
+    mockedCollabFullSyncBatch.mockResolvedValueOnce(undefined);
+    mockedCollabIndexedDBExists.mockResolvedValueOnce(true);
+    const ws = createWs();
+    const bc = createBroadcastChannel();
+    const databaseId = 'abcabcab-3333-4333-8333-abcabcabcabc';
+    const rowId = 'defdefde-4444-4444-8444-defdefdefdef';
+    const rowKey = `${databaseId}_rows_${rowId}`;
+    const databaseDoc = createDatabaseDocWithRows(databaseId, [rowId]);
+    const sharedRowDoc = createDatabaseRowDoc(rowId, databaseId, { 'server-field': 'server-value' });
+    const legacyRowDoc = createDatabaseRowDoc(rowId, databaseId, { 'legacy-field': 'legacy-value' });
+    const sharedProvider = { destroy: jest.fn().mockResolvedValue(undefined) };
+    const legacyProvider = { destroy: jest.fn().mockResolvedValue(undefined) };
+    const { result } = renderHook(() => useSync(ws, bc, defaultEventEmitter, defaultWorkspaceId));
+
+    mockedListCollabIndexedDBNames.mockResolvedValueOnce(new Set());
+    mockedOpenRowCollabDBWithProvider.mockResolvedValueOnce({
+      doc: sharedRowDoc,
+      provider: sharedProvider,
+    } as never);
+    mockedOpenCollabDBWithProvider.mockResolvedValueOnce({
+      doc: legacyRowDoc,
+      provider: legacyProvider,
+    } as never);
+
+    act(() => {
+      result.current.registerSyncContext({ doc: databaseDoc, collabType: Types.Database });
+    });
+
+    await act(async () => {
+      await result.current.syncAllToServer('workspace-sync');
+    });
+
+    const [, items] = mockedCollabFullSyncBatch.mock.calls[0]!;
+    const rowItem = items.find((item) => item.objectId === rowId);
+    const encodedRowDoc = createDoc(rowId);
+
+    expect(mockedCollabIndexedDBExists).toHaveBeenCalledWith(rowKey);
+    expect(rowItem).toBeDefined();
+    Y.applyUpdate(encodedRowDoc, rowItem!.docState);
+    expect(getRowCellData(encodedRowDoc, 'server-field')).toBe('server-value');
+    expect(getRowCellData(encodedRowDoc, 'legacy-field')).toBe('legacy-value');
+    expect(sharedProvider.destroy.mock.invocationCallOrder[0]!).toBeGreaterThan(
+      legacyProvider.destroy.mock.invocationCallOrder[0]!
+    );
   });
 
   it('syncAllToServer tolerates batch API errors', async () => {

--- a/src/components/ws/sync/useBatchSync.ts
+++ b/src/components/ws/sync/useBatchSync.ts
@@ -1,9 +1,14 @@
 import { useCallback, useEffect, useRef } from 'react';
 import * as Y from 'yjs';
 
-import { getRowKey , getMetaJSON } from '@/application/database-yjs/row_meta';
-import { openCollabDBWithProvider } from '@/application/db';
-import { getCachedRowSubDoc, getCachedRowSubDocIds, awaitPendingRowDocEnsures } from '@/application/services/js-services/cache';
+import { getRowKey, getMetaJSON } from '@/application/database-yjs/row_meta';
+import { listCollabIndexedDBNames, openCollabDBWithProvider, openRowCollabDBWithProvider } from '@/application/db';
+import {
+  getCachedRowSubDoc,
+  getCachedRowSubDocIds,
+  awaitPendingRowDocEnsures,
+  mergeLegacyRowDocIfExists,
+} from '@/application/services/js-services/cache';
 import { collabFullSyncBatch, createOrphanedView, checkIfCollabExists } from '@/application/services/js-services/http/http_api';
 import { withRetry } from '@/application/services/js-services/http/core';
 import { waitForDrain } from '@/application/sync-outbox';
@@ -157,6 +162,8 @@ export function useBatchSync(refs: SyncRefs) {
         }
       });
 
+      const existingIndexedDBNames = unregisteredRows.length > 0 ? await listCollabIndexedDBNames() : new Set<string>();
+
       for (let i = 0; i < unregisteredRows.length; i += ROW_SYNC_CONCURRENCY) {
         const slice = unregisteredRows.slice(i, i + ROW_SYNC_CONCURRENCY);
 
@@ -166,21 +173,26 @@ export function useBatchSync(refs: SyncRefs) {
               // Use skipCache to avoid permanently pinning every row doc in memory.
               // Destroy the provider immediately after reading — we only need the
               // encoded state for the batch request.
-              const { doc: rowDoc, provider } = await openCollabDBWithProvider(rowKey, { skipCache: true });
+              const { doc: rowDoc, provider } = await openRowCollabDBWithProvider(rowId, { skipCache: true });
 
               await provider.destroy();
 
               // If the row was never cached locally, the doc will be empty.
               // Skip it — uploading an empty state would overwrite the server's
               // real data during duplicate.
-              const rowSharedRoot = rowDoc.getMap(YjsEditorKey.data_section);
-              const rowMeta = rowSharedRoot.get(YjsEditorKey.meta) as Y.Map<unknown> | undefined;
+              let rowSharedRoot = rowDoc.getMap(YjsEditorKey.data_section);
+
+              if (existingIndexedDBNames.has(rowKey)) {
+                await mergeLegacyRowDocIfExists(rowKey, rowId, rowDoc, { legacyExists: true });
+                rowSharedRoot = rowDoc.getMap(YjsEditorKey.data_section);
+              }
 
               if (!rowSharedRoot.has(YjsEditorKey.database_row)) {
                 rowDoc.destroy();
                 return;
               }
 
+              const rowMeta = rowSharedRoot.get(YjsEditorKey.meta) as Y.Map<unknown> | undefined;
               const rowDocumentId = rowMeta ? getMetaJSON(rowId, rowMeta).documentId : '';
 
               if (rowDocumentId && !registeredObjectIds.has(rowDocumentId)) {

--- a/src/components/ws/sync/useBatchSync.ts
+++ b/src/components/ws/sync/useBatchSync.ts
@@ -2,7 +2,12 @@ import { useCallback, useEffect, useRef } from 'react';
 import * as Y from 'yjs';
 
 import { getRowKey, getMetaJSON } from '@/application/database-yjs/row_meta';
-import { listCollabIndexedDBNames, openCollabDBWithProvider, openRowCollabDBWithProvider } from '@/application/db';
+import {
+  collabIndexedDBExists,
+  listCollabIndexedDBNames,
+  openCollabDBWithProvider,
+  openRowCollabDBWithProvider,
+} from '@/application/db';
 import {
   getCachedRowSubDoc,
   getCachedRowSubDocIds,
@@ -171,45 +176,51 @@ export function useBatchSync(refs: SyncRefs) {
           slice.map(async ({ rowId, rowKey }) => {
             try {
               // Use skipCache to avoid permanently pinning every row doc in memory.
-              // Destroy the provider immediately after reading — we only need the
-              // encoded state for the batch request.
               const { doc: rowDoc, provider } = await openRowCollabDBWithProvider(rowId, { skipCache: true });
 
-              await provider.destroy();
+              try {
+                // If the row was never cached locally, the doc will be empty.
+                // Skip it — uploading an empty state would overwrite the server's
+                // real data during duplicate.
+                let rowSharedRoot = rowDoc.getMap(YjsEditorKey.data_section);
 
-              // If the row was never cached locally, the doc will be empty.
-              // Skip it — uploading an empty state would overwrite the server's
-              // real data during duplicate.
-              let rowSharedRoot = rowDoc.getMap(YjsEditorKey.data_section);
+                const legacyExists =
+                  existingIndexedDBNames.has(rowKey) ||
+                  (existingIndexedDBNames.size === 0 && (await collabIndexedDBExists(rowKey)));
 
-              if (existingIndexedDBNames.has(rowKey)) {
-                await mergeLegacyRowDocIfExists(rowKey, rowId, rowDoc, { legacyExists: true });
-                rowSharedRoot = rowDoc.getMap(YjsEditorKey.data_section);
+                if (legacyExists) {
+                  await mergeLegacyRowDocIfExists(rowKey, rowId, rowDoc, { legacyExists: true });
+                  rowSharedRoot = rowDoc.getMap(YjsEditorKey.data_section);
+                }
+
+                if (!rowSharedRoot.has(YjsEditorKey.database_row)) {
+                  return;
+                }
+
+                const rowMeta = rowSharedRoot.get(YjsEditorKey.meta) as Y.Map<unknown> | undefined;
+                const rowDocumentId = rowMeta ? getMetaJSON(rowId, rowMeta).documentId : '';
+
+                if (rowDocumentId && !registeredObjectIds.has(rowDocumentId)) {
+                  unregisteredRowDocumentIds.add(rowDocumentId);
+                }
+
+                const docState = Y.encodeStateAsUpdate(rowDoc);
+                const stateVector = Y.encodeStateVector(rowDoc);
+
+                items.push({
+                  objectId: rowId,
+                  collabType: Types.DatabaseRow,
+                  stateVector,
+                  docState,
+                });
+              } finally {
+                try {
+                  await provider.destroy();
+                } finally {
+                  rowDoc.destroy();
+                }
               }
 
-              if (!rowSharedRoot.has(YjsEditorKey.database_row)) {
-                rowDoc.destroy();
-                return;
-              }
-
-              const rowMeta = rowSharedRoot.get(YjsEditorKey.meta) as Y.Map<unknown> | undefined;
-              const rowDocumentId = rowMeta ? getMetaJSON(rowId, rowMeta).documentId : '';
-
-              if (rowDocumentId && !registeredObjectIds.has(rowDocumentId)) {
-                unregisteredRowDocumentIds.add(rowDocumentId);
-              }
-
-              const docState = Y.encodeStateAsUpdate(rowDoc);
-              const stateVector = Y.encodeStateVector(rowDoc);
-
-              rowDoc.destroy();
-
-              items.push({
-                objectId: rowId,
-                collabType: Types.DatabaseRow,
-                stateVector,
-                docState,
-              });
             } catch (e) {
               Log.warn('Failed to load unregistered row doc for sync', { rowKey, error: e });
             }

--- a/src/components/ws/sync/useCollabMessageHandler.ts
+++ b/src/components/ws/sync/useCollabMessageHandler.ts
@@ -3,7 +3,7 @@ import EventEmitter from 'events';
 import { useCallback, useEffect, useRef } from 'react';
 import * as Y from 'yjs';
 
-import { openCollabDB } from '@/application/db';
+import { deleteCollabDB, openCollabDB } from '@/application/db';
 import { handleMessage, SyncContext } from '@/application/services/js-services/sync-protocol';
 import { User, YDoc } from '@/application/types';
 import { collab } from '@/proto/messages';
@@ -157,6 +157,7 @@ export function useCollabMessageHandler(
               // `applyCollabMessage` would queue every subsequent message
               // and the doc would stay stuck until reload.
               await context.discardPendingUpdates?.();
+              await deleteCollabDB(previousDoc.guid, { destroyDoc: false });
               previousDoc.destroy();
 
               const localContext = context;

--- a/src/components/ws/sync/useCollabVersionRevert.ts
+++ b/src/components/ws/sync/useCollabVersionRevert.ts
@@ -3,7 +3,7 @@ import EventEmitter from 'events';
 import { useCallback } from 'react';
 import * as Y from 'yjs';
 
-import { openCollabDB } from '@/application/db';
+import { deleteCollabDB, openCollabDB } from '@/application/db';
 import * as http from '@/application/services/js-services/http/http_api';
 import { SyncContext } from '@/application/services/js-services/sync-protocol';
 import { User, YDoc } from '@/application/types';
@@ -76,6 +76,7 @@ export function useCollabVersionRevert(deps: CollabVersionRevertDeps) {
         Log.debug('[Version] Collab version changed:', viewId, previousDoc.version, nextVersion);
         previousDoc.emit('reset', [context, nextVersion]);
         refs.skipFlushOnDestroy.current.add(previousDoc.guid);
+        await deleteCollabDB(previousDoc.guid, { destroyDoc: false });
         previousDoc.destroy();
 
         try {

--- a/src/components/ws/sync/useWorkspaceNotifications.ts
+++ b/src/components/ws/sync/useWorkspaceNotifications.ts
@@ -3,10 +3,13 @@ import EventEmitter from 'events';
 import { useEffect } from 'react';
 
 import { APP_EVENTS } from '@/application/constants';
+import { deleteCollabDB } from '@/application/db';
+import { deleteOutboxByObjectId } from '@/application/sync-outbox';
 import { notification } from '@/proto/messages';
 import { Log } from '@/utils/log';
 
 type WorkspaceNotification = notification.IWorkspaceNotification;
+const PERMISSION_CHANGED_REASON_OBJECT_DELETED = 1;
 
 function dispatchNotifications(
   eventEmitter: EventEmitter,
@@ -18,6 +21,14 @@ function dispatchNotifications(
 
   if (n.permissionChanged) {
     eventEmitter.emit(APP_EVENTS.PERMISSION_CHANGED, n.permissionChanged);
+
+    if (
+      n.permissionChanged.objectId &&
+      n.permissionChanged.reason === PERMISSION_CHANGED_REASON_OBJECT_DELETED
+    ) {
+      void deleteOutboxByObjectId(n.permissionChanged.objectId);
+      void deleteCollabDB(n.permissionChanged.objectId, { destroyDoc: false });
+    }
   }
 
   if (n.sectionChanged) {


### PR DESCRIPTION
## Summary
- add shared Dexie-backed collab storage tables for high-cardinality row Yjs data
- keep `openCollabDB(objectId)` semantics while routing rows through shared storage to avoid one IndexedDB database per row
- merge legacy per-row IndexedDB data into shared storage before normal load and batch sync
- tighten cache deletion/reset paths, pending open disposal, workspace-info refresh, and blob RID cache clearing
- add load-more row UI support for large database row rendering

## Tests
- `pnpm type-check`
- `pnpm jest src/application/db/__tests__/index.test.ts src/application/services/js-services/cache/__tests__/cache.test.ts src/components/ws/__tests__/useSync.test.ts src/components/app/layers/__tests__/AppAuthLayer.test.tsx src/components/database/components/grid/grid-row/__tests__/useRenderRows.test.tsx --no-coverage --runInBand`

## Summary by Sourcery

Introduce shared IndexedDB-backed collab storage for row documents, migrate legacy per-row caches into this shared store, and improve workspace bootstrap and database grid UX for large datasets and transient failures.

New Features:
- Add shared collab storage tables and persistence for high-cardinality row Yjs data, avoiding one IndexedDB database per row.
- Support opening row collab documents through a shared persistence layer with migration from legacy per-row IndexedDB caches.
- Expose a load-more row UI and incremental row visibility for embedded database grids in document blocks.
- Provide a workspace bootstrap error screen with retry handling when workspace info fails to load.

Bug Fixes:
- Ensure collab providers and docs are properly disposed on access changes, deletions, or version resets, preventing stale caches and IndexedDB leaks.
- Fix workspace switching to ignore stale workspace-info responses and to reuse in-flight requests safely.
- Clear blob RID checkpoints consistently when shared collab cache databases or per-database row caches are deleted.
- Handle retryable workspace-info failures automatically on network/server issues without requiring a manual refresh.

Enhancements:
- Refine collab provider caching with explicit disposed-state tracking and safer concurrent open handling.
- Add shared collab compaction with snapshots and batched update tails to reduce IndexedDB growth for row storage.
- Improve database row sync to merge legacy row caches before batching unregistered rows to the server.
- Extend database condition signatures to handle bigint-safe stringification for caching.
- Enhance grid context to track remaining row count and last visible row for better embedded grid interactions.

Tests:
- Add unit tests for collab shared storage internals, including snapshot/update reads and blob RID checkpoint clearing.
- Add tests for legacy row cache migration into shared row storage and for row rendering with load-more behavior.
- Add tests ensuring AppAuthLayer correctly forces fresh workspace-info loads and ignores stale responses on workspace switches.