### PR TITLE
Add web link preview unfurling

### DIFF
--- a/api/_lib/__tests__/unfurl.test.ts
+++ b/api/_lib/__tests__/unfurl.test.ts
@@ -1,4 +1,5 @@
 import { unfurl } from '../unfurl';
+import { isAllowedHttpUrl } from '../url-safety';
 
 const originalFetch = global.fetch;
 
@@ -64,6 +65,18 @@ describe('unfurl', () => {
     expect(global.fetch).toHaveBeenCalledTimes(1);
   });
 
+  it('rejects redirects to IPv4-mapped IPv6 private hosts before fetching the redirect target', async () => {
+    global.fetch = jest.fn().mockResolvedValue(
+      mockResponse({
+        status: 302,
+        headers: { location: 'http://[::ffff:127.0.0.1]/admin' },
+      })
+    ) as unknown as typeof fetch;
+
+    await expect(unfurl('https://example.com/redirect')).rejects.toThrow('Blocked redirect target');
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+  });
+
   it('follows allowed redirects and extracts metadata from the final response', async () => {
     global.fetch = jest
       .fn()
@@ -96,5 +109,17 @@ describe('unfurl', () => {
       'https://redirected.example/final',
       expect.objectContaining({ redirect: 'manual' })
     );
+  });
+});
+
+describe('url safety', () => {
+  it('blocks IPv4-mapped IPv6 private address literals', () => {
+    expect(isAllowedHttpUrl(new URL('http://[::ffff:127.0.0.1]/'))).toBe(false);
+    expect(isAllowedHttpUrl(new URL('http://[::ffff:7f00:1]/'))).toBe(false);
+    expect(isAllowedHttpUrl(new URL('http://[::ffff:c0a8:101]/'))).toBe(false);
+  });
+
+  it('allows public IPv4-mapped IPv6 address literals', () => {
+    expect(isAllowedHttpUrl(new URL('http://[::ffff:0808:0808]/'))).toBe(true);
   });
 });

