### PR TITLE
Support sidebar space reordering

### DIFF
--- a/src/application/services/js-services/http/page-api.ts
+++ b/src/application/services/js-services/http/page-api.ts
@@ -102,7 +102,7 @@ export async function restorePage(workspaceId: string, viewId?: string) {
   return executeAPIVoidRequest(() => getAxios()?.post<APIResponse>(url));
 }
 
-export async function movePageTo(workspaceId: string, viewId: string, parentViewId: string, prevViewId?: string) {
+export async function movePageTo(workspaceId: string, viewId: string, parentViewId: string, prevViewId?: string | null) {
   const url = `/api/workspace/${workspaceId}/page-view/${viewId}/move`;
 
   return executeAPIVoidRequest(() =>

--- a/src/components/app/outline/Outline.tsx
+++ b/src/components/app/outline/Outline.tsx
@@ -1,9 +1,16 @@
+import { combine } from '@atlaskit/pragmatic-drag-and-drop/combine';
+import { monitorForElements } from '@atlaskit/pragmatic-drag-and-drop/element/adapter';
+import { reorder } from '@atlaskit/pragmatic-drag-and-drop/reorder';
+import { autoScrollForElements } from '@atlaskit/pragmatic-drag-and-drop-auto-scroll/element';
+import { extractClosestEdge, type Edge } from '@atlaskit/pragmatic-drag-and-drop-hitbox/closest-edge';
+import { getReorderDestinationIndex } from '@atlaskit/pragmatic-drag-and-drop-hitbox/util/get-reorder-destination-index';
 import React, { lazy, Suspense, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { useTranslation } from 'react-i18next';
+import { toast } from 'sonner';
 
-import { ViewService } from '@/application/services/domains';
-import { View, ViewLayout } from '@/application/types';
+import { PageService, ViewService } from '@/application/services/domains';
+import { Role, View, ViewLayout } from '@/application/types';
 import { ReactComponent as MoreIcon } from '@/assets/icons/more.svg';
 import { ReactComponent as PlusIcon } from '@/assets/icons/plus.svg';
 import { findView, getOutlineExpands, setOutlineExpands } from '@/components/_shared/outline/utils';
@@ -16,7 +23,9 @@ import {
   useLoadViewChildrenBatch,
   useLoadViewChildren,
   useMarkViewChildrenStale,
+  useRefreshOutline,
   useSidebarSelectedViewId,
+  useUserWorkspaceInfo,
 } from '@/components/app/app.hooks';
 import { Favorite } from '@/components/app/favorite';
 import { resolveAncestorViewIds } from '@/components/app/hooks/resolveAncestorViewIds';
@@ -58,6 +67,123 @@ export function Outline({ width }: { width: number }) {
   const loadViewChildren = useLoadViewChildren();
   const loadViewChildrenBatch = useLoadViewChildrenBatch();
   const markViewChildrenStale = useMarkViewChildrenStale();
+  const refreshOutline = useRefreshOutline();
+  const userWorkspaceInfo = useUserWorkspaceInfo();
+  const canReorderSpaces = userWorkspaceInfo?.selectedWorkspace.role === Role.Owner;
+  const [spaceDragInstanceId] = useState(() => Symbol('space-drag-instance'));
+  const spaceListRef = useRef<HTMLDivElement>(null);
+  const visibleSpacesFromOutline = useMemo(
+    () => outline?.filter((view) => !view.extra?.is_hidden_space) ?? [],
+    [outline]
+  );
+  const [optimisticSpaceIds, setOptimisticSpaceIds] = useState<string[] | null>(null);
+  const visibleSpaces = useMemo(() => {
+    if (!optimisticSpaceIds) return visibleSpacesFromOutline;
+
+    const spaceById = new Map(visibleSpacesFromOutline.map((space) => [space.view_id, space]));
+    const orderedSpaces = optimisticSpaceIds
+      .map((spaceId) => spaceById.get(spaceId))
+      .filter((space): space is View => Boolean(space));
+    const orderedSpaceIds = new Set(orderedSpaces.map((space) => space.view_id));
+
+    return [
+      ...orderedSpaces,
+      ...visibleSpacesFromOutline.filter((space) => !orderedSpaceIds.has(space.view_id)),
+    ];
+  }, [optimisticSpaceIds, visibleSpacesFromOutline]);
+  const visibleSpacesRef = useRef<View[]>(visibleSpaces);
+  const spaceReorderRequestSeqRef = useRef(0);
+
+  useEffect(() => {
+    visibleSpacesRef.current = visibleSpaces;
+  }, [visibleSpaces]);
+
+  useEffect(() => {
+    setOptimisticSpaceIds(null);
+    spaceReorderRequestSeqRef.current += 1;
+  }, [currentWorkspaceId]);
+
+  const reorderSpaces = useCallback(
+    async (sourceId: string, targetId: string, closestEdgeOfTarget: Edge | null) => {
+      if (!currentWorkspaceId || !canReorderSpaces) return;
+
+      const currentSpaces = visibleSpacesRef.current;
+      const startIndex = currentSpaces.findIndex((space) => space.view_id === sourceId);
+      const indexOfTarget = currentSpaces.findIndex((space) => space.view_id === targetId);
+
+      if (startIndex < 0 || indexOfTarget < 0) return;
+
+      const finishIndex = getReorderDestinationIndex({
+        startIndex,
+        indexOfTarget,
+        closestEdgeOfTarget,
+        axis: 'vertical',
+      });
+
+      if (finishIndex === startIndex) return;
+
+      const nextSpaces = reorder({
+        list: currentSpaces,
+        startIndex,
+        finishIndex,
+      });
+      const requestSeq = ++spaceReorderRequestSeqRef.current;
+      const movedSpace = currentSpaces[startIndex];
+      const prevViewId = finishIndex > 0 ? nextSpaces[finishIndex - 1]?.view_id : null;
+
+      visibleSpacesRef.current = nextSpaces;
+      setOptimisticSpaceIds(nextSpaces.map((space) => space.view_id));
+
+      try {
+        await PageService.moveTo(currentWorkspaceId, movedSpace.view_id, currentWorkspaceId, prevViewId);
+        await refreshOutline?.();
+        if (spaceReorderRequestSeqRef.current === requestSeq) {
+          setOptimisticSpaceIds(null);
+        }
+      } catch (error) {
+        if (spaceReorderRequestSeqRef.current !== requestSeq) return;
+
+        setOptimisticSpaceIds(null);
+        toast.error('Failed to reorder spaces');
+        Log.error('[Outline] Failed to reorder spaces', error);
+      }
+    },
+    [canReorderSpaces, currentWorkspaceId, refreshOutline]
+  );
+
+  useEffect(() => {
+    const element = spaceListRef.current;
+
+    if (!canReorderSpaces || !element) return;
+
+    function canRespond({ source }: { source: { data: Record<string, unknown> } }) {
+      return source.data.type === 'space' && source.data.instanceId === spaceDragInstanceId;
+    }
+
+    return combine(
+      monitorForElements({
+        canMonitor: canRespond,
+        onDrop({ location, source }) {
+          const target = location.current.dropTargets[0];
+
+          if (!target) return;
+
+          const sourceId = String(source.data.id ?? '');
+          const targetId = String(target.data.id ?? '');
+
+          if (!sourceId || !targetId || sourceId === targetId) return;
+
+          const closestEdgeOfTarget = extractClosestEdge(target.data);
+
+          void reorderSpaces(sourceId, targetId, closestEdgeOfTarget);
+        },
+      }),
+      autoScrollForElements({
+        canScroll: canRespond,
+        element,
+      })
+    );
+  }, [canReorderSpaces, reorderSpaces, spaceDragInstanceId]);
 
   const [menuProps, setMenuProps] = useState<
     | {
@@ -481,7 +607,7 @@ export function Outline({ width }: { width: number }) {
 
   return (
     <>
-      <div className={'folder-views flex w-full flex-1 flex-col px-[8px] pb-[10px] pt-1'}>
+      <div ref={spaceListRef} className={'folder-views flex w-full flex-1 flex-col px-[8px] pb-[10px] pt-1'}>
         <Favorite />
         <ShareWithMe width={width - 20} />
         {!outline || outline.length === 0 ? (
@@ -493,21 +619,21 @@ export function Outline({ width }: { width: number }) {
             <DirectoryStructure />
           </div>
         ) : (
-          outline
-            .filter((view) => !view.extra?.is_hidden_space)
-            .map((view) => (
-              <SpaceItem
-                view={view}
-                key={view.view_id}
-                width={width - 20}
-                renderExtra={renderActions}
-                expandIds={expandViewIds}
-                toggleExpand={toggleExpandView}
-                onClickView={onClickView}
-                loadingViewIds={loadingViewIds}
-                loadedViewIds={loadedViewIds}
-              />
-            ))
+          visibleSpaces.map((view) => (
+            <SpaceItem
+              view={view}
+              key={view.view_id}
+              width={width - 20}
+              renderExtra={renderActions}
+              expandIds={expandViewIds}
+              toggleExpand={toggleExpandView}
+              onClickView={onClickView}
+              loadingViewIds={loadingViewIds}
+              loadedViewIds={loadedViewIds}
+              canReorder={canReorderSpaces && visibleSpaces.length > 1}
+              dragInstanceId={spaceDragInstanceId}
+            />
+          ))
         )}
       </div>
       {menuProps &&

--- a/src/components/app/outline/SpaceItem.tsx
+++ b/src/components/app/outline/SpaceItem.tsx
@@ -1,10 +1,22 @@
+import { combine } from '@atlaskit/pragmatic-drag-and-drop/combine';
+import { draggable, dropTargetForElements } from '@atlaskit/pragmatic-drag-and-drop/element/adapter';
+import { attachClosestEdge, extractClosestEdge, type Edge } from '@atlaskit/pragmatic-drag-and-drop-hitbox/closest-edge';
 import { Tooltip } from '@mui/material';
-import React, { useMemo } from 'react';
+import React, { useEffect, useMemo, useRef } from 'react';
 
 import { View } from '@/application/types';
 import { ReactComponent as PrivateIcon } from '@/assets/icons/lock.svg';
 import SpaceIcon from '@/components/_shared/view-icon/SpaceIcon';
 import ViewItem from '@/components/app/outline/ViewItem';
+import { DropRowIndicator } from '@/components/database/components/drag-and-drop/DropRowIndicator';
+import { cn } from '@/lib/utils';
+
+type SpaceDragState =
+  | { type: 'idle' }
+  | { type: 'dragging' }
+  | { type: 'over'; closestEdge: Edge | null };
+
+const idleState: SpaceDragState = { type: 'idle' };
 
 function SpaceItem({
   view,
@@ -16,6 +28,8 @@ function SpaceItem({
   onClickSpace,
   loadingViewIds,
   loadedViewIds,
+  canReorder,
+  dragInstanceId,
 }: {
   view: View;
   width: number;
@@ -26,10 +40,90 @@ function SpaceItem({
   onClickSpace?: (viewId: string) => void;
   loadingViewIds?: Set<string>;
   loadedViewIds?: Set<string>;
+  canReorder?: boolean;
+  dragInstanceId?: symbol;
 }) {
   const [hovered, setHovered] = React.useState<boolean>(false);
+  const [dragState, setDragState] = React.useState<SpaceDragState>(idleState);
+  const rowRef = useRef<HTMLDivElement>(null);
+  const suppressClickRef = useRef(false);
+  const suppressClickTimeoutRef = useRef<number>();
   const isExpanded = expandIds.includes(view.view_id);
   const isPrivate = view.is_private;
+
+  useEffect(() => {
+    return () => {
+      if (suppressClickTimeoutRef.current !== undefined) {
+        window.clearTimeout(suppressClickTimeoutRef.current);
+      }
+    };
+  }, []);
+
+  useEffect(() => {
+    const element = rowRef.current;
+
+    if (!canReorder || !dragInstanceId || !element) return;
+
+    const data = {
+      type: 'space',
+      instanceId: dragInstanceId,
+      id: view.view_id,
+    };
+
+    return combine(
+      draggable({
+        element,
+        getInitialData: () => data,
+        onDragStart() {
+          suppressClickRef.current = true;
+          if (suppressClickTimeoutRef.current !== undefined) {
+            window.clearTimeout(suppressClickTimeoutRef.current);
+            suppressClickTimeoutRef.current = undefined;
+          }
+
+          setDragState({ type: 'dragging' });
+        },
+        onDrop() {
+          suppressClickTimeoutRef.current = window.setTimeout(() => {
+            suppressClickRef.current = false;
+            suppressClickTimeoutRef.current = undefined;
+          }, 0);
+
+          setDragState(idleState);
+        },
+      }),
+      dropTargetForElements({
+        element,
+        canDrop: ({ source }) =>
+          source.data.type === 'space' &&
+          source.data.instanceId === dragInstanceId &&
+          source.data.id !== view.view_id,
+        getIsSticky: () => true,
+        getData({ input }) {
+          return attachClosestEdge(data, {
+            element,
+            input,
+            allowedEdges: ['top', 'bottom'],
+          });
+        },
+        onDrag({ self }) {
+          const closestEdge = extractClosestEdge(self.data);
+
+          setDragState((current) => {
+            if (current.type === 'over' && current.closestEdge === closestEdge) return current;
+            return { type: 'over', closestEdge };
+          });
+        },
+        onDragLeave() {
+          setDragState(idleState);
+        },
+        onDrop() {
+          setDragState(idleState);
+        },
+      })
+    );
+  }, [canReorder, dragInstanceId, view.view_id]);
+
   const renderItem = useMemo(() => {
     if (!view) return null;
     const extra = view?.extra;
@@ -37,20 +131,32 @@ function SpaceItem({
 
     return (
       <div
+        ref={rowRef}
         data-testid={`space-${view.view_id}`}
         data-expanded={isExpanded}
         style={{
           width,
         }}
         onClick={() => {
+          if (suppressClickRef.current) {
+            suppressClickRef.current = false;
+            if (suppressClickTimeoutRef.current !== undefined) {
+              window.clearTimeout(suppressClickTimeoutRef.current);
+              suppressClickTimeoutRef.current = undefined;
+            }
+
+            return;
+          }
+
           toggleExpand(view.view_id, !isExpanded);
           onClickSpace?.(view.view_id);
         }}
         onMouseEnter={() => setHovered(true)}
         onMouseLeave={() => setHovered(false)}
-        className={
-          'flex min-h-[30px] w-full cursor-pointer select-none items-center gap-0.5 truncate rounded-[8px] px-1 py-0.5  text-sm hover:bg-fill-content-hover focus:bg-fill-content-hover focus:outline-none'
-        }
+        className={cn(
+          'relative flex min-h-[30px] w-full cursor-pointer select-none items-center gap-0.5 truncate rounded-[8px] px-1 py-0.5 text-sm hover:bg-fill-content-hover focus:bg-fill-content-hover focus:outline-none',
+          dragState.type === 'dragging' && 'opacity-40'
+        )}
       >
         <SpaceIcon
           className={'icon mr-1.5 !h-5 !w-5 !min-w-5'}
@@ -70,9 +176,10 @@ function SpaceItem({
           </div>
         </Tooltip>
         {renderExtra && renderExtra({ hovered, view })}
+        {dragState.type === 'over' ? <DropRowIndicator edge={dragState.closestEdge} /> : null}
       </div>
     );
-  }, [hovered, isExpanded, isPrivate, onClickSpace, renderExtra, toggleExpand, view, width]);
+  }, [dragState, hovered, isExpanded, isPrivate, onClickSpace, renderExtra, toggleExpand, view, width]);
 
   const isLoading = loadingViewIds?.has(view.view_id) && (!view.children || view.children.length === 0);
 


### PR DESCRIPTION
## Summary
- Add drag-and-drop reordering for top-level sidebar spaces
- Persist reordered spaces through the page-view move API using the workspace root and previous sibling id
- Keep the original space row UI draggable without a separate handle, with optimistic ordering and stale-response guards

## Verification
- pnpm run lint
- pnpm run build

## Summary by Sourcery

Add drag-and-drop reordering for top-level sidebar spaces with optimistic UI updates and persistence via the page move API.

New Features:
- Enable owners to reorder visible top-level sidebar spaces via drag-and-drop without a separate drag handle.

Enhancements:
- Integrate optimistic reordering with stale-response guards and error handling when persisting space order changes.
- Update space list rendering and space item visuals to reflect drag state and drop positions using row indicators.