### PR TITLE
Fix legacy row cache recovery

### DIFF
--- a/src/application/db/index.ts
+++ b/src/application/db/index.ts
@@ -9,6 +9,10 @@ import {
   type CollabStorageTable,
   type CollabUpdateRecord,
 } from '@/application/db/tables/collab_storage';
+import {
+  localCollabRecoverySchema,
+  type LocalCollabRecoveryTable,
+} from '@/application/db/tables/local_collab_recovery';
 import { rowSchema, rowTable } from '@/application/db/tables/rows';
 import { syncOutboxSchema, SyncOutboxTable } from '@/application/db/tables/sync_outbox';
 import { userSchema, UserTable } from '@/application/db/tables/users';
@@ -27,14 +31,23 @@ type DexieTables = ViewMetasTable &
   WorkspaceMemberProfileTable &
   VersionsTable &
   SyncOutboxTable &
-  CollabStorageTable;
+  CollabStorageTable &
+  LocalCollabRecoveryTable;
 
 export type Dexie<T = DexieTables> = BaseDexie & T;
 
 export const db = new BaseDexie(`${databasePrefix}_cache`) as Dexie;
 const _schema = Object.assign(
   {},
-  { ...viewMetasSchema, ...userSchema, ...rowSchema, ...versionSchema, ...syncOutboxSchema, ...collabStorageSchema }
+  {
+    ...viewMetasSchema,
+    ...userSchema,
+    ...rowSchema,
+    ...versionSchema,
+    ...syncOutboxSchema,
+    ...collabStorageSchema,
+    ...localCollabRecoverySchema,
+  }
 );
 
 // Version 1: Initial schema with view_metas, users, and rows
@@ -145,6 +158,19 @@ db.version(7).stores({
   ...versionSchema,
   ...syncOutboxSchema,
   ...collabStorageSchema,
+});
+
+// Version 8: Durable recovery manifest for local collab data that must be
+// uploaded independently from React's opened-doc lifecycle.
+db.version(8).stores({
+  ...viewMetasSchema,
+  ...userSchema,
+  ...rowSchema,
+  ...workspaceMemberProfileSchema,
+  ...versionSchema,
+  ...syncOutboxSchema,
+  ...collabStorageSchema,
+  ...localCollabRecoverySchema,
 });
 
 const openedSet = new Set<string>();

--- a/src/application/db/tables/local_collab_recovery.ts
+++ b/src/application/db/tables/local_collab_recovery.ts
@@ -1,0 +1,37 @@
+import { Table } from 'dexie';
+
+export type LocalCollabRecoveryStatus =
+  | 'discovered'
+  | 'merged'
+  | 'uploading'
+  | 'synced'
+  | 'legacy_deleted'
+  | 'failed'
+  | 'skipped';
+
+export interface LocalCollabRecoveryRecord {
+  workspaceId: string;
+  objectId: string;
+  collabType: number;
+  databaseId: string;
+  databaseIdAliases?: string[];
+  legacyDbName: string;
+  legacyCacheDeleted?: boolean;
+  source: 'legacy';
+  status: LocalCollabRecoveryStatus;
+  attempts: number;
+  discoveredAt: number;
+  updatedAt: number;
+  lastLocalAt: number;
+  lastSyncedAt?: number;
+  error?: string;
+}
+
+export type LocalCollabRecoveryTable = {
+  local_collab_recovery: Table<LocalCollabRecoveryRecord, [string, string]>;
+};
+
+export const localCollabRecoverySchema = {
+  local_collab_recovery:
+    '[workspaceId+objectId], workspaceId, status, [workspaceId+status], legacyDbName, updatedAt',
+};

