### PR TITLE
Add paste-as URL layouts for simple table cells

### DIFF
--- a/playwright/e2e/page/paste/paste-tables.spec.ts
+++ b/playwright/e2e/page/paste/paste-tables.spec.ts
@@ -16,9 +16,7 @@ import { testLog } from '../../../support/test-helpers';
 /**
  * Paste content into the Slate editor by calling insertData directly.
  */
-async function pasteContent(page: Page, html: string, plainText: string) {
-  await expect(EditorSelectors.slateEditor(page).first()).toBeVisible({ timeout: 10000 });
-
+async function getDocumentEditorIndex(page: Page) {
   const editors = EditorSelectors.slateEditor(page);
   const editorCount = await editors.count();
 
@@ -39,8 +37,13 @@ async function pasteContent(page: Page, html: string, plainText: string) {
     throw new Error('No editor found');
   }
 
-  await editors.nth(targetIndex).click({ force: true });
-  await page.waitForTimeout(300);
+  return targetIndex;
+}
+
+async function pasteContent(page: Page, html: string, plainText: string) {
+  await expect(EditorSelectors.slateEditor(page).first()).toBeVisible({ timeout: 10000 });
+
+  const targetIndex = await getDocumentEditorIndex(page);
 
   await page.evaluate(
     ({ html, plainText, idx }) => {
@@ -97,10 +100,25 @@ async function pasteContent(page: Page, html: string, plainText: string) {
  * Call this between sequential pastes so each paste starts in its own block.
  */
 async function moveCursorToEnd(page: Page) {
-  const isMac = process.platform === 'darwin';
-  await page.keyboard.press(isMac ? 'Meta+ArrowDown' : 'Control+End');
-  await page.waitForTimeout(200);
-  await page.keyboard.press('Enter');
+  const editor = EditorSelectors.slateEditor(page).nth(await getDocumentEditorIndex(page));
+  const box = await editor.boundingBox();
+
+  if (!box) {
+    const isMac = process.platform === 'darwin';
+
+    await page.keyboard.press(isMac ? 'Meta+ArrowDown' : 'Control+End');
+    await page.waitForTimeout(200);
+    await page.keyboard.press('Enter');
+    await page.waitForTimeout(300);
+    return;
+  }
+
+  const x = box.x + Math.min(320, box.width / 2);
+  const y = box.y + box.height - 196;
+
+  await page.mouse.click(x, y);
+  await page.waitForTimeout(300);
+  await page.mouse.click(x, y);
   await page.waitForTimeout(300);
 }
 
@@ -115,7 +133,7 @@ async function createTestPage(page: Page, request: import('@playwright/test').AP
   await page.waitForTimeout(2000);
 
   await createDocumentPageAndNavigate(page);
-  await EditorSelectors.firstEditor(page).click({ force: true });
+  await EditorSelectors.slateEditor(page).nth(await getDocumentEditorIndex(page)).click({ force: true });
   await page.waitForTimeout(500);
 }
 

--- a/playwright/e2e/page/simple-table.spec.ts
+++ b/playwright/e2e/page/simple-table.spec.ts
@@ -166,6 +166,46 @@ async function getTableWidth(page: Page, tableIndex = 0) {
   return getTableEl(page, tableIndex).evaluate(el => el.getBoundingClientRect().width);
 }
 
+async function pastePlainText(page: Page, text: string, html?: string) {
+  if (html) {
+    await page.context().grantPermissions(['clipboard-read', 'clipboard-write']);
+    await page.evaluate(async ({ plainText, htmlText }) => {
+      await navigator.clipboard.write([
+        new ClipboardItem({
+          'text/plain': new Blob([plainText], { type: 'text/plain' }),
+          'text/html': new Blob([htmlText], { type: 'text/html' }),
+        }),
+      ]);
+    }, { plainText: text, htmlText: html });
+    await page.keyboard.press(`${MOD_KEY}+V`);
+    return;
+  }
+
+  await page.evaluate(({ plainText, htmlText }) => {
+    const target = document.querySelector('[data-slate-editor="true"]') as HTMLElement | null;
+
+    if (!target) throw new Error('No slate editor found');
+
+    const clipboardData = new DataTransfer();
+
+    clipboardData.setData('text/plain', plainText);
+    if (htmlText) {
+      clipboardData.setData('text/html', htmlText);
+    }
+
+    const pasteEvent = new ClipboardEvent('paste', {
+      bubbles: true,
+      cancelable: true,
+    });
+
+    Object.defineProperty(pasteEvent, 'clipboardData', {
+      value: clipboardData,
+    });
+
+    target.dispatchEvent(pasteEvent);
+  }, { plainText: text, htmlText: html });
+}
+
 // ============================================================================
 // Tests
 // ============================================================================
@@ -202,6 +242,106 @@ test.describe('SimpleTable', () => {
     await page.waitForTimeout(300);
 
     await expect(getCell(page, 0, 0)).toContainText('Hello');
+  });
+
+  test('should show paste-as layouts for pasted URLs in table cells', async ({ page }) => {
+    await insertTableViaSlashCommand(page);
+
+    const cell = getCell(page, 0, 0);
+    const url = 'https://github.com/AppFlowy-IO/AppFlowy-Web/issues/53';
+
+    await cell.click();
+    const initialCellWidth = await cell.evaluate(el => el.getBoundingClientRect().width);
+
+    await pastePlainText(page, url);
+
+    const pasteAsPanel = page.getByTestId('paste-as-panel');
+
+    await expect(pasteAsPanel).toBeVisible({ timeout: 5000 });
+    await expect(page.getByTestId('paste-as-mention')).toBeVisible();
+    await expect(page.getByTestId('paste-as-url')).toBeVisible();
+    await expect(page.getByTestId('paste-as-bookmark')).toBeVisible();
+    await expect(page.getByTestId('paste-as-embed')).toBeVisible();
+    await expect(cell).toContainText(url);
+    await expect(cell.locator('.link-preview-card')).toHaveCount(0);
+
+    await page.getByTestId('paste-as-bookmark').click();
+    await expect(pasteAsPanel).toBeHidden({ timeout: 5000 });
+
+    const card = cell.locator('.link-preview-card-bookmark').first();
+
+    await expect(card).toBeVisible({ timeout: 5000 });
+
+    const metrics = await card.evaluate((cardEl) => {
+      const cellEl = cardEl.closest('td[data-block-type="simple_table_cell"]') as HTMLElement | null;
+
+      if (!cellEl) throw new Error('No table cell found for link preview');
+
+      const cardRect = cardEl.getBoundingClientRect();
+      const cellRect = cellEl.getBoundingClientRect();
+      const cellStyle = getComputedStyle(cellEl);
+      const cellContentWidth =
+        cellRect.width - parseFloat(cellStyle.paddingLeft) - parseFloat(cellStyle.paddingRight);
+
+      return {
+        cardLeft: cardRect.left,
+        cardRight: cardRect.right,
+        cardWidth: cardRect.width,
+        cellLeft: cellRect.left,
+        cellRight: cellRect.right,
+        cellWidth: cellRect.width,
+        cellContentWidth,
+      };
+    });
+
+    expect(metrics.cardLeft).toBeGreaterThanOrEqual(metrics.cellLeft - 1);
+    expect(metrics.cardRight).toBeLessThanOrEqual(metrics.cellRight + 1);
+    expect(metrics.cardWidth).toBeLessThanOrEqual(metrics.cellContentWidth + 1);
+    expect(metrics.cellWidth).toBeLessThanOrEqual(initialCellWidth + 1);
+
+    const urlCell = getCell(page, 0, 1);
+    const plainUrl = 'https://appflowy.io/simple-table-url-layout';
+
+    await urlCell.click();
+    await pastePlainText(page, plainUrl);
+    await expect(pasteAsPanel).toBeVisible({ timeout: 5000 });
+    await page.getByTestId('paste-as-url').click();
+    await expect(pasteAsPanel).toBeHidden({ timeout: 5000 });
+    await expect(urlCell).toContainText(plainUrl);
+    await expect(urlCell.locator('.link-preview-card')).toHaveCount(0);
+
+  });
+
+  test('should convert pasted URLs to mentions in table cells', async ({ page }) => {
+    await insertTableViaSlashCommand(page);
+
+    const mentionCell = getCell(page, 0, 0);
+    const mentionUrl = 'https://appflowy.io/simple-table-mention-layout';
+
+    await mentionCell.click();
+    await pastePlainText(page, mentionUrl);
+    const pasteAsPanel = page.getByTestId('paste-as-panel');
+
+    await expect(pasteAsPanel).toBeVisible({ timeout: 5000 });
+    await page.getByTestId('paste-as-mention').click();
+    await expect(pasteAsPanel).toBeHidden({ timeout: 5000 });
+    await expect(mentionCell.locator('.mention')).toBeVisible({ timeout: 5000 });
+  });
+
+  test('should show paste-as for HTML links in table cells', async ({ page }) => {
+    await insertTableViaSlashCommand(page);
+
+    const embedCell = getCell(page, 0, 0);
+    const embedUrl = 'https://appflowy.io/simple-table-embed-layout';
+
+    await embedCell.click();
+    await pastePlainText(page, embedUrl, `<a href="${embedUrl}">${embedUrl}</a>`);
+    const pasteAsPanel = page.getByTestId('paste-as-panel');
+
+    await expect(pasteAsPanel).toBeVisible({ timeout: 5000 });
+    await page.getByTestId('paste-as-embed').click();
+    await expect(pasteAsPanel).toBeHidden({ timeout: 5000 });
+    await expect(embedCell.locator('.link-preview-card-embed')).toBeVisible({ timeout: 5000 });
   });
 
   // ==========================================================================

--- a/playwright/e2e/page/simple-table.spec.ts
+++ b/playwright/e2e/page/simple-table.spec.ts
@@ -167,8 +167,9 @@ async function getTableWidth(page: Page, tableIndex = 0) {
 }
 
 async function pastePlainText(page: Page, text: string, html?: string) {
+  await page.context().grantPermissions(['clipboard-read', 'clipboard-write']);
+
   if (html) {
-    await page.context().grantPermissions(['clipboard-read', 'clipboard-write']);
     await page.evaluate(async ({ plainText, htmlText }) => {
       await navigator.clipboard.write([
         new ClipboardItem({
@@ -181,29 +182,10 @@ async function pastePlainText(page: Page, text: string, html?: string) {
     return;
   }
 
-  await page.evaluate(({ plainText, htmlText }) => {
-    const target = document.querySelector('[data-slate-editor="true"]') as HTMLElement | null;
-
-    if (!target) throw new Error('No slate editor found');
-
-    const clipboardData = new DataTransfer();
-
-    clipboardData.setData('text/plain', plainText);
-    if (htmlText) {
-      clipboardData.setData('text/html', htmlText);
-    }
-
-    const pasteEvent = new ClipboardEvent('paste', {
-      bubbles: true,
-      cancelable: true,
-    });
-
-    Object.defineProperty(pasteEvent, 'clipboardData', {
-      value: clipboardData,
-    });
-
-    target.dispatchEvent(pasteEvent);
-  }, { plainText: text, htmlText: html });
+  await page.evaluate(async (plainText) => {
+    await navigator.clipboard.writeText(plainText);
+  }, text);
+  await page.keyboard.press(`${MOD_KEY}+V`);
 }
 
 // ============================================================================

--- a/src/@types/translations/ar-SA.json
+++ b/src/@types/translations/ar-SA.json
@@ -1399,7 +1399,16 @@
         "paste": "لصق"
       },
       "action": "أجراءات",
-      "autoCompletionMenuItemName": "عنصر قائمة الإكمال التلقائي"
+      "autoCompletionMenuItemName": "عنصر قائمة الإكمال التلقائي",
+      "urlPreview": {
+        "pasteAs": {
+          "title": "لصق كـ",
+          "mention": "إشارة",
+          "url": "URL",
+          "bookmark": "إشارة مرجعية",
+          "embed": "تضمين"
+        }
+      }
     },
     "textBlock": {
       "placeholder": "اكتب \"/\" للأوامر"

--- a/src/@types/translations/ca-ES.json
+++ b/src/@types/translations/ca-ES.json
@@ -694,6 +694,15 @@
         "toContinue": "per continuar",
         "newDatabase": "Nova base de dades",
         "linkToDatabase": "Enllaç a la base de dades"
+      },
+      "urlPreview": {
+        "pasteAs": {
+          "title": "Enganxa com a",
+          "mention": "Menció",
+          "url": "URL",
+          "bookmark": "Marcador",
+          "embed": "Incrustació"
+        }
       }
     },
     "textBlock": {

--- a/src/@types/translations/ckb-KU.json
+++ b/src/@types/translations/ckb-KU.json
@@ -800,7 +800,16 @@
       "outline": {
         "addHeadingToCreateOutline": "بۆ دروستکردنی خشتەی ناوەڕۆک سەردێڕەکان داخڵ بکە"
       },
-      "openAI": "AI ژیری دەستکرد"
+      "openAI": "AI ژیری دەستکرد",
+      "urlPreview": {
+        "pasteAs": {
+          "title": "وەک دابنێ",
+          "mention": "ئاماژە",
+          "url": "URL",
+          "bookmark": "دڵخواز",
+          "embed": "جێگیرکردن"
+        }
+      }
     },
     "textBlock": {
       "placeholder": "بۆ فەرمانەکان '/' بنووسە"

--- a/src/@types/translations/cs-CZ.json
+++ b/src/@types/translations/cs-CZ.json
@@ -697,7 +697,16 @@
         "cut": "Vyjmout",
         "paste": "Vložit"
       },
-      "action": "Příkazy"
+      "action": "Příkazy",
+      "urlPreview": {
+        "pasteAs": {
+          "title": "Vložit jako",
+          "mention": "Zmínka",
+          "url": "URL",
+          "bookmark": "Záložka",
+          "embed": "Vložený obsah"
+        }
+      }
     },
     "textBlock": {
       "placeholder": "Napište \"/\" pro zadání příkazu"

--- a/src/@types/translations/de-DE.json
+++ b/src/@types/translations/de-DE.json
@@ -1883,7 +1883,14 @@
       },
       "urlPreview": {
         "copiedToPasteBoard": "Der Link wurde in die Zwischenablage kopiert",
-        "convertToLink": "Konvertieren zum eingebetteten Link"
+        "convertToLink": "Konvertieren zum eingebetteten Link",
+        "pasteAs": {
+          "title": "Einfügen als",
+          "mention": "Erwähnung",
+          "url": "URL",
+          "bookmark": "Lesezeichen",
+          "embed": "Einbetten"
+        }
       },
       "outline": {
         "addHeadingToCreateOutline": "Füge Überschriften hinzu, um ein Inhaltsverzeichnis zu erstellen.",

--- a/src/@types/translations/en.json
+++ b/src/@types/translations/en.json
@@ -2268,7 +2268,14 @@
       },
       "urlPreview": {
         "copiedToPasteBoard": "The link has been copied to the clipboard",
-        "convertToLink": "Convert to embed link"
+        "convertToLink": "Convert to embed link",
+        "pasteAs": {
+          "title": "Paste as",
+          "mention": "Mention",
+          "url": "URL",
+          "bookmark": "Bookmark",
+          "embed": "Embed"
+        }
       },
       "outline": {
         "outlineBlock": "Table of Contents",

--- a/src/@types/translations/es-VE.json
+++ b/src/@types/translations/es-VE.json
@@ -968,7 +968,14 @@
       },
       "urlPreview": {
         "copiedToPasteBoard": "El enlace ha sido copiado al portapapeles.",
-        "convertToLink": "Convertir en enlace incrustado"
+        "convertToLink": "Convertir en enlace incrustado",
+        "pasteAs": {
+          "title": "Pegar como",
+          "mention": "Mención",
+          "url": "URL",
+          "bookmark": "Marcador",
+          "embed": "Insertar"
+        }
       },
       "outline": {
         "addHeadingToCreateOutline": "Agregue encabezados para crear una tabla de contenido.",

--- a/src/@types/translations/eu-ES.json
+++ b/src/@types/translations/eu-ES.json
@@ -497,6 +497,15 @@
       },
       "outline": {
         "addHeadingToCreateOutline": "Gehitu goiburuak aurkibidea sortzeko."
+      },
+      "urlPreview": {
+        "pasteAs": {
+          "title": "Itsatsi honela",
+          "mention": "Aipamena",
+          "url": "URL",
+          "bookmark": "Laster-marka",
+          "embed": "Kapsulatu"
+        }
       }
     },
     "textBlock": {

--- a/src/@types/translations/fa.json
+++ b/src/@types/translations/fa.json
@@ -533,7 +533,16 @@
       "outline": {
         "addHeadingToCreateOutline": "برای ایجاد فهرست مطالب سر‌فصل‌ها را وارد کنید"
       },
-      "openAI": "AI"
+      "openAI": "AI",
+      "urlPreview": {
+        "pasteAs": {
+          "title": "جای‌گذاری به‌عنوان",
+          "mention": "اشاره",
+          "url": "URL",
+          "bookmark": "نشانک",
+          "embed": "جاسازی"
+        }
+      }
     },
     "textBlock": {
       "placeholder": "برای دستورات '/' را تایپ کنید"

--- a/src/@types/translations/fr-CA.json
+++ b/src/@types/translations/fr-CA.json
@@ -772,7 +772,14 @@
         "copiedToPasteBoard": "Le lien de l'image a été copié dans le presse-papiers"
       },
       "urlPreview": {
-        "copiedToPasteBoard": "Le lien a été copié dans le presse-papier"
+        "copiedToPasteBoard": "Le lien a été copié dans le presse-papier",
+        "pasteAs": {
+          "title": "Coller comme",
+          "mention": "Mention",
+          "url": "URL",
+          "bookmark": "Signet",
+          "embed": "Intégrer"
+        }
       },
       "outline": {
         "addHeadingToCreateOutline": "Ajoutez des titres pour créer une table des matières."

--- a/src/@types/translations/fr-FR.json
+++ b/src/@types/translations/fr-FR.json
@@ -1861,7 +1861,14 @@
       },
       "urlPreview": {
         "copiedToPasteBoard": "Le lien a été copié dans le presse-papier",
-        "convertToLink": "Convertir en lien intégré"
+        "convertToLink": "Convertir en lien intégré",
+        "pasteAs": {
+          "title": "Coller comme",
+          "mention": "Mention",
+          "url": "URL",
+          "bookmark": "Favori",
+          "embed": "Intégrer"
+        }
       },
       "outline": {
         "addHeadingToCreateOutline": "Ajoutez des titres pour créer une table des matières.",

--- a/src/@types/translations/he.json
+++ b/src/@types/translations/he.json
@@ -1390,7 +1390,14 @@
       },
       "urlPreview": {
         "copiedToPasteBoard": "הקישור הועתק ללוח הגזירים",
-        "convertToLink": "המרה לקישור להטמעה"
+        "convertToLink": "המרה לקישור להטמעה",
+        "pasteAs": {
+          "title": "הדבק בתור",
+          "mention": "אזכור",
+          "url": "URL",
+          "bookmark": "סימנייה",
+          "embed": "הטמעה"
+        }
       },
       "outline": {
         "addHeadingToCreateOutline": "יש להוסיף כותרות ראשיות כדי ליצור תוכן עניינים.",

--- a/src/@types/translations/hu-HU.json
+++ b/src/@types/translations/hu-HU.json
@@ -499,6 +499,15 @@
       },
       "outline": {
         "addHeadingToCreateOutline": "Adjon hozzá címeket a tartalomjegyzék létrehozásához."
+      },
+      "urlPreview": {
+        "pasteAs": {
+          "title": "Beillesztés másként",
+          "mention": "Említés",
+          "url": "URL",
+          "bookmark": "Könyvjelző",
+          "embed": "Beágyazás"
+        }
       }
     },
     "textBlock": {

--- a/src/@types/translations/id-ID.json
+++ b/src/@types/translations/id-ID.json
@@ -693,6 +693,15 @@
         "copy": "Salin",
         "cut": "Potong",
         "paste": "Tempel"
+      },
+      "urlPreview": {
+        "pasteAs": {
+          "title": "Tempel sebagai",
+          "mention": "Sebutan",
+          "url": "URL",
+          "bookmark": "Markah",
+          "embed": "Sematkan"
+        }
       }
     },
     "textBlock": {

--- a/src/@types/translations/it-IT.json
+++ b/src/@types/translations/it-IT.json
@@ -888,7 +888,14 @@
       },
       "urlPreview": {
         "copiedToPasteBoard": "Il link è stato copiato negli appunti",
-        "convertToLink": "Convertire in link da incorporare"
+        "convertToLink": "Convertire in link da incorporare",
+        "pasteAs": {
+          "title": "Incolla come",
+          "mention": "Menzione",
+          "url": "URL",
+          "bookmark": "Segnalibro",
+          "embed": "Incorpora"
+        }
       },
       "outline": {
         "addHeadingToCreateOutline": "Aggiungi intestazioni per creare un sommario.",

--- a/src/@types/translations/ja-JP.json
+++ b/src/@types/translations/ja-JP.json
@@ -1638,7 +1638,14 @@
       },
       "urlPreview": {
         "copiedToPasteBoard": "リンクがクリップボードにコピーされました",
-        "convertToLink": "埋め込みリンクに変換"
+        "convertToLink": "埋め込みリンクに変換",
+        "pasteAs": {
+          "title": "貼り付け形式",
+          "mention": "メンション",
+          "url": "URL",
+          "bookmark": "ブックマーク",
+          "embed": "埋め込み"
+        }
       },
       "outline": {
         "addHeadingToCreateOutline": "目次を作成するには見出しを追加してください。",

--- a/src/@types/translations/ko-KR.json
+++ b/src/@types/translations/ko-KR.json
@@ -1850,7 +1850,14 @@
       },
       "urlPreview": {
         "copiedToPasteBoard": "링크가 클립보드에 복사되었습니다",
-        "convertToLink": "링크로 변환"
+        "convertToLink": "링크로 변환",
+        "pasteAs": {
+          "title": "다음으로 붙여넣기",
+          "mention": "멘션",
+          "url": "URL",
+          "bookmark": "북마크",
+          "embed": "임베드"
+        }
       },
       "outline": {
         "addHeadingToCreateOutline": "목차를 만들려면 헤딩을 추가하세요.",

--- a/src/@types/translations/pl-PL.json
+++ b/src/@types/translations/pl-PL.json
@@ -756,7 +756,16 @@
         "cut": "Wytnij",
         "paste": "Wklej"
       },
-      "action": "Akcje"
+      "action": "Akcje",
+      "urlPreview": {
+        "pasteAs": {
+          "title": "Wklej jako",
+          "mention": "Wzmianka",
+          "url": "URL",
+          "bookmark": "Zakładka",
+          "embed": "Osadź"
+        }
+      }
     },
     "textBlock": {
       "placeholder": "Wpisz „/” dla poleceń"

--- a/src/@types/translations/pt-BR.json
+++ b/src/@types/translations/pt-BR.json
@@ -1094,7 +1094,14 @@
         "copiedToPasteBoard": "O link da imagem foi copiado para a área de transferência"
       },
       "urlPreview": {
-        "copiedToPasteBoard": "O link foi copiado para a área de transferência"
+        "copiedToPasteBoard": "O link foi copiado para a área de transferência",
+        "pasteAs": {
+          "title": "Colar como",
+          "mention": "Menção",
+          "url": "URL",
+          "bookmark": "Favorito",
+          "embed": "Incorporar"
+        }
       },
       "outline": {
         "addHeadingToCreateOutline": "Adicione títulos para criar um sumário."

--- a/src/@types/translations/pt-PT.json
+++ b/src/@types/translations/pt-PT.json
@@ -642,6 +642,15 @@
         "copy": "Cópia",
         "cut": "Corte",
         "paste": "Colar"
+      },
+      "urlPreview": {
+        "pasteAs": {
+          "title": "Colar como",
+          "mention": "Menção",
+          "url": "URL",
+          "bookmark": "Marcador",
+          "embed": "Incorporar"
+        }
       }
     },
     "textBlock": {

--- a/src/@types/translations/ru-RU.json
+++ b/src/@types/translations/ru-RU.json
@@ -1493,7 +1493,14 @@
       },
       "urlPreview": {
         "copiedToPasteBoard": "Ссылка скопирована в буфер обмена",
-        "convertToLink": "Сделать встроенной ссылкой"
+        "convertToLink": "Сделать встроенной ссылкой",
+        "pasteAs": {
+          "title": "Вставить как",
+          "mention": "Упоминание",
+          "url": "URL",
+          "bookmark": "Закладка",
+          "embed": "Встроить"
+        }
       },
       "outline": {
         "addHeadingToCreateOutline": "Добавьте заголовки, чтобы создать оглавление.",

--- a/src/@types/translations/sv-SE.json
+++ b/src/@types/translations/sv-SE.json
@@ -563,6 +563,15 @@
       },
       "outline": {
         "addHeadingToCreateOutline": "Lägg till rubriker för att skapa en innehållsförteckning."
+      },
+      "urlPreview": {
+        "pasteAs": {
+          "title": "Klistra in som",
+          "mention": "Omnämnande",
+          "url": "URL",
+          "bookmark": "Bokmärke",
+          "embed": "Bädda in"
+        }
       }
     },
     "textBlock": {

--- a/src/@types/translations/th-TH.json
+++ b/src/@types/translations/th-TH.json
@@ -1824,7 +1824,14 @@
       },
       "urlPreview": {
         "copiedToPasteBoard": "คัดลอกลิงก์ไปยังคลิปบอร์ดแล้ว",
-        "convertToLink": "แปลงเป็นลิงค์ฝัง"
+        "convertToLink": "แปลงเป็นลิงค์ฝัง",
+        "pasteAs": {
+          "title": "วางเป็น",
+          "mention": "การกล่าวถึง",
+          "url": "URL",
+          "bookmark": "บุ๊กมาร์ก",
+          "embed": "ฝัง"
+        }
       },
       "outline": {
         "addHeadingToCreateOutline": "เพิ่มหัวข้อเพื่อสร้างสารบัญ",

--- a/src/@types/translations/tr-TR.json
+++ b/src/@types/translations/tr-TR.json
@@ -1578,7 +1578,14 @@
       },
       "urlPreview": {
         "copiedToPasteBoard": "Bağlantı panoya kopyalandı",
-        "convertToLink": "Gömülü bağlantıya dönüştür"
+        "convertToLink": "Gömülü bağlantıya dönüştür",
+        "pasteAs": {
+          "title": "Şu olarak yapıştır",
+          "mention": "Bahsetme",
+          "url": "URL",
+          "bookmark": "Yer imi",
+          "embed": "Yerleştir"
+        }
       },
       "outline": {
         "addHeadingToCreateOutline": "İçindekiler tablosu oluşturmak için başlıklar ekleyin.",

--- a/src/@types/translations/uk-UA.json
+++ b/src/@types/translations/uk-UA.json
@@ -1643,7 +1643,14 @@
       },
       "urlPreview": {
         "copiedToPasteBoard": "Посилання скопійовано в буфер обміну",
-        "convertToLink": "Перетворити на вбудоване посилання"
+        "convertToLink": "Перетворити на вбудоване посилання",
+        "pasteAs": {
+          "title": "Вставити як",
+          "mention": "Згадка",
+          "url": "URL",
+          "bookmark": "Закладка",
+          "embed": "Вбудувати"
+        }
       },
       "outline": {
         "addHeadingToCreateOutline": "Додайте заголовки, щоб створити зміст.",

--- a/src/@types/translations/vi-VN.json
+++ b/src/@types/translations/vi-VN.json
@@ -1655,7 +1655,14 @@
       },
       "urlPreview": {
         "copiedToPasteBoard": "Liên kết đã được sao chép vào clipboard",
-        "convertToLink": "Chuyển đổi thành liên kết nhúng"
+        "convertToLink": "Chuyển đổi thành liên kết nhúng",
+        "pasteAs": {
+          "title": "Dán dưới dạng",
+          "mention": "Đề cập",
+          "url": "URL",
+          "bookmark": "Dấu trang",
+          "embed": "Nhúng"
+        }
       },
       "outline": {
         "addHeadingToCreateOutline": "Thêm tiêu đề để tạo mục lục.",

--- a/src/@types/translations/vi.json
+++ b/src/@types/translations/vi.json
@@ -5,5 +5,18 @@
       "showGroupContent": "Bạn có chắc chắn muốn hiển thị nhóm này trên bảng không?",
       "failedToLoad": "Không tải được chế độ xem bảng"
     }
+  },
+  "document": {
+    "plugins": {
+      "urlPreview": {
+        "pasteAs": {
+          "title": "Dán dưới dạng",
+          "mention": "Đề cập",
+          "url": "URL",
+          "bookmark": "Dấu trang",
+          "embed": "Nhúng"
+        }
+      }
+    }
   }
 }

