### PR TITLE
Fix stale trash state after remote restore

### DIFF
--- a/playwright/bdd/features/database/row-document.feature
+++ b/playwright/bdd/features/database/row-document.feature
@@ -6,3 +6,5 @@ Feature: Database row document
     When I add image link "https://example.com/row-page-image.png" to the card row page
     And I close the card row page
     Then the card primary cell shows a row document icon
+    When I switch the database to a new Grid view
+    Then the grid primary cell shows a row document icon

--- a/playwright/bdd/features/database/row-document.feature
+++ b/playwright/bdd/features/database/row-document.feature
@@ -1,0 +1,8 @@
+Feature: Database row document
+  Row document content should be reflected in the database primary cell.
+
+  Scenario: Image link content shows the row document indicator
+    Given a board database with a card is open
+    When I add image link "https://example.com/row-page-image.png" to the card row page
+    And I close the card row page
+    Then the card primary cell shows a row document icon

--- a/playwright/bdd/steps/database-row-document.steps.ts
+++ b/playwright/bdd/steps/database-row-document.steps.ts
@@ -66,6 +66,7 @@ async function addNewCard(page: Page, cardName: string) {
     .filter({ hasText: 'To Do' });
 
   await todoColumn.getByText('New').click({ force: true });
+  await page.waitForTimeout(500);
   await page.keyboard.type(cardName, { delay: 30 });
   await page.keyboard.press('Enter');
   await page.waitForTimeout(2000);

--- a/playwright/bdd/steps/database-row-document.steps.ts
+++ b/playwright/bdd/steps/database-row-document.steps.ts
@@ -2,17 +2,19 @@ import { expect, Page } from '@playwright/test';
 import { createBdd } from 'playwright-bdd';
 import { v4 as uuidv4 } from 'uuid';
 
-import { signInAndCreateDatabaseView } from '../../support/database-ui-helpers';
+import { signInAndCreateDatabaseView, waitForGridReady } from '../../support/database-ui-helpers';
 import { closeRowDetailWithEscape } from '../../support/row-detail-helpers';
-import { BoardSelectors, RowDetailSelectors } from '../../support/selectors';
+import { BoardSelectors, DatabaseGridSelectors, DatabaseViewSelectors, RowDetailSelectors } from '../../support/selectors';
 import { generateRandomEmail } from '../../support/test-config';
 
 const { Given, When, Then } = createBdd();
 
-let currentCardName = '';
+const cardNamesByPage = new WeakMap<Page, string>();
 
 Given('a board database with a card is open', async ({ page, request }) => {
-  currentCardName = `ImageLink-${uuidv4().slice(0, 6)}`;
+  const currentCardName = `ImageLink-${uuidv4().slice(0, 6)}`;
+
+  cardNamesByPage.set(page, currentCardName);
 
   await signInAndCreateDatabaseView(page, request, generateRandomEmail(), 'Board', {
     createWaitMs: 7000,
@@ -27,6 +29,8 @@ Given('a board database with a card is open', async ({ page, request }) => {
 });
 
 When('I add image link {string} to the card row page', async ({ page }, imageUrl: string) => {
+  const currentCardName = getCurrentCardName(page);
+
   await cardByName(page, currentCardName).click({ force: true });
   await expect(RowDetailSelectors.modal(page)).toBeVisible({ timeout: 15000 });
 
@@ -56,8 +60,28 @@ When('I close the card row page', async ({ page }) => {
   await page.waitForTimeout(2000);
 });
 
+When('I switch the database to a new Grid view', async ({ page }) => {
+  await DatabaseViewSelectors.addViewButton(page).click({ force: true });
+  await DatabaseViewSelectors.viewTypeOption(page, 'Grid').click({ force: true });
+  await expect(DatabaseViewSelectors.viewTab(page).filter({ hasText: 'Grid' })).toBeVisible({ timeout: 15000 });
+  await expect(DatabaseViewSelectors.viewTab(page).filter({ hasText: 'Grid' })).toHaveAttribute('data-state', 'active', {
+    timeout: 15000,
+  });
+  await waitForGridReady(page);
+});
+
 Then('the card primary cell shows a row document icon', async ({ page }) => {
+  const currentCardName = getCurrentCardName(page);
+
   await expect(cardByName(page, currentCardName).locator('.custom-icon')).toBeVisible({ timeout: 15000 });
+});
+
+Then('the grid primary cell shows a row document icon', async ({ page }) => {
+  const currentCardName = getCurrentCardName(page);
+  const row = DatabaseGridSelectors.dataRows(page).filter({ hasText: currentCardName }).first();
+
+  await expect(row).toBeVisible({ timeout: 15000 });
+  await expect(row.locator('.custom-icon')).toBeVisible({ timeout: 15000 });
 });
 
 async function addNewCard(page: Page, cardName: string) {
@@ -89,4 +113,14 @@ async function focusRowDocumentEditor(page: Page) {
 
 function cardByName(page: Page, cardName: string) {
   return BoardSelectors.boardContainer(page).locator('.board-card').filter({ hasText: cardName }).first();
+}
+
+function getCurrentCardName(page: Page) {
+  const cardName = cardNamesByPage.get(page);
+
+  if (!cardName) {
+    throw new Error('No current card name is available for this scenario');
+  }
+
+  return cardName;
 }

--- a/playwright/bdd/steps/database-row-document.steps.ts
+++ b/playwright/bdd/steps/database-row-document.steps.ts
@@ -1,0 +1,91 @@
+import { expect, Page } from '@playwright/test';
+import { createBdd } from 'playwright-bdd';
+import { v4 as uuidv4 } from 'uuid';
+
+import { signInAndCreateDatabaseView } from '../../support/database-ui-helpers';
+import { closeRowDetailWithEscape } from '../../support/row-detail-helpers';
+import { BoardSelectors, RowDetailSelectors } from '../../support/selectors';
+import { generateRandomEmail } from '../../support/test-config';
+
+const { Given, When, Then } = createBdd();
+
+let currentCardName = '';
+
+Given('a board database with a card is open', async ({ page, request }) => {
+  currentCardName = `ImageLink-${uuidv4().slice(0, 6)}`;
+
+  await signInAndCreateDatabaseView(page, request, generateRandomEmail(), 'Board', {
+    createWaitMs: 7000,
+    verify: async (p) => {
+      await expect(BoardSelectors.boardContainer(p)).toBeVisible({ timeout: 15000 });
+      await expect(BoardSelectors.cards(p).first()).toBeVisible({ timeout: 15000 });
+    },
+  });
+
+  await addNewCard(page, currentCardName);
+  await expect(cardByName(page, currentCardName)).toBeVisible({ timeout: 15000 });
+});
+
+When('I add image link {string} to the card row page', async ({ page }, imageUrl: string) => {
+  await cardByName(page, currentCardName).click({ force: true });
+  await expect(RowDetailSelectors.modal(page)).toBeVisible({ timeout: 15000 });
+
+  await focusRowDocumentEditor(page);
+  await page.keyboard.type('/image', { delay: 30 });
+
+  const imageCommand = page.getByTestId('slash-menu-image');
+
+  await expect(imageCommand).toBeVisible({ timeout: 10000 });
+  await imageCommand.click({ force: true });
+
+  const popover = page.locator('.MuiPopover-root:visible').last();
+
+  await expect(popover).toBeVisible({ timeout: 10000 });
+  await popover.getByText('Embed link', { exact: true }).click({ force: true });
+
+  const input = popover.getByPlaceholder('Paste or type an image link');
+
+  await expect(input).toBeVisible({ timeout: 10000 });
+  await input.fill(imageUrl);
+  await input.press('Enter');
+  await expect(popover).toBeHidden({ timeout: 10000 });
+});
+
+When('I close the card row page', async ({ page }) => {
+  await closeRowDetailWithEscape(page);
+  await page.waitForTimeout(2000);
+});
+
+Then('the card primary cell shows a row document icon', async ({ page }) => {
+  await expect(cardByName(page, currentCardName).locator('.custom-icon')).toBeVisible({ timeout: 15000 });
+});
+
+async function addNewCard(page: Page, cardName: string) {
+  const todoColumn = BoardSelectors.boardContainer(page)
+    .locator('[data-column-id]')
+    .filter({ hasText: 'To Do' });
+
+  await todoColumn.getByText('New').click({ force: true });
+  await page.keyboard.type(cardName, { delay: 30 });
+  await page.keyboard.press('Enter');
+  await page.waitForTimeout(2000);
+}
+
+async function focusRowDocumentEditor(page: Page) {
+  const dialog = page.locator('[role="dialog"]');
+  const scrollContainer = dialog.locator('.appflowy-scroll-container');
+
+  if ((await scrollContainer.count()) > 0) {
+    await scrollContainer.evaluate((el) => el.scrollTo(0, 9999));
+    await page.waitForTimeout(500);
+  }
+
+  const editor = dialog.locator('[data-testid="editor-content"], [role="textbox"][contenteditable="true"]').first();
+
+  await expect(editor).toBeVisible({ timeout: 15000 });
+  await editor.click({ force: true });
+}
+
+function cardByName(page: Page, cardName: string) {
+  return BoardSelectors.boardContainer(page).locator('.board-card').filter({ hasText: cardName }).first();
+}

--- a/src/application/slate-yjs/utils/editor.ts
+++ b/src/application/slate-yjs/utils/editor.ts
@@ -46,7 +46,15 @@ import {
   turnToBlock,
   updateBlockParent,
 } from '@/application/slate-yjs/utils/yjs';
-import { BlockData, BlockType, ToggleListBlockData, YBlock, YjsEditorKey, YSharedRoot } from '@/application/types';
+import {
+  BlockData,
+  BlockType,
+  CollabOrigin,
+  ToggleListBlockData,
+  YBlock,
+  YjsEditorKey,
+  YSharedRoot,
+} from '@/application/types';
 
 import { YjsEditor } from '../plugins/withYjs';
 
@@ -1174,7 +1182,7 @@ export function addBlock(
     extendNextSiblingsToToggleHeading(sharedRoot, newBlock);
   });
 
-  executeOperations(sharedRoot, operations, 'addBlock');
+  executeOperations(sharedRoot, operations, 'addBlock', CollabOrigin.LocalManual);
 
   return newBlockId;
 }

--- a/src/components/app/hooks/__tests__/useWorkspaceData.trashRefresh.test.tsx
+++ b/src/components/app/hooks/__tests__/useWorkspaceData.trashRefresh.test.tsx
@@ -48,6 +48,17 @@ jest.mock('@/application/services/domains', () => ({
 const workspaceId = 'workspace-id';
 const restoredViewId = 'restored-view-id';
 
+function createDeferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+
+  return { promise, resolve, reject };
+}
+
 const createView = (viewId: string, overrides: Partial<View> = {}): View => ({
   view_id: viewId,
   name: overrides.name ?? viewId,
@@ -144,6 +155,68 @@ describe('useWorkspaceData trash refresh', () => {
 
     await waitFor(() => {
       expect(ViewService.getTrash).toHaveBeenCalledTimes(initialTrashRequestCount + 1);
+      expect(result.current.trashList).toEqual([]);
+    });
+  });
+
+  it('ignores stale trash refresh responses from overlapping folder notifications', async () => {
+    const eventEmitter = new EventEmitter();
+    const restoredView = createView(restoredViewId);
+    const trashRequests: Array<ReturnType<typeof createDeferred<View[]>>> = [];
+
+    (ViewService.getTrash as jest.Mock).mockImplementation(() => {
+      const deferred = createDeferred<View[]>();
+
+      trashRequests.push(deferred);
+      return deferred.promise;
+    });
+
+    const { result } = renderHook(() => useWorkspaceData(), {
+      wrapper: createWrapper(eventEmitter),
+    });
+
+    await waitFor(() => {
+      expect(trashRequests).toHaveLength(1);
+    });
+
+    await act(async () => {
+      trashRequests[0].resolve([restoredView]);
+    });
+
+    await waitFor(() => {
+      expect(result.current.trashList?.map((view) => view.view_id)).toEqual([restoredViewId]);
+    });
+
+    await act(async () => {
+      eventEmitter.emit(APP_EVENTS.FOLDER_VIEW_CHANGED, {
+        changeType: 1,
+        folderRid: '2-1',
+        parentViewId: 'space-id',
+        viewJson: JSON.stringify(restoredView),
+      });
+      eventEmitter.emit(APP_EVENTS.FOLDER_OUTLINE_CHANGED, {
+        folderRid: '3-1',
+        outlineDiffJson: JSON.stringify([{ op: 'replace', path: '/outline', value: [] }]),
+      });
+    });
+
+    await waitFor(() => {
+      expect(trashRequests).toHaveLength(3);
+    });
+
+    await act(async () => {
+      trashRequests[2].resolve([]);
+    });
+
+    await waitFor(() => {
+      expect(result.current.trashList).toEqual([]);
+    });
+
+    await act(async () => {
+      trashRequests[1].resolve([restoredView]);
+    });
+
+    await waitFor(() => {
       expect(result.current.trashList).toEqual([]);
     });
   });

--- a/src/components/app/hooks/__tests__/useWorkspaceData.trashRefresh.test.tsx
+++ b/src/components/app/hooks/__tests__/useWorkspaceData.trashRefresh.test.tsx
@@ -1,0 +1,150 @@
+import EventEmitter from 'events';
+
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { type ReactNode } from 'react';
+import { MemoryRouter } from 'react-router-dom';
+
+import { APP_EVENTS } from '@/application/constants';
+import { AccessService, ViewService } from '@/application/services/domains';
+import { Role, View, ViewLayout } from '@/application/types';
+import { AuthInternalContext, AuthInternalContextType } from '@/components/app/contexts/AuthInternalContext';
+import { SyncInternalContext, SyncInternalContextType } from '@/components/app/contexts/SyncInternalContext';
+
+import { useWorkspaceData } from '../useWorkspaceData';
+
+jest.mock('lodash-es', () => ({
+  sortBy: (items: Record<string, unknown>[], key: string) =>
+    [...items].sort((a, b) => String(a[key] ?? '').localeCompare(String(b[key] ?? ''))),
+  uniqBy: (items: Record<string, unknown>[], key: string) => {
+    const seen = new Set<unknown>();
+
+    return items.filter((item) => {
+      const value = item[key];
+
+      if (seen.has(value)) return false;
+      seen.add(value);
+      return true;
+    });
+  },
+}));
+
+jest.mock('@/application/services/domains', () => ({
+  AccessService: {
+    getShareWithMe: jest.fn(),
+  },
+  ViewService: {
+    get: jest.fn(),
+    getDatabaseRelations: jest.fn(),
+    getMultiple: jest.fn(),
+    getOutline: jest.fn(),
+    getTrash: jest.fn(),
+    invalidateCache: jest.fn(),
+  },
+  WorkspaceService: {
+    getMentionableUsers: jest.fn(),
+  },
+}));
+
+const workspaceId = 'workspace-id';
+const restoredViewId = 'restored-view-id';
+
+const createView = (viewId: string, overrides: Partial<View> = {}): View => ({
+  view_id: viewId,
+  name: overrides.name ?? viewId,
+  icon: overrides.icon ?? null,
+  layout: overrides.layout ?? ViewLayout.Document,
+  extra: overrides.extra ?? null,
+  children: overrides.children ?? [],
+  has_children: overrides.has_children,
+  is_published: overrides.is_published ?? false,
+  is_private: overrides.is_private ?? false,
+  ...overrides,
+});
+
+function createWrapper(eventEmitter: EventEmitter) {
+  const authContext: AuthInternalContextType = {
+    currentWorkspaceId: workspaceId,
+    isAuthenticated: true,
+    onChangeWorkspace: jest.fn(),
+    userWorkspaceInfo: {
+      userId: 'user-id',
+      selectedWorkspace: {
+        id: workspaceId,
+        databaseStorageId: 'database-storage-id',
+        role: Role.Owner,
+      },
+    } as AuthInternalContextType['userWorkspaceInfo'],
+  };
+
+  const syncContext = {
+    eventEmitter,
+    awarenessMap: {},
+    broadcastChannel: {},
+    flushAllSync: jest.fn(),
+    registerSyncContext: jest.fn(),
+    revertCollabVersion: jest.fn(),
+    scheduleDeferredCleanup: jest.fn(),
+    syncAllToServer: jest.fn(),
+    webSocket: {},
+  } as unknown as SyncInternalContextType;
+
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <MemoryRouter future={{ v7_relativeSplatPath: true, v7_startTransition: true }}>
+        <AuthInternalContext.Provider value={authContext}>
+          <SyncInternalContext.Provider value={syncContext}>
+            {children}
+          </SyncInternalContext.Provider>
+        </AuthInternalContext.Provider>
+      </MemoryRouter>
+    );
+  };
+}
+
+describe('useWorkspaceData trash refresh', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    (AccessService.getShareWithMe as jest.Mock).mockResolvedValue(null);
+    (ViewService.getDatabaseRelations as jest.Mock).mockResolvedValue({});
+    (ViewService.getMultiple as jest.Mock).mockResolvedValue([]);
+    (ViewService.getOutline as jest.Mock).mockResolvedValue({
+      outline: [],
+      folderRid: '1-1',
+    });
+  });
+
+  it('refreshes stale trash state when a remote restore adds the view back to the folder', async () => {
+    const eventEmitter = new EventEmitter();
+    const restoredView = createView(restoredViewId);
+    let trashResponse: View[] = [restoredView];
+
+    (ViewService.getTrash as jest.Mock).mockImplementation(async () => trashResponse);
+
+    const { result } = renderHook(() => useWorkspaceData(), {
+      wrapper: createWrapper(eventEmitter),
+    });
+
+    await waitFor(() => {
+      expect(result.current.trashList?.map((view) => view.view_id)).toEqual([restoredViewId]);
+    });
+
+    const initialTrashRequestCount = (ViewService.getTrash as jest.Mock).mock.calls.length;
+
+    trashResponse = [];
+
+    await act(async () => {
+      eventEmitter.emit(APP_EVENTS.FOLDER_VIEW_CHANGED, {
+        changeType: 1,
+        folderRid: '2-1',
+        parentViewId: 'space-id',
+        viewJson: JSON.stringify(restoredView),
+      });
+    });
+
+    await waitFor(() => {
+      expect(ViewService.getTrash).toHaveBeenCalledTimes(initialTrashRequestCount + 1);
+      expect(result.current.trashList).toEqual([]);
+    });
+  });
+});

--- a/src/components/app/hooks/useWorkspaceData.ts
+++ b/src/components/app/hooks/useWorkspaceData.ts
@@ -169,6 +169,7 @@ export function useWorkspaceData() {
   const [workspaceDatabases, setWorkspaceDatabases] = useState<DatabaseRelations | undefined>(undefined);
   const workspaceDatabasesRef = useRef<DatabaseRelations | undefined>(undefined);
   const [requestAccessError, setRequestAccessError] = useState<RequestAccessError | null>(null);
+  const trashRequestSeqRef = useRef(0);
 
   const mentionableUsersRef = useRef<MentionablePerson[]>([]);
 
@@ -567,11 +568,17 @@ export function useWorkspaceData() {
   // Load trash list
   const loadTrash = useCallback(
     async (currentWorkspaceId: string) => {
+      const requestSeq = ++trashRequestSeqRef.current;
+
       try {
         const res = await ViewService.getTrash(currentWorkspaceId);
 
         if (!res) {
           throw new Error('App trash not found');
+        }
+
+        if (requestSeq !== trashRequestSeqRef.current) {
+          return;
         }
 
         setTrashList(sortBy(uniqBy(res, 'view_id') as unknown as View[], 'last_edited_time').reverse());

--- a/src/components/app/hooks/useWorkspaceData.ts
+++ b/src/components/app/hooks/useWorkspaceData.ts
@@ -564,6 +564,34 @@ export function useWorkspaceData() {
     setLoadedViewIdsRevision((r) => r + 1);
   }, [stableOutlineRef, currentWorkspaceId]);
 
+  // Load trash list
+  const loadTrash = useCallback(
+    async (currentWorkspaceId: string) => {
+      try {
+        const res = await ViewService.getTrash(currentWorkspaceId);
+
+        if (!res) {
+          throw new Error('App trash not found');
+        }
+
+        setTrashList(sortBy(uniqBy(res, 'view_id') as unknown as View[], 'last_edited_time').reverse());
+      } catch (e) {
+        return Promise.reject('App trash not found');
+      }
+    },
+    []
+  );
+
+  // Remote delete/restore arrives as folder changes. Keep the app-level trash
+  // state fresh because deleted-page routing is derived from `trashList`.
+  const refreshTrashListInBackground = useCallback(() => {
+    if (!currentWorkspaceId) return;
+
+    void loadTrash(currentWorkspaceId).catch((error) => {
+      Log.warn('[Trash] Failed to refresh trash list after folder change', error);
+    });
+  }, [currentWorkspaceId, loadTrash]);
+
   useEffect(() => {
     const handleShareViewsChanged = () => {
       if (!currentWorkspaceId) return;
@@ -589,6 +617,7 @@ export function useWorkspaceData() {
       // If no diff JSON provided, fall back to full outline reload
       if (!payload?.outlineDiffJson) {
         Log.debug('[Outline] [FolderOutlineChanged] No diff JSON, reloading outline');
+        refreshTrashListInBackground();
         void loadOutline(currentWorkspaceId, false);
         return;
       }
@@ -600,11 +629,13 @@ export function useWorkspaceData() {
         patch = JSON.parse(payload.outlineDiffJson) as JsonPatchOperation[];
       } catch (error) {
         Log.warn('[Outline] [FolderOutlineChanged] Failed to parse outline diff, reloading outline', error);
+        refreshTrashListInBackground();
         void loadOutline(currentWorkspaceId, false);
         return;
       }
 
       if (!patch || !Array.isArray(patch)) {
+        refreshTrashListInBackground();
         void loadOutline(currentWorkspaceId, false);
         return;
       }
@@ -624,6 +655,8 @@ export function useWorkspaceData() {
         updateLastFolderRid(patchRid);
         return;
       }
+
+      refreshTrashListInBackground();
 
       Log.debug('[Outline] [FolderOutlineChanged] parsed patch', patch);
 
@@ -710,7 +743,15 @@ export function useWorkspaceData() {
         eventEmitter.off(APP_EVENTS.FOLDER_OUTLINE_CHANGED, handleFolderOutlineChanged);
       }
     };
-  }, [currentWorkspaceId, eventEmitter, loadOutline, replaceOutlinePreservingChildren, stableOutlineRef, updateLastFolderRid]);
+  }, [
+    currentWorkspaceId,
+    eventEmitter,
+    loadOutline,
+    refreshTrashListInBackground,
+    replaceOutlinePreservingChildren,
+    stableOutlineRef,
+    updateLastFolderRid,
+  ]);
 
   // Handle granular FolderViewChanged notifications
   useEffect(() => {
@@ -730,6 +771,7 @@ export function useWorkspaceData() {
 
       const changeType = payload.changeType ?? 0;
       let nextOutline = stableOutlineRef.current;
+      let shouldRefreshTrash = false;
 
       switch (changeType) {
         case FOLDER_VIEW_CHANGE_TYPE.VIEW_FIELDS_CHANGED: {
@@ -748,6 +790,8 @@ export function useWorkspaceData() {
         }
 
         case FOLDER_VIEW_CHANGE_TYPE.VIEW_ADDED: {
+          shouldRefreshTrash = true;
+
           if (!payload.viewJson || !payload.parentViewId) break;
           try {
             const newView = JSON.parse(payload.viewJson) as View;
@@ -764,6 +808,8 @@ export function useWorkspaceData() {
         }
 
         case FOLDER_VIEW_CHANGE_TYPE.VIEW_REMOVED: {
+          shouldRefreshTrash = true;
+
           const parentId = payload.viewId;
           const childIds = payload.childViewIds ?? [];
 
@@ -803,9 +849,14 @@ export function useWorkspaceData() {
         default: {
           // Unknown change type — fall back to full reload
           Log.debug('[Outline] [FolderViewChanged] Unknown change_type, reloading outline', changeType);
+          refreshTrashListInBackground();
           void loadOutline(currentWorkspaceId, false);
           return;
         }
+      }
+
+      if (shouldRefreshTrash) {
+        refreshTrashListInBackground();
       }
 
       if (nextOutline !== stableOutlineRef.current) {
@@ -830,7 +881,14 @@ export function useWorkspaceData() {
         eventEmitter.off(APP_EVENTS.FOLDER_VIEW_CHANGED, handleFolderViewChanged);
       }
     };
-  }, [currentWorkspaceId, eventEmitter, loadOutline, stableOutlineRef, updateLastFolderRid]);
+  }, [
+    currentWorkspaceId,
+    eventEmitter,
+    loadOutline,
+    refreshTrashListInBackground,
+    stableOutlineRef,
+    updateLastFolderRid,
+  ]);
 
   // Load favorite views
   const loadFavoriteViews = useCallback(async () => {
@@ -870,24 +928,6 @@ export function useWorkspaceData() {
       console.error('Recent views not found');
     }
   }, [currentWorkspaceId]);
-
-  // Load trash list
-  const loadTrash = useCallback(
-    async (currentWorkspaceId: string) => {
-      try {
-        const res = await ViewService.getTrash(currentWorkspaceId);
-
-        if (!res) {
-          throw new Error('App trash not found');
-        }
-
-        setTrashList(sortBy(uniqBy(res, 'view_id') as unknown as View[], 'last_edited_time').reverse());
-      } catch (e) {
-        return Promise.reject('App trash not found');
-      }
-    },
-    []
-  );
 
   // Get cached database relations (synchronous, returns immediately)
   const getCachedDatabaseRelations = useCallback(() => {

--- a/src/components/database/components/database-row/DatabaseRowSubDocument.tsx
+++ b/src/components/database/components/database-row/DatabaseRowSubDocument.tsx
@@ -15,7 +15,7 @@ import { useUpdateRowMetaDispatch } from '@/application/database-yjs/dispatch';
 import { openCollabDB } from '@/application/db';
 import { getCachedRowSubDoc, getOrCreateRowSubDoc, trackRowDocEnsure } from '@/application/services/js-services/cache';
 import { YjsEditor } from '@/application/slate-yjs';
-import { initializeDocumentStructure } from '@/application/slate-yjs/utils/yjs';
+import { dataStringTOJson, initializeDocumentStructure } from '@/application/slate-yjs/utils/yjs';
 import {
   BlockType,
   CollabOrigin,
@@ -33,6 +33,65 @@ import { useCurrentWorkspaceIdOptional } from '@/components/app/app.hooks';
 import { Editor } from '@/components/editor';
 import { useCurrentUserOptional } from '@/components/main/app.hooks';
 import { Log } from '@/utils/log';
+
+type ContentNode = {
+  type?: BlockType | string;
+  text?: string;
+  children?: unknown[];
+  data?: Record<string, unknown>;
+};
+
+function hasNonEmptyString(value: unknown) {
+  return typeof value === 'string' && value.length > 0;
+}
+
+function hasImageContent(data: Record<string, unknown> | undefined) {
+  if (!data) return false;
+
+  return (
+    hasNonEmptyString(data.url) ||
+    hasNonEmptyString(data.retry_local_url) ||
+    hasNonEmptyString(data.pending_upload_id)
+  );
+}
+
+function hasEditorNodeContent(node: unknown): boolean {
+  if (typeof node !== 'object' || node === null) return false;
+
+  const contentNode = node as ContentNode;
+
+  if ('text' in contentNode) {
+    return hasNonEmptyString(contentNode.text);
+  }
+
+  if (contentNode.type === BlockType.ImageBlock) {
+    return hasImageContent(contentNode.data);
+  }
+
+  if (contentNode.type === YjsEditorKey.text) {
+    return contentNode.children?.some(hasEditorNodeContent) ?? false;
+  }
+
+  if (contentNode.type && contentNode.type !== BlockType.Page && contentNode.type !== BlockType.Paragraph) {
+    return true;
+  }
+
+  return contentNode.children?.some(hasEditorNodeContent) ?? false;
+}
+
+function hasYjsBlockContent(block: Y.Map<unknown>) {
+  const type = block.get(YjsEditorKey.block_type);
+
+  if (!type || type === BlockType.Page || type === BlockType.Paragraph) {
+    return false;
+  }
+
+  if (type === BlockType.ImageBlock) {
+    return hasImageContent(dataStringTOJson(block.get(YjsEditorKey.block_data) as string) as Record<string, unknown>);
+  }
+
+  return true;
+}
 
 /**
  * DatabaseRowSubDocument - Full-featured component for row documents in app mode.
@@ -140,53 +199,7 @@ export const DatabaseRowSubDocument = memo(({ rowId }: { rowId: string }) => {
         return false;
       }
 
-      const children = editor.children;
-
-      if (children.length === 0) {
-        return true;
-      }
-
-      if (children.length === 1) {
-        const firstChild = children[0];
-        const firstChildBlockType = 'type' in firstChild ? (firstChild.type as BlockType) : BlockType.Paragraph;
-
-        if (firstChildBlockType !== BlockType.Paragraph) {
-          return false;
-        }
-
-        // Check if the paragraph has any text content
-        // AppFlowy Slate structure: paragraph -> text node (type: 'text') -> leaf nodes ({text: '...'})
-        if ('children' in firstChild && Array.isArray(firstChild.children)) {
-          const hasContent = firstChild.children.some((child: unknown) => {
-            // Check for direct leaf node with text property (standard Slate)
-            if (typeof child === 'object' && child !== null && 'text' in child) {
-              return (child as { text: string }).text.length > 0;
-            }
-
-            // Check for AppFlowy text node structure: {type: 'text', children: [{text: '...'}]}
-            if (
-              typeof child === 'object' &&
-              child !== null &&
-              'type' in child &&
-              (child as { type: string }).type === 'text' &&
-              'children' in child &&
-              Array.isArray((child as { children: unknown[] }).children)
-            ) {
-              const textNode = child as { children: Array<{ text?: string }> };
-
-              return textNode.children.some((leaf) => leaf.text && leaf.text.length > 0);
-            }
-
-            return true; // Non-text nodes (embeds, etc.) count as content
-          });
-
-          return !hasContent;
-        }
-
-        return true;
-      }
-
-      return false;
+      return !editor.children.some(hasEditorNodeContent);
     },
     [meta?.isEmptyDocument]
   );
@@ -218,9 +231,7 @@ export const DatabaseRowSubDocument = memo(({ rowId }: { rowId: string }) => {
 
         if (blocks) {
           for (const block of blocks.values()) {
-            const type = block.get(YjsEditorKey.block_type);
-
-            if (type && type !== BlockType.Page && type !== BlockType.Paragraph) {
+            if (hasYjsBlockContent(block)) {
               return true;
             }
           }

--- a/src/components/editor/components/blocks/database/components/DatabaseContent.tsx
+++ b/src/components/editor/components/blocks/database/components/DatabaseContent.tsx
@@ -6,7 +6,7 @@ import { getPublishedDatabaseRenderRowMap } from '@/application/publish-snapshot
 import { LoadView, LoadViewMeta, UIVariant, YDoc } from '@/application/types';
 import { Database } from '@/components/database';
 
-const EMBEDDED_DATABASE_FIXED_HEIGHT = 300;
+const EMBEDDED_DATABASE_FIXED_HEIGHT = 600;
 
 interface DatabaseContentProps {
   /**

--- a/src/components/editor/plugins/withInsertData.ts
+++ b/src/components/editor/plugins/withInsertData.ts
@@ -11,7 +11,15 @@ import {
   isInsideSimpleTableCell,
 } from '@/application/slate-yjs/utils/editor';
 import { assertDocExists, getBlock, getChildrenArray } from '@/application/slate-yjs/utils/yjs';
-import { BlockType, FieldURLType, FileBlockData, ImageBlockData, ImageType, YjsEditorKey } from '@/application/types';
+import {
+  BlockType,
+  CollabOrigin,
+  FieldURLType,
+  FileBlockData,
+  ImageBlockData,
+  ImageType,
+  YjsEditorKey,
+} from '@/application/types';
 import { convertSlateFragmentTo } from '@/components/editor/utils/fragment';
 import { FileHandler } from '@/utils/file';
 import { Log } from '@/utils/log';
@@ -369,7 +377,7 @@ function insertFragmentAsSiblings(editor: YjsEditor, fragment: Node[]): boolean 
       } else {
         insertedIds = slateContentInsertToYData(parentId, index + 1, fragment, doc);
       }
-    });
+    }, CollabOrigin.LocalManual);
 
     // Place the cursor at the end of the last inserted block so subsequent
     // edits target a valid location (not the now-deleted original block).


### PR DESCRIPTION
## Summary
- Refresh app trash state when remote folder structural notifications arrive
- Covers restore and delete folder-view changes, plus outline patch fallback paths
- Add regression coverage for clearing stale trash state after a remote restore

## Verification
- pnpm jest src/components/app/hooks/__tests__/useWorkspaceData.preserveLoadedChildren.test.ts src/components/app/hooks/__tests__/useWorkspaceData.trashRefresh.test.tsx --no-coverage
- pnpm eslint --quiet --ext .ts,.tsx src/components/app/hooks/useWorkspaceData.ts src/components/app/hooks/__tests__/useWorkspaceData.trashRefresh.test.tsx --ignore-path .eslintignore.web
- pnpm run type-check
- git diff --check

## Summary by Sourcery

Refresh workspace trash state in response to remote folder structural changes and add regression coverage for remote restores.

Bug Fixes:
- Ensure app-level trash list is refreshed when remote delete/restore operations modify the folder outline, preventing stale trash state after restores.

Tests:
- Add hook tests verifying that trash state is reloaded when folder view change events indicate a restored view is re-added to the outline.