### PR TITLE
fix: share GoTrue login completion flow

### DIFF
--- a/playwright/bdd/features/auth/mock-login-flows.feature
+++ b/playwright/bdd/features/auth/mock-login-flows.feature
@@ -1,0 +1,14 @@
+Feature: Mocked login flows
+  Completed GoTrue sign-in methods should use the same AppFlowy auth completion flow.
+
+  Scenario Outline: Sign in with a mocked provider
+    Given mocked AppFlowy auth APIs are configured for "<method>" sign in
+    When I complete "<method>" sign in
+    Then I am redirected to the app
+    And the saved auth token is the refreshed token for "<method>" sign in
+
+    Examples:
+      | method         |
+      | password       |
+      | email OTP      |
+      | OAuth callback |

--- a/playwright/bdd/steps/mock-login-flows.steps.ts
+++ b/playwright/bdd/steps/mock-login-flows.steps.ts
@@ -1,0 +1,322 @@
+import { expect, Page, Route } from '@playwright/test';
+import { createBdd } from 'playwright-bdd';
+import { v4 as uuidv4 } from 'uuid';
+
+import { AuthSelectors } from '../../support/selectors';
+import { generateRandomEmail, setupPageErrorHandling, TestConfig } from '../../support/test-config';
+
+const { Given, When, Then, Before } = createBdd();
+
+type SignInMethod = 'password' | 'email OTP' | 'OAuth callback';
+
+type MockLoginState = {
+  method: SignInMethod;
+  email: string;
+  password: string;
+  otpCode: string;
+  userId: string;
+  workspaceId: string;
+  initialAccessToken: string;
+  initialRefreshToken: string;
+  refreshedAccessToken: string;
+  refreshedRefreshToken: string;
+  verifiedAccessTokens: string[];
+  refreshTokenRequests: Array<{ refresh_token?: string }>;
+};
+
+const loginStateByPage = new WeakMap<Page, MockLoginState>();
+
+Before(async ({ page }) => {
+  setupPageErrorHandling(page);
+  await page.setViewportSize({ width: 1280, height: 720 });
+});
+
+Given('mocked AppFlowy auth APIs are configured for {string} sign in', async ({ page }, methodValue: string) => {
+  const method = parseSignInMethod(methodValue);
+  const state = createMockLoginState(method);
+
+  loginStateByPage.set(page, state);
+  await mockAuthProviders(page);
+  await mockCompletedSessionApis(page, state);
+  await mockGoTrueSignInApis(page, state);
+});
+
+When('I complete {string} sign in', async ({ page }, methodValue: string) => {
+  const method = parseSignInMethod(methodValue);
+  const state = getLoginState(page, method);
+
+  switch (method) {
+    case 'password':
+      await completePasswordSignIn(page, state);
+      break;
+    case 'email OTP':
+      await completeEmailOtpSignIn(page, state);
+      break;
+    case 'OAuth callback':
+      await completeOAuthCallbackSignIn(page, state);
+      break;
+  }
+});
+
+Then('I am redirected to the app', async ({ page }) => {
+  await expect(page).toHaveURL(/\/app(?:\/|$)/, { timeout: 15000 });
+});
+
+Then('the saved auth token is the refreshed token for {string} sign in', async ({ page }, methodValue: string) => {
+  const method = parseSignInMethod(methodValue);
+  const state = getLoginState(page, method);
+  const token = await page.evaluate(() => {
+    const raw = localStorage.getItem('token');
+
+    return raw ? JSON.parse(raw) as { access_token?: string; refresh_token?: string; user?: { id?: string; email?: string } } : null;
+  });
+
+  expect(state.verifiedAccessTokens).toEqual([state.initialAccessToken]);
+  expect(state.refreshTokenRequests).toEqual([{ refresh_token: state.initialRefreshToken }]);
+  expect(token?.access_token).toBe(state.refreshedAccessToken);
+  expect(token?.refresh_token).toBe(state.refreshedRefreshToken);
+  expect(token?.user?.id).toBe(state.userId);
+  expect(token?.user?.email).toBe(state.email);
+});
+
+function parseSignInMethod(value: string): SignInMethod {
+  if (value === 'password' || value === 'email OTP' || value === 'OAuth callback') {
+    return value;
+  }
+
+  throw new Error(`Unsupported sign-in method: ${value}`);
+}
+
+function getLoginState(page: Page, method: SignInMethod): MockLoginState {
+  const state = loginStateByPage.get(page);
+
+  if (!state) {
+    throw new Error('Mock login state has not been configured');
+  }
+
+  if (state.method !== method) {
+    throw new Error(`Expected mock login method ${state.method}, got ${method}`);
+  }
+
+  return state;
+}
+
+function createMockLoginState(method: SignInMethod): MockLoginState {
+  const email = generateRandomEmail();
+  const userId = uuidv4();
+
+  return {
+    method,
+    email,
+    password: 'SecurePassword123!',
+    otpCode: '123456',
+    userId,
+    workspaceId: uuidv4(),
+    initialAccessToken: `${methodTokenPrefix(method)}-initial-access-${uuidv4()}`,
+    initialRefreshToken: `${methodTokenPrefix(method)}-initial-refresh-${uuidv4()}`,
+    refreshedAccessToken: `${methodTokenPrefix(method)}-refreshed-access-${uuidv4()}`,
+    refreshedRefreshToken: `${methodTokenPrefix(method)}-refreshed-refresh-${uuidv4()}`,
+    verifiedAccessTokens: [],
+    refreshTokenRequests: [],
+  };
+}
+
+function methodTokenPrefix(method: SignInMethod) {
+  return method.toLowerCase().replace(/\s+/g, '-');
+}
+
+async function mockAuthProviders(page: Page) {
+  await page.route('**/api/server-info/auth-providers', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        code: 0,
+        data: {
+          count: 3,
+          providers: ['email', 'password', 'google'],
+          signup_disabled: false,
+          mailer_autoconfirm: true,
+        },
+        message: 'success',
+      }),
+    })
+  );
+}
+
+async function mockCompletedSessionApis(page: Page, state: MockLoginState) {
+  await page.route('**/api/user/verify/**', (route) => {
+    state.verifiedAccessTokens.push(decodeURIComponent(route.request().url().split('/api/user/verify/')[1] || ''));
+
+    return route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        code: 0,
+        data: { is_new: false },
+        message: 'success',
+      }),
+    });
+  });
+
+  await page.route(/\/api\/user\/profile(?:\?|$)/, (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        code: 0,
+        data: {
+          uid: 1,
+          uuid: state.userId,
+          email: state.email,
+          name: 'Mock User',
+          metadata: { timezone: { default_timezone: 'UTC', timezone: 'UTC' } },
+          encryption_sign: null,
+          latest_workspace_id: state.workspaceId,
+          updated_at: Date.now(),
+        },
+        message: 'success',
+      }),
+    })
+  );
+
+  await page.route(/\/api\/user\/workspace(?:\?|$)/, (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        code: 0,
+        data: {
+          user_profile: { uuid: state.userId },
+          visiting_workspace: createWorkspacePayload(state.workspaceId),
+          workspaces: [createWorkspacePayload(state.workspaceId)],
+        },
+        message: 'success',
+      }),
+    })
+  );
+
+  await page.route(/\/api\/server-info(?:\?|$)/, (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        code: 0,
+        data: { enable_page_history: true, ai_enabled: false },
+        message: 'success',
+      }),
+    })
+  );
+}
+
+async function mockGoTrueSignInApis(page: Page, state: MockLoginState) {
+  await page.route(/\/token\?grant_type=password$/, (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(createGoTrueToken(state, 'initial')),
+    })
+  );
+
+  await page.route(/\/verify$/, (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(createGoTrueToken(state, 'initial')),
+    })
+  );
+
+  await page.route(/\/magiclink$/, (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({}),
+    })
+  );
+
+  await page.route(/\/token\?grant_type=refresh_token$/, async (route) => {
+    state.refreshTokenRequests.push(readPostData(route));
+
+    return route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(createGoTrueToken(state, 'refreshed')),
+    });
+  });
+}
+
+async function completePasswordSignIn(page: Page, state: MockLoginState) {
+  await page.goto(`/login?redirectTo=${encodeURIComponent('/app')}`, { waitUntil: 'domcontentloaded' });
+  await expect(AuthSelectors.emailInput(page)).toBeVisible();
+  await AuthSelectors.emailInput(page).fill(state.email);
+  await AuthSelectors.passwordSignInButton(page).click();
+  await expect(page).toHaveURL(/action=enterPassword/);
+  await AuthSelectors.passwordInput(page).fill(state.password);
+
+  const refreshResponse = page.waitForResponse(/\/token\?grant_type=refresh_token$/);
+
+  await AuthSelectors.passwordSubmitButton(page).click();
+  await refreshResponse;
+}
+
+async function completeEmailOtpSignIn(page: Page, state: MockLoginState) {
+  await page.goto(`/login?redirectTo=${encodeURIComponent('/app')}`, { waitUntil: 'domcontentloaded' });
+  await expect(AuthSelectors.emailInput(page)).toBeVisible();
+  await AuthSelectors.emailInput(page).fill(state.email);
+
+  const magicLinkResponse = page.waitForResponse(/\/magiclink$/);
+
+  await AuthSelectors.magicLinkButton(page).click();
+  await magicLinkResponse;
+  await expect(page).toHaveURL(/action=checkEmail/);
+  await AuthSelectors.enterCodeManuallyButton(page).click();
+  await AuthSelectors.otpCodeInput(page).fill(state.otpCode);
+
+  const refreshResponse = page.waitForResponse(/\/token\?grant_type=refresh_token$/);
+
+  await AuthSelectors.otpSubmitButton(page).click();
+  await refreshResponse;
+}
+
+async function completeOAuthCallbackSignIn(page: Page, state: MockLoginState) {
+  const refreshResponse = page.waitForResponse(/\/token\?grant_type=refresh_token$/);
+
+  await page.goto(
+    `/auth/callback#access_token=${encodeURIComponent(state.initialAccessToken)}&refresh_token=${encodeURIComponent(state.initialRefreshToken)}`,
+    { waitUntil: 'domcontentloaded' }
+  );
+  await refreshResponse;
+}
+
+function createGoTrueToken(state: MockLoginState, variant: 'initial' | 'refreshed') {
+  return {
+    access_token: variant === 'initial' ? state.initialAccessToken : state.refreshedAccessToken,
+    refresh_token: variant === 'initial' ? state.initialRefreshToken : state.refreshedRefreshToken,
+    expires_at: Math.floor(Date.now() / 1000) + 3600,
+    user: {
+      id: state.userId,
+      email: state.email,
+    },
+  };
+}
+
+function createWorkspacePayload(workspaceId: string) {
+  return {
+    workspace_id: workspaceId,
+    owner_uid: 1,
+    owner_name: 'Mock User',
+    workspace_name: 'Mock Workspace',
+    icon: '',
+    created_at: new Date().toISOString(),
+    member_count: 1,
+    database_storage_id: uuidv4(),
+  };
+}
+
+function readPostData(route: Route) {
+  try {
+    return route.request().postDataJSON() as { refresh_token?: string };
+  } catch {
+    return {};
+  }
+}

