### PR TITLE
fix: prevent paste from indenting blocks under the current block

### DIFF
--- a/playwright/e2e/editor/blocks/paste_indent.spec.ts
+++ b/playwright/e2e/editor/blocks/paste_indent.spec.ts
@@ -1,0 +1,236 @@
+import { test, expect, Page } from '@playwright/test';
+import { EditorSelectors } from '../../../support/selectors';
+import { generateRandomEmail, setupPageErrorHandling } from '../../../support/test-config';
+import { signInAndWaitForApp } from '../../../support/auth-flow-helpers';
+import { createDocumentPageAndNavigate } from '../../../support/page-utils';
+
+/**
+ * Repro: type "1","2","3","4" on separate lines, select all, copy,
+ * then paste on a new line. The pasted blocks should NOT be indented
+ * (i.e. should appear as siblings of the original blocks at the same
+ * indent level), but a bug causes them to be nested under the last block.
+ */
+test.describe('Editor - Paste Indentation', () => {
+  const testEmail = generateRandomEmail();
+  const isMac = process.platform === 'darwin';
+  const cmdKey = isMac ? 'Meta' : 'Control';
+
+  test.beforeEach(async ({ page }) => {
+    setupPageErrorHandling(page);
+    await page.setViewportSize({ width: 1280, height: 720 });
+  });
+
+  async function setupEditor(
+    page: Page,
+    request: import('@playwright/test').APIRequestContext
+  ) {
+    await signInAndWaitForApp(page, request, testEmail);
+    await expect(page).toHaveURL(/\/app/, { timeout: 30000 });
+    await page.waitForTimeout(1000);
+
+    await createDocumentPageAndNavigate(page);
+    await EditorSelectors.firstEditor(page).click({ force: true });
+    await page.waitForTimeout(500);
+  }
+
+  test('pasting copied lines on a new line should not indent the pasted blocks', async ({
+    page,
+    request,
+  }) => {
+    await setupEditor(page, request);
+
+    // Type 1\n2\n3\n4
+    await page.keyboard.type('1');
+    await page.keyboard.press('Enter');
+    await page.keyboard.type('2');
+    await page.keyboard.press('Enter');
+    await page.keyboard.type('3');
+    await page.keyboard.press('Enter');
+    await page.keyboard.type('4');
+    await page.waitForTimeout(300);
+
+    // Select all and copy
+    await page.keyboard.press(`${cmdKey}+a`);
+    await page.waitForTimeout(200);
+    await page.keyboard.press(`${cmdKey}+a`);
+    await page.waitForTimeout(200);
+    await page.keyboard.press(`${cmdKey}+c`);
+    await page.waitForTimeout(300);
+
+    // Move to end and create a new empty line, then paste
+    await page.keyboard.press(`${cmdKey}+End`);
+    await page.waitForTimeout(100);
+    await page.keyboard.press('End');
+    await page.keyboard.press('Enter');
+    await page.waitForTimeout(200);
+
+    await page.keyboard.press(`${cmdKey}+v`);
+    await page.waitForTimeout(800);
+
+    // Collect text blocks with their indent depth (number of parent
+    // [data-block-type] ancestors inside the editor).
+    const editor = EditorSelectors.slateEditor(page);
+    const blocks = await editor.locator('[data-block-type]').evaluateAll((els) =>
+      els.map((el) => {
+        let depth = 0;
+        let parent: HTMLElement | null = el.parentElement;
+        while (parent) {
+          if (parent.hasAttribute('data-block-type')) depth += 1;
+          parent = parent.parentElement;
+        }
+        return {
+          text: (el as HTMLElement).innerText.trim(),
+          depth,
+        };
+      })
+    );
+
+    // Keep only the leaf text blocks for the values we typed/pasted
+    const numeric = blocks.filter((b) => /^[1-4]$/.test(b.text));
+
+    // Expect 8 entries: original 1,2,3,4 and pasted 1,2,3,4
+    expect(numeric.length).toBe(8);
+
+    // All numeric blocks should be at the same depth (no indentation
+    // introduced by paste). If the bug is present, the pasted blocks
+    // will have greater depth than the originals.
+    const depths = numeric.map((b) => b.depth);
+    const minDepth = Math.min(...depths);
+    const maxDepth = Math.max(...depths);
+    expect(maxDepth).toBe(minDepth);
+
+    // Strict assertion on paste position. The empty placeholder block created
+    // by Enter must be REPLACED by the pasted content, so the top-level
+    // sequence (in document order) must be exactly:
+    //   "1","2","3","4","1","2","3","4"
+    // optionally followed by a single trailing empty block that the editor
+    // maintains for the cursor — but NO empty block between the original "4"
+    // and the first pasted "1".
+    const topLevel = blocks
+      .filter((b) => b.depth === minDepth)
+      .map((b) => b.text);
+
+    // Drop only a final trailing empty block (cursor-tail), not interior ones.
+    const trimmed = topLevel.length > 0 && topLevel[topLevel.length - 1] === ''
+      ? topLevel.slice(0, -1)
+      : topLevel;
+
+    expect(trimmed).toEqual(['1', '2', '3', '4', '1', '2', '3', '4']);
+
+    // No empty placeholder should remain anywhere between non-empty entries.
+    expect(trimmed.every((t) => t !== '')).toBe(true);
+  });
+
+  test('after deleting the last source line, Backspace should still remove blocks', async ({
+    page,
+    request,
+  }) => {
+    await setupEditor(page, request);
+
+    await page.keyboard.type('1');
+    await page.keyboard.press('Enter');
+    await page.keyboard.type('2');
+    await page.keyboard.press('Enter');
+    await page.keyboard.type('3');
+    await page.keyboard.press('Enter');
+    await page.keyboard.type('4');
+    await page.waitForTimeout(300);
+
+    await page.keyboard.press(`${cmdKey}+a`);
+    await page.waitForTimeout(150);
+    await page.keyboard.press(`${cmdKey}+a`);
+    await page.waitForTimeout(150);
+    await page.keyboard.press(`${cmdKey}+c`);
+    await page.waitForTimeout(300);
+
+    await page.keyboard.press(`${cmdKey}+End`);
+    await page.keyboard.press('End');
+    await page.keyboard.press('Enter');
+    await page.waitForTimeout(150);
+    await page.keyboard.press(`${cmdKey}+v`);
+    await page.waitForTimeout(800);
+
+    const editor = EditorSelectors.slateEditor(page);
+
+    // Delete the "4" on the source line: navigate to it and remove the char.
+    // After paste cursor is at end of pasted content; move back to original "4".
+    // Easiest: just press Backspace until "4" is gone, then one more Backspace
+    // and assert something actually changed in the document.
+    const before = await editor.innerText();
+
+    // Click on the original "4" block at depth 0
+    const originalFour = editor
+      .locator('[data-block-type]')
+      .filter({ hasText: /^4$/ })
+      .first();
+
+    await originalFour.click();
+    await page.keyboard.press('End');
+    await page.keyboard.press('Backspace'); // remove '4'
+    await page.waitForTimeout(150);
+
+    // Now the original block is empty. Backspace again must delete/merge —
+    // the document text must change again.
+    const afterDelete4 = await editor.innerText();
+
+    await page.keyboard.press('Backspace');
+    await page.waitForTimeout(200);
+
+    const afterSecondBackspace = await editor.innerText();
+
+    expect(afterSecondBackspace).not.toBe(afterDelete4);
+    expect(before).not.toBe(afterSecondBackspace);
+  });
+
+  test('pasting over an expanded selection replaces the selected range', async ({
+    page,
+    request,
+  }) => {
+    await setupEditor(page, request);
+
+    // Source: 1,2,3,4
+    await page.keyboard.type('1');
+    await page.keyboard.press('Enter');
+    await page.keyboard.type('2');
+    await page.keyboard.press('Enter');
+    await page.keyboard.type('3');
+    await page.keyboard.press('Enter');
+    await page.keyboard.type('4');
+    await page.waitForTimeout(300);
+
+    // Select all → copy
+    await page.keyboard.press(`${cmdKey}+a`);
+    await page.waitForTimeout(150);
+    await page.keyboard.press(`${cmdKey}+a`);
+    await page.waitForTimeout(150);
+    await page.keyboard.press(`${cmdKey}+c`);
+    await page.waitForTimeout(300);
+
+    // Now paste back OVER the same selection (still selected after copy).
+    // Mirrors Slate's `Transforms.insertFragment` semantics: the expanded
+    // range must be deleted first, then the pasted blocks inserted in its
+    // place — so the document should contain exactly one copy of 1..4.
+    await page.keyboard.press(`${cmdKey}+v`);
+    await page.waitForTimeout(800);
+
+    const editor = EditorSelectors.slateEditor(page);
+    const topLevelBlocks = await editor.locator('[data-block-type]').evaluateAll((els) =>
+      els.map((el) => {
+        let depth = 0;
+        let parent: HTMLElement | null = el.parentElement;
+        while (parent) {
+          if (parent.hasAttribute('data-block-type')) depth += 1;
+          parent = parent.parentElement;
+        }
+        return { text: (el as HTMLElement).innerText.trim(), depth };
+      })
+    );
+
+    const minDepth = Math.min(...topLevelBlocks.map((b) => b.depth));
+    const top = topLevelBlocks.filter((b) => b.depth === minDepth).map((b) => b.text);
+    const trimmed = top.length > 0 && top[top.length - 1] === '' ? top.slice(0, -1) : top;
+
+    // Exactly one copy of the source — not duplicated.
+    expect(trimmed).toEqual(['1', '2', '3', '4']);
+  });
+});

