### PR TITLE
Fix batch sync protobuf request body

### DIFF
--- a/src/application/services/js-services/http/__tests__/collab-api.test.ts
+++ b/src/application/services/js-services/http/__tests__/collab-api.test.ts
@@ -1,0 +1,54 @@
+import { collab } from '@/proto/messages';
+import { getAxios } from '@/application/services/js-services/http/core';
+
+import { collabFullSyncBatch } from '../collab-api';
+
+jest.mock('@/application/services/js-services/device-id', () => ({
+  getOrCreateDeviceId: jest.fn(() => 'test-device-id'),
+}));
+
+jest.mock('@/application/services/js-services/http/core', () => ({
+  executeAPIRequest: jest.fn(),
+  executeAPIVoidRequest: jest.fn(),
+  getAxios: jest.fn(),
+  parseRetryAfterSecs: jest.fn(),
+}));
+
+const mockGetAxios = getAxios as unknown as jest.Mock;
+
+describe('collabFullSyncBatch', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('sends the encoded protobuf view instead of the pooled backing buffer', async () => {
+    const responseBody = collab.CollabBatchSyncResponse.encode(
+      collab.CollabBatchSyncResponse.create({
+        results: [],
+        responseCompression: collab.PayloadCompressionType.COMPRESSION_NONE,
+      })
+    ).finish();
+    const post = jest.fn().mockResolvedValue({
+      status: 200,
+      data: responseBody,
+      headers: {},
+    });
+
+    mockGetAxios.mockReturnValue({ post });
+
+    await collabFullSyncBatch('workspace-id', [
+      {
+        objectId: 'object-id',
+        collabType: 0,
+        stateVector: new Uint8Array([1]),
+        docState: new Uint8Array([2]),
+      },
+    ]);
+
+    const [, requestBody, config] = post.mock.calls[0];
+
+    expect(ArrayBuffer.isView(requestBody)).toBe(true);
+    expect(requestBody.byteLength).toBeLessThan(requestBody.buffer.byteLength);
+    expect(config.transformRequest[0](requestBody)).toBe(requestBody);
+  });
+});

--- a/src/application/services/js-services/http/collab-api.ts
+++ b/src/application/services/js-services/http/collab-api.ts
@@ -100,6 +100,9 @@ export async function collabFullSyncBatch(
       'device-id': deviceId,
     },
     responseType: 'arraybuffer',
+    // Axios' default transform sends typed-array `.buffer`, which can include
+    // protobufjs' pooled zero padding beyond this Uint8Array view.
+    transformRequest: [(data: Uint8Array) => data],
     validateStatus: (status) => status === 200 || status === 429 || status === 503,
   });
 


### PR DESCRIPTION
## Summary
- bypass axios' default typed-array transform for batch sync protobuf requests
- add a regression test that preserves the encoded protobuf view instead of sending the pooled backing buffer

## Why
The web batch-sync request was encoded by protobufjs as a small Uint8Array view backed by an 8192-byte buffer. Axios default transform converted the view to .buffer, causing the server to receive an 8192-byte body with zero padding and fail protobuf decode with invalid tag value: 0.

## Tests
- pnpm exec jest src/application/services/js-services/http/__tests__/collab-api.test.ts --runInBand --no-coverage
- pnpm run type-check

## Summary by Sourcery

Ensure collab full-sync batch requests send the correct protobuf-encoded payload without including pooled buffer padding.

Bug Fixes:
- Prevent Axios from converting protobuf batch sync Uint8Array views into their full backing buffers, which previously produced oversized request bodies and decode failures.

Tests:
- Add a regression test verifying that collab full-sync batch requests send the encoded protobuf view rather than the pooled backing buffer and that the custom Axios transform preserves the view.