--- a/src/application/services/js-services/cached-api.ts
+++ b/src/application/services/js-services/cached-api.ts
@@ -300,12 +300,19 @@ export async function loginAuth(url: string) {
   return finishAuthFlow('loginAuth', () => signInWithUrl(url));
 }
 
-async function finishAuthFlow(logContext: string, runAuthFlow: () => Promise<unknown>) {
+async function finishAuthFlow(
+  logContext: string,
+  runAuthFlow: () => Promise<unknown>,
+  options?: { emitSessionValid?: boolean }
+) {
   Log.info(`[Auth] ${logContext}: completing login flow`);
   try {
     await runAuthFlow();
     Log.info(`[Auth] ${logContext}: success, calling afterAuth`);
-    emit(EventType.SESSION_VALID);
+    if (options?.emitSessionValid !== false) {
+      emit(EventType.SESSION_VALID);
+    }
+
     afterAuth();
   } catch (e) {
     Log.error(`[Auth] ${logContext}: failed`, e);
@@ -453,6 +460,9 @@ export { createRow, deleteRow };
 // Auth wrapper functions (replace @withSignIn decorator)
 // ============================================================================
 
+// These low-level GoTrue functions complete provider-specific work only. UI login
+// paths should use the redirect-aware wrappers below so session events and
+// afterAuth() stay consistent across OAuth, password, signup, and OTP.
 export {
   signInWithPassword,
   signUpWithPassword,
@@ -509,5 +519,7 @@ export async function signInMagicLinkWithRedirect({ email, redirectTo }: { email
 
 export async function signInOTPWithRedirect(params: { email: string; code: string; redirectTo: string; type?: 'magiclink' | 'recovery' | 'signup' }) {
   saveRedirectTo(params.redirectTo);
-  return finishAuthFlow('signInOTP', () => signInOTP(params));
+  return finishAuthFlow('signInOTP', () => signInOTP(params), {
+    emitSessionValid: params.type !== 'recovery',
+  });
 }

--- a/src/application/services/js-services/cached-api.ts
+++ b/src/application/services/js-services/cached-api.ts
@@ -297,15 +297,18 @@ export async function getPublishInfoCached(viewId: string) {
 }
 
 export async function loginAuth(url: string) {
-  Log.info('[Auth] loginAuth: processing OAuth callback');
+  return finishAuthFlow('loginAuth', () => signInWithUrl(url));
+}
+
+async function finishAuthFlow(logContext: string, runAuthFlow: () => Promise<unknown>) {
+  Log.info(`[Auth] ${logContext}: completing login flow`);
   try {
-    await signInWithUrl(url);
-    Log.info('[Auth] loginAuth: success, calling afterAuth');
+    await runAuthFlow();
+    Log.info(`[Auth] ${logContext}: success, calling afterAuth`);
     emit(EventType.SESSION_VALID);
     afterAuth();
-    return;
   } catch (e) {
-    Log.error('[Auth] loginAuth: failed', e);
+    Log.error(`[Auth] ${logContext}: failed`, e);
     emit(EventType.SESSION_INVALID);
     return Promise.reject(e);
   }
@@ -491,12 +494,12 @@ export async function signInSamlWithRedirect(params: { redirectTo: string; domai
 
 export async function signInWithPasswordWithRedirect(params: { email: string; password: string; redirectTo: string }) {
   saveRedirectTo(params.redirectTo);
-  return signInWithPassword(params);
+  return finishAuthFlow('signInWithPassword', () => signInWithPassword(params));
 }
 
 export async function signUpWithPasswordWithRedirect(params: { email: string; password: string; redirectTo: string }) {
   saveRedirectTo(params.redirectTo);
-  return signUpWithPassword(params);
+  return finishAuthFlow('signUpWithPassword', () => signUpWithPassword(params));
 }
 
 export async function signInMagicLinkWithRedirect({ email, redirectTo }: { email: string; redirectTo: string }) {
@@ -506,5 +509,5 @@ export async function signInMagicLinkWithRedirect({ email, redirectTo }: { email
 
 export async function signInOTPWithRedirect(params: { email: string; code: string; redirectTo: string; type?: 'magiclink' | 'recovery' | 'signup' }) {
   saveRedirectTo(params.redirectTo);
-  return signInOTP(params);
+  return finishAuthFlow('signInOTP', () => signInOTP(params));
 }

--- a/src/application/services/js-services/http/__tests__/gotrue.test.ts
+++ b/src/application/services/js-services/http/__tests__/gotrue.test.ts
@@ -1,0 +1,139 @@
+const mockGrantClient = {
+  interceptors: {
+    request: {
+      use: jest.fn(),
+    },
+  },
+  post: jest.fn(),
+};
+
+const mockAxiosCreate = jest.fn(() => mockGrantClient);
+
+jest.mock('axios', () => ({
+  __esModule: true,
+  default: {
+    create: mockAxiosCreate,
+  },
+  create: mockAxiosCreate,
+}));
+
+jest.mock('@/application/session/token', () => ({
+  getTokenParsed: jest.fn(),
+  saveGoTrueAuth: jest.fn(),
+}));
+
+jest.mock('../cloud-auth', () => ({
+  verifyToken: jest.fn(),
+}));
+
+jest.mock('@/utils/log', () => ({
+  Log: {
+    debug: jest.fn(),
+    error: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+  },
+}));
+
+const { signInWithUrl } = require('../auth-api') as typeof import('../auth-api');
+const { initGrantService, signInOTP, signInWithPassword } = require('../gotrue') as typeof import('../gotrue');
+const { verifyToken } = require('../cloud-auth') as { verifyToken: jest.Mock };
+const { saveGoTrueAuth } = require('@/application/session/token') as { saveGoTrueAuth: jest.Mock };
+
+describe('GoTrue login token completion', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    localStorage.clear();
+    initGrantService('http://localhost/gotrue');
+  });
+
+  it('refreshes and saves the token after AppFlowy Cloud verifies the password login token', async () => {
+    const loginToken = {
+      access_token: 'login-access-token',
+      expires_at: 123,
+      refresh_token: 'login-refresh-token',
+    };
+    const refreshedToken = {
+      access_token: 'refreshed-access-token',
+      expires_at: 456,
+      refresh_token: 'refreshed-refresh-token',
+    };
+
+    mockGrantClient.post
+      .mockResolvedValueOnce({ data: loginToken })
+      .mockResolvedValueOnce({ data: refreshedToken });
+    (verifyToken as jest.Mock).mockResolvedValueOnce({ is_new: false });
+
+    await signInWithPassword({
+      email: 'admin@example.com',
+      password: 'password',
+      redirectTo: '/app',
+    });
+
+    expect(mockGrantClient.post).toHaveBeenNthCalledWith(1, '/token?grant_type=password', {
+      email: 'admin@example.com',
+      password: 'password',
+    });
+    expect(verifyToken).toHaveBeenCalledWith(loginToken.access_token);
+    expect(mockGrantClient.post).toHaveBeenNthCalledWith(2, '/token?grant_type=refresh_token', {
+      refresh_token: loginToken.refresh_token,
+    });
+    expect(saveGoTrueAuth).toHaveBeenCalledTimes(1);
+    expect(saveGoTrueAuth).toHaveBeenCalledWith(JSON.stringify(refreshedToken));
+  });
+
+  it('uses the same verify-refresh-save flow for OAuth callback tokens', async () => {
+    const refreshedToken = {
+      access_token: 'oauth-refreshed-access-token',
+      expires_at: 456,
+      refresh_token: 'oauth-refreshed-refresh-token',
+    };
+
+    mockGrantClient.post.mockResolvedValueOnce({ data: refreshedToken });
+    verifyToken.mockResolvedValueOnce({ is_new: false });
+
+    await signInWithUrl('http://localhost/auth/callback#access_token=oauth-access-token&refresh_token=oauth-refresh-token');
+
+    expect(verifyToken).toHaveBeenCalledWith('oauth-access-token');
+    expect(mockGrantClient.post).toHaveBeenCalledWith('/token?grant_type=refresh_token', {
+      refresh_token: 'oauth-refresh-token',
+    });
+    expect(saveGoTrueAuth).toHaveBeenCalledTimes(1);
+    expect(saveGoTrueAuth).toHaveBeenCalledWith(JSON.stringify(refreshedToken));
+  });
+
+  it('uses the same verify-refresh-save flow for email OTP tokens', async () => {
+    const otpToken = {
+      access_token: 'otp-access-token',
+      expires_at: 123,
+      refresh_token: 'otp-refresh-token',
+    };
+    const refreshedToken = {
+      access_token: 'otp-refreshed-access-token',
+      expires_at: 456,
+      refresh_token: 'otp-refreshed-refresh-token',
+    };
+
+    mockGrantClient.post
+      .mockResolvedValueOnce({ data: otpToken })
+      .mockResolvedValueOnce({ data: refreshedToken });
+    verifyToken.mockResolvedValueOnce({ is_new: false });
+
+    await signInOTP({
+      email: 'admin@example.com',
+      code: '123456',
+    });
+
+    expect(mockGrantClient.post).toHaveBeenNthCalledWith(1, '/verify', {
+      email: 'admin@example.com',
+      token: '123456',
+      type: 'magiclink',
+    });
+    expect(verifyToken).toHaveBeenCalledWith(otpToken.access_token);
+    expect(mockGrantClient.post).toHaveBeenNthCalledWith(2, '/token?grant_type=refresh_token', {
+      refresh_token: otpToken.refresh_token,
+    });
+    expect(saveGoTrueAuth).toHaveBeenCalledTimes(1);
+    expect(saveGoTrueAuth).toHaveBeenCalledWith(JSON.stringify(refreshedToken));
+  });
+});

--- a/src/application/services/js-services/http/__tests__/gotrue.test.ts
+++ b/src/application/services/js-services/http/__tests__/gotrue.test.ts
@@ -40,9 +40,12 @@ const { initGrantService, signInOTP, signInWithPassword } = require('../gotrue')
 const { verifyToken } = require('../cloud-auth') as { verifyToken: jest.Mock };
 const { saveGoTrueAuth } = require('@/application/session/token') as { saveGoTrueAuth: jest.Mock };
 
+type AuthVariant = 'password' | 'oauth' | 'otp';
+
 describe('GoTrue login token completion', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockGrantClient.post.mockReset();
     localStorage.clear();
     initGrantService('http://localhost/gotrue');
   });
@@ -136,4 +139,100 @@ describe('GoTrue login token completion', () => {
     expect(saveGoTrueAuth).toHaveBeenCalledTimes(1);
     expect(saveGoTrueAuth).toHaveBeenCalledWith(JSON.stringify(refreshedToken));
   });
+
+  it.each<AuthVariant>(['password', 'oauth', 'otp'])(
+    'rejects and skips refresh/save when AppFlowy Cloud verification fails for %s sign-in',
+    async (variant) => {
+      const initialToken = createToken(`${variant}-initial`);
+
+      queueInitialSignInResponse(variant, initialToken);
+      verifyToken.mockRejectedValueOnce({
+        code: 401,
+        message: 'Backend says no [request-id]',
+      });
+
+      await expect(runAuthVariant(variant, initialToken)).rejects.toEqual(expectedVerifyError(variant));
+      expect(refreshTokenCalls()).toHaveLength(0);
+      expect(saveGoTrueAuth).not.toHaveBeenCalled();
+    }
+  );
+
+  it.each<AuthVariant>(['password', 'oauth', 'otp'])(
+    'clears an existing token before verifying %s sign-in',
+    async (variant) => {
+      const initialToken = createToken(`${variant}-initial`);
+      const refreshedToken = createToken(`${variant}-refreshed`);
+      const removeItemSpy = jest.spyOn(Storage.prototype, 'removeItem');
+
+      localStorage.setItem('token', 'old-token');
+      queueInitialSignInResponse(variant, initialToken);
+      queueRefreshResponse(refreshedToken);
+      verifyToken.mockResolvedValueOnce({ is_new: false });
+
+      try {
+        await runAuthVariant(variant, initialToken);
+
+        const tokenRemoveCallIndex = removeItemSpy.mock.calls.findIndex(([key]) => key === 'token');
+
+        expect(tokenRemoveCallIndex).toBeGreaterThanOrEqual(0);
+        expect(removeItemSpy.mock.invocationCallOrder[tokenRemoveCallIndex])
+          .toBeLessThan(verifyToken.mock.invocationCallOrder[0]);
+      } finally {
+        removeItemSpy.mockRestore();
+      }
+    }
+  );
 });
+
+function createToken(prefix: string) {
+  return {
+    access_token: `${prefix}-access-token`,
+    expires_at: 123,
+    refresh_token: `${prefix}-refresh-token`,
+  };
+}
+
+function queueInitialSignInResponse(variant: AuthVariant, token: ReturnType<typeof createToken>) {
+  if (variant !== 'oauth') {
+    mockGrantClient.post.mockResolvedValueOnce({ data: token });
+  }
+}
+
+function queueRefreshResponse(token: ReturnType<typeof createToken>) {
+  mockGrantClient.post.mockResolvedValueOnce({ data: token });
+}
+
+function refreshTokenCalls() {
+  return mockGrantClient.post.mock.calls.filter(([url]) => url === '/token?grant_type=refresh_token');
+}
+
+function expectedVerifyError(variant: AuthVariant) {
+  switch (variant) {
+    case 'password':
+      return { code: 401, message: 'Backend says no' };
+    case 'oauth':
+      return { code: 401, message: 'Verify token failed' };
+    case 'otp':
+      return { code: 401, message: 'Failed to create user account' };
+  }
+}
+
+function runAuthVariant(variant: AuthVariant, token: ReturnType<typeof createToken>) {
+  switch (variant) {
+    case 'password':
+      return signInWithPassword({
+        email: 'admin@example.com',
+        password: 'password',
+        redirectTo: '/app',
+      });
+    case 'oauth':
+      return signInWithUrl(
+        `http://localhost/auth/callback#access_token=${token.access_token}&refresh_token=${token.refresh_token}`
+      );
+    case 'otp':
+      return signInOTP({
+        email: 'admin@example.com',
+        code: '123456',
+      });
+  }
+}

--- a/src/application/services/js-services/http/auth-api.ts
+++ b/src/application/services/js-services/http/auth-api.ts
@@ -1,9 +1,11 @@
 import { AuthProvider } from '@/application/types';
 import { Log } from '@/utils/log';
 
-import { refreshToken } from './gotrue';
+import { verifyAndRefreshGoTrueToken } from './gotrue';
 import { parseGoTrueErrorFromUrl } from './gotrue-error';
 import { APIError, APIResponse, executeAPIRequest, getAxios } from './core';
+
+export { verifyToken } from './cloud-auth';
 
 export interface ServerInfo {
   enable_page_history: boolean;
@@ -53,52 +55,14 @@ export async function signInWithUrl(url: string) {
 
   Log.info('[Auth] signInWithUrl: tokens extracted from callback URL');
 
-  // CRITICAL: Clear old token BEFORE processing new OAuth tokens
-  // This prevents axios interceptor from trying to auto-refresh the old expired token
-  // during verifyToken() API call, which would cause a race condition where:
-  // 1. verifyToken() makes API call with NEW token in URL
-  // 2. Axios interceptor sees OLD token in localStorage, tries to refresh it
-  // 3. Old token refresh fails → invalidToken() called → session invalidated
-  // 4. Meanwhile, OAuth flow is trying to save NEW token → conflicts with invalidation
-  // By clearing the old token first, we ensure axios interceptor skips auto-refresh
-  const hadOldToken = !!localStorage.getItem('token');
-
-  if (hadOldToken) {
-    Log.info('[Auth] signInWithUrl: clearing old token to prevent race condition');
-    localStorage.removeItem('token');
-  }
-
-  Log.info('[Auth] signInWithUrl: verifying token with AppFlowy Cloud');
-  try {
-    await verifyToken(accessToken);
-  } catch (e) {
-    Log.error('[Auth] signInWithUrl: verifyToken failed', { message: (e as Error)?.message });
-    return Promise.reject({
-      code: -1,
-      message: 'Verify token failed',
-    });
-  }
-
-  Log.info('[Auth] signInWithUrl: refreshing token');
-  try {
-    await refreshToken(refresh_token);
-  } catch (e) {
-    Log.error('[Auth] signInWithUrl: refreshToken failed', { message: (e as Error)?.message });
-    return Promise.reject({
-      code: -1,
-      message: 'Refresh token failed',
-    });
-  }
-
-  Log.info('[Auth] signInWithUrl: OAuth callback processed successfully');
-}
-
-export async function verifyToken(accessToken: string) {
-  const url = `/api/user/verify/${accessToken}`;
-
-  return executeAPIRequest<{ is_new: boolean }>(() =>
-    getAxios()?.get<APIResponse<{ is_new: boolean }>>(url)
-  );
+  return verifyAndRefreshGoTrueToken({
+    accessToken,
+    refreshToken: refresh_token,
+    logContext: 'signInWithUrl',
+    verifyErrorMessage: 'Verify token failed',
+    refreshErrorMessage: 'Refresh token failed',
+    useVerifyErrorMessage: false,
+  });
 }
 
 export async function getServerInfo(): Promise<ServerInfo> {

--- a/src/application/services/js-services/http/cloud-auth.ts
+++ b/src/application/services/js-services/http/cloud-auth.ts
@@ -1,0 +1,9 @@
+import { APIResponse, executeAPIRequest, getAxios } from './core';
+
+export async function verifyToken(accessToken: string) {
+  const url = `/api/user/verify/${accessToken}`;
+
+  return executeAPIRequest<{ is_new: boolean }>(() =>
+    getAxios()?.get<APIResponse<{ is_new: boolean }>>(url)
+  );
+}

--- a/src/application/services/js-services/http/gotrue.ts
+++ b/src/application/services/js-services/http/gotrue.ts
@@ -1,16 +1,24 @@
 import axios, { AxiosInstance } from 'axios';
 
 import { emit, EventType } from '@/application/session';
-import { afterAuth } from '@/application/session/sign_in';
 import { getTokenParsed, saveGoTrueAuth } from '@/application/session/token';
 
 import { Log } from '@/utils/log';
-import { verifyToken } from './auth-api';
+import { verifyToken } from './cloud-auth';
 import { GoTrueErrorCode, parseGoTrueError } from './gotrue-error';
 
 export * from './gotrue-error';
 
 let axiosInstance: AxiosInstance | null = null;
+
+interface VerifyAndRefreshGoTrueTokenParams {
+  accessToken: string;
+  refreshToken: string;
+  logContext: string;
+  verifyErrorMessage?: string;
+  refreshErrorMessage?: string;
+  useVerifyErrorMessage?: boolean;
+}
 
 export function initGrantService(baseURL: string) {
   if (axiosInstance) {
@@ -58,6 +66,57 @@ export async function refreshToken(refresh_token: string) {
   return newToken;
 }
 
+function normalizeAuthFlowError(error: unknown, fallbackMessage: string, useErrorMessage: boolean) {
+  const err = error as { message?: string; code?: number };
+  const message =
+    useErrorMessage && typeof err?.message === 'string'
+      ? err.message.replace(/\s*\[.*\]$/, '')
+      : fallbackMessage;
+
+  return {
+    code: err?.code ?? -1,
+    message,
+  };
+}
+
+export async function verifyAndRefreshGoTrueToken({
+  accessToken,
+  refreshToken: refresh_token,
+  logContext,
+  verifyErrorMessage = 'Failed to verify token',
+  refreshErrorMessage = 'Failed to refresh token',
+  useVerifyErrorMessage = true,
+}: VerifyAndRefreshGoTrueTokenParams) {
+  // Clear the previous session before AppFlowy Cloud verification so axios
+  // interceptors cannot refresh or invalidate an old token during the new login.
+  if (localStorage.getItem('token')) {
+    Log.info(`[Auth] ${logContext}: clearing old token before auth flow`);
+    localStorage.removeItem('token');
+  }
+
+  Log.info(`[Auth] ${logContext}: verifying token with AppFlowy Cloud`);
+  try {
+    const result = await verifyToken(accessToken);
+
+    Log.info(`[Auth] ${logContext}: verifyToken completed`, { isNewUser: result.is_new });
+  } catch (error: unknown) {
+    const normalized = normalizeAuthFlowError(error, verifyErrorMessage, useVerifyErrorMessage);
+
+    Log.error(`[Auth] ${logContext}: verifyToken failed`, normalized);
+    return Promise.reject(normalized);
+  }
+
+  Log.info(`[Auth] ${logContext}: refreshing token`);
+  try {
+    await refreshToken(refresh_token);
+  } catch (error: unknown) {
+    const normalized = normalizeAuthFlowError(error, refreshErrorMessage, false);
+
+    Log.error(`[Auth] ${logContext}: refreshToken failed`, normalized);
+    return Promise.reject(normalized);
+  }
+}
+
 export async function signInWithPassword(params: { email: string; password: string; redirectTo: string }) {
   Log.info('[Auth] signInWithPassword: starting', { email: params.email });
   try {
@@ -73,33 +132,14 @@ export async function signInWithPassword(params: { email: string; password: stri
     const data = response?.data;
 
     if (data) {
-      Log.info('[Auth] signInWithPassword: GoTrue returned tokens, verifying with AppFlowy Cloud');
-      try {
-        await verifyToken(data.access_token);
-        saveGoTrueAuth(JSON.stringify(data));
-        Log.info('[Auth] signInWithPassword: token verified and saved');
-      } catch (error: unknown) {
-        const err = error as { message?: string; code?: number };
-
-        Log.error('[Auth] signInWithPassword: verifyToken failed', { code: err?.code, message: err?.message });
-        emit(EventType.SESSION_INVALID);
-        const message =
-          typeof err?.message === 'string'
-            ? err.message.replace(/\s*\[.*\]$/, '')
-            : 'Failed to verify token';
-
-        return Promise.reject({
-          code: err?.code ?? -1,
-          message,
-        });
-      }
-
-      Log.info('[Auth] signInWithPassword: success, calling afterAuth');
-      emit(EventType.SESSION_VALID);
-      afterAuth();
+      Log.info('[Auth] signInWithPassword: GoTrue returned tokens, completing auth flow');
+      return verifyAndRefreshGoTrueToken({
+        accessToken: data.access_token,
+        refreshToken: data.refresh_token,
+        logContext: 'signInWithPassword',
+      });
     } else {
       Log.error('[Auth] signInWithPassword: GoTrue returned no data');
-      emit(EventType.SESSION_INVALID);
       return Promise.reject({
         code: -1,
         message: 'Failed to sign in with password',
@@ -116,7 +156,6 @@ export async function signInWithPassword(params: { email: string; password: stri
     });
 
     Log.error('[Auth] signInWithPassword: failed', { status: e.response?.status, code: error.code, message: error.message });
-    emit(EventType.SESSION_INVALID);
 
     return Promise.reject({
       code: error.code,
@@ -183,46 +222,14 @@ export async function signUpWithPassword(params: { email: string; password: stri
         });
       }
 
-      Log.info('[Auth] signUpWithPassword: verifying token with AppFlowy Cloud');
-      try {
-        await verifyToken(data.access_token as string);
-      } catch (error: unknown) {
-        const err = error as { message?: string; code?: number };
-
-        Log.error('[Auth] signUpWithPassword: verifyToken failed', { code: err?.code, message: err?.message });
-        emit(EventType.SESSION_INVALID);
-        const message =
-          typeof err?.message === 'string'
-            ? err.message.replace(/\s*\[.*\]$/, '')
-            : 'Failed to verify token';
-
-        return Promise.reject({
-          code: err?.code ?? -1,
-          message,
-        });
-      }
-
-      Log.info('[Auth] signUpWithPassword: refreshing token');
-      try {
-        await refreshToken(data.refresh_token as string);
-      } catch (error: unknown) {
-        const err = error as { message?: string; code?: number };
-
-        Log.error('[Auth] signUpWithPassword: refreshToken failed', { code: err?.code, message: (err as Error)?.message });
-        emit(EventType.SESSION_INVALID);
-
-        return Promise.reject({
-          code: err?.code ?? -1,
-          message: 'Failed to refresh token',
-        });
-      }
-
-      Log.info('[Auth] signUpWithPassword: success, calling afterAuth');
-      emit(EventType.SESSION_VALID);
-      afterAuth();
+      Log.info('[Auth] signUpWithPassword: GoTrue returned tokens, completing auth flow');
+      return verifyAndRefreshGoTrueToken({
+        accessToken: data.access_token as string,
+        refreshToken: data.refresh_token as string,
+        logContext: 'signUpWithPassword',
+      });
     } else {
       Log.error('[Auth] signUpWithPassword: GoTrue returned no data');
-      emit(EventType.SESSION_INVALID);
       return Promise.reject({
         code: -1,
         message: 'Failed to sign up with password',
@@ -238,7 +245,6 @@ export async function signUpWithPassword(params: { email: string; password: stri
     });
 
     Log.error('[Auth] signUpWithPassword: failed', { status: e.response?.status, code: error.code, message: error.message });
-    emit(EventType.SESSION_INVALID);
 
     return Promise.reject({
       code: error.code,
@@ -351,41 +357,16 @@ export async function signInOTP({
 
     if (data) {
       if (!data.code) {
-        Log.info('[Auth] signInOTP: GoTrue returned tokens, saving to localStorage');
-        saveGoTrueAuth(JSON.stringify(data));
-
-        // Verify token with AppFlowy Cloud to create user if needed
-        let isNewUser = false;
-
-        Log.info('[Auth] signInOTP: verifying token with AppFlowy Cloud');
-        try {
-          const result = await verifyToken(data.access_token);
-
-          isNewUser = result.is_new;
-          Log.info('[Auth] signInOTP: verifyToken completed', { isNewUser });
-        } catch (error) {
-          Log.error('[Auth] signInOTP: verifyToken failed', error);
-          emit(EventType.SESSION_INVALID);
-
-          return Promise.reject({
-            code: -1,
-            message: 'Failed to create user account',
-          });
-        }
-
-        // Emit session valid only after everything is complete
-        if (type === 'magiclink' || type === 'signup') {
-          emit(EventType.SESSION_VALID);
-        }
-
-        // afterAuth() handles redirect: it blocks stale /app/{uuid} paths
-        // (safe for new users) while allowing invitation paths like
-        // /app/accept-guest-invitation. Defaults to /app when no redirectTo exists.
-        Log.info('[Auth] signInOTP: success, calling afterAuth');
-        afterAuth();
+        Log.info('[Auth] signInOTP: GoTrue returned tokens, completing auth flow');
+        return verifyAndRefreshGoTrueToken({
+          accessToken: data.access_token,
+          refreshToken: data.refresh_token,
+          logContext: 'signInOTP',
+          verifyErrorMessage: 'Failed to create user account',
+          useVerifyErrorMessage: false,
+        });
       } else {
         Log.error('[Auth] signInOTP: GoTrue returned error', { code: data.code, msg: data.msg });
-        emit(EventType.SESSION_INVALID);
         return Promise.reject({
           code: data.code,
           message: data.msg,
@@ -393,7 +374,6 @@ export async function signInOTP({
       }
     } else {
       Log.error('[Auth] signInOTP: GoTrue returned no data');
-      emit(EventType.SESSION_INVALID);
       return Promise.reject({
         code: 'invalid_token',
         message: 'Invalid token',
@@ -402,7 +382,6 @@ export async function signInOTP({
     // eslint-disable-next-line
   } catch (e: any) {
     Log.error('[Auth] signInOTP: failed', { status: e.response?.status, code: e.response?.data?.code, message: e.response?.data?.msg || e.message });
-    emit(EventType.SESSION_INVALID);
     return Promise.reject({
       code: e.response?.data?.code || e.response?.status,
       message: e.response?.data?.msg || e.message,


### PR DESCRIPTION
## Summary
- centralize completed GoTrue login token handling across OAuth, password, signup, and email OTP
- verify with AppFlowy Cloud, refresh/save the GoTrue token, then finish session redirect through one wrapper path
- add unit coverage for OAuth, password, and email OTP sharing the verify-refresh-save sequence
- add Playwright BDD coverage for mocked password, email OTP, and OAuth callback sign-in flows

Fixes #313

## Tests
- pnpm jest src/application/services/js-services/http/__tests__/gotrue.test.ts --no-coverage
- pnpm jest src/application/services/js-services/http/__tests__/http_api.test.ts --no-coverage
- pnpm run type-check
- pnpm exec eslint --quiet --ext .ts src/application/services/js-services/http/gotrue.ts src/application/services/js-services/http/auth-api.ts src/application/services/js-services/http/cloud-auth.ts src/application/services/js-services/http/__tests__/gotrue.test.ts src/application/services/js-services/cached-api.ts
- pnpm exec bddgen test -c playwright.bdd.config.ts
- BASE_URL=http://127.0.0.1:3000 pnpm exec playwright test -c playwright.bdd.config.ts playwright/.features-gen/playwright/bdd/features/auth/mock-login-flows.feature.spec.js --workers=1