### PR TITLE
fix: support toggling toggle lists in the published view

### DIFF
--- a/playwright/bdd/features/editor/toggle-list-publish.feature
+++ b/playwright/bdd/features/editor/toggle-list-publish.feature
@@ -1,0 +1,22 @@
+Feature: Published toggle list interactions
+  Regression coverage for "support toggle on publish". A toggle list must stay
+  interactive in the read-only published view: clicking its toggle icon collapses
+  and expands the inner content even though the published document is rendered with
+  a static (non-Yjs) editor that has no shared root.
+
+  Background:
+    Given a blank document page is open
+
+  Scenario: Toggle list collapses and expands in the published view
+    When I type "> Parent Toggle" in the editor
+    And I press "Enter"
+    And I type "Hidden Child" in the editor
+    Then the editor visibly contains "Hidden Child"
+    When I publish the current page
+    And I open the published page
+    Then the editor visibly contains "Parent Toggle"
+    And the editor visibly contains "Hidden Child"
+    When I toggle the toggle list icon
+    Then the editor does not visibly contain "Hidden Child"
+    When I toggle the toggle list icon
+    Then the editor visibly contains "Hidden Child"

--- a/playwright/bdd/steps/toggle-list-publish.steps.ts
+++ b/playwright/bdd/steps/toggle-list-publish.steps.ts
@@ -1,0 +1,55 @@
+import { expect, Page } from '@playwright/test';
+import { createBdd } from 'playwright-bdd';
+
+import { EditorSelectors, ShareSelectors } from '../../support/selectors';
+
+const { When } = createBdd();
+
+// Keyed by page so parallel scenarios never share a published URL.
+const publishedUrlByPage = new WeakMap<Page, string>();
+
+When('I publish the current page', async ({ page }) => {
+  // Give Yjs time to flush the freshly typed content to the server before publishing.
+  await page.waitForTimeout(2000);
+
+  // Open the share popover. Evaluate-click bypasses the sticky header overlay that
+  // otherwise intercepts pointer events on the share button.
+  await expect(ShareSelectors.shareButton(page)).toBeVisible({ timeout: 10000 });
+  await ShareSelectors.shareButton(page).evaluate((el: HTMLElement) => el.click());
+  await page.waitForTimeout(1000);
+
+  // Switch to the Publish tab and confirm publishing.
+  await ShareSelectors.sharePopover(page).getByText('Publish', { exact: true }).click({ force: true });
+  await page.waitForTimeout(1000);
+  await expect(ShareSelectors.publishConfirmButton(page)).toBeVisible({ timeout: 10000 });
+  await expect(ShareSelectors.publishConfirmButton(page)).toBeEnabled();
+  await ShareSelectors.publishConfirmButton(page).click({ force: true });
+  await page.waitForTimeout(5000);
+
+  // Build the published URL from the namespace + publish name shown in the popover.
+  await expect(ShareSelectors.publishNamespace(page)).toBeVisible({ timeout: 10000 });
+  const origin = new URL(page.url()).origin;
+  const namespace = ((await ShareSelectors.publishNamespace(page).textContent()) ?? '').trim();
+  const publishName = (await ShareSelectors.publishNameInput(page).inputValue()).trim();
+
+  expect(namespace, 'Expected a publish namespace').not.toBe('');
+  expect(publishName, 'Expected a publish name').not.toBe('');
+
+  publishedUrlByPage.set(page, `${origin}/${namespace}/${publishName}`);
+
+  // Close the popover so it does not overlap the published view navigation.
+  await page.keyboard.press('Escape');
+  await page.waitForTimeout(500);
+});
+
+When('I open the published page', async ({ page }) => {
+  const publishedUrl = publishedUrlByPage.get(page);
+
+  expect(publishedUrl, 'Expected the page to be published before opening it').toBeTruthy();
+
+  await page.goto(publishedUrl as string);
+  await expect(page).toHaveURL(new RegExp(new URL(publishedUrl as string).pathname), { timeout: 15000 });
+  await expect(EditorSelectors.firstEditor(page)).toBeVisible({ timeout: 15000 });
+  // Let the static editor finish hydrating the published document.
+  await page.waitForTimeout(2000);
+});