--- a/src/application/local-collab-recovery/__tests__/index.test.ts
+++ b/src/application/local-collab-recovery/__tests__/index.test.ts
@@ -1,0 +1,220 @@
+import * as Y from 'yjs';
+
+import { deleteCollabDB, listCollabIndexedDBNames, openRowCollabDBWithProvider } from '@/application/db';
+import {
+  parseLegacyRowDatabaseName,
+  recoverLegacyDatabaseRowsForWorkspace,
+} from '@/application/local-collab-recovery';
+import { mergeLegacyRowDocIfExists } from '@/application/services/js-services/cache';
+import { withRetry } from '@/application/services/js-services/http/core';
+import { collabFullSyncBatchStrict } from '@/application/services/js-services/http/http_api';
+import { Types, YDoc, YjsDatabaseKey, YjsEditorKey } from '@/application/types';
+
+jest.mock('@/application/db', () => {
+  const records = new Map<string, Record<string, unknown>>();
+  const recordKey = (workspaceId: string, objectId: string) => `${workspaceId}:${objectId}`;
+  const recoveryTable = {
+    get: jest.fn(async ([workspaceId, objectId]: [string, string]) => {
+      return records.get(recordKey(workspaceId, objectId));
+    }),
+    put: jest.fn(async (record: { workspaceId: string; objectId: string }) => {
+      records.set(recordKey(record.workspaceId, record.objectId), record);
+    }),
+    where: jest.fn((indexName: string) => ({
+      equals: jest.fn((value: string) => ({
+        filter: jest.fn((predicate: (record: Record<string, unknown>) => boolean) => ({
+          toArray: jest.fn(async () => {
+            return Array.from(records.values()).filter((record) => {
+              if (indexName === 'workspaceId' && record.workspaceId !== value) return false;
+              return predicate(record);
+            });
+          }),
+        })),
+      })),
+    })),
+  };
+
+  return {
+    db: {
+      local_collab_recovery: recoveryTable,
+    },
+    __mockRecords: records,
+    listCollabIndexedDBNames: jest.fn(),
+    collabIndexedDBExists: jest.fn(),
+    openCollabDBWithProvider: jest.fn(),
+    openRowCollabDBWithProvider: jest.fn(),
+    deleteCollabDB: jest.fn(),
+  };
+});
+
+jest.mock('@/application/services/js-services/cache', () => ({
+  mergeLegacyRowDocIfExists: jest.fn(),
+}));
+
+jest.mock('@/application/services/js-services/http/http_api', () => ({
+  collabFullSyncBatchStrict: jest.fn(),
+}));
+
+jest.mock('@/application/services/js-services/http/core', () => ({
+  withRetry: jest.fn((fn: () => Promise<unknown>) => fn()),
+}));
+
+const mockedListCollabIndexedDBNames = listCollabIndexedDBNames as jest.MockedFunction<typeof listCollabIndexedDBNames>;
+const mockedOpenRowCollabDBWithProvider = openRowCollabDBWithProvider as jest.MockedFunction<
+  typeof openRowCollabDBWithProvider
+>;
+const mockedDeleteCollabDB = deleteCollabDB as jest.MockedFunction<typeof deleteCollabDB>;
+const mockedMergeLegacyRowDocIfExists = mergeLegacyRowDocIfExists as jest.MockedFunction<
+  typeof mergeLegacyRowDocIfExists
+>;
+const mockedCollabFullSyncBatchStrict = collabFullSyncBatchStrict as jest.MockedFunction<
+  typeof collabFullSyncBatchStrict
+>;
+const mockedWithRetry = withRetry as jest.MockedFunction<typeof withRetry>;
+const mockedDbModule = jest.requireMock('@/application/db') as {
+  __mockRecords: Map<string, Record<string, unknown>>;
+};
+
+function mockRecordKey(workspaceId: string, objectId: string) {
+  return `${workspaceId}:${objectId}`;
+}
+
+function createRowDoc(rowId: string, databaseId: string) {
+  const doc = new Y.Doc({ guid: rowId }) as YDoc;
+  const sharedRoot = doc.getMap(YjsEditorKey.data_section);
+  const row = new Y.Map();
+
+  row.set(YjsDatabaseKey.id, rowId);
+  row.set(YjsDatabaseKey.database_id, databaseId);
+  sharedRoot.set(YjsEditorKey.database_row, row);
+
+  return doc;
+}
+
+describe('local collab recovery', () => {
+  const workspaceId = '82a2fdf6-d985-4112-84b6-86e052ec1ed3';
+  const databaseId = '5b6ed219-a7c9-4017-bf6c-b156c27f5cf0';
+  const viewId = 'e654058e-dc95-55ff-89d6-68b208faa346';
+  const rowId = '0b6e61d4-ed44-4dee-9704-0bcb6b7205b1';
+  const rowKey = `${databaseId}_rows_${rowId}`;
+  const legacyViewRowKey = `${viewId}_rows_${rowId}`;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedDbModule.__mockRecords.clear();
+    localStorage.clear();
+    mockedListCollabIndexedDBNames.mockResolvedValue(new Set([rowKey]));
+    mockedMergeLegacyRowDocIfExists.mockResolvedValue(true);
+    mockedCollabFullSyncBatchStrict.mockResolvedValue(undefined);
+    mockedDeleteCollabDB.mockResolvedValue(true);
+    mockedWithRetry.mockImplementation((fn: () => Promise<unknown>) => fn() as never);
+  });
+
+  it('parses legacy row IndexedDB names', () => {
+    expect(parseLegacyRowDatabaseName(rowKey)).toEqual({
+      databaseId,
+      rowId,
+      rowKey,
+    });
+    expect(parseLegacyRowDatabaseName(`${databaseId}_rows_not-a-row-id`)).toBeNull();
+  });
+
+  it('deletes the legacy cache after merging into shared row storage', async () => {
+    const rowDoc = createRowDoc(rowId, databaseId);
+    const provider = { destroy: jest.fn().mockResolvedValue(undefined) };
+
+    mockedOpenRowCollabDBWithProvider.mockResolvedValue({
+      doc: rowDoc,
+      provider,
+    } as never);
+
+    const summary = await recoverLegacyDatabaseRowsForWorkspace({
+      workspaceId,
+      databaseRelations: {
+        [databaseId]: viewId,
+      },
+    });
+
+    expect(summary.uploaded).toBe(1);
+    expect(mockedMergeLegacyRowDocIfExists).toHaveBeenCalledWith(rowKey, rowId, rowDoc, {
+      legacyExists: true,
+      deleteLegacyCache: false,
+    });
+    expect(mockedMergeLegacyRowDocIfExists.mock.invocationCallOrder[0]).toBeLessThan(
+      mockedDeleteCollabDB.mock.invocationCallOrder[0]
+    );
+    expect(mockedDeleteCollabDB.mock.invocationCallOrder[0]).toBeLessThan(
+      mockedCollabFullSyncBatchStrict.mock.invocationCallOrder[0]
+    );
+    expect(mockedCollabFullSyncBatchStrict).toHaveBeenCalledWith(
+      workspaceId,
+      expect.arrayContaining([
+        expect.objectContaining({
+          objectId: rowId,
+          collabType: Types.DatabaseRow,
+        }),
+      ])
+    );
+    expect(mockedDeleteCollabDB).toHaveBeenCalledWith(rowKey);
+    expect(mockedDbModule.__mockRecords.get(mockRecordKey(workspaceId, rowId))).toMatchObject({
+      legacyCacheDeleted: true,
+      status: 'legacy_deleted',
+    });
+  });
+
+  it('recovers legacy rows keyed by database view id', async () => {
+    const rowDoc = createRowDoc(rowId, viewId);
+
+    mockedListCollabIndexedDBNames.mockResolvedValue(new Set([legacyViewRowKey]));
+    mockedOpenRowCollabDBWithProvider.mockResolvedValue({
+      doc: rowDoc,
+      provider: { destroy: jest.fn().mockResolvedValue(undefined) },
+    } as never);
+
+    const summary = await recoverLegacyDatabaseRowsForWorkspace({
+      workspaceId,
+      databaseRelations: {
+        [databaseId]: viewId,
+      },
+    });
+
+    const row = rowDoc.getMap(YjsEditorKey.data_section).get(YjsEditorKey.database_row) as Y.Map<unknown>;
+
+    expect(summary.uploaded).toBe(1);
+    expect(row.get(YjsDatabaseKey.database_id)).toBe(databaseId);
+    expect(mockedMergeLegacyRowDocIfExists).toHaveBeenCalledWith(legacyViewRowKey, rowId, rowDoc, {
+      legacyExists: true,
+      deleteLegacyCache: false,
+    });
+    expect(mockedDbModule.__mockRecords.get(mockRecordKey(workspaceId, rowId))).toMatchObject({
+      databaseId,
+      legacyDbName: legacyViewRowKey,
+      status: 'legacy_deleted',
+    });
+    expect(mockedDeleteCollabDB).toHaveBeenCalledWith(legacyViewRowKey);
+  });
+
+  it('keeps the recovered row retryable when upload fails', async () => {
+    const rowDoc = createRowDoc(rowId, databaseId);
+
+    mockedOpenRowCollabDBWithProvider.mockResolvedValue({
+      doc: rowDoc,
+      provider: { destroy: jest.fn().mockResolvedValue(undefined) },
+    } as never);
+    mockedCollabFullSyncBatchStrict.mockRejectedValue(new Error('server rejected batch'));
+
+    const summary = await recoverLegacyDatabaseRowsForWorkspace({
+      workspaceId,
+      databaseRelations: {
+        [databaseId]: viewId,
+      },
+    });
+
+    expect(summary.failed).toBe(1);
+    expect(mockedDeleteCollabDB).toHaveBeenCalledWith(rowKey);
+    expect(mockedDbModule.__mockRecords.get(mockRecordKey(workspaceId, rowId))).toMatchObject({
+      legacyCacheDeleted: true,
+      status: 'failed',
+    });
+  });
+});