--- a/src/components/editor/plugins/withInsertData.ts
+++ b/src/components/editor/plugins/withInsertData.ts
@@ -1,12 +1,17 @@
-import { Element, Node } from 'slate';
+import { Editor, Element, Node, Range, Transforms } from 'slate';
 import { ReactEditor } from 'slate-react';
 
 import { YjsEditor } from '@/application/slate-yjs';
 import { CustomEditor } from '@/application/slate-yjs/command';
-import { findSlateEntryByBlockId, getBlockEntry, isInsideSimpleTableCell } from '@/application/slate-yjs/utils/editor';
-import { BlockType, FieldURLType, FileBlockData, ImageBlockData, ImageType } from '@/application/types';
+import { slateContentInsertToYData } from '@/application/slate-yjs/utils/convert';
+import { findSlateEntryByBlockId, getBlockEntry, getSharedRoot, isInsideSimpleTableCell } from '@/application/slate-yjs/utils/editor';
+import { assertDocExists, getBlock, getChildrenArray } from '@/application/slate-yjs/utils/yjs';
+import { BlockType, FieldURLType, FileBlockData, ImageBlockData, ImageType, YjsEditorKey } from '@/application/types';
 import { convertSlateFragmentTo } from '@/components/editor/utils/fragment';
 import { FileHandler } from '@/utils/file';
