### PR TITLE
Add find and replace and page locking

### DIFF
--- a/playwright/e2e/editor/find-and-replace.spec.ts
+++ b/playwright/e2e/editor/find-and-replace.spec.ts
@@ -1,0 +1,286 @@
+import { test, expect, Page } from '@playwright/test';
+
+import { signInAndWaitForApp } from '../../support/auth-flow-helpers';
+import { DropdownSelectors, EditorSelectors, HeaderSelectors } from '../../support/selectors';
+import { generateRandomEmail } from '../../support/test-config';
+
+/**
+ * Find & Replace Tests
+ *
+ * Covers the in-document find/replace panel migrated from the desktop app:
+ * the header "…" menu item, Cmd/Ctrl+F, match highlighting/navigation,
+ * match-case, and replace / replace-all.
+ *
+ * Uses a unique search token ("zqxmatch") so counts are deterministic even if
+ * the default landing document already contains other text.
+ */
+
+const TOKEN_LINE = 'Zqxmatch zqxmatch ZQXMATCH tail';
+
+// --- panel selectors (data-testids added in FindReplacePanel.tsx) ---
+const panel = (page: Page) => page.getByTestId('find-and-replace-panel');
+const findInput = (page: Page) => page.getByTestId('find-and-replace-find-input');
+const replaceInput = (page: Page) => page.getByTestId('find-and-replace-replace-input');
+const nextBtn = (page: Page) => page.getByTestId('find-and-replace-next');
+const prevBtn = (page: Page) => page.getByTestId('find-and-replace-previous');
+const caseBtn = (page: Page) => page.getByTestId('find-and-replace-case-sensitive');
+const closeBtn = (page: Page) => page.getByTestId('find-and-replace-close');
+const replaceToggle = (page: Page) => page.getByTestId('find-and-replace-toggle');
+const replaceBtn = (page: Page) => page.getByTestId('find-and-replace-replace');
+const replaceAllBtn = (page: Page) => page.getByTestId('find-and-replace-replace-all');
+
+const highlights = (page: Page) => page.locator('.search-match-highlight');
+const currentHighlight = (page: Page) => page.locator('.search-match-highlight-current');
+
+async function setup(page: Page, request: import('@playwright/test').APIRequestContext, email: string) {
+  page.on('pageerror', (err) => {
+    if (err.message.includes('No workspace or service found')) return;
+  });
+  await signInAndWaitForApp(page, request, email);
+  await expect(page).toHaveURL(/\/app/);
+  await page.waitForTimeout(3000);
+  await expect(EditorSelectors.slateEditor(page)).toBeVisible({ timeout: 20000 });
+}
+
+/** Type a known line of content into the open document's editor. */
+async function typeContent(page: Page, text: string) {
+  await EditorSelectors.firstEditor(page).click({ force: true });
+  await page.keyboard.press('Enter');
+  await page.keyboard.type(text);
+  await page.waitForTimeout(800);
+}
+
+async function openFindReplaceFromMenu(page: Page) {
+  await HeaderSelectors.moreActionsButton(page).click();
+  await expect(DropdownSelectors.content(page)).toBeVisible();
+  await page.getByTestId('more-page-find-and-replace').click();
+  await expect(panel(page)).toBeVisible();
+}
+
+/** Type into the find field and wait for the debounced search (200ms) to settle. */
+async function search(page: Page, query: string) {
+  await findInput(page).fill(query);
+  await page.waitForTimeout(500);
+}
+
+test.describe('Find & Replace', () => {
+  let testEmail: string;
+
+  test.beforeEach(() => {
+    testEmail = generateRandomEmail();
+  });
+
+  test.describe('Entry points & lifecycle', () => {
+    test('header menu shows "Find and replace" and "Version history" labels', async ({ page, request }) => {
+      await setup(page, request, testEmail);
+
+      await HeaderSelectors.moreActionsButton(page).click();
+      const dropdown = DropdownSelectors.content(page);
+
+      await expect(dropdown).toBeVisible();
+      // Find & replace migrated item + the renamed "Version history" (was "Page History")
+      await expect(dropdown.getByText('Find and replace')).toBeVisible();
+      await expect(dropdown.getByText('Version history')).toBeVisible();
+      await expect(dropdown.getByText('Page History')).toHaveCount(0);
+    });
+
+    test('menu item opens the panel with the replace row visible', async ({ page, request }) => {
+      await setup(page, request, testEmail);
+      await openFindReplaceFromMenu(page);
+
+      await expect(findInput(page)).toBeVisible();
+      await expect(replaceInput(page)).toBeVisible();
+    });
+
+    test('Cmd/Ctrl+F opens the panel in find-only mode', async ({ page, request }) => {
+      await setup(page, request, testEmail);
+      await typeContent(page, TOKEN_LINE);
+
+      await EditorSelectors.firstEditor(page).click({ force: true });
+      await page.keyboard.press('ControlOrMeta+f');
+
+      await expect(panel(page)).toBeVisible();
+      // Find-only: the replace row should not be shown until the toggle is used.
+      await expect(replaceInput(page)).toHaveCount(0);
+    });
+
+    test('Escape and the close button both dismiss the panel', async ({ page, request }) => {
+      await setup(page, request, testEmail);
+
+      await openFindReplaceFromMenu(page);
+      await findInput(page).press('Escape');
+      await expect(panel(page)).toBeHidden();
+
+      await openFindReplaceFromMenu(page);
+      await closeBtn(page).click();
+      await expect(panel(page)).toBeHidden();
+    });
+  });
+
+  test.describe('Find behavior', () => {
+    test('highlights all matches and shows the n/total count', async ({ page, request }) => {
+      await setup(page, request, testEmail);
+      await typeContent(page, TOKEN_LINE);
+      await openFindReplaceFromMenu(page);
+
+      await search(page, 'zqxmatch');
+
+      await expect(panel(page)).toContainText('1/3');
+      await expect(highlights(page)).toHaveCount(3);
+      await expect(currentHighlight(page)).toHaveCount(1);
+    });
+
+    test('shows "No results" for a query with no matches', async ({ page, request }) => {
+      await setup(page, request, testEmail);
+      await typeContent(page, TOKEN_LINE);
+      await openFindReplaceFromMenu(page);
+
+      await search(page, 'no-such-token-xyz');
+
+      await expect(panel(page)).toContainText('No results');
+      await expect(highlights(page)).toHaveCount(0);
+    });
+
+    test('Next / Enter advances and wraps around', async ({ page, request }) => {
+      await setup(page, request, testEmail);
+      await typeContent(page, TOKEN_LINE);
+      await openFindReplaceFromMenu(page);
+      await search(page, 'zqxmatch');
+
+      await expect(panel(page)).toContainText('1/3');
+      await nextBtn(page).click();
+      await expect(panel(page)).toContainText('2/3');
+      // Enter inside the find field also advances.
+      await findInput(page).press('Enter');
+      await expect(panel(page)).toContainText('3/3');
+      // Wrap back to the first match.
+      await nextBtn(page).click();
+      await expect(panel(page)).toContainText('1/3');
+    });
+
+    test('Previous / Shift+Enter goes backward and wraps', async ({ page, request }) => {
+      await setup(page, request, testEmail);
+      await typeContent(page, TOKEN_LINE);
+      await openFindReplaceFromMenu(page);
+      await search(page, 'zqxmatch');
+
+      await expect(panel(page)).toContainText('1/3');
+      // From the first match, previous wraps to the last.
+      await prevBtn(page).click();
+      await expect(panel(page)).toContainText('3/3');
+      await findInput(page).press('Shift+Enter');
+      await expect(panel(page)).toContainText('2/3');
+    });
+
+    test('match-case toggle filters to exact-case matches', async ({ page, request }) => {
+      await setup(page, request, testEmail);
+      await typeContent(page, TOKEN_LINE);
+      await openFindReplaceFromMenu(page);
+
+      await search(page, 'zqxmatch');
+      await expect(panel(page)).toContainText('1/3');
+
+      // Enable case sensitivity → only the exact lowercase "zqxmatch" matches.
+      await caseBtn(page).click();
+      await page.waitForTimeout(500);
+      await expect(panel(page)).toContainText('1/1');
+      await expect(highlights(page)).toHaveCount(1);
+    });
+  });
+
+  test.describe('Replace behavior', () => {
+    test('Replace swaps the current match and re-searches', async ({ page, request }) => {
+      await setup(page, request, testEmail);
+      await typeContent(page, TOKEN_LINE);
+      await openFindReplaceFromMenu(page);
+      await search(page, 'zqxmatch');
+      await expect(panel(page)).toContainText('1/3');
+
+      await replaceInput(page).fill('replacedword');
+      await replaceBtn(page).click();
+      await page.waitForTimeout(600);
+
+      // One occurrence replaced → two left.
+      await expect(panel(page)).toContainText('1/2');
+      await expect(EditorSelectors.firstEditor(page)).toContainText('replacedword');
+    });
+
+    test('Replace All replaces every match and reports the count', async ({ page, request }) => {
+      await setup(page, request, testEmail);
+      await typeContent(page, TOKEN_LINE);
+      await openFindReplaceFromMenu(page);
+      await search(page, 'zqxmatch');
+      await expect(panel(page)).toContainText('1/3');
+
+      await replaceInput(page).fill('omegaword');
+      await replaceAllBtn(page).click();
+
+      // Success toast (sonner) + the panel now finds nothing.
+      await expect(page.getByText(/Replaced\s+\d+\s+match/i)).toBeVisible({ timeout: 5000 });
+      await expect(panel(page)).toContainText('No results');
+      await expect(EditorSelectors.firstEditor(page)).not.toContainText('zqxmatch', { ignoreCase: true });
+    });
+
+    test('Replace and Replace All are disabled when there are no matches', async ({ page, request }) => {
+      await setup(page, request, testEmail);
+      await typeContent(page, TOKEN_LINE);
+      await openFindReplaceFromMenu(page);
+
+      await search(page, 'no-such-token-xyz');
+      await expect(replaceBtn(page)).toBeDisabled();
+      await expect(replaceAllBtn(page)).toBeDisabled();
+    });
+  });
+
+  test.describe('Selection pre-fill', () => {
+    test('opening find with a selection pre-fills the query', async ({ page, request }) => {
+      await setup(page, request, testEmail);
+      await typeContent(page, 'preselected token here');
+
+      // Drive Slate's selection directly via the editor exposed by
+      // CollaborativeEditor in test mode (window.Cypress is set during sign-in).
+      await page.evaluate((needle) => {
+        const ed = (window as { __TEST_EDITOR__?: unknown }).__TEST_EDITOR__ as
+          | (Record<string, unknown> & { children: unknown[]; select: (range: unknown) => void })
+          | undefined;
+
+        if (!ed) throw new Error('__TEST_EDITOR__ not exposed by the editor');
+
+        type N = { text?: string; children?: N[] };
+        const find = (node: N, path: number[]): { path: number[]; offset: number } | null => {
+          if (typeof node.text === 'string') {
+            const i = node.text.indexOf(needle);
+
+            return i >= 0 ? { path, offset: i } : null;
+          }
+          if (Array.isArray(node.children)) {
+            for (let k = 0; k < node.children.length; k++) {
+              const r = find(node.children[k], [...path, k]);
+
+              if (r) return r;
+            }
+          }
+          return null;
+        };
+
+        for (let i = 0; i < ed.children.length; i++) {
+          const hit = find(ed.children[i] as N, [i]);
+
+          if (hit) {
+            ed.select({
+              anchor: { path: hit.path, offset: hit.offset },
+              focus: { path: hit.path, offset: hit.offset + needle.length },
+            });
+            return;
+          }
+        }
+        throw new Error(`Text "${needle}" not found in editor`);
+      }, 'preselected');
+
+      await page.keyboard.press('ControlOrMeta+f');
+
+      await expect(panel(page)).toBeVisible();
+      await expect(findInput(page)).toHaveValue('preselected');
+    });
+  });
+});

