### PR TITLE
Fix workspace reorder drag behavior

### DIFF
--- a/playwright/bdd/features/workspace/workspace-reorder.feature
+++ b/playwright/bdd/features/workspace/workspace-reorder.feature
@@ -1,0 +1,38 @@
+@workspace-reorder
+Feature: Workspace list drag-and-drop reordering
+  Users can drag workspaces in the dropdown to set a personal display order.
+  The new order is persisted server-side via PUT /api/workspace/reorder and
+  survives closing and reopening the dropdown.
+
+  Scenario: Reordering a workspace persists after reopening the list
+    Given I am signed in with three new workspaces named "Alpha WS", "Bravo WS", "Charlie WS"
+    When I open the workspace dropdown
+    Then the tracked workspaces appear in order "Alpha WS, Bravo WS, Charlie WS"
+    When I drag workspace "Charlie WS" above workspace "Alpha WS"
+    Then the tracked workspaces appear in order "Charlie WS, Alpha WS, Bravo WS"
+    When I close the workspace dropdown
+    And I open the workspace dropdown
+    Then the tracked workspaces appear in order "Charlie WS, Alpha WS, Bravo WS"
+
+  Scenario: Reordering through an overflowing dropdown auto-scrolls the workspace list
+    Given I am signed in with 12 new workspaces named "Overflow WS"
+    When I open the workspace dropdown
+    Then the workspace dropdown list is scrollable
+    When I drag workspace "Overflow WS 01" to the bottom edge of the workspace list until it reaches the end
+    Then the workspace dropdown list scrolled during the drag
+    And the tracked workspaces appear in order "Overflow WS 02, Overflow WS 03, Overflow WS 04, Overflow WS 05, Overflow WS 06, Overflow WS 07, Overflow WS 08, Overflow WS 09, Overflow WS 10, Overflow WS 11, Overflow WS 12, Overflow WS 01"
+
+  Scenario: Rapid consecutive reorders save serially and keep the latest order
+    Given I am signed in with three new workspaces named "Rapid Alpha WS", "Rapid Bravo WS", "Rapid Charlie WS"
+    And workspace reorder saves are delayed
+    When I open the workspace dropdown
+    And I drag workspace "Rapid Charlie WS" above workspace "Rapid Alpha WS"
+    And the first workspace reorder save has started
+    And I drag workspace "Rapid Bravo WS" above workspace "Rapid Charlie WS"
+    Then only one workspace reorder save has started while the first save is pending
+    When the delayed workspace reorder save completes
+    Then the latest workspace reorder save contains tracked workspaces in order "Rapid Bravo WS, Rapid Charlie WS, Rapid Alpha WS"
+    And the tracked workspaces appear in order "Rapid Bravo WS, Rapid Charlie WS, Rapid Alpha WS"
+    When I close the workspace dropdown
+    And I open the workspace dropdown
+    Then the tracked workspaces appear in order "Rapid Bravo WS, Rapid Charlie WS, Rapid Alpha WS"