--- a/api/_lib/__tests__/unfurl.test.ts
+++ b/api/_lib/__tests__/unfurl.test.ts
@@ -1,0 +1,100 @@
+import { unfurl } from '../unfurl';
+
+const originalFetch = global.fetch;
+
+function mockResponse({
+  body = '',
+  headers = {},
+  ok,
+  status = 200,
+}: {
+  body?: string;
+  headers?: Record<string, string>;
+  ok?: boolean;
+  status?: number;
+}): Response {
+  const lowerCaseHeaders = Object.fromEntries(Object.entries(headers).map(([key, value]) => [key.toLowerCase(), value]));
+
+  return {
+    body: undefined,
+    headers: {
+      get: (name: string) => lowerCaseHeaders[name.toLowerCase()] ?? null,
+    },
+    ok: ok ?? status < 400,
+    status,
+    text: async () => body,
+  } as Response;
+}
+
+function htmlResponse(html: string, status = 200): Response {
+  return mockResponse({
+    body: html,
+    headers: { 'content-type': 'text/html; charset=utf-8' },
+    status,
+  });
+}
+
+describe('unfurl', () => {
+  afterEach(() => {
+    global.fetch = originalFetch;
+    jest.clearAllMocks();
+  });
+
+  it('rejects fetch failures so lower-priority providers can run', async () => {
+    global.fetch = jest.fn().mockRejectedValue(new Error('network error')) as unknown as typeof fetch;
+
+    await expect(unfurl('https://example.com/path')).rejects.toThrow('network error');
+  });
+
+  it('rejects non-OK responses so lower-priority providers can run', async () => {
+    global.fetch = jest.fn().mockResolvedValue(htmlResponse('', 403)) as unknown as typeof fetch;
+
+    await expect(unfurl('https://example.com/blocked')).rejects.toThrow('Failed to fetch link preview: 403');
+  });
+
+  it('rejects redirects to blocked hosts before fetching the redirect target', async () => {
+    global.fetch = jest.fn().mockResolvedValue(
+      mockResponse({
+        status: 302,
+        headers: { location: 'http://127.0.0.1/admin' },
+      })
+    ) as unknown as typeof fetch;
+
+    await expect(unfurl('https://example.com/redirect')).rejects.toThrow('Blocked redirect target');
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('follows allowed redirects and extracts metadata from the final response', async () => {
+    global.fetch = jest
+      .fn()
+      .mockResolvedValueOnce(
+        mockResponse({
+          status: 302,
+          headers: { location: 'https://redirected.example/final' },
+        })
+      )
+      .mockResolvedValueOnce(
+        htmlResponse(
+          '<head><meta property="og:title" content="Redirected page"><meta property="og:image" content="/cover.png"></head>'
+        )
+      ) as unknown as typeof fetch;
+
+    await expect(unfurl('https://example.com/start')).resolves.toMatchObject({
+      title: 'Redirected page',
+      description: '',
+      image: { url: 'https://redirected.example/cover.png' },
+      logo: { url: 'https://www.google.com/s2/favicons?domain=redirected.example&sz=128' },
+    });
+
+    expect(global.fetch).toHaveBeenNthCalledWith(
+      1,
+      'https://example.com/start',
+      expect.objectContaining({ redirect: 'manual' })
+    );
+    expect(global.fetch).toHaveBeenNthCalledWith(
+      2,
+      'https://redirected.example/final',
+      expect.objectContaining({ redirect: 'manual' })
+    );
+  });
+});

--- a/api/_lib/unfurl.ts
+++ b/api/_lib/unfurl.ts
@@ -45,12 +45,14 @@ export async function unfurl(rawUrl: string): Promise<UnfurlResult> {
   }
 
   const contentType = response.headers.get('content-type')?.toLowerCase() ?? '';
+
   if (!isHtml(contentType)) {
     void response.body?.cancel().catch(() => undefined);
     return nonHtmlResult(url, host, contentType);
   }
 
   const head = await readHead(response);
+
   return extractMetadata(head, url, host);
 }
 
@@ -112,6 +114,7 @@ function isHtml(contentType: string): boolean {
 // Read only up to </head> (or 50KB) to keep the function fast and cheap.
 async function readHead(response: Response): Promise<string> {
   const reader = response.body?.getReader();
+
   if (!reader) return response.text();
 
   const decoder = new TextDecoder('utf-8');
@@ -120,11 +123,13 @@ async function readHead(response: Response): Promise<string> {
 
   while (received < MAX_HTML_BYTES) {
     const { done, value } = await reader.read();
+
     if (done) break;
     received += value.byteLength;
     html += decoder.decode(value, { stream: true });
 
     const headEnd = html.toLowerCase().indexOf('</head>');
+
     if (headEnd !== -1) {
       html = html.slice(0, headEnd + '</head>'.length);
       break;
@@ -157,17 +162,21 @@ function extractMetadata(head: string, url: URL, host: string): UnfurlResult {
 
 function extractFavicon(links: Array<Record<string, string>>, url: URL): string | undefined {
   const rels = ['icon', 'shortcut icon', 'apple-touch-icon', 'apple-touch-icon-precomposed'];
+
   for (const rel of rels) {
     const href = links.find((attrs) => (attrs.rel ?? '').toLowerCase() === rel)?.href;
+
     if (href) return resolveOptional(url, href);
   }
 
   const anyIcon = links.find((attrs) => (attrs.rel ?? '').toLowerCase().includes('icon'))?.href;
+
   return anyIcon ? resolveOptional(url, anyIcon) : undefined;
 }
 
 function matchTags(html: string, tag: 'meta' | 'link'): Array<Record<string, string>> {
   const regex = new RegExp(`<${tag}\\b[^>]*>`, 'gi');
+
   return (html.match(regex) ?? []).map(parseAttributes);
 }
 
@@ -191,6 +200,7 @@ function extractTitleTag(html: string): string | undefined {
 
 function nonHtmlResult(url: URL, host: string, contentType: string): UnfurlResult {
   const filename = url.pathname.split('/').filter(Boolean).pop() || host;
+
   return {
     title: decodeURIComponentSafe(filename),
     description: contentType ? `Type: ${contentType}` : '',
@@ -206,6 +216,7 @@ function resolveOptional(base: URL, href?: string): string | undefined {
   if (!href) return undefined;
 
   const decoded = decodeEntities(href).trim();
+
   if (!decoded) return undefined;
 
   try {
@@ -248,6 +259,7 @@ function decodeEntities(value: string): string {
     if (entity[0] === '#') {
       const isHex = entity[1] === 'x' || entity[1] === 'X';
       const code = isHex ? parseInt(entity.slice(2), 16) : parseInt(entity.slice(1), 10);
+
       return Number.isFinite(code) ? String.fromCodePoint(code) : match;
     }
 

--- a/api/_lib/unfurl.ts
+++ b/api/_lib/unfurl.ts
@@ -1,0 +1,256 @@
+// Server-side link unfurler.
+//
+// Mirrors the desktop DefaultParser
+// (AppFlowy-Premium/frontend/appflowy_flutter/lib/plugins/document/presentation/
+//  editor_plugins/link_preview/link_parsers/default_parser.dart)
+// so web link mentions reach parity with the desktop app: a browser cannot
+// scrape cross-origin pages (CORS), so the same fetch + metadata extraction
+// runs here instead. Prefer Open Graph, fall back to <title>, then host.
+//
+// Dependency-free on purpose: only the <head> meta/link tags are needed, so we
+// parse them directly rather than pulling an HTML parser into the function.
+
+import { isAllowedHttpUrl } from './url-safety';
+
+const MAX_HTML_BYTES = 50 * 1024; // the <head> carries all the metadata we read
+const REQUEST_TIMEOUT_MS = 8000;
+const DESCRIPTION_MAX_LENGTH = 240;
+const USER_AGENT = 'Mozilla/5.0 (compatible; AppFlowyBot/1.0; +https://appflowy.io)';
+const MAX_REDIRECTS = 5;
+
+export interface UnfurlImage {
+  url: string;
+}
+
+export interface UnfurlResult {
+  title: string;
+  description: string;
+  image?: UnfurlImage;
+  logo?: UnfurlImage;
+}
+
+interface FetchedHtml {
+  response: Response;
+  url: URL;
+}
+
+export async function unfurl(rawUrl: string): Promise<UnfurlResult> {
+  const initialUrl = new URL(rawUrl);
+  const { response, url } = await fetchHtml(initialUrl);
+  const host = url.hostname.replace(/^www\./, '');
+
+  if (!response.ok) {
+    void response.body?.cancel().catch(() => undefined);
+    throw new Error(`Failed to fetch link preview: ${response.status}`);
+  }
+
+  const contentType = response.headers.get('content-type')?.toLowerCase() ?? '';
+  if (!isHtml(contentType)) {
+    void response.body?.cancel().catch(() => undefined);
+    return nonHtmlResult(url, host, contentType);
+  }
+
+  const head = await readHead(response);
+  return extractMetadata(head, url, host);
+}
+
+async function fetchHtml(url: URL): Promise<FetchedHtml> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+
+  try {
+    return await fetchHtmlFollowingAllowedRedirects(url, controller.signal);
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+async function fetchHtmlFollowingAllowedRedirects(initialUrl: URL, signal: AbortSignal): Promise<FetchedHtml> {
+  let currentUrl = initialUrl;
+
+  for (let redirects = 0; redirects <= MAX_REDIRECTS; redirects += 1) {
+    if (!isAllowedHttpUrl(currentUrl)) {
+      throw new Error('Blocked redirect target');
+    }
+
+    const response = await fetch(currentUrl.toString(), {
+      redirect: 'manual',
+      signal,
+      headers: {
+        'User-Agent': USER_AGENT,
+        Accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+      },
+    });
+
+    if (!isRedirectResponse(response.status)) return { response, url: currentUrl };
+
+    const location = response.headers.get('location');
+
+    void response.body?.cancel().catch(() => undefined);
+    if (!location) throw new Error('Redirect response missing Location header');
+
+    const nextUrl = new URL(location, currentUrl);
+
+    if (!isAllowedHttpUrl(nextUrl)) {
+      throw new Error('Blocked redirect target');
+    }
+
+    currentUrl = nextUrl;
+  }
+
+  throw new Error('Too many redirects');
+}
+
+function isRedirectResponse(status: number): boolean {
+  return status === 301 || status === 302 || status === 303 || status === 307 || status === 308;
+}
+
+function isHtml(contentType: string): boolean {
+  return contentType === '' || contentType.includes('text/html') || contentType.includes('application/xhtml');
+}
+
+// Read only up to </head> (or 50KB) to keep the function fast and cheap.
+async function readHead(response: Response): Promise<string> {
+  const reader = response.body?.getReader();
+  if (!reader) return response.text();
+
+  const decoder = new TextDecoder('utf-8');
+  let html = '';
+  let received = 0;
+
+  while (received < MAX_HTML_BYTES) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    received += value.byteLength;
+    html += decoder.decode(value, { stream: true });
+
+    const headEnd = html.toLowerCase().indexOf('</head>');
+    if (headEnd !== -1) {
+      html = html.slice(0, headEnd + '</head>'.length);
+      break;
+    }
+  }
+
+  void reader.cancel().catch(() => undefined);
+  return html;
+}
+
+function extractMetadata(head: string, url: URL, host: string): UnfurlResult {
+  const metas = matchTags(head, 'meta');
+  const links = matchTags(head, 'link');
+
+  const og = (property: string) => metas.find((attrs) => attrs.property === property)?.content;
+  const named = (name: string) => metas.find((attrs) => attrs.name === name)?.content;
+
+  const title = clean(og('og:title')) || clean(extractTitleTag(head)) || clean(named('title')) || host;
+  const description = clean(og('og:description')) || clean(named('description'));
+  const image = resolveOptional(url, og('og:image'));
+  const favicon = extractFavicon(links, url) ?? defaultFavicon(host);
+
+  return {
+    title,
+    description: truncate(description),
+    ...(image ? { image: { url: image } } : {}),
+    logo: { url: favicon },
+  };
+}
+
+function extractFavicon(links: Array<Record<string, string>>, url: URL): string | undefined {
+  const rels = ['icon', 'shortcut icon', 'apple-touch-icon', 'apple-touch-icon-precomposed'];
+  for (const rel of rels) {
+    const href = links.find((attrs) => (attrs.rel ?? '').toLowerCase() === rel)?.href;
+    if (href) return resolveOptional(url, href);
+  }
+
+  const anyIcon = links.find((attrs) => (attrs.rel ?? '').toLowerCase().includes('icon'))?.href;
+  return anyIcon ? resolveOptional(url, anyIcon) : undefined;
+}
+
+function matchTags(html: string, tag: 'meta' | 'link'): Array<Record<string, string>> {
+  const regex = new RegExp(`<${tag}\\b[^>]*>`, 'gi');
+  return (html.match(regex) ?? []).map(parseAttributes);
+}
+
+const ATTR_REGEX = /([a-zA-Z_:.-]+)\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s"'>]+))/g;
+
+function parseAttributes(tag: string): Record<string, string> {
+  const attrs: Record<string, string> = {};
+  let match: RegExpExecArray | null;
+
+  ATTR_REGEX.lastIndex = 0;
+  while ((match = ATTR_REGEX.exec(tag)) !== null) {
+    attrs[match[1].toLowerCase()] = match[2] ?? match[3] ?? match[4] ?? '';
+  }
+
+  return attrs;
+}
+
+function extractTitleTag(html: string): string | undefined {
+  return /<title[^>]*>([\s\S]*?)<\/title>/i.exec(html)?.[1];
+}
+
+function nonHtmlResult(url: URL, host: string, contentType: string): UnfurlResult {
+  const filename = url.pathname.split('/').filter(Boolean).pop() || host;
+  return {
+    title: decodeURIComponentSafe(filename),
+    description: contentType ? `Type: ${contentType}` : '',
+    logo: { url: defaultFavicon(host) },
+  };
+}
+
+function defaultFavicon(host: string): string {
+  return `https://www.google.com/s2/favicons?domain=${host}&sz=128`;
+}
+
+function resolveOptional(base: URL, href?: string): string | undefined {
+  if (!href) return undefined;
+
+  const decoded = decodeEntities(href).trim();
+  if (!decoded) return undefined;
+
+  try {
+    return new URL(decoded, base).toString();
+  } catch {
+    return decoded;
+  }
+}
+
+function clean(value?: string): string {
+  return decodeEntities(value ?? '')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function truncate(value: string): string {
+  if (value.length <= DESCRIPTION_MAX_LENGTH) return value;
+  return `${value.slice(0, DESCRIPTION_MAX_LENGTH - 1).trimEnd()}…`;
+}
+
+function decodeURIComponentSafe(value: string): string {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+}
+
+const NAMED_ENTITIES: Record<string, string> = {
+  amp: '&',
+  lt: '<',
+  gt: '>',
+  quot: '"',
+  apos: "'",
+  nbsp: ' ',
+};
+
+function decodeEntities(value: string): string {
+  return value.replace(/&(#x?[0-9a-fA-F]+|[a-zA-Z]+);/g, (match, entity: string) => {
+    if (entity[0] === '#') {
+      const isHex = entity[1] === 'x' || entity[1] === 'X';
+      const code = isHex ? parseInt(entity.slice(2), 16) : parseInt(entity.slice(1), 10);
+      return Number.isFinite(code) ? String.fromCodePoint(code) : match;
+    }
+
+    return NAMED_ENTITIES[entity.toLowerCase()] ?? match;
+  });
+}

--- a/api/_lib/url-safety.ts
+++ b/api/_lib/url-safety.ts
@@ -8,6 +8,7 @@ export function isBlockedHost(hostname: string): boolean {
   }
 
   const v4 = /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/.exec(host);
+
   if (v4) {
     const a = Number(v4[1]);
     const b = Number(v4[2]);

--- a/api/_lib/url-safety.ts
+++ b/api/_lib/url-safety.ts
@@ -1,0 +1,31 @@
+// Best-effort SSRF guard for literal private / loopback / link-local hosts.
+// This does not cover hostnames that resolve to private IPs via DNS.
+export function isBlockedHost(hostname: string): boolean {
+  const host = hostname.toLowerCase().replace(/^\[|\]$/g, '');
+
+  if (host === 'localhost' || host.endsWith('.localhost') || host.endsWith('.internal')) {
+    return true;
+  }
+
+  const v4 = /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/.exec(host);
+  if (v4) {
+    const a = Number(v4[1]);
+    const b = Number(v4[2]);
+
+    if (a === 0 || a === 10 || a === 127) return true;
+    if (a === 169 && b === 254) return true; // link-local + cloud metadata
+    if (a === 172 && b >= 16 && b <= 31) return true;
+    if (a === 192 && b === 168) return true;
+    if (a === 100 && b >= 64 && b <= 127) return true; // CGNAT
+  }
+
+  if (host === '::1' || host.startsWith('fc') || host.startsWith('fd') || host.startsWith('fe80')) {
+    return true;
+  }
+
+  return false;
+}
+
+export function isAllowedHttpUrl(url: URL): boolean {
+  return (url.protocol === 'http:' || url.protocol === 'https:') && !isBlockedHost(url.hostname);
+}

--- a/api/_lib/url-safety.ts
+++ b/api/_lib/url-safety.ts
@@ -7,18 +7,15 @@ export function isBlockedHost(hostname: string): boolean {
     return true;
   }
 
-  const v4 = /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/.exec(host);
+  const mappedV4 = parseIPv4MappedIPv6(host);
 
-  if (v4) {
-    const a = Number(v4[1]);
-    const b = Number(v4[2]);
-
-    if (a === 0 || a === 10 || a === 127) return true;
-    if (a === 169 && b === 254) return true; // link-local + cloud metadata
-    if (a === 172 && b >= 16 && b <= 31) return true;
-    if (a === 192 && b === 168) return true;
-    if (a === 100 && b >= 64 && b <= 127) return true; // CGNAT
+  if (mappedV4 && isBlockedIPv4(mappedV4)) {
+    return true;
   }
+
+  const v4 = parseIPv4(host);
+
+  if (v4 && isBlockedIPv4(v4)) return true;
 
   if (host === '::1' || host.startsWith('fc') || host.startsWith('fd') || host.startsWith('fe80')) {
     return true;
@@ -29,4 +26,51 @@ export function isBlockedHost(hostname: string): boolean {
 
 export function isAllowedHttpUrl(url: URL): boolean {
   return (url.protocol === 'http:' || url.protocol === 'https:') && !isBlockedHost(url.hostname);
+}
+
+function parseIPv4(host: string): [number, number, number, number] | null {
+  const v4 = /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/.exec(host);
+
+  if (!v4) return null;
+
+  const octets = [Number(v4[1]), Number(v4[2]), Number(v4[3]), Number(v4[4])] as [
+    number,
+    number,
+    number,
+    number,
+  ];
+
+  return octets.every((octet) => octet >= 0 && octet <= 255) ? octets : null;
+}
+
+function parseIPv4MappedIPv6(host: string): [number, number, number, number] | null {
+  if (!host.startsWith('::ffff:')) return null;
+
+  const embedded = host.slice('::ffff:'.length);
+  const dotted = parseIPv4(embedded);
+
+  if (dotted) return dotted;
+
+  const parts = embedded.split(':');
+
+  if (parts.length < 2) return null;
+
+  const high = Number.parseInt(parts[parts.length - 2], 16);
+  const low = Number.parseInt(parts[parts.length - 1], 16);
+
+  if (!Number.isInteger(high) || !Number.isInteger(low) || high < 0 || high > 0xffff || low < 0 || low > 0xffff) {
+    return null;
+  }
+
+  return [high >> 8, high & 0xff, low >> 8, low & 0xff];
+}
+
+function isBlockedIPv4([a, b]: [number, number, number, number]): boolean {
+  if (a === 0 || a === 10 || a === 127) return true;
+  if (a === 169 && b === 254) return true; // link-local + cloud metadata
+  if (a === 172 && b >= 16 && b <= 31) return true;
+  if (a === 192 && b === 168) return true;
+  if (a === 100 && b >= 64 && b <= 127) return true; // CGNAT
+
+  return false;
 }

--- a/api/link-preview.ts
+++ b/api/link-preview.ts
@@ -1,0 +1,50 @@
+import type { IncomingMessage, ServerResponse } from 'http';
+
+import { isAllowedHttpUrl } from './_lib/url-safety';
+import { unfurl } from './_lib/unfurl';
+
+// Cache successful previews at the edge so repeat loads are cheap, mirroring the
+// desktop LinkInfoCache.
+const CACHE_CONTROL = 'public, s-maxage=600, stale-while-revalidate=86400';
+
+export default async function handler(req: IncomingMessage, res: ServerResponse): Promise<void> {
+  const target = readUrlParam(req);
+  if (!target) return sendJson(res, 400, { error: 'Missing "url" query parameter' });
+
+  let parsed: URL;
+  try {
+    parsed = new URL(target);
+  } catch {
+    return sendJson(res, 400, { error: 'Invalid URL' });
+  }
+
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    return sendJson(res, 400, { error: 'Unsupported protocol' });
+  }
+
+  if (!isAllowedHttpUrl(parsed)) {
+    return sendJson(res, 400, { error: 'Blocked host' });
+  }
+
+  try {
+    const data = await unfurl(parsed.toString());
+    res.setHeader('Cache-Control', CACHE_CONTROL);
+    return sendJson(res, 200, data);
+  } catch {
+    return sendJson(res, 502, { error: 'Failed to fetch link preview' });
+  }
+}
+
+function readUrlParam(req: IncomingMessage): string | null {
+  try {
+    return new URL(req.url ?? '', 'http://localhost').searchParams.get('url');
+  } catch {
+    return null;
+  }
+}
+
+function sendJson(res: ServerResponse, status: number, body: unknown): void {
+  res.statusCode = status;
+  res.setHeader('Content-Type', 'application/json; charset=utf-8');
+  res.end(JSON.stringify(body));
+}

--- a/api/link-preview.ts
+++ b/api/link-preview.ts
@@ -1,7 +1,8 @@
+import { unfurl } from './_lib/unfurl';
+import { isAllowedHttpUrl } from './_lib/url-safety';
+
 import type { IncomingMessage, ServerResponse } from 'http';
 
-import { isAllowedHttpUrl } from './_lib/url-safety';
-import { unfurl } from './_lib/unfurl';
 
 // Cache successful previews at the edge so repeat loads are cheap, mirroring the
 // desktop LinkInfoCache.
@@ -9,9 +10,11 @@ const CACHE_CONTROL = 'public, s-maxage=600, stale-while-revalidate=86400';
 
 export default async function handler(req: IncomingMessage, res: ServerResponse): Promise<void> {
   const target = readUrlParam(req);
+
   if (!target) return sendJson(res, 400, { error: 'Missing "url" query parameter' });
 
   let parsed: URL;
+
   try {
     parsed = new URL(target);
   } catch {
@@ -28,6 +31,7 @@ export default async function handler(req: IncomingMessage, res: ServerResponse)
 
   try {
     const data = await unfurl(parsed.toString());
+
     res.setHeader('Cache-Control', CACHE_CONTROL);
     return sendJson(res, 200, data);
   } catch {

--- a/src/application/db/__tests__/index.test.ts
+++ b/src/application/db/__tests__/index.test.ts
@@ -27,8 +27,19 @@ class FakeProvider {
 }
 
 describe('collab IndexedDB persistence internals', () => {
+  const originalIndexedDB = globalThis.indexedDB;
+
+  beforeEach(() => {
+    jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+  });
+
   afterEach(() => {
+    Object.defineProperty(globalThis, 'indexedDB', {
+      configurable: true,
+      value: originalIndexedDB,
+    });
     jest.restoreAllMocks();
+    jest.useRealTimers();
     localStorage.clear();
   });
 
@@ -91,5 +102,41 @@ describe('collab IndexedDB persistence internals', () => {
     expect(localStorage.getItem('af_database_blob_rid:database-1')).toBeNull();
     expect(localStorage.getItem('af_database_blob_rid:database-2')).toBeNull();
     expect(localStorage.getItem('unrelated-key')).toBe('keep');
+  });
+
+  it('waits for a blocked IndexedDB delete to succeed', async () => {
+    const request = {} as IDBOpenDBRequest;
+    const deleteDatabase = jest.fn(() => request);
+
+    Object.defineProperty(globalThis, 'indexedDB', {
+      configurable: true,
+      value: { deleteDatabase },
+    });
+
+    const deleted = __dbTestUtils.deleteIndexedDBDatabase('blocked-then-deleted');
+
+    request.onblocked?.({} as Event);
+    request.onsuccess?.({} as Event);
+
+    await expect(deleted).resolves.toBe(true);
+    expect(deleteDatabase).toHaveBeenCalledWith('blocked-then-deleted');
+  });
+
+  it('fails a blocked IndexedDB delete after the unblock timeout', async () => {
+    jest.useFakeTimers();
+    const request = {} as IDBOpenDBRequest;
+    const deleteDatabase = jest.fn(() => request);
+
+    Object.defineProperty(globalThis, 'indexedDB', {
+      configurable: true,
+      value: { deleteDatabase },
+    });
+
+    const deleted = __dbTestUtils.deleteIndexedDBDatabase('blocked-forever', { blockedTimeoutMs: 10 });
+
+    request.onblocked?.({} as Event);
+    jest.advanceTimersByTime(10);
+
+    await expect(deleted).resolves.toBe(false);
   });
 });

--- a/src/application/db/index.ts
+++ b/src/application/db/index.ts
@@ -352,6 +352,7 @@ const pendingRowOpens = new Map<string, Promise<CachedProviderEntry>>();
 const DATABASE_BLOB_RID_PREFIX = 'af_database_blob_rid:';
 const SHARED_COLLAB_COMPACT_UPDATE_THRESHOLD = 200;
 const SHARED_COLLAB_COMPACT_MAX_RETRIES = 3;
+const DELETE_INDEXEDDB_BLOCKED_TIMEOUT_MS = 2000;
 
 type CollabPersistenceProvider = IndexeddbPersistence | SharedIndexeddbPersistence;
 type SharedCollabOpenOptions = { awaitSync?: boolean; expectedVersion?: string; forceReset?: boolean; skipCache?: boolean };
@@ -759,21 +760,46 @@ async function disposeRowProvider(name: string, options: { destroyDoc?: boolean 
   return disposed;
 }
 
-async function deleteIndexedDBDatabase(name: string) {
+async function deleteIndexedDBDatabase(
+  name: string,
+  options: { blockedTimeoutMs?: number } = {}
+) {
   if (typeof indexedDB === 'undefined') return true;
 
   return new Promise<boolean>((resolve) => {
     const request = indexedDB.deleteDatabase(name);
+    let settled = false;
+    let blockedTimeout: ReturnType<typeof setTimeout> | undefined;
 
-    request.onsuccess = () => resolve(true);
+    const resolveOnce = (deleted: boolean) => {
+      if (settled) return;
+
+      settled = true;
+
+      if (blockedTimeout) {
+        clearTimeout(blockedTimeout);
+      }
+
+      resolve(deleted);
+    };
+
+    request.onsuccess = () => resolveOnce(true);
     request.onerror = () => {
       Log.warn('[DB] failed to delete collab IndexedDB database', { name, error: request.error });
-      resolve(false);
+      resolveOnce(false);
     };
 
     request.onblocked = () => {
       Log.warn('[DB] delete collab IndexedDB database blocked', { name });
-      resolve(false);
+
+      if (blockedTimeout) {
+        clearTimeout(blockedTimeout);
+      }
+
+      blockedTimeout = setTimeout(() => {
+        Log.warn('[DB] delete collab IndexedDB database timed out after blocked', { name });
+        resolveOnce(false);
+      }, options.blockedTimeoutMs ?? DELETE_INDEXEDDB_BLOCKED_TIMEOUT_MS);
     };
   });
 }
@@ -1259,6 +1285,7 @@ export async function clearData() {
 export const __dbTestUtils = {
   createCachedProviderEntry,
   clearBlobRidCheckpointsForDeletedDatabases,
+  deleteIndexedDBDatabase,
   destroyProviderEntry,
   readSharedCollabRecordsForSync,
   waitForProviderEntry,

--- a/src/application/services/js-services/http/__tests__/http_api.test.ts
+++ b/src/application/services/js-services/http/__tests__/http_api.test.ts
@@ -93,6 +93,31 @@ describe('http_api client (unit)', () => {
     expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/server-info/auth-providers');
   });
 
+  it('identifies server-info requests as web so page history is not hidden by native client gates', async () => {
+    const module = await import('../http_api');
+    module.initAPIService(baseConfig);
+
+    mockAxiosInstance.get.mockResolvedValueOnce({
+      data: {
+        code: 0,
+        data: {
+          enable_page_history: true,
+          ai_enabled: true,
+        },
+      },
+    });
+
+    await expect(module.getServerInfo()).resolves.toEqual({
+      enable_page_history: true,
+      ai_enabled: true,
+    });
+    expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/server-info', {
+      headers: {
+        'x-platform': 'web',
+      },
+    });
+  });
+
   it('falls back to password provider when API responds with error', async () => {
     const module = await import('../http_api');
     module.initAPIService(baseConfig);

--- a/src/application/services/js-services/http/auth-api.ts
+++ b/src/application/services/js-services/http/auth-api.ts
@@ -70,7 +70,11 @@ export async function getServerInfo(): Promise<ServerInfo> {
 
   try {
     return await executeAPIRequest<ServerInfo>(() =>
-      getAxios()?.get<APIResponse<ServerInfo>>(url)
+      getAxios()?.get<APIResponse<ServerInfo>>(url, {
+        headers: {
+          'x-platform': 'web',
+        },
+      })
     );
   } catch (error) {
     console.warn('Server info API returned error:', (error as APIError)?.message);

--- a/src/components/app/hooks/__tests__/resolveAncestorViewIds.test.ts
+++ b/src/components/app/hooks/__tests__/resolveAncestorViewIds.test.ts
@@ -1,0 +1,172 @@
+import { View, ViewLayout } from '@/application/types';
+import { resolveAncestorViewIds } from '@/components/app/hooks/resolveAncestorViewIds';
+
+const WORKSPACE_ID = 'workspace-root';
+
+function makeView(view_id: string, parent_view_id: string | undefined, overrides: Partial<View> = {}): View {
+  return {
+    view_id,
+    name: view_id,
+    icon: null,
+    layout: ViewLayout.Document,
+    extra: { is_space: false },
+    children: [],
+    is_published: false,
+    is_private: false,
+    parent_view_id,
+    ...overrides,
+  };
+}
+
+/**
+ * Build a nested outline tree: space → folder → page (3 levels deep).
+ * Returns both the tree and the individual views so tests can shape shallow vs.
+ * full outlines and back a remote `fetchView`.
+ */
+function buildTree() {
+  const page = makeView('page', 'folder');
+  const folder = makeView('folder', 'space', { children: [page] });
+  const space = makeView('space', WORKSPACE_ID, { extra: { is_space: true }, children: [folder] });
+
+  return { space, folder, page };
+}
+
+describe('resolveAncestorViewIds', () => {
+  it('reads the ancestor chain straight from the loaded tree without fetching (fast path)', async () => {
+    const { space, folder, page } = buildTree();
+    const fetchView = jest.fn(async () => null as View | null);
+
+    const result = await resolveAncestorViewIds({
+      selectedViewId: page.view_id,
+      workspaceId: WORKSPACE_ID,
+      outline: [space],
+      fetchView,
+    });
+
+    // Ancestors are returned root-first, excluding the selected leaf.
+    expect(result).toEqual(['space', 'folder']);
+    expect(fetchView).not.toHaveBeenCalled();
+  });
+
+  it('returns an empty array for a top-level space (nothing to expand)', async () => {
+    const { space } = buildTree();
+    const fetchView = jest.fn(async () => null as View | null);
+
+    const result = await resolveAncestorViewIds({
+      selectedViewId: space.view_id,
+      workspaceId: WORKSPACE_ID,
+      outline: [space],
+      fetchView,
+    });
+
+    expect(result).toEqual([]);
+    expect(fetchView).not.toHaveBeenCalled();
+  });
+
+  it('walks parent_view_id from remote when the view is absent from the shallow outline', async () => {
+    const { space, folder, page } = buildTree();
+    // Shallow outline: only the top-level space, no children loaded.
+    const shallowSpace = makeView('space', WORKSPACE_ID, { extra: { is_space: true }, children: [], has_children: true });
+
+    const remote: Record<string, View> = { page, folder, space };
+    const fetchView = jest.fn(async (_workspaceId: string, viewId: string) => remote[viewId] ?? null);
+
+    const result = await resolveAncestorViewIds({
+      selectedViewId: page.view_id,
+      workspaceId: WORKSPACE_ID,
+      outline: [shallowSpace],
+      fetchView,
+    });
+
+    expect(result).toEqual(['space', 'folder']);
+    // page (missing) and folder (missing) are fetched; space is already in the
+    // outline so it is read locally rather than fetched.
+    expect(fetchView.mock.calls.map((c) => c[1])).toEqual(['page', 'folder']);
+  });
+
+  it('only fetches the nodes missing from the outline (mixed path)', async () => {
+    const { space, folder, page } = buildTree();
+    // Outline has the space + folder, but not the deeply-nested page.
+    const partialFolder = makeView('folder', 'space', { children: [], has_children: true });
+    const partialSpace = makeView('space', WORKSPACE_ID, { extra: { is_space: true }, children: [partialFolder] });
+
+    const remote: Record<string, View> = { page };
+    const fetchView = jest.fn(async (_workspaceId: string, viewId: string) => remote[viewId] ?? null);
+
+    const result = await resolveAncestorViewIds({
+      selectedViewId: page.view_id,
+      workspaceId: WORKSPACE_ID,
+      outline: [partialSpace],
+      fetchView,
+    });
+
+    expect(result).toEqual(['space', 'folder']);
+    // Only `page` needs a fetch — folder and space resolve from the outline.
+    expect(fetchView.mock.calls.map((c) => c[1])).toEqual(['page']);
+  });
+
+  it('returns null when the view cannot be resolved (fetch rejects)', async () => {
+    const fetchView = jest.fn(async () => {
+      throw new Error('403 forbidden');
+    });
+
+    const result = await resolveAncestorViewIds({
+      selectedViewId: 'ghost',
+      workspaceId: WORKSPACE_ID,
+      outline: [],
+      fetchView,
+    });
+
+    expect(result).toBeNull();
+  });
+
+  it('returns null when the remote fetch resolves to no view', async () => {
+    const fetchView = jest.fn(async () => null);
+
+    const result = await resolveAncestorViewIds({
+      selectedViewId: 'ghost',
+      workspaceId: WORKSPACE_ID,
+      outline: [],
+      fetchView,
+    });
+
+    expect(result).toBeNull();
+  });
+
+  it('stops at the workspace root and never includes it', async () => {
+    const { space, folder, page } = buildTree();
+    const fetchView = jest.fn(async () => null as View | null);
+
+    const result = await resolveAncestorViewIds({
+      selectedViewId: page.view_id,
+      workspaceId: WORKSPACE_ID,
+      outline: [space],
+      fetchView,
+    });
+
+    expect(result).not.toContain(WORKSPACE_ID);
+    // space's parent IS the workspace root, so the chain ends at space.
+    expect(result?.[0]).toBe('space');
+  });
+
+  it('terminates on a parent_view_id cycle instead of looping forever', async () => {
+    // a → b → a (a malformed cycle that never reaches the workspace root).
+    const a = makeView('a', 'b');
+    const b = makeView('b', 'a');
+
+    const remote: Record<string, View> = { a, b };
+    const fetchView = jest.fn(async (_workspaceId: string, viewId: string) => remote[viewId] ?? null);
+
+    const result = await resolveAncestorViewIds({
+      selectedViewId: 'a',
+      workspaceId: WORKSPACE_ID,
+      outline: [],
+      fetchView,
+    });
+
+    // Walk: a→push b, b→push a, then a is already visited → stop.
+    expect(result).toEqual(['a', 'b']);
+    // Each node fetched exactly once thanks to the visited guard.
+    expect(fetchView).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/components/app/hooks/resolveAncestorViewIds.ts
+++ b/src/components/app/hooks/resolveAncestorViewIds.ts
@@ -1,0 +1,76 @@
+import { View } from '@/application/types';
+import { findAncestors, findView } from '@/components/_shared/outline/utils';
+
+export interface ResolveAncestorViewIdsParams {
+  /** The view the sidebar should reveal (the active / selected view). */
+  selectedViewId: string;
+  /** Workspace root id — the walk stops here and never expands it. */
+  workspaceId: string;
+  /** The currently loaded (possibly shallow, depth=1) outline tree. */
+  outline: View[];
+  /**
+   * Fetch a single view from remote when it isn't in the loaded outline. Injected
+   * so this stays a pure, testable function (production passes `ViewService.get`).
+   * Returning `null` (or rejecting) is treated as "not found".
+   */
+  fetchView: (workspaceId: string, viewId: string) => Promise<View | null>;
+}
+
+/**
+ * Resolve the ancestor view ids (root → … → the selected view's parent) that
+ * must be expanded to reveal `selectedViewId` in the sidebar.
+ *
+ * - Fast path: the whole chain is already in the loaded tree, so we read it
+ *   straight from the outline without any network round-trips.
+ * - Slow path: the view (or part of its branch) isn't in the shallow outline —
+ *   walk `parent_view_id` upward, preferring the loaded tree and falling back to
+ *   `fetchView` per node.
+ *
+ * Returns:
+ * - a (possibly empty) array of ancestor ids to expand — empty means the view
+ *   has no ancestors to open (e.g. it's a top-level space); or
+ * - `null` when the chain can't be resolved (view deleted / no access),
+ *   signalling the caller to leave the sidebar as-is rather than force it open.
+ */
+export async function resolveAncestorViewIds(params: ResolveAncestorViewIdsParams): Promise<string[] | null> {
+  const { selectedViewId, workspaceId, outline, fetchView } = params;
+
+  // Fast path: fully resolvable from the loaded tree (no fetches).
+  const localAncestors = findAncestors(outline, selectedViewId);
+
+  if (localAncestors) {
+    return localAncestors.slice(0, -1).map((view) => view.view_id);
+  }
+
+  // Slow path: walk parent_view_id up to (but not including) the workspace root.
+  const ancestorIds: string[] = [];
+  const visited = new Set<string>();
+  let cursorId: string | undefined = selectedViewId;
+
+  while (cursorId && cursorId !== workspaceId && !visited.has(cursorId)) {
+    visited.add(cursorId);
+
+    let view: View | null = findView(outline, cursorId);
+
+    if (!view) {
+      try {
+        view = await fetchView(workspaceId, cursorId);
+      } catch {
+        // View not found / no access — leave the sidebar as-is.
+        return null;
+      }
+    }
+
+    if (!view) return null;
+
+    const parentId: string | undefined = view.parent_view_id;
+
+    if (parentId && parentId !== workspaceId) {
+      ancestorIds.unshift(parentId);
+    }
+
+    cursorId = parentId;
+  }
+
+  return ancestorIds;
+}

--- a/src/components/app/outline/Outline.tsx
+++ b/src/components/app/outline/Outline.tsx
@@ -2,6 +2,7 @@ import React, { lazy, Suspense, useCallback, useEffect, useMemo, useRef, useStat
 import { createPortal } from 'react-dom';
 import { useTranslation } from 'react-i18next';
 
+import { ViewService } from '@/application/services/domains';
 import { View, ViewLayout } from '@/application/types';
 import { ReactComponent as MoreIcon } from '@/assets/icons/more.svg';
 import { ReactComponent as PlusIcon } from '@/assets/icons/plus.svg';
@@ -15,8 +16,10 @@ import {
   useLoadViewChildrenBatch,
   useLoadViewChildren,
   useMarkViewChildrenStale,
+  useSidebarSelectedViewId,
 } from '@/components/app/app.hooks';
 import { Favorite } from '@/components/app/favorite';
+import { resolveAncestorViewIds } from '@/components/app/hooks/resolveAncestorViewIds';
 import SpaceItem from '@/components/app/outline/SpaceItem';
 import { ShareWithMe } from '@/components/app/share-with-me';
 import ViewActionsPopover from '@/components/app/view-actions/ViewActionsPopover';
@@ -50,6 +53,7 @@ function collectSubtreeViewIds(rootView: View): string[] {
 export function Outline({ width }: { width: number }) {
   const outline = useAppOutline();
   const currentWorkspaceId = useCurrentWorkspaceId();
+  const selectedViewId = useSidebarSelectedViewId();
   const loadedViewIds = useLoadedViewIds();
   const loadViewChildren = useLoadViewChildren();
   const loadViewChildrenBatch = useLoadViewChildrenBatch();
@@ -80,6 +84,16 @@ export function Outline({ width }: { width: number }) {
     if (!open) setImportTarget(undefined);
   }, []);
 
+  const revealedViewIdRef = useRef<string | undefined>(undefined);
+  // Latest outline, read by the async reveal walk below. Kept in a ref so the
+  // walk isn't torn down every time the outline updates (e.g. as it lazy-loads
+  // the very branch the walk is populating).
+  const outlineRef = useRef(outline);
+
+  useEffect(() => {
+    outlineRef.current = outline;
+  });
+
   const loadingViewIdsRef = useRef<Set<string>>(new Set());
   const autoLoadRetryAfterRef = useRef<Map<string, number>>(new Map());
   const validatingRestoreIdsRef = useRef<Set<string>>(new Set());
@@ -99,8 +113,79 @@ export function Outline({ width }: { width: number }) {
     autoLoadRetryAfterRef.current = new Map();
     validatingRestoreIdsRef.current = new Set();
     validatedExistingRestoreIdsRef.current = new Set();
+    revealedViewIdRef.current = undefined;
     setLoadingRevision((r) => r + 1);
   }, [currentWorkspaceId]);
+
+  // Expand the given ancestor ids and route them through the startup auto-load
+  // path. Expanding alone only flips the UI flag — queuing them in
+  // pendingAutoLoadIds is what makes the existing cascade fetch + merge each
+  // node's children top-down, so an unloaded branch actually renders.
+  const expandAncestors = useCallback((ancestorIds: string[]) => {
+    if (ancestorIds.length === 0) return;
+
+    // Persist expand state outside the state updaters below — updater functions
+    // must stay pure (React may invoke them more than once). setOutlineExpands
+    // is idempotent, so writing every ancestor (not only newly-added ones) is
+    // safe, and it mirrors how toggleExpandView persists expand state.
+    ancestorIds.forEach((id) => setOutlineExpands(id, true));
+
+    setExpandViewIds((prev) => {
+      const prevSet = new Set(prev);
+      const missing = ancestorIds.filter((id) => !prevSet.has(id));
+
+      return missing.length === 0 ? prev : [...prev, ...missing];
+    });
+
+    setPendingAutoLoadIds((prev) => {
+      const prevSet = new Set(prev);
+      const missing = ancestorIds.filter((id) => !prevSet.has(id));
+
+      return missing.length === 0 ? prev : [...prev, ...missing];
+    });
+  }, []);
+
+  // Reveal the active view in the sidebar by expanding its ancestor folders.
+  // This is what makes the tree open to the page you land on — e.g. the
+  // last-viewed page that `/app` auto-redirects to on load.
+  //
+  // Fast path: the whole ancestor chain is already in the loaded tree.
+  // Slow path: the view (or part of its branch) isn't in the shallow (depth=1)
+  // outline — walk parent_view_id from remote to resolve the chain, then expand
+  // + lazy-load down to it. If a node can't be resolved (deleted / no access),
+  // we leave the sidebar as-is rather than forcing it open.
+  //
+  // The ref gate keeps this to once per selected view: it runs on navigation,
+  // not on every outline change, so a folder the user manually collapses while
+  // staying on the same page won't snap back open.
+  useEffect(() => {
+    if (!selectedViewId || !currentWorkspaceId) return;
+    if (revealedViewIdRef.current === selectedViewId) return;
+
+    let cancelled = false;
+
+    void resolveAncestorViewIds({
+      selectedViewId,
+      workspaceId: currentWorkspaceId,
+      outline: outlineRef.current || [],
+      fetchView: (workspaceId, viewId) => ViewService.get(workspaceId, viewId),
+    }).then((ancestorIds) => {
+      if (cancelled) return;
+
+      // Mark revealed only once the walk finishes, so a transient unmount
+      // (e.g. StrictMode's mount → unmount → mount) doesn't cancel the only
+      // walk and then gate the retry. null means the chain couldn't be
+      // resolved — leave the sidebar as-is; an empty array means nothing to
+      // expand.
+      revealedViewIdRef.current = selectedViewId;
+      if (!ancestorIds) return;
+      expandAncestors(ancestorIds);
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [selectedViewId, currentWorkspaceId, expandAncestors]);
 
   // Validate restored expanded IDs that are not in the current tree and prune only truly stale IDs.
   // This avoids keeping deleted/moved IDs forever, while preserving valid deep IDs.

--- a/src/components/document/history/DocumentHistoryModal.tsx
+++ b/src/components/document/history/DocumentHistoryModal.tsx
@@ -1,3 +1,4 @@
+import { Dialog, DialogContent, DialogTitle } from '@mui/material';
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import * as Y from 'yjs';
@@ -18,7 +19,6 @@ import { useSubscriptionPlan } from '@/components/app/hooks/useSubscriptionPlan'
 import { Editor } from '@/components/editor';
 import { EditorContextState } from '@/components/editor/EditorContext';
 import { useCurrentUser } from '@/components/main/app.hooks';
-import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { cn } from '@/lib/utils';
 import { Log } from '@/utils/log';
 
@@ -26,12 +26,7 @@ import { VersionList } from './DocumentHistoryVersionList';
 
 type PreviewEditorProps = Pick<
   EditorContextState,
-  | 'loadViewMeta'
-  | 'createRow'
-  | 'eventEmitter'
-  | 'getMentionUser'
-  | 'getViewIdFromDatabaseId'
-  | 'loadDatabaseRelations'
+  'loadViewMeta' | 'createRow' | 'eventEmitter' | 'getMentionUser' | 'getViewIdFromDatabaseId' | 'loadDatabaseRelations'
 >;
 
 type VersionPreviewBodyProps = {
@@ -91,11 +86,7 @@ export function DocumentHistoryModal({
     icon: ViewIcon | null;
   };
 }) {
-  const {
-    loadViewMeta,
-    createRow,
-    getViewIdFromDatabaseId,
-  } = useAppOperations();
+  const { loadViewMeta, createRow, getViewIdFromDatabaseId } = useAppOperations();
   const { getCollabHistory, previewCollabVersion, revertCollabVersion } = useCollabHistory();
   const getSubscriptions = useGetSubscriptions();
   const eventEmitter = useEventEmitter();
@@ -321,19 +312,27 @@ export function DocumentHistoryModal({
   }, [clearPreviewDocs]);
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent
-        data-testid="version-history-modal"
-        className={cn(
-          'flex !h-full !w-full rounded-2xl bg-surface-layer-02 p-0',
-          '!max-h-[min(920px,_calc(100vh-160px))] !min-h-[min(689px,_calc(100vh-40px))] !min-w-[min(984px,_calc(100vw-40px))] !max-w-[min(1680px,_calc(100vw-240px))] '
-        )}
-        showCloseButton={false}
-      >
+    <Dialog
+      open={open}
+      onClose={() => onOpenChange(false)}
+      fullWidth
+      maxWidth={false}
+      keepMounted={false}
+      disableAutoFocus={false}
+      disableEnforceFocus={false}
+      disableRestoreFocus
+      PaperProps={{
+        className: cn(
+          'flex !h-full !w-full overflow-hidden rounded-2xl bg-surface-layer-02',
+          '!max-h-[min(920px,_calc(100vh-160px))] !min-h-[min(689px,_calc(100vh-40px))] !min-w-[min(984px,_calc(100vw-40px))] !max-w-[min(1680px,_calc(100vw-240px))]'
+        ),
+      }}
+    >
+      <DialogContent data-testid='version-history-modal' className='flex h-full w-full p-0'>
         <div className='order-2 flex min-w-0 flex-1 flex-col overflow-hidden rounded-t-2xl md:order-1 md:rounded-l-2xl md:rounded-tr-none'>
-          <DialogHeader className='border-b border-border px-6 py-4'>
-            <DialogTitle>{view?.name || t('untitled')}</DialogTitle>
-          </DialogHeader>
+          <DialogTitle className='border-b border-border px-6 py-4 text-base font-bold text-text-primary'>
+            {view?.name || t('untitled')}
+          </DialogTitle>
           <div className='flex-1 overflow-hidden'>
             <VersionPreviewBody
               loading={loading}

--- a/src/components/document/history/DocumentHistoryModal.tsx
+++ b/src/components/document/history/DocumentHistoryModal.tsx
@@ -1,5 +1,5 @@
 import { Dialog, DialogContent, DialogTitle } from '@mui/material';
-import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { memo, useCallback, useEffect, useId, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import * as Y from 'yjs';
 
@@ -96,6 +96,7 @@ export function DocumentHistoryModal({
   const currentUser = useCurrentUser();
   const { isPro } = useSubscriptionPlan(getSubscriptions);
   const { t } = useTranslation();
+  const titleId = useId();
   const [versions, setVersions] = useState<CollabVersionRecord[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -315,6 +316,7 @@ export function DocumentHistoryModal({
     <Dialog
       open={open}
       onClose={() => onOpenChange(false)}
+      aria-labelledby={titleId}
       fullWidth
       maxWidth={false}
       keepMounted={false}
@@ -330,7 +332,7 @@ export function DocumentHistoryModal({
     >
       <DialogContent data-testid='version-history-modal' className='flex h-full w-full overflow-hidden p-0'>
         <div className='order-2 flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden rounded-t-2xl md:order-1 md:rounded-l-2xl md:rounded-tr-none'>
-          <DialogTitle className='border-b border-border px-6 py-4 text-base font-bold text-text-primary'>
+          <DialogTitle id={titleId} className='border-b border-border px-6 py-4 text-base font-bold text-text-primary'>
             {view?.name || t('untitled')}
           </DialogTitle>
           <div className='min-h-0 flex-1 overflow-hidden'>

--- a/src/components/document/history/DocumentHistoryModal.tsx
+++ b/src/components/document/history/DocumentHistoryModal.tsx
@@ -58,7 +58,7 @@ const VersionPreviewBody = memo(function VersionPreviewBody({
   }
 
   return (
-    <div style={{ pointerEvents: 'none' }}>
+    <div className='appflowy-scroller h-full overflow-y-auto overflow-x-hidden'>
       <Editor
         workspaceId={workspaceId || ''}
         viewId={viewId}
@@ -328,12 +328,12 @@ export function DocumentHistoryModal({
         ),
       }}
     >
-      <DialogContent data-testid='version-history-modal' className='flex h-full w-full p-0'>
-        <div className='order-2 flex min-w-0 flex-1 flex-col overflow-hidden rounded-t-2xl md:order-1 md:rounded-l-2xl md:rounded-tr-none'>
+      <DialogContent data-testid='version-history-modal' className='flex h-full w-full overflow-hidden p-0'>
+        <div className='order-2 flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden rounded-t-2xl md:order-1 md:rounded-l-2xl md:rounded-tr-none'>
           <DialogTitle className='border-b border-border px-6 py-4 text-base font-bold text-text-primary'>
             {view?.name || t('untitled')}
           </DialogTitle>
-          <div className='flex-1 overflow-hidden'>
+          <div className='min-h-0 flex-1 overflow-hidden'>
             <VersionPreviewBody
               loading={loading}
               error={error}

--- a/src/components/editor/components/blocks/image/useImageWithRetry.ts
+++ b/src/components/editor/components/blocks/image/useImageWithRetry.ts
@@ -161,13 +161,21 @@ export function useImageWithRetry(
       // The pending-promotion timer checks this so we don't briefly flash the
       // "still uploading…" UI between fetch success and <img> decode.
       let settled = false;
+      // Latest non-ok result, read by the pending-promotion timer below. Only an
+      // explicit "upload pipeline still in flight" signal (425/503 → 'not-ready')
+      // should surface the "Waiting for upload to finish…" copy. A slow or failing
+      // *remote* image is not an upload, so it must stay in 'loading'.
+      let latestResult: CheckImageResult | null = null;
 
       setPhase('loading');
       setLastError(null);
 
-      // Promote loading → pending if we cross the threshold without success.
+      // Promote loading → pending only when the server says the upload is still
+      // finishing. Otherwise keep the plain loading spinner — a slow or broken
+      // remote/external image must not be mislabeled as "waiting for upload".
       scheduleTimer(() => {
         if (controller.signal.aborted || settled) return;
+        if (latestResult?.errorKind !== 'not-ready') return;
         setPhase((p) => (p === 'loading' ? 'pending' : p));
       }, PENDING_AFTER_MS);
 
@@ -241,6 +249,7 @@ export function useImageWithRetry(
         }
 
         setLastError(result);
+        latestResult = result;
 
         const schedule = backoffSchedule(result.errorKind);
         const exhausted = attempt >= schedule.length;
@@ -251,6 +260,13 @@ export function useImageWithRetry(
           settled = true;
           controllersRef.current.delete(controller);
           return;
+        }
+
+        // If the upload pipeline reports "not ready" only after we've already
+        // waited past the threshold, surface the "Waiting for upload to finish…"
+        // copy now — the one-shot timer above may have fired earlier without it.
+        if (result.errorKind === 'not-ready' && elapsed >= PENDING_AFTER_MS) {
+          setPhase((p) => (p === 'loading' ? 'pending' : p));
         }
 
         await sleep(jitter(schedule[attempt]));

--- a/src/components/editor/components/leaf/mention/MentionExternalLink.tsx
+++ b/src/components/editor/components/leaf/mention/MentionExternalLink.tsx
@@ -1,22 +1,58 @@
-import React, { useEffect } from 'react';
+import { debounce } from 'lodash-es';
+import { type MouseEvent, memo, useCallback, useEffect, useMemo, useState } from 'react';
 
+import { MentionLinkPreviewCard } from '@/components/editor/components/leaf/mention/MentionLinkPreviewCard';
+import { Popover, PopoverAnchor, PopoverContent } from '@/components/ui/popover';
 import { buildFallbackLinkPreviewData, fetchLinkPreviewData, LinkPreviewData } from '@/utils/link-preview';
+import { openUrl } from '@/utils/url';
 
 interface RemoteLinkPreviewData {
   data: LinkPreviewData;
   url: string;
 }
 
-function MentionExternalLink ({
+// Memoized: this renders as an editor leaf, which re-renders on every selection
+// / typing change. Re-rendering only when `url` changes mirrors the sibling
+// Href / LinkPreview components.
+const MentionExternalLink = memo(function MentionExternalLink ({
   url,
 }: {
   url: string;
 }) {
-  const fallbackData = React.useMemo(() => buildFallbackLinkPreviewData(url), [url]);
-  const [remotePreview, setRemotePreview] = React.useState<RemoteLinkPreviewData | null>(null);
+  const fallbackData = useMemo(() => buildFallbackLinkPreviewData(url), [url]);
+  const [remotePreview, setRemotePreview] = useState<RemoteLinkPreviewData | null>(null);
   const data = remotePreview && remotePreview.url === url ? remotePreview.data : fallbackData;
+  const [open, setOpen] = useState(false);
+  const [anchor, setAnchor] = useState<HTMLSpanElement | null>(null);
+  const [isVisible, setIsVisible] = useState(false);
+
+  // Defer the preview fetch until the chip is near the viewport so a document
+  // with many link mentions doesn't fire N requests up front. Falls back to
+  // eager fetching where IntersectionObserver is unavailable.
+  useEffect(() => {
+    if (isVisible) return;
+    if (!anchor || typeof IntersectionObserver === 'undefined') {
+      setIsVisible(true);
+      return;
+    }
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries[0]?.isIntersecting) {
+          setIsVisible(true);
+        }
+      },
+      { rootMargin: '200px' }
+    );
+
+    observer.observe(anchor);
+
+    return () => observer.disconnect();
+  }, [anchor, isVisible]);
 
   useEffect(() => {
+    if (!isVisible) return;
+
     const controller = new AbortController();
 
     setRemotePreview(null);
@@ -33,29 +69,79 @@ function MentionExternalLink ({
       });
 
     return () => controller.abort();
+  }, [url, isVisible]);
+
+  // Hover, not click: show the rich preview after a short delay and keep it open
+  // while the pointer moves onto the card (matches the desktop hover behaviour).
+  const debounceShow = useMemo(() => debounce(() => setOpen(true), 120), []);
+  const debounceHide = useMemo(() => debounce(() => setOpen(false), 240), []);
+
+  useEffect(
+    () => () => {
+      debounceShow.cancel();
+      debounceHide.cancel();
+    },
+    [debounceShow, debounceHide]
+  );
+
+  const handleOpenLink = useCallback(() => {
+    void openUrl(url, '_blank');
   }, [url]);
+
+  const handleEnter = useCallback(
+    (event: MouseEvent) => {
+      if (event.buttons > 0) return;
+      debounceHide.cancel();
+      debounceShow();
+    },
+    [debounceHide, debounceShow]
+  );
+
+  const handleLeave = useCallback(() => {
+    debounceShow.cancel();
+    debounceHide();
+  }, [debounceShow, debounceHide]);
 
   const imageUrl = data.logo?.url || data.image?.url;
 
   return (
-    <span
-      onClick={() => {
-        window.open(url, '_blank');
-      }}
-      className={'cursor-pointer inline-flex gap-1.5 text-text-primary hover:underline'}
-    >
-      {imageUrl && (
-        <span className={'mt-0.5'}>
-          <img
-            className={'object-cover w-5 h-5'}
-            src={imageUrl}
-            alt={data.title}
-          />
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverAnchor asChild>
+        <span
+          ref={setAnchor}
+          onClick={handleOpenLink}
+          onMouseEnter={handleEnter}
+          onMouseLeave={handleLeave}
+          className={'cursor-pointer inline-flex gap-1.5 text-text-primary hover:underline'}
+        >
+          {imageUrl ? (
+            <span className={'mt-0.5'}>
+              <img className={'object-cover w-5 h-5'} src={imageUrl} alt={data.title} />
+            </span>
+          ) : null}
+          <span className={'leading-[24px]'}>{data.title || url}</span>
         </span>
-      )}
-      <span className={'leading-[24px]'}>{data.title || url}</span>
-    </span>
+      </PopoverAnchor>
+      {/* Portaled by Radix -> escapes the `td { overflow: hidden }` of simple tables.
+          Radix portals bubble events through the React tree, so stop click/mousedown
+          here to avoid reaching MentionLeaf's onClick={select} (which would select the
+          mention text and pop the toolbar). */}
+      <PopoverContent
+        side={'top'}
+        align={'start'}
+        sideOffset={6}
+        className={'w-[280px] overflow-hidden p-0'}
+        onOpenAutoFocus={(event) => event.preventDefault()}
+        onCloseAutoFocus={(event) => event.preventDefault()}
+        onClick={(event) => event.stopPropagation()}
+        onMouseDown={(event) => event.stopPropagation()}
+        onMouseEnter={() => debounceHide.cancel()}
+        onMouseLeave={handleLeave}
+      >
+        <MentionLinkPreviewCard url={url} data={data} onOpen={handleOpenLink} />
+      </PopoverContent>
+    </Popover>
   );
-}
+});
 
 export default MentionExternalLink;

--- a/src/components/editor/components/leaf/mention/MentionExternalLink.tsx
+++ b/src/components/editor/components/leaf/mention/MentionExternalLink.tsx
@@ -31,7 +31,9 @@ const MentionExternalLink = memo(function MentionExternalLink ({
   // eager fetching where IntersectionObserver is unavailable.
   useEffect(() => {
     if (isVisible) return;
-    if (!anchor || typeof IntersectionObserver === 'undefined') {
+    if (!anchor) return;
+
+    if (typeof IntersectionObserver === 'undefined') {
       setIsVisible(true);
       return;
     }

--- a/src/components/editor/components/leaf/mention/MentionLinkPreviewCard.tsx
+++ b/src/components/editor/components/leaf/mention/MentionLinkPreviewCard.tsx
@@ -1,0 +1,54 @@
+import { memo } from 'react';
+
+import { LinkPreviewData } from '@/utils/link-preview';
+
+const WWW_PREFIX = /^www\./;
+
+function hostLabel(url: string): string {
+  try {
+    return new URL(url).hostname.replace(WWW_PREFIX, '');
+  } catch {
+    return url;
+  }
+}
+
+/**
+ * The rich hover card shown for an inline external-link mention. Mirrors the
+ * desktop MentionLinkPreview layout: og:image banner, title, description (up to
+ * three lines) and a favicon + site footer.
+ */
+export const MentionLinkPreviewCard = memo(function MentionLinkPreviewCard({
+  url,
+  data,
+  onOpen,
+}: {
+  url: string;
+  data: LinkPreviewData;
+  onOpen: () => void;
+}) {
+  const image = data.image?.url;
+  const favicon = data.logo?.url;
+
+  return (
+    <div onClick={onOpen} contentEditable={false} className={'flex cursor-pointer flex-col'}>
+      {image ? <img src={image} alt={''} className={'h-[120px] w-full flex-none object-cover object-center'} /> : null}
+      <div className={'flex flex-col gap-1 p-4'}>
+        <div className={'truncate text-sm font-semibold text-text-primary'}>{data.title || url}</div>
+        {data.description ? (
+          <div
+            className={'overflow-hidden text-xs text-text-secondary'}
+            style={{ display: '-webkit-box', WebkitLineClamp: 3, WebkitBoxOrient: 'vertical' }}
+          >
+            {data.description}
+          </div>
+        ) : null}
+        <div className={'mt-2 flex items-center gap-1.5'}>
+          {favicon ? <img src={favicon} alt={''} className={'h-4 w-4 flex-none rounded-sm object-contain'} /> : null}
+          <span className={'truncate text-xs font-bold text-text-primary'}>{hostLabel(url)}</span>
+        </div>
+      </div>
+    </div>
+  );
+});
+
+export default MentionLinkPreviewCard;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,6 +2,9 @@ import ReactDOM from 'react-dom/client';
 
 import '@/i18n/config';
 import App from '@/components/main/App';
+import { registerAppflowyLinkPreviewProvider } from '@/utils/link-preview-remote';
 import './styles/global.css';
+
+registerAppflowyLinkPreviewProvider();
 
 ReactDOM.createRoot(document.getElementById('root')!).render(<App />);

--- a/src/utils/__tests__/link-preview-remote.test.ts
+++ b/src/utils/__tests__/link-preview-remote.test.ts
@@ -1,0 +1,72 @@
+import { LinkPreviewProviderContext } from '../link-preview';
+import { appflowyLinkPreviewProvider } from '../link-preview-remote';
+
+function buildContext(url: string): LinkPreviewProviderContext {
+  return {
+    normalizedUrl: url,
+    fallbackData: { title: url, description: '' },
+    parsedUrl: new URL(url),
+  };
+}
+
+describe('appflowy link preview provider', () => {
+  const originalFetch = global.fetch;
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    jest.clearAllMocks();
+  });
+
+  it('only handles http(s) urls', () => {
+    expect(appflowyLinkPreviewProvider.canHandle(buildContext('https://example.com'))).toBe(true);
+    expect(appflowyLinkPreviewProvider.canHandle(buildContext('http://example.com'))).toBe(true);
+    expect(
+      appflowyLinkPreviewProvider.canHandle({
+        normalizedUrl: 'mailto:nathan@appflowy.io',
+        fallbackData: { title: '', description: '' },
+        parsedUrl: new URL('mailto:nathan@appflowy.io'),
+      })
+    ).toBe(false);
+  });
+
+  it('maps the unfurl endpoint response into preview data', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        title: 'AppFlowy',
+        description: 'Bring projects, wikis, and teams together.',
+        image: { url: 'https://example.com/cover.png' },
+        logo: { url: 'https://example.com/favicon.svg' },
+      }),
+    }) as unknown as typeof fetch;
+
+    await expect(appflowyLinkPreviewProvider.fetch(buildContext('https://example.com/path'))).resolves.toEqual({
+      title: 'AppFlowy',
+      description: 'Bring projects, wikis, and teams together.',
+      image: { url: 'https://example.com/cover.png' },
+      logo: { url: 'https://example.com/favicon.svg' },
+    });
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      `/api/link-preview?url=${encodeURIComponent('https://example.com/path')}`,
+      expect.objectContaining({ signal: undefined })
+    );
+  });
+
+  it('returns undefined so the next provider can run when the endpoint fails', async () => {
+    global.fetch = jest.fn().mockResolvedValue({ ok: false }) as unknown as typeof fetch;
+
+    await expect(appflowyLinkPreviewProvider.fetch(buildContext('https://example.com'))).resolves.toBeUndefined();
+  });
+
+  it('returns undefined when the endpoint returns no title or invalid json', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => {
+        throw new Error('not json');
+      },
+    }) as unknown as typeof fetch;
+
+    await expect(appflowyLinkPreviewProvider.fetch(buildContext('https://example.com'))).resolves.toBeUndefined();
+  });
+});

--- a/src/utils/image.ts
+++ b/src/utils/image.ts
@@ -125,7 +125,10 @@ const validateImageLoad = (imageUrl: string): Promise<CheckImageResult> => {
 
     // Set a timeout to handle very slow loads
     const timeoutId = setTimeout(() => {
-      resolve(errorResult(408, 'Request Timeout', 'not-ready', 'Image loading timed out'));
+      // External images are never AppFlowy uploads, so a slow load is a network
+      // timeout — not 'not-ready'. Classifying it as 'network' keeps it out of
+      // the "Waiting for upload to finish…" upload-pending state.
+      resolve(errorResult(408, 'Request Timeout', 'network', 'Image loading timed out'));
     }, 10000); // 10 second timeout
 
     img.onload = () => {

--- a/src/utils/link-preview-remote.ts
+++ b/src/utils/link-preview-remote.ts
@@ -1,0 +1,54 @@
+import { LinkPreviewData, LinkPreviewProvider, registerLinkPreviewProvider } from '@/utils/link-preview';
+
+const REMOTE_PREVIEW_ENDPOINT = '/api/link-preview';
+
+// Run ahead of the microlink (100) and github (110) providers so the
+// AppFlowy-hosted unfurler — which mirrors the desktop scraper — is the primary
+// source, leaving those third-party services as graceful fallbacks.
+const REMOTE_PREVIEW_PRIORITY = 60;
+
+export const appflowyLinkPreviewProvider: LinkPreviewProvider = {
+  id: 'appflowy-unfurl',
+  priority: REMOTE_PREVIEW_PRIORITY,
+  canHandle: (context) => {
+    const protocol = context.parsedUrl?.protocol;
+
+    return protocol === 'http:' || protocol === 'https:';
+  },
+  async fetch(context) {
+    const endpoint = `${REMOTE_PREVIEW_ENDPOINT}?url=${encodeURIComponent(context.normalizedUrl)}`;
+    const response = await fetch(endpoint, { signal: context.signal });
+
+    if (!response.ok) return undefined;
+
+    let data: Partial<LinkPreviewData> | null = null;
+
+    try {
+      data = (await response.json()) as Partial<LinkPreviewData>;
+    } catch {
+      return undefined;
+    }
+
+    if (!data || !data.title) return undefined;
+
+    return {
+      title: data.title,
+      description: data.description ?? '',
+      ...(data.image?.url ? { image: { url: data.image.url } } : {}),
+      ...(data.logo?.url ? { logo: { url: data.logo.url } } : {}),
+    };
+  },
+};
+
+let registered = false;
+
+/**
+ * Registers the AppFlowy-hosted link preview provider. Called once at app
+ * startup; kept out of the link-preview module itself so unit tests exercise
+ * the default providers in isolation.
+ */
+export function registerAppflowyLinkPreviewProvider(): void {
+  if (registered) return;
+  registered = true;
+  registerLinkPreviewProvider(appflowyLinkPreviewProvider);
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -47,6 +47,7 @@
   },
   "include": [
     "src",
+    "api",
     ".storybook",
     "vite.config.ts",
     "deploy/**/*.ts"

--- a/vercel.json
+++ b/vercel.json
@@ -1,3 +1,3 @@
 {
-  "routes": [{ "src": "/[^.]+", "dest": "/", "status": 200 }]
+  "rewrites": [{ "source": "/((?!api/).*)", "destination": "/" }]
 }


### PR DESCRIPTION
## Summary
- add a server-side link preview endpoint with redirect target validation for SSRF-sensitive hosts
- register the AppFlowy unfurl provider ahead of Microlink/GitHub while preserving fallback behavior on server fetch failures
- add hover previews for external-link mentions and reveal selected sidebar ancestors on load
- keep slow external image loads out of the upload-pending state

## Review
- reviewed the current diff and found no blocking issues
- verified redirect-based SSRF handling and fallback-provider behavior with focused tests

## Tests
- pnpm exec jest src/utils/__tests__/link-preview.test.ts src/utils/__tests__/link-preview-remote.test.ts api/_lib/__tests__/unfurl.test.ts src/components/app/hooks/__tests__/resolveAncestorViewIds.test.ts --no-coverage --runInBand
- pnpm exec tsc --noEmit --project tsconfig.web.json

## Summary by Sourcery

Add a server-side link unfurling endpoint and wire it into web link previews while improving sidebar reveal behavior and upload status handling.

New Features:
- Introduce a server-side /api/link-preview endpoint that unfurls external URLs with basic SSRF-safe redirect handling.
- Add a high-priority AppFlowy link preview provider that uses the new unfurl endpoint before third-party providers.
- Enable rich hover cards for external-link mentions in the editor, including delayed fetching based on viewport visibility.

Enhancements:
- Automatically expand sidebar ancestors to reveal the currently selected view when navigating into the app.
- Prevent slow or failing external images from entering the upload-pending state, keeping them in a generic loading state instead.

Tests:
- Add unit tests for the URL ancestor resolution helper used to reveal sidebar views.
- Add unit tests for the server-side unfurl logic, including redirect and failure handling.
- Add unit tests for the AppFlowy remote link preview provider integration.