--- a/playwright/e2e/page/lock-page.spec.ts
+++ b/playwright/e2e/page/lock-page.spec.ts
@@ -1,0 +1,148 @@
+import { test, expect, Page } from '@playwright/test';
+
+import { signInAndWaitForApp } from '../../support/auth-flow-helpers';
+import { DropdownSelectors, EditorSelectors, HeaderSelectors } from '../../support/selectors';
+import { generateRandomEmail } from '../../support/test-config';
+
+/**
+ * Lock Page Tests
+ *
+ * Covers the "Lock page" toggle migrated from desktop: toggling persists the
+ * folder `is_locked` attribute (via the updatePage endpoint), which makes the
+ * document read-only, shows the orange "Locked" badge, and toasts.
+ */
+
+const PAGE_LOCKED_TOAST = 'Page locked. Editing is disabled until someone unlocks it.';
+const PAGE_UNLOCKED_TOAST = 'Page unlocked. Editing is enabled.';
+
+const lockItem = (page: Page) => page.getByTestId('more-page-lock');
+const lockSwitch = (page: Page) => lockItem(page).locator('[data-slot="switch"]');
+const lockedBadge = (page: Page) => page.getByTestId('page-locked-badge');
+const bodyEditor = (page: Page) => page.getByTestId('editor-content');
+
+async function setup(page: Page, request: import('@playwright/test').APIRequestContext, email: string) {
+  page.on('pageerror', (err) => {
+    if (err.message.includes('No workspace or service found')) return;
+  });
+  await signInAndWaitForApp(page, request, email);
+  await expect(page).toHaveURL(/\/app/);
+  await page.waitForTimeout(3000);
+  await expect(EditorSelectors.slateEditor(page)).toBeVisible({ timeout: 20000 });
+}
+
+async function openMoreMenu(page: Page) {
+  await HeaderSelectors.moreActionsButton(page).click();
+  await expect(DropdownSelectors.content(page)).toBeVisible();
+}
+
+/** Click the Lock page toggle (menu stays open) and wait for the expected toast. */
+async function toggleLock(page: Page, expectLocked: boolean) {
+  await openMoreMenu(page);
+  await expect(lockItem(page)).toBeVisible();
+  await lockItem(page).click();
+  await expect(page.getByText(expectLocked ? PAGE_LOCKED_TOAST : PAGE_UNLOCKED_TOAST)).toBeVisible({ timeout: 5000 });
+  // Close the menu so the editor/badge are observable.
+  await page.keyboard.press('Escape');
+  await expect(DropdownSelectors.content(page)).toBeHidden();
+}
+
+test.describe('Lock Page', () => {
+  let testEmail: string;
+
+  test.beforeEach(() => {
+    testEmail = generateRandomEmail();
+  });
+
+  test('Lock page toggle is present and off by default for a document', async ({ page, request }) => {
+    await setup(page, request, testEmail);
+    await openMoreMenu(page);
+
+    await expect(lockItem(page)).toBeVisible();
+    await expect(lockSwitch(page)).toHaveAttribute('data-state', 'unchecked');
+    await expect(bodyEditor(page)).toHaveAttribute('contenteditable', 'true');
+  });
+
+  test('locking shows the toast, the "Locked" badge, and makes the editor read-only', async ({ page, request }) => {
+    await setup(page, request, testEmail);
+
+    await toggleLock(page, true);
+
+    await expect(lockedBadge(page)).toBeVisible({ timeout: 10000 });
+    await expect(lockedBadge(page)).toContainText('Locked');
+    await expect(bodyEditor(page)).toHaveAttribute('contenteditable', 'false', { timeout: 10000 });
+  });
+
+  test('unlocking removes the badge and re-enables editing', async ({ page, request }) => {
+    await setup(page, request, testEmail);
+
+    await toggleLock(page, true);
+    await expect(lockedBadge(page)).toBeVisible({ timeout: 10000 });
+
+    await toggleLock(page, false);
+    await expect(lockedBadge(page)).toBeHidden({ timeout: 10000 });
+    await expect(bodyEditor(page)).toHaveAttribute('contenteditable', 'true', { timeout: 10000 });
+  });
+
+  test('the toggle reflects the current lock state when the menu is reopened', async ({ page, request }) => {
+    await setup(page, request, testEmail);
+
+    await toggleLock(page, true);
+    await expect(lockedBadge(page)).toBeVisible({ timeout: 10000 });
+
+    await openMoreMenu(page);
+    await expect(lockSwitch(page)).toHaveAttribute('data-state', 'checked');
+    await page.keyboard.press('Escape');
+  });
+
+  test('lock state persists across a reload', async ({ page, request }) => {
+    await setup(page, request, testEmail);
+
+    await toggleLock(page, true);
+    await expect(lockedBadge(page)).toBeVisible({ timeout: 10000 });
+
+    await page.reload();
+    await page.waitForTimeout(3000);
+
+    await expect(lockedBadge(page)).toBeVisible({ timeout: 15000 });
+    await expect(bodyEditor(page)).toHaveAttribute('contenteditable', 'false', { timeout: 10000 });
+  });
+
+  test('the locked badge exposes an explanatory tooltip', async ({ page, request }) => {
+    await setup(page, request, testEmail);
+    await toggleLock(page, true);
+    await expect(lockedBadge(page)).toBeVisible({ timeout: 10000 });
+
+    await lockedBadge(page).hover();
+    await expect(page.getByText('Page locked to prevent accidental editing. Click to unlock.')).toBeVisible({
+      timeout: 5000,
+    });
+  });
+
+  test('on a locked page, Find & Replace can find but cannot replace', async ({ page, request }) => {
+    await setup(page, request, testEmail);
+
+    // Add searchable content before locking.
+    await EditorSelectors.firstEditor(page).click({ force: true });
+    await page.keyboard.press('Enter');
+    await page.keyboard.type('lockedsearch lockedsearch');
+    await page.waitForTimeout(800);
+
+    await toggleLock(page, true);
+    await expect(bodyEditor(page)).toHaveAttribute('contenteditable', 'false', { timeout: 10000 });
+
+    // Open Find & Replace from the header menu.
+    await HeaderSelectors.moreActionsButton(page).click();
+    await expect(DropdownSelectors.content(page)).toBeVisible();
+    await page.getByTestId('more-page-find-and-replace').click();
+    await expect(page.getByTestId('find-and-replace-panel')).toBeVisible();
+
+    await page.getByTestId('find-and-replace-find-input').fill('lockedsearch');
+    await page.waitForTimeout(500);
+
+    // Find still works...
+    await expect(page.getByTestId('find-and-replace-panel')).toContainText('1/2');
+    // ...but replace is disabled on a read-only page.
+    await expect(page.getByTestId('find-and-replace-replace')).toBeDisabled();
+    await expect(page.getByTestId('find-and-replace-replace-all')).toBeDisabled();
+  });
+});

