### PR TITLE
Stabilize embedded database layout and view switching

### DIFF
--- a/src/components/database/components/board/column/CardList.tsx
+++ b/src/components/database/components/board/column/CardList.tsx
@@ -18,6 +18,11 @@ export interface RenderCard {
 
 const CARD_LIST_MAX_HEIGHT = 2000;
 
+const CARD_LIST_STYLE = {
+  maxHeight: CARD_LIST_MAX_HEIGHT,
+  overflowY: 'auto',
+} as const;
+
 function CardList({
   data,
   fieldId,
@@ -91,12 +96,8 @@ function CardList({
   return (
     <div
       ref={parentRef}
-      className='appflowy-custom-scroller w-full shrink-0'
-      style={{
-        height: CARD_LIST_MAX_HEIGHT,
-        maxHeight: CARD_LIST_MAX_HEIGHT,
-        overflowY: 'auto',
-      }}
+      className='appflowy-custom-scroller w-full min-h-0 flex-1'
+      style={CARD_LIST_STYLE}
     >
       <div
         style={{

--- a/src/components/database/components/grid/grid-table/GridVirtualizer.tsx
+++ b/src/components/database/components/grid/grid-table/GridVirtualizer.tsx
@@ -14,6 +14,7 @@ import DatabaseStickyBottomOverlay from '@/components/database/components/sticky
 import DatabaseStickyHorizontalScrollbar from '@/components/database/components/sticky-overlay/DatabaseStickyHorizontalScrollbar';
 import DatabaseStickyTopOverlay from '@/components/database/components/sticky-overlay/DatabaseStickyTopOverlay';
 import { useGridContext } from '@/components/database/grid/useGridContext';
+import { cn } from '@/lib/utils';
 
 import { useColumnResize } from '../grid-column/useColumnResize';
 
@@ -175,7 +176,10 @@ function GridVirtualizer({ columns }: { columns: RenderColumn[] }) {
         onMouseEnter={handleMouseEnter}
         onMouseLeave={handleMouseLeave}
         ref={parentRef}
-        className={'appflowy-custom-scroller appflowy-hidden-horizontal-scrollbar'}
+        className={cn(
+          'appflowy-custom-scroller appflowy-hidden-horizontal-scrollbar',
+          isDocumentBlock && 'min-h-0 flex-1'
+        )}
         style={{
           overflowY: 'auto',
           overflowX: 'auto',

--- a/src/components/database/components/grid/grid-table/useGridVirtualizer.ts
+++ b/src/components/database/components/grid/grid-table/useGridVirtualizer.ts
@@ -29,8 +29,12 @@ export function useGridVirtualizer({ data, columns }: { columns: RenderColumn[];
 
   const getScrollElement = useCallback(() => {
     if (!parentRef.current) return null;
+    // Embedded databases have their own bounded scroll viewport (parentRef itself).
+    // Using the outer page scroll container would let @tanstack/react-virtual call
+    // scrollTo(0) on the document, jumping the user away on view switches.
+    if (isDocumentBlock) return parentRef.current;
     return parentRef.current.closest('.appflowy-scroll-container') || getScrollParent(parentRef.current);
-  }, [parentRef]);
+  }, [parentRef, isDocumentBlock]);
 
   const measureParentOffset = useCallback(() => {
     const scrollElement = getScrollElement();

--- a/src/components/database/grid/Grid.tsx
+++ b/src/components/database/grid/Grid.tsx
@@ -22,7 +22,7 @@ export function Grid() {
     <GridProvider rowOrders={rowOrders}>
       <div
         data-testid='database-grid'
-        className={`database-grid relative grid-table-${viewId} flex w-full flex-1 flex-col`}
+        className={`database-grid relative grid-table-${viewId} flex w-full min-h-0 flex-1 flex-col`}
       >
         <GridVirtualizer columns={fields} />
       </div>

--- a/src/components/database/grid/GridProvider.tsx
+++ b/src/components/database/grid/GridProvider.tsx
@@ -128,7 +128,7 @@ export const GridProvider = ({ children, rowOrders }: { children: React.ReactNod
 
   return (
     <GridContext.Provider value={contextValue}>
-      <div ref={ref} className={'flex-1'}>
+      <div ref={ref} className={'flex min-h-0 flex-1 flex-col'}>
         {children}
       </div>
     </GridContext.Provider>

--- a/src/components/editor/components/blocks/database/components/DatabaseContent.tsx
+++ b/src/components/editor/components/blocks/database/components/DatabaseContent.tsx
@@ -6,6 +6,8 @@ import { getPublishedDatabaseRenderRowMap } from '@/application/publish-snapshot
 import { LoadView, LoadViewMeta, UIVariant, YDoc } from '@/application/types';
 import { Database } from '@/components/database';
 
+const EMBEDDED_DATABASE_FIXED_HEIGHT = 300;
+
 interface DatabaseContentProps {
   /**
    * The base/primary view ID for the embedded database.
@@ -62,7 +64,7 @@ export const DatabaseContent = ({
   onViewAdded,
   onViewIdsChanged,
   context,
-  fixedHeight,
+  fixedHeight = EMBEDDED_DATABASE_FIXED_HEIGHT,
   onRendered,
 }: DatabaseContentProps) => {
   const { t } = useTranslation();

--- a/src/components/editor/editor.scss
+++ b/src/components/editor/editor.scss
@@ -76,9 +76,7 @@
   }
 
   &.block-element[data-block-type="grid"], &.block-element[data-block-type="board"], &.block-element[data-block-type="calendar"] {
-    .database-tabs, .grid-row-filed-cell, .column {
-      @apply bg-fill-theme-select;
-    }
+    @apply bg-fill-theme-select;
   }
 
   &.block-element[data-block-type="simple_table"] {


### PR DESCRIPTION
## Summary
- Embedded database blocks render in a fixed 300px viewport; switching between Grid and Board tabs no longer reflows the document or scrolls the page to top.
- Grid rows scroll **inside** the bounded panel; Board card lists scroll within each Kanban column (no more giant empty space below a single card).
- Block-selection highlight now paints the entire database block uniformly instead of striping just the tab bar and header row.

## Root causes addressed
1. `@tanstack/react-virtual`'s Grid virtualizer was resolving its scroll element to the outer page scroller via `.closest('.appflowy-scroll-container')`. On view switch it called `scrollTo(0)` on the document, kicking the user to the top.
2. Several flex-col wrappers (`GridProvider`, `.database-grid`, grid scroller) were missing `min-h-0`, so children with `flex-1` grew to content size and overflowed the 300px panel (clipped by `overflow-hidden`).
3. `CardList` had a hard-coded `height: 2000px` that ignored the column's available height.
4. The block-selection SCSS rule only targeted `.database-tabs, .grid-row-filed-cell, .column`, producing a partial stripe.

## Test plan
- [ ] Open a document containing an embedded grid database (Grid + Board views).
- [ ] Switch Grid ↔ Board several times — page scroll position stays put; no document height jump.
- [ ] Add rows beyond 300px height — verify Grid scrolls internally.
- [ ] Switch to Board — verify cards fill the column and scroll within when overflowing.
- [ ] Select the database block (Cmd+A or click) — entire block is uniformly tinted.
- [ ] Open a non-embedded (full-page) database — verify Grid still scrolls with the page as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Stabilize embedded database layout and scrolling behavior for grid and board views to prevent page jumps and ensure consistent block highlighting.

New Features:
- Introduce a fixed default viewport height for embedded database blocks so their content scrolls within a bounded panel rather than resizing the document.

Bug Fixes:
- Ensure embedded grid views use their own scroll container so view switching no longer scrolls the main document to the top.
- Allow board card lists to respect column height and scroll internally instead of relying on a hard-coded large height.
- Apply block selection highlighting to the entire embedded database block instead of only specific sub-elements.

Enhancements:
- Tighten layout constraints in grid-related containers using flex and min-height utilities so grid content fits correctly within the embedded viewport.