--- a/playwright/bdd/steps/workspace-reorder.steps.ts
+++ b/playwright/bdd/steps/workspace-reorder.steps.ts
@@ -1,0 +1,430 @@
+import { APIRequestContext, expect, Page } from '@playwright/test';
+import { createBdd } from 'playwright-bdd';
+
+import { signInAndWaitForApp } from '../../support/auth-flow-helpers';
+import { WorkspaceSelectors } from '../../support/selectors';
+import { generateRandomEmail, setupPageErrorHandling, TestConfig } from '../../support/test-config';
+
+const { Given, When, Then, Before } = createBdd();
+
+type ReorderState = {
+  trackedWorkspaces: Array<{ name: string; id: string }>;
+  lastDragAutoScrolled?: boolean;
+  reorderRequestWorkspaceIds?: string[][];
+  completedReorderSaveCount?: number;
+  firstReorderSaveStarted?: Promise<void>;
+  firstReorderSaveCompleted?: Promise<void>;
+  releaseFirstReorderSave?: () => void;
+};
+
+const stateByPage = new WeakMap<Page, ReorderState>();
+
+Before(async ({ page }) => {
+  stateByPage.delete(page);
+  setupPageErrorHandling(page);
+  await page.setViewportSize({ width: 1440, height: 900 });
+});
+
+Given(
+  'I am signed in with three new workspaces named {string}, {string}, {string}',
+  async ({ page, request }, name1: string, name2: string, name3: string) => {
+    await signInWithNewWorkspaces(page, request, [name1, name2, name3]);
+  }
+);
+
+Given('I am signed in with {int} new workspaces named {string}', async ({ page, request }, count: number, prefix: string) => {
+  const names = Array.from({ length: count }, (_, index) => `${prefix} ${String(index + 1).padStart(2, '0')}`);
+
+  await signInWithNewWorkspaces(page, request, names);
+});
+
+Given('workspace reorder saves are delayed', async ({ page }) => {
+  const state = requireState(page);
+  const firstStarted = createDeferred<void>();
+  const firstCompleted = createDeferred<void>();
+  const releaseFirst = createDeferred<void>();
+
+  state.reorderRequestWorkspaceIds = [];
+  state.completedReorderSaveCount = 0;
+  state.firstReorderSaveStarted = firstStarted.promise;
+  state.firstReorderSaveCompleted = firstCompleted.promise;
+  state.releaseFirstReorderSave = () => releaseFirst.resolve();
+
+  await page.route(/\/api\/workspace\/reorder(?:\?|$)/, async (route) => {
+    const requestIndex = (state.reorderRequestWorkspaceIds?.length ?? 0) + 1;
+
+    state.reorderRequestWorkspaceIds?.push(getReorderRequestWorkspaceIds(route.request().postData()));
+
+    if (requestIndex === 1) {
+      firstStarted.resolve();
+      await releaseFirst.promise;
+    }
+
+    const response = await route.fetch();
+
+    await route.fulfill({ response });
+    state.completedReorderSaveCount = (state.completedReorderSaveCount ?? 0) + 1;
+
+    if (requestIndex === 1) {
+      firstCompleted.resolve();
+    }
+  });
+});
+
+When('the first workspace reorder save has started', async ({ page }) => {
+  const state = requireState(page);
+
+  if (!state.firstReorderSaveStarted) {
+    throw new Error('Workspace reorder saves were not configured to be delayed');
+  }
+
+  await state.firstReorderSaveStarted;
+});
+
+When('I open the workspace dropdown', async ({ page }) => {
+  await WorkspaceSelectors.dropdownTrigger(page).click();
+  await expect(WorkspaceSelectors.dropdownContent(page)).toBeVisible({ timeout: 15000 });
+  // Wait for the WorkspaceList's internal refetch to settle so the rendered
+  // order reflects server state, not a stale snapshot.
+  await page.waitForTimeout(800);
+});
+
+When('I close the workspace dropdown', async ({ page }) => {
+  await page.keyboard.press('Escape');
+  await expect(WorkspaceSelectors.dropdownContent(page)).toHaveCount(0, { timeout: 5000 });
+  await page.waitForTimeout(300);
+});
+
+When(
+  'I drag workspace {string} above workspace {string}',
+  async ({ page }, sourceName: string, targetName: string) => {
+    await dragWorkspaceItem(page, sourceName, targetName, 'top');
+  }
+);
+
+When(
+  'I drag workspace {string} to the bottom edge of the workspace list until it reaches the end',
+  async ({ page }, sourceName: string) => {
+    const state = requireState(page);
+
+    state.lastDragAutoScrolled = await dragWorkspaceItemToListEndWithAutoScroll(page, sourceName);
+  }
+);
+
+When('the delayed workspace reorder save completes', async ({ page }) => {
+  const state = requireState(page);
+
+  if (!state.releaseFirstReorderSave || !state.firstReorderSaveCompleted) {
+    throw new Error('Workspace reorder saves were not configured to be delayed');
+  }
+
+  state.releaseFirstReorderSave();
+  await state.firstReorderSaveCompleted;
+});
+
+Then('the workspace dropdown list is scrollable', async ({ page }) => {
+  await expect
+    .poll(
+      () =>
+        WorkspaceSelectors.list(page).evaluate((element) => {
+          return element.scrollHeight > element.clientHeight;
+        }),
+      {
+        message: 'expected workspace dropdown list to overflow vertically',
+        timeout: 5000,
+      }
+    )
+    .toBe(true);
+});
+
+Then('the workspace dropdown list scrolled during the drag', async ({ page }) => {
+  expect(requireState(page).lastDragAutoScrolled).toBe(true);
+});
+
+Then('only one workspace reorder save has started while the first save is pending', async ({ page }) => {
+  const state = requireState(page);
+
+  await page.waitForTimeout(500);
+  expect(state.reorderRequestWorkspaceIds ?? []).toHaveLength(1);
+});
+
+Then(
+  'the latest workspace reorder save contains tracked workspaces in order {string}',
+  async ({ page }, expectedCsv: string) => {
+    const state = requireState(page);
+    const expected = parseOrderedNames(expectedCsv);
+
+    await expect
+      .poll(
+        () => ({
+          completed: state.completedReorderSaveCount ?? 0,
+          started: state.reorderRequestWorkspaceIds?.length ?? 0,
+        }),
+        {
+          message: 'expected both serialized workspace reorder saves to complete',
+          timeout: 10000,
+        }
+      )
+      .toEqual({ completed: 2, started: 2 });
+
+    const reorderRequests = state.reorderRequestWorkspaceIds ?? [];
+    const latestIds = reorderRequests[reorderRequests.length - 1] ?? [];
+
+    expect(mapTrackedIdsToNames(state, latestIds)).toEqual(expected);
+  }
+);
+
+Then(
+  'the tracked workspaces appear in order {string}',
+  async ({ page }, expectedCsv: string) => {
+    const state = requireState(page);
+    const expected = parseOrderedNames(expectedCsv);
+    const tracked = new Set(state.trackedWorkspaces.map((workspace) => workspace.name));
+
+    await expect
+      .poll(
+        async () => {
+          const all = await WorkspaceSelectors.itemName(page).allInnerTexts();
+          return all.map((text) => text.trim()).filter((name) => tracked.has(name));
+        },
+        {
+          message: `expected tracked workspaces in order ${JSON.stringify(expected)}`,
+          timeout: 10000,
+        }
+      )
+      .toEqual(expected);
+  }
+);
+
+async function signInWithNewWorkspaces(page: Page, request: APIRequestContext, names: string[]): Promise<void> {
+  await signInAndWaitForApp(page, request, generateRandomEmail());
+  await expect(page).toHaveURL(/\/app/, { timeout: 30000 });
+
+  const token = await getAuthToken(page);
+
+  if (!token) {
+    throw new Error('Cannot create workspaces: no auth token in browser storage');
+  }
+
+  const trackedWorkspaces: ReorderState['trackedWorkspaces'] = [];
+
+  for (const name of names) {
+    trackedWorkspaces.push({
+      id: await createWorkspaceViaApi(request, token, name),
+      name,
+    });
+  }
+
+  stateByPage.set(page, { trackedWorkspaces });
+
+  // Reload so the newly-created workspaces are picked up by the in-memory
+  // userWorkspaceInfo context that hydrates the dropdown.
+  await page.reload({ waitUntil: 'domcontentloaded' });
+  await page.waitForTimeout(2000);
+}
+
+async function dragWorkspaceItem(
+  page: Page,
+  sourceName: string,
+  targetName: string,
+  edge: 'top' | 'bottom'
+): Promise<void> {
+  const sourceItem = workspaceItemByName(page, sourceName);
+  const targetItem = workspaceItemByName(page, targetName);
+
+  await expect(sourceItem).toBeVisible({ timeout: 10000 });
+  await expect(targetItem).toBeVisible({ timeout: 10000 });
+
+  const sourceBox = await sourceItem.boundingBox();
+  const targetBox = await targetItem.boundingBox();
+
+  if (!sourceBox || !targetBox) {
+    throw new Error('Could not measure workspace item bounding boxes');
+  }
+
+  const startX = sourceBox.x + sourceBox.width / 2;
+  const startY = sourceBox.y + sourceBox.height / 2;
+  const endX = targetBox.x + targetBox.width / 2;
+  const endY =
+    edge === 'top'
+      ? targetBox.y + targetBox.height * 0.15
+      : targetBox.y + targetBox.height * 0.85;
+
+  // Mirrors the editor block drag pattern (playwright/e2e/editor/editor-basic.spec.ts):
+  // pragmatic-drag-and-drop responds to native HTML5 drag events triggered by
+  // Chromium when mouse movement crosses the drag threshold on a draggable element.
+  await page.mouse.move(startX, startY);
+  await page.mouse.down();
+  await page.waitForTimeout(150);
+  await page.mouse.move(endX, endY, { steps: 10 });
+  await page.waitForTimeout(300);
+  await page.mouse.up();
+  // Wait for the optimistic update + server PUT /api/workspace/reorder + refetch.
+  await page.waitForTimeout(1500);
+}
+
+async function dragWorkspaceItemToListEndWithAutoScroll(page: Page, sourceName: string): Promise<boolean> {
+  const sourceItem = workspaceItemByName(page, sourceName);
+  const scrollContainer = WorkspaceSelectors.list(page);
+
+  await expect(sourceItem).toBeVisible({ timeout: 10000 });
+  await expect(scrollContainer).toBeVisible({ timeout: 10000 });
+  await scrollContainer.evaluate((element) => {
+    element.scrollTop = 0;
+  });
+
+  const sourceBox = await sourceItem.boundingBox();
+  const containerBox = await scrollContainer.boundingBox();
+
+  if (!sourceBox || !containerBox) {
+    throw new Error('Could not measure workspace item or list bounding boxes');
+  }
+
+  const startX = sourceBox.x + sourceBox.width / 2;
+  const startY = sourceBox.y + sourceBox.height / 2;
+  const edgeX = containerBox.x + containerBox.width / 2;
+  const edgeY = containerBox.y + containerBox.height - 8;
+  let mouseDown = false;
+  let didScroll = false;
+
+  try {
+    await page.mouse.move(startX, startY);
+    await page.mouse.down();
+    mouseDown = true;
+    await page.waitForTimeout(150);
+
+    for (let attempt = 0; attempt < 60; attempt += 1) {
+      await page.mouse.move(edgeX, edgeY, { steps: 5 });
+      await page.waitForTimeout(100);
+
+      const scrollState = await scrollContainer.evaluate((element) => ({
+        maxScrollTop: element.scrollHeight - element.clientHeight,
+        scrollTop: element.scrollTop,
+      }));
+
+      didScroll = didScroll || scrollState.scrollTop > 0;
+
+      if (didScroll && scrollState.scrollTop >= scrollState.maxScrollTop - 2) {
+        break;
+      }
+    }
+
+    if (!didScroll) {
+      throw new Error('Workspace list did not auto-scroll while dragging near its bottom edge');
+    }
+
+    await page.mouse.move(edgeX, edgeY, { steps: 10 });
+    await page.waitForTimeout(300);
+    await page.mouse.up();
+    mouseDown = false;
+    await page.waitForTimeout(1500);
+
+    return didScroll;
+  } catch (error) {
+    if (mouseDown) {
+      await page.mouse.up();
+    }
+
+    throw error;
+  }
+}
+
+function workspaceItemByName(page: Page, name: string) {
+  return WorkspaceSelectors.item(page).filter({ hasText: name }).first();
+}
+
+function parseOrderedNames(csv: string): string[] {
+  return csv
+    .split(',')
+    .map((part) => part.trim())
+    .filter((part) => part.length > 0);
+}
+
+function requireState(page: Page): ReorderState {
+  const state = stateByPage.get(page);
+
+  if (!state) {
+    throw new Error('Reorder scenario state was not initialized');
+  }
+
+  return state;
+}
+
+function createDeferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((promiseResolve, promiseReject) => {
+    resolve = promiseResolve;
+    reject = promiseReject;
+  });
+
+  return { promise, resolve, reject };
+}
+
+function getReorderRequestWorkspaceIds(postData: string | null): string[] {
+  if (!postData) return [];
+
+  try {
+    const body = JSON.parse(postData) as { workspace_ids?: unknown };
+
+    if (!Array.isArray(body.workspace_ids)) return [];
+
+    return body.workspace_ids.map(String);
+  } catch {
+    return [];
+  }
+}
+
+function mapTrackedIdsToNames(state: ReorderState, workspaceIds: string[]): string[] {
+  const nameById = new Map(state.trackedWorkspaces.map((workspace) => [workspace.id, workspace.name]));
+
+  return workspaceIds
+    .map((id) => nameById.get(id))
+    .filter((name): name is string => Boolean(name));
+}
+
+async function createWorkspaceViaApi(
+  request: APIRequestContext,
+  token: string,
+  name: string
+): Promise<string> {
+  const response = await request.post(`${TestConfig.apiUrl}/api/workspace`, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    },
+    data: { workspace_name: name },
+    failOnStatusCode: false,
+  });
+  const body = (await response.json().catch(() => null)) as {
+    code?: number;
+    message?: string;
+    data?: { workspace_id?: string };
+  } | null;
+
+  if (!response.ok() || body?.code !== 0 || !body.data?.workspace_id) {
+    throw new Error(
+      `Failed to create workspace "${name}": HTTP ${response.status()} ${JSON.stringify(body)}`
+    );
+  }
+
+  return body.data.workspace_id;
+}
+
+async function getAuthToken(page: Page): Promise<string> {
+  return page.evaluate(() => {
+    const directToken = localStorage.getItem('af_auth_token');
+
+    if (directToken) return directToken;
+
+    const rawToken = localStorage.getItem('token');
+
+    if (!rawToken) return '';
+
+    try {
+      return (JSON.parse(rawToken) as { access_token?: string }).access_token || '';
+    } catch {
+      return '';
+    }
+  });
+}

