### PR TITLE
Support Notion zip import into selected view

### DIFF
--- a/src/@types/translations/en.json
+++ b/src/@types/translations/en.json
@@ -254,6 +254,7 @@
     "csv": "CSV",
     "database": "Database",
     "success": "Imported successfully",
+    "notionImportStarted": "Notion import started. Pages will appear in this view when ready.",
     "failed": "Import failed"
   },
   "teamSpace": "Team space",

--- a/src/application/services/js-services/http/import-api.ts
+++ b/src/application/services/js-services/http/import-api.ts
@@ -27,24 +27,62 @@ interface CreateImportTaskRaw {
   multipart?: ImportMultipartUploadInfo | null;
 }
 
-export async function createImportTask(file: File) {
+export interface ImportUploadTask {
+  taskId: string;
+  presignedUrl: string;
+  multipart: ImportMultipartUploadInfo | null;
+}
+
+export interface CreateNotionImportTaskPayload {
+  content_length: number;
+  md5_base64: string;
+}
+
+function toImportUploadTask(data: CreateImportTaskRaw): ImportUploadTask {
+  return {
+    taskId: data.task_id,
+    presignedUrl: data.presigned_url,
+    multipart: data.multipart ?? null,
+  };
+}
+
+export async function createImportTask(file: File): Promise<ImportUploadTask> {
   const url = `/api/import/create`;
   const fileName = file.name.split('.').slice(0, -1).join('.') || crypto.randomUUID();
 
   return executeAPIRequest<CreateImportTaskRaw>(() =>
-    getAxios()?.post<APIResponse<CreateImportTaskRaw>>(url, {
-      workspace_name: fileName,
-      content_length: file.size,
-    }, {
+    getAxios()?.post<APIResponse<CreateImportTaskRaw>>(
+      url,
+      {
+        workspace_name: fileName,
+        content_length: file.size,
+      },
+      {
+        headers: {
+          'X-Host': getConfigValue('APPFLOWY_BASE_URL', ''),
+        },
+      }
+    )
+  ).then(toImportUploadTask);
+}
+
+export async function createNotionImportTask(
+  workspaceId: string,
+  parentViewId: string,
+  payload: CreateNotionImportTaskPayload
+): Promise<ImportUploadTask> {
+  const url = `/api/import/${encodeURIComponent(workspaceId)}/notion`;
+
+  return executeAPIRequest<CreateImportTaskRaw>(() =>
+    getAxios()?.post<APIResponse<CreateImportTaskRaw>>(url, payload, {
+      params: {
+        page_id: parentViewId,
+      },
       headers: {
         'X-Host': getConfigValue('APPFLOWY_BASE_URL', ''),
       },
     })
-  ).then((data) => ({
-    taskId: data.task_id,
-    presignedUrl: data.presigned_url,
-    multipart: data.multipart ?? null,
-  }));
+  ).then(toImportUploadTask);
 }
 
 export async function uploadImportFile(presignedUrl: string, file: File, onProgress: (progress: number) => void) {
@@ -77,7 +115,7 @@ export async function uploadImportFile(presignedUrl: string, file: File, onProgr
 export async function uploadImportFileMultipart(
   file: File,
   multipart: ImportMultipartUploadInfo,
-  onProgress: (progress: number) => void,
+  onProgress: (progress: number) => void
 ) {
   const MAX_CONCURRENCY = 5;
   const partCount = multipart.part_presigned_urls.length;
@@ -166,9 +204,7 @@ async function completeImportMultipart(data: {
 }) {
   const url = `/api/import/complete-multipart`;
 
-  return executeAPIVoidRequest(() =>
-    getAxios()?.post<APIResponse>(url, data)
-  );
+  return executeAPIVoidRequest(() => getAxios()?.post<APIResponse>(url, data));
 }
 
 export async function createDatabaseCsvImportTask(

--- a/src/components/app/import/ImportDialog.tsx
+++ b/src/components/app/import/ImportDialog.tsx
@@ -6,24 +6,22 @@ import { toast } from 'sonner';
 import { ViewLayout } from '@/application/types';
 import { ReactComponent as CloseIcon } from '@/assets/icons/close.svg';
 import { ReactComponent as DatabaseIcon } from '@/assets/icons/database.svg';
+import { ReactComponent as NotionIcon } from '@/assets/icons/notion.svg';
 import { ReactComponent as TextIcon } from '@/assets/icons/text.svg';
-import {
-  useAppOperations,
-  useCurrentWorkspaceId,
-  useOpenPageModal,
-  useToView,
-} from '@/components/app/app.hooks';
+import { useAppOperations, useCurrentWorkspaceId, useOpenPageModal, useToView } from '@/components/app/app.hooks';
 import {
   ImportAbortError,
   importCsvAsDatabase,
+  importNotionZipToView,
   populateDocumentWithMarkdown,
   stripFileExtension,
 } from '@/components/app/import/import-service';
 
 const MARKDOWN_ACCEPT = '.md,.markdown,.txt,text/markdown,text/plain';
 const CSV_ACCEPT = '.csv,text/csv';
+const NOTION_ACCEPT = '.zip,application/zip,application/x-zip,application/x-zip-compressed';
 
-type ImportFormat = 'markdown' | 'csv';
+type ImportFormat = 'markdown' | 'csv' | 'notion';
 
 interface ImportDialogProps {
   open: boolean;
@@ -41,6 +39,7 @@ export default function ImportDialog({ open, parentViewId, prevViewId, onOpenCha
   const [active, setActive] = useState<ImportFormat | null>(null);
   const markdownInputRef = useRef<HTMLInputElement>(null);
   const csvInputRef = useRef<HTMLInputElement>(null);
+  const notionInputRef = useRef<HTMLInputElement>(null);
   const abortRef = useRef<AbortController | null>(null);
 
   // Abort any in-flight import on unmount so polling doesn't keep running
@@ -84,7 +83,7 @@ export default function ImportDialog({ open, parentViewId, prevViewId, onOpenCha
         setActive(null);
       }
     },
-    [workspaceId, addPage, parentViewId, prevViewId, openPageModal, close, t],
+    [workspaceId, addPage, parentViewId, prevViewId, openPageModal, close, t]
   );
 
   const handleCsv = useCallback(
@@ -115,7 +114,37 @@ export default function ImportDialog({ open, parentViewId, prevViewId, onOpenCha
         setActive(null);
       }
     },
-    [workspaceId, parentViewId, toView, close, t],
+    [workspaceId, parentViewId, toView, close, t]
+  );
+
+  const handleNotion = useCallback(
+    async (file: File) => {
+      if (!workspaceId) return;
+      const controller = new AbortController();
+
+      abortRef.current?.abort();
+      abortRef.current = controller;
+      setActive('notion');
+      try {
+        await importNotionZipToView({
+          workspaceId,
+          parentViewId,
+          file,
+          signal: controller.signal,
+        });
+
+        toast.success(t('importPanel.notionImportStarted'));
+        close();
+        // eslint-disable-next-line
+      } catch (e: any) {
+        if (e instanceof ImportAbortError) return;
+        toast.error(e?.message ?? t('importPanel.failed'));
+      } finally {
+        if (abortRef.current === controller) abortRef.current = null;
+        setActive(null);
+      }
+    },
+    [workspaceId, parentViewId, close, t]
   );
 
   const onMarkdownPicked = useCallback(
@@ -125,7 +154,7 @@ export default function ImportDialog({ open, parentViewId, prevViewId, onOpenCha
       event.target.value = '';
       if (file) void handleMarkdown(file);
     },
-    [handleMarkdown],
+    [handleMarkdown]
   );
 
   const onCsvPicked = useCallback(
@@ -135,7 +164,17 @@ export default function ImportDialog({ open, parentViewId, prevViewId, onOpenCha
       event.target.value = '';
       if (file) void handleCsv(file);
     },
-    [handleCsv],
+    [handleCsv]
+  );
+
+  const onNotionPicked = useCallback(
+    (event: React.ChangeEvent<HTMLInputElement>) => {
+      const file = event.target.files?.[0];
+
+      event.target.value = '';
+      if (file) void handleNotion(file);
+    },
+    [handleNotion]
   );
 
   return (
@@ -186,6 +225,18 @@ export default function ImportDialog({ open, parentViewId, prevViewId, onOpenCha
             <span className='text-sm'>{t('importPanel.csv')}</span>
             {active === 'csv' && <CircularProgress size={14} className='ml-auto' />}
           </button>
+
+          <button
+            type='button'
+            disabled={!!active}
+            onClick={() => notionInputRef.current?.click()}
+            className='flex items-center gap-3 rounded-300 bg-fill-content px-4 py-3 text-left text-text-primary hover:bg-fill-content-hover disabled:opacity-60'
+            data-testid='import-notion'
+          >
+            <NotionIcon className='h-5 w-5 text-icon-primary' />
+            <span className='text-sm'>{t('importPanel.notionZip')}</span>
+            {active === 'notion' && <CircularProgress size={14} className='ml-auto' />}
+          </button>
         </div>
 
         <input
@@ -203,6 +254,14 @@ export default function ImportDialog({ open, parentViewId, prevViewId, onOpenCha
           className='hidden'
           data-testid='import-csv-input'
           onChange={onCsvPicked}
+        />
+        <input
+          ref={notionInputRef}
+          type='file'
+          accept={NOTION_ACCEPT}
+          className='hidden'
+          data-testid='import-notion-input'
+          onChange={onNotionPicked}
         />
       </div>
     </Dialog>

--- a/src/components/app/import/import-service.ts
+++ b/src/components/app/import/import-service.ts
@@ -3,24 +3,17 @@ import * as Y from 'yjs';
 import { getCollab, updateCollab } from '@/application/services/js-services/http/collab-api';
 import {
   cancelDatabaseCsvImportTask,
+  cancelImportTask,
   createDatabaseCsvImportTask,
+  createNotionImportTask,
   getDatabaseCsvImportStatus,
+  uploadImportFile,
+  uploadImportFileMultipart,
   uploadDatabaseCsvImportFile,
 } from '@/application/services/js-services/http/import-api';
 import { slateContentInsertToYData } from '@/application/slate-yjs/utils/convert';
-import {
-  deleteBlock,
-  getBlock,
-  getChildrenArray,
-  getPageId,
-} from '@/application/slate-yjs/utils/yjs';
-import {
-  DatabaseCsvImportLayout,
-  DatabaseCsvImportMode,
-  Types,
-  YjsEditorKey,
-  YSharedRoot,
-} from '@/application/types';
+import { deleteBlock, getBlock, getChildrenArray, getPageId } from '@/application/slate-yjs/utils/yjs';
+import { DatabaseCsvImportLayout, DatabaseCsvImportMode, Types, YjsEditorKey, YSharedRoot } from '@/application/types';
 import { parsedBlockToSlateElement } from '@/components/app/import/markdown-to-blocks';
 import { parseMarkdown } from '@/components/editor/parsers/markdown-parser';
 import { calculateMd5 } from '@/utils/md5';
@@ -41,17 +34,10 @@ export function stripFileExtension(name: string): string {
  * locally with `slateContentInsertToYData`, and PUT the encoded update back via `updateCollab`.
  * The page must already exist (created via PageService.add by the caller).
  */
-export async function populateDocumentWithMarkdown(
-  workspaceId: string,
-  viewId: string,
-  file: File,
-): Promise<void> {
+export async function populateDocumentWithMarkdown(workspaceId: string, viewId: string, file: File): Promise<void> {
   // Fetch the file text and the (empty) page collab in parallel — they're independent
   // and the markdown parse is much cheaper than either round trip.
-  const [text, collab] = await Promise.all([
-    file.text(),
-    getCollab(workspaceId, viewId, Types.Document),
-  ]);
+  const [text, collab] = await Promise.all([file.text(), getCollab(workspaceId, viewId, Types.Document)]);
   const blocks = parseMarkdown(text);
 
   if (blocks.length === 0) return;
@@ -95,9 +81,21 @@ export interface ImportCsvResult {
   viewId: string;
 }
 
+export interface ImportNotionInput {
+  workspaceId: string;
+  parentViewId: string;
+  file: File;
+  onProgress?: (fraction: number) => void;
+  signal?: AbortSignal;
+}
+
+export interface ImportNotionResult {
+  taskId: string;
+}
+
 export class ImportAbortError extends Error {
   constructor() {
-    super('CSV import aborted');
+    super('Import aborted');
     this.name = 'ImportAbortError';
   }
 }
@@ -164,6 +162,41 @@ export async function importCsvAsDatabase(input: ImportCsvInput): Promise<Import
     void cancelDatabaseCsvImportTask(workspaceId, task.task_id).catch(noop);
     throw err;
   }
+}
+
+/**
+ * Upload a Notion export zip into an existing workspace under the selected view.
+ * The server processes the imported workspace asynchronously after upload.
+ */
+export async function importNotionZipToView(input: ImportNotionInput): Promise<ImportNotionResult> {
+  const { workspaceId, parentViewId, file, onProgress, signal } = input;
+
+  throwIfAborted(signal);
+  const md5_base64 = await calculateMd5(file);
+
+  throwIfAborted(signal);
+  const task = await createNotionImportTask(workspaceId, parentViewId, {
+    content_length: file.size,
+    md5_base64,
+  });
+
+  try {
+    throwIfAborted(signal);
+    if (task.multipart) {
+      await uploadImportFileMultipart(file, task.multipart, onProgress ?? noopProgress);
+    } else {
+      await uploadImportFile(task.presignedUrl, file, onProgress ?? noopProgress);
+    }
+
+    return { taskId: task.taskId };
+  } catch (err) {
+    void cancelImportTask(task.taskId).catch(noop);
+    throw err;
+  }
+}
+
+function noopProgress(): void {
+  /* swallow */
 }
 
 function noop(): void {


### PR DESCRIPTION
## Summary
- add a Notion import task API for existing workspace/view imports
- upload Notion export zip files from the selected-view import dialog
- add Notion as an option next to Text & Markdown and CSV imports

## Verification
- pnpm run type-check
- pnpm run lint
- git diff --check

## Summary by Sourcery

Add support for importing Notion export zip files into an existing workspace view via the import dialog and backend import API.

New Features:
- Expose a Notion zip import option in the selected-view import dialog alongside existing Markdown and CSV imports.
- Introduce a Notion-specific import task API that uploads export zip files into a chosen workspace view and supports multipart uploads.

Enhancements:
- Generalize the import upload task handling and error messaging to work across CSV and Notion imports.