### PR TITLE
Fix web sync fallback during reconnect

### DIFF
--- a/src/application/services/js-services/__tests__/sync.test.ts
+++ b/src/application/services/js-services/__tests__/sync.test.ts
@@ -96,6 +96,113 @@ const mockSync = (clientCount: number, tracer = defaultTracer): SyncContext[] =>
   return clients;
 };
 
+interface QueuedSyncBus {
+  clients: SyncContext[];
+  online: boolean[];
+  texts: Y.Text[];
+  disconnect: (index: number) => void;
+  reconnect: (index: number) => void;
+  publishManifest: (index: number) => void;
+  publishManifests: () => void;
+  drain: () => void;
+}
+
+const createQueuedSyncBus = (clientCount: number): QueuedSyncBus => {
+  outboxMock.__clearTestClients();
+
+  const guid = random.uuidv4();
+  const clients: SyncContext[] = [];
+  const online = Array.from({ length: clientCount }, () => true);
+  const queue: Array<{ sender: number; message: messages.IMessage }> = [];
+
+  const enqueue = (sender: number, message: messages.IMessage) => {
+    if (!online[sender]) return;
+    queue.push({ sender, message });
+  };
+
+  for (let i = 0; i < clientCount; i += 1) {
+    const doc = new Y.Doc({ guid });
+
+    clients.push({
+      doc,
+      awareness: new awarenessProtocol.Awareness(doc),
+      emit: (message) => enqueue(i, message),
+      collabType: Types.Document,
+    });
+  }
+
+  clients.forEach((client) => initSync(client));
+  queue.length = 0;
+
+  const publishManifest = (index: number) => {
+    const client = clients[index];
+
+    client.emit({
+      collabMessage: {
+        objectId: client.doc.guid,
+        collabType: client.collabType,
+        syncRequest: {
+          stateVector: Y.encodeStateVector(client.doc),
+          lastMessageId: { timestamp: 0, counter: 0 },
+          version: client.doc.version,
+        },
+      },
+    });
+  };
+
+  const publishManifests = () => {
+    clients.forEach((_, index) => publishManifest(index));
+  };
+
+  const drain = () => {
+    let guard = 0;
+
+    while (queue.length > 0) {
+      if (guard > 1_000) {
+        throw new Error('sync queue did not settle');
+      }
+
+      guard += 1;
+      const { sender, message } = queue.shift()!;
+
+      if (!online[sender] || !message.collabMessage) continue;
+
+      clients.forEach((client, index) => {
+        if (index !== sender && online[index]) {
+          handleMessage(client, message.collabMessage!);
+        }
+      });
+    }
+  };
+
+  const disconnect = (index: number) => {
+    online[index] = false;
+  };
+
+  const reconnect = (index: number) => {
+    online[index] = true;
+    publishManifests();
+  };
+
+  return {
+    clients,
+    online,
+    texts: clients.map((client) => client.doc.getText('test')),
+    disconnect,
+    reconnect,
+    publishManifest,
+    publishManifests,
+    drain,
+  };
+};
+
+const expectTextConvergence = (texts: Y.Text[], expectedChars: string) => {
+  const values = texts.map((text) => text.toString());
+
+  expect(new Set(values).size).toBe(1);
+  expect([...values[0]].sort().join('')).toBe(expectedChars);
+};
+
 describe('sync protocol', () => {
   it('should exchange updates between client and server', () => {
     const [local, remote] = mockSync(2);
@@ -113,5 +220,147 @@ describe('sync protocol', () => {
     // remote -> local
     txt2.insert(5, ' World');
     expect(txt1.toString()).toEqual('Hello World');
+  });
+
+  it('converges three online clients after concurrent same-position edits', () => {
+    const { texts, publishManifests, drain } = createQueuedSyncBus(3);
+
+    texts[0].insert(0, 'A');
+    texts[1].insert(0, 'B');
+    texts[2].insert(0, 'C');
+
+    publishManifests();
+    drain();
+
+    expectTextConvergence(texts, 'ABC');
+  });
+
+  it('converges when one client edits offline and then reconnects', () => {
+    const { texts, disconnect, reconnect, publishManifest, drain } = createQueuedSyncBus(3);
+
+    disconnect(2);
+
+    texts[0].insert(0, 'A');
+    texts[1].insert(0, 'B');
+    texts[2].insert(0, 'C');
+
+    publishManifest(0);
+    publishManifest(1);
+    drain();
+
+    expect(texts[0].toString()).toEqual(texts[1].toString());
+    expect([...texts[0].toString()].sort().join('')).toBe('AB');
+    expect(texts[2].toString()).toBe('C');
+
+    reconnect(2);
+    drain();
+
+    expectTextConvergence(texts, 'ABC');
+  });
+
+  it('converges when two offline clients reconnect in ascending order', () => {
+    const { texts, disconnect, reconnect, publishManifest, drain } = createQueuedSyncBus(3);
+
+    disconnect(0);
+    disconnect(1);
+
+    texts[0].insert(0, 'A');
+    texts[1].insert(0, 'B');
+    texts[2].insert(0, 'C');
+
+    publishManifest(2);
+    drain();
+    expect(texts.map((text) => text.toString())).toEqual(['A', 'B', 'C']);
+
+    reconnect(0);
+    drain();
+    expect(texts[0].toString()).toEqual(texts[2].toString());
+    expect([...texts[0].toString()].sort().join('')).toBe('AC');
+    expect(texts[1].toString()).toBe('B');
+
+    reconnect(1);
+    drain();
+
+    expectTextConvergence(texts, 'ABC');
+  });
+
+  it('converges when two offline clients reconnect in reverse order', () => {
+    const { texts, disconnect, reconnect, publishManifest, drain } = createQueuedSyncBus(3);
+
+    disconnect(0);
+    disconnect(1);
+
+    texts[0].insert(0, 'A');
+    texts[1].insert(0, 'B');
+    texts[2].insert(0, 'C');
+
+    publishManifest(2);
+    drain();
+    expect(texts.map((text) => text.toString())).toEqual(['A', 'B', 'C']);
+
+    reconnect(1);
+    drain();
+    expect(texts[1].toString()).toEqual(texts[2].toString());
+    expect([...texts[1].toString()].sort().join('')).toBe('BC');
+    expect(texts[0].toString()).toBe('A');
+
+    reconnect(0);
+    drain();
+
+    expectTextConvergence(texts, 'ABC');
+  });
+
+  it('converges when all clients edit offline and reconnect left to right', () => {
+    const { texts, disconnect, reconnect, drain } = createQueuedSyncBus(3);
+
+    disconnect(0);
+    disconnect(1);
+    disconnect(2);
+
+    texts[0].insert(0, 'A');
+    texts[1].insert(0, 'B');
+    texts[2].insert(0, 'C');
+
+    reconnect(0);
+    drain();
+    expect(texts.map((text) => text.toString())).toEqual(['A', 'B', 'C']);
+
+    reconnect(1);
+    drain();
+    expect(texts[0].toString()).toEqual(texts[1].toString());
+    expect([...texts[0].toString()].sort().join('')).toBe('AB');
+    expect(texts[2].toString()).toBe('C');
+
+    reconnect(2);
+    drain();
+
+    expectTextConvergence(texts, 'ABC');
+  });
+
+  it('converges when all clients edit offline and reconnect right to left', () => {
+    const { texts, disconnect, reconnect, drain } = createQueuedSyncBus(3);
+
+    disconnect(0);
+    disconnect(1);
+    disconnect(2);
+
+    texts[0].insert(0, 'A');
+    texts[1].insert(0, 'B');
+    texts[2].insert(0, 'C');
+
+    reconnect(2);
+    drain();
+    expect(texts.map((text) => text.toString())).toEqual(['A', 'B', 'C']);
+
+    reconnect(1);
+    drain();
+    expect(texts[1].toString()).toEqual(texts[2].toString());
+    expect([...texts[1].toString()].sort().join('')).toBe('BC');
+    expect(texts[0].toString()).toBe('A');
+
+    reconnect(0);
+    drain();
+
+    expectTextConvergence(texts, 'ABC');
   });
 });

--- a/src/application/services/js-services/http/collab-api.ts
+++ b/src/application/services/js-services/http/collab-api.ts
@@ -13,6 +13,14 @@ import { Log } from '@/utils/log';
 
 import { APIResponse, APIError, executeAPIRequest, executeAPIVoidRequest, getAxios, parseRetryAfterSecs } from './core';
 
+export interface CollabFullSyncBatchResult {
+  objectId: string;
+  collabType: Types;
+  missingUpdate: Uint8Array;
+  serverStateVector: Uint8Array;
+  error?: string;
+}
+
 export async function updateCollab(
   workspaceId: string,
   objectId: string,
@@ -61,7 +69,7 @@ export async function collabFullSyncBatch(
     stateVector: Uint8Array;
     docState: Uint8Array;
   }>
-): Promise<void> {
+): Promise<CollabFullSyncBatchResult[]> {
   const url = `/api/workspace/v1/${workspaceId}/collab/full-sync/batch`;
 
   // Build the protobuf request
@@ -113,6 +121,7 @@ export async function collabFullSyncBatch(
   // Decode and check the response for errors
   const responseData = new Uint8Array(response.data);
   const batchResponse = collab.CollabBatchSyncResponse.decode(responseData);
+  const results: CollabFullSyncBatchResult[] = [];
 
   // Check for any errors in the results
   for (const result of batchResponse.results) {
@@ -123,7 +132,17 @@ export async function collabFullSyncBatch(
         error: result.error,
       });
     }
+
+    results.push({
+      objectId: result.objectId ?? '',
+      collabType: result.collabType as Types,
+      missingUpdate: result.missingUpdate ?? new Uint8Array(),
+      serverStateVector: result.serverStateVector ?? new Uint8Array(),
+      error: result.error || undefined,
+    });
   }
+
+  return results;
 }
 
 export async function getCollab(workspaceId: string, objectId: string, collabType: Types) {

--- a/src/application/services/js-services/sync-protocol.ts
+++ b/src/application/services/js-services/sync-protocol.ts
@@ -41,6 +41,19 @@ export interface SyncContext {
    */
   discardPendingUpdates?: () => Promise<void>;
   /**
+   * Called after a local Yjs update is observed. The WebSocket path still owns
+   * immediate delivery; this hook lets the app schedule a debounced HTTP full
+   * sync when the WebSocket is reconnecting.
+   */
+  onLocalUpdate?: (objectId: string) => void;
+  /**
+   * Called after this context participates in a WebSocket state-vector sync
+   * exchange. A completed manifest-style exchange reconciles the full Yjs
+   * state, so HTTP fallback dirty markers for the object can be cleared when
+   * the socket is open.
+   */
+  onManifestSync?: (objectId: string) => void;
+  /**
    * Cleanup function to remove update/awareness observers and cancel debounced sends.
    * Set by initSync, called during deferred sync context cleanup.
    */
@@ -83,6 +96,7 @@ const handleSyncRequest = (ctx: SyncContext, message: collab.ISyncRequest): void
       },
     },
   });