--- a/src/application/slate-yjs/command/index.ts
+++ b/src/application/slate-yjs/command/index.ts
@@ -470,6 +470,28 @@ export const CustomEditor = {
   },
 
   toggleToggleList(editor: YjsEditor, blockId: string) {
+    // The published view renders with a static Slate editor that has no Yjs
+    // shared root. Toggle the collapsed state directly on the Slate node so the
+    // block can still be expanded/collapsed in read-only mode.
+    if (!editor.sharedRoot) {
+      const entry = findSlateEntryByBlockId(editor, blockId);
+
+      if (!entry) {
+        Log.warn('Toggle list block not found', blockId);
+        return;
+      }
+
+      const [node, path] = entry;
+      const data = (node.data || {}) as ToggleListBlockData;
+
+      Transforms.setNodes(
+        editor,
+        { data: { ...data, collapsed: !data.collapsed } } as Partial<Element>,
+        { at: path }
+      );
+      return;
+    }
+
     const sharedRoot = getSharedRoot(editor);
     const data = dataStringTOJson(getBlock(blockId, sharedRoot).get(YjsEditorKey.block_data)) as ToggleListBlockData;
     const { selection } = editor;

--- a/src/components/editor/components/blocks/toggle-list/ToggleList.tsx
+++ b/src/components/editor/components/blocks/toggle-list/ToggleList.tsx
@@ -38,7 +38,7 @@ export const ToggleList = memo(
       <>
         <div {...attributes} ref={ref} className={className} id={level ? `heading-${blockId}` : undefined}>
           {children}
-          {!readOnly && !collapsed && node.children.slice(1).length === 0 && (
+          {!readOnly && !collapsed && node.children.length <= 1 && (
             <div
               onMouseDown={(e) => {
                 e.preventDefault();


### PR DESCRIPTION
## Problem

On a **published page**, toggle list blocks could not be expanded or collapsed — clicking the toggle icon did nothing, so the inner content stayed hidden/shown with no way to change it.

## Root cause

The published view renders documents through `StaticEditor`, a plain Slate editor with **no Yjs binding** (`editor.sharedRoot` is `undefined`). `CustomEditor.toggleToggleList` called `getSharedRoot(editor)` on its first line, which throws `"Shared root not found"`. The click handler in `ToggleIcon` therefore threw on every click and the `collapsed` flag (stored in `node.data`) never changed.

This is a regression: #64 (`fix: support toggle on publish`) originally made this work when the published view was still Yjs-backed; #318 (`fix: publish database with embeded db`) introduced `StaticEditor` and silently re-broke it.

## Fix

In `toggleToggleList`, when there is no shared root (static/published editor), toggle `collapsed` directly on the Slate node via `Transforms.setNodes`. A fresh `data` object reference is emitted so the memoized `ToggleList` recomputes and re-renders. The existing Yjs path is unchanged.

Also dropped a per-render array allocation in `ToggleList` (`children.slice(1).length === 0` → `children.length <= 1`, logically identical).

## Test

New Playwright BDD scenario `playwright/bdd/features/editor/toggle-list-publish.feature`: create a toggle list with a child, publish, open the published URL, and assert the toggle icon collapses/expands the inner content.

Verified as a genuine regression guard:

| State | Result |
|---|---|
| With fix | ✅ pass |
| Fix reverted | ❌ fail — child stays visible after clicking toggle (the reported bug) |
| Fix restored | ✅ pass |

All three toggle scenarios green (`Toggle list interactions collapse and expand content`, `Empty toggle list clears back to paragraph`, and the new published-view one); `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Fix toggle list expand/collapse behavior in the published static editor view and add regression coverage for published toggle lists.

Bug Fixes:
- Allow toggle list blocks to be expanded and collapsed in the read-only published view where no Yjs shared root is available.

Enhancements:
- Avoid unnecessary array slicing when checking for empty toggle list content in the editor UI.

Tests:
- Add Playwright BDD step definitions and a feature scenario to verify toggle list interactions in the published view, including publishing a page and toggling nested content.