### PR TITLE
Fix AppFlowy rich clipboard paste

### DIFF
--- a/src/components/editor/clipboard/__tests__/appflowy-fragment.test.ts
+++ b/src/components/editor/clipboard/__tests__/appflowy-fragment.test.ts
@@ -1,0 +1,349 @@
+import { Element } from 'slate';
+
+import { BlockType, YjsEditorKey } from '@/application/types';
+
+import {
+  APPFLOWY_FRAGMENT_MIME,
+  appFlowyDocumentToSlateFragment,
+  clipboardPayloadToSlateFragment,
+  extractAppFlowyClipboardFragment,
+} from '../appflowy-fragment';
+
+function createClipboardData(data: Record<string, string>): Pick<DataTransfer, 'getData'> {
+  return {
+    getData: jest.fn((type: string) => data[type] ?? ''),
+  };
+}
+
+function encodeWebFragment(payload: unknown): string {
+  return Buffer.from(encodeURIComponent(JSON.stringify(payload))).toString('base64');
+}
+
+function encodeDesktopCarrier(payload: unknown): string {
+  return Buffer.from(JSON.stringify(payload), 'utf8').toString('base64');
+}
+
+function textChildren(node: Element) {
+  return ((node.children[0] as Element).children ?? []) as Array<Record<string, unknown>>;
+}
+
+describe('AppFlowy clipboard fragment paste support', () => {
+  const desktopDocument = {
+    document: {
+      type: BlockType.Page,
+      children: [
+        {
+          type: BlockType.HeadingBlock,
+          data: {
+            level: 2,
+            delta: [{ insert: 'Roadmap', attributes: { bold: true } }],
+          },
+          children: [],
+        },
+        {
+          type: BlockType.Paragraph,
+          data: {
+            align: 'center',
+            delta: [
+              { insert: 'Visit ' },
+              { insert: 'AppFlowy', attributes: { href: 'https://appflowy.io', italic: true } },
+            ],
+          },
+          children: [],
+        },
+        {
+          type: BlockType.BulletedListBlock,
+          data: {
+            delta: [{ insert: 'Parent' }],
+          },
+          children: [
+            {
+              type: BlockType.BulletedListBlock,
+              data: {
+                delta: [{ insert: 'Child', attributes: { underline: true } }],
+              },
+              children: [],
+            },
+          ],
+        },
+      ],
+    },
+  };
+
+  it('converts desktop document JSON into Slate blocks without losing rich text data', () => {
+    const fragment = appFlowyDocumentToSlateFragment(desktopDocument);
+
+    expect(fragment).toHaveLength(3);
+
+    const heading = fragment?.[0] as Element;
+    const paragraph = fragment?.[1] as Element;
+    const list = fragment?.[2] as Element;
+
+    expect(heading).toMatchObject({
+      type: BlockType.HeadingBlock,
+      data: { level: 2 },
+      children: [
+        {
+          type: YjsEditorKey.text,
+          children: [{ text: 'Roadmap', bold: true }],
+        },
+      ],
+    });
+    expect(heading.data).not.toHaveProperty(YjsEditorKey.delta);
+
+    expect(paragraph.data).toEqual({ align: 'center' });
+    expect(textChildren(paragraph)).toEqual([
+      { text: 'Visit ' },
+      { text: 'AppFlowy', href: 'https://appflowy.io', italic: true },
+    ]);
+
+    expect(list.children[1]).toMatchObject({
+      type: BlockType.BulletedListBlock,
+      children: [
+        {
+          type: YjsEditorKey.text,
+          children: [{ text: 'Child', underline: true }],
+        },
+      ],
+    });
+  });
+
+  it('preserves simple table structure from desktop JSON', () => {
+    const tableDocument = {
+      document: {
+        type: BlockType.Page,
+        children: [
+          {
+            type: BlockType.SimpleTableBlock,
+            data: {},
+            children: [
+              {
+                type: BlockType.SimpleTableRowBlock,
+                data: {},
+                children: [
+                  {
+                    type: BlockType.SimpleTableCellBlock,
+                    data: {},
+                    children: [
+                      {
+                        type: BlockType.Paragraph,
+                        data: { delta: [{ insert: 'A1' }] },
+                        children: [],
+                      },
+                    ],
+                  },
+                  {
+                    type: BlockType.SimpleTableCellBlock,
+                    data: {},
+                    children: [
+                      {
+                        type: BlockType.Paragraph,
+                        data: { delta: [{ insert: 'B1' }] },
+                        children: [],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    };
+
+    const fragment = appFlowyDocumentToSlateFragment(tableDocument);
+    const table = fragment?.[0] as Element;
+    const row = table.children[1] as Element;
+    const firstCell = row.children[1] as Element;
+    const firstParagraph = firstCell.children[1] as Element;
+
+    expect(table.type).toBe(BlockType.SimpleTableBlock);
+    expect((table.children[0] as Element).type).toBe(YjsEditorKey.text);
+    expect(row.type).toBe(BlockType.SimpleTableRowBlock);
+    expect(firstCell.type).toBe(BlockType.SimpleTableCellBlock);
+    expect(textChildren(firstParagraph)).toEqual([{ text: 'A1' }]);
+  });
+
+  it('reads web AppFlowy MIME fragments before fallback formats', () => {
+    const appFlowyFragment = [
+      {
+        type: BlockType.Paragraph,
+        data: {},
+        children: [{ type: YjsEditorKey.text, children: [{ text: 'Native fragment' }] }],
+      },
+    ];
+    const jsonFallback = JSON.stringify({
+      document: {
+        type: BlockType.Page,
+        children: [
+          {
+            type: BlockType.Paragraph,
+            data: { delta: [{ insert: 'JSON fallback' }] },
+            children: [],
+          },
+        ],
+      },
+    });
+
+    const result = extractAppFlowyClipboardFragment(
+      createClipboardData({
+        [APPFLOWY_FRAGMENT_MIME]: encodeWebFragment(appFlowyFragment),
+        'application/json': jsonFallback,
+      })
+    );
+
+    expect(result?.source).toBe(APPFLOWY_FRAGMENT_MIME);
+    expect(textChildren(result?.fragment[0] as Element)).toEqual([{ text: 'Native fragment' }]);
+  });
+
+  it('reads Flutter desktop private in-app JSON', () => {
+    const result = extractAppFlowyClipboardFragment(
+      createClipboardData({
+        'io.appflowy.InAppJsonType': JSON.stringify(desktopDocument),
+      })
+    );
+
+    expect(result?.source).toBe('io.appflowy.InAppJsonType');
+    expect((result?.fragment[0] as Element).type).toBe(BlockType.HeadingBlock);
+    expect(textChildren(result?.fragment[0] as Element)).toEqual([{ text: 'Roadmap', bold: true }]);
+  });
+
+  it('reads desktop private MIME aliases from non-macOS clipboard bridges', () => {
+    const result = extractAppFlowyClipboardFragment(
+      createClipboardData({
+        'application/x-private;appId=io.appflowy.InAppJsonType': JSON.stringify(desktopDocument),
+      })
+    );
+
+    expect(result?.source).toBe('application/x-private;appId=io.appflowy.InAppJsonType');
+    expect((result?.fragment[2] as Element).type).toBe(BlockType.BulletedListBlock);
+    expect(textChildren(result?.fragment[2] as Element)).toEqual([{ text: 'Parent' }]);
+  });
+
+  it('reads desktop table JSON fragments from the table-specific format', () => {
+    const tableFragment = [
+      {
+        type: BlockType.SimpleTableCellBlock,
+        data: {},
+        children: [
+          {
+            type: BlockType.Paragraph,
+            data: { delta: [{ insert: 'Cell text' }] },
+            children: [],
+          },
+        ],
+      },
+    ];
+
+    const result = extractAppFlowyClipboardFragment(
+      createClipboardData({
+        'io.appflowy.TableJsonType': JSON.stringify(tableFragment),
+      })
+    );
+
+    const cell = result?.fragment[0] as Element;
+    const paragraph = cell.children[1] as Element;
+
+    expect(result?.source).toBe('io.appflowy.TableJsonType');
+    expect(cell.type).toBe(BlockType.SimpleTableCellBlock);
+    expect(textChildren(paragraph)).toEqual([{ text: 'Cell text' }]);
+  });
+
+  it('reads validated AppFlowy document JSON from application/json', () => {
+    const result = extractAppFlowyClipboardFragment(
+      createClipboardData({
+        'application/json': JSON.stringify(desktopDocument),
+      })
+    );
+
+    expect(result?.source).toBe('application/json');
+    expect((result?.fragment[0] as Element).type).toBe(BlockType.HeadingBlock);
+  });
+
+  it('reads the HTML carrier when custom clipboard MIME types are unavailable', () => {
+    const result = extractAppFlowyClipboardFragment(
+      createClipboardData({
+        'text/html': `<meta data-appflowy-fragment="${encodeDesktopCarrier(desktopDocument)}"><p>Roadmap</p>`,
+      })
+    );
+
+    expect(result?.source).toBe('text/html:data-appflowy-fragment');
+    expect((result?.fragment[1] as Element).data).toEqual({ align: 'center' });
+    expect(textChildren(result?.fragment[1] as Element)).toEqual([
+      { text: 'Visit ' },
+      { text: 'AppFlowy', href: 'https://appflowy.io', italic: true },
+    ]);
+  });
+
+  it('preserves non-ASCII text from the desktop HTML carrier', () => {
+    const result = extractAppFlowyClipboardFragment(
+      createClipboardData({
+        'text/html': `<span data-appflowy-fragment="${encodeDesktopCarrier({
+          document: {
+            type: BlockType.Page,
+            children: [
+              {
+                type: BlockType.Paragraph,
+                data: {
+                  delta: [{ insert: '你好 AppFlowy' }],
+                },
+                children: [],
+              },
+            ],
+          },
+        })}"></span>`,
+      })
+    );
+
+    expect(textChildren(result?.fragment[0] as Element)).toEqual([{ text: '你好 AppFlowy' }]);
+  });
+
+  it('ignores unrelated JSON clipboard data so HTML/plain paste can handle it', () => {
+    const result = extractAppFlowyClipboardFragment(
+      createClipboardData({
+        'application/json': JSON.stringify({ type: 'not-appflowy', value: 42 }),
+      })
+    );
+
+    expect(result).toBeNull();
+  });
+
+  it('ignores raw AppFlowy-like blocks in generic application/json', () => {
+    const result = extractAppFlowyClipboardFragment(
+      createClipboardData({
+        'application/json': JSON.stringify({
+          type: BlockType.Paragraph,
+          data: { delta: [{ insert: 'Looks like a block' }] },
+          children: [],
+        }),
+      })
+    );
+
+    expect(result).toBeNull();
+  });
+
+  it('normalizes valid web fragments that have empty block children', () => {
+    const fragment = clipboardPayloadToSlateFragment(
+      encodeWebFragment([
+        {
+          type: BlockType.DividerBlock,
+          data: {},
+          children: [],
+        },
+      ])
+    );
+
+    expect(fragment).toEqual([
+      {
+        type: BlockType.DividerBlock,
+        data: {},
+        children: [
+          {
+            type: YjsEditorKey.text,
+            children: [{ text: '' }],
+          },
+        ],
+      },
+    ]);
+  });
+});

--- a/src/components/editor/clipboard/__tests__/table-fragment.test.ts
+++ b/src/components/editor/clipboard/__tests__/table-fragment.test.ts
@@ -1,0 +1,123 @@
+import { Element } from 'slate';
+
+import { BlockType, YjsEditorKey } from '@/application/types';
+
+import { appFlowyDocumentToSlateFragment } from '../appflowy-fragment';
+import { containsSimpleTableBlocks, extractTSVFromTableFragment } from '../table-fragment';
+
+describe('table clipboard fragment helpers', () => {
+  it('extracts TSV from desktop table fragments without counting text wrappers as rows or cells', () => {
+    const fragment = appFlowyDocumentToSlateFragment({
+      document: {
+        type: BlockType.Page,
+        children: [
+          {
+            type: BlockType.SimpleTableBlock,
+            data: {},
+            children: [
+              {
+                type: BlockType.SimpleTableRowBlock,
+                data: {},
+                children: [
+                  {
+                    type: BlockType.SimpleTableCellBlock,
+                    data: {},
+                    children: [
+                      {
+                        type: BlockType.Paragraph,
+                        data: { delta: [{ insert: 'A1' }] },
+                        children: [],
+                      },
+                    ],
+                  },
+                  {
+                    type: BlockType.SimpleTableCellBlock,
+                    data: {},
+                    children: [
+                      {
+                        type: BlockType.Paragraph,
+                        data: { delta: [{ insert: 'B1' }] },
+                        children: [],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    });
+
+    expect(fragment).not.toBeNull();
+    expect(extractTSVFromTableFragment(fragment ?? [])).toBe('A1\tB1');
+  });
+
+  it('extracts TSV from row and cell fragments', () => {
+    const row = {
+      type: BlockType.SimpleTableRowBlock,
+      data: {},
+      children: [
+        {
+          type: YjsEditorKey.text,
+          children: [{ text: '' }],
+        },
+        createCell('A1'),
+        createCell('B1'),
+      ],
+    } as Element;
+
+    expect(extractTSVFromTableFragment([row])).toBe('A1\tB1');
+    expect(extractTSVFromTableFragment([createCell('A1')])).toBe('A1');
+  });
+
+  it('detects table blocks nested under another element', () => {
+    const fragment = [
+      {
+        type: BlockType.ColumnsBlock,
+        data: {},
+        children: [
+          {
+            type: YjsEditorKey.text,
+            children: [{ text: '' }],
+          },
+          {
+            type: BlockType.SimpleTableCellBlock,
+            data: {},
+            children: [
+              {
+                type: YjsEditorKey.text,
+                children: [{ text: '' }],
+              },
+            ],
+          },
+        ],
+      },
+    ] as Element[];
+
+    expect(containsSimpleTableBlocks(fragment)).toBe(true);
+  });
+});
+
+function createCell(text: string): Element {
+  return {
+    type: BlockType.SimpleTableCellBlock,
+    data: {},
+    children: [
+      {
+        type: YjsEditorKey.text,
+        children: [{ text: '' }],
+      },
+      {
+        type: BlockType.Paragraph,
+        data: {},
+        children: [
+          {
+            type: YjsEditorKey.text,
+            children: [{ text }],
+          },
+        ],
+      },
+    ],
+  } as Element;
+}

--- a/src/components/editor/clipboard/appflowy-fragment.ts
+++ b/src/components/editor/clipboard/appflowy-fragment.ts
@@ -1,0 +1,429 @@
+import { Element, Node as SlateNode, Text } from 'slate';
+
+import { BlockType, YjsEditorKey } from '@/application/types';
+
+export const APPFLOWY_FRAGMENT_MIME = 'application/x-appflowy-fragment';
+export const APPFLOWY_HTML_FRAGMENT_ATTR = 'data-appflowy-fragment';
+
+const DESKTOP_IN_APP_JSON_FORMATS = [
+  'io.appflowy.InAppJsonType',
+  'application/x-private;appId=io.appflowy.InAppJsonType',
+  'application/x-private;appid=io.appflowy.InAppJsonType',
+];
+
+const DESKTOP_TABLE_JSON_FORMATS = [
+  'io.appflowy.TableJsonType',
+  'application/x-private;appId=io.appflowy.TableJsonType',
+  'application/x-private;appid=io.appflowy.TableJsonType',
+];
+
+const KNOWN_BLOCK_TYPES = new Set<string>(Object.values(BlockType));
+
+type JsonRecord = Record<string, unknown>;
+
+interface DesktopDeltaInsert {
+  insert?: unknown;
+  attributes?: unknown;
+}
+
+interface DesktopNode {
+  type: string;
+  data?: JsonRecord;
+  children?: DesktopNode[];
+}
+
+interface RichClipboardCandidate {
+  source: string;
+  value: string;
+}
+
+interface ClipboardFragmentReader {
+  id: string;
+  read(data: Pick<DataTransfer, 'getData'>): RichClipboardCandidate[];
+  parse(raw: string): SlateNode[] | null;
+}
+
+export interface RichClipboardFragment {
+  source: string;
+  fragment: SlateNode[];
+}
+
+const CLIPBOARD_FRAGMENT_READERS: ClipboardFragmentReader[] = [
+  createFormatReader('appflowy-web-fragment', [APPFLOWY_FRAGMENT_MIME]),
+  createFormatReader('appflowy-desktop-in-app-json', DESKTOP_IN_APP_JSON_FORMATS),
+  createFormatReader('appflowy-desktop-table-json', DESKTOP_TABLE_JSON_FORMATS),
+  createFormatReader(
+    'appflowy-application-json',
+    [
+      // Generic JSON is shared by many apps, so accept only the full AppFlowy
+      // document envelope here. Trusted AppFlowy-specific formats above can
+      // still carry raw node arrays.
+      'application/json',
+    ],
+    appFlowyDocumentPayloadToSlateFragment
+  ),
+  {
+    id: 'appflowy-html-fragment',
+    read(data) {
+      const html = getClipboardData(data, 'text/html');
+      const value = extractAppFlowyFragmentFromHTML(html);
+
+      return value
+        ? [
+            {
+              source: `text/html:${APPFLOWY_HTML_FRAGMENT_ATTR}`,
+              value,
+            },
+          ]
+        : [];
+    },
+    parse: clipboardPayloadToSlateFragment,
+  },
+];
+
+export function extractAppFlowyClipboardFragment(data: Pick<DataTransfer, 'getData'>): RichClipboardFragment | null {
+  for (const reader of CLIPBOARD_FRAGMENT_READERS) {
+    for (const candidate of reader.read(data)) {
+      const fragment = reader.parse(candidate.value);
+
+      if (fragment) {
+        return {
+          source: candidate.source,
+          fragment,
+        };
+      }
+    }
+  }
+
+  return null;
+}
+
+export function clipboardPayloadToSlateFragment(raw: string): SlateNode[] | null {
+  const payload = decodeClipboardPayload(raw);
+
+  if (!payload) return null;
+
+  return payloadToSlateFragment(payload);
+}
+
+export function payloadToSlateFragment(payload: unknown): SlateNode[] | null {
+  if (isSlateFragment(payload) && !containsDesktopDelta(payload)) {
+    return normalizeSlateFragment(payload);
+  }
+
+  return appFlowyDocumentToSlateFragment(payload);
+}
+
+export function appFlowyDocumentToSlateFragment(payload: unknown): SlateNode[] | null {
+  const nodes = getDesktopTopLevelNodes(payload);
+
+  if (!nodes) return null;
+
+  const fragment = nodes.map(desktopNodeToSlateElement).filter(Boolean) as Element[];
+
+  return fragment.length > 0 ? fragment : null;
+}
+
+function appFlowyDocumentPayloadToSlateFragment(raw: string): SlateNode[] | null {
+  const payload = decodeClipboardPayload(raw);
+
+  if (!isAppFlowyDocumentEnvelope(payload)) return null;
+
+  return appFlowyDocumentToSlateFragment(payload);
+}
+
+function createFormatReader(
+  id: string,
+  formats: string[],
+  parse: ClipboardFragmentReader['parse'] = clipboardPayloadToSlateFragment
+): ClipboardFragmentReader {
+  return {
+    id,
+    read(data) {
+      return formats.flatMap((source) => {
+        const value = getClipboardData(data, source);
+
+        return value ? [{ source, value }] : [];
+      });
+    },
+    parse,
+  };
+}
+
+function getClipboardData(data: Pick<DataTransfer, 'getData'>, type: string): string {
+  try {
+    return data.getData(type) || '';
+  } catch {
+    return '';
+  }
+}
+
+export function extractAppFlowyFragmentFromHTML(html: string | undefined): string | undefined {
+  if (!html) return undefined;
+
+  const match = html.match(/\sdata-appflowy-fragment=(["'])(.+?)\1/m);
+
+  return match ? decodeHtmlAttribute(match[2]) : undefined;
+}
+
+function decodeHtmlAttribute(value: string): string {
+  return value
+    .replace(/&quot;/g, '"')
+    .replace(/&#34;/g, '"')
+    .replace(/&#x22;/gi, '"')
+    .replace(/&apos;/g, "'")
+    .replace(/&#39;/g, "'")
+    .replace(/&#x27;/gi, "'")
+    .replace(/&amp;/g, '&');
+}
+
+function decodeClipboardPayload(raw: string): unknown | null {
+  const trimmed = raw.trim();
+
+  if (!trimmed) return null;
+
+  const jsonPayload = parseJson(trimmed);
+
+  if (jsonPayload !== null) return jsonPayload;
+
+  for (const decoded of decodeEncodedPayloads(trimmed)) {
+    const payload = parseJson(decoded);
+
+    if (payload !== null) return payload;
+  }
+
+  return null;
+}
+
+function parseJson(value: string): unknown | null {
+  try {
+    return JSON.parse(value);
+  } catch {
+    return null;
+  }
+}
+
+function decodeEncodedPayloads(value: string): string[] {
+  const decoded: string[] = [];
+
+  try {
+    decoded.push(decodeURIComponent(value));
+  } catch {
+    // ignore
+  }
+
+  const base64 = decodeBase64(value);
+
+  if (base64) {
+    const utf8 = decodeBinaryUtf8(base64.binary);
+
+    if (utf8) decoded.push(utf8);
+
+    if (base64.binary.includes('%')) {
+      try {
+        decoded.push(decodeURIComponent(base64.binary));
+      } catch {
+        // Web copy uses URI-encoded JSON before base64.
+      }
+    }
+
+    decoded.push(base64.binary);
+  }
+
+  return Array.from(new Set(decoded));
+}
+
+function decodeBase64(value: string): { binary: string } | null {
+  try {
+    if (typeof globalThis.atob === 'function') {
+      return {
+        binary: globalThis.atob(value),
+      };
+    }
+
+    if (typeof Buffer !== 'undefined') {
+      return {
+        binary: Buffer.from(value, 'base64').toString('binary'),
+      };
+    }
+  } catch {
+    return null;
+  }
+
+  return null;
+}
+
+function decodeBinaryUtf8(binary: string): string | null {
+  try {
+    if (typeof TextDecoder !== 'undefined') {
+      const bytes = Uint8Array.from(binary, (char) => char.charCodeAt(0));
+
+      return new TextDecoder().decode(bytes);
+    }
+
+    if (typeof Buffer !== 'undefined') {
+      return Buffer.from(binary, 'binary').toString('utf8');
+    }
+  } catch {
+    return null;
+  }
+
+  return null;
+}
+
+function isAppFlowyDocumentEnvelope(payload: unknown): boolean {
+  const document = asRecord(payload)?.document;
+
+  return isDesktopNode(document) && document.type === BlockType.Page;
+}
+
+function getDesktopTopLevelNodes(payload: unknown): DesktopNode[] | null {
+  const document = asRecord(payload)?.document;
+
+  if (isDesktopNode(document)) {
+    return document.type === BlockType.Page ? document.children ?? [] : [document];
+  }
+
+  if (Array.isArray(payload) && payload.every(isDesktopNode)) {
+    return payload;
+  }
+
+  if (isDesktopNode(payload)) {
+    return payload.type === BlockType.Page ? payload.children ?? [] : [payload];
+  }
+
+  return null;
+}
+
+function desktopNodeToSlateElement(node: DesktopNode): Element | null {
+  if (!node.type) return null;
+
+  const data = omitDelta(node.data);
+  const textChildren = deltaToSlateTextChildren(node.data?.delta);
+  const nestedChildren = (node.children ?? []).map(desktopNodeToSlateElement).filter(Boolean) as Element[];
+
+  return {
+    type: node.type,
+    data,
+    children: [
+      {
+        type: YjsEditorKey.text,
+        children: textChildren,
+      } as Element,
+      ...nestedChildren,
+    ],
+  };
+}
+
+function deltaToSlateTextChildren(delta: unknown): Text[] {
+  if (!Array.isArray(delta)) {
+    return [
+      {
+        text: '',
+      },
+    ];
+  }
+
+  const textNodes = delta.flatMap((op: DesktopDeltaInsert) => {
+    if (typeof op?.insert !== 'string') return [];
+
+    const attributes = asRecord(op.attributes) ?? {};
+
+    return [
+      {
+        ...attributes,
+        text: op.insert,
+      } as Text,
+    ];
+  });
+
+  return textNodes.length > 0
+    ? textNodes
+    : [
+        {
+          text: '',
+        },
+      ];
+}
+
+function omitDelta(data: unknown): JsonRecord {
+  const record = asRecord(data);
+
+  if (!record) return {};
+
+  const sanitized: JsonRecord = {};
+
+  for (const [key, value] of Object.entries(record)) {
+    if (key === YjsEditorKey.delta) continue;
+    if (value === undefined || value === null) continue;
+    sanitized[key] = value;
+  }
+
+  return sanitized;
+}
+
+function normalizeSlateFragment(fragment: SlateNode[]): SlateNode[] {
+  return fragment.map(normalizeSlateNode).filter(Boolean) as SlateNode[];
+}
+
+function normalizeSlateNode(node: SlateNode): SlateNode | null {
+  if (Text.isText(node)) return node;
+  if (!Element.isElement(node)) return null;
+
+  const children = node.children.map(normalizeSlateNode).filter(Boolean) as SlateNode[];
+
+  if (children.length === 0) {
+    children.push({
+      type: YjsEditorKey.text,
+      children: [
+        {
+          text: '',
+        },
+      ],
+    } as Element);
+  }
+
+  return {
+    ...node,
+    children,
+  };
+}
+
+function isSlateFragment(payload: unknown): payload is SlateNode[] {
+  return Array.isArray(payload) && payload.every(isSlateNodeLike);
+}
+
+function isSlateNodeLike(value: unknown): value is SlateNode {
+  if (Text.isText(value)) return true;
+  if (!Element.isElement(value)) return false;
+
+  return typeof value.type === 'string' && Array.isArray(value.children);
+}
+
+function containsDesktopDelta(payload: unknown): boolean {
+  if (Array.isArray(payload)) return payload.some(containsDesktopDelta);
+
+  const record = asRecord(payload);
+
+  if (!record) return false;
+
+  const data = asRecord(record.data);
+
+  if (Array.isArray(data?.delta)) return true;
+
+  return Array.isArray(record.children) && record.children.some(containsDesktopDelta);
+}
+
+function isDesktopNode(value: unknown): value is DesktopNode {
+  const record = asRecord(value);
+
+  if (!record || typeof record.type !== 'string' || !KNOWN_BLOCK_TYPES.has(record.type)) return false;
+
+  const children = record.children;
+
+  return children === undefined || (Array.isArray(children) && children.every(isDesktopNode));
+}
+
+function asRecord(value: unknown): JsonRecord | null {
+  return typeof value === 'object' && value !== null && !Array.isArray(value) ? (value as JsonRecord) : null;
+}

--- a/src/components/editor/clipboard/table-fragment.ts
+++ b/src/components/editor/clipboard/table-fragment.ts
@@ -1,0 +1,68 @@
+import { Element, Node as SlateNode } from 'slate';
+
+import { BlockType } from '@/application/types';
+
+const TABLE_BLOCK_TYPES = new Set<string>([
+  BlockType.SimpleTableBlock,
+  BlockType.SimpleTableRowBlock,
+  BlockType.SimpleTableCellBlock,
+]);
+
+export function containsSimpleTableBlocks(nodes: SlateNode[]): boolean {
+  return nodes.some(containsSimpleTableBlock);
+}
+
+export function extractTSVFromTableFragment(nodes: SlateNode[]): string | null {
+  const rows: string[][] = [];
+
+  for (const node of nodes) {
+    if (!Element.isElement(node)) continue;
+
+    if (node.type === BlockType.SimpleTableBlock) {
+      rows.push(...extractRowsFromTable(node));
+    } else if (node.type === BlockType.SimpleTableRowBlock) {
+      const row = extractCellsFromRow(node);
+
+      if (row.length > 0) rows.push(row);
+    } else if (node.type === BlockType.SimpleTableCellBlock) {
+      rows.push([SlateNode.string(node)]);
+    } else {
+      rows.push([SlateNode.string(node)]);
+    }
+  }
+
+  return rows.length > 0 ? rows.map((row) => row.join('\t')).join('\n') : null;
+}
+
+function containsSimpleTableBlock(node: SlateNode): boolean {
+  if (!Element.isElement(node)) return false;
+  if (TABLE_BLOCK_TYPES.has(node.type as string)) return true;
+
+  return node.children.some(containsSimpleTableBlock);
+}
+
+function extractRowsFromTable(table: Element): string[][] {
+  const rows: string[][] = [];
+
+  for (const row of table.children) {
+    if (!Element.isElement(row) || row.type !== BlockType.SimpleTableRowBlock) continue;
+
+    const cells = extractCellsFromRow(row);
+
+    if (cells.length > 0) rows.push(cells);
+  }
+
+  return rows;
+}
+
+function extractCellsFromRow(row: Element): string[] {
+  const cells: string[] = [];
+
+  for (const cell of row.children) {
+    if (!Element.isElement(cell) || cell.type !== BlockType.SimpleTableCellBlock) continue;
+
+    cells.push(SlateNode.string(cell));
+  }
+
+  return cells;
+}

--- a/src/components/editor/plugins/withInsertData.ts
+++ b/src/components/editor/plugins/withInsertData.ts
@@ -20,6 +20,8 @@ import {
   ImageType,
   YjsEditorKey,
 } from '@/application/types';
+import { extractAppFlowyClipboardFragment } from '@/components/editor/clipboard/appflowy-fragment';
+import { containsSimpleTableBlocks, extractTSVFromTableFragment } from '@/components/editor/clipboard/table-fragment';
 import { convertSlateFragmentTo } from '@/components/editor/utils/fragment';
 import { FileHandler } from '@/utils/file';
 import { Log } from '@/utils/log';
@@ -33,6 +35,8 @@ export const withInsertData = (editor: ReactEditor) => {
   const e = editor as YjsEditor;
 
   editor.insertData = (data: DataTransfer) => {
+    const richFragment = extractAppFlowyClipboardFragment(data);
+
     // When pasting inside a table cell, check if the fragment contains table blocks
     // and prevent nesting tables. Instead, extract text and fill adjacent cells.
     const tableCheckEntry = getBlockEntry(e);
@@ -51,24 +55,16 @@ export const withInsertData = (editor: ReactEditor) => {
 
       // Check for Slate fragment containing table blocks
       const fragment = data.getData('application/x-slate-fragment');
+      const parsedFragment = richFragment?.fragment;
 
       if (fragment) {
         try {
           const decoded = decodeURIComponent(window.atob(fragment));
           const parsed = JSON.parse(decoded) as Node[];
 
-          // Check if fragment contains table blocks
-          const hasTable = parsed.some(
-            (n: Node) =>
-              Element.isElement(n) &&
-              [BlockType.SimpleTableBlock, BlockType.SimpleTableRowBlock, BlockType.SimpleTableCellBlock].includes(
-                n.type as BlockType
-              )
-          );
-
-          if (hasTable) {
+          if (containsSimpleTableBlocks(parsed)) {
             // Extract text from table cells and paste as TSV
-            const texts = extractTextsFromFragment(parsed);
+            const texts = extractTSVFromTableFragment(parsed);
 
             if (texts) {
               const handled = editor.insertTextData(createTSVDataTransfer(texts));
@@ -80,6 +76,24 @@ export const withInsertData = (editor: ReactEditor) => {
           // Fall through to default handling
         }
       }
+
+      if (parsedFragment && containsSimpleTableBlocks(parsedFragment)) {
+        const texts = extractTSVFromTableFragment(parsedFragment);
+
+        if (texts) {
+          const handled = editor.insertTextData(createTSVDataTransfer(texts));
+
+          if (handled) return;
+        }
+      }
+    }
+
+    if (richFragment) {
+      const newFragment = convertSlateFragmentTo(richFragment.fragment);
+
+      if (insertFragmentAsSiblings(e, newFragment)) return;
+
+      return e.insertFragment(newFragment);
     }
 
     const rawFragment =
@@ -404,54 +418,6 @@ function insertFragmentAsSiblings(editor: YjsEditor, fragment: Node[]): boolean 
     Log.error('insertFragmentAsSiblings failed', err);
     return false;
   }
-}
-
-/**
- * Extract text content from a Slate fragment that contains table cells.
- * Returns a TSV string (tab-separated rows).
- */
-function extractTextsFromFragment(nodes: Node[]): string | null {
-  const rows: string[][] = [];
-
-  for (const node of nodes) {
-    if (Element.isElement(node)) {
-      if (node.type === BlockType.SimpleTableBlock) {
-        // Table > Row > Cell > Paragraph
-        for (const row of (node.children || []) as Element[]) {
-          const cellTexts: string[] = [];
-
-          for (const cell of (row.children || []) as Element[]) {
-            const text = Node.string(cell);
-
-            cellTexts.push(text);
-          }
-
-          if (cellTexts.length > 0) {
-            rows.push(cellTexts);
-          }
-        }
-      } else if (node.type === BlockType.SimpleTableRowBlock) {
-        const cellTexts: string[] = [];
-
-        for (const cell of (node.children || []) as Element[]) {
-          cellTexts.push(Node.string(cell));
-        }
-
-        if (cellTexts.length > 0) {
-          rows.push(cellTexts);
-        }
-      } else if (node.type === BlockType.SimpleTableCellBlock) {
-        rows.push([Node.string(node)]);
-      } else {
-        // Non-table content — just get text
-        rows.push([Node.string(node)]);
-      }
-    }
-  }
-
-  if (rows.length === 0) return null;
-
-  return rows.map((row) => row.join('\t')).join('\n');
 }
 
 /**


### PR DESCRIPTION
## Summary
- add an ordered rich clipboard reader for AppFlowy native, desktop, JSON, and HTML-carrier paste payloads
- convert desktop AppFlowy document JSON into the web editor Slate/Yjs fragment shape
- handle table fragments separately so table-cell paste becomes TSV without text-wrapper rows/cells
- add regression coverage for desktop payloads, table payloads, generic JSON fallback, and non-ASCII UTF-8 carrier text

## Tests
- pnpm jest src/components/editor/clipboard/__tests__/appflowy-fragment.test.ts src/components/editor/clipboard/__tests__/table-fragment.test.ts --no-coverage --runInBand
- pnpm run type-check
- pnpm eslint --quiet --ext .ts src/components/editor/clipboard/appflowy-fragment.ts src/components/editor/clipboard/table-fragment.ts src/components/editor/clipboard/__tests__/appflowy-fragment.test.ts src/components/editor/clipboard/__tests__/table-fragment.test.ts src/components/editor/plugins/withInsertData.ts --ignore-path .eslintignore.web

## Summary by Sourcery

Improve handling of AppFlowy rich clipboard data when pasting into the editor, including table-aware behavior and broader desktop/native compatibility.

New Features:
- Support ordered detection and parsing of AppFlowy clipboard payloads from native, desktop, JSON, and HTML carriers into Slate fragments.
- Convert AppFlowy desktop document JSON structures into the web editor's Slate/Yjs fragment shape for consistent pasting behavior.

Bug Fixes:
- Handle pasted table fragments from AppFlowy by converting table-cell content into TSV, avoiding nested tables and text-wrapper rows or cells in table pastes.

Tests:
- Add comprehensive tests for AppFlowy clipboard fragment parsing across native, desktop, JSON, and HTML carriers, including non-ASCII UTF-8 content.
- Add tests for table fragment detection and TSV extraction from various table-related clipboard payload shapes.