### PR TITLE
Fix pending database blob row persistence

### DIFF
--- a/src/application/database-blob/index.ts
+++ b/src/application/database-blob/index.ts
@@ -42,12 +42,21 @@ type SharedPrefetchEntry = {
   promise?: Promise<database_blob.DatabaseBlobDiffResponse>;
 };
 
+type FetchDiffResult = {
+  diff: database_blob.DatabaseBlobDiffResponse;
+  ready: boolean;
+};
+
 const RID_CACHE_PREFIX = 'af_database_blob_rid:';
 const APPLY_CONCURRENCY = 6;
 const MAX_ROW_DOC_SEEDS = 2000;
 const MAX_ROW_DOC_SEEDS_LOOKUP = 10000;
+const BLOB_DIFF_PENDING_RETRIES = 1;
+const BLOB_DIFF_DEFAULT_RETRY_MS = 1000;
+const BLOB_DIFF_MAX_RETRY_MS = 5000;
 
 const readyStatus = database_blob.DiffStatus.READY;
+const pendingStatus = database_blob.DiffStatus.PENDING;
 const sharedPrefetchEntries = new Map<string, SharedPrefetchEntry>();
 
 function ridCacheKey(databaseId: string) {
@@ -68,6 +77,15 @@ function sharedPrefetchKeyForOptions(workspaceId: string, databaseId: string, op
 
 function sharedPrefetchEntryMatchesDatabase(sharedKey: string, databaseId: string) {
   return sharedKey.includes(`:${databaseId}:`) || sharedKey.endsWith(`:${databaseId}`);
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => window.setTimeout(resolve, ms));
+}
+
+function retryDelayMs(retryAfterSecs?: number | null): number {
+  if (!retryAfterSecs || retryAfterSecs <= 0) return BLOB_DIFF_DEFAULT_RETRY_MS;
+  return Math.min(retryAfterSecs * 1000, BLOB_DIFF_MAX_RETRY_MS);
 }
 
 function applyPrefetchOptions(entry: SharedPrefetchEntry, options?: PrefetchOptions) {
@@ -769,7 +787,47 @@ async function applyDiff(
   });
 }
 