+  ctx.onManifestSync?.(doc.guid);
 };
 
 const handleAccessChanged = (ctx: SyncContext, message: collab.IAccessChanged): void => {
@@ -190,6 +204,7 @@ export const initSync = (ctx: SyncContext) => {
       version: doc.version ?? null,
       payload: update,
     });
+    ctx.onLocalUpdate?.(doc.guid);
   };
 
   const onDestroy = () => {

--- a/src/application/sync-outbox/__tests__/sync-outbox.test.ts
+++ b/src/application/sync-outbox/__tests__/sync-outbox.test.ts
@@ -1,0 +1,240 @@
+import * as Y from 'yjs';
+
+import { Types } from '@/application/types';
+
+interface MockSyncOutboxRecord {
+  id?: number;
+  userId: string;
+  workspaceId: string;
+  objectId: string;
+  collabType: number;
+  version?: string | null;
+  payload: Uint8Array;
+  createdAt: number;
+}
+
+let mockRecords: MockSyncOutboxRecord[] = [];
+let mockNextId = 1;
+
+function mockMatchesIndex(index: string, key: unknown[], record: MockSyncOutboxRecord) {
+  if (index === '[userId+workspaceId]') {
+    return record.userId === key[0] && record.workspaceId === key[1];
+  }
+
+  if (index === '[userId+workspaceId+objectId]') {
+    return record.userId === key[0] && record.workspaceId === key[1] && record.objectId === key[2];
+  }
+
+  throw new Error(`Unsupported mock index: ${index}`);
+}
+
+const mockSyncOutboxTable = {
+  add: jest.fn(async (row: Omit<MockSyncOutboxRecord, 'id'>) => {
+    const id = mockNextId++;
+
+    mockRecords.push({ ...row, id });
+    return id;
+  }),
+  bulkDelete: jest.fn(async (ids: number[]) => {
+    const idsToDelete = new Set(ids);
+
+    mockRecords = mockRecords.filter((record) => !idsToDelete.has(record.id ?? -1));
+  }),
+  clear: jest.fn(async () => {
+    mockRecords = [];
+  }),
+  where: jest.fn((index: string) => ({
+    equals: (key: unknown[]) => ({
+      count: async () => mockRecords.filter((record) => mockMatchesIndex(index, key, record)).length,
+      delete: async () => {
+        mockRecords = mockRecords.filter((record) => !mockMatchesIndex(index, key, record));
+      },
+      each: async (callback: (record: MockSyncOutboxRecord) => void) => {
+        mockRecords.filter((record) => mockMatchesIndex(index, key, record)).forEach(callback);
+      },
+      sortBy: async (field: keyof MockSyncOutboxRecord) =>
+        mockRecords
+          .filter((record) => mockMatchesIndex(index, key, record))
+          .slice()
+          .sort((a, b) => Number(a[field] ?? 0) - Number(b[field] ?? 0)),
+    }),
+  })),
+};
+
+jest.mock('@/application/db', () => ({
+  db: {
+    sync_outbox: mockSyncOutboxTable,
+  },
+}));
+
+jest.mock('@/utils/log', () => ({
+  Log: {
+    debug: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  },
+}));
+
+import {
+  clearDrainConfig,
+  configureDrain,
+  enqueueOutboxUpdate,
+  setCurrentSession,
+  startDrainAll,
+} from '@/application/sync-outbox';
+
+const userId = 'user-1';
+const workspaceId = 'workspace-1';
+const objectId = '11111111-1111-4111-8111-111111111111';
+
+function makeUpdate(value: string) {
+  const doc = new Y.Doc({ guid: objectId });
+
+  doc.getMap('root').set('value', value);
+  return Y.encodeStateAsUpdate(doc);
+}
+
+async function flushPromises() {
+  for (let i = 0; i < 5; i += 1) {
+    await Promise.resolve();
+  }
+}
+
+describe('sync outbox live send', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockRecords = [];
+    mockNextId = 1;
+    clearDrainConfig();
+    setCurrentSession({ userId, workspaceId });
+  });
+
+  afterEach(() => {
+    clearDrainConfig();
+    setCurrentSession(null);
+  });
+
+  it('sends immediately when the transport is ready and removes the durable copy after enqueue lands', async () => {
+    const send = jest.fn();
+
+    configureDrain({
+      userId,
+      workspaceId,
+      send,
+      isReady: () => true,
+    });
+
+    enqueueOutboxUpdate({
+      objectId,
+      collabType: Types.Document,
+      version: null,
+      payload: makeUpdate('draft'),
+    });
+
+    expect(send).toHaveBeenCalledTimes(1);
+    expect(mockRecords).toHaveLength(1);
+
+    await flushPromises();
+
+    expect(send).toHaveBeenCalledTimes(1);
+    expect(mockRecords).toHaveLength(0);
+  });
+
+  it('drains queued records when startDrainAll runs after the transport becomes ready', async () => {
+    let ready = false;
+    const send = jest.fn();
+
+    configureDrain({
+      userId,
+      workspaceId,
+      send,
+      isReady: () => ready,
+    });
+
+    enqueueOutboxUpdate({
+      objectId,
+      collabType: Types.Document,
+      version: null,
+      payload: makeUpdate('draft'),
+    });
+
+    await flushPromises();
+
+    expect(send).not.toHaveBeenCalled();
+    expect(mockRecords).toHaveLength(1);
+
+    ready = true;
+    startDrainAll();
+    await flushPromises();
+
+    expect(send).toHaveBeenCalledTimes(1);
+    expect(mockRecords).toHaveLength(0);
+  });
+
+  it('uses the queued row when the immediate send fails', async () => {
+    const send = jest
+      .fn()
+      .mockImplementationOnce(() => {
+        throw new Error('transient send failure');
+      })
+      .mockImplementation(() => undefined);
+
+    configureDrain({
+      userId,
+      workspaceId,
+      send,
+      isReady: () => true,
+    });
+
+    enqueueOutboxUpdate({
+      objectId,
+      collabType: Types.Document,
+      version: null,
+      payload: makeUpdate('draft'),
+    });
+
+    await flushPromises();
+
+    expect(send).toHaveBeenCalledTimes(2);
+    expect(mockRecords).toHaveLength(0);
+  });
+
+  it('live sends the current update and drains older queued records', async () => {
+    let ready = false;
+    const send = jest.fn();
+
+    configureDrain({
+      userId,
+      workspaceId,
+      send,
+      isReady: () => ready,
+    });
+
+    enqueueOutboxUpdate({
+      objectId,
+      collabType: Types.Document,
+      version: null,
+      payload: makeUpdate('old'),
+    });
+    await flushPromises();
+
+    expect(send).not.toHaveBeenCalled();
+    expect(mockRecords).toHaveLength(1);
+
+    ready = true;
+
+    enqueueOutboxUpdate({
+      objectId,
+      collabType: Types.Document,
+      version: null,
+      payload: makeUpdate('new'),
+    });
+
+    expect(send).toHaveBeenCalledTimes(1);
+
+    await flushPromises();
+
+    expect(send).toHaveBeenCalledTimes(2);
+    expect(mockRecords).toHaveLength(0);
+  });
+});