--- a/src/@types/translations/en.json
+++ b/src/@types/translations/en.json
@@ -153,6 +153,7 @@
   },
   "shareAction": {
     "buttonText": "Share",
+    "findAndReplace": "Find and replace",
     "workInProgress": "Coming soon",
     "markdown": "Markdown",
     "html": "HTML",
@@ -265,6 +266,7 @@
     "rename": "Rename",
     "delete": "Delete",
     "duplicate": "Duplicate",
+    "lockPage": "Lock page",
     "unfavorite": "Remove from Favorites",
     "favorite": "Add to Favorites",
     "openNewTab": "Open in a new tab",
@@ -2821,14 +2823,33 @@
   },
   "findAndReplace": {
     "find": "Find",
+    "findAndReplace": "Find & replace",
     "previousMatch": "Previous match",
     "nextMatch": "Next match",
     "close": "Close",
     "replace": "Replace",
     "replaceAll": "Replace all",
+    "all": "All",
     "noResult": "No results",
     "caseSensitive": "Case sensitive",
-    "searchMore": "Search to find more results"
+    "matchCase": "Match case",
+    "searchMore": "Search to find more results",
+    "findTextfieldHint": "Find text on page...",
+    "replaceTextfieldHint": "Replace with...",
+    "switchFindHint": "Switch to Find",
+    "switchFindAndReplaceHint": "Switch to Find & Replace",
+    "replacedMoreThanOneSuccessfully": "Replaced {} matches",
+    "replacedOneSuccessfully": "Replaced 1 match",
+    "noPermissionHint": "Replace is disabled while in read-only or locked mode",
+    "noMoreResultToast": "No more results found, looping around"
+  },
+  "lockPage": {
+    "lockPage": "Locked",
+    "reLockPage": "Re-lock",
+    "lockTooltip": "Page locked to prevent accidental editing. Click to unlock.",
+    "pageLockedToast": "Page locked. Editing is disabled until someone unlocks it.",
+    "pageUnlockedToast": "Page unlocked. Editing is enabled.",
+    "lockedOperationTooltip": "Page locked to prevent accidental editing."
   },
   "error": {
     "weAreSorry": "We're sorry",
@@ -3858,7 +3879,7 @@
     "comingSoonToWeb": "Coming soon to the web 👋. You can use this feature right now on our desktop or mobile app."
   },
   "versionHistory": {
-    "versionHistory": "Page History",
+    "versionHistory": "Version history",
     "all": "All",
     "last7Days": "Last 7 days",
     "last30Days": "Last 30 days",

--- a/src/application/constants.ts
+++ b/src/application/constants.ts
@@ -75,4 +75,7 @@ export const APP_EVENTS = {
   FOLDER_VIEW_CHANGED: 'folder-view-changed',             // Granular folder view change (sidebar update)
   INBOX_NOTIFICATION: 'inbox-notification',               // Inbox notification push for notification center refresh
   COLLAB_DOC_RESET: 'collab-doc-reset',                   // Collab version reset replaced active Y.Doc instance
+
+  // Editor events
+  FIND_AND_REPLACE: 'find-and-replace',                   // Open the in-document find & replace panel for a view
 };

--- a/src/application/types.ts
+++ b/src/application/types.ts
@@ -1201,6 +1201,8 @@ export interface View {
   has_children?: boolean;
   is_published: boolean;
   is_private: boolean;
+  /** Whether the page is locked (read-only) for everyone until unlocked. Synced via the folder. */
+  is_locked?: boolean;
   last_edited_time?: string;
   favorited_at?: string;
   last_viewed_at?: string;
@@ -1341,6 +1343,7 @@ export interface UpdatePagePayload {
     value: string;
   };
   extra?: Partial<ViewExtra>;
+  is_locked?: boolean;
 }
 
 export type ViewMetaCover = ViewCover;

--- a/src/components/app/ViewModal.tsx
+++ b/src/components/app/ViewModal.tsx
@@ -324,11 +324,13 @@ function ViewModal({ viewId, open, onClose }: { viewId?: string; open: boolean; 
     );
   }, [effectiveViewId, handleClose, movePageOpen, outline, t, toView]);
 