--- a/src/@types/translations/zh-CN.json
+++ b/src/@types/translations/zh-CN.json
@@ -1417,7 +1417,14 @@
         "copiedToPasteBoard": "图片链接已复制到剪贴板"
       },
       "urlPreview": {
-        "copiedToPasteBoard": "链接已复制到剪贴板"
+        "copiedToPasteBoard": "链接已复制到剪贴板",
+        "pasteAs": {
+          "title": "粘贴为",
+          "mention": "提及",
+          "url": "URL",
+          "bookmark": "书签",
+          "embed": "嵌入"
+        }
       },
       "outline": {
         "addHeadingToCreateOutline": "添加标题以创建目录。"

--- a/src/@types/translations/zh-TW.json
+++ b/src/@types/translations/zh-TW.json
@@ -967,7 +967,14 @@
       },
       "urlPreview": {
         "copiedToPasteBoard": "連結已複製到剪貼簿",
-        "convertToLink": "轉換為嵌入鏈接"
+        "convertToLink": "轉換為嵌入鏈接",
+        "pasteAs": {
+          "title": "貼上為",
+          "mention": "提及",
+          "url": "URL",
+          "bookmark": "書籤",
+          "embed": "嵌入"
+        }
       },
       "outline": {
         "addHeadingToCreateOutline": "新增標題以建立目錄。",

--- a/src/application/types.ts
+++ b/src/application/types.ts
@@ -109,8 +109,14 @@ export interface MathEquationBlockData extends BlockData {
   formula?: string;
 }
 
+export enum LinkPreviewType {
+  Bookmark = 'bookmark',
+  Embed = 'embed',
+}
+
 export interface LinkPreviewBlockData extends BlockData {
   url?: string;
+  preview_type?: LinkPreviewType;
 }
 
 export enum FieldURLType {

--- a/src/components/editor/components/blocks/link-preview/LinkPreview.tsx
+++ b/src/components/editor/components/blocks/link-preview/LinkPreview.tsx
@@ -2,6 +2,7 @@ import axios from 'axios';
 import { forwardRef, memo, useEffect, useState } from 'react';
 import { useReadOnly } from 'slate-react';
 
+import { LinkPreviewType } from '@/application/types';
 import emptyImageSrc from '@/assets/images/empty.png';
 import { EditorElementProps, LinkPreviewNode } from '@/components/editor/editor.type';
 
@@ -14,6 +15,8 @@ export const LinkPreview = memo(
     } | null>(null);
     const [notFound, setNotFound] = useState<boolean>(false);
     const url = node.data.url;
+    const previewType = node.data.preview_type ?? LinkPreviewType.Bookmark;
+    const isEmbed = previewType === LinkPreviewType.Embed;
 
     useEffect(() => {
       if (!url) return;
@@ -38,6 +41,7 @@ export const LinkPreview = memo(
       })();
     }, [url]);
     const readOnly = useReadOnly();
+    const imageUrl = data?.image?.url;
 
     return (
       <div
@@ -47,38 +51,67 @@ export const LinkPreview = memo(
         contentEditable={readOnly ? false : undefined}
         {...attributes}
         ref={ref}
-        className={`link-preview-block relative w-full cursor-pointer`}
+        className={'link-preview-block relative w-full min-w-0 cursor-pointer'}
       >
-        <div className={'embed-block items-center p-4'} contentEditable={false}>
+        <div
+          className={`link-preview-card link-preview-card-${previewType} embed-block min-w-0 ${
+            isEmbed ? 'flex-col items-stretch p-0' : 'items-center p-4'
+          }`}
+          contentEditable={false}
+        >
           {notFound ? (
-            <div className={'flex w-full items-center'}>
-              <div
-                className={
-                  'mr-2 flex h-[80px] w-[120px] min-w-[80px] items-center justify-center rounded border text-text-primary'
-                }
-              >
-                <img src={emptyImageSrc} alt={'Empty state'} className={'h-full object-cover object-center'} />
-              </div>
-              <div className={'flex flex-1 flex-col'}>
-                <div className={'text-function-error'}>The link cannot be previewed. Click to open in a new tab.</div>
-                <div className={'text-sm text-text-secondary'}>{url}</div>
+            <div className={`link-preview-not-found flex w-full min-w-0 ${isEmbed ? 'flex-col' : 'items-center'}`}>
+              {!isEmbed && (
+                <div
+                  className={
+                    'link-preview-empty-thumb mr-2 flex h-[80px] w-[120px] min-w-[80px] items-center justify-center rounded border text-text-primary'
+                  }
+                >
+                  <img
+                    src={emptyImageSrc}
+                    alt={'Empty state'}
+                    className={'link-preview-empty-image h-full object-cover object-center'}
+                  />
+                </div>
+              )}
+              <div className={`link-preview-content flex min-w-0 flex-1 flex-col ${isEmbed ? 'p-4' : ''}`}>
+                <div className={'link-preview-title text-function-error'}>
+                  The link cannot be previewed. Click to open in a new tab.
+                </div>
+                <div className={'link-preview-url text-sm text-text-secondary'}>{url}</div>
               </div>
             </div>
           ) : (
             <>
-              <img
-                src={data?.image?.url}
-                alt={''}
-                className={'container max-h-[80px] max-w-[120px] rounded bg-cover bg-center max-sm:w-[25%]'}
-              />
-              <div className={'flex flex-1 flex-col justify-center gap-2 overflow-hidden'}>
-                <div className={'max-h-[48px] overflow-hidden truncate text-base font-bold text-text-primary'}>
+              {imageUrl && (
+                <img
+                  src={imageUrl}
+                  alt={''}
+                  className={
+                    isEmbed
+                      ? 'link-preview-image link-preview-embed-image max-h-[320px] w-full object-cover object-center'
+                      : 'link-preview-image h-[80px] w-[120px] flex-none rounded object-cover object-center max-sm:w-[25%]'
+                  }
+                />
+              )}
+              <div
+                className={`link-preview-content flex min-w-0 flex-1 flex-col justify-center gap-2 overflow-hidden ${
+                  isEmbed ? 'p-4' : ''
+                }`}
+              >
+                <div
+                  className={
+                    'link-preview-title max-h-[48px] overflow-hidden truncate text-base font-bold text-text-primary'
+                  }
+                >
                   {data?.title}
                 </div>
-                <div className={'max-h-[64px] overflow-hidden truncate text-sm text-text-primary'}>
+                <div
+                  className={'link-preview-description max-h-[64px] overflow-hidden truncate text-sm text-text-primary'}
+                >
                   {data?.description}
                 </div>
-                <div className={'truncate whitespace-nowrap text-xs text-text-secondary'}>{url}</div>
+                <div className={'link-preview-url truncate whitespace-nowrap text-xs text-text-secondary'}>{url}</div>
               </div>
             </>
           )}
@@ -89,6 +122,7 @@ export const LinkPreview = memo(
       </div>
     );
   }),
-  (prev, next) => prev.node.data.url === next.node.data.url
+  (prev, next) =>
+    prev.node.data.url === next.node.data.url && prev.node.data.preview_type === next.node.data.preview_type
 );
 export default LinkPreview;