--- a/playwright/support/selectors.ts
+++ b/playwright/support/selectors.ts
@@ -166,6 +166,7 @@ export const ShareSelectors = {
 export const WorkspaceSelectors = {
   dropdownTrigger: (page: Page) => page.getByTestId('workspace-dropdown-trigger'),
   dropdownContent: (page: Page) => page.getByTestId('workspace-dropdown-content'),
+  list: (page: Page) => page.getByTestId('workspace-list'),
   item: (page: Page) => page.getByTestId('workspace-item'),
   itemName: (page: Page) => page.getByTestId('workspace-item-name'),
   memberCount: (page: Page) => page.getByTestId('workspace-member-count'),

--- a/src/application/services/domains/workspace.ts
+++ b/src/application/services/domains/workspace.ts
@@ -18,4 +18,5 @@ export {
   approveTurnGuestToMember,
   addRecentPages,
   updatePublishNamespace,
+  reorderWorkspaces as reorder,
 } from '../js-services/http/workspace-api';

--- a/src/application/services/js-services/http/workspace-api.ts
+++ b/src/application/services/js-services/http/workspace-api.ts
@@ -275,3 +275,13 @@ export async function updatePublishNamespace(workspaceId: string, payload: Uploa
     getAxios()?.put<APIResponse>(url, payload)
   );
 }
+
+export async function reorderWorkspaces(workspaceIds: string[]) {
+  const url = `/api/workspace/reorder`;
+
+  return executeAPIVoidRequest(() =>
+    getAxios()?.put<APIResponse>(url, {
+      workspace_ids: workspaceIds,
+    })
+  );
+}

--- a/src/components/app/workspaces/MobileWorkspaces.tsx
+++ b/src/components/app/workspaces/MobileWorkspaces.tsx
@@ -105,6 +105,7 @@ function MobileWorkspaces({ onClose }: { onClose: () => void }) {
               changeLoading={changeLoading || undefined}
               showActions={false}
               useDropdownItem={false}
+              autoScrollContainerRef={ref}
             />
           )}
         </div>