-  // Check if view is in shareWithMe and determine readonly status
+  // Check if view is in shareWithMe and determine readonly status.
+  // `resolvedView` includes the server-fetched fallback, so locked pages opened
+  // before their outline branch is loaded still flip the editor to read-only.
   const isReadOnly = useMemo(() => {
     if (!effectiveViewId) return false;
-    return getViewReadOnlyStatus(effectiveViewId, outline);
-  }, [getViewReadOnlyStatus, effectiveViewId, outline]);
+    return getViewReadOnlyStatus(effectiveViewId, outline, resolvedView);
+  }, [getViewReadOnlyStatus, effectiveViewId, outline, resolvedView]);
 
   const View = useMemo(() => {
     switch (layout) {

--- a/src/components/app/header/AppHeader.tsx
+++ b/src/components/app/header/AppHeader.tsx
@@ -8,6 +8,7 @@ import { useOutlinePopover } from '@/components/_shared/outline/outline.hooks';
 import OutlinePopover from '@/components/_shared/outline/OutlinePopover';
 import BreadcrumbSkeleton from '@/components/_shared/skeleton/BreadcrumbSkeleton';
 import { useAppRendered, useToView, useBreadcrumb } from '@/components/app/app.hooks';
+import LockedBadge from '@/components/app/header/LockedBadge';
 import Recent from '@/components/app/recent/Recent';
 
 const RightMenu = lazy(() => import('@/components/app/header/RightMenu'));
@@ -85,6 +86,7 @@ export function AppHeader({ onOpenDrawer, openDrawer, onCloseDrawer }: AppHeader
             <Breadcrumb toView={toView} variant={UIVariant.App} crumbs={crumbs} />
           )}
         </div>
+        <LockedBadge />
         {rendered && (
           <Suspense fallback={null}>
             <RightMenu />

--- a/src/components/app/header/LockedBadge.tsx
+++ b/src/components/app/header/LockedBadge.tsx
@@ -1,0 +1,38 @@
+import { useTranslation } from 'react-i18next';
+
+import { ReactComponent as LockIcon } from '@/assets/icons/lock.svg';
+import { useAppView, useAppViewId } from '@/components/app/app.hooks';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+
+/**
+ * Orange "Locked" status pill shown in the header when the current page is
+ * locked. Read-only indicator for everyone viewing the page; unlocking is done
+ * via the "Lock page" toggle in the more-actions menu.
+ */
+function LockedBadge() {
+  const { t } = useTranslation();
+  const viewId = useAppViewId();
+  const view = useAppView(viewId);
+
+  if (!view?.is_locked) return null;
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <div
+          data-testid={'page-locked-badge'}
+          className={
+            'flex shrink-0 select-none items-center gap-1 rounded-300 border border-border-warning-thick ' +
+            'bg-fill-warning-light px-2 py-0.5 text-xs font-medium text-text-warning'
+          }
+        >
+          <LockIcon className={'h-3.5 w-3.5 text-icon-warning-thick'} />
+          {t('lockPage.lockPage')}
+        </div>
+      </TooltipTrigger>
+      <TooltipContent>{t('lockPage.lockTooltip')}</TooltipContent>
+    </Tooltip>
+  );
+}
+
+export default LockedBadge;

--- a/src/components/app/header/MoreActions.tsx
+++ b/src/components/app/header/MoreActions.tsx
@@ -1,13 +1,15 @@
 import { lazy, Suspense, useCallback, useEffect, useMemo, useState, type ComponentProps } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import { APP_EVENTS } from '@/application/constants';
 import { Role, ViewLayout } from '@/application/types';
 import { ReactComponent as AddToPageIcon } from '@/assets/icons/add_to_page.svg';
 import { ReactComponent as MoreIcon } from '@/assets/icons/more.svg';
+import { ReactComponent as SearchIcon } from '@/assets/icons/search.svg';
 import { findViewInShareWithMe } from '@/components/_shared/outline/utils';
 import { useAIChatContext } from '@/components/ai-chat/AIChatProvider';
 import { AIService } from '@/application/services/domains';
-import { useAIEnabled, useAppOutline, useAppView, useCurrentWorkspaceId, usePageHistoryEnabled, useUserWorkspaceInfo } from '@/components/app/app.hooks';
+import { useAIEnabled, useAppOutline, useAppView, useCurrentWorkspaceId, useEventEmitter, usePageHistoryEnabled, useUserWorkspaceInfo } from '@/components/app/app.hooks';
 import DocumentInfo from '@/components/app/header/DocumentInfo';
 import { Button } from '@/components/ui/button';
 import {
@@ -110,6 +112,13 @@ function MoreActions({
   const pageHistoryEnabled = usePageHistoryEnabled();
   const showHistory = enableVersionHistory && pageHistoryEnabled && view?.layout === ViewLayout.Document;
 
+  const eventEmitter = useEventEmitter();
+  const isDocument = view?.layout === ViewLayout.Document;
+  const handleFindAndReplace = useCallback(() => {
+    handleClose();
+    eventEmitter?.emit(APP_EVENTS.FIND_AND_REPLACE, { viewId });
+  }, [eventEmitter, viewId, handleClose]);
+
   useEffect(() => {
     if (!showHistory && historyOpen) {
       setHistoryOpen(false);
@@ -135,7 +144,26 @@ function MoreActions({
         <DropdownMenuContent {...menuContentProps}>
           <DropdownMenuGroup>{ChatOptions}</DropdownMenuGroup>
 
-          {role === Role.Guest || shareWithMeView ? null : (
+          {role === Role.Guest || shareWithMeView ? (
+            // Guests and shared-with-me viewers don't get the editing actions
+            // in MoreActionsContent, but Find still works in read-only mode
+            // (the panel disables Replace itself), so surface it here.
+            isDocument && (
+              <>
+                <DropdownMenuItem
+                  data-testid={'more-page-find-and-replace'}
+                  onSelect={(event) => {
+                    event.preventDefault();
+                    handleFindAndReplace();
+                  }}
+                >
+                  <SearchIcon />
+                  {t('shareAction.findAndReplace')}
+                </DropdownMenuItem>
+                <DropdownMenuSeparator />
+              </>
+            )
+          ) : (
             <>
               <MoreActionsContent
                 itemClicked={() => {
@@ -144,6 +172,7 @@ function MoreActions({
                 onDeleted={onDeleted}
                 viewId={viewId}
                 onOpenHistory={showHistory ? handleOpenHistory : undefined}
+                onFindAndReplace={isDocument ? handleFindAndReplace : undefined}
               />
               <DropdownMenuSeparator />
             </>

--- a/src/components/app/header/MoreActionsContent.tsx
+++ b/src/components/app/header/MoreActionsContent.tsx
@@ -6,7 +6,9 @@ import { ViewLayout } from '@/application/types';
 import { canBeMoved } from '@/application/view-utils';
 import { ReactComponent as DeleteIcon } from '@/assets/icons/delete.svg';
 import { ReactComponent as DuplicateIcon } from '@/assets/icons/duplicate.svg';
+import { ReactComponent as LockIcon } from '@/assets/icons/lock.svg';
 import { ReactComponent as MoveToIcon } from '@/assets/icons/move_to.svg';
+import { ReactComponent as SearchIcon } from '@/assets/icons/search.svg';
 import { ReactComponent as TimeIcon } from '@/assets/icons/time.svg';
 import { ViewService, PageService } from '@/application/services/domains';
 import { findView } from '@/components/_shared/outline/utils';
@@ -20,7 +22,8 @@ import {
 } from '@/components/app/app.hooks';
 import { useSyncInternal } from '@/components/app/contexts/SyncInternalContext';
 import MovePagePopover from '@/components/app/view-actions/MovePagePopover';
-import { DropdownMenuGroup, DropdownMenuItem } from '@/components/ui/dropdown-menu';
+import { DropdownMenuGroup, DropdownMenuItem, DropdownMenuSeparator } from '@/components/ui/dropdown-menu';
+import { Switch } from '@/components/ui/switch';
 
 const DUPLICATE_PRE_SYNC_TIMEOUT_MS = 8000;
 
@@ -28,11 +31,13 @@ function MoreActionsContent({
   itemClicked,
   viewId,
   onOpenHistory,
+  onFindAndReplace,
 }: {
   itemClicked?: () => void;
   onDeleted?: () => void;
   viewId: string;
   onOpenHistory?: () => void;
+  onFindAndReplace?: () => void;
 }) {
   const { t } = useTranslation();
   const { openDeleteModal, showBlockingLoader, hideBlockingLoader } = useAppOverlayContext();
@@ -109,10 +114,41 @@ function MoreActionsContent({
   }, []);
 
   const isDocument = layout === ViewLayout.Document;
+  const isLocked = !!view?.is_locked;
+
+  const handleToggleLock = useCallback(async () => {
+    if (!workspaceId || !view) return;
+    const next = !view.is_locked;
+
+    try {
+      await PageService.update(workspaceId, viewId, { name: view.name, is_locked: next });
+      void refreshOutline?.();
+      toast.success(next ? t('lockPage.pageLockedToast') : t('lockPage.pageUnlockedToast'));
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } catch (e: any) {
+      toast.error(e.message);
+    }
+  }, [workspaceId, view, viewId, refreshOutline, t]);
 
   return (
     <DropdownMenuGroup>
       <div ref={containerRef} />
+      {isDocument && (
+        <>
+          <DropdownMenuItem
+            data-testid={'more-page-lock'}
+            onSelect={(event) => {
+              event.preventDefault();
+              void handleToggleLock();
+            }}
+          >
+            <LockIcon />
+            <span className={'flex-1'}>{t('disclosureAction.lockPage')}</span>
+            <Switch checked={isLocked} tabIndex={-1} aria-hidden className={'pointer-events-none'} />
+          </DropdownMenuItem>
+          <DropdownMenuSeparator />
+        </>
+      )}
       <DropdownMenuItem
         data-testid={'more-page-duplicate'}
         className={`${layout === ViewLayout.AIChat ? 'hidden' : ''}`}
@@ -142,6 +178,19 @@ function MoreActionsContent({
             {t('disclosureAction.moveTo')}
           </DropdownMenuItem>
         </MovePagePopover>
+      )}
+
+      {isDocument && onFindAndReplace && (
+        <DropdownMenuItem
+          data-testid={'more-page-find-and-replace'}
+          onSelect={(event) => {
+            event.preventDefault();
+            onFindAndReplace();
+          }}
+        >
+          <SearchIcon />
+          {t('shareAction.findAndReplace')}
+        </DropdownMenuItem>
       )}
 
       <DropdownMenuItem

--- a/src/components/app/hooks/__tests__/useViewOperations.lockReadOnly.test.ts
+++ b/src/components/app/hooks/__tests__/useViewOperations.lockReadOnly.test.ts
@@ -1,0 +1,108 @@
+import { AccessLevel, View, ViewExtra, ViewLayout } from '@/application/types';
+import { getPlatform } from '@/utils/platform';
+
+import { getViewReadOnlyStatus } from '../useViewOperations';
+
+// useViewOperations pulls in service/loader modules at import time; stub the
+// heavy ones so the pure getViewReadOnlyStatus function can be tested in isolation.
+jest.mock('@/application/services/domains', () => ({
+  CollabService: {},
+  ViewService: {},
+  WorkspaceService: {},
+}));
+jest.mock('@/application/view-loader', () => ({ openView: jest.fn() }));
+jest.mock('@/utils/platform', () => ({ getPlatform: jest.fn(() => ({ isMobile: false })) }));
+
+const mockGetPlatform = getPlatform as jest.MockedFunction<typeof getPlatform>;
+
+function createView(overrides: Partial<View>): View {
+  return {
+    view_id: 'view-id',
+    name: 'View',
+    icon: null,
+    layout: ViewLayout.Document,
+    extra: null,
+    children: [],
+    is_published: false,
+    is_private: false,
+    ...overrides,
+  };
+}
+
+/** Wrap views inside the hidden "Shared with me" space that findViewInShareWithMe looks for. */
+function shareWithMeOutline(...children: View[]): View[] {
+  return [
+    createView({
+      view_id: 'share-with-me-space',
+      extra: { is_space: true, is_hidden_space: true } as ViewExtra,
+      children,
+    }),
+  ];
+}
+
+describe('getViewReadOnlyStatus (lock + access)', () => {
+  beforeEach(() => {
+    mockGetPlatform.mockReturnValue({ isMobile: false } as ReturnType<typeof getPlatform>);
+  });
+
+  it('returns false when there is no outline', () => {
+    expect(getViewReadOnlyStatus('view-id', undefined)).toBe(false);
+  });
+
+  it('always returns true on mobile, regardless of lock/access', () => {
+    mockGetPlatform.mockReturnValue({ isMobile: true } as ReturnType<typeof getPlatform>);
+
+    expect(getViewReadOnlyStatus('view-id', [])).toBe(true);
+  });
+
+  it('returns true for a locked view in the workspace outline', () => {
+    const outline = [createView({ view_id: 'view-id', is_locked: true })];
+
+    expect(getViewReadOnlyStatus('view-id', outline)).toBe(true);
+  });
+
+  it('returns false for an unlocked, owned view', () => {
+    const outline = [createView({ view_id: 'view-id', is_locked: false })];
+
+    expect(getViewReadOnlyStatus('view-id', outline)).toBe(false);
+  });
+
+  it('returns true for a locked view found in the shared-with-me space', () => {
+    const outline = shareWithMeOutline(
+      createView({ view_id: 'view-id', is_locked: true, access_level: AccessLevel.ReadAndWrite })
+    );
+
+    expect(getViewReadOnlyStatus('view-id', outline)).toBe(true);
+  });
+
+  it('returns true for a shared view with read-only access', () => {
+    const outline = shareWithMeOutline(
+      createView({ view_id: 'view-id', access_level: AccessLevel.ReadAndComment })
+    );
+
+    expect(getViewReadOnlyStatus('view-id', outline)).toBe(true);
+  });
+
+  it('returns false for a shared view with write access (and not locked)', () => {
+    const outline = shareWithMeOutline(
+      createView({ view_id: 'view-id', access_level: AccessLevel.ReadAndWrite })
+    );
+
+    expect(getViewReadOnlyStatus('view-id', outline)).toBe(false);
+  });
+
+  it('honors the lock when the view is only present in the fallback (not yet in the outline)', () => {
+    // Simulates AppPage opening a page by direct URL before the outline branch
+    // has loaded — outline does not contain the view, but the server-fetched
+    // fallback does and reports is_locked=true.
+    const fallback = createView({ view_id: 'view-id', is_locked: true });
+
+    expect(getViewReadOnlyStatus('view-id', [], fallback)).toBe(true);
+  });
+
+  it('ignores a fallback view that does not match the requested viewId', () => {
+    const fallback = createView({ view_id: 'some-other-view', is_locked: true });
+
+    expect(getViewReadOnlyStatus('view-id', [], fallback)).toBe(false);
+  });
+});

--- a/src/components/app/hooks/useViewOperations.ts
+++ b/src/components/app/hooks/useViewOperations.ts
@@ -26,15 +26,34 @@ import { useSyncInternal } from '../contexts/SyncInternalContext';
 
 import { useDatabaseIdentity } from './useDatabaseIdentity';
 
-export function getViewReadOnlyStatus(viewId: string, outline?: View[]) {
+/**
+ * Determine whether the editor should be read-only for the given view.
+ *
+ * `fallbackView` is the resolved view object the page hosts already have
+ * (e.g. AppPage's `outlineView ?? fallbackView`, ViewModal's `resolvedView`).
+ * It's checked first so that locked pages remain read-only even when the page
+ * is opened before the outline branch loads — in that case `findView(outline)`
+ * misses the view and a lock check against the outline alone would let edits
+ * through.
+ */
+export function getViewReadOnlyStatus(viewId: string, outline?: View[], fallbackView?: View | null) {
   const isMobile = getPlatform().isMobile;
 
   if (isMobile) return true; // Mobile has highest priority - always readonly
+
+  // Lock check uses the resolved view first, falling back to the outline so
+  // direct-URL loads (before outline arrives) still honor the lock.
+  if (fallbackView?.view_id === viewId && fallbackView.is_locked) return true;
 
   if (!outline) return false;
 
   // Check if view exists in shareWithMe
   const shareWithMeView = findViewInShareWithMe(outline, viewId);
+
+  // A locked page is read-only for everyone until it is unlocked.
+  const view = findView(outline, viewId) ?? shareWithMeView;
+
+  if (view?.is_locked) return true;
 
   if (shareWithMeView?.access_level !== undefined) {
     // If found in shareWithMe, check access level
@@ -89,9 +108,12 @@ export function useViewOperations() {
   });
 
   // Check if view should be readonly based on access permissions
-  const getViewReadOnlyStatusFromOutline = useCallback((viewId: string, outline?: View[]) => {
-    return getViewReadOnlyStatus(viewId, outline);
-  }, []);
+  const getViewReadOnlyStatusFromOutline = useCallback(
+    (viewId: string, outline?: View[], fallbackView?: View | null) => {
+      return getViewReadOnlyStatus(viewId, outline, fallbackView);
+    },
+    []
+  );
 
   /**
    * Load view document WITHOUT binding sync.

--- a/src/components/editor/CollaborativeEditor.tsx
+++ b/src/components/editor/CollaborativeEditor.tsx
@@ -8,6 +8,7 @@ import { CustomEditor } from '@/application/slate-yjs/command';
 import { withYHistory } from '@/application/slate-yjs/plugins/withHistory';
 import { withYjs, YjsEditor } from '@/application/slate-yjs/plugins/withYjs';
 import { BlockType, CollabOrigin, YDoc } from '@/application/types';
+import { FindReplaceProvider } from '@/components/editor/components/find-replace/FindReplaceContext';
 import EditorEditable from '@/components/editor/Editable';
 import { useEditorContext } from '@/components/editor/EditorContext';
 import { withPlugins } from '@/components/editor/plugins';
@@ -321,7 +322,9 @@ function CollaborativeEditor({
 
   return (
     <Slate key={key} editor={editor} initialValue={defaultInitialValue} onChange={handleSlateChange}>
-      <EditorEditable />
+      <FindReplaceProvider>
+        <EditorEditable />
+      </FindReplaceProvider>
     </Slate>
   );
 }

--- a/src/components/editor/Editable.tsx
+++ b/src/components/editor/Editable.tsx
@@ -10,6 +10,7 @@ import { CustomEditor } from '@/application/slate-yjs/command';
 import { BlockType } from '@/application/types';
 import { BlockPopoverProvider } from '@/components/editor/components/block-popover/BlockPopoverContext';
 import { useDecorate } from '@/components/editor/components/blocks/code/useDecorate';
+import { useFindReplaceDecorations } from '@/components/editor/components/find-replace/FindReplaceContext';
 import { Leaf } from '@/components/editor/components/leaf';
 import HrefPopover from '@/components/editor/components/leaf/href/HrefPopover';
 import { LeafContext } from '@/components/editor/components/leaf/leaf.hooks';
@@ -64,6 +65,7 @@ function scrollSelectionIntoView(_editor: ReactEditor, domRange: globalThis.Rang
 const EditorEditable = () => {
   const { readOnly, viewId, workspaceId, fullWidth } = useEditorContext();
   const { decorateState } = useEditorLocalState();
+  const { getMatchDecorations } = useFindReplaceDecorations();
   const editor = useSlate();
 
   const codeDecorate = useDecorate(editor);
@@ -74,22 +76,27 @@ const EditorEditable = () => {
         class_name: string;
       })[] = [];
 
-      if (!decorateState) return [];
+      if (decorateState) {
+        Object.values(decorateState).forEach((state) => {
+          const intersection = Range.intersection(state.range, Editor.range(editor, path));
 
-      Object.values(decorateState).forEach((state) => {
-        const intersection = Range.intersection(state.range, Editor.range(editor, path));
+          if (intersection) {
+            highlightRanges.push({
+              ...intersection,
+              class_name: state.class_name,
+            });
+          }
+        });
+      }
 
-        if (intersection) {
-          highlightRanges.push({
-            ...intersection,
-            class_name: state.class_name,
-          });
-        }
-      });
+      // Find & replace match highlights (already scoped to this text node's path).
+      for (const match of getMatchDecorations(path)) {
+        highlightRanges.push(match as Range & { class_name: string });
+      }
 
       return highlightRanges;
     },
-    [editor, decorateState]
+    [editor, decorateState, getMatchDecorations]
   );
   const renderElement = useCallback((props: RenderElementProps) => {
     return (

--- a/src/components/editor/components/find-replace/FindReplaceContext.tsx
+++ b/src/components/editor/components/find-replace/FindReplaceContext.tsx
@@ -1,0 +1,489 @@
+import { debounce } from 'lodash-es';
+import {
+  createContext,
+  lazy,
+  ReactNode,
+  Suspense,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import { useTranslation } from 'react-i18next';
+import { BaseRange, Editor, Path, Transforms } from 'slate';
+import { ReactEditor, useSlate } from 'slate-react';
+
+import { APP_EVENTS } from '@/application/constants';
+import { YjsEditor } from '@/application/slate-yjs';
+import { CustomEditor } from '@/application/slate-yjs/command';
+import { notify } from '@/components/_shared/notify';
+import { useEventEmitter } from '@/components/app/app.hooks';
+import { useEditorContext } from '@/components/editor/EditorContext';
+import { createHotkey, HOT_KEY_NAME } from '@/utils/hotkeys';
+
+import { findMatches, pathToKey } from './searchUtils';
+
+// Lazy-loaded so the panel's icons/buttons/tooltip code only ship when a user
+// actually opens find & replace, mirroring DocumentHistoryModal's pattern.
+const FindReplacePanel = lazy(() => import('./FindReplacePanel'));
+
+const MATCH_CLASS = 'search-match-highlight';
+const CURRENT_MATCH_CLASS = 'search-match-highlight search-match-highlight-current';
+const SEARCH_DEBOUNCE_MS = 200;
+
+/** Cheap structural equality for two ordered lists of match ranges. */
+function rangesEqual(a: BaseRange[], b: BaseRange[]): boolean {
+  if (a.length !== b.length) return false;
+
+  for (let i = 0; i < a.length; i++) {
+    const ra = a[i];
+    const rb = b[i];
+
+    if (ra.anchor.offset !== rb.anchor.offset || ra.focus.offset !== rb.focus.offset) return false;
+    if (!Path.equals(ra.anchor.path, rb.anchor.path) || !Path.equals(ra.focus.path, rb.focus.path)) return false;
+  }
+
+  return true;
+}
+
+export interface FindReplaceContextValue {
+  open: boolean;
+  showReplace: boolean;
+  query: string;
+  replaceText: string;
+  caseSensitive: boolean;
+  readOnly: boolean;
+  /** Total number of matches found for the current query. */
+  matchCount: number;
+  /** Zero-based index of the active match, or -1 when there are none. */
+  currentIndex: number;
+  /** Increments each time the panel is asked to open, so it can (re)focus its input. */
+  focusToken: number;
+  setQuery: (value: string) => void;
+  setReplaceText: (value: string) => void;
+  setShowReplace: (value: boolean) => void;
+  toggleCaseSensitive: () => void;
+  goToNext: () => void;
+  goToPrevious: () => void;
+  replaceCurrent: () => void;
+  replaceAll: () => void;
+  close: () => void;
+}
+
+/**
+ * Decorations are intentionally kept in a separate context so that the editor
+ * surface (which only needs `getMatchDecorations`) doesn't re-render on every
+ * find-input keystroke — it re-renders only when match positions actually change.
+ */
+export interface FindReplaceDecorationsValue {
+  /** Decoration ranges (with highlight class) for a given text-node path. */
+  getMatchDecorations: (path: Path) => (BaseRange & { class_name: string })[];
+}
+
+const noop = () => undefined;
+
+const defaultValue: FindReplaceContextValue = {
+  open: false,
+  showReplace: false,
+  query: '',
+  replaceText: '',
+  caseSensitive: false,
+  readOnly: true,
+  matchCount: 0,
+  currentIndex: -1,
+  focusToken: 0,
+  setQuery: noop,
+  setReplaceText: noop,
+  setShowReplace: noop,
+  toggleCaseSensitive: noop,
+  goToNext: noop,
+  goToPrevious: noop,
+  replaceCurrent: noop,
+  replaceAll: noop,
+  close: noop,
+};
+
+const defaultDecorationsValue: FindReplaceDecorationsValue = {
+  getMatchDecorations: () => [],
+};
+
+const FindReplaceContext = createContext<FindReplaceContextValue>(defaultValue);
+const FindReplaceDecorationsContext =
+  createContext<FindReplaceDecorationsValue>(defaultDecorationsValue);
+
+export function useFindReplace() {
+  return useContext(FindReplaceContext);
+}
+
+/** Narrow hook for the editor surface — only re-renders when decorations change. */
+export function useFindReplaceDecorations() {
+  return useContext(FindReplaceDecorationsContext);
+}
+
+export function FindReplaceProvider({ children }: { children: ReactNode }) {
+  const editor = useSlate() as YjsEditor;
+  const { viewId, readOnly } = useEditorContext();
+  const eventEmitter = useEventEmitter();
+  const { t } = useTranslation();
+
+  const [open, setOpen] = useState(false);
+  const [showReplace, setShowReplace] = useState(false);
+  const [query, setQueryState] = useState('');
+  const [replaceText, setReplaceText] = useState('');
+  const [caseSensitive, setCaseSensitive] = useState(false);
+  const [matches, setMatches] = useState<BaseRange[]>([]);
+  const [currentIndex, setCurrentIndex] = useState(-1);
+  const [focusToken, setFocusToken] = useState(0);
+
+  // Refs mirror the latest state for use inside long-lived listeners / handlers
+  // that must not be recreated on every keystroke.
+  const matchesRef = useRef(matches);
+  const currentIndexRef = useRef(currentIndex);
+  const queryRef = useRef(query);
+  const caseSensitiveRef = useRef(caseSensitive);
+  const replaceTextRef = useRef(replaceText);
+  const openRef = useRef(open);
+
+  useEffect(() => {
+    openRef.current = open;
+  }, [open]);
+  useEffect(() => {
+    matchesRef.current = matches;
+  }, [matches]);
+  useEffect(() => {
+    currentIndexRef.current = currentIndex;
+  }, [currentIndex]);
+  useEffect(() => {
+    queryRef.current = query;
+  }, [query]);
+  useEffect(() => {
+    caseSensitiveRef.current = caseSensitive;
+  }, [caseSensitive]);
+  useEffect(() => {
+    replaceTextRef.current = replaceText;
+  }, [replaceText]);
+
+  const recompute = useCallback(
+    (nextQuery: string, nextCaseSensitive: boolean, options?: { resetIndex?: boolean }): BaseRange[] => {
+      const next = findMatches(editor, nextQuery, nextCaseSensitive);
+
+      // Keep the previous reference when nothing changed so the live-resync
+      // effect below cannot loop and decorations don't needlessly re-render.
+      setMatches((prev) => (rangesEqual(prev, next) ? prev : next));
+      setCurrentIndex((prev) => {
+        if (next.length === 0) return -1;
+        if (options?.resetIndex || prev < 0) return 0;
+        return Math.min(prev, next.length - 1);
+      });
+      // Return the freshly-computed matches so callers (e.g. replace handlers)
+      // can act on the up-to-date result without waiting for the ref sync effect.
+      return next;
+    },
+    [editor]
+  );
+
+  const debouncedRecompute = useMemo(
+    () => debounce((q: string, cs: boolean) => recompute(q, cs, { resetIndex: true }), SEARCH_DEBOUNCE_MS),
+    [recompute]
+  );
+
+  // A non-resetting recompute used to keep highlights aligned with live edits.
+  const debouncedResync = useMemo(
+    () => debounce((q: string, cs: boolean) => recompute(q, cs), SEARCH_DEBOUNCE_MS),
+    [recompute]
+  );
+
+  useEffect(() => () => debouncedRecompute.cancel(), [debouncedRecompute]);
+  useEffect(() => () => debouncedResync.cancel(), [debouncedResync]);
+
+  // The provider re-renders on every editor change (via useSlate). While the
+  // panel is open, re-run the search so matches track the document content.
+  // recompute() preserves the matches reference when unchanged, so this settles.
+  useEffect(() => {
+    if (!openRef.current || !queryRef.current) return;
+    debouncedResync(queryRef.current, caseSensitiveRef.current);
+  });
+
+  const setQuery = useCallback(
+    (value: string) => {
+      setQueryState(value);
+      debouncedRecompute(value, caseSensitiveRef.current);
+    },
+    [debouncedRecompute]
+  );
+
+  const toggleCaseSensitive = useCallback(() => {
+    setCaseSensitive((prev) => {
+      const next = !prev;
+
+      // Drop any pending debounced search scheduled with the *previous*
+      // case-sensitivity, otherwise it would fire after this sync recompute
+      // and overwrite the just-computed exact-case results.
+      debouncedRecompute.cancel();
+      debouncedResync.cancel();
+      recompute(queryRef.current, next, { resetIndex: true });
+      return next;
+    });
+  }, [debouncedRecompute, debouncedResync, recompute]);
+
+  const scrollToMatch = useCallback(
+    (index: number) => {
+      const range = matchesRef.current[index];
+
+      if (!range) return;
+
+      try {
+        const domRange = ReactEditor.toDOMRange(editor, range);
+        const node = domRange.startContainer.parentElement;
+
+        node?.scrollIntoView({ block: 'center', behavior: 'smooth' });
+      } catch {
+        // The match may not be mounted yet (e.g. inside a collapsed toggle); ignore.
+      }
+    },
+    [editor]
+  );
+
+  // Scroll the active match into view whenever it changes while the panel is open.
+  useEffect(() => {
+    if (!open || currentIndex < 0) return;
+    scrollToMatch(currentIndex);
+  }, [open, currentIndex, scrollToMatch]);
+
+  const goToNext = useCallback(() => {
+    const length = matchesRef.current.length;
+
+    if (length === 0) return;
+    setCurrentIndex((prev) => (prev + 1) % length);
+  }, []);
+
+  const goToPrevious = useCallback(() => {
+    const length = matchesRef.current.length;
+
+    if (length === 0) return;
+    setCurrentIndex((prev) => (prev - 1 + length) % length);
+  }, []);
+
+  const replaceCurrent = useCallback(() => {
+    if (readOnly) return;
+    // The find input feeds setQuery() which schedules a debounced recompute.
+    // If the user types a new query then clicks Replace within the 200ms window,
+    // matchesRef still points to the previous query's ranges. Cancel any pending
+    // recompute and run a synchronous one, using its return value directly so we
+    // don't read from matchesRef (which only updates after the next render).
+    debouncedRecompute.cancel();
+    debouncedResync.cancel();
+    const fresh = recompute(queryRef.current, caseSensitiveRef.current);
+
+    if (fresh.length === 0) return;
+    const index = Math.min(Math.max(currentIndexRef.current, 0), fresh.length - 1);
+    const range = fresh[index];
+
+    if (!range) return;
+
+    ReactEditor.focus(editor);
+    Editor.withoutNormalizing(editor, () => {
+      const start = Editor.start(editor, range);
+
+      Transforms.delete(editor, { at: range });
+      if (replaceTextRef.current) {
+        Transforms.insertText(editor, replaceTextRef.current, { at: start });
+      }
+    });
+
+    recompute(queryRef.current, caseSensitiveRef.current);
+  }, [debouncedRecompute, debouncedResync, editor, readOnly, recompute]);
+
+  const replaceAll = useCallback(() => {
+    if (readOnly) return;
+    // Same staleness guard as replaceCurrent — flush any pending search and
+    // operate on the freshly-computed match list, not the (possibly stale) ref.
+    debouncedRecompute.cancel();
+    debouncedResync.cancel();
+    const all = recompute(queryRef.current, caseSensitiveRef.current, { resetIndex: true });
+
+    if (all.length === 0) return;
+    const count = all.length;
+
+    ReactEditor.focus(editor);
+    Editor.withoutNormalizing(editor, () => {
+      // Replace from the last match backwards so earlier offsets stay valid.
+      for (let i = all.length - 1; i >= 0; i--) {
+        const range = all[i];
+        const start = Editor.start(editor, range);
+
+        Transforms.delete(editor, { at: range });
+        if (replaceTextRef.current) {
+          Transforms.insertText(editor, replaceTextRef.current, { at: start });
+        }
+      }
+    });
+
+    recompute(queryRef.current, caseSensitiveRef.current, { resetIndex: true });
+    notify.success(
+      count === 1
+        ? t('findAndReplace.replacedOneSuccessfully')
+        : t('findAndReplace.replacedMoreThanOneSuccessfully').replace('{}', String(count))
+    );
+  }, [debouncedRecompute, debouncedResync, editor, readOnly, recompute, t]);
+
+  const close = useCallback(() => {
+    setOpen(false);
+    setMatches([]);
+    setCurrentIndex(-1);
+  }, []);
+
+  const openPanel = useCallback(
+    (options?: { showReplace?: boolean }) => {
+      setOpen(true);
+      setFocusToken((token) => token + 1);
+      if (options?.showReplace !== undefined) {
+        setShowReplace(options.showReplace);
+      }
+
+      // Seed the query from an active text selection, like native browser find.
+      let initialQuery = queryRef.current;
+      const selection = editor.selection;
+
+      if (selection && ReactEditor.hasRange(editor, selection)) {
+        const selected = CustomEditor.getSelectionContent(editor, selection);
+
+        if (selected && !selected.includes('\n')) {
+          initialQuery = selected;
+          setQueryState(selected);
+        }
+      }
+
+      recompute(initialQuery, caseSensitiveRef.current, { resetIndex: true });
+    },
+    [editor, recompute]
+  );
+
+  const openPanelRef = useRef(openPanel);
+
+  useEffect(() => {
+    openPanelRef.current = openPanel;
+  }, [openPanel]);
+
+  // Open the panel when the header "Find and replace" menu item targets this view.
+  useEffect(() => {
+    if (!eventEmitter) return;
+    const handler = (payload?: { viewId?: string }) => {
+      if (payload?.viewId && payload.viewId !== viewId) return;
+      openPanelRef.current({ showReplace: true });
+    };
+
+    eventEmitter.on(APP_EVENTS.FIND_AND_REPLACE, handler);
+    return () => {
+      eventEmitter.off(APP_EVENTS.FIND_AND_REPLACE, handler);
+    };
+  }, [eventEmitter, viewId]);
+
+  // Cmd/Ctrl+F inside this editor opens the in-document find panel.
+  useEffect(() => {
+    let dom: HTMLElement | null = null;
+
+    try {
+      dom = ReactEditor.toDOMNode(editor, editor);
+    } catch {
+      return;
+    }
+
+    const handler = (event: KeyboardEvent) => {
+      if (!createHotkey(HOT_KEY_NAME.FIND_REPLACE)(event)) return;
+      event.preventDefault();
+      event.stopPropagation();
+      openPanelRef.current();
+    };
+
+    dom.addEventListener('keydown', handler);
+    return () => {
+      dom?.removeEventListener('keydown', handler);
+    };
+  }, [editor]);
+
+  const decorationsByPath = useMemo(() => {
+    const map = new Map<string, (BaseRange & { class_name: string })[]>();
+
+    matches.forEach((range, index) => {
+      const key = pathToKey(range.anchor.path);
+      const list = map.get(key) ?? [];
+
+      list.push({ ...range, class_name: index === currentIndex ? CURRENT_MATCH_CLASS : MATCH_CLASS });
+      map.set(key, list);
+    });
+
+    return map;
+  }, [matches, currentIndex]);
+
+  const getMatchDecorations = useCallback(
+    (path: Path) => {
+      if (!open) return [];
+      return decorationsByPath.get(pathToKey(path)) ?? [];
+    },
+    [open, decorationsByPath]
+  );
+
+  const value = useMemo<FindReplaceContextValue>(
+    () => ({
+      open,
+      showReplace,
+      query,
+      replaceText,
+      caseSensitive,
+      readOnly,
+      matchCount: matches.length,
+      currentIndex,
+      focusToken,
+      setQuery,
+      setReplaceText,
+      setShowReplace,
+      toggleCaseSensitive,
+      goToNext,
+      goToPrevious,
+      replaceCurrent,
+      replaceAll,
+      close,
+    }),
+    [
+      open,
+      showReplace,
+      query,
+      replaceText,
+      caseSensitive,
+      readOnly,
+      matches.length,
+      currentIndex,
+      focusToken,
+      setQuery,
+      setReplaceText,
+      setShowReplace,
+      toggleCaseSensitive,
+      goToNext,
+      goToPrevious,
+      replaceCurrent,
+      replaceAll,
+      close,
+    ]
+  );
+
+  const decorationsValue = useMemo<FindReplaceDecorationsValue>(
+    () => ({ getMatchDecorations }),
+    [getMatchDecorations]
+  );
+
+  return (
+    <FindReplaceDecorationsContext.Provider value={decorationsValue}>
+      <FindReplaceContext.Provider value={value}>
+        {children}
+        {open && (
+          <Suspense fallback={null}>
+            <FindReplacePanel />
+          </Suspense>
+        )}
+      </FindReplaceContext.Provider>
+    </FindReplaceDecorationsContext.Provider>
+  );
+}

--- a/src/components/editor/components/find-replace/FindReplacePanel.tsx
+++ b/src/components/editor/components/find-replace/FindReplacePanel.tsx
@@ -1,0 +1,249 @@
+import { KeyboardEvent, ReactNode, useEffect, useRef } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { ReactComponent as AltArrowDownIcon } from '@/assets/icons/alt_arrow_down.svg';
+import { ReactComponent as AltArrowRightIcon } from '@/assets/icons/alt_arrow_right.svg';
+import { ReactComponent as AltArrowUpIcon } from '@/assets/icons/alt_arrow_up.svg';
+import { ReactComponent as CloseIcon } from '@/assets/icons/close.svg';
+import { ReactComponent as ReplaceIcon } from '@/assets/icons/replace.svg';
+import { ReactComponent as SearchIcon } from '@/assets/icons/search.svg';
+import { ReactComponent as TextFormatIcon } from '@/assets/icons/text_format.svg';
+import { Button } from '@/components/ui/button';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+import { cn } from '@/lib/utils';
+
+import { useFindReplace } from './FindReplaceContext';
+
+function ToolbarIconButton({
+  tooltip,
+  onClick,
+  disabled,
+  active,
+  testId,
+  children,
+}: {
+  tooltip: string;
+  onClick: () => void;
+  disabled?: boolean;
+  active?: boolean;
+  testId?: string;
+  children: ReactNode;
+}) {
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Button
+          size={'icon-sm'}
+          variant={'ghost'}
+          disabled={disabled}
+          data-testid={testId}
+          className={cn(active && 'bg-fill-theme-select text-icon-theme-thick')}
+          onClick={onClick}
+        >
+          {children}
+        </Button>
+      </TooltipTrigger>
+      <TooltipContent>{tooltip}</TooltipContent>
+    </Tooltip>
+  );
+}
+
+function FindReplacePanel() {
+  const { t } = useTranslation();
+  const {
+    showReplace,
+    query,
+    replaceText,
+    caseSensitive,
+    readOnly,
+    matchCount,
+    currentIndex,
+    focusToken,
+    setQuery,
+    setReplaceText,
+    setShowReplace,
+    toggleCaseSensitive,
+    goToNext,
+    goToPrevious,
+    replaceCurrent,
+    replaceAll,
+    close,
+  } = useFindReplace();
+
+  const findInputRef = useRef<HTMLInputElement>(null);
+
+  // Focus & select the find field whenever the panel is (re)opened.
+  useEffect(() => {
+    const input = findInputRef.current;
+
+    if (!input) return;
+    input.focus();
+    input.select();
+  }, [focusToken]);
+
+  const hasMatches = matchCount > 0;
+  const replaceDisabled = readOnly || !hasMatches || !query;
+
+  const matchLabel = query ? (hasMatches ? `${currentIndex + 1}/${matchCount}` : t('findAndReplace.noResult')) : '';
+
+  const handleFindKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === 'Enter') {
+      event.preventDefault();
+      if (event.shiftKey) {
+        goToPrevious();
+      } else {
+        goToNext();
+      }
+    } else if (event.key === 'Escape') {
+      event.preventDefault();
+      close();
+    }
+  };
+
+  const handleReplaceKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === 'Enter') {
+      event.preventDefault();
+      replaceCurrent();
+    } else if (event.key === 'Escape') {
+      event.preventDefault();
+      close();
+    }
+  };
+
+  return (
+    <div
+      data-testid={'find-and-replace-panel'}
+      className={
+        // Anchored flush against the bottom of the 48px sticky header
+        // (HEADER_HEIGHT in AppHeader.tsx) — no vertical gap.
+        'fixed right-6 top-12 z-20 flex w-[420px] max-w-[calc(100vw-2rem)] items-start gap-1 ' +
+        'rounded-b-xl border border-t-0 border-border-primary bg-surface-primary p-2 shadow-lg'
+      }
+      onMouseDown={(e) => e.stopPropagation()}
+    >
+      <ToolbarIconButton
+        tooltip={showReplace ? t('findAndReplace.switchFindHint') : t('findAndReplace.switchFindAndReplaceHint')}
+        testId={'find-and-replace-toggle'}
+        onClick={() => setShowReplace(!showReplace)}
+      >
+        <AltArrowRightIcon className={cn('transition-transform', showReplace && 'rotate-90')} />
+      </ToolbarIconButton>
+
+      <div className={'flex flex-1 flex-col gap-2'}>
+        {/* Find row */}
+        <div className={'flex items-center gap-1'}>
+          <div
+            className={
+              'flex h-8 flex-1 items-center gap-2 rounded-300 border border-border-primary bg-fill-content px-2 ' +
+              'focus-within:border-border-theme-thick'
+            }
+          >
+            <SearchIcon className={'h-4 w-4 shrink-0 text-icon-secondary'} />
+            <input
+              ref={findInputRef}
+              data-testid={'find-and-replace-find-input'}
+              className={'min-w-0 flex-1 bg-transparent text-sm text-text-primary outline-none placeholder:text-text-tertiary'}
+              placeholder={t('findAndReplace.findTextfieldHint')}
+              value={query}
+              spellCheck={false}
+              autoComplete={'off'}
+              onChange={(e) => setQuery(e.target.value)}
+              onKeyDown={handleFindKeyDown}
+            />
+            {matchLabel && <span className={'shrink-0 whitespace-nowrap text-xs text-text-tertiary'}>{matchLabel}</span>}
+          </div>
+
+          <ToolbarIconButton
+            tooltip={t('findAndReplace.previousMatch')}
+            testId={'find-and-replace-previous'}
+            disabled={!hasMatches}
+            onClick={goToPrevious}
+          >
+            <AltArrowUpIcon />
+          </ToolbarIconButton>
+          <ToolbarIconButton
+            tooltip={t('findAndReplace.nextMatch')}
+            testId={'find-and-replace-next'}
+            disabled={!hasMatches}
+            onClick={goToNext}
+          >
+            <AltArrowDownIcon />
+          </ToolbarIconButton>
+          <ToolbarIconButton
+            tooltip={t('findAndReplace.matchCase')}
+            testId={'find-and-replace-case-sensitive'}
+            active={caseSensitive}
+            onClick={toggleCaseSensitive}
+          >
+            <TextFormatIcon />
+          </ToolbarIconButton>
+          <ToolbarIconButton tooltip={t('findAndReplace.close')} testId={'find-and-replace-close'} onClick={close}>
+            <CloseIcon />
+          </ToolbarIconButton>
+        </div>
+
+        {/* Replace row */}
+        {showReplace && (
+          <div className={'flex items-center gap-1'}>
+            <div
+              className={
+                'flex h-8 flex-1 items-center gap-2 rounded-300 border border-border-primary bg-fill-content px-2 ' +
+                'focus-within:border-border-theme-thick'
+              }
+            >
+              <ReplaceIcon className={'h-4 w-4 shrink-0 text-icon-secondary'} />
+              <input
+                data-testid={'find-and-replace-replace-input'}
+                className={
+                  'min-w-0 flex-1 bg-transparent text-sm text-text-primary outline-none placeholder:text-text-tertiary'
+                }
+                placeholder={t('findAndReplace.replaceTextfieldHint')}
+                value={replaceText}
+                spellCheck={false}
+                autoComplete={'off'}
+                disabled={readOnly}
+                onChange={(e) => setReplaceText(e.target.value)}
+                onKeyDown={handleReplaceKeyDown}
+              />
+            </div>
+
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <span tabIndex={-1}>
+                  <Button
+                    size={'sm'}
+                    variant={'outline'}
+                    data-testid={'find-and-replace-replace'}
+                    disabled={replaceDisabled}
+                    onClick={replaceCurrent}
+                  >
+                    {t('findAndReplace.replace')}
+                  </Button>
+                </span>
+              </TooltipTrigger>
+              {readOnly && <TooltipContent>{t('findAndReplace.noPermissionHint')}</TooltipContent>}
+            </Tooltip>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <span tabIndex={-1}>
+                  <Button
+                    size={'sm'}
+                    variant={'outline'}
+                    data-testid={'find-and-replace-replace-all'}
+                    disabled={replaceDisabled}
+                    onClick={replaceAll}
+                  >
+                    {t('findAndReplace.replaceAll')}
+                  </Button>
+                </span>
+              </TooltipTrigger>
+              {readOnly && <TooltipContent>{t('findAndReplace.noPermissionHint')}</TooltipContent>}
+            </Tooltip>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default FindReplacePanel;

--- a/src/components/editor/components/find-replace/__tests__/searchUtils.test.ts
+++ b/src/components/editor/components/find-replace/__tests__/searchUtils.test.ts
@@ -1,0 +1,143 @@
+import { createEditor, Descendant, Editor } from 'slate';
+
+import { findMatches } from '../searchUtils';
+
+/**
+ * Build a minimal Slate editor whose document is `children`. findMatches only
+ * traverses text leaves, so plain element/text nodes are enough here. We cast
+ * through `unknown` because the test nodes intentionally omit the app's custom
+ * Slate element fields (blockId, etc.) that findMatches never reads.
+ */
+function editorWith(children: unknown[]): Editor {
+  const editor = createEditor();
+
+  editor.children = children as Descendant[];
+  return editor;
+}
+
+const paragraph = (texts: unknown[]) => ({ type: 'paragraph', children: texts });
+const leaf = (text: string, extra: Record<string, unknown> = {}) => ({ text, ...extra });
+
+describe('findMatches', () => {
+  it('returns no matches for an empty query', () => {
+    const editor = editorWith([paragraph([leaf('hello world')])]);
+
+    expect(findMatches(editor, '', false)).toEqual([]);
+  });
+
+  it('finds a single match with correct anchor/focus offsets', () => {
+    const editor = editorWith([paragraph([leaf('say hello')])]);
+
+    const matches = findMatches(editor, 'hello', false);
+
+    expect(matches).toHaveLength(1);
+    expect(matches[0].anchor).toEqual({ path: [0, 0], offset: 4 });
+    expect(matches[0].focus).toEqual({ path: [0, 0], offset: 9 });
+  });
+
+  it('finds multiple matches within one text node in ascending offset order', () => {
+    const editor = editorWith([paragraph([leaf('hello world hello')])]);
+
+    const matches = findMatches(editor, 'hello', false);
+
+    expect(matches).toHaveLength(2);
+    expect(matches[0].anchor.offset).toBe(0);
+    expect(matches[0].focus.offset).toBe(5);
+    expect(matches[1].anchor.offset).toBe(12);
+    expect(matches[1].focus.offset).toBe(17);
+  });
+
+  it('finds matches across multiple blocks in document order', () => {
+    const editor = editorWith([paragraph([leaf('foo bar')]), paragraph([leaf('bar foo')])]);
+
+    const matches = findMatches(editor, 'foo', false);
+
+    expect(matches).toHaveLength(2);
+    expect(matches[0].anchor.path).toEqual([0, 0]);
+    expect(matches[0].anchor.offset).toBe(0);
+    expect(matches[1].anchor.path).toEqual([1, 0]);
+    expect(matches[1].anchor.offset).toBe(4);
+  });
+
+  it('matches case-insensitively by default', () => {
+    const editor = editorWith([paragraph([leaf('Hello hello HELLO')])]);
+
+    expect(findMatches(editor, 'hello', false)).toHaveLength(3);
+  });
+
+  it('matches only the exact case when caseSensitive is true', () => {
+    const editor = editorWith([paragraph([leaf('Hello hello HELLO')])]);
+
+    const matches = findMatches(editor, 'hello', true);
+
+    expect(matches).toHaveLength(1);
+    expect(matches[0].anchor.offset).toBe(6);
+  });
+
+  it('returns non-overlapping matches for repeating patterns', () => {
+    const editor = editorWith([paragraph([leaf('aaaa')])]);
+
+    const matches = findMatches(editor, 'aa', false);
+
+    expect(matches).toHaveLength(2);
+    expect(matches[0].anchor.offset).toBe(0);
+    expect(matches[1].anchor.offset).toBe(2);
+  });
+
+  it('returns an empty array when the query is absent', () => {
+    const editor = editorWith([paragraph([leaf('hello world')])]);
+
+    expect(findMatches(editor, 'zzz', false)).toEqual([]);
+  });
+
+  it('skips mention and formula leaves', () => {
+    const editor = editorWith([
+      paragraph([
+        leaf('secret', { mention: { type: 'page', page_id: 'p1' } }),
+        leaf('value', { formula: 'secret' }),
+      ]),
+    ]);
+
+    expect(findMatches(editor, 'secret', false)).toEqual([]);
+    expect(findMatches(editor, 'value', false)).toEqual([]);
+  });
+
+  it('ignores empty text nodes without throwing', () => {
+    const editor = editorWith([paragraph([leaf('')]), paragraph([leaf('match')])]);
+
+    const matches = findMatches(editor, 'match', false);
+
+    expect(matches).toHaveLength(1);
+    expect(matches[0].anchor.path).toEqual([1, 0]);
+  });
+
+  it('treats the query literally (no regex interpretation)', () => {
+    const editor = editorWith([paragraph([leaf('a.b.c')])]);
+
+    // "." should match literal dots only, at offsets 1 and 3.
+    const dots = findMatches(editor, '.', false);
+
+    expect(dots).toHaveLength(2);
+    expect(dots.map((m) => m.anchor.offset)).toEqual([1, 3]);
+
+    // A multi-char literal substring still works.
+    expect(findMatches(editor, 'a.b', false)).toHaveLength(1);
+  });
+
+  it('produces in-bounds Slate offsets for characters whose lowercase expands (e.g. Turkish İ)', () => {
+    // Original length 5 (5 UTF-16 code units); naive toLowerCase() yields a
+    // 6-unit string, so a folded-offset implementation could overrun the node.
+    const original = 'İello'; // U+0130 + 'ello'
+    const editor = editorWith([paragraph([leaf(original)])]);
+
+    const matches = findMatches(editor, 'İ', false);
+
+    // Whatever the match length, the focus offset must never exceed the
+    // original text node's length — otherwise Slate gets an invalid range.
+    for (const m of matches) {
+      expect(m.anchor.offset).toBeGreaterThanOrEqual(0);
+      expect(m.focus.offset).toBeLessThanOrEqual(original.length);
+      expect(m.focus.offset).toBeGreaterThan(m.anchor.offset);
+    }
+  });
+});

--- a/src/components/editor/components/find-replace/searchUtils.ts
+++ b/src/components/editor/components/find-replace/searchUtils.ts
@@ -1,0 +1,69 @@
+import { BaseRange, Editor, Path, Text } from 'slate';
+
+/** Escape regex metacharacters so the user's query is matched literally. */
+const REGEX_META = /[.*+?^${}()|[\]\\]/g;
+const escapeRegex = (s: string) => s.replace(REGEX_META, '\\$&');
+
+/**
+ * Find all occurrences of `query` within the editor's text leaves.
+ *
+ * Matching is performed per text node (leaf). A phrase that is split across
+ * mark boundaries (e.g. a word that is partially bold) lives in multiple
+ * Slate text nodes and therefore is not matched as a single hit — this mirrors
+ * the common "find text on page" behaviour while keeping decoration lookups
+ * O(1) per node.
+ *
+ * Returned ranges are in document order. Each range is fully contained within
+ * a single text node, so `anchor.path` equals `focus.path`.
+ *
+ * Uses a regex with the `iu` flag for case-insensitive search rather than
+ * lowercasing both sides: `String.prototype.toLowerCase()` can change a
+ * string's length (e.g. Turkish `İ` → `i̇`), which would produce Slate
+ * offsets that overrun the original text node. RegExp `exec` reports indices
+ * and match lengths in the *original* string, so the resulting Slate ranges
+ * are always within bounds.
+ */
+export function findMatches(editor: Editor, query: string, caseSensitive: boolean): BaseRange[] {
+  const ranges: BaseRange[] = [];
+
+  if (!query) return ranges;
+
+  const pattern = new RegExp(escapeRegex(query), caseSensitive ? 'gu' : 'giu');
+
+  for (const [node, path] of Editor.nodes(editor, {
+    at: [],
+    match: (n) => Text.isText(n),
+  })) {
+    const textNode = node as Text;
+
+    // Atomic inline leaves (mentions, formulas) render dynamic content, so their
+    // raw `.text` is a placeholder rather than the visible string — skip them.
+    if (textNode.mention || textNode.formula) continue;
+
+    const raw = textNode.text || '';
+
+    if (!raw) continue;
+
+    pattern.lastIndex = 0;
+    let match: RegExpExecArray | null;
+
+    while ((match = pattern.exec(raw)) !== null) {
+      const start = match.index;
+      const end = start + match[0].length;
+
+      ranges.push({
+        anchor: { path, offset: start },
+        focus: { path, offset: end },
+      });
+
+      // Guard against zero-width matches creating an infinite loop. (Shouldn't
+      // happen for a literal escaped query, but defensive.)
+      if (pattern.lastIndex === start) pattern.lastIndex = start + 1;
+    }
+  }
+
+  return ranges;
+}
+
+/** Stable string key for a Slate path, used to index decorations by text node. */
+export const pathToKey = (path: Path): string => path.join('.');

--- a/src/components/editor/editor.scss
+++ b/src/components/editor/editor.scss
@@ -616,6 +616,17 @@ span[data-slate-placeholder="true"]:not(.inline-block-content) {
   }
 }
 
+// Find & replace search match highlighting. Applied as a Slate leaf class via
+// the editor decorate function (see FindReplaceContext).
+.search-match-highlight {
+  border-radius: 2px;
+  background-color: rgba(250, 204, 21, 0.4);
+}
+
+.search-match-highlight-current {
+  background-color: rgba(249, 115, 22, 0.7);
+}
+
 #appflowy-ai-writer {
   @apply bg-background-primary;
   #appflowy-editor > div {

--- a/src/pages/AppPage.tsx
+++ b/src/pages/AppPage.tsx
@@ -454,11 +454,13 @@ function AppPage() {
 
   const requestInstance = getAxiosInstance();
 
-  // Check if view is in shareWithMe and determine readonly status
+  // Check if view is in shareWithMe and determine readonly status.
+  // `view` is the merged outline-or-fallback object, so the lock check honors
+  // pages opened by direct URL before the outline branch has loaded.
   const isReadOnly = useMemo(() => {
     if (!viewId) return false;
-    return getViewReadOnlyStatus(viewId, outline);
-  }, [viewId, outline]);
+    return getViewReadOnlyStatus(viewId, outline, view);
+  }, [viewId, outline, view]);
 
   const viewDom = useMemo(() => {
     // Check if doc belongs to current viewId (handles race condition when doc from old view arrives after navigation)


### PR DESCRIPTION
Summary:
- Add in-editor find and replace panel with keyboard shortcut, match navigation, match case, replace, and replace all
- Add page lock toggle, locked badge, and read-only handling for locked pages
- Add focused unit coverage plus Playwright specs for find/replace and lock page flows

Tests:
- pnpm exec jest src/components/editor/components/find-replace/__tests__/searchUtils.test.ts src/components/app/hooks/__tests__/useViewOperations.lockReadOnly.test.ts --runInBand --no-coverage
- pnpm run type-check
- git diff --check
- git diff --cached --check

## Summary by Sourcery

Add an in-editor find and replace experience and support for locking pages, including UI entry points and read-only enforcement.

New Features:
- Introduce an in-editor find and replace panel with keyboard shortcut, match navigation, case sensitivity, and replace/replace-all controls.
- Add a page lock toggle in the page actions menu plus a visible locked status badge in the header.

Enhancements:
- Ensure editor read-only status respects page locks even when pages are opened before their outline branch has loaded.
- Highlight search matches in the editor with distinct styling for the current match.

Tests:
- Add Jest unit tests for find/replace search utilities and view read-only behavior with locked pages.
- Add Playwright end-to-end tests covering find/replace flows and page locking, including persistence, badge display, and read-only behavior on locked pages.