--- a/src/components/editor/components/blocks/simple-table/SimpleTable.tsx
+++ b/src/components/editor/components/blocks/simple-table/SimpleTable.tsx
@@ -42,6 +42,9 @@ const SimpleTable = memo(
         return { width, bgColor };
       });
     }, [columnCount, column_colors, column_widths]);
+    const tableWidth = useMemo(() => {
+      return columns.reduce((sum, column) => sum + column.width, 0);
+    }, [columns]);
     const colGroup = useMemo(() => {
       if (!columns) return null;
       return <colgroup>
@@ -108,7 +111,7 @@ const SimpleTable = memo(
         <SimpleTableContext.Provider value={contextValue}>
           <div className="simple-table-root-wrapper">
             <div className="simple-table-scroll-container">
-              <table>
+              <table style={tableWidth ? { width: `${tableWidth}px` } : undefined}>
                 {colGroup}
                 <tbody>
                 {children}

--- a/src/components/editor/components/blocks/simple-table/simple-table.scss
+++ b/src/components/editor/components/blocks/simple-table/simple-table.scss
@@ -18,6 +18,7 @@
   table {
     border-collapse: separate;
     border-spacing: 0;
+    table-layout: fixed;
   }
 
   td[data-block-type="simple_table_cell"] {

--- a/src/components/editor/components/leaf/href/Href.tsx
+++ b/src/components/editor/components/leaf/href/Href.tsx
@@ -65,7 +65,7 @@ export const Href = memo(({ text, children, leaf, textColor }: { leaf: Text; chi
           backgroundColor: selected ? 'var(--content-blue-100)' : undefined,
           color: textColor || 'var(--text-action)',
         }}
-        className={`cursor-pointer select-auto py-0.5 underline`}
+        className={'href-link cursor-pointer select-auto py-0.5 underline'}
       >
         {children}
         {hovered && (

--- a/src/components/editor/components/panels/PanelsContext.tsx
+++ b/src/components/editor/components/panels/PanelsContext.tsx
@@ -5,12 +5,15 @@ import { ReactEditor } from 'slate-react';
 
 import { SOFT_BREAK_TYPES } from '@/application/slate-yjs/command/const';
 import { BlockType } from '@/application/types';
+import { PASTE_AS_MENU_EVENT } from '@/components/editor/components/panels/paste-as-panel/constants';
+import type { PasteAsMenuPayload } from '@/components/editor/components/panels/paste-as-panel/constants';
 import { getRangeRect } from '@/components/editor/components/toolbar/selection-toolbar/utils';
 
 export enum PanelType {
   Slash = 'slash',
   Mention = 'mention',
   PageReference = 'pageReference',
+  PasteAs = 'pasteAs',
 }
 
 export interface PanelContextType {
@@ -22,6 +25,7 @@ export interface PanelContextType {
   isPanelOpen: (panel: PanelType) => boolean;
   searchText?: string;
   removeContent: () => void;
+  getPasteAsPayload: () => PasteAsMenuPayload | undefined;
 }
 
 export const PanelContext = createContext<PanelContextType | undefined>(undefined);
@@ -35,15 +39,19 @@ export const PanelProvider = ({ children, editor }: { children: React.ReactNode;
   const endSelection = useRef<BaseRange | null>(null);
   const [searchText, setSearchText] = useState('');
   const openRef = useRef(false);
+  const activePanelRef = useRef<PanelType | undefined>(undefined);
+  const pasteAsPayloadRef = useRef<PasteAsMenuPayload | undefined>(undefined);
 
   useEffect(() => {
     openRef.current = activePanel !== undefined;
+    activePanelRef.current = activePanel;
   }, [activePanel]);
 
   const closePanel = useCallback(() => {
     setActivePanel(undefined);
     startSelection.current = null;
     endSelection.current = null;
+    pasteAsPayloadRef.current = undefined;
     setSearchText('');
   }, []);
 
@@ -71,6 +79,7 @@ export const PanelProvider = ({ children, editor }: { children: React.ReactNode;
     (panel: PanelType, position: { top: number; left: number }) => {
       setActivePanel(panel);
       setPanelPosition(position);
+      pasteAsPayloadRef.current = undefined;
       const { selection } = editor;
 
       if (!selection) return;
@@ -80,12 +89,42 @@ export const PanelProvider = ({ children, editor }: { children: React.ReactNode;
     [editor]
   );
 
+  useEffect(() => {
+    const slateDom = ReactEditor.toDOMNode(editor, editor);
+    const handlePasteAsMenu = (event: Event) => {
+      const detail = (event as CustomEvent<PasteAsMenuPayload>).detail;
+
+      if (!detail) return;
+
+      const rect = detail.position ?? getRangeRect();
+
+      if (!rect) return;
+
+      pasteAsPayloadRef.current = detail;
+      setActivePanel(PanelType.PasteAs);
+      setPanelPosition({ top: rect.top, left: rect.left });
+      setSearchText('');
+      startSelection.current = detail.range;
+      endSelection.current = detail.range;
+    };
+
+    slateDom.addEventListener(PASTE_AS_MENU_EVENT, handlePasteAsMenu);
+
+    return () => {
+      slateDom.removeEventListener(PASTE_AS_MENU_EVENT, handlePasteAsMenu);
+    };
+  }, [editor]);
+
   const isPanelOpen = useCallback(
     (panel: PanelType) => {
       return activePanel === panel;
     },
     [activePanel]
   );
+
+  const getPasteAsPayload = useCallback(() => {
+    return pasteAsPayloadRef.current;
+  }, []);
 
   useEffect(() => {
     const { insertText } = editor;
@@ -169,6 +208,7 @@ export const PanelProvider = ({ children, editor }: { children: React.ReactNode;
     editor.onChange = () => {
       onChange();
       if (!openRef.current) return;
+      if (activePanelRef.current === PanelType.PasteAs) return;
       const { selection } = editor;
       let start = startSelection.current?.focus;
 
@@ -262,6 +302,7 @@ export const PanelProvider = ({ children, editor }: { children: React.ReactNode;
       panelPosition,
       searchText,
       removeContent,
+      getPasteAsPayload,
     }),
     [
       activePanel,
@@ -271,6 +312,7 @@ export const PanelProvider = ({ children, editor }: { children: React.ReactNode;
       panelPosition,
       searchText,
       removeContent,
+      getPasteAsPayload,
     ]
   );
 

--- a/src/components/editor/components/panels/index.tsx
+++ b/src/components/editor/components/panels/index.tsx
@@ -7,6 +7,7 @@ import { getRangeRect } from '@/components/editor/components/toolbar/selection-t
 import { createHotkey, HOT_KEY_NAME } from '@/utils/hotkeys';
 
 import { MentionPanel } from './mention-panel';
+import { PasteAsPanel } from './paste-as-panel';
 import { SlashPanel } from './slash-panel';
 
 function Panels () {
@@ -41,6 +42,7 @@ function Panels () {
   return (
     <>
       <MentionPanel />
+      <PasteAsPanel />
       <SlashPanel setEmojiPosition={setEmojiPosition} />
       {createPortal(<CustomIconPopover
         onOpenChange={open => {

--- a/src/components/editor/components/panels/paste-as-panel/PasteAsPanel.tsx
+++ b/src/components/editor/components/panels/paste-as-panel/PasteAsPanel.tsx
@@ -31,6 +31,22 @@ import { isValidVideoUrl, videoTypeData } from '@/utils/video-url';
 import { PasteAsMenuType } from './constants';
 import type { PasteAsMenuPayload } from './constants';
 
+const PASTE_AS_PANEL_WIDTH = 260;
+const PASTE_AS_PANEL_VERTICAL_PADDING = 16;
+const PASTE_AS_PANEL_HEADER_HEIGHT = 24;
+const PASTE_AS_PANEL_OPTION_HEIGHT = 36;
+const PASTE_AS_PANEL_GAP = 4;
+const PASTE_AS_PANEL_EDGE_OFFSET = 16;
+
+function getPasteAsPanelHeight(optionCount: number) {
+  return (
+    PASTE_AS_PANEL_VERTICAL_PADDING +
+    PASTE_AS_PANEL_HEADER_HEIGHT +
+    optionCount * PASTE_AS_PANEL_OPTION_HEIGHT +
+    optionCount * PASTE_AS_PANEL_GAP
+  );
+}
+
 function isValidPasteRange(editor: YjsEditor, payload: PasteAsMenuPayload) {
   const { range, url } = payload;
 
@@ -181,10 +197,16 @@ export function PasteAsPanel() {
   useEffect(() => {
     if (!open || !panelPosition) return;
 
-    const origins = calculateOptimalOrigins(panelPosition, 260, 184, undefined, 16);
+    const origins = calculateOptimalOrigins(
+      panelPosition,
+      PASTE_AS_PANEL_WIDTH,
+      getPasteAsPanelHeight(options.length),
+      undefined,
+      PASTE_AS_PANEL_EDGE_OFFSET
+    );
 
     setTransformOrigin(origins.transformOrigin);
-  }, [open, panelPosition]);
+  }, [open, options.length, panelPosition]);
 
   useEffect(() => {
     if (!open) return;
@@ -239,7 +261,7 @@ export function PasteAsPanel() {
       open={open}
       transformOrigin={transformOrigin}
     >
-      <div className={'flex w-[260px] flex-col gap-1 p-2'}>
+      <div className={'flex flex-col gap-1 p-2'} style={{ width: PASTE_AS_PANEL_WIDTH }}>
         <div className={'px-2 py-1 text-xs font-medium text-text-secondary'}>
           {t('document.plugins.urlPreview.pasteAs.title', { defaultValue: 'Paste as' })}
         </div>

--- a/src/components/editor/components/panels/paste-as-panel/PasteAsPanel.tsx
+++ b/src/components/editor/components/panels/paste-as-panel/PasteAsPanel.tsx
@@ -1,0 +1,267 @@
+import { Button } from '@mui/material';
+import { PopoverOrigin } from '@mui/material/Popover/Popover';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Editor, Transforms } from 'slate';
+import { ReactEditor, useSlateStatic } from 'slate-react';
+
+import { YjsEditor } from '@/application/slate-yjs';
+import { CustomEditor } from '@/application/slate-yjs/command';
+import { findSlateEntryByBlockId, getBlockEntry } from '@/application/slate-yjs/utils/editor';
+import {
+  AlignType,
+  BlockData,
+  BlockType,
+  LinkPreviewBlockData,
+  LinkPreviewType,
+  MentionType,
+  VideoBlockData,
+  VideoType,
+} from '@/application/types';
+import { ReactComponent as AtIcon } from '@/assets/icons/at.svg';
+import { ReactComponent as LinkIcon } from '@/assets/icons/link.svg';
+import { ReactComponent as RefPageIcon } from '@/assets/icons/ref_page.svg';
+import { ReactComponent as VideoIcon } from '@/assets/icons/video.svg';
+import { calculateOptimalOrigins, Popover } from '@/components/_shared/popover';
+import { usePanelContext } from '@/components/editor/components/panels/Panels.hooks';
+import { PanelType } from '@/components/editor/components/panels/PanelsContext';
+import { processUrl } from '@/utils/url';
+import { isValidVideoUrl, videoTypeData } from '@/utils/video-url';
+
+import { PasteAsMenuType } from './constants';
+import type { PasteAsMenuPayload } from './constants';
+
+function isValidPasteRange(editor: YjsEditor, payload: PasteAsMenuPayload) {
+  const { range, url } = payload;
+
+  if (!Editor.hasPath(editor, range.anchor.path) || !Editor.hasPath(editor, range.focus.path)) {
+    return false;
+  }
+
+  return editor.string(range) === url;
+}
+
+export function PasteAsPanel() {
+  const { closePanel, getPasteAsPayload, isPanelOpen, panelPosition } = usePanelContext();
+  const editor = useSlateStatic() as YjsEditor;
+  const { t } = useTranslation();
+  const open = isPanelOpen(PanelType.PasteAs);
+  const [selectedType, setSelectedType] = useState<PasteAsMenuType>(PasteAsMenuType.Mention);
+  const selectedTypeRef = useRef<PasteAsMenuType>(PasteAsMenuType.Mention);
+  const [transformOrigin, setTransformOrigin] = useState<PopoverOrigin | undefined>(undefined);
+
+  const turnIntoBlock = useCallback(
+    (type: BlockType, data: BlockData) => {
+      const block = getBlockEntry(editor);
+
+      if (!block) return;
+
+      const [node] = block;
+      const blockId = node.blockId;
+
+      if (!blockId) return;
+
+      const isEmpty = !CustomEditor.getBlockTextContent(node, 2);
+
+      const newBlockId = isEmpty
+        ? CustomEditor.turnToBlock(editor, blockId, type, data)
+        : CustomEditor.addBelowBlock(editor, blockId, type, data);
+
+      if (newBlockId) {
+        const entry = findSlateEntryByBlockId(editor, newBlockId);
+
+        if (!entry) return;
+
+        ReactEditor.focus(editor);
+        Transforms.select(editor, Editor.start(editor, entry[1]));
+      } else {
+        ReactEditor.focus(editor);
+      }
+    },
+    [editor]
+  );
+
+  const selectPasteRange = useCallback(
+    (payload: PasteAsMenuPayload) => {
+      if (!isValidPasteRange(editor, payload)) return false;
+
+      ReactEditor.focus(editor);
+      Transforms.select(editor, payload.range);
+      return true;
+    },
+    [editor]
+  );
+
+  const handleSelect = useCallback(
+    (type: PasteAsMenuType) => {
+      const payload = getPasteAsPayload();
+
+      closePanel();
+
+      if (!payload || !selectPasteRange(payload)) return;
+
+      if (type === PasteAsMenuType.Url) {
+        Transforms.collapse(editor, { edge: 'end' });
+        return;
+      }
+
+      const url = processUrl(payload.url) || payload.url;
+
+      Transforms.delete(editor);
+
+      if (type === PasteAsMenuType.Mention) {
+        Transforms.insertNodes(
+          editor,
+          {
+            text: '@',
+            mention: {
+              type: MentionType.externalLink,
+              url,
+            },
+          },
+          { select: true, voids: false }
+        );
+        Transforms.collapse(editor, { edge: 'end' });
+        return;
+      }
+
+      if (type === PasteAsMenuType.Embed && isValidVideoUrl(url)) {
+        turnIntoBlock(BlockType.VideoBlock, {
+          url,
+          align: AlignType.Center,
+          ...videoTypeData(VideoType.External),
+        } as VideoBlockData);
+        return;
+      }
+
+      turnIntoBlock(BlockType.LinkPreview, {
+        url,
+        preview_type: type === PasteAsMenuType.Embed ? LinkPreviewType.Embed : LinkPreviewType.Bookmark,
+      } as LinkPreviewBlockData);
+    },
+    [closePanel, editor, getPasteAsPayload, selectPasteRange, turnIntoBlock]
+  );
+
+  const options = useMemo(
+    () => [
+      {
+        icon: <AtIcon />,
+        label: t('document.plugins.urlPreview.pasteAs.mention', { defaultValue: 'Mention' }),
+        type: PasteAsMenuType.Mention,
+      },
+      {
+        icon: <LinkIcon />,
+        label: t('document.plugins.urlPreview.pasteAs.url', { defaultValue: 'URL' }),
+        type: PasteAsMenuType.Url,
+      },
+      {
+        icon: <RefPageIcon />,
+        label: t('document.plugins.urlPreview.pasteAs.bookmark', { defaultValue: 'Bookmark' }),
+        type: PasteAsMenuType.Bookmark,
+      },
+      {
+        icon: <VideoIcon />,
+        label: t('document.plugins.urlPreview.pasteAs.embed', { defaultValue: 'Embed' }),
+        type: PasteAsMenuType.Embed,
+      },
+    ],
+    [t]
+  );
+
+  useEffect(() => {
+    selectedTypeRef.current = selectedType;
+  }, [selectedType]);
+
+  useEffect(() => {
+    if (open) {
+      setSelectedType(PasteAsMenuType.Mention);
+    }
+  }, [open]);
+
+  useEffect(() => {
+    if (!open || !panelPosition) return;
+
+    const origins = calculateOptimalOrigins(panelPosition, 260, 184, undefined, 16);
+
+    setTransformOrigin(origins.transformOrigin);
+  }, [open, panelPosition]);
+
+  useEffect(() => {
+    if (!open) return;
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      const index = options.findIndex((option) => option.type === selectedTypeRef.current);
+
+      switch (e.key) {
+        case 'Enter':
+          e.preventDefault();
+          e.stopPropagation();
+          handleSelect(selectedTypeRef.current);
+          break;
+        case 'ArrowUp':
+        case 'ArrowDown': {
+          e.preventDefault();
+          e.stopPropagation();
+
+          const nextIndex =
+            e.key === 'ArrowDown'
+              ? (index + 1) % options.length
+              : (index - 1 + options.length) % options.length;
+
+          setSelectedType(options[nextIndex].type);
+          break;
+        }
+
+        default:
+          break;
+      }
+    };
+
+    const slateDom = ReactEditor.toDOMNode(editor, editor);
+
+    slateDom.addEventListener('keydown', handleKeyDown);
+    return () => {
+      slateDom.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [editor, handleSelect, open, options]);
+
+  return (
+    <Popover
+      adjustOrigins={false}
+      anchorPosition={panelPosition}
+      anchorReference={'anchorPosition'}
+      data-testid={'paste-as-panel'}
+      disableAutoFocus={true}
+      disableEnforceFocus={true}
+      disableRestoreFocus={true}
+      onClose={closePanel}
+      onMouseDown={(e) => e.preventDefault()}
+      open={open}
+      transformOrigin={transformOrigin}
+    >
+      <div className={'flex w-[260px] flex-col gap-1 p-2'}>
+        <div className={'px-2 py-1 text-xs font-medium text-text-secondary'}>
+          {t('document.plugins.urlPreview.pasteAs.title', { defaultValue: 'Paste as' })}
+        </div>
+        {options.map((option) => (
+          <Button
+            color={'inherit'}
+            data-testid={`paste-as-${option.type}`}
+            key={option.type}
+            onClick={() => handleSelect(option.type)}
+            onMouseEnter={() => setSelectedType(option.type)}
+            size={'small'}
+            startIcon={option.icon}
+            className={`h-9 justify-start hover:bg-fill-content-hover ${
+              selectedType === option.type ? 'bg-fill-content-hover' : ''
+            }`}
+          >
+            {option.label}
+          </Button>
+        ))}
+      </div>
+    </Popover>
+  );
+}
+
+export default PasteAsPanel;

--- a/src/components/editor/components/panels/paste-as-panel/constants.ts
+++ b/src/components/editor/components/panels/paste-as-panel/constants.ts
@@ -1,0 +1,19 @@
+import type { Range } from 'slate';
+
+export const PASTE_AS_MENU_EVENT = 'appflowy:paste-as-menu';
+
+export enum PasteAsMenuType {
+  Mention = 'mention',
+  Url = 'url',
+  Bookmark = 'bookmark',
+  Embed = 'embed',
+}
+
+export interface PasteAsMenuPayload {
+  url: string;
+  range: Range;
+  position?: {
+    top: number;
+    left: number;
+  };
+}

--- a/src/components/editor/components/panels/paste-as-panel/index.ts
+++ b/src/components/editor/components/panels/paste-as-panel/index.ts
@@ -1,0 +1,2 @@
+export * from './PasteAsPanel';
+export * from './constants';

--- a/src/components/editor/editor.scss
+++ b/src/components/editor/editor.scss
@@ -137,6 +137,63 @@
   }
 }
 
+.block-element[data-block-type="table/cell"],
+td[data-block-type="simple_table_cell"] {
+  .href-link {
+    overflow-wrap: anywhere;
+    word-break: break-word;
+  }
+
+  .block-element[data-block-type="link_preview"],
+  .link-preview-block,
+  .link-preview-card,
+  .link-preview-not-found,
+  .link-preview-content {
+    min-width: 0;
+    max-width: 100%;
+  }
+
+  .block-element[data-block-type="link_preview"],
+  .link-preview-block,
+  .link-preview-card {
+    width: 100%;
+    box-sizing: border-box;
+  }
+
+  .link-preview-card {
+    overflow: hidden;
+  }
+
+  .link-preview-card-bookmark {
+    gap: 8px;
+    padding: 8px;
+  }
+
+  .link-preview-card-bookmark .link-preview-image,
+  .link-preview-card-bookmark .link-preview-empty-thumb {
+    width: min(96px, 40%);
+    min-width: 0;
+    flex-shrink: 1;
+  }
+
+  .link-preview-title,
+  .link-preview-description,
+  .link-preview-url {
+    overflow: hidden;
+    overflow-wrap: anywhere;
+    text-overflow: ellipsis;
+    word-break: break-word;
+  }
+
+  .link-preview-url {
+    white-space: normal;
+  }
+
+  .link-preview-card-embed .link-preview-embed-image {
+    max-height: 220px;
+  }
+}
+
 .text-element {
   z-index: 2;
 }

--- a/src/components/editor/plugins/withInsertData.ts
+++ b/src/components/editor/plugins/withInsertData.ts
@@ -26,6 +26,7 @@ import { convertSlateFragmentTo } from '@/components/editor/utils/fragment';
 import { FileHandler } from '@/utils/file';
 import { Log } from '@/utils/log';
 import { createPendingUploadId } from '@/utils/pending-upload';
+import { processUrl } from '@/utils/url';
 
 type BlockElement = Element & { blockId?: string };
 
@@ -45,10 +46,17 @@ export const withInsertData = (editor: ReactEditor) => {
     if (tableCheckBlockId && isInsideSimpleTableCell(e, tableCheckBlockId)) {
       // Check plain text for TSV (tab-separated values)
       const plainText = data.getData('text/plain')?.trim();
+      const singleURLText = getSingleURLTextFromClipboard(data);
 
       if (plainText && plainText.includes('\t')) {
         // Delegate to insertTextData which has our TSV handler
         const handled = editor.insertTextData(data);
+
+        if (handled) return;
+      }
+
+      if (singleURLText) {
+        const handled = editor.insertTextData(createTextDataTransfer(singleURLText, data.getData('text/html')));
 
         if (handled) return;
       }
@@ -282,6 +290,37 @@ export const withInsertData = (editor: ReactEditor) => {
   return editor;
 };
 
+function isSingleURLText(text: string): boolean {
+  if (text.split(/\r\n|\r|\n/).filter(Boolean).length !== 1) return false;
+
+  return Boolean(processUrl(text));
+}
+
+function getSingleURLTextFromClipboard(data: DataTransfer): string | undefined {
+  const plainText = data.getData('text/plain')?.trim();
+
+  if (plainText && isSingleURLText(plainText)) return plainText;
+
+  const html = data.getData('text/html')?.trim();
+
+  if (!html) return undefined;
+
+  try {
+    const doc = new DOMParser().parseFromString(html, 'text/html');
+    const textContent = doc.body.textContent?.trim();
+
+    if (textContent && isSingleURLText(textContent)) return textContent;
+
+    const href = doc.querySelector('a[href]')?.getAttribute('href')?.trim();
+
+    if (href && isSingleURLText(href)) return href;
+  } catch {
+    return undefined;
+  }
+
+  return undefined;
+}
+
 /**
  * When Slate copies content, it encodes the full Slate fragment as a base64
  * blob in the `data-slate-fragment` HTML attribute. The system clipboard
@@ -424,8 +463,17 @@ function insertFragmentAsSiblings(editor: YjsEditor, fragment: Node[]): boolean 
  * Create a DataTransfer object with TSV text data.
  */
 function createTSVDataTransfer(tsv: string): DataTransfer {
+  return createTextDataTransfer(tsv);
+}
+
+function createTextDataTransfer(text: string, html?: string): DataTransfer {
   const dt = new DataTransfer();
 
-  dt.setData('text/plain', tsv);
+  dt.setData('text/plain', text);
+
+  if (html) {
+    dt.setData('text/html', html);
+  }
+
   return dt;
 }

--- a/src/components/editor/plugins/withInsertData.ts
+++ b/src/components/editor/plugins/withInsertData.ts
@@ -26,7 +26,7 @@ import { convertSlateFragmentTo } from '@/components/editor/utils/fragment';
 import { FileHandler } from '@/utils/file';
 import { Log } from '@/utils/log';
 import { createPendingUploadId } from '@/utils/pending-upload';
-import { processUrl } from '@/utils/url';
+import { isSingleURLText } from '@/utils/url';
 
 type BlockElement = Element & { blockId?: string };
 
@@ -75,7 +75,7 @@ export const withInsertData = (editor: ReactEditor) => {
             const texts = extractTSVFromTableFragment(parsed);
 
             if (texts) {
-              const handled = editor.insertTextData(createTSVDataTransfer(texts));
+              const handled = editor.insertTextData(createTextDataTransfer(texts));
 
               if (handled) return;
             }
@@ -89,7 +89,7 @@ export const withInsertData = (editor: ReactEditor) => {
         const texts = extractTSVFromTableFragment(parsedFragment);
 
         if (texts) {
-          const handled = editor.insertTextData(createTSVDataTransfer(texts));
+          const handled = editor.insertTextData(createTextDataTransfer(texts));
 
           if (handled) return;
         }
@@ -290,12 +290,6 @@ export const withInsertData = (editor: ReactEditor) => {
   return editor;
 };
 
-function isSingleURLText(text: string): boolean {
-  if (text.split(/\r\n|\r|\n/).filter(Boolean).length !== 1) return false;
-
-  return Boolean(processUrl(text));
-}
-
 function getSingleURLTextFromClipboard(data: DataTransfer): string | undefined {
   const plainText = data.getData('text/plain')?.trim();
 
@@ -457,13 +451,6 @@ function insertFragmentAsSiblings(editor: YjsEditor, fragment: Node[]): boolean 
     Log.error('insertFragmentAsSiblings failed', err);
     return false;
   }
-}
-
-/**
- * Create a DataTransfer object with TSV text data.
- */
-function createTSVDataTransfer(tsv: string): DataTransfer {
-  return createTextDataTransfer(tsv);
 }
 
 function createTextDataTransfer(text: string, html?: string): DataTransfer {

--- a/src/components/editor/plugins/withPasted.ts
+++ b/src/components/editor/plugins/withPasted.ts
@@ -3,6 +3,7 @@ import { ReactEditor } from 'slate-react';
 import isURL from 'validator/lib/isURL';
 
 import { YjsEditor } from '@/application/slate-yjs';
+import { EditorMarkFormat } from '@/application/slate-yjs/types';
 import { SOFT_BREAK_TYPES } from '@/application/slate-yjs/command/const';
 import { slateContentInsertToYData } from '@/application/slate-yjs/utils/convert';
 import { getBlockEntry, getSharedRoot, getParentSimpleTableCellBlockId, isInsideSimpleTableCell } from '@/application/slate-yjs/utils/editor';
@@ -16,7 +17,7 @@ import { PASTE_AS_MENU_EVENT } from '@/components/editor/components/panels/paste
 import type { PasteAsMenuPayload } from '@/components/editor/components/panels/paste-as-panel/constants';
 import { getRangeRect } from '@/components/editor/components/toolbar/selection-toolbar/utils';
 import { detectMarkdown, detectTSV } from '@/components/editor/utils/markdown-detector';
-import { processUrl } from '@/utils/url';
+import { isSingleURLText, processUrl } from '@/utils/url';
 import { isValidVideoUrl, videoTypeData } from '@/utils/video-url';
 
 /**
@@ -132,12 +133,6 @@ function extractCellTextsFromHTML(html: string): string[][] {
   } catch {
     return [];
   }
-}
-
-function isSingleURLText(text: string): boolean {
-  if (text.split(/\r\n|\r|\n/).filter(Boolean).length !== 1) return false;
-
-  return Boolean(processUrl(text));
 }
 
 /**
@@ -523,11 +518,13 @@ function insertLinkedURLTextAndShowPasteAsMenu(editor: ReactEditor, url: string)
 
   if (!point) return false;
 
-  Transforms.insertNodes(editor, { text: url, href }, { at: point, select: true, voids: false });
+  editor.insertText(url);
 
   const insertedRange = getInsertedURLRange(editor, url, point);
 
   if (insertedRange) {
+    Transforms.select(editor, insertedRange);
+    editor.addMark(EditorMarkFormat.Href, href);
     Transforms.select(editor, insertedRange);
     Transforms.collapse(editor, { edge: 'end' });
     dispatchPasteAsMenuEvent(editor, { url, range: insertedRange });

--- a/src/components/editor/plugins/withPasted.ts
+++ b/src/components/editor/plugins/withPasted.ts
@@ -1,4 +1,4 @@
-import { BasePoint, Element, Text, Transforms } from 'slate';
+import { BasePoint, Editor, Element, Range, Text, Transforms } from 'slate';
 import { ReactEditor } from 'slate-react';
 import isURL from 'validator/lib/isURL';
 
@@ -12,6 +12,9 @@ import { parseHTML } from '@/components/editor/parsers/html-parser';
 import { parseMarkdown } from '@/components/editor/parsers/markdown-parser';
 import { parseTSVTable } from '@/components/editor/parsers/table-parser';
 import { ParsedBlock } from '@/components/editor/parsers/types';
+import { PASTE_AS_MENU_EVENT } from '@/components/editor/components/panels/paste-as-panel/constants';
+import type { PasteAsMenuPayload } from '@/components/editor/components/panels/paste-as-panel/constants';
+import { getRangeRect } from '@/components/editor/components/toolbar/selection-toolbar/utils';
 import { detectMarkdown, detectTSV } from '@/components/editor/utils/markdown-detector';
 import { processUrl } from '@/utils/url';
 import { isValidVideoUrl, videoTypeData } from '@/utils/video-url';
@@ -73,6 +76,10 @@ export const withPasted = (editor: ReactEditor) => {
             return handlePasteIntoTableCells(editor as YjsEditor, blockId, tsvText);
           }
         }
+
+        if (plainText && isSingleURLText(plainText)) {
+          return handleURLPaste(editor, plainText);
+        }
       }
     }
 
@@ -125,6 +132,12 @@ function extractCellTextsFromHTML(html: string): string[][] {
   } catch {
     return [];
   }
+}
+
+function isSingleURLText(text: string): boolean {
+  if (text.split(/\r\n|\r|\n/).filter(Boolean).length !== 1) return false;
+
+  return Boolean(processUrl(text));
 }
 
 /**
@@ -292,10 +305,11 @@ function handlePlainTextPaste(editor: ReactEditor, text: string): boolean {
 
   // Special case: Single line
   if (lineLength === 1) {
-    const isUrl = !!processUrl(text);
+    const pastedText = text.trim();
+    const isUrl = !!processUrl(pastedText);
 
     if (isUrl) {
-      return handleURLPaste(editor, text);
+      return handleURLPaste(editor, pastedText);
     }
 
     // Check if it's Markdown (even for single line)
@@ -402,6 +416,10 @@ function handleURLPaste(editor: ReactEditor, url: string): boolean {
     }
   }
 
+  if (isPastingInsideSimpleTableCell(editor)) {
+    return insertLinkedURLTextAndShowPasteAsMenu(editor, url);
+  }
+
   // Check for video URLs
   const isVideoUrl = isValidVideoUrl(url);
 
@@ -417,6 +435,105 @@ function handleURLPaste(editor: ReactEditor, url: string): boolean {
     type: BlockType.LinkPreview,
     data: { url } as LinkPreviewBlockData,
   });
+}
+
+function isPastingInsideSimpleTableCell(editor: ReactEditor): boolean {
+  const entry = getBlockEntry(editor as YjsEditor);
+  const blockId = entry?.[0].blockId;
+
+  return Boolean(blockId && isInsideSimpleTableCell(editor as YjsEditor, blockId));
+}
+
+function cloneRange(range: Range): Range {
+  return {
+    anchor: {
+      path: [...range.anchor.path],
+      offset: range.anchor.offset,
+    },
+    focus: {
+      path: [...range.focus.path],
+      offset: range.focus.offset,
+    },
+  };
+}
+
+function getInsertedURLRange(editor: ReactEditor, url: string, insertionPoint: BasePoint): Range | undefined {
+  const selection = editor.selection;
+
+  if (selection && editor.string(selection) === url) {
+    return cloneRange(selection);
+  }
+
+  const end = selection ? Range.end(selection) : { path: insertionPoint.path, offset: insertionPoint.offset + url.length };
+  const start = {
+    path: [...end.path],
+    offset: Math.max(0, end.offset - url.length),
+  };
+  const fallbackRange: Range = {
+    anchor: start,
+    focus: {
+      path: [...end.path],
+      offset: end.offset,
+    },
+  };
+
+  if (Editor.hasPath(editor, start.path) && editor.string(fallbackRange) === url) {
+    return fallbackRange;
+  }
+
+  return undefined;
+}
+
+function dispatchPasteAsMenuEvent(editor: ReactEditor, payload: Omit<PasteAsMenuPayload, 'position'>) {
+  window.setTimeout(() => {
+    try {
+      const rect = getRangeRect();
+      const position = rect
+        ? {
+            top: rect.bottom + 4,
+            left: rect.left,
+          }
+        : undefined;
+      const editorDom = ReactEditor.toDOMNode(editor, editor);
+
+      editorDom.dispatchEvent(
+        new CustomEvent<PasteAsMenuPayload>(PASTE_AS_MENU_EVENT, {
+          detail: {
+            ...payload,
+            position,
+          },
+        })
+      );
+    } catch (error) {
+      console.error('Error showing paste-as menu:', error);
+    }
+  });
+}
+
+function insertLinkedURLTextAndShowPasteAsMenu(editor: ReactEditor, url: string): boolean {
+  const href = processUrl(url) || url;
+
+  if (!editor.selection) return false;
+
+  if (Range.isExpanded(editor.selection)) {
+    Transforms.delete(editor);
+  }
+
+  const point = editor.selection?.anchor as BasePoint | undefined;
+
+  if (!point) return false;
+
+  Transforms.insertNodes(editor, { text: url, href }, { at: point, select: true, voids: false });
+
+  const insertedRange = getInsertedURLRange(editor, url, point);
+
+  if (insertedRange) {
+    Transforms.select(editor, insertedRange);
+    Transforms.collapse(editor, { edge: 'end' });
+    dispatchPasteAsMenuEvent(editor, { url, range: insertedRange });
+  }
+
+  return true;
 }
 
 /**

--- a/src/slate-editor.d.ts
+++ b/src/slate-editor.d.ts
@@ -27,6 +27,12 @@ interface EditorInlineAttributes {
     date?: string;
     reminder_id?: string;
     reminder_option?: string;
+    include_time?: boolean;
+    // external link
+    url?: string;
+    // mention person
+    person_id?: string;
+    person_name?: string;
   };
   af_text_color?: string;
   af_background_color?: string;

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -15,6 +15,15 @@ export function isValidUrl(input: string) {
   return isURL(input, { require_protocol: true, require_host: false });
 }
 
+export function isSingleURLText(input: string) {
+  const trimmed = input.trim();
+
+  if (!trimmed) return false;
+  if (trimmed.split(/\r\n|\r|\n/).filter(Boolean).length !== 1) return false;
+
+  return Boolean(processUrl(trimmed));
+}
+
 // Process the URL to make sure it's a valid URL
 // If it's not a valid URL(eg: 'appflowy.io' or '192.168.1.2'), we'll add 'https://' to the URL
 export function processUrl(input: string) {


### PR DESCRIPTION
## Summary
- add a Paste as menu for single URL pastes in simple table cells
- support URL, Mention, Bookmark, and Embed layout conversions
- keep simple table column widths stable when links and previews are inserted
- cover plain URL and HTML link clipboard paths in simple table tests

## Tests
- `pnpm exec tsc --noEmit --project tsconfig.web.json --pretty false`
- `pnpm exec eslint --quiet --ext .ts,.tsx` on changed source files
- `pnpm exec playwright test playwright/e2e/page/simple-table.spec.ts -g "paste-as|mentions in table cells|HTML links in table cells|should create a 2x2 table via /table slash command|set to page width should divide page width equally among columns" --project=chromium`

Related to #53

## Summary by Sourcery

Add a contextual "paste as" menu for URL pastes inside simple table cells, enabling different URL representations while preserving table layout and link preview behavior.

New Features:
- Introduce a paste-as panel that lets users convert pasted URLs into mentions, plain URLs, bookmarks, or embeds.
- Support URL-to-mention conversion for external links, including inside simple table cells.
- Allow turning pasted URLs into link preview blocks with configurable bookmark or embed layouts.

Enhancements:
- Ensure link previews and href links wrap and size correctly inside table and simple table cells without expanding column widths.
- Stabilize simple table widths by fixing table layout and deriving table width from column definitions.
- Refine link preview rendering to support distinct bookmark vs embed styling and avoid unnecessary re-renders based on preview type.

Tests:
- Extend simple table Playwright tests to cover paste-as behavior, mentions, and HTML link pasting in table cells.