-async function fetchReadyDiff(workspaceId: string, databaseId: string, options?: { forceFullSync?: boolean }) {
+async function persistDiffToIndexedDB(
+  databaseId: string,
+  diff: database_blob.DatabaseBlobDiffResponse,
+  options: { source: string; writeRid: boolean }
+) {
+  const applyStartedAt = Date.now();
+
+  try {
+    await applyDiff(databaseId, diff, { seedCache: false });
+    Log.debug('[Database] blob diff persisted to IndexedDB', {
+      databaseId,
+      source: options.source,
+      durationMs: Date.now() - applyStartedAt,
+      ...summarizeDiff(diff),
+    });
+
+    if (!options.writeRid) return;
+
+    const maxRid = maxRidFromDiff(diff);
+
+    if (maxRid) {
+      writeCachedRid(databaseId, maxRid);
+      Log.debug('[Database] blob updated rid cache', { databaseId, maxRid });
+    }
+  } catch (error) {
+    Log.warn('[Database] blob diff persist failed', {
+      databaseId,
+      source: options.source,
+      error,
+    });
+  }
+}
+
+async function fetchReadyDiff(
+  workspaceId: string,
+  databaseId: string,
+  options?: {
+    forceFullSync?: boolean;
+    onPendingDiff?: (diff: database_blob.DatabaseBlobDiffResponse, attempt: number) => void;
+  }
+): Promise<FetchDiffResult> {
   const cachedRid = options?.forceFullSync ? null : readCachedRid(databaseId);
   const request = database_blob.DatabaseBlobDiffRequest.create({
     maxKnownRid: cachedRid ? { timestamp: cachedRid.timestamp, seqNo: cachedRid.seqNo } : undefined,
@@ -783,22 +841,59 @@ async function fetchReadyDiff(workspaceId: string, databaseId: string, options?:
     maxKnownRid: cachedRid ?? null,
   });
 
-  const startedAt = Date.now();
-  const diff = await databaseBlobDiff(workspaceId, databaseId, request);
+  const firstAttemptStartedAt = Date.now();
+  const maxAttempts = BLOB_DIFF_PENDING_RETRIES + 1;
 
-  Log.debug('[Database] blob diff response', {
-    databaseId,
-    status: diff.status,
-    retryAfterSecs: diff.retryAfterSecs ?? null,
-    durationMs: Date.now() - startedAt,
-    ...summarizeDiff(diff),
-  });
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    const attemptStartedAt = Date.now();
+    const diff = await databaseBlobDiff(workspaceId, databaseId, request);
 
-  if (diff.status !== readyStatus) {
-    throw new Error('database blob diff is not ready');
+    Log.debug('[Database] blob diff response', {
+      databaseId,
+      status: diff.status,
+      retryAfterSecs: diff.retryAfterSecs ?? null,
+      attempt,
+      durationMs: Date.now() - attemptStartedAt,
+      totalDurationMs: Date.now() - firstAttemptStartedAt,
+      ...summarizeDiff(diff),
+    });
+
+    if (diff.status === readyStatus) {
+      return { diff, ready: true };
+    }
+
+    if (diff.status !== pendingStatus) {
+      throw new Error(
+        `database blob diff failed: status=${diff.status}, attempts=${attempt}, message=${diff.message ?? 'none'}`
+      );
+    }
+
+    options?.onPendingDiff?.(diff, attempt);
+
+    if (attempt === maxAttempts) {
+      Log.warn('[Database] blob diff still pending; falling back to row sync', {
+        databaseId,
+        attempts: attempt,
+        message: diff.message ?? null,
+        ...summarizeDiff(diff),
+      });
+      return { diff, ready: false };
+    }
+
+    const delayMs = retryDelayMs(diff.retryAfterSecs);
+
+    Log.debug('[Database] blob diff pending; retrying', {
+      databaseId,
+      attempt,
+      nextAttempt: attempt + 1,
+      delayMs,
+      message: diff.message ?? null,
+    });
+
+    await sleep(delayMs);
   }
 
-  return diff;
+  throw new Error('database blob diff is not ready');
 }
 
 export async function prefetchDatabaseBlobDiff(
@@ -831,16 +926,16 @@ export async function prefetchDatabaseBlobDiff(
 
   applyPrefetchOptions(entry, options);
 
-  const promise = (async () => {
-    const diff = await fetchReadyDiff(workspaceId, databaseId, {
-      forceFullSync: options?.forceFullSync,
-    });
+  let pendingPersistQueue: Promise<void> = Promise.resolve();
+
+  const seedDiff = (diff: database_blob.DatabaseBlobDiffResponse, source: string) => {
     const seedSummary = seedRowDocCacheFromDiff(databaseId, diff, {
       priorityRowIds: Array.from(entry.priorityRowIds),
     });
 
     Log.debug('[Database] blob seed cache prepared', {
       databaseId,
+      source,
       forceFullSync: options?.forceFullSync ?? false,
       ...seedSummary,
       seedCount: rowDocSeedCache.size,
@@ -850,36 +945,45 @@ export async function prefetchDatabaseBlobDiff(
     // Signal that seeds are available before the slow IndexedDB persist.
     notifySeedsReady(entry);
 
-    if (options?.forceFullSync) {
-      Log.debug('[Database] blob full seed persistence skipped', {
-        databaseId,
-        ...summarizeDiff(diff),
-      });
+    return seedSummary;
+  };
+
+  const handlePendingDiff = (diff: database_blob.DatabaseBlobDiffResponse, attempt: number) => {
+    const summary = summarizeDiff(diff);
+
+    if (summary.rowDocStates === 0) return;
+
+    seedDiff(diff, 'pending');
+
+    pendingPersistQueue = pendingPersistQueue.then(() =>
+      persistDiffToIndexedDB(databaseId, diff, {
+        source: `pending attempt ${attempt}`,
+        writeRid: false,
+      })
+    );
+  };
+
+  const promise = (async () => {
+    const { diff, ready } = await fetchReadyDiff(workspaceId, databaseId, {
+      forceFullSync: options?.forceFullSync,
+      onPendingDiff: handlePendingDiff,
+    });
+
+    if (!ready) {
+      if (!entry.seedsReady) {
+        notifySeedsReady(entry);
+      }
+
+      await pendingPersistQueue;
       return diff;
     }
 
-    const applyStartedAt = Date.now();
-
-    try {
-      await applyDiff(databaseId, diff, { seedCache: false });
-      Log.debug('[Database] blob diff persisted to IndexedDB', {
-        databaseId,
-        durationMs: Date.now() - applyStartedAt,
-        ...summarizeDiff(diff),
-      });
-
-      const maxRid = maxRidFromDiff(diff);
-
-      if (maxRid) {
-        writeCachedRid(databaseId, maxRid);
-        Log.debug('[Database] blob updated rid cache', { databaseId, maxRid });
-      }
-    } catch (error) {
-      Log.warn('[Database] blob diff persist failed', {
-        databaseId,
-        error,
-      });
-    }
+    seedDiff(diff, 'ready');
+    await pendingPersistQueue;
+    await persistDiffToIndexedDB(databaseId, diff, {
+      source: options?.forceFullSync ? 'ready full' : 'ready delta',
+      writeRid: !options?.forceFullSync,
+    });
 
     return diff;
   })().finally(() => {

--- a/src/application/database-yjs/hooks/useBackgroundRowDocLoader.ts
+++ b/src/application/database-yjs/hooks/useBackgroundRowDocLoader.ts
@@ -3,6 +3,7 @@ import * as Y from 'yjs';
 
 import { useDatabaseContext, useDatabaseView, useDatabaseViewId, useRowMap } from '@/application/database-yjs/context';
 import { hasRowConditionData } from '@/application/database-yjs/condition-value-cache';
+import { openRowCollabDBWithProvider } from '@/application/db';
 import { getRowKey } from '@/application/database-yjs/row_meta';
 import { YDoc, YjsDatabaseKey } from '@/application/types';
 
@@ -53,7 +54,7 @@ function getAllStoreValues<T>(db: IDBDatabase, storeName: string) {
   });
 }
 
-async function openReadOnlyRowDoc(rowKey: string) {
+async function openLegacyReadOnlyRowDoc(rowKey: string) {
   const db = await openIndexedDB(rowKey);
 
   try {
@@ -72,17 +73,31 @@ async function openReadOnlyRowDoc(rowKey: string) {
   }
 }
 
-function openEphemeralRowDoc(rowKey: string) {
-  const pending = pendingEphemeralRowDocs.get(rowKey);
+async function openReadOnlyRowDoc(rowKey: string, rowId: string) {
+  const { doc, provider } = await openRowCollabDBWithProvider(rowId, { skipCache: true });
+
+  await provider.destroy();
+
+  if (hasRowConditionData(doc)) {
+    return doc;
+  }
+
+  doc.destroy();
+  return openLegacyReadOnlyRowDoc(rowKey);
+}
+
+function openEphemeralRowDoc(rowKey: string, rowId: string) {
+  const pendingKey = `${rowKey}:${rowId}`;
+  const pending = pendingEphemeralRowDocs.get(pendingKey);
 
   if (pending) return pending;
 
-  const promise = openReadOnlyRowDoc(rowKey);
+  const promise = openReadOnlyRowDoc(rowKey, rowId);
 
-  pendingEphemeralRowDocs.set(rowKey, promise);
+  pendingEphemeralRowDocs.set(pendingKey, promise);
   promise.finally(() => {
-    if (pendingEphemeralRowDocs.get(rowKey) === promise) {
-      pendingEphemeralRowDocs.delete(rowKey);
+    if (pendingEphemeralRowDocs.get(pendingKey) === promise) {
+      pendingEphemeralRowDocs.delete(pendingKey);
     }
   }).catch(() => undefined);
 
@@ -501,7 +516,7 @@ export function useBackgroundRowDocLoader(hasConditions: boolean) {
               // module-level pending map dedupes concurrent opens across views
               // without retaining the doc in the process-wide row cache.
               const rowKey = getRowKey(databaseDoc.guid, rowId);
-              const pending = openEphemeralRowDoc(rowKey);
+              const pending = openEphemeralRowDoc(rowKey, rowId);
 
               store.cachedRowDocPending.set(rowId, pending);
 

--- a/src/application/database-yjs/selector.ts
+++ b/src/application/database-yjs/selector.ts
@@ -1187,7 +1187,16 @@ export function useRowOrdersSelector() {
   const fields = useDatabaseFields();
   const filters = view?.get(YjsDatabaseKey.filters);
   const database = useDatabase();
-  const { databaseDoc, loadView, createRow, getViewIdFromDatabaseId, ensureRow, loadRowFromSeed } = useDatabaseContext();
+  const {
+    databaseDoc,
+    loadView,
+    createRow,
+    getViewIdFromDatabaseId,
+    ensureRow,
+    loadRowFromSeed,
+    blobPrefetchComplete,
+    seedsReady,
+  } = useDatabaseContext();
 
   const [rowOrdersState, setRowOrdersState] = useState<{
     rows?: Row[];
@@ -1281,12 +1290,12 @@ export function useRowOrdersSelector() {
                 // An opened row doc can still receive its row data from sync; don't settle it as unavailable yet.
                 const rowDocOpenedForHydration = Boolean(seededDoc || ensuredDoc);
 
-                if (
-                  conditionSignatureRef.current === requestConditionSignature &&
+                const shouldMarkUnavailable =
                   !ensuredHasConditionData &&
-                  !rowDocOpenedForHydration &&
-                  !hasRowConditionData(rowDocsForConditionsRef.current[rowId])
-                ) {
+                  !hasRowConditionData(rowDocsForConditionsRef.current[rowId]) &&
+                  (!rowDocOpenedForHydration || seedsReady || blobPrefetchComplete);
+
+                if (conditionSignatureRef.current === requestConditionSignature && shouldMarkUnavailable) {
                   markConditionRowsUnavailable([{ id: rowId, height: 0 }]);
                 }
               }
@@ -1304,7 +1313,7 @@ export function useRowOrdersSelector() {
           })();
         });
     },
-    [ensureRow, loadRowFromSeed, markConditionRowsUnavailable]
+    [blobPrefetchComplete, ensureRow, loadRowFromSeed, markConditionRowsUnavailable, seedsReady]
   );
 
   // Getter for relation cell text (used in sorting/filtering)

--- a/src/components/database/components/cell/file-media/FileMediaCell.tsx
+++ b/src/components/database/components/cell/file-media/FileMediaCell.tsx
@@ -24,7 +24,10 @@ export function FileMediaCell({
   rowId,
   readOnly,
 }: CellProps<FileMediaCellType>) {
-  const value = cell?.data;
+  const rawValue = cell?.data;
+  const value = useMemo(() => {
+    return Array.isArray(rawValue) ? rawValue.filter(Boolean) : [];
+  }, [rawValue]);
   const { workspaceId, databasePageId } = useDatabaseContext();
   const [openPreview, setOpenPreview] = React.useState(false);
   const previewIndexRef = React.useRef(0);


### PR DESCRIPTION
## Summary
- seed usable row doc states from PENDING blob diff responses immediately
- retry a pending blob diff only once, then fall back to normal row sync
- persist PENDING creates/rowDocStates into IndexedDB before marking blob prefetch complete
- read fallback row docs from shared row storage and guard file media cells against malformed values

## Review fix
- The React/data-loading review issue was that blob prefetch could become complete while pending row states were still only in memory. The fallback path now drains the pending IndexedDB persist queue before resolving, while seeds still unblock rendering early.

## Test
- pnpm run lint

## Summary by Sourcery

Improve robustness of database blob prefetching and row loading when diff responses remain pending, ensuring pending row states are persisted and safely consumed.

Bug Fixes:
- Ensure pending database blob diff responses seed and persist row doc states before marking blob prefetch as complete to avoid losing in-memory state.
- Retry pending blob diff requests only once before falling back to normal row sync to prevent indefinite pending states.
- Guard file media cells against malformed or non-array cell data that could break rendering.
- Use shared row storage when reopening ephemeral row docs so that malformed legacy row docs do not block condition evaluation.
- Avoid prematurely marking condition rows as unavailable while blob seeds may still arrive, based on blob prefetch and seed readiness flags.