+import { Log } from '@/utils/log';
+
+type BlockElement = Element & { blockId?: string };
 
 
 export const withInsertData = (editor: ReactEditor) => {
@@ -18,7 +23,7 @@ export const withInsertData = (editor: ReactEditor) => {
     // When pasting inside a table cell, check if the fragment contains table blocks
     // and prevent nesting tables. Instead, extract text and fill adjacent cells.
     const tableCheckEntry = getBlockEntry(e);
-    const tableCheckBlockId = tableCheckEntry ? (tableCheckEntry[0] as Element & { blockId?: string }).blockId : undefined;
+    const tableCheckBlockId = tableCheckEntry ? (tableCheckEntry[0] as BlockElement).blockId : undefined;
 
     if (tableCheckBlockId && isInsideSimpleTableCell(e, tableCheckBlockId)) {
       // Check plain text for TSV (tab-separated values)
@@ -60,14 +65,25 @@ export const withInsertData = (editor: ReactEditor) => {
       }
     }
 
-    const fragment = data.getData('application/x-slate-fragment');
+    const rawFragment =
+      data.getData('application/x-slate-fragment') ||
+      extractSlateFragmentFromHTML(data.getData('text/html'));
 
-    if (fragment) {
-      const decoded = decodeURIComponent(window.atob(fragment));
-      const parsed = JSON.parse(decoded) as Node[];
-      const newFragment = convertSlateFragmentTo(parsed);
+    if (rawFragment) {
+      const parsed = decodeSlateFragment(rawFragment);
 
-      return e.insertFragment(newFragment);
+      if (parsed) {
+        const newFragment = convertSlateFragmentTo(parsed);
+
+        // Slate's default insertFragment nests pasted blocks under the current
+        // block when the cursor sits deep inside a text wrapper. Use the YJS
+        // insertion path instead so the pasted blocks become siblings of the
+        // current block at the same indent level.
+        if (insertFragmentAsSiblings(e, newFragment)) return;
+
+        return e.insertFragment(newFragment);
+      }
+      // Malformed fragment data — fall through to other handlers.
     }
 
     // Do something with the data...
@@ -161,6 +177,146 @@ export const withInsertData = (editor: ReactEditor) => {
 
   return editor;
 };
+
+/**
+ * When Slate copies content, it encodes the full Slate fragment as a base64
+ * blob in the `data-slate-fragment` HTML attribute. The system clipboard
+ * often drops the `application/x-slate-fragment` MIME entry, so we recover
+ * the fragment from the HTML attribute when available.
+ *
+ * Uses the same regex shape as `slate-dom`'s `getSlateFragmentAttribute`.
+ */
+function extractSlateFragmentFromHTML(html: string | undefined): string | undefined {
+  if (!html) return undefined;
+
+  const match = html.match(/data-slate-fragment="(.+?)"/m);
+
+  return match ? match[1] : undefined;
+}
+
+/**
+ * Decode the base64+URI-encoded JSON Slate fragment. Returns `null` for
+ * malformed input so the caller can fall back gracefully instead of throwing
+ * out of the paste handler.
+ */
+function decodeSlateFragment(raw: string): Node[] | null {
+  try {
+    return JSON.parse(decodeURIComponent(window.atob(raw))) as Node[];
+  } catch (err) {
+    Log.warn('decodeSlateFragment: malformed clipboard fragment', err);
+    return null;
+  }
+}
+
+/**
+ * Inserts a Slate fragment as siblings of the current block using the YJS
+ * shared doc, mirroring the path used by `insertParsedBlocks` for HTML paste.
+ *
+ * Returns true if the fragment was inserted; false if the caller should fall
+ * back to Slate's default `insertFragment`.
+ *
+ * Mirrors two behaviors of Slate's `Transforms.insertFragment`:
+ *  - If the selection is expanded, delete the selected range first.
+ *  - After insertion, place the cursor at the end of the last inserted block.
+ */
+function insertFragmentAsSiblings(editor: YjsEditor, fragment: Node[]): boolean {
+  if (fragment.length === 0) return false;
+
+  try {
+    // Every fragment node must be a block-level element with a text wrapper
+    // child — anything else (loose text, inline-only fragments) goes through
+    // Slate's default path so inline pastes still work.
+    const allBlocks = fragment.every((n) => {
+      if (!Element.isElement(n)) return false;
+      const children = n.children;
+
+      return (
+        Array.isArray(children) &&
+        children.length > 0 &&
+        Element.isElement(children[0]) &&
+        children[0].type === YjsEditorKey.text
+      );
+    });
+
+    if (!allBlocks) return false;
+
+    // Match Slate's default `Transforms.insertFragment`: collapse expanded
+    // selection by deleting the selected range first. Re-fetch the block
+    // entry afterward because the deletion changes which block holds the
+    // cursor and whether it is empty.
+    if (editor.selection && !Range.isCollapsed(editor.selection)) {
+      Transforms.delete(editor);
+    }
+
+    const entry = getBlockEntry(editor);
+
+    if (!entry) return false;
+
+    const [node] = entry;
+    const blockId = (node as BlockElement).blockId;
+
+    if (!blockId) return false;
+
+    const sharedRoot = getSharedRoot(editor);
+    const block = getBlock(blockId, sharedRoot);
+
+    if (!block) return false;
+
+    const parentId = block.get(YjsEditorKey.block_parent);
+    const parent = getBlock(parentId, sharedRoot);
+
+    if (!parent) return false;
+
+    const parentChildren = getChildrenArray(parent.get(YjsEditorKey.block_children), sharedRoot);
+    const index = parentChildren.toArray().findIndex((id) => id === blockId);
+
+    if (index < 0) return false;
+
+    // If the current block is empty (no text, no children), the user expects
+    // paste to fill that block — not push it above the pasted content. Insert
+    // at the current index and remove the empty original.
+    const isEmpty =
+      CustomEditor.getBlockTextContent(node as Node).length === 0 &&
+      (node.children?.length ?? 0) <= 1;
+
+    const doc = assertDocExists(sharedRoot);
+    let insertedIds: string[] = [];
+
+    doc.transact(() => {
+      if (isEmpty) {
+        insertedIds = slateContentInsertToYData(parentId, index, fragment, doc);
+        CustomEditor.deleteBlock(editor, blockId);
+      } else {
+        insertedIds = slateContentInsertToYData(parentId, index + 1, fragment, doc);
+      }
+    });
+
+    // Place the cursor at the end of the last inserted block so subsequent
+    // edits target a valid location (not the now-deleted original block).
+    const lastId = insertedIds[insertedIds.length - 1];
+
+    if (lastId) {
+      const lastEntry = findSlateEntryByBlockId(editor, lastId);
+
+      if (lastEntry) {
+        const [, path] = lastEntry;
+
+        try {
+          Transforms.select(editor, Editor.end(editor, path));
+        } catch (err) {
+          // Editor.end can throw if the path was rebuilt mid-transact; the
+          // selection will be re-derived on the next user keystroke.
+          Log.warn('insertFragmentAsSiblings: could not set selection', err);
+        }
+      }
+    }
+
+    return true;
+  } catch (err) {
+    Log.error('insertFragmentAsSiblings failed', err);
+    return false;
+  }
+}
 
 /**
  * Extract text content from a Slate fragment that contains table cells.

--- a/src/components/editor/utils/fragment.ts
+++ b/src/components/editor/utils/fragment.ts
@@ -516,46 +516,63 @@ export function deserializeHTML(html: string) {
 }
 
 export function convertSlateFragmentTo(fragment: SlateNode[]) {
-  const traverse = (node: SlateNode) => {
+  const traverse = (node: SlateNode): SlateNode | null => {
     if (SlateText.isText(node)) {
       return node;
     }
 
-    if (SlateElement.isElement(node)) {
-      const isTextChildren = node.children.every(SlateText.isText);
-      const children = node.children.map(traverse).filter(Boolean) as SlateText[];
-      const blockId = generateBlockId();
-
-      let type = node.type as BlockType;
-
-      if (!Object.values(BlockType).includes(type)) {
-        type = BlockType.Paragraph;
-      }
-
-      const blockChildren = isTextChildren
-        ? [
-            {
-              textId: blockId,
-              children: isTextChildren ? children : [],
-            },
-          ]
-        : [
-            {
-              textId: blockId,
-              children: [{ text: '' }],
-            },
-            ...children,
-          ];
-
-      return {
-        blockId,
-        data: node.data,
-        type,
-        children: blockChildren,
-      };
+    if (!SlateElement.isElement(node)) {
+      return null;
     }
 
-    return null;
+    // Text wrapper child of a block: preserve its shape (don't convert to a block).
+    // Without this, `'text'` falls through the BlockType check below and gets
+    // turned into a nested Paragraph block, which is the root cause of pasted
+    // content being indented one level deeper than the source.
+    if (node.type === YjsEditorKey.text) {
+      const textChildren = node.children.filter(SlateText.isText);
+
+      return {
+        textId: generateBlockId(),
+        type: YjsEditorKey.text,
+        children: textChildren,
+      } as unknown as SlateElement;
+    }
+
+    const blockId = generateBlockId();
+
+    let type = node.type as BlockType;
+
+    if (!Object.values(BlockType).includes(type)) {
+      type = BlockType.Paragraph;
+    }
+
+    const mappedChildren = node.children
+      .map(traverse)
+      .filter(Boolean) as SlateNode[];
+
+    const hasTextWrapper =
+      mappedChildren.length > 0 &&
+      SlateElement.isElement(mappedChildren[0]) &&
+      mappedChildren[0].type === YjsEditorKey.text;
+
+    const blockChildren = hasTextWrapper
+      ? mappedChildren
+      : [
+          {
+            textId: blockId,
+            type: YjsEditorKey.text,
+            children: [{ text: '' }],
+          },
+          ...mappedChildren,
+        ];
+
+    return {
+      blockId,
+      data: node.data,
+      type,
+      children: blockChildren,
+    } as unknown as SlateElement;
   };
 
   return fragment.map(traverse).filter(Boolean) as SlateElement[];


### PR DESCRIPTION
## Summary

Pasting content copied from within the editor produced blocks that were nested one level under the cursor's parent — e.g. typing `1,2,3,4` then select-all → copy → Enter → paste rendered the pasted lines indented under `4`. Deleting that parent then broke Backspace because the empty parent still held nested children.

Three root causes were fixed:

- **`convertSlateFragmentTo`** treated Slate's inner text-wrapper element (`type: 'text'`) as a regular block. Since `'text'` isn't in the `BlockType` enum it was rewritten into a nested `Paragraph`, double-wrapping every pasted block.
- **Slate fragment was not being read from HTML.** The system clipboard often drops the `application/x-slate-fragment` MIME entry; Slate's own `slate-dom` falls back to a regex on `data-slate-fragment` in the HTML. We weren't doing that, so paste went through the HTML-parser path with stale shape.
- **Slate's `insertFragment` nests the fragment** when the cursor sits inside a text-wrapper (deep path). A new `insertFragmentAsSiblings` writes pasted blocks directly to the YJS doc as siblings of the current block.

The sibling-insert path also mirrors `Transforms.insertFragment` semantics: deletes the expanded selection first, replaces the current block if empty, and places the cursor at the end of the last inserted block.

## Test plan

- [x] `playwright/e2e/editor/blocks/paste_indent.spec.ts` — 3 cases (indent regression, Backspace-after-delete, paste-over-selection)
- [x] All `playwright/e2e/editor/blocks/` tests pass (12/12) — no regression in code-block paste, scroll, or unsupported-block tests
- [ ] Manual sanity: paste across documents, paste plain text from outside the editor, paste inside a table cell, paste a single inline word

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Fix pasting Slate fragments so blocks are inserted as siblings at the correct indent level instead of becoming nested under the current block.

Bug Fixes:
- Correct handling of Slate text-wrapper nodes when converting fragments to prevent pasted blocks from being double-wrapped and indented.
- Recover Slate fragments from HTML when the dedicated clipboard MIME type is missing, avoiding fallback to stale HTML parsing on paste.
- Insert pasted block fragments directly into the YJS document as siblings of the current block, including proper handling of empty target blocks and expanded selections.

Enhancements:
- Improve fragment conversion to preserve text-wrapper structure and ensure generated blocks always include an appropriate text child wrapper.
- Align cursor placement after YJS-based fragment insertion with Slate’s default `insertFragment` semantics for a consistent editing experience.

Tests:
- Add Playwright end-to-end coverage for paste indentation behavior, backspace-after-delete, and pasting over a selection in the blocks editor.