### PR TITLE
Fix link preview paste and favicon rendering

### DIFF
--- a/api/_lib/__tests__/unfurl.test.ts
+++ b/api/_lib/__tests__/unfurl.test.ts
@@ -47,10 +47,31 @@ describe('unfurl', () => {
     await expect(unfurl('https://example.com/path')).rejects.toThrow('network error');
   });
 
-  it('rejects non-OK responses so lower-priority providers can run', async () => {
+  it('parses metadata from non-OK responses instead of rejecting (mirrors the desktop parser)', async () => {
+    global.fetch = jest
+      .fn()
+      .mockResolvedValue(
+        htmlResponse(
+          '<head><meta property="og:title" content="Sign in"><meta property="og:site_name" content="Example"></head>',
+          404
+        )
+      ) as unknown as typeof fetch;
+
+    await expect(unfurl('https://example.com/private')).resolves.toMatchObject({
+      title: 'Sign in',
+      siteName: 'Example',
+      logo: { url: 'https://www.google.com/s2/favicons?domain=example.com&sz=128' },
+    });
+  });
+
+  it('falls back to the host title for non-OK responses without metadata', async () => {
     global.fetch = jest.fn().mockResolvedValue(htmlResponse('', 403)) as unknown as typeof fetch;
 
-    await expect(unfurl('https://example.com/blocked')).rejects.toThrow('Failed to fetch link preview: 403');
+    await expect(unfurl('https://example.com/blocked')).resolves.toMatchObject({
+      title: 'example.com',
+      description: '',
+      logo: { url: 'https://www.google.com/s2/favicons?domain=example.com&sz=128' },
+    });
   });
 
   it('rejects redirects to blocked hosts before fetching the redirect target', async () => {
@@ -109,6 +130,19 @@ describe('unfurl', () => {
       'https://redirected.example/final',
       expect.objectContaining({ redirect: 'manual' })
     );
+  });
+
+  it('adds a dark-mode favicon for GitHub hosts so the icon stays visible on dark UI', async () => {
+    global.fetch = jest
+      .fn()
+      .mockResolvedValue(
+        htmlResponse('<head><meta property="og:title" content="GitHub repo"></head>')
+      ) as unknown as typeof fetch;
+
+    await expect(unfurl('https://github.com/AppFlowy-IO/AppFlowy')).resolves.toMatchObject({
+      title: 'GitHub repo',
+      logoDark: { url: 'https://github.githubassets.com/favicons/favicon-dark.png' },
+    });
   });
 });
 

--- a/api/_lib/unfurl.ts
+++ b/api/_lib/unfurl.ts
@@ -25,8 +25,20 @@ export interface UnfurlImage {
 export interface UnfurlResult {
   title: string;
   description: string;
+  siteName?: string;
   image?: UnfurlImage;
   logo?: UnfurlImage;
+  // A favicon variant for dark themes. Some sites (notably GitHub) ship a
+  // near-black monochrome favicon that is invisible on a dark background; the
+  // client picks this when in dark mode. Mirrors the desktop parser's
+  // darkFaviconUrl.
+  logoDark?: UnfurlImage;
+}
+
+const GITHUB_DARK_FAVICON = 'https://github.githubassets.com/favicons/favicon-dark.png';
+
+function isGithubHost(host: string): boolean {
+  return host === 'github.com' || host.endsWith('.github.com');
 }
 
 interface FetchedHtml {
@@ -39,11 +51,11 @@ export async function unfurl(rawUrl: string): Promise<UnfurlResult> {
   const { response, url } = await fetchHtml(initialUrl);
   const host = url.hostname.replace(/^www\./, '');
 
-  if (!response.ok) {
-    void response.body?.cancel().catch(() => undefined);
-    throw new Error(`Failed to fetch link preview: ${response.status}`);
-  }
-
+  // Parse the response body regardless of HTTP status. Many sites return useful
+  // Open Graph metadata on non-2xx responses (login walls, soft 404s, etc.), and
+  // this mirrors the desktop DefaultParser, which never inspects the status code.
+  // When the body carries no metadata, extractMetadata still falls back to the
+  // host title + favicon.
   const contentType = response.headers.get('content-type')?.toLowerCase() ?? '';
 
   if (!isHtml(contentType)) {
@@ -149,14 +161,17 @@ function extractMetadata(head: string, url: URL, host: string): UnfurlResult {
 
   const title = clean(og('og:title')) || clean(extractTitleTag(head)) || clean(named('title')) || host;
   const description = clean(og('og:description')) || clean(named('description'));
+  const siteName = clean(og('og:site_name'));
   const image = resolveOptional(url, og('og:image'));
   const favicon = extractFavicon(links, url) ?? defaultFavicon(host);
 
   return {
     title,
     description: truncate(description),
+    ...(siteName ? { siteName } : {}),
     ...(image ? { image: { url: image } } : {}),
     logo: { url: favicon },
+    ...(isGithubHost(host) ? { logoDark: { url: GITHUB_DARK_FAVICON } } : {}),
   };
 }
 

--- a/src/components/editor/components/leaf/mention/MentionExternalLink.tsx
+++ b/src/components/editor/components/leaf/mention/MentionExternalLink.tsx
@@ -1,7 +1,9 @@
 import { debounce } from 'lodash-es';
-import { type MouseEvent, memo, useCallback, useEffect, useMemo, useState } from 'react';
+import { type MouseEvent, memo, useCallback, useContext, useEffect, useMemo, useState } from 'react';
 
+import { ReactComponent as EarthIcon } from '@/assets/icons/earth.svg';
 import { MentionLinkPreviewCard } from '@/components/editor/components/leaf/mention/MentionLinkPreviewCard';
+import { ThemeModeContext } from '@/components/main/useAppThemeMode';
 import { Popover, PopoverAnchor, PopoverContent } from '@/components/ui/popover';
 import { buildFallbackLinkPreviewData, fetchLinkPreviewData, LinkPreviewData } from '@/utils/link-preview';
 import { openUrl } from '@/utils/url';
@@ -19,12 +21,14 @@ const MentionExternalLink = memo(function MentionExternalLink ({
 }: {
   url: string;
 }) {
+  const isDark = useContext(ThemeModeContext)?.isDark ?? false;
   const fallbackData = useMemo(() => buildFallbackLinkPreviewData(url), [url]);
   const [remotePreview, setRemotePreview] = useState<RemoteLinkPreviewData | null>(null);
   const data = remotePreview && remotePreview.url === url ? remotePreview.data : fallbackData;
   const [open, setOpen] = useState(false);
   const [anchor, setAnchor] = useState<HTMLSpanElement | null>(null);
   const [isVisible, setIsVisible] = useState(false);
+  const [failedIconUrl, setFailedIconUrl] = useState<string | null>(null);
 
   // Defer the preview fetch until the chip is near the viewport so a document
   // with many link mentions doesn't fire N requests up front. Falls back to
@@ -104,7 +108,12 @@ const MentionExternalLink = memo(function MentionExternalLink ({
     debounceHide();
   }, [debounceShow, debounceHide]);
 
-  const imageUrl = data.logo?.url || data.image?.url;
+  const imageUrl = (isDark ? data.logoDark?.url : undefined) || data.logo?.url || data.image?.url;
+  // Mirror the desktop buildIconWidget: always show an icon, falling back to a
+  // globe when the favicon is missing or fails to load (e.g. a 404 favicon).
+  // Derive the error state from the URL that failed so it resets during render
+  // when `imageUrl` changes — no effect, no extra render, no stale-error flash.
+  const iconError = imageUrl !== undefined && imageUrl === failedIconUrl;
 
   return (
     <Popover open={open} onOpenChange={setOpen}>
@@ -114,12 +123,20 @@ const MentionExternalLink = memo(function MentionExternalLink ({
           onClick={handleOpenLink}
           onMouseEnter={handleEnter}
           onMouseLeave={handleLeave}
-          className={'cursor-pointer inline-flex gap-1.5 text-text-primary hover:underline'}
+          className={'cursor-pointer inline-flex items-center gap-1 text-text-primary hover:underline'}
         >
-          {imageUrl ? (
-            <span className={'mt-0.5'}>
-              <img className={'object-cover w-5 h-5'} src={imageUrl} alt={data.title} />
-            </span>
+          {imageUrl && !iconError ? (
+            <img
+              className={'h-[18px] w-[18px] flex-none rounded-sm object-contain'}
+              src={imageUrl}
+              alt={''}
+              onError={() => setFailedIconUrl(imageUrl ?? null)}
+            />
+          ) : (
+            <EarthIcon className={'h-[18px] w-[18px] flex-none text-text-secondary'} />
+          )}
+          {data.siteName ? (
+            <span className={'leading-[24px] text-text-secondary'}>{data.siteName}</span>
           ) : null}
           <span className={'leading-[24px]'}>{data.title || url}</span>
         </span>

--- a/src/components/editor/components/leaf/mention/MentionLinkPreviewCard.tsx
+++ b/src/components/editor/components/leaf/mention/MentionLinkPreviewCard.tsx
@@ -1,5 +1,7 @@
-import { memo } from 'react';
+import { memo, useContext } from 'react';
 
+import { ReactComponent as EarthIcon } from '@/assets/icons/earth.svg';
+import { ThemeModeContext } from '@/components/main/useAppThemeMode';
 import { LinkPreviewData } from '@/utils/link-preview';
 
 const WWW_PREFIX = /^www\./;
@@ -26,8 +28,9 @@ export const MentionLinkPreviewCard = memo(function MentionLinkPreviewCard({
   data: LinkPreviewData;
   onOpen: () => void;
 }) {
+  const isDark = useContext(ThemeModeContext)?.isDark ?? false;
   const image = data.image?.url;
-  const favicon = data.logo?.url;
+  const favicon = (isDark ? data.logoDark?.url : undefined) || data.logo?.url;
 
   return (
     <div onClick={onOpen} contentEditable={false} className={'flex cursor-pointer flex-col'}>
@@ -43,8 +46,12 @@ export const MentionLinkPreviewCard = memo(function MentionLinkPreviewCard({
           </div>
         ) : null}
         <div className={'mt-2 flex items-center gap-1.5'}>
-          {favicon ? <img src={favicon} alt={''} className={'h-4 w-4 flex-none rounded-sm object-contain'} /> : null}
-          <span className={'truncate text-xs font-bold text-text-primary'}>{hostLabel(url)}</span>
+          {favicon ? (
+            <img src={favicon} alt={''} className={'h-4 w-4 flex-none rounded-sm object-contain'} />
+          ) : (
+            <EarthIcon className={'h-4 w-4 flex-none text-text-secondary'} />
+          )}
+          <span className={'truncate text-xs font-bold text-text-primary'}>{data.siteName || hostLabel(url)}</span>
         </div>
       </div>
     </div>

--- a/src/components/editor/plugins/withPasted.ts
+++ b/src/components/editor/plugins/withPasted.ts
@@ -13,14 +13,7 @@ import {
   isInsideSimpleTableCell,
 } from '@/application/slate-yjs/utils/editor';
 import { assertDocExists, getBlock, getChildrenArray, getText } from '@/application/slate-yjs/utils/yjs';
-import {
-  BlockType,
-  LinkPreviewBlockData,
-  MentionType,
-  VideoBlockData,
-  VideoType,
-  YjsEditorKey,
-} from '@/application/types';
+import { BlockType, MentionType, YjsEditorKey } from '@/application/types';
 import { parseHTML } from '@/components/editor/parsers/html-parser';
 import { parseMarkdown } from '@/components/editor/parsers/markdown-parser';
 import { parsePlainTextFragments } from '@/components/editor/parsers/paste-fragment-detectors';
@@ -31,7 +24,6 @@ import type { PasteAsMenuPayload } from '@/components/editor/components/panels/p
 import { getRangeRect } from '@/components/editor/components/toolbar/selection-toolbar/utils';
 import { detectMarkdown, detectTSV } from '@/components/editor/utils/markdown-detector';
 import { isSingleURLText, processUrl } from '@/utils/url';
-import { isValidVideoUrl, videoTypeData } from '@/utils/video-url';
 
 /**
  * Enhances Slate editor with improved paste handling
@@ -395,7 +387,12 @@ function handleMarkdownPaste(editor: ReactEditor, markdown: string): boolean {
 }
 
 /**
- * Handles URL paste (link previews, videos, page references)
+ * Handles URL paste.
+ *
+ * Internal AppFlowy links that point at a specific block are inserted as a
+ * page-reference mention directly. Every other URL is pasted as an inline link
+ * and the "Paste as" menu (Mention / URL / Bookmark / Embed) is shown so the
+ * user can choose how to render it — matching the desktop app's behavior.
  */
 function handleURLPaste(editor: ReactEditor, url: string): boolean {
   // Check for AppFlowy internal links
@@ -430,32 +427,9 @@ function handleURLPaste(editor: ReactEditor, url: string): boolean {
     }
   }
 
-  if (isPastingInsideSimpleTableCell(editor)) {
-    return insertLinkedURLTextAndShowPasteAsMenu(editor, url);
-  }
-
-  // Check for video URLs
-  const isVideoUrl = isValidVideoUrl(url);
-
-  if (isVideoUrl) {
-    return insertBlock(editor, {
-      type: BlockType.VideoBlock,
-      data: { url: processUrl(url) || url, ...videoTypeData(VideoType.External) } as VideoBlockData,
-    });
-  }
-
-  // Default: Link preview
-  return insertBlock(editor, {
-    type: BlockType.LinkPreview,
-    data: { url } as LinkPreviewBlockData,
-  });
-}
-
-function isPastingInsideSimpleTableCell(editor: ReactEditor): boolean {
-  const entry = getBlockEntry(editor as YjsEditor);
-  const blockId = entry?.[0].blockId;
-
-  return Boolean(blockId && isInsideSimpleTableCell(editor as YjsEditor, blockId));
+  // Insert the URL as an inline link and show the "Paste as" menu so the user
+  // can convert it to a Mention / Bookmark / Embed (matches desktop behavior).
+  return insertLinkedURLTextAndShowPasteAsMenu(editor, url);
 }
 
 function cloneRange(range: Range): Range {
@@ -570,58 +544,6 @@ function handleMultiLinePlainText(editor: ReactEditor, lines: string[]): boolean
     }));
 
   return insertParsedBlocks(editor, blocks);
-}
-
-/**
- * Helper to insert a single block (for URL handlers).
- *
- * Writes directly to Yjs via slateContentInsertToYData rather than going
- * through Transforms.insertNodes — Slate's applyInsertNode binding short-
- * circuits for non-text nodes (see applyToYjs.ts), so embed blocks like
- * LinkPreview/VideoBlock would render in Slate's local state but never
- * persist to the Y.Doc. The block was lost as soon as the editor unmounted
- * (e.g. closing a database row card right after pasting a URL).
- */
-function insertBlock(editor: ReactEditor, block: { type: BlockType; data: object }): boolean {
-  const point = editor.selection?.anchor;
-
-  if (!point) return false;
-
-  try {
-    const entry = getBlockEntry(editor as YjsEditor, point);
-
-    if (!entry) return false;
-
-    const [node] = entry;
-    const blockId = (node as { blockId?: string }).blockId;
-
-    if (!blockId) return false;
-
-    const sharedRoot = getSharedRoot(editor as YjsEditor);
-    const currentBlock = getBlock(blockId, sharedRoot);
-    const parentId = currentBlock.get(YjsEditorKey.block_parent);
-    const parent = getBlock(parentId, sharedRoot);
-    const parentChildren = getChildrenArray(parent.get(YjsEditorKey.block_children), sharedRoot);
-    const index = parentChildren.toArray().findIndex((id) => id === blockId);
-    const doc = assertDocExists(sharedRoot);
-
-    // slateContentInsertToYData expects Slate Element shape; the data
-    // payload becomes the Yjs block's `data` field as-is.
-    const slateNode: Element = {
-      type: block.type,
-      data: block.data,
-      children: [{ text: '' }],
-    } as unknown as Element;
-
-    doc.transact(() => {
-      slateContentInsertToYData(parentId, index + 1, [slateNode], doc);
-    });
-
-    return true;
-  } catch (error) {
-    console.error('Error inserting block:', error);
-    return false;
-  }
 }
 
 /**

--- a/src/utils/__tests__/link-preview.test.ts
+++ b/src/utils/__tests__/link-preview.test.ts
@@ -328,6 +328,7 @@ describe('link preview providers', () => {
     await expect(fetchLinkPreviewData('https://github.com/AppFlowy-IO/AppFlowy-Web/issues/53')).resolves.toEqual({
       title: 'Issue title - AppFlowy-IO/AppFlowy-Web#53',
       description: 'Issue body',
+      siteName: 'GitHub',
       image: { url: 'https://avatars.githubusercontent.com/u/1?v=4' },
     });
     expect(mockedAxios.get).toHaveBeenCalledTimes(2);

--- a/src/utils/link-preview-remote.ts
+++ b/src/utils/link-preview-remote.ts
@@ -34,8 +34,10 @@ export const appflowyLinkPreviewProvider: LinkPreviewProvider = {
     return {
       title: data.title,
       description: data.description ?? '',
+      ...(data.siteName ? { siteName: data.siteName } : {}),
       ...(data.image?.url ? { image: { url: data.image.url } } : {}),
       ...(data.logo?.url ? { logo: { url: data.logo.url } } : {}),
+      ...(data.logoDark?.url ? { logoDark: { url: data.logoDark.url } } : {}),
     };
   },
 };

--- a/src/utils/link-preview.ts
+++ b/src/utils/link-preview.ts
@@ -18,8 +18,12 @@ export interface LinkPreviewImageData {
 export interface LinkPreviewData {
   image?: LinkPreviewImageData;
   logo?: LinkPreviewImageData;
+  // Favicon variant for dark themes (e.g. GitHub's light octocat), used when the
+  // default favicon is a near-black monochrome icon that vanishes on dark UI.
+  logoDark?: LinkPreviewImageData;
   title: string;
   description: string;
+  siteName?: string;
 }
 
 export interface LinkPreviewProviderContext {
@@ -138,6 +142,7 @@ const githubProvider: LinkPreviewProvider = {
       return {
         title,
         description,
+        siteName: 'GitHub',
         ...(issue.user?.avatar_url ? { image: { url: issue.user.avatar_url } } : {}),
       };
     }
@@ -151,6 +156,7 @@ const githubProvider: LinkPreviewProvider = {
     return {
       title: repository.full_name || `${target.owner}/${target.repo}`,
       description: truncateDescription(repository.description || repository.html_url || ''),
+      siteName: 'GitHub',
       ...(repository.owner?.avatar_url ? { image: { url: repository.owner.avatar_url } } : {}),
     };
   },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,8 @@
 import react from '@vitejs/plugin-react';
+import type { IncomingMessage, ServerResponse } from 'http';
 import path from 'path';
 import { visualizer } from 'rollup-plugin-visualizer';
-import { defineConfig } from 'vite';
+import { defineConfig, type ViteDevServer } from 'vite';
 import istanbul from 'vite-plugin-istanbul';
 import svgr from 'vite-plugin-svgr';
 import { totalBundleSize } from 'vite-plugin-total-bundle-size';
@@ -73,11 +74,47 @@ function namespaceRedirectPlugin() {
   };
 }
 
+// Runs the /api/link-preview serverless function in dev. Vite does not execute
+// the Vercel functions under `api/`, so without this the link-preview unfurler
+// only works in production and every pasted URL degrades to its raw text
+// locally (no favicon / title / image). The handler uses Node's IncomingMessage
+// / ServerResponse, which is exactly what the connect dev-server middleware
+// passes, so we can invoke it directly.
+function linkPreviewApiPlugin() {
+  return {
+    name: 'link-preview-api',
+    apply: 'serve' as const,
+    configureServer(server: ViteDevServer) {
+      server.middlewares.use((req, res, next) => {
+        if (!req.url || !req.url.startsWith('/api/link-preview')) {
+          return next();
+        }
+
+        server
+          .ssrLoadModule('/api/link-preview.ts')
+          .then((mod) =>
+            (mod.default as (req: IncomingMessage, res: ServerResponse) => Promise<void>)(
+              req as IncomingMessage,
+              res as ServerResponse
+            )
+          )
+          .catch((error: unknown) => {
+            server.config.logger.error(`[link-preview] ${error instanceof Error ? error.message : String(error)}`);
+            res.statusCode = 502;
+            res.setHeader('Content-Type', 'application/json; charset=utf-8');
+            res.end(JSON.stringify({ error: 'Failed to fetch link preview' }));
+          });
+      });
+    },
+  };
+}
+
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [
     react(),
     isDev ? namespaceRedirectPlugin() : undefined,
+    isDev ? linkPreviewApiPlugin() : undefined,
     // Strip data-testid attributes in production builds
     isProd ? stripTestIdPlugin() : undefined,
     svgr({


### PR DESCRIPTION
## Summary
- show external link mentions with site names, theme-aware favicons, and a globe fallback
- keep remote unfurl metadata for siteName/logoDark and parse useful metadata from non-OK HTML responses
- paste URLs inline with the Paste as menu, and wire /api/link-preview into Vite dev mode

## Tests
- Type-checking passed
- Targeted unit tests passed
- ESLint on touched files passed

## Summary by Sourcery

Align link paste behavior and external link previews with the desktop app, while improving favicon handling and dev-time link-preview support.

New Features:
- Render external link mentions and preview cards with site names, theme-aware favicons, and a globe fallback icon.
- Support dark-mode-specific favicons for GitHub and expose them through the unfurl API and client link-preview data.
- Run the /api/link-preview serverless handler in Vite dev mode so link previews work locally.

Bug Fixes:
- Paste non-AppFlowy URLs as inline links and show the "Paste as" menu instead of always inserting link-preview or video blocks, matching desktop behavior.
- Parse and surface metadata from non-OK HTML responses and fall back to host-based titles instead of treating them as hard errors.

Enhancements:
- Extend link-preview unfurling to derive site names and improve favicon selection, including GitHub-specific dark favicons.
- Improve external link mention and preview card layout and accessibility by adjusting icon sizing, alignment, and hover behavior.

Tests:
- Add and update unfurl and link-preview tests to cover non-OK responses, dark favicons, and GitHub-specific metadata.