--- a/src/components/app/workspaces/WorkspaceItem.tsx
+++ b/src/components/app/workspaces/WorkspaceItem.tsx
@@ -1,12 +1,24 @@
+import { combine } from '@atlaskit/pragmatic-drag-and-drop/combine';
+import { draggable, dropTargetForElements } from '@atlaskit/pragmatic-drag-and-drop/element/adapter';
+import { attachClosestEdge, extractClosestEdge, type Edge } from '@atlaskit/pragmatic-drag-and-drop-hitbox/closest-edge';
 import { CircularProgress } from '@mui/material';
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { Role, Workspace } from '@/application/types';
 import MoreActions from '@/components/app/workspaces/MoreActions';
+import { DropRowIndicator } from '@/components/database/components/drag-and-drop/DropRowIndicator';
 import { Avatar, AvatarFallback } from '@/components/ui/avatar';
 import { DropdownMenuItem, DropdownMenuItemTick, dropdownMenuItemVariants } from '@/components/ui/dropdown-menu';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+import { cn } from '@/lib/utils';
+
+type WorkspaceDragState =
+  | { type: 'idle' }
+  | { type: 'dragging' }
+  | { type: 'over'; closestEdge: Edge | null };
+
+const idleState: WorkspaceDragState = { type: 'idle' };
 
 export function WorkspaceItem({
   workspace,
@@ -19,6 +31,8 @@ export function WorkspaceItem({
   onLeave,
   useDropdownItem = true,
   workspaceCount,
+  canReorder,
+  dragInstanceId,
 }: {
   showActions?: boolean;
   workspace: Workspace;
@@ -30,10 +44,90 @@ export function WorkspaceItem({
   onLeave?: (workspace: Workspace) => void;
   useDropdownItem?: boolean;
   workspaceCount?: number;
+  canReorder?: boolean;
+  dragInstanceId?: symbol;
 }) {
   const { t } = useTranslation();
   const [hovered, setHovered] = useState(false);
+  const [dragState, setDragState] = useState<WorkspaceDragState>(idleState);
+  const rowRef = useRef<HTMLDivElement | HTMLButtonElement>(null);
+  const suppressClickRef = useRef(false);
+  const suppressClickTimeoutRef = useRef<number>();
   const isGuest = workspace.role === Role.Guest;
+
+  useEffect(() => {
+    return () => {
+      if (suppressClickTimeoutRef.current !== undefined) {
+        window.clearTimeout(suppressClickTimeoutRef.current);
+      }
+    };
+  }, []);
+
+  useEffect(() => {
+    const element = rowRef.current;
+
+    if (!canReorder || !dragInstanceId || !element) return;
+
+    const data = {
+      type: 'workspace',
+      instanceId: dragInstanceId,
+      id: workspace.id,
+    };
+
+    return combine(
+      draggable({
+        element,
+        getInitialData: () => data,
+        onDragStart() {
+          suppressClickRef.current = true;
+          if (suppressClickTimeoutRef.current !== undefined) {
+            window.clearTimeout(suppressClickTimeoutRef.current);
+            suppressClickTimeoutRef.current = undefined;
+          }
+
+          setDragState({ type: 'dragging' });
+        },
+        onDrop() {
+          suppressClickTimeoutRef.current = window.setTimeout(() => {
+            suppressClickRef.current = false;
+            suppressClickTimeoutRef.current = undefined;
+          }, 0);
+
+          setDragState(idleState);
+        },
+      }),
+      dropTargetForElements({
+        element,
+        canDrop: ({ source }) =>
+          source.data.type === 'workspace' &&
+          source.data.instanceId === dragInstanceId &&
+          source.data.id !== workspace.id,
+        getIsSticky: () => true,
+        getData({ input }) {
+          return attachClosestEdge(data, {
+            element,
+            input,
+            allowedEdges: ['top', 'bottom'],
+          });
+        },
+        onDrag({ self }) {
+          const closestEdge = extractClosestEdge(self.data);
+
+          setDragState((current) => {
+            if (current.type === 'over' && current.closestEdge === closestEdge) return current;
+            return { type: 'over', closestEdge };
+          });
+        },
+        onDragLeave() {
+          setDragState(idleState);
+        },
+        onDrop() {
+          setDragState(idleState);
+        },
+      })
+    );
+  }, [canReorder, dragInstanceId, workspace.id]);
+
   const renderActions = useMemo(() => {
     if (changeLoading === workspace.id) return <CircularProgress size={16} />;
 
@@ -74,10 +168,33 @@ export function WorkspaceItem({
     );
   }, [changeLoading, currentWorkspaceId, hovered, onDelete, onLeave, onUpdate, showActions, workspace, workspaceCount]);
 
-  const handleSelect = useCallback(() => {
-    if (workspace.id === currentWorkspaceId) return;
-    void onChange(workspace.id);
-  }, [currentWorkspaceId, onChange, workspace.id]);
+  const consumeSuppressedClick = useCallback(() => {
+    if (!suppressClickRef.current) return false;
+
+    suppressClickRef.current = false;
+    if (suppressClickTimeoutRef.current !== undefined) {
+      window.clearTimeout(suppressClickTimeoutRef.current);
+      suppressClickTimeoutRef.current = undefined;
+    }
+
+    return true;
+  }, []);
+
+  // Shared activation handler for both Radix `onSelect` (Event) and native
+  // button `onClick` (MouseEvent). preventDefault on the Radix event keeps the
+  // dropdown open after a drag; on the button it's harmless.
+  const handleActivate = useCallback(
+    (event?: { preventDefault(): void }) => {
+      if (consumeSuppressedClick()) {
+        event?.preventDefault();
+        return;
+      }
+
+      if (workspace.id === currentWorkspaceId) return;
+      void onChange(workspace.id);
+    },
+    [consumeSuppressedClick, currentWorkspaceId, onChange, workspace.id]
+  );
 
   const content = (
     <>
@@ -112,16 +229,17 @@ export function WorkspaceItem({
         )}
       </div>
       {renderActions}
+      {dragState.type === 'over' ? <DropRowIndicator edge={dragState.closestEdge} /> : null}
     </>
   );
 
   if (useDropdownItem) {
     return (
       <DropdownMenuItem
-        key={workspace.id}
+        ref={rowRef as React.RefObject<HTMLDivElement>}
         data-testid='workspace-item'
-        className={'relative'}
-        onSelect={handleSelect}
+        className={cn('relative', dragState.type === 'dragging' && 'opacity-40')}
+        onSelect={handleActivate}
         onMouseEnter={() => setHovered(true)}
         onMouseLeave={() => setHovered(false)}
       >
@@ -132,11 +250,14 @@ export function WorkspaceItem({
 
   return (
     <button
+      ref={rowRef as React.RefObject<HTMLButtonElement>}
       type='button'
-      key={workspace.id}
       data-testid='workspace-item'
-      className={dropdownMenuItemVariants({ variant: 'default', className: 'relative w-full text-left' })}
-      onClick={handleSelect}
+      className={dropdownMenuItemVariants({
+        variant: 'default',
+        className: cn('relative w-full text-left', dragState.type === 'dragging' && 'opacity-40'),
+      })}
+      onClick={() => handleActivate()}
       onMouseEnter={() => setHovered(true)}
       onMouseLeave={() => setHovered(false)}
     >

--- a/src/components/app/workspaces/WorkspaceList.tsx
+++ b/src/components/app/workspaces/WorkspaceList.tsx
@@ -1,8 +1,20 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { combine } from '@atlaskit/pragmatic-drag-and-drop/combine';
+import { monitorForElements } from '@atlaskit/pragmatic-drag-and-drop/element/adapter';
+import { reorder } from '@atlaskit/pragmatic-drag-and-drop/reorder';
+import { autoScrollForElements } from '@atlaskit/pragmatic-drag-and-drop-auto-scroll/element';
+import { extractClosestEdge, type Edge } from '@atlaskit/pragmatic-drag-and-drop-hitbox/closest-edge';
+import { getReorderDestinationIndex } from '@atlaskit/pragmatic-drag-and-drop-hitbox/util/get-reorder-destination-index';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { toast } from 'sonner';
 
 import { WorkspaceService } from '@/application/services/domains';
 import { Workspace } from '@/application/types';
 import { WorkspaceItem } from '@/components/app/workspaces/WorkspaceItem';
+import { Log } from '@/utils/log';
+
+type ScrollContainerRef = {
+  current: HTMLElement | null;
+};
 
 function WorkspaceList({
   defaultWorkspaces,
@@ -14,6 +26,7 @@ function WorkspaceList({
   onDelete,
   onLeave,
   useDropdownItem = true,
+  autoScrollContainerRef,
 }: {
   currentWorkspaceId?: string;
   changeLoading?: string;
@@ -25,6 +38,7 @@ function WorkspaceList({
   onDelete?: (workspace: Workspace) => void;
   onLeave?: (workspace: Workspace) => void;
   useDropdownItem?: boolean;
+  autoScrollContainerRef?: ScrollContainerRef;
 }) {
   const [workspaces, setWorkspaces] = useState<Workspace[]>(defaultWorkspaces || []);
   const fetchWorkspaces = useCallback(async () => {
@@ -37,21 +51,143 @@ function WorkspaceList({
     }
   }, []);
 
-  const sortedWorkspaces = useMemo(() => {
-    // Sort by creation time ascending (oldest first), matching desktop app behavior
-    return [...workspaces].sort((a, b) => {
-      if (!a.createdAt || !b.createdAt) return 0;
-      return a.createdAt < b.createdAt ? -1 : a.createdAt > b.createdAt ? 1 : 0;
-    });
-  }, [workspaces]);
+  // The server returns workspaces in the user's preferred order
+  // (af_workspace_member.position), so we render them as received.
+  const [optimisticWorkspaceIds, setOptimisticWorkspaceIds] = useState<string[] | null>(null);
+  const orderedWorkspaces = useMemo(() => {
+    if (!optimisticWorkspaceIds) return workspaces;
+
+    const byId = new Map(workspaces.map((workspace) => [workspace.id, workspace]));
+    const ordered = optimisticWorkspaceIds
+      .map((id) => byId.get(id))
+      .filter((workspace): workspace is Workspace => Boolean(workspace));
+    const seenIds = new Set(ordered.map((workspace) => workspace.id));
+
+    return [
+      ...ordered,
+      ...workspaces.filter((workspace) => !seenIds.has(workspace.id)),
+    ];
+  }, [optimisticWorkspaceIds, workspaces]);
+
+  // Latest ordered list, read by the async reorder callback. Kept in a ref so
+  // `reorderWorkspaces` (and therefore the monitor effect) doesn't need to
+  // depend on `orderedWorkspaces` — depending on it would tear down and
+  // re-register the drag monitor on every order change.
+  const orderedWorkspacesRef = useRef<Workspace[]>(orderedWorkspaces);
+  const pendingReorderIdsRef = useRef<string[] | null>(null);
+  const isSavingReorderRef = useRef(false);
+  const listRef = useRef<HTMLDivElement>(null);
+  const [dragInstanceId] = useState(() => Symbol('workspace-drag-instance'));
+  const canReorder = orderedWorkspaces.length > 1;
+
+  useEffect(() => {
+    orderedWorkspacesRef.current = orderedWorkspaces;
+  }, [orderedWorkspaces]);
+
+  const flushPendingReorders = useCallback(async () => {
+    if (isSavingReorderRef.current) return;
+
+    isSavingReorderRef.current = true;
+
+    try {
+      while (pendingReorderIdsRef.current) {
+        const nextIds = pendingReorderIdsRef.current;
+
+        pendingReorderIdsRef.current = null;
+        await WorkspaceService.reorder(nextIds);
+
+        if (pendingReorderIdsRef.current) continue;
+
+        await fetchWorkspaces();
+
+        if (!pendingReorderIdsRef.current) {
+          setOptimisticWorkspaceIds(null);
+        }
+      }
+    } catch (error) {
+      pendingReorderIdsRef.current = null;
+      setOptimisticWorkspaceIds(null);
+      await fetchWorkspaces();
+      toast.error('Failed to reorder workspaces');
+      Log.error('[WorkspaceList] Failed to reorder workspaces', error);
+    } finally {
+      isSavingReorderRef.current = false;
+    }
+  }, [fetchWorkspaces]);
+
+  const reorderWorkspaces = useCallback(
+    (sourceId: string, targetId: string, closestEdgeOfTarget: Edge | null) => {
+      const current = orderedWorkspacesRef.current;
+      const startIndex = current.findIndex((workspace) => workspace.id === sourceId);
+      const indexOfTarget = current.findIndex((workspace) => workspace.id === targetId);
+
+      if (startIndex < 0 || indexOfTarget < 0) return;
+
+      const finishIndex = getReorderDestinationIndex({
+        startIndex,
+        indexOfTarget,
+        closestEdgeOfTarget,
+        axis: 'vertical',
+      });
+
+      if (finishIndex === startIndex) return;
+
+      const next = reorder({
+        list: current,
+        startIndex,
+        finishIndex,
+      });
+      const nextIds = next.map((workspace) => workspace.id);
+
+      orderedWorkspacesRef.current = next;
+      pendingReorderIdsRef.current = nextIds;
+      setOptimisticWorkspaceIds(nextIds);
+      void flushPendingReorders();
+    },
+    [flushPendingReorders]
+  );
+
+  useEffect(() => {
+    const element = autoScrollContainerRef?.current ?? listRef.current;
+
+    if (!canReorder || !element) return;
+
+    function canRespond({ source }: { source: { data: Record<string, unknown> } }) {
+      return source.data.type === 'workspace' && source.data.instanceId === dragInstanceId;
+    }
+
+    return combine(
+      monitorForElements({
+        canMonitor: canRespond,
+        onDrop({ location, source }) {
+          const target = location.current.dropTargets[0];
+
+          if (!target) return;
+
+          const sourceId = String(source.data.id ?? '');
+          const targetId = String(target.data.id ?? '');
+
+          if (!sourceId || !targetId || sourceId === targetId) return;
+
+          const closestEdgeOfTarget = extractClosestEdge(target.data);
+
+          void reorderWorkspaces(sourceId, targetId, closestEdgeOfTarget);
+        },
+      }),
+      autoScrollForElements({
+        canScroll: canRespond,
+        element,
+      })
+    );
+  }, [autoScrollContainerRef, canReorder, dragInstanceId, reorderWorkspaces]);
 
   useEffect(() => {
     void fetchWorkspaces();
   }, [fetchWorkspaces]);
 
   return (
-    <>
-      {sortedWorkspaces.map((workspace) => {
+    <div ref={listRef}>
+      {orderedWorkspaces.map((workspace) => {
         return (
           <WorkspaceItem
             key={workspace.id}
@@ -64,11 +200,13 @@ function WorkspaceList({
             onLeave={onLeave}
             showActions={showActions}
             useDropdownItem={useDropdownItem}
-            workspaceCount={sortedWorkspaces.length}
+            workspaceCount={orderedWorkspaces.length}
+            canReorder={canReorder}
+            dragInstanceId={dragInstanceId}
           />
         );
       })}
-    </>
+    </div>
   );
 }
 

--- a/src/components/app/workspaces/Workspaces.tsx
+++ b/src/components/app/workspaces/Workspaces.tsx
@@ -56,6 +56,7 @@ export function Workspaces() {
   const [open, setOpen] = useState(false);
   const [hoveredHeader, setHoveredHeader] = useState<boolean>(false);
   const ref = useRef<HTMLDivElement | null>(null);
+  const workspaceListScrollRef = useRef<HTMLDivElement | null>(null);
   const navigate = useNavigate();
   const [changeLoading, setChangeLoading] = useState<string | null>(null);
   const handleSignOut = useCallback(() => {
@@ -171,19 +172,23 @@ export function Workspaces() {
             <DropdownMenuLabel className='w-full overflow-hidden'>
               <span className='truncate'>{currentUser?.email}</span>
             </DropdownMenuLabel>
-            <DropdownMenuGroup
-              data-testid='workspace-list'
-              className={'appflowy-scroller max-h-[200px] flex-1 overflow-y-auto overflow-x-hidden'}
-            >
-              <WorkspaceList
-                defaultWorkspaces={userWorkspaceInfo?.workspaces}
-                currentWorkspaceId={currentWorkspaceId}
-                onChange={handleChange}
-                changeLoading={changeLoading || undefined}
-                onUpdate={setOpenRenameWorkspace}
-                onDelete={setOpenDeleteWorkspace}
-                onLeave={setOpenLeaveWorkspace}
-              />
+            <DropdownMenuGroup>
+              <div
+                ref={workspaceListScrollRef}
+                data-testid='workspace-list'
+                className={'appflowy-scroller max-h-[200px] flex-1 overflow-y-auto overflow-x-hidden'}
+              >
+                <WorkspaceList
+                  defaultWorkspaces={userWorkspaceInfo?.workspaces}
+                  currentWorkspaceId={currentWorkspaceId}
+                  onChange={handleChange}
+                  changeLoading={changeLoading || undefined}
+                  onUpdate={setOpenRenameWorkspace}
+                  onDelete={setOpenDeleteWorkspace}
+                  onLeave={setOpenLeaveWorkspace}
+                  autoScrollContainerRef={workspaceListScrollRef}
+                />
+              </div>
             </DropdownMenuGroup>
             <DropdownMenuItem
               onSelect={() => {


### PR DESCRIPTION
## Summary
- add workspace reorder API wiring and drag/drop support for the workspace list
- attach auto-scroll to the actual desktop/mobile scroll containers
- serialize overlapping reorder saves and coalesce rapid drops to the latest order
- add Playwright BDD coverage for persistence, overflow auto-scroll, and rapid consecutive saves

## Tests
- pnpm type-check
- pnpm exec bddgen test -c playwright.bdd.config.ts
- pnpm exec playwright test -c playwright.bdd.config.ts playwright/.features-gen/playwright/bdd/features/workspace/workspace-reorder.feature.spec.js --workers=1

## Summary by Sourcery

Implement drag-and-drop reordering for the workspace list with server-side persistence and robust handling of rapid consecutive saves.

New Features:
- Enable drag-and-drop reordering of workspaces in the desktop and mobile workspace lists with visual drop indicators.
- Persist user-defined workspace order via a new workspace reorder API endpoint exposed through the domain service.

Bug Fixes:
- Prevent accidental workspace activation clicks immediately after completing a drag operation in the workspace list.
- Ensure workspace auto-scroll during drag uses the actual scroll container for both dropdown and mobile layouts.

Enhancements:
- Render workspaces in the server-defined order and apply optimistic ordering updates while reorder saves are in flight, falling back safely on errors.
- Scope drag interactions to a specific workspace list instance and centralize drag monitoring for better performance.

Tests:
- Add Playwright BDD feature coverage for workspace reordering persistence, overflow auto-scroll behavior, and serialized rapid reorder saves.
- Introduce selector helpers and step definitions to support workspace reorder drag-and-drop flows in end-to-end tests.