--- a/src/application/local-collab-recovery/index.ts
+++ b/src/application/local-collab-recovery/index.ts
@@ -1,0 +1,694 @@
+import { validate as uuidValidate } from 'uuid';
+import * as Y from 'yjs';
+
+import {
+  collabIndexedDBExists,
+  db,
+  deleteCollabDB,
+  listCollabIndexedDBNames,
+  openCollabDBWithProvider,
+  openRowCollabDBWithProvider,
+} from '@/application/db';
+import {
+  LocalCollabRecoveryRecord,
+  LocalCollabRecoveryStatus,
+} from '@/application/db/tables/local_collab_recovery';
+import { getRowKey } from '@/application/database-yjs/row_meta';
+import { mergeLegacyRowDocIfExists } from '@/application/services/js-services/cache';
+import { withRetry } from '@/application/services/js-services/http/core';
+import { collabFullSyncBatchStrict } from '@/application/services/js-services/http/http_api';
+import { DatabaseRelations, Types, YDatabase, YDoc, YjsDatabaseKey, YjsEditorKey } from '@/application/types';
+import { Log } from '@/utils/log';
+
+const LEGACY_ROW_DELIMITER = '_rows_';
+const RECOVERY_LOCK_TTL_MS = 120_000;
+const RECOVERY_MERGE_CONCURRENCY = 12;
+const RECOVERY_UPLOAD_BATCH_SIZE = 50;
+const RECOVERY_RETRY_DELAYS = [30_000, 30_000, 30_000];
+const RECOVERY_LOCK_PREFIX = 'af_local_collab_recovery_lock:';
+
+const retryableStatuses = new Set<LocalCollabRecoveryStatus>([
+  'discovered',
+  'merged',
+  'uploading',
+  'synced',
+  'failed',
+]);
+const runningWorkspaces = new Set<string>();
+
+type LegacyRowCandidate = {
+  databaseId: string;
+  databaseIdAliases?: string[];
+  rowId: string;
+  rowKey: string;
+};
+
+type DatabasePrefixMatch = {
+  databaseId: string;
+  aliases: string[];
+};
+
+type RecoveryLock = {
+  ownerId: string;
+  refresh: () => boolean;
+  release: () => void;
+};
+
+type RecoveryUpload = {
+  record: LocalCollabRecoveryRecord;
+  legacyCacheDeletedDuringPrepare?: boolean;
+  item: {
+    objectId: string;
+    collabType: Types;
+    stateVector: Uint8Array;
+    docState: Uint8Array;
+  };
+};
+
+export type LocalCollabRecoverySummary = {
+  discovered: number;
+  prepared: number;
+  uploaded: number;
+  deleted: number;
+  skipped: number;
+  failed: number;
+  lockSkipped: boolean;
+};
+
+function now() {
+  return Date.now();
+}
+
+function chunk<T>(items: T[], size: number) {
+  const chunks: T[][] = [];
+
+  for (let i = 0; i < items.length; i += size) {
+    chunks.push(items.slice(i, i + size));
+  }
+
+  return chunks;
+}
+
+function normalizeError(error: unknown) {
+  if (error instanceof Error) return error.message;
+  if (typeof error === 'string') return error;
+
+  try {
+    return JSON.stringify(error);
+  } catch {
+    return String(error);
+  }
+}
+
+function lockKey(workspaceId: string) {
+  return `${RECOVERY_LOCK_PREFIX}${workspaceId}`;
+}
+
+function createOwnerId() {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+
+  return `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+}
+
+function tryAcquireRecoveryLock(workspaceId: string): RecoveryLock | null {
+  if (typeof localStorage === 'undefined') {
+    const ownerId = createOwnerId();
+
+    return {
+      ownerId,
+      refresh: () => true,
+      release: () => undefined,
+    };
+  }
+
+  const key = lockKey(workspaceId);
+  const ownerId = createOwnerId();
+
+  const writeLock = () => {
+    localStorage.setItem(
+      key,
+      JSON.stringify({
+        ownerId,
+        expiresAt: now() + RECOVERY_LOCK_TTL_MS,
+      })
+    );
+  };
+
+  try {
+    const raw = localStorage.getItem(key);
+    const existing = raw ? JSON.parse(raw) as { ownerId?: string; expiresAt?: number } : null;
+
+    if (existing?.expiresAt && existing.expiresAt > now() && existing.ownerId !== ownerId) {
+      return null;
+    }
+
+    writeLock();
+    const confirmed = JSON.parse(localStorage.getItem(key) || '{}') as { ownerId?: string };
+
+    if (confirmed.ownerId !== ownerId) return null;
+
+    return {
+      ownerId,
+      refresh: () => {
+        try {
+          const current = JSON.parse(localStorage.getItem(key) || '{}') as { ownerId?: string };
+
+          if (current.ownerId !== ownerId) return false;
+          writeLock();
+          return true;
+        } catch {
+          return false;
+        }
+      },
+      release: () => {
+        try {
+          const current = JSON.parse(localStorage.getItem(key) || '{}') as { ownerId?: string };
+
+          if (current.ownerId === ownerId) {
+            localStorage.removeItem(key);
+          }
+        } catch {
+          // Ignore lock cleanup failures.
+        }
+      },
+    };
+  } catch (error) {
+    Log.warn('[Recovery] failed to acquire local collab recovery lock', { workspaceId, error });
+    return null;
+  }
+}
+
+export function parseLegacyRowDatabaseName(name: string): LegacyRowCandidate | null {
+  const delimiterIndex = name.indexOf(LEGACY_ROW_DELIMITER);
+
+  if (delimiterIndex <= 0) return null;
+
+  const databaseId = name.slice(0, delimiterIndex);
+  const rowId = name.slice(delimiterIndex + LEGACY_ROW_DELIMITER.length);
+
+  if (!uuidValidate(databaseId) || !uuidValidate(rowId)) return null;
+
+  return {
+    databaseId,
+    rowId,
+    rowKey: name,
+  };
+}
+
+function uniqueValidIds(ids: Array<string | null | undefined>) {
+  return Array.from(new Set(ids.filter((id): id is string => Boolean(id && uuidValidate(id)))));
+}
+
+function buildDatabasePrefixMap(databaseRelations: DatabaseRelations | undefined) {
+  const databaseAliases = new Map<string, Set<string>>();
+
+  Object.entries(databaseRelations ?? {}).forEach(([databaseId, viewId]) => {
+    if (!uuidValidate(databaseId)) return;
+
+    const aliases = databaseAliases.get(databaseId) ?? new Set<string>();
+
+    aliases.add(databaseId);
+
+    if (uuidValidate(viewId)) {
+      aliases.add(viewId);
+    }
+
+    databaseAliases.set(databaseId, aliases);
+  });
+
+  const prefixMap = new Map<string, DatabasePrefixMatch>();
+
+  databaseAliases.forEach((aliases, databaseId) => {
+    const match = {
+      databaseId,
+      aliases: Array.from(aliases),
+    };
+
+    match.aliases.forEach((alias) => prefixMap.set(alias, match));
+  });
+
+  return prefixMap;
+}
+
+function getDistinctDatabaseMatches(prefixMap: Map<string, DatabasePrefixMatch>) {
+  const matches = new Map<string, DatabasePrefixMatch>();
+
+  prefixMap.forEach((match) => {
+    matches.set(match.databaseId, match);
+  });
+
+  return Array.from(matches.values());
+}
+
+function getDatabaseRow(doc: YDoc) {
+  const sharedRoot = doc.getMap(YjsEditorKey.data_section);
+
+  return sharedRoot.get(YjsEditorKey.database_row) as Y.Map<unknown> | undefined;
+}
+
+function normalizeDatabaseRowIdentity(doc: YDoc, databaseId: string, acceptedDatabaseIds: string[], rowId: string) {
+  const row = getDatabaseRow(doc);
+
+  if (!(row instanceof Y.Map)) return false;
+  if (row.get(YjsDatabaseKey.id) !== rowId) return false;
+
+  const rowDatabaseId = row.get(YjsDatabaseKey.database_id);
+
+  if (rowDatabaseId === databaseId) return true;
+
+  if (typeof rowDatabaseId === 'string' && acceptedDatabaseIds.includes(rowDatabaseId)) {
+    row.set(YjsDatabaseKey.database_id, databaseId);
+    return true;
+  }
+
+  return false;
+}
+
+function collectRowIdsFromDatabaseDoc(databaseDoc: YDoc): string[] {
+  const sharedRoot = databaseDoc.getMap(YjsEditorKey.data_section);
+  const database = sharedRoot.get(YjsEditorKey.database) as YDatabase | undefined;
+  const views = database?.get(YjsDatabaseKey.views);
+  const rowIds = new Set<string>();
+
+  views?.forEach((view) => {
+    const rowOrders = view?.get(YjsDatabaseKey.row_orders);
+
+    if (!rowOrders) return;
+
+    for (let i = 0; i < rowOrders.length; i += 1) {
+      const row = rowOrders.get(i) as { id?: string } | undefined;
+
+      if (row?.id && uuidValidate(row.id)) {
+        rowIds.add(row.id);
+      }
+    }
+  });
+
+  return Array.from(rowIds);
+}
+
+async function discoverLegacyRowsFromDatabaseDocs(prefixMap: Map<string, DatabasePrefixMatch>) {
+  const candidates: LegacyRowCandidate[] = [];
+
+  for (const match of getDistinctDatabaseMatches(prefixMap)) {
+    const rowIds = new Set<string>();
+
+    for (const databaseDocKey of match.aliases) {
+      if (!(await collabIndexedDBExists(databaseDocKey))) continue;
+
+      const { doc, provider } = await openCollabDBWithProvider(databaseDocKey, { skipCache: true });
+
+      try {
+        collectRowIdsFromDatabaseDoc(doc).forEach((rowId) => rowIds.add(rowId));
+      } finally {
+        await provider.destroy();
+        doc.destroy();
+      }
+    }
+
+    for (const rowId of rowIds) {
+      for (const prefix of match.aliases) {
+        const rowKey = getRowKey(prefix, rowId);
+
+        if (await collabIndexedDBExists(rowKey)) {
+          candidates.push({
+            databaseId: match.databaseId,
+            databaseIdAliases: match.aliases,
+            rowId,
+            rowKey,
+          });
+        }
+      }
+    }
+  }
+
+  return candidates;
+}
+
+export async function discoverLegacyRowDatabases(databaseRelations: DatabaseRelations | undefined) {
+  const prefixMap = buildDatabasePrefixMap(databaseRelations);
+  const candidates = new Map<string, LegacyRowCandidate>();
+  const indexedDbNames = await listCollabIndexedDBNames();
+
+  indexedDbNames.forEach((name) => {
+    const parsed = parseLegacyRowDatabaseName(name);
+    const match = parsed ? prefixMap.get(parsed.databaseId) : null;
+
+    if (!parsed || !match) return;
+    candidates.set(parsed.rowKey, {
+      databaseId: match.databaseId,
+      databaseIdAliases: match.aliases,
+      rowId: parsed.rowId,
+      rowKey: parsed.rowKey,
+    });
+  });
+
+  if (indexedDbNames.size === 0) {
+    const probedCandidates = await discoverLegacyRowsFromDatabaseDocs(prefixMap);
+
+    probedCandidates.forEach((candidate) => {
+      candidates.set(candidate.rowKey, candidate);
+    });
+  }
+
+  return Array.from(candidates.values());
+}
+
+async function upsertDiscoveredCandidate(workspaceId: string, candidate: LegacyRowCandidate) {
+  const key: [string, string] = [workspaceId, candidate.rowId];
+  const existing = await db.local_collab_recovery.get(key);
+
+  if (existing?.status === 'legacy_deleted' || existing?.status === 'skipped') {
+    return existing;
+  }
+
+  const timestamp = now();
+  const status = existing?.status && existing.status !== 'uploading' ? existing.status : 'discovered';
+  const record: LocalCollabRecoveryRecord = {
+    workspaceId,
+    objectId: candidate.rowId,
+    databaseId: candidate.databaseId,
+    databaseIdAliases: candidate.databaseIdAliases,
+    legacyDbName: candidate.rowKey,
+    legacyCacheDeleted: existing?.legacyCacheDeleted ?? false,
+    collabType: Types.DatabaseRow,
+    source: 'legacy',
+    status,
+    attempts: existing?.attempts ?? 0,
+    discoveredAt: existing?.discoveredAt ?? timestamp,
+    updatedAt: timestamp,
+    lastLocalAt: timestamp,
+    lastSyncedAt: existing?.lastSyncedAt,
+    error: existing?.error,
+  };
+
+  await db.local_collab_recovery.put(record);
+  return record;
+}
+
+async function updateRecoveryRecord(
+  record: LocalCollabRecoveryRecord,
+  updates: Partial<LocalCollabRecoveryRecord>
+) {
+  const nextRecord = {
+    ...record,
+    ...updates,
+    updatedAt: now(),
+  };
+
+  await db.local_collab_recovery.put(nextRecord);
+  return nextRecord;
+}
+
+async function loadRetryableRecords(workspaceId: string) {
+  return db.local_collab_recovery
+    .where('workspaceId')
+    .equals(workspaceId)
+    .filter((record) => retryableStatuses.has(record.status))
+    .toArray();
+}
+
+async function deleteMergedLegacyCache(record: LocalCollabRecoveryRecord) {
+  if (record.legacyCacheDeleted) {
+    return { record, deleted: false };
+  }
+
+  const deleted = await deleteCollabDB(record.legacyDbName);
+
+  if (!deleted) {
+    const nextRecord = await updateRecoveryRecord(record, {
+      error: 'Merged row into shared cache, but failed to delete legacy IndexedDB cache',
+    });
+
+    return { record: nextRecord, deleted: false };
+  }
+
+  const nextRecord = await updateRecoveryRecord(record, {
+    legacyCacheDeleted: true,
+    error: undefined,
+  });
+
+  return { record: nextRecord, deleted: true };
+}
+
+async function prepareRecoveryUpload(record: LocalCollabRecoveryRecord): Promise<RecoveryUpload | null> {
+  const { doc, provider } = await openRowCollabDBWithProvider(record.objectId, { skipCache: true });
+  let updatedRecord: LocalCollabRecoveryRecord | null = null;
+  let item: RecoveryUpload['item'] | null = null;
+
+  try {
+    if (record.status !== 'merged' && record.status !== 'uploading' && record.status !== 'synced') {
+      await mergeLegacyRowDocIfExists(record.legacyDbName, record.objectId, doc, {
+        legacyExists: true,
+        deleteLegacyCache: false,
+      });
+    }
+
+    const legacyPrefix = parseLegacyRowDatabaseName(record.legacyDbName)?.databaseId;
+    const acceptedDatabaseIds = uniqueValidIds([
+      record.databaseId,
+      legacyPrefix,
+      ...(record.databaseIdAliases ?? []),
+    ]);
+
+    if (!normalizeDatabaseRowIdentity(doc, record.databaseId, acceptedDatabaseIds, record.objectId)) {
+      await updateRecoveryRecord(record, {
+        status: 'skipped',
+        error: 'Legacy row does not contain matching database_row data',
+      });
+      return null;
+    }
+
+    item = {
+      objectId: record.objectId,
+      collabType: Types.DatabaseRow,
+      stateVector: Y.encodeStateVector(doc),
+      docState: Y.encodeStateAsUpdate(doc),
+    };
+
+    updatedRecord = record.status === 'merged' || record.status === 'uploading' || record.status === 'synced'
+      ? record
+      : await updateRecoveryRecord(record, { status: 'merged', error: undefined });
+  } finally {
+    await provider.destroy();
+    doc.destroy();
+  }
+
+  if (!updatedRecord || !item) return null;
+
+  const { record: recordAfterDelete, deleted } = await deleteMergedLegacyCache(updatedRecord);
+
+  return {
+    record: recordAfterDelete,
+    legacyCacheDeletedDuringPrepare: deleted,
+    item,
+  };
+}
+
+async function markBatchFailed(records: LocalCollabRecoveryRecord[], error: unknown) {
+  await Promise.all(
+    records.map((record) =>
+      updateRecoveryRecord(record, {
+        status: 'failed',
+        attempts: record.attempts + 1,
+        error: normalizeError(error),
+      })
+    )
+  );
+}
+
+async function deleteUploadedLegacyCache(record: LocalCollabRecoveryRecord) {
+  if (record.legacyCacheDeleted) {
+    await updateRecoveryRecord(record, {
+      status: 'legacy_deleted',
+      lastSyncedAt: record.lastSyncedAt ?? now(),
+      error: undefined,
+    });
+    return false;
+  }
+
+  const deleted = await deleteCollabDB(record.legacyDbName);
+
+  if (!deleted) {
+    await updateRecoveryRecord(record, {
+      status: 'synced',
+      error: 'Uploaded row, but failed to delete legacy IndexedDB cache',
+    });
+    return false;
+  }
+
+  await updateRecoveryRecord(record, {
+    status: 'legacy_deleted',
+    legacyCacheDeleted: true,
+    lastSyncedAt: record.lastSyncedAt ?? now(),
+    error: undefined,
+  });
+  return true;
+}
+
+async function uploadRecoveryBatch(workspaceId: string, uploads: RecoveryUpload[]) {
+  const uploadingRecords = await Promise.all(
+    uploads.map((upload) =>
+      updateRecoveryRecord(upload.record, {
+        status: 'uploading',
+        attempts: upload.record.attempts + 1,
+        error: undefined,
+      })
+    )
+  );
+
+  try {
+    await withRetry(() => collabFullSyncBatchStrict(workspaceId, uploads.map((upload) => upload.item)), {
+      delays: RECOVERY_RETRY_DELAYS,
+    });
+  } catch (error) {
+    await markBatchFailed(uploadingRecords, error);
+    throw error;
+  }
+
+  const syncedAt = now();
+  const syncedRecords = await Promise.all(
+    uploadingRecords.map((record) =>
+      updateRecoveryRecord(record, {
+        status: 'synced',
+        lastSyncedAt: syncedAt,
+        error: undefined,
+      })
+    )
+  );
+
+  let deleted = 0;
+
+  for (const record of syncedRecords) {
+    if (await deleteUploadedLegacyCache(record)) {
+      deleted += 1;
+    }
+  }
+
+  return deleted;
+}
+
+export async function recoverLegacyDatabaseRowsForWorkspace(options: {
+  workspaceId: string;
+  databaseRelations: DatabaseRelations | undefined;
+}): Promise<LocalCollabRecoverySummary> {
+  const summary: LocalCollabRecoverySummary = {
+    discovered: 0,
+    prepared: 0,
+    uploaded: 0,
+    deleted: 0,
+    skipped: 0,
+    failed: 0,
+    lockSkipped: false,
+  };
+  const { workspaceId, databaseRelations } = options;
+  const hasDatabases = Object.keys(databaseRelations ?? {}).some((databaseId) => uuidValidate(databaseId));
+
+  if (!workspaceId || !hasDatabases) return summary;
+  if (runningWorkspaces.has(workspaceId)) {
+    return { ...summary, lockSkipped: true };
+  }
+
+  const lock = tryAcquireRecoveryLock(workspaceId);
+
+  if (!lock) {
+    return { ...summary, lockSkipped: true };
+  }
+
+  runningWorkspaces.add(workspaceId);
+
+  try {
+    const candidates = await discoverLegacyRowDatabases(databaseRelations);
+
+    summary.discovered = candidates.length;
+    await Promise.all(candidates.map((candidate) => upsertDiscoveredCandidate(workspaceId, candidate)));
+
+    const records = await loadRetryableRecords(workspaceId);
+    const uploads: RecoveryUpload[] = [];
+
+    for (const recordsChunk of chunk(records, RECOVERY_MERGE_CONCURRENCY)) {
+      if (!lock.refresh()) {
+        summary.lockSkipped = true;
+        return summary;
+      }
+
+      const prepared = await Promise.all(
+        recordsChunk.map(async (record) => {
+          try {
+            if (record.status === 'synced') {
+              if (await deleteUploadedLegacyCache(record)) {
+                summary.deleted += 1;
+              }
+
+              return null;
+            }
+
+            return await prepareRecoveryUpload(record);
+          } catch (error) {
+            summary.failed += 1;
+            await updateRecoveryRecord(record, {
+              status: 'failed',
+              attempts: record.attempts + 1,
+              error: normalizeError(error),
+            });
+            return null;
+          }
+        })
+      );
+
+      prepared.forEach((upload) => {
+        if (!upload) return;
+
+        if (upload.legacyCacheDeletedDuringPrepare) {
+          summary.deleted += 1;
+        }
+
+        uploads.push(upload);
+      });
+    }
+
+    summary.prepared = uploads.length;
+
+    for (const uploadsChunk of chunk(uploads, RECOVERY_UPLOAD_BATCH_SIZE)) {
+      if (!lock.refresh()) {
+        summary.lockSkipped = true;
+        return summary;
+      }
+
+      try {
+        summary.deleted += await uploadRecoveryBatch(workspaceId, uploadsChunk);
+        summary.uploaded += uploadsChunk.length;
+      } catch (error) {
+        summary.failed += uploadsChunk.length;
+        Log.warn('[Recovery] failed to upload recovered legacy rows', {
+          workspaceId,
+          count: uploadsChunk.length,
+          error,
+        });
+      }
+    }
+
+    summary.skipped = Math.max(0, records.length - uploads.length - summary.failed - summary.deleted);
+
+    if (
+      summary.discovered > 0 ||
+      summary.prepared > 0 ||
+      summary.uploaded > 0 ||
+      summary.deleted > 0 ||
+      summary.skipped > 0 ||
+      summary.failed > 0
+    ) {
+      Log.info('[Recovery] legacy database row recovery completed', {
+        workspaceId,
+        ...summary,
+      });
+    }
+
+    return summary;
+  } finally {
+    runningWorkspaces.delete(workspaceId);
+    lock.release();
+  }
+}

--- a/src/application/services/js-services/cache/__tests__/cache.test.ts
+++ b/src/application/services/js-services/cache/__tests__/cache.test.ts
@@ -264,6 +264,38 @@ describe('database row legacy cache migration', () => {
     expect(legacyProvider.destroy).toHaveBeenCalledTimes(1);
   });
 
+  it('can keep the legacy row cache after a recovery merge', async () => {
+    const rowId = 'row-legacy-recovery';
+    const databaseId = 'database-legacy-recovery';
+    const rowKey = `${databaseId}_rows_${rowId}`;
+    const sharedDoc = createRowDoc(rowId, databaseId, { 'server-field': 'server-value' });
+    const legacyDoc = createRowDoc(rowId, databaseId, { 'legacy-field': 'legacy-value' });
+    const legacyProvider = { destroy: jest.fn().mockResolvedValue(undefined) };
+
+    mockedCollabIndexedDBExists.mockResolvedValue(true);
+    mockedOpenCollabDBWithProvider.mockResolvedValue({
+      doc: legacyDoc,
+      provider: legacyProvider,
+    } as never);
+
+    await expect(
+      mergeLegacyRowDocIfExists(rowKey, rowId, sharedDoc, {
+        deleteLegacyCache: false,
+      })
+    ).resolves.toBe(true);
+
+    expect(getCellData(sharedDoc, 'server-field')).toBe('server-value');
+    expect(getCellData(sharedDoc, 'legacy-field')).toBe('legacy-value');
+    expect(db.collab_custom.put).toHaveBeenCalledWith(
+      expect.objectContaining({
+        objectId: rowId,
+        key: `legacy-row-backfill:${rowKey}`,
+      })
+    );
+    expect(mockedDeleteCollabDB).not.toHaveBeenCalled();
+    expect(legacyProvider.destroy).toHaveBeenCalledTimes(1);
+  });
+
   it('skips legacy row migration after the one-time backfill marker exists', async () => {
     const rowId = 'row-legacy-marked';
     const databaseId = 'database-legacy-marked';

--- a/src/application/services/js-services/cache/index.ts
+++ b/src/application/services/js-services/cache/index.ts
@@ -680,7 +680,7 @@ export async function mergeLegacyRowDocIfExists(
   rowKey: string,
   rowObjectId: string,
   doc: YDoc,
-  options: { legacyExists?: boolean } = {}
+  options: { legacyExists?: boolean; deleteLegacyCache?: boolean } = {}
 ) {
   if (rowKey === rowObjectId) {
     return false;
@@ -732,7 +732,7 @@ export async function mergeLegacyRowDocIfExists(
     await provider.destroy();
     legacyDoc.destroy();
 
-    if (consumedLegacyCache) {
+    if (consumedLegacyCache && options.deleteLegacyCache !== false) {
       await deleteLegacyRowCache(rowKey, rowObjectId);
     }
   }

--- a/src/application/services/js-services/http/__tests__/http_api.test.ts
+++ b/src/application/services/js-services/http/__tests__/http_api.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 
-import { AuthProvider } from '@/application/types';
+import { AuthProvider, Types } from '@/application/types';
+import { collab } from '@/proto/messages';
 
 const mockAxiosInstance = {
   interceptors: { request: { use: jest.fn() }, response: { use: jest.fn() } },
@@ -52,6 +53,7 @@ describe('http_api client (unit)', () => {
     jest.resetModules();
     mockAxiosCreate.mockClear();
     mockAxiosInstance.get.mockReset();
+    mockAxiosInstance.post.mockReset();
   });
 
   it('initializes axios instance once with provided config', async () => {
@@ -127,5 +129,48 @@ describe('http_api client (unit)', () => {
     await expect(module.getAuthProviders()).resolves.toEqual([AuthProvider.PASSWORD]);
     expect(errorSpy).toHaveBeenCalled();
     errorSpy.mockRestore();
+  });
+
+  it('marks batch item errors as non-retryable API errors', async () => {
+    const module = await import('../http_api');
+
+    module.initAPIService(baseConfig);
+
+    const responseData = collab.CollabBatchSyncResponse.encode(
+      collab.CollabBatchSyncResponse.create({
+        results: [
+          {
+            objectId: 'row-id',
+            collabType: Types.DatabaseRow,
+            error: 'row was deleted',
+          },
+        ],
+      })
+    ).finish();
+
+    mockAxiosInstance.post.mockResolvedValueOnce({
+      status: 200,
+      data: responseData,
+      headers: {},
+    });
+
+    await expect(
+      module.collabFullSyncBatchStrict('workspace-id', [
+        {
+          objectId: 'row-id',
+          collabType: Types.DatabaseRow,
+          stateVector: new Uint8Array(),
+          docState: new Uint8Array(),
+        },
+      ])
+    ).rejects.toMatchObject({
+      code: 400,
+      results: [
+        expect.objectContaining({
+          objectId: 'row-id',
+          error: 'row was deleted',
+        }),
+      ],
+    });
   });
 });

--- a/src/application/services/js-services/http/collab-api.ts
+++ b/src/application/services/js-services/http/collab-api.ts
@@ -61,7 +61,7 @@ export async function collabFullSyncBatch(
     stateVector: Uint8Array;
     docState: Uint8Array;
   }>
-): Promise<void> {
+): Promise<collab.CollabBatchSyncResponse> {
   const url = `/api/workspace/v1/${workspaceId}/collab/full-sync/batch`;
 
   // Build the protobuf request
@@ -124,6 +124,33 @@ export async function collabFullSyncBatch(
       });
     }
   }
+
+  return batchResponse;
+}
+
+export async function collabFullSyncBatchStrict(
+  workspaceId: string,
+  items: Array<{
+    objectId: string;
+    collabType: Types;
+    stateVector: Uint8Array;
+    docState: Uint8Array;
+  }>
+): Promise<void> {
+  const response = await collabFullSyncBatch(workspaceId, items);
+  const failedResults = response.results.filter((result) => result.error);
+
+  if (failedResults.length === 0) return;
+
+  const error = new Error(
+    `Collab batch sync failed for ${failedResults.length} object(s): ${failedResults
+      .map((result) => result.objectId)
+      .join(', ')}`
+  ) as Error & APIError & { results: typeof failedResults };
+
+  error.code = 400;
+  error.results = failedResults;
+  throw error;
 }
 
 export async function getCollab(workspaceId: string, objectId: string, collabType: Types) {

--- a/src/application/services/js-services/http/http_api.ts
+++ b/src/application/services/js-services/http/http_api.ts
@@ -88,6 +88,7 @@ export {
 export {
   updateCollab,
   collabFullSyncBatch,
+  collabFullSyncBatchStrict,
   getCollab,
   getPageCollab,
   databaseBlobDiff,

--- a/src/application/sync-outbox/index.ts
+++ b/src/application/sync-outbox/index.ts
@@ -149,6 +149,12 @@ export function enqueueOutboxUpdate(record: Omit<SyncOutboxRecord, 'id' | 'creat
 
   addPromise
     .then(() => {
+      Log.debug('[outbox] enqueue persisted', {
+        workspaceId,
+        objectId: record.objectId,
+        collabType: record.collabType,
+        payloadBytes: record.payload.byteLength,
+      });
       scheduleDrain(record.objectId);
     })
     .catch((error) => {
@@ -268,6 +274,11 @@ export function startDrainAll() {
 
     try {
       const objectIds = await distinctObjectIdsForSession(drainConfig.userId, drainConfig.workspaceId);
+
+      Log.debug('[outbox] startDrainAll discovered pending objects', {
+        workspaceId: drainConfig.workspaceId,
+        objectCount: objectIds.length,
+      });
 
       for (const objectId of objectIds) {
         scheduleDrain(objectId);
@@ -537,6 +548,16 @@ async function drainObjectWhileReady(objectId: string): Promise<void> {
       : Y.mergeUpdates(records.map((r) => r.payload));
     const collabType = records[records.length - 1].collabType as Types;
     const version = records[records.length - 1].version;
+    const payloadBytes = records.reduce((sum, record) => sum + record.payload.byteLength, 0);
+
+    Log.debug('[outbox] draining object', {
+      workspaceId,
+      objectId,
+      collabType,
+      recordCount: records.length,
+      payloadBytes,
+      mergedBytes: merged.byteLength,
+    });
 
     const message: messages.IMessage = {
       collabMessage: {
@@ -559,6 +580,13 @@ async function drainObjectWhileReady(objectId: string): Promise<void> {
 
     try {
       config.send(message);
+      Log.debug('[outbox] sent object update', {
+        workspaceId,
+        objectId,
+        collabType,
+        recordCount: records.length,
+        mergedBytes: merged.byteLength,
+      });
     } catch (error) {
       Log.warn('[outbox] send failed; leaving records for retry', { objectId, error });
       return;
@@ -568,6 +596,11 @@ async function drainObjectWhileReady(objectId: string): Promise<void> {
 
     try {
       await db.sync_outbox.bulkDelete(ids);
+      Log.debug('[outbox] deleted drained records', {
+        workspaceId,
+        objectId,
+        deletedCount: ids.length,
+      });
     } catch (error) {
       Log.error('[outbox] bulkDelete failed after send', { objectId, error });
       return;

--- a/src/components/app/layers/AppBusinessLayer.tsx
+++ b/src/components/app/layers/AppBusinessLayer.tsx
@@ -132,48 +132,6 @@ export const AppBusinessLayer: FC<AppBusinessLayerProps> = ({ children }) => {
   const { createRow } = useRowOperations();
 
   useEffect(() => {
-    if (!currentWorkspaceId) return;
-    if (typeof window === 'undefined' || typeof document === 'undefined') return;
-
-    let cancelled = false;
-
-    const runLegacyRowRecovery = () => {
-      void (async () => {
-        try {
-          const databaseRelations = await loadDatabaseRelations();
-
-          if (cancelled || !databaseRelations) return;
-          const { recoverLegacyDatabaseRowsForWorkspace } = await import('@/application/local-collab-recovery');
-
-          if (cancelled) return;
-          await recoverLegacyDatabaseRowsForWorkspace({
-            workspaceId: currentWorkspaceId,
-            databaseRelations,
-          });
-        } catch (error) {
-          console.warn('[Recovery] failed to run legacy row recovery', error);
-        }
-      })();
-    };
-
-    const handleVisibilityChange = () => {
-      if (document.visibilityState === 'visible') {
-        runLegacyRowRecovery();
-      }
-    };
-
-    runLegacyRowRecovery();
-    window.addEventListener('online', runLegacyRowRecovery);
-    document.addEventListener('visibilitychange', handleVisibilityChange);
-
-    return () => {
-      cancelled = true;
-      window.removeEventListener('online', runLegacyRowRecovery);
-      document.removeEventListener('visibilitychange', handleVisibilityChange);
-    };
-  }, [currentWorkspaceId, loadDatabaseRelations]);
-
-  useEffect(() => {
     if (typeof window === 'undefined') return;
 
     const globalWindow = window as typeof window & {

--- a/src/components/app/layers/AppBusinessLayer.tsx
+++ b/src/components/app/layers/AppBusinessLayer.tsx
@@ -132,6 +132,48 @@ export const AppBusinessLayer: FC<AppBusinessLayerProps> = ({ children }) => {
   const { createRow } = useRowOperations();
 
   useEffect(() => {
+    if (!currentWorkspaceId) return;
+    if (typeof window === 'undefined' || typeof document === 'undefined') return;
+
+    let cancelled = false;
+
+    const runLegacyRowRecovery = () => {
+      void (async () => {
+        try {
+          const databaseRelations = await loadDatabaseRelations();
+
+          if (cancelled || !databaseRelations) return;
+          const { recoverLegacyDatabaseRowsForWorkspace } = await import('@/application/local-collab-recovery');
+
+          if (cancelled) return;
+          await recoverLegacyDatabaseRowsForWorkspace({
+            workspaceId: currentWorkspaceId,
+            databaseRelations,
+          });
+        } catch (error) {
+          console.warn('[Recovery] failed to run legacy row recovery', error);
+        }
+      })();
+    };
+
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === 'visible') {
+        runLegacyRowRecovery();
+      }
+    };
+
+    runLegacyRowRecovery();
+    window.addEventListener('online', runLegacyRowRecovery);
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+
+    return () => {
+      cancelled = true;
+      window.removeEventListener('online', runLegacyRowRecovery);
+      document.removeEventListener('visibilitychange', handleVisibilityChange);
+    };
+  }, [currentWorkspaceId, loadDatabaseRelations]);
+
+  useEffect(() => {
     if (typeof window === 'undefined') return;
 
     const globalWindow = window as typeof window & {


### PR DESCRIPTION
## Summary
- add a local recovery worker for legacy per-row IndexedDB caches
- recover both canonical database-id row keys and legacy view-id row keys into shared row storage
- upload recovered row docs with strict batch error handling and delete legacy caches after durable merge
- lazy-load the recovery worker from AppBusinessLayer

## Tests
- pnpm exec jest src/application/local-collab-recovery/__tests__/index.test.ts src/application/services/js-services/http/__tests__/http_api.test.ts src/application/services/js-services/cache/__tests__/cache.test.ts --no-coverage --runInBand
- pnpm run lint

Note: scripts/export-indexeddb-to-zip.js is still untracked locally and is not included in this PR.

## Summary by Sourcery

Add a local recovery workflow for legacy per-row IndexedDB caches to migrate database row docs into shared storage and upload them via a stricter collab batch API, with durable tracking in IndexedDB and lazy initialization from the app business layer.

New Features:
- Introduce a local collab recovery module that discovers legacy per-row database row caches and prepares them for upload into shared collab storage.
- Add a strict collab batch sync API variant that surfaces per-item errors as non-retryable API errors.
- Add a durable IndexedDB table to track local collab recovery state per workspace and object and drive resumable recovery workflows.
- Trigger legacy row recovery from the app business layer when a workspace is active and the app is online or becomes visible.

Bug Fixes:
- Ensure legacy database row caches for both database-id and view-id keyed rows are merged into shared row storage and normalized to canonical database IDs before upload.
- Allow merging legacy row docs into shared storage without always deleting the legacy cache, so recovery flows can control cache cleanup semantics.
- Treat collab batch responses with per-item errors as failures instead of silently succeeding, preventing partial data loss during recovery uploads.

Enhancements:
- Extend local cache migration logic to record one-time backfill markers while optionally retaining legacy caches for recovery flows.
- Refine error handling and retry logic around collab batch uploads used during recovery, including detailed batch failure propagation.
- Guard legacy recovery execution with a lightweight client-side lock and workspace-level run tracking to avoid redundant concurrent recovery runs.

Tests:
- Add unit tests for the local collab recovery module covering legacy row discovery, merge-and-delete behavior, view-id keyed recovery, and failure handling.
- Add a cache migration test ensuring legacy row caches can be merged without deletion when requested and that recovery markers are written.
- Add an HTTP API test verifying the strict collab batch sync API treats per-item errors as non-retryable API errors.