--- a/src/application/sync-outbox/index.ts
+++ b/src/application/sync-outbox/index.ts
@@ -110,25 +110,13 @@ export function enqueueOutboxUpdate(record: Omit<SyncOutboxRecord, 'id' | 'creat
   };
 
   // Fan out to sibling tabs immediately, regardless of WebSocket state. The
-  // server send happens later through the outbox drain; the peer broadcast
-  // keeps multi-tab collaboration responsive during reconnect windows.
+  // server send uses the same update shape below when the WebSocket is open;
+  // the durable outbox row remains the fallback when it is not.
   const broadcast = drainConfig?.broadcast;
 
   if (broadcast && drainConfig?.workspaceId === workspaceId) {
-    const peerMessage: messages.IMessage = {
-      collabMessage: {
-        objectId: record.objectId,
-        collabType: record.collabType,
-        update: {
-          flags: FLAGS_LIB0V1,
-          payload: record.payload,
-          version: record.version ?? undefined,
-        } as collab.IUpdate,
-      },
-    };
-
     try {
-      broadcast(peerMessage);
+      broadcast(buildUpdateMessage(record));
     } catch (error) {
       Log.warn('[outbox] broadcast failed', { objectId: record.objectId, error });
     }
@@ -143,15 +131,59 @@ export function enqueueOutboxUpdate(record: Omit<SyncOutboxRecord, 'id' | 'creat
 
   const addPromise: Promise<unknown> = db.sync_outbox.add(row as SyncOutboxRecord);
   const set = inflightAdds.get(record.objectId) ?? new Set<Promise<unknown>>();
+  let sentImmediately = false;
+
+  const activeConfig = drainConfig;
+
+  if (
+    activeConfig &&
+    activeConfig.userId === enqueueUserId &&
+    activeConfig.workspaceId === enqueueWorkspaceId &&
+    !isPurging &&
+    !suppressedObjects.has(record.objectId) &&
+    activeConfig.isReady()
+  ) {
+    try {
+      activeConfig.send(buildUpdateMessage(record));
+      sentImmediately = true;
+    } catch (error) {
+      Log.warn('[outbox] immediate send failed; durable row will drain', { objectId: record.objectId, error });
+    }
+  }
 
   set.add(addPromise);
   inflightAdds.set(record.objectId, set);
 
   addPromise
-    .then(() => {
+    .then(async (id) => {
+      if (sentImmediately) {
+        if (typeof id === 'number') {
+          try {
+            await db.sync_outbox.bulkDelete([id]);
+          } catch (error) {
+            Log.warn('[outbox] immediate-send cleanup failed; leaving row for drain', {
+              objectId: record.objectId,
+              id,
+              error,
+            });
+          }
+        }
+
+        // A live keystroke may have followed older queued records. Kick a
+        // normal drain so those older rows are reconciled instead of waiting
+        // for refresh/reconnect.
+        scheduleDrain(record.objectId);
+        return;
+      }
+
       scheduleDrain(record.objectId);
     })
     .catch((error) => {
+      if (sentImmediately) {
+        Log.warn('[outbox] enqueue failed after immediate send', { objectId: record.objectId, error });
+        return;
+      }
+
       Log.error('[outbox] enqueue failed', { objectId: record.objectId, error });
 
       // IDB write failed (quota exhausted, upgrade blocked, etc.). Fall back
@@ -458,6 +490,20 @@ async function distinctObjectIdsForSession(userId: string, workspaceId: string):
   return Array.from(ids);
 }
 
+function buildUpdateMessage(record: Pick<SyncOutboxRecord, 'objectId' | 'collabType' | 'payload' | 'version'>): messages.IMessage {
+  return {
+    collabMessage: {
+      objectId: record.objectId,
+      collabType: record.collabType,
+      update: {
+        flags: FLAGS_LIB0V1,
+        payload: record.payload,
+        version: record.version ?? undefined,
+      } as collab.IUpdate,
+    },
+  };
+}
+
 function scheduleDrain(objectId: string) {
   if (!drainConfig) return;
 
@@ -521,7 +567,9 @@ async function drainObjectWhileReady(objectId: string): Promise<void> {
     // swapped out (workspace change / sign-out) or is not ready (WS closed).
     const config = drainConfig;
 
-    if (!config || config !== initialConfig || !config.isReady()) return;
+    if (!config || config !== initialConfig) return;
+
+    if (!config.isReady()) return;
 
     const userId = config.userId;
     const workspaceId = config.workspaceId;
@@ -557,10 +605,12 @@ async function drainObjectWhileReady(objectId: string): Promise<void> {
     // and will be picked up by a future drain.
     if (suppressedObjects.has(objectId) || drainConfig !== initialConfig || isPurging) return;
 
+    if (!config.isReady()) return;
+
     try {
       config.send(message);
     } catch (error) {
-      Log.warn('[outbox] send failed; leaving records for retry', { objectId, error });
+      Log.warn('[outbox] send failed; leaving records queued', { objectId, error });
       return;
     }
 

--- a/src/components/ws/__tests__/useSync.test.ts
+++ b/src/components/ws/__tests__/useSync.test.ts
@@ -215,6 +215,12 @@ const createDeferred = <T>(): Deferred<T> => {
   return { promise, resolve, reject };
 };
 
+const flushPromises = async () => {
+  for (let i = 0; i < 5; i += 1) {
+    await Promise.resolve();
+  }
+};
+
 const mockedOpenCollabDB = openCollabDB as jest.MockedFunction<typeof openCollabDB>;
 const mockedOpenCollabDBWithProvider = openCollabDBWithProvider as jest.MockedFunction<typeof openCollabDBWithProvider>;
 const mockedOpenRowCollabDBWithProvider = openRowCollabDBWithProvider as jest.MockedFunction<typeof openRowCollabDBWithProvider>;
@@ -868,8 +874,208 @@ describe('useSync public API', () => {
     outboxMock.clearDrainConfig();
   });
 
+  it('background syncs dirty registered docs over HTTP while websocket is reconnecting', async () => {
+    jest.useFakeTimers();
+    mockedCollabFullSyncBatch.mockResolvedValue([]);
+
+    try {
+      const ws = {
+        ...createWs(),
+        readyState: 0,
+      } as AppflowyWebSocketType;
+      const bc = createBroadcastChannel();
+      const docA = createDoc('abababab-aaaa-4aaa-8aaa-abababababab');
+      const docB = createDoc('bcbcbcbc-bbbb-4bbb-8bbb-bcbcbcbcbcbc');
+      const { result, unmount } = renderHook(() => useSync(ws, bc, defaultEventEmitter, defaultWorkspaceId));
+
+      act(() => {
+        result.current.registerSyncContext({ doc: docA, collabType: Types.Document });
+        result.current.registerSyncContext({ doc: docB, collabType: Types.Document });
+      });
+
+      act(() => {
+        docA.getMap('root').set('dirty', true);
+      });
+
+      expect(mockedCollabFullSyncBatch).not.toHaveBeenCalled();
+
+      await act(async () => {
+        jest.advanceTimersByTime(5_000);
+        await flushPromises();
+      });
+
+      expect(mockedCollabFullSyncBatch).toHaveBeenCalledTimes(1);
+      const [workspaceId, items] = mockedCollabFullSyncBatch.mock.calls[0]!;
+
+      expect(workspaceId).toBe(defaultWorkspaceId);
+      expect(items).toHaveLength(1);
+      expect(items[0]).toEqual(
+        expect.objectContaining({
+          objectId: docA.guid,
+          collabType: Types.Document,
+          stateVector: expect.any(Uint8Array),
+          docState: expect.any(Uint8Array),
+        })
+      );
+
+      unmount();
+      docA.destroy();
+      docB.destroy();
+    } finally {
+      jest.runOnlyPendingTimers();
+      jest.useRealTimers();
+    }
+  });
+
+  it('keeps dirty docs for HTTP fallback when websocket opens before outbox drains and closes again', async () => {
+    jest.useFakeTimers();
+    mockedCollabFullSyncBatch.mockResolvedValue([]);
+    const outboxMock = jest.requireMock('@/application/sync-outbox');
+
+    outboxMock.waitForDrain.mockResolvedValueOnce(false);
+
+    try {
+      const ws = {
+        ...createWs(),
+        readyState: 0,
+      } as AppflowyWebSocketType;
+      const bc = createBroadcastChannel();
+      const doc = createDoc('cdcdcdcd-1111-4111-8111-cdcdcdcdcdcd');
+      const { result, rerender, unmount } = renderHook(() => useSync(ws, bc, defaultEventEmitter, defaultWorkspaceId));
+
+      act(() => {
+        result.current.registerSyncContext({ doc, collabType: Types.Document });
+        doc.getMap('root').set('dirty', true);
+      });
+
+      act(() => {
+        ws.readyState = 1;
+        rerender();
+      });
+
+      await act(async () => {
+        await flushPromises();
+      });
+
+      act(() => {
+        ws.readyState = 0;
+        rerender();
+      });
+
+      await act(async () => {
+        jest.advanceTimersByTime(5_000);
+        await flushPromises();
+      });
+
+      expect(mockedCollabFullSyncBatch).toHaveBeenCalledTimes(1);
+      expect(mockedCollabFullSyncBatch.mock.calls[0]?.[1]).toEqual([
+        expect.objectContaining({
+          objectId: doc.guid,
+          collabType: Types.Document,
+        }),
+      ]);
+
+      unmount();
+      doc.destroy();
+    } finally {
+      jest.runOnlyPendingTimers();
+      jest.useRealTimers();
+    }
+  });
+
+  it('background syncs recent open-window edits after websocket disconnects', async () => {
+    jest.useFakeTimers();
+    mockedCollabFullSyncBatch.mockResolvedValue([]);
+
+    try {
+      const ws = {
+        ...createWs(),
+        readyState: 1,
+      } as AppflowyWebSocketType;
+      const bc = createBroadcastChannel();
+      const doc = createDoc('cececece-2222-4222-8222-cececececece');
+      const { result, rerender, unmount } = renderHook(() => useSync(ws, bc, defaultEventEmitter, defaultWorkspaceId));
+
+      act(() => {
+        result.current.registerSyncContext({ doc, collabType: Types.Document });
+        doc.getMap('root').set('open-window-edit', true);
+      });
+
+      await act(async () => {
+        jest.advanceTimersByTime(5_000);
+        await flushPromises();
+      });
+
+      expect(mockedCollabFullSyncBatch).not.toHaveBeenCalled();
+
+      act(() => {
+        ws.readyState = 0;
+        rerender();
+      });
+
+      await act(async () => {
+        jest.advanceTimersByTime(5_000);
+        await flushPromises();
+      });
+
+      expect(mockedCollabFullSyncBatch).toHaveBeenCalledTimes(1);
+      expect(mockedCollabFullSyncBatch.mock.calls[0]?.[1]).toEqual([
+        expect.objectContaining({
+          objectId: doc.guid,
+          collabType: Types.Document,
+        }),
+      ]);
+
+      unmount();
+      doc.destroy();
+    } finally {
+      jest.runOnlyPendingTimers();
+      jest.useRealTimers();
+    }
+  });
+
+  it('clears recent dirty edits after websocket manifest sync', async () => {
+    jest.useFakeTimers();
+    mockedCollabFullSyncBatch.mockResolvedValue([]);
+
+    try {
+      const ws = {
+        ...createWs(),
+        readyState: 1,
+      } as AppflowyWebSocketType;
+      const bc = createBroadcastChannel();
+      const doc = createDoc('cfcfcfcf-3333-4333-8333-cfcfcfcfcfcf');
+      const { result, rerender, unmount } = renderHook(() => useSync(ws, bc, defaultEventEmitter, defaultWorkspaceId));
+      let syncContext: { onManifestSync?: (objectId: string) => void } | undefined;
+
+      act(() => {
+        syncContext = result.current.registerSyncContext({ doc, collabType: Types.Document });
+        doc.getMap('root').set('open-window-edit', true);
+      });
+
+      act(() => {
+        syncContext?.onManifestSync?.(doc.guid);
+        ws.readyState = 0;
+        rerender();
+      });
+
+      await act(async () => {
+        jest.advanceTimersByTime(5_000);
+        await flushPromises();
+      });
+
+      expect(mockedCollabFullSyncBatch).not.toHaveBeenCalled();
+
+      unmount();
+      doc.destroy();
+    } finally {
+      jest.runOnlyPendingTimers();
+      jest.useRealTimers();
+    }
+  });
+
   it('syncAllToServer sends one batch for all registered contexts', async () => {
-    mockedCollabFullSyncBatch.mockResolvedValueOnce(undefined);
+    mockedCollabFullSyncBatch.mockResolvedValueOnce([]);
     const ws = createWs();
     const bc = createBroadcastChannel();
     const docA = createDoc('cccccccc-cccc-4ccc-8ccc-cccccccccccc');
@@ -895,8 +1101,166 @@ describe('useSync public API', () => {
     expect(items.every((item) => item.docState instanceof Uint8Array)).toBe(true);
   });
 
+  it('syncAllToServer applies missing updates returned by HTTP full-sync', async () => {
+    const ws = createWs();
+    const bc = createBroadcastChannel();
+    const localDoc = createDoc('efefefef-1111-4111-8111-efefefefefef');
+    const serverDoc = createDoc(localDoc.guid);
+    const { result } = renderHook(() => useSync(ws, bc, defaultEventEmitter, defaultWorkspaceId));
+
+    serverDoc.getMap('root').set('server', 'value');
+    const missingUpdate = Y.encodeStateAsUpdate(serverDoc, Y.encodeStateVector(localDoc));
+
+    mockedCollabFullSyncBatch.mockResolvedValueOnce([
+      {
+        objectId: localDoc.guid,
+        collabType: Types.Document,
+        missingUpdate,
+        serverStateVector: Y.encodeStateVector(serverDoc),
+      },
+    ]);
+
+    act(() => {
+      result.current.registerSyncContext({ doc: localDoc, collabType: Types.Document });
+    });
+
+    await act(async () => {
+      await result.current.syncAllToServer('workspace-sync');
+    });
+
+    expect(localDoc.getMap('root').get('server')).toBe('value');
+  });
+
+  it('syncAllToServer sends sync request when HTTP missing update has dependencies', async () => {
+    const ws = createWs();
+    const bc = createBroadcastChannel();
+    const sendMessage = ws.sendMessage as jest.Mock;
+    const localDoc = createDoc('fafafafa-1111-4111-8111-fafafafafafa');
+    const serverDoc = createDoc(localDoc.guid);
+    const { result } = renderHook(() => useSync(ws, bc, defaultEventEmitter, defaultWorkspaceId));
+
+    serverDoc.getMap('root').set('first', 'server-first');
+    const stateAfterFirstChange = Y.encodeStateVector(serverDoc);
+
+    serverDoc.getMap('root').set('second', 'server-second');
+    const dependentMissingUpdate = Y.encodeStateAsUpdate(serverDoc, stateAfterFirstChange);
+
+    mockedCollabFullSyncBatch.mockResolvedValueOnce([
+      {
+        objectId: localDoc.guid,
+        collabType: Types.Document,
+        missingUpdate: dependentMissingUpdate,
+        serverStateVector: Y.encodeStateVector(serverDoc),
+      },
+    ]);
+
+    act(() => {
+      result.current.registerSyncContext({ doc: localDoc, collabType: Types.Document });
+    });
+    sendMessage.mockClear();
+
+    await act(async () => {
+      await result.current.syncAllToServer('workspace-sync');
+    });
+
+    const syncRequestCalls = sendMessage.mock.calls.filter((call) => call[0]?.collabMessage?.syncRequest);
+
+    expect(syncRequestCalls).toHaveLength(1);
+    expect(syncRequestCalls[0]?.[0]).toEqual(
+      expect.objectContaining({
+        collabMessage: expect.objectContaining({
+          objectId: localDoc.guid,
+          collabType: Types.Document,
+          syncRequest: expect.objectContaining({
+            stateVector: expect.any(Uint8Array),
+            lastMessageId: { timestamp: 0, counter: 0 },
+          }),
+        }),
+      })
+    );
+  });
+
+  it('syncAllToServer keeps newer dirty edits when HTTP missing update has dependencies', async () => {
+    jest.useFakeTimers();
+    const firstFullSync = createDeferred<Awaited<ReturnType<typeof httpApi.collabFullSyncBatch>>>();
+
+    mockedCollabFullSyncBatch.mockImplementationOnce(() => firstFullSync.promise);
+    mockedCollabFullSyncBatch.mockResolvedValue([]);
+
+    try {
+      const ws = {
+        ...createWs(),
+        readyState: 1,
+      } as AppflowyWebSocketType;
+      const bc = createBroadcastChannel();
+      const localDoc = createDoc('fbfbfbfb-1111-4111-8111-fbfbfbfbfbfb');
+      const serverDoc = createDoc(localDoc.guid);
+      const { result, rerender, unmount } = renderHook(() => useSync(ws, bc, defaultEventEmitter, defaultWorkspaceId));
+
+      serverDoc.getMap('root').set('first', 'server-first');
+      const stateAfterFirstChange = Y.encodeStateVector(serverDoc);
+
+      serverDoc.getMap('root').set('second', 'server-second');
+      const dependentMissingUpdate = Y.encodeStateAsUpdate(serverDoc, stateAfterFirstChange);
+
+      act(() => {
+        result.current.registerSyncContext({ doc: localDoc, collabType: Types.Document });
+        localDoc.getMap('root').set('before-http', true);
+      });
+
+      let syncPromise!: Promise<void>;
+
+      await act(async () => {
+        syncPromise = result.current.syncAllToServer(defaultWorkspaceId);
+        await flushPromises();
+      });
+
+      expect(mockedCollabFullSyncBatch).toHaveBeenCalledTimes(1);
+
+      act(() => {
+        localDoc.getMap('root').set('during-http', true);
+      });
+
+      await act(async () => {
+        firstFullSync.resolve([
+          {
+            objectId: localDoc.guid,
+            collabType: Types.Document,
+            missingUpdate: dependentMissingUpdate,
+            serverStateVector: Y.encodeStateVector(serverDoc),
+          },
+        ]);
+        await syncPromise;
+      });
+
+      act(() => {
+        ws.readyState = 0;
+        rerender();
+      });
+
+      await act(async () => {
+        jest.advanceTimersByTime(5_000);
+        await flushPromises();
+      });
+
+      expect(mockedCollabFullSyncBatch).toHaveBeenCalledTimes(2);
+      expect(mockedCollabFullSyncBatch.mock.calls[1]?.[1]).toEqual([
+        expect.objectContaining({
+          objectId: localDoc.guid,
+          collabType: Types.Document,
+        }),
+      ]);
+
+      unmount();
+      localDoc.destroy();
+    } finally {
+      jest.runOnlyPendingTimers();
+      jest.useRealTimers();
+    }
+  });
+
   it('syncAllToServer merges legacy row updates before encoding unregistered shared rows', async () => {
-    mockedCollabFullSyncBatch.mockResolvedValueOnce(undefined);
+    mockedCollabFullSyncBatch.mockResolvedValueOnce([]);
     const ws = createWs();
     const bc = createBroadcastChannel();
     const databaseId = 'abcabcab-1111-4111-8111-abcabcabcabc';
@@ -944,7 +1308,7 @@ describe('useSync public API', () => {
   });
 
   it('syncAllToServer probes legacy row cache when IndexedDB enumeration is empty', async () => {
-    mockedCollabFullSyncBatch.mockResolvedValueOnce(undefined);
+    mockedCollabFullSyncBatch.mockResolvedValueOnce([]);
     mockedCollabIndexedDBExists.mockResolvedValueOnce(true);
     const ws = createWs();
     const bc = createBroadcastChannel();

--- a/src/components/ws/sync/useBatchSync.ts
+++ b/src/components/ws/sync/useBatchSync.ts
@@ -18,6 +18,7 @@ import { collabFullSyncBatch, createOrphanedView, checkIfCollabExists } from '@/
 import { withRetry } from '@/application/services/js-services/http/core';
 import { waitForDrain } from '@/application/sync-outbox';
 import { Types, YDatabase, YjsDatabaseKey, YjsEditorKey } from '@/application/types';
+import { applyYDoc } from '@/application/ydoc/apply';
 import { Log } from '@/utils/log';
 
 import { SyncRefs } from './syncRefs';
@@ -25,6 +26,22 @@ import { SyncRefs } from './syncRefs';
 // 30s base delay for batch sync retries (rate-limited / server-busy).
 // withRetry adds jitter and honours server Retry-After when present.
 const BATCH_SYNC_DELAYS = [30_000, 30_000, 30_000];
+const WS_READY_STATE_OPEN = 1;
+const BACKGROUND_HTTP_SYNC_DELAY_MS = 5_000;
+const BACKGROUND_HTTP_SYNC_RECENT_EDIT_WINDOW_MS = 10 * 60 * 1000;
+const BACKGROUND_HTTP_SYNC_TYPES = new Set<Types>([
+  Types.Document,
+  Types.Database,
+  Types.WorkspaceDatabase,
+  Types.Folder,
+  Types.DatabaseRow,
+]);
+const EMPTY_YJS_UPDATE_MAX_BYTES = 2;
+
+interface BackgroundDirtyEdit {
+  seq: number;
+  editedAt: number;
+}
 
 /**
  * Collect all unique row IDs from every view in a database Y.Doc.
@@ -59,8 +76,255 @@ function collectAllRowIds(databaseDoc: Y.Doc): string[] {
   return Array.from(rowIdSet);
 }
 
-export function useBatchSync(refs: SyncRefs) {
+export function useBatchSync(
+  refs: SyncRefs,
+  options?: {
+    workspaceId?: string;
+    wsReadyState?: number;
+  }
+) {
   const batchSyncAbortRef = useRef<AbortController | null>(null);
+  const backgroundHttpSyncAbortRef = useRef<AbortController | null>(null);
+  const backgroundHttpSyncTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const backgroundHttpSyncInFlightRef = useRef(false);
+  const backgroundDirtyEditsRef = useRef<Map<string, BackgroundDirtyEdit>>(new Map());
+  const backgroundDirtySeqRef = useRef(0);
+  const wsReadyStateRef = useRef<number | undefined>(options?.wsReadyState);
+  const workspaceIdRef = useRef<string | undefined>(options?.workspaceId);
+  const runBackgroundHttpSyncRef = useRef<() => Promise<void>>(async () => undefined);
+
+  const clearBackgroundHttpSyncTimer = useCallback(() => {
+    if (backgroundHttpSyncTimerRef.current) {
+      clearTimeout(backgroundHttpSyncTimerRef.current);
+      backgroundHttpSyncTimerRef.current = null;
+    }
+  }, []);
+
+  const scheduleBackgroundHttpSyncTimer = useCallback(() => {
+    const workspaceId = workspaceIdRef.current;
+    const readyState = wsReadyStateRef.current;
+
+    if (!workspaceId || readyState === undefined || readyState === WS_READY_STATE_OPEN) return;
+
+    clearBackgroundHttpSyncTimer();
+    backgroundHttpSyncTimerRef.current = setTimeout(() => {
+      backgroundHttpSyncTimerRef.current = null;
+      void runBackgroundHttpSyncRef.current();
+    }, BACKGROUND_HTTP_SYNC_DELAY_MS);
+  }, [clearBackgroundHttpSyncTimer]);
+
+  useEffect(() => {
+    const previousWorkspaceId = workspaceIdRef.current;
+
+    workspaceIdRef.current = options?.workspaceId;
+
+    if (previousWorkspaceId && previousWorkspaceId !== options?.workspaceId) {
+      backgroundDirtyEditsRef.current.clear();
+      clearBackgroundHttpSyncTimer();
+      backgroundHttpSyncAbortRef.current?.abort();
+    }
+  }, [options?.workspaceId, clearBackgroundHttpSyncTimer]);
+
+  useEffect(() => {
+    wsReadyStateRef.current = options?.wsReadyState;
+
+    if (options?.wsReadyState === WS_READY_STATE_OPEN) {
+      clearBackgroundHttpSyncTimer();
+      backgroundHttpSyncAbortRef.current?.abort();
+      return;
+    }
+
+    if (backgroundDirtyEditsRef.current.size > 0) {
+      scheduleBackgroundHttpSyncTimer();
+    }
+  }, [options?.wsReadyState, clearBackgroundHttpSyncTimer, scheduleBackgroundHttpSyncTimer]);
+
+  const buildBackgroundHttpSyncItems = useCallback((objectIds: Iterable<string>) => {
+    const ids = new Set(objectIds);
+    const items: Array<{
+      objectId: string;
+      collabType: Types;
+      stateVector: Uint8Array;
+      docState: Uint8Array;
+    }> = [];
+
+    refs.registeredContexts.current.forEach((context) => {
+      const { doc, collabType } = context;
+
+      if (!doc || collabType === undefined || !ids.has(doc.guid)) return;
+      if (!BACKGROUND_HTTP_SYNC_TYPES.has(collabType)) return;
+
+      items.push({
+        objectId: doc.guid,
+        collabType,
+        stateVector: Y.encodeStateVector(doc),
+        docState: Y.encodeStateAsUpdate(doc),
+      });
+    });
+
+    return items;
+  }, [refs]);
+
+  const clearBackgroundDirtyEdits = useCallback((objectIds: Iterable<string>) => {
+    for (const objectId of objectIds) {
+      backgroundDirtyEditsRef.current.delete(objectId);
+    }
+  }, []);
+
+  const notifyManifestSync = useCallback((objectId: string) => {
+    if (wsReadyStateRef.current !== WS_READY_STATE_OPEN) return;
+
+    clearBackgroundDirtyEdits([objectId]);
+  }, [clearBackgroundDirtyEdits]);
+
+  const applyFullSyncResults = useCallback((results: Awaited<ReturnType<typeof collabFullSyncBatch>>) => {
+    for (const result of results) {
+      if (result.error) {
+        Log.warn('[sync] HTTP full-sync result error', {
+          objectId: result.objectId,
+          collabType: result.collabType,
+          error: result.error,
+        });
+        continue;
+      }
+
+      const missingUpdate = result.missingUpdate;
+
+      if (!missingUpdate || missingUpdate.byteLength <= EMPTY_YJS_UPDATE_MAX_BYTES) {
+        continue;
+      }
+
+      const context = refs.registeredContexts.current.get(result.objectId);
+
+      if (!context?.doc) {
+        Log.debug('[sync] HTTP full-sync missing update skipped: context not registered', {
+          objectId: result.objectId,
+        });
+        continue;
+      }
+
+      try {
+        applyYDoc(context.doc, missingUpdate);
+
+        if (context.doc.store.pendingStructs || context.doc.store.pendingDs) {
+          Log.debug('[sync] HTTP full-sync missing update has pending dependencies; sending sync request', {
+            objectId: result.objectId,
+            collabType: context.collabType,
+          });
+          context.emit({
+            collabMessage: {
+              objectId: context.doc.guid,
+              collabType: context.collabType,
+              syncRequest: {
+                stateVector: Y.encodeStateVector(context.doc),
+                lastMessageId: context.lastMessageId || { timestamp: 0, counter: 0 },
+                version: context.doc.version,
+              },
+            },
+          });
+        }
+      } catch (error) {
+        Log.warn('[sync] failed to apply HTTP full-sync missing update', {
+          objectId: result.objectId,
+          error,
+        });
+      }
+    }
+  }, [refs]);
+
+  const runBackgroundHttpSync = useCallback(async () => {
+    if (backgroundHttpSyncInFlightRef.current) return;
+
+    const workspaceId = workspaceIdRef.current;
+    const readyState = wsReadyStateRef.current;
+
+    if (!workspaceId || readyState === undefined || readyState === WS_READY_STATE_OPEN) return;
+
+    const now = Date.now();
+    const dirtySnapshot = Array.from(backgroundDirtyEditsRef.current.entries()).filter(([objectId, dirty]) => {
+      if (now - dirty.editedAt <= BACKGROUND_HTTP_SYNC_RECENT_EDIT_WINDOW_MS) return true;
+
+      if (backgroundDirtyEditsRef.current.get(objectId)?.seq === dirty.seq) {
+        backgroundDirtyEditsRef.current.delete(objectId);
+      }
+
+      return false;
+    });
+
+    if (dirtySnapshot.length === 0) return;
+
+    const items = buildBackgroundHttpSyncItems(dirtySnapshot.map(([objectId]) => objectId));
+    const itemIds = new Set(items.map((item) => item.objectId));
+
+    for (const [objectId, dirty] of dirtySnapshot) {
+      if (!itemIds.has(objectId) && backgroundDirtyEditsRef.current.get(objectId)?.seq === dirty.seq) {
+        backgroundDirtyEditsRef.current.delete(objectId);
+      }
+    }
+
+    if (items.length === 0) return;
+
+    backgroundHttpSyncInFlightRef.current = true;
+    backgroundHttpSyncAbortRef.current?.abort();
+    const controller = new AbortController();
+
+    backgroundHttpSyncAbortRef.current = controller;
+
+    try {
+      Log.debug('[sync] background HTTP full-sync started', {
+        workspaceId,
+        items: items.length,
+      });
+      const results = await withRetry(() => collabFullSyncBatch(workspaceId, items), {
+        delays: BATCH_SYNC_DELAYS,
+        signal: controller.signal,
+      });
+      applyFullSyncResults(results);
+
+      for (const [objectId, dirty] of dirtySnapshot) {
+        if (itemIds.has(objectId) && backgroundDirtyEditsRef.current.get(objectId)?.seq === dirty.seq) {
+          backgroundDirtyEditsRef.current.delete(objectId);
+        }
+      }
+
+      Log.debug('[sync] background HTTP full-sync completed', {
+        workspaceId,
+        items: items.length,
+      });
+    } catch (error) {
+      if (!controller.signal.aborted) {
+        Log.warn('[sync] background HTTP full-sync failed', { workspaceId, error });
+      }
+    } finally {
+      if (backgroundHttpSyncAbortRef.current === controller) {
+        backgroundHttpSyncAbortRef.current = null;
+      }
+
+      backgroundHttpSyncInFlightRef.current = false;
+
+      if (backgroundDirtyEditsRef.current.size > 0) {
+        scheduleBackgroundHttpSyncTimer();
+      }
+    }
+  }, [applyFullSyncResults, buildBackgroundHttpSyncItems, scheduleBackgroundHttpSyncTimer]);
+
+  useEffect(() => {
+    runBackgroundHttpSyncRef.current = runBackgroundHttpSync;
+  }, [runBackgroundHttpSync]);
+
+  const notifyLocalEdit = useCallback((objectId: string) => {
+    const readyState = wsReadyStateRef.current;
+
+    backgroundDirtySeqRef.current += 1;
+    backgroundDirtyEditsRef.current.set(objectId, {
+      seq: backgroundDirtySeqRef.current,
+      editedAt: Date.now(),
+    });
+
+    if (readyState === undefined || readyState === WS_READY_STATE_OPEN) return;
+
+    scheduleBackgroundHttpSyncTimer();
+  }, [scheduleBackgroundHttpSyncTimer]);
 
   /**
    * Wait until the persistent sync_outbox has drained for every registered
@@ -335,32 +599,49 @@ export function useBatchSync(refs: SyncRefs) {
       const controller = new AbortController();
 
       batchSyncAbortRef.current = controller;
+      const dirtySeqBeforeSync = new Map(
+        items.map((item) => [item.objectId, backgroundDirtyEditsRef.current.get(item.objectId)?.seq])
+      );
 
       try {
-        await withRetry(() => collabFullSyncBatch(workspaceId, items), {
+        const results = await withRetry(() => collabFullSyncBatch(workspaceId, items), {
           delays: BATCH_SYNC_DELAYS,
           signal: controller.signal,
         });
+
+        applyFullSyncResults(results);
+        for (const item of items) {
+          const seq = dirtySeqBeforeSync.get(item.objectId);
+
+          if (seq !== undefined && backgroundDirtyEditsRef.current.get(item.objectId)?.seq === seq) {
+            backgroundDirtyEditsRef.current.delete(item.objectId);
+          }
+        }
+
         Log.debug('Batch sync completed successfully');
       } catch (error) {
         Log.warn('Failed to batch sync collabs to server', { error });
         // Don't throw - we still want to attempt the duplicate
       }
     },
-    [refs, flushAllSync]
+    [refs, flushAllSync, applyFullSyncResults]
   );
 
   // Cancel all pending deferred cleanup timers and in-flight batch sync on unmount
   useEffect(() => {
     const timers = refs.pendingCleanups.current;
     const abortRef = batchSyncAbortRef;
+    const backgroundAbortRef = backgroundHttpSyncAbortRef;
 
     return () => {
       timers.forEach((timer) => clearTimeout(timer));
       timers.clear();
       abortRef.current?.abort();
+      backgroundAbortRef.current?.abort();
+      clearBackgroundHttpSyncTimer();
+      backgroundDirtyEditsRef.current.clear();
     };
-  }, [refs]);
+  }, [refs, clearBackgroundHttpSyncTimer]);
 
-  return { flushAllSync, syncAllToServer };
+  return { flushAllSync, syncAllToServer, notifyLocalEdit, notifyManifestSync };
 }

--- a/src/components/ws/sync/useBatchSync.ts
+++ b/src/components/ws/sync/useBatchSync.ts
@@ -279,6 +279,7 @@ export function useBatchSync(
         delays: BATCH_SYNC_DELAYS,
         signal: controller.signal,
       });
+
       applyFullSyncResults(results);
 
       for (const [objectId, dirty] of dirtySnapshot) {
@@ -632,6 +633,7 @@ export function useBatchSync(
     const timers = refs.pendingCleanups.current;
     const abortRef = batchSyncAbortRef;
     const backgroundAbortRef = backgroundHttpSyncAbortRef;
+    const dirtyEdits = backgroundDirtyEditsRef.current;
 
     return () => {
       timers.forEach((timer) => clearTimeout(timer));
@@ -639,7 +641,7 @@ export function useBatchSync(
       abortRef.current?.abort();
       backgroundAbortRef.current?.abort();
       clearBackgroundHttpSyncTimer();
-      backgroundDirtyEditsRef.current.clear();
+      dirtyEdits.clear();
     };
   }, [refs, clearBackgroundHttpSyncTimer]);
 

--- a/src/components/ws/sync/useSyncContextLifecycle.ts
+++ b/src/components/ws/sync/useSyncContextLifecycle.ts
@@ -39,7 +39,9 @@ import { RegisterSyncContext } from './types';
 export function useSyncContextLifecycle(
   refs: SyncRefs,
   sendMessage: (message: messages.IMessage) => void,
-  postMessage: (message: messages.IMessage) => void
+  postMessage: (message: messages.IMessage) => void,
+  onLocalUpdate?: (objectId: string) => void,
+  onManifestSync?: (objectId: string) => void
 ) {
   const cancelDeferredCleanup = useCallback((objectId: string) => {
     const timer = refs.pendingCleanups.current.get(objectId);
@@ -157,6 +159,8 @@ export function useSyncContextLifecycle(
       if (existingContext !== undefined) {
         // If same doc instance, reuse the existing context
         if (existingContext.doc === context.doc) {
+          existingContext.onLocalUpdate = onLocalUpdate;
+          existingContext.onManifestSync = onManifestSync;
           const refCount = incrementContextRefCount(context.doc.guid);
 
           Log.debug(`Reusing existing sync context for objectId ${context.doc.guid}; owner count=${refCount}`);
@@ -177,6 +181,8 @@ export function useSyncContextLifecycle(
       // SyncContext extends RegisterSyncContext by attaching the emit function and destroy handler
       const syncContext = context as SyncContext;
 
+      syncContext.onLocalUpdate = onLocalUpdate;
+      syncContext.onManifestSync = onManifestSync;
       refs.registeredContexts.current.set(syncContext.doc.guid, syncContext);
       const handleDocDestroy = () => {
         const objectId = syncContext.doc.guid;
@@ -221,7 +227,7 @@ export function useSyncContextLifecycle(
 
       return syncContext;
     },
-    [refs, sendMessage, postMessage, cancelDeferredCleanup, unregisterSyncContext, incrementContextRefCount]
+    [refs, sendMessage, postMessage, onLocalUpdate, onManifestSync, cancelDeferredCleanup, unregisterSyncContext, incrementContextRefCount]
   );
 
   return {

--- a/src/components/ws/useSync.ts
+++ b/src/components/ws/useSync.ts
@@ -151,7 +151,7 @@ export const useSync = (
   eventEmitter: EventEmitter,
   workspaceId: string
 ): SyncContextType => {
-  const { sendMessage, lastMessage } = ws;
+  const { sendMessage, lastMessage, readyState } = ws;
   const { postMessage, lastBroadcastMessage } = bc;
   const currentUser = useCurrentUserOptional();
 
@@ -192,12 +192,22 @@ export const useSync = (
   // WebSocket notifications and cross-tab BroadcastChannel relays.
   useWorkspaceNotifications(wsNotification, bcNotification, eventEmitter);
 
+  // ── Batch sync utilities ─────────────────────────────────────────────
+  // flushAllSync: drain buffered local updates to WebSocket for every registered doc.
+  // syncAllToServer: full HTTP batch sync (used before operations like "Duplicate").
+  // notifyLocalEdit: debounced HTTP full-sync fallback while WebSocket is reconnecting.
+  // notifyManifestSync: clears HTTP fallback markers after a WS manifest/state-vector exchange.
+  const { flushAllSync, syncAllToServer, notifyLocalEdit, notifyManifestSync } = useBatchSync(refs, {
+    workspaceId,
+    wsReadyState: readyState,
+  });
+
   // ── Sync context lifecycle ───────────────────────────────────────────
   // Provides registerSyncContext / unregisterSyncContext / scheduleDeferredCleanup.
   // Manages ref-counting so multiple components sharing the same Y.Doc don't
   // tear it down prematurely.
   const { registerSyncContext, unregisterSyncContext, scheduleDeferredCleanup } =
-    useSyncContextLifecycle(refs, sendMessage, postMessage);
+    useSyncContextLifecycle(refs, sendMessage, postMessage, notifyLocalEdit, notifyManifestSync);
 
   // ── Incoming collab messages ─────────────────────────────────────────
   // Watches wsCollabMessage / bcCollabMessage and routes them through a per-objectId
@@ -211,11 +221,6 @@ export const useSync = (
     registerSyncContext,
     scheduleDeferredCleanup
   );
-
-  // ── Batch sync utilities ─────────────────────────────────────────────
-  // flushAllSync: drain buffered local updates to WebSocket for every registered doc.
-  // syncAllToServer: full HTTP batch sync (used before operations like "Duplicate").
-  const { flushAllSync, syncAllToServer } = useBatchSync(refs);
 
   // ── User-initiated version revert ────────────────────────────────────
   // Tears down the current doc, calls the server revert API, rebuilds a fresh doc


### PR DESCRIPTION
## Summary
- send local Yjs outbox updates immediately when the WebSocket transport is ready while keeping the durable outbox fallback
- add HTTP full-sync fallback for dirty registered docs while WebSocket is reconnecting/disconnected, including missing-update application
- preserve newer dirty edits across in-flight HTTP full sync and cover multi-client manifest/reconnect convergence

## Tests
- pnpm jest src/components/ws/__tests__/useSync.test.ts --runInBand --no-coverage
- pnpm jest src/application/services/js-services/__tests__/sync.test.ts --runInBand --no-coverage
- pnpm jest src/application/sync-outbox/__tests__/sync-outbox.test.ts --runInBand --no-coverage
- pnpm type-check

## Summary by Sourcery

Improve realtime collaboration resilience by adding HTTP full-sync fallbacks during websocket reconnects and sending local updates immediately when the transport is ready, while ensuring multi-client Yjs state convergence.

New Features:
- Add background HTTP full-sync of dirty collaboration documents while the websocket is reconnecting or disconnected, including recent-edit tracking and type filtering.
- Introduce application-level handling of HTTP full-sync responses to apply missing Yjs updates and trigger websocket sync requests when dependencies remain.

Bug Fixes:
- Ensure local Yjs updates are sent immediately over websocket when available while retaining the durable outbox as a fallback, preventing stalls after reconnects.
- Fix loss of newer edits by preserving and re-syncing dirty documents across in-flight HTTP full-sync operations and subsequent reconnect windows.
- Guarantee multi-client document state convergence across mixed online/offline scenarios by exercising manifest-based sync flows.

Enhancements:
- Extend batch sync hooks and lifecycle to track local edits and manifest sync events, enabling smarter coordination between websocket and HTTP fallback paths.
- Refine outbox draining to respect current transport readiness, reuse a shared update-message builder, and avoid redundant sends when the connection is unavailable.

Tests:
- Add websocket sync hook tests covering HTTP fallback sync of dirty docs, recent open-window edits, missing-update application, and dirty-edit preservation across reconnects.
- Add sync protocol tests simulating multi-client online/offline edit scenarios to verify eventual Yjs text convergence.
- Add sync-outbox tests to validate immediate send behavior, durable row cleanup, fallback when immediate send fails, and coordinated draining of queued updates.