### PR TITLE
feat: support copy link to block render

### DIFF
--- a/src/components/editor/components/toolbar/block-controls/HoverControls.hooks.ts
+++ b/src/components/editor/components/toolbar/block-controls/HoverControls.hooks.ts
@@ -9,6 +9,32 @@ import { getScrollParent } from '@/components/global-comment/utils';
 
 import { findEventNode, getBlockActionsPosition, getBlockCssProperty } from './utils';
 
+const TABLE_ROOT_TYPES = [BlockType.TableBlock, BlockType.SimpleTableBlock];
+
+export function getTableHoverControlsRoot(blockElement: HTMLElement) {
+  for (const type of TABLE_ROOT_TYPES) {
+    const tableRoot = blockElement.closest(`[data-block-type="${type}"]`);
+
+    if (tableRoot instanceof HTMLElement) {
+      return tableRoot;
+    }
+  }
+
+  return null;
+}
+
+export function shouldShowHoverControlsForBlock(node: Element, blockElement: HTMLElement) {
+  for (const type of TABLE_ROOT_TYPES) {
+    const tableRoot = blockElement.closest(`[data-block-type="${type}"]`);
+
+    if (tableRoot && node.type !== type) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
 export function useHoverControls({ disabled }: { disabled: boolean }) {
   const editor = useSlateStatic() as YjsEditor;
   const ref = useRef<HTMLDivElement>(null);
@@ -128,12 +154,26 @@ export function useHoverControls({ disabled }: { disabled: boolean }) {
         return;
       }
 
-      const blockElement = ReactEditor.toDOMNode(editor, node);
+      let blockElement = ReactEditor.toDOMNode(editor, node);
 
       if (!blockElement) return;
-      const shouldSkipParentTypes = [BlockType.TableBlock, BlockType.SimpleTableBlock];
+      const tableRootElement = getTableHoverControlsRoot(blockElement);
 
-      if (shouldSkipParentTypes.some((type) => blockElement.closest(`[data-block-type="${type}"]`))) {
+      if (tableRootElement) {
+        try {
+          const tableRootNode = ReactEditor.toSlateNode(editor, tableRootElement);
+
+          if (Element.isElement(tableRootNode)) {
+            node = tableRootNode;
+            blockElement = tableRootElement;
+          }
+        } catch {
+          close();
+          return;
+        }
+      }
+
+      if (!shouldShowHoverControlsForBlock(node, blockElement)) {
         close();
         return;
       }

--- a/src/components/editor/components/toolbar/block-controls/HoverControls.hooks.ts
+++ b/src/components/editor/components/toolbar/block-controls/HoverControls.hooks.ts
@@ -24,15 +24,11 @@ export function getTableHoverControlsRoot(blockElement: HTMLElement) {
 }
 
 export function shouldShowHoverControlsForBlock(node: Element, blockElement: HTMLElement) {
-  for (const type of TABLE_ROOT_TYPES) {
-    const tableRoot = blockElement.closest(`[data-block-type="${type}"]`);
+  const tableRoot = getTableHoverControlsRoot(blockElement);
 
-    if (tableRoot && node.type !== type) {
-      return false;
-    }
-  }
+  if (!tableRoot) return true;
 
-  return true;
+  return tableRoot.getAttribute('data-block-type') === node.type;
 }
 
 export function useHoverControls({ disabled }: { disabled: boolean }) {

--- a/src/components/editor/components/toolbar/block-controls/__tests__/HoverControls.hooks.test.ts
+++ b/src/components/editor/components/toolbar/block-controls/__tests__/HoverControls.hooks.test.ts
@@ -1,0 +1,46 @@
+import { Element } from 'slate';
+
+import { BlockType } from '@/application/types';
+import {
+  getTableHoverControlsRoot,
+  shouldShowHoverControlsForBlock,
+} from '@/components/editor/components/toolbar/block-controls/HoverControls.hooks';
+
+describe('shouldShowHoverControlsForBlock', () => {
+  const createBlockElement = (type: BlockType, parent?: HTMLElement) => {
+    const element = document.createElement('div');
+
+    element.setAttribute('data-block-type', type);
+    parent?.appendChild(element);
+
+    return element;
+  };
+
+  const createNode = (type: BlockType): Element => ({
+    type,
+    blockId: `${type}-block`,
+    data: {},
+    children: [{ text: '' }],
+  } as Element);
+
+  it('shows controls for the simple table root block', () => {
+    const tableElement = createBlockElement(BlockType.SimpleTableBlock);
+
+    expect(shouldShowHoverControlsForBlock(createNode(BlockType.SimpleTableBlock), tableElement)).toBe(true);
+  });
+
+  it('hides controls for blocks inside a simple table', () => {
+    const tableElement = createBlockElement(BlockType.SimpleTableBlock);
+    const paragraphElement = createBlockElement(BlockType.Paragraph, tableElement);
+
+    expect(shouldShowHoverControlsForBlock(createNode(BlockType.Paragraph), paragraphElement)).toBe(false);
+  });
+
+  it('uses the simple table root as the controls target for nested blocks', () => {
+    const tableElement = createBlockElement(BlockType.SimpleTableBlock);
+    const cellElement = createBlockElement(BlockType.SimpleTableCellBlock, tableElement);
+    const paragraphElement = createBlockElement(BlockType.Paragraph, cellElement);
+
+    expect(getTableHoverControlsRoot(paragraphElement)).toBe(tableElement);
+  });
+});

--- a/src/components/editor/plugins/__tests__/withPasted.test.ts
+++ b/src/components/editor/plugins/__tests__/withPasted.test.ts
@@ -1,0 +1,38 @@
+import { parseAppFlowyBlockLink, getSingleURLTextFromClipboardData } from '../appflowy-block-link';
+
+function createClipboardData(data: Record<string, string>): Pick<DataTransfer, 'getData'> {
+  return {
+    getData: jest.fn((type: string) => data[type] ?? ''),
+  };
+}
+
+describe('withPasted AppFlowy block link support', () => {
+  const blockLink =
+    'https://test.appflowy.com/app/6f79bb5a-d432-4155-84a0-2e5c44f2cd51/21191004-0b3d-497e-b17c-ac65fa82c78a?blockId=wsZx6I';
+
+  it('parses desktop copy-link-to-block URLs by AppFlowy route shape, independent of host', () => {
+    expect(parseAppFlowyBlockLink(blockLink)).toEqual({
+      pageId: '21191004-0b3d-497e-b17c-ac65fa82c78a',
+      blockId: 'wsZx6I',
+    });
+  });
+
+  it('reads a single AppFlowy block link from URI clipboard formats before HTML paste handling', () => {
+    expect(
+      getSingleURLTextFromClipboardData(
+        createClipboardData({
+          'text/uri-list': blockLink,
+          'text/html': `<ul><li><a href="${blockLink}"></a></li></ul>`,
+        })
+      )
+    ).toBe(blockLink);
+  });
+
+  it('ignores AppFlowy page URLs without blockId', () => {
+    expect(
+      parseAppFlowyBlockLink(
+        'https://test.appflowy.com/app/6f79bb5a-d432-4155-84a0-2e5c44f2cd51/21191004-0b3d-497e-b17c-ac65fa82c78a'
+      )
+    ).toBeNull();
+  });
+});

--- a/src/components/editor/plugins/__tests__/withPasted.test.ts
+++ b/src/components/editor/plugins/__tests__/withPasted.test.ts
@@ -10,11 +10,19 @@ describe('withPasted AppFlowy block link support', () => {
   const blockLink =
     'https://test.appflowy.com/app/6f79bb5a-d432-4155-84a0-2e5c44f2cd51/21191004-0b3d-497e-b17c-ac65fa82c78a?blockId=wsZx6I';
 
-  it('parses desktop copy-link-to-block URLs by AppFlowy route shape, independent of host', () => {
+  it('parses desktop copy-link-to-block URLs by AppFlowy route shape', () => {
     expect(parseAppFlowyBlockLink(blockLink)).toEqual({
       pageId: '21191004-0b3d-497e-b17c-ac65fa82c78a',
       blockId: 'wsZx6I',
     });
+  });
+
+  it('parses block links only for the expected host when host validation is provided', () => {
+    expect(parseAppFlowyBlockLink(blockLink, 'test.appflowy.com')).toEqual({
+      pageId: '21191004-0b3d-497e-b17c-ac65fa82c78a',
+      blockId: 'wsZx6I',
+    });
+    expect(parseAppFlowyBlockLink(blockLink, 'evil.example.com')).toBeNull();
   });
 
   it('reads a single AppFlowy block link from URI clipboard formats before HTML paste handling', () => {

--- a/src/components/editor/plugins/appflowy-block-link.ts
+++ b/src/components/editor/plugins/appflowy-block-link.ts
@@ -1,0 +1,98 @@
+export interface AppFlowyBlockLink {
+  pageId: string;
+  blockId: string;
+}
+
+const UUID_PATTERN = '[0-9a-fA-F-]{36}';
+const APPFLOWY_BLOCK_LINK_PATTERN = new RegExp(
+  `^https?://[^/]+/app/(${UUID_PATTERN})/(${UUID_PATTERN})(?:[?#][^\\s]*)?$`
+);
+
+export function parseAppFlowyBlockLink(url: string): AppFlowyBlockLink | null {
+  const trimmed = url.trim();
+  const match = APPFLOWY_BLOCK_LINK_PATTERN.exec(trimmed);
+
+  if (!match) return null;
+
+  let parsedUrl: URL;
+
+  try {
+    parsedUrl = new URL(trimmed);
+  } catch {
+    return null;
+  }
+
+  const blockId = parsedUrl.searchParams.get('blockId');
+
+  if (!blockId) return null;
+
+  return {
+    pageId: match[2],
+    blockId,
+  };
+}
+
+export function getSingleURLTextFromClipboardData(data: Pick<DataTransfer, 'getData'>): string | undefined {
+  return (
+    getSingleURLText(getClipboardData(data, 'text/plain')) ??
+    getSingleURLTextFromUriList(getClipboardData(data, 'text/uri-list')) ??
+    getSingleURLTextFromHTML(getClipboardData(data, 'text/html'))
+  );
+}
+
+function getClipboardData(data: Pick<DataTransfer, 'getData'>, type: string): string {
+  try {
+    return data.getData(type) || '';
+  } catch {
+    return '';
+  }
+}
+
+function getSingleURLText(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+
+  if (!trimmed) return undefined;
+  if (trimmed.split(/\r\n|\r|\n/).filter(Boolean).length !== 1) return undefined;
+
+  return isHTTPURL(trimmed) ? trimmed : undefined;
+}
+
+function getSingleURLTextFromUriList(value: string | undefined): string | undefined {
+  const urls = value
+    ?.split(/\r\n|\r|\n/)
+    .map((line) => line.trim())
+    .filter((line) => line && !line.startsWith('#'));
+
+  if (!urls || urls.length !== 1) return undefined;
+
+  return isHTTPURL(urls[0]) ? urls[0] : undefined;
+}
+
+function getSingleURLTextFromHTML(html: string | undefined): string | undefined {
+  const trimmed = html?.trim();
+
+  if (!trimmed || typeof DOMParser === 'undefined') return undefined;
+
+  try {
+    const doc = new DOMParser().parseFromString(trimmed, 'text/html');
+    const text = getSingleURLText(doc.body.textContent ?? undefined);
+
+    if (text) return text;
+
+    const href = doc.querySelector('a[href]')?.getAttribute('href')?.trim();
+
+    return getSingleURLText(href);
+  } catch {
+    return undefined;
+  }
+}
+
+function isHTTPURL(value: string): boolean {
+  try {
+    const url = new URL(value);
+
+    return url.protocol === 'http:' || url.protocol === 'https:';
+  } catch {
+    return false;
+  }
+}

--- a/src/components/editor/plugins/appflowy-block-link.ts
+++ b/src/components/editor/plugins/appflowy-block-link.ts
@@ -3,31 +3,28 @@ export interface AppFlowyBlockLink {
   blockId: string;
 }
 
-const UUID_PATTERN = '[0-9a-fA-F-]{36}';
-const APPFLOWY_BLOCK_LINK_PATTERN = new RegExp(
-  `^https?://[^/]+/app/(${UUID_PATTERN})/(${UUID_PATTERN})(?:[?#][^\\s]*)?$`
-);
-
-export function parseAppFlowyBlockLink(url: string): AppFlowyBlockLink | null {
-  const trimmed = url.trim();
-  const match = APPFLOWY_BLOCK_LINK_PATTERN.exec(trimmed);
-
-  if (!match) return null;
-
+export function parseAppFlowyBlockLink(raw: string, expectedHostname?: string): AppFlowyBlockLink | null {
   let parsedUrl: URL;
 
   try {
-    parsedUrl = new URL(trimmed);
+    parsedUrl = new URL(raw.trim());
   } catch {
     return null;
   }
+
+  if (!isHttpUrl(parsedUrl)) return null;
+  if (expectedHostname && parsedUrl.hostname !== expectedHostname) return null;
+
+  const segments = parsedUrl.pathname.split('/').filter(Boolean);
+
+  if (segments.length !== 3 || segments[0] !== 'app') return null;
 
   const blockId = parsedUrl.searchParams.get('blockId');
 
   if (!blockId) return null;
 
   return {
-    pageId: match[2],
+    pageId: segments[2],
     blockId,
   };
 }
@@ -49,23 +46,11 @@ function getClipboardData(data: Pick<DataTransfer, 'getData'>, type: string): st
 }
 
 function getSingleURLText(value: string | undefined): string | undefined {
-  const trimmed = value?.trim();
-
-  if (!trimmed) return undefined;
-  if (trimmed.split(/\r\n|\r|\n/).filter(Boolean).length !== 1) return undefined;
-
-  return isHTTPURL(trimmed) ? trimmed : undefined;
+  return pickSingleHttpUrl(value?.split(/\r\n|\r|\n/));
 }
 
 function getSingleURLTextFromUriList(value: string | undefined): string | undefined {
-  const urls = value
-    ?.split(/\r\n|\r|\n/)
-    .map((line) => line.trim())
-    .filter((line) => line && !line.startsWith('#'));
-
-  if (!urls || urls.length !== 1) return undefined;
-
-  return isHTTPURL(urls[0]) ? urls[0] : undefined;
+  return pickSingleHttpUrl(value?.split(/\r\n|\r|\n/).filter((line) => !line.trim().startsWith('#')));
 }
 
 function getSingleURLTextFromHTML(html: string | undefined): string | undefined {
@@ -75,24 +60,38 @@ function getSingleURLTextFromHTML(html: string | undefined): string | undefined 
 
   try {
     const doc = new DOMParser().parseFromString(trimmed, 'text/html');
-    const text = getSingleURLText(doc.body.textContent ?? undefined);
+    const text = pickSingleHttpUrl(doc.body.textContent?.split(/\r\n|\r|\n/));
 
     if (text) return text;
 
     const href = doc.querySelector('a[href]')?.getAttribute('href')?.trim();
 
-    return getSingleURLText(href);
+    return pickSingleHttpUrl(href ? [href] : undefined);
   } catch {
     return undefined;
   }
 }
 
-function isHTTPURL(value: string): boolean {
+function pickSingleHttpUrl(lines: string[] | undefined): string | undefined {
+  const normalized = lines?.map((line) => line.trim()).filter(Boolean);
+
+  if (!normalized || normalized.length !== 1) return undefined;
+
+  return tryParseHttpUrl(normalized[0]) ? normalized[0] : undefined;
+}
+
+function tryParseHttpUrl(value: string | undefined): URL | null {
+  if (!value) return null;
+
   try {
     const url = new URL(value);
 
-    return url.protocol === 'http:' || url.protocol === 'https:';
+    return isHttpUrl(url) ? url : null;
   } catch {
-    return false;
+    return null;
   }
+}
+
+function isHttpUrl(url: URL): boolean {
+  return url.protocol === 'http:' || url.protocol === 'https:';
 }

--- a/src/components/editor/plugins/withPasted.ts
+++ b/src/components/editor/plugins/withPasted.ts
@@ -20,6 +20,7 @@ import { isSingleURLText, processUrl } from '@/utils/url';
 import { isValidVideoUrl, videoTypeData } from '@/utils/video-url';
 
 import { getSingleURLTextFromClipboardData, parseAppFlowyBlockLink } from './appflowy-block-link';
+import type { AppFlowyBlockLink } from './appflowy-block-link';
 
 /**
  * Enhances Slate editor with improved paste handling
@@ -55,6 +56,7 @@ export const withPasted = (editor: ReactEditor) => {
     const html = data.getData('text/html');
     const text = data.getData('text/plain');
     const clipboardURL = getSingleURLTextFromClipboardData(data);
+    const clipboardBlockLink = clipboardURL ? parseAppFlowyBlockLink(clipboardURL, window.location.hostname) : null;
 
     // Priority 0: If pasting tabular content (TSV/multi-cell) inside a table cell,
     // fill adjacent cells instead of inserting as blocks
@@ -86,8 +88,8 @@ export const withPasted = (editor: ReactEditor) => {
       }
     }
 
-    if (clipboardURL && parseAppFlowyBlockLink(clipboardURL)) {
-      return handleURLPaste(editor, clipboardURL);
+    if (clipboardURL && clipboardBlockLink) {
+      return handleURLPaste(editor, clipboardURL, clipboardBlockLink);
     }
 
     // Priority 1: HTML (if available)
@@ -384,9 +386,9 @@ function handleMarkdownPaste(editor: ReactEditor, markdown: string): boolean {
 /**
  * Handles URL paste (link previews, videos, page references)
  */
-function handleURLPaste(editor: ReactEditor, url: string): boolean {
+function handleURLPaste(editor: ReactEditor, url: string, parsedBlockLink?: AppFlowyBlockLink): boolean {
   // Check for AppFlowy internal links
-  const blockLink = parseAppFlowyBlockLink(url);
+  const blockLink = parsedBlockLink ?? parseAppFlowyBlockLink(url, window.location.hostname);
 
   if (blockLink) {
     const point = editor.selection?.anchor as BasePoint;

--- a/src/components/editor/plugins/withPasted.ts
+++ b/src/components/editor/plugins/withPasted.ts
@@ -1,6 +1,5 @@
 import { BasePoint, Editor, Element, Range, Text, Transforms } from 'slate';
 import { ReactEditor } from 'slate-react';
-import isURL from 'validator/lib/isURL';
 
 import { YjsEditor } from '@/application/slate-yjs';
 import { EditorMarkFormat } from '@/application/slate-yjs/types';
@@ -19,6 +18,8 @@ import { getRangeRect } from '@/components/editor/components/toolbar/selection-t
 import { detectMarkdown, detectTSV } from '@/components/editor/utils/markdown-detector';
 import { isSingleURLText, processUrl } from '@/utils/url';
 import { isValidVideoUrl, videoTypeData } from '@/utils/video-url';
+
+import { getSingleURLTextFromClipboardData, parseAppFlowyBlockLink } from './appflowy-block-link';
 
 /**
  * Enhances Slate editor with improved paste handling
@@ -53,6 +54,7 @@ export const withPasted = (editor: ReactEditor) => {
 
     const html = data.getData('text/html');
     const text = data.getData('text/plain');
+    const clipboardURL = getSingleURLTextFromClipboardData(data);
 
     // Priority 0: If pasting tabular content (TSV/multi-cell) inside a table cell,
     // fill adjacent cells instead of inserting as blocks
@@ -82,6 +84,10 @@ export const withPasted = (editor: ReactEditor) => {
           return handleURLPaste(editor, plainText);
         }
       }
+    }
+
+    if (clipboardURL && parseAppFlowyBlockLink(clipboardURL)) {
+      return handleURLPaste(editor, clipboardURL);
     }
 
     // Priority 1: HTML (if available)
@@ -380,34 +386,26 @@ function handleMarkdownPaste(editor: ReactEditor, markdown: string): boolean {
  */
 function handleURLPaste(editor: ReactEditor, url: string): boolean {
   // Check for AppFlowy internal links
-  const isAppFlowyLinkUrl = isURL(url, {
-    host_whitelist: [window.location.hostname],
-  });
+  const blockLink = parseAppFlowyBlockLink(url);
 
-  if (isAppFlowyLinkUrl) {
-    const urlObj = new URL(url);
-    const blockId = urlObj.searchParams.get('blockId');
+  if (blockLink) {
+    const point = editor.selection?.anchor as BasePoint;
 
-    if (blockId) {
-      const pageId = urlObj.pathname.split('/').pop();
-      const point = editor.selection?.anchor as BasePoint;
-
-      if (point) {
-        Transforms.insertNodes(
-          editor,
-          {
-            text: '@',
-            mention: {
-              type: MentionType.PageRef,
-              page_id: pageId,
-              block_id: blockId,
-            },
+    if (point) {
+      Transforms.insertNodes(
+        editor,
+        {
+          text: '@',
+          mention: {
+            type: MentionType.PageRef,
+            page_id: blockLink.pageId,
+            block_id: blockLink.blockId,
           },
-          { at: point, select: true, voids: false }
-        );
+        },
+        { at: point, select: true, voids: false }
+      );
 
-        return true;
-      }
+      return true;
     }
   }
 


### PR DESCRIPTION
<!---
Thank you for submitting a pull request to the AppFlowy Web! The team will dedicate their best efforts to reviewing and approving your PR. If you have any questions or feedback, feel free to join our [Discord](https://discord.gg/wdjWUXXhtw).
-->


### **Description**
<!---
Provide a clear and concise description of the changes introduced in this pull request for AppFlowy Web. What problem does it solve? What value does it add?
-->

closes https://github.com/AppFlowy-IO/AppFlowy/issues/8748

<img width="844" height="218" alt="Screenshot 2026-05-22 at 10 42 47" src="https://github.com/user-attachments/assets/36fb5130-aee8-4252-a68a-cd9bc7d7fba6" />
<img width="439" height="103" alt="Screenshot 2026-05-22 at 10 43 05" src="https://github.com/user-attachments/assets/f240db0a-93cb-4b1b-a5f8-c3f9e22f05cf" />

---

### **Checklist**
<!---
Before marking your pull request as ready for review, ensure the following checklist is complete.
-->

#### **General**
- [ ] I've included relevant documentation or comments for the changes introduced.
- [ ] I've tested the changes in multiple environments (e.g., different browsers, operating systems).

#### **Testing**
- [ ] I've added or updated tests to validate the changes introduced for AppFlowy Web.

#### **Feature-Specific**
- [ ] For feature additions, I've added a preview (video, screenshot, or demo) in the "Feature Preview" section.
- [ ] I've verified that this feature integrates seamlessly with existing functionality.

## Summary by Sourcery

Add support for interpreting pasted AppFlowy block links as page-reference mentions and improve hover controls behavior for table blocks.

New Features:
- Recognize AppFlowy block URLs from clipboard data and insert corresponding page-reference mentions when pasted.

Enhancements:
- Centralize parsing and detection of AppFlowy block links from various clipboard formats.
- Adjust hover controls to correctly anchor and display on table root blocks instead of nested elements.

Tests:
- Add unit tests covering AppFlowy block link parsing and clipboard URL extraction logic.
- Add unit test scaffolding for hover controls behavior around table blocks.