### PR TITLE
Add public-to-private move access BDD coverage

### DIFF
--- a/playwright/bdd/features/page/public-to-private-move-access.feature
+++ b/playwright/bdd/features/page/public-to-private-move-access.feature
@@ -1,7 +1,8 @@
 @public-to-private-move-access
 Feature: Public page moved under private page access
   The ptp0527 server-side fixture provides one owner and three workspace members.
-  The scenario creates temporary pages so the fixed fixture membership is not mutated.
+  The scenario creates a temporary public page and moves it under the seeded
+  private target so fixed membership/share relationships are not mutated.
 
   Background:
     Given the seeded ptp0527 public-to-private fixture exists
@@ -12,7 +13,7 @@ Feature: Public page moved under private page access
   Scenario: Moving a public space page under a private page refreshes access
     Given I sign in as seeded public-to-private "owner"
     And I create a temporary public-to-private public space page
-    And I create a temporary public-to-private private target page shared with "member 1"
+    And I use the seeded public-to-private private target page shared with "member 1"
     When I open the temporary public-to-private movable page
     Then the temporary public-to-private movable page title is visible
     When I open the public-to-private share panel

--- a/playwright/bdd/steps/public-to-private-move-access.steps.ts
+++ b/playwright/bdd/steps/public-to-private-move-access.steps.ts
@@ -2,11 +2,7 @@ import { APIRequestContext, expect, Page } from '@playwright/test';
 import { createBdd } from 'playwright-bdd';
 
 import { signInWithPasswordViaUi } from '../../support/auth-flow-helpers';
-import {
-  PageSelectors,
-  ShareSelectors,
-  SidebarSelectors,
-} from '../../support/selectors';
+import { PageSelectors, ShareSelectors, SidebarSelectors } from '../../support/selectors';
 import { setupPageErrorHandling, TestConfig } from '../../support/test-config';
 
 const { Given, When, Then, Before, After } = createBdd();
@@ -16,6 +12,10 @@ const SPACE_PERMISSION_PUBLIC = 0;
 const SPACE_PERMISSION_PRIVATE = 1;
 const ACCESS_LEVEL_READ_ONLY = 10;
 const VIEW_LAYOUT_DOCUMENT = 0;
+const SEEDED_PRIVATE_SPACE_ID = 'a93fc48d-db30-4a0f-8bec-a6f0ff2b071c';
+const SEEDED_PRIVATE_TARGET_PAGE_ID = '0574b0b2-5cd7-4893-8c2d-7b23c66a6c56';
+const SEEDED_PRIVATE_SPACE_NAME = 'ptp0527 BDD Seeded Private Space';
+const SEEDED_PRIVATE_TARGET_PAGE_NAME = 'ptp0527 BDD Seeded Private Target Page';
 
 const SEEDED_ACCOUNTS = {
   owner: 'ptp0527-own@appflowy.local',
@@ -32,6 +32,7 @@ type ScenarioState = {
   ownerToken?: string;
   movablePage?: TemporaryView;
   privateTarget?: TemporaryView;
+  privateTargetIsSeeded?: boolean;
 };
 
 type TemporaryView = {
@@ -50,6 +51,12 @@ type ApiResponse<T> = {
 type Workspace = {
   workspace_id: string;
   role?: string;
+};
+
+type FolderView = {
+  view_id: string;
+  name: string;
+  children?: FolderView[];
 };
 
 const stateByPage = new WeakMap<Page, ScenarioState>();
@@ -96,6 +103,9 @@ Given('I create a temporary public-to-private public space page', async ({ page,
   const ownerToken = requireOwnerToken(state);
   const spaceName = `ptp0527 BDD Public Space ${state.runId}`;
   const pageTitle = `ptp0527 BDD Movable Public Page ${state.runId}`;
+
+  await cleanupStaleTemporaryViews(request, ownerToken, workspaceId);
+
   const space = await postApi<{ view_id: string }>(request, ownerToken, `/api/workspace/${workspaceId}/space`, {
     name: spaceName,
     space_icon: 'icon',
@@ -162,6 +172,30 @@ Given(
   }
 );
 
+Given(
+  'I use the seeded public-to-private private target page shared with {string}',
+  async ({ page, request }, accountAliasValue: string) => {
+    const state = getState(page);
+    const workspaceId = requireWorkspaceId(state);
+    const ownerToken = requireOwnerToken(state);
+    const sharedEmail = accountEmail(accountAliasValue);
+
+    if (sharedEmail !== SEEDED_ACCOUNTS['member 1']) {
+      throw new Error(`The seeded public-to-private target is shared only with member 1, got ${accountAliasValue}`);
+    }
+
+    await getApi(request, ownerToken, `/api/workspace/${workspaceId}/page-view/${SEEDED_PRIVATE_TARGET_PAGE_ID}`);
+
+    state.privateTarget = {
+      spaceId: SEEDED_PRIVATE_SPACE_ID,
+      spaceName: SEEDED_PRIVATE_SPACE_NAME,
+      pageId: SEEDED_PRIVATE_TARGET_PAGE_ID,
+      pageTitle: SEEDED_PRIVATE_TARGET_PAGE_NAME,
+    };
+    state.privateTargetIsSeeded = true;
+  }
+);
+
 When('I open the temporary public-to-private movable page', async ({ page }) => {
   const state = getState(page);
   const workspaceId = requireWorkspaceId(state);
@@ -187,15 +221,10 @@ When('I move the temporary public-to-private page under the private target page'
   const movablePage = requireMovablePage(state);
   const privateTarget = requirePrivateTarget(state);
 
-  await postVoidApi(
-    request,
-    ownerToken,
-    `/api/workspace/${workspaceId}/page-view/${movablePage.pageId}/move`,
-    {
-      new_parent_view_id: privateTarget.pageId,
-      prev_view_id: null,
-    }
-  );
+  await postVoidApi(request, ownerToken, `/api/workspace/${workspaceId}/page-view/${movablePage.pageId}/move`, {
+    new_parent_view_id: privateTarget.pageId,
+    prev_view_id: null,
+  });
   await page.reload({ waitUntil: 'domcontentloaded' });
   await expect(SidebarSelectors.pageHeader(page)).toBeVisible({ timeout: 30000 });
 });
@@ -228,14 +257,17 @@ Then('the public-to-private share panel only shows {string}', async ({ page }, a
   }
 });
 
-Then('the public-to-private share panel shows {string} with {string}', async ({ page }, aliasValue: string, accessText: string) => {
-  const email = accountEmail(aliasValue);
-  const row = sharePersonRow(page, email);
+Then(
+  'the public-to-private share panel shows {string} with {string}',
+  async ({ page }, aliasValue: string, accessText: string) => {
+    const email = accountEmail(aliasValue);
+    const row = sharePersonRow(page, email);
 
-  await expect(row).toBeVisible({ timeout: 15000 });
-  await expect(row.getByText(email, { exact: true }).first()).toBeVisible();
-  await expect(row.getByText(accessText, { exact: true }).first()).toBeVisible();
-});
+    await expect(row).toBeVisible({ timeout: 15000 });
+    await expect(row.getByText(email, { exact: true }).first()).toBeVisible();
+    await expect(row.getByText(accessText, { exact: true }).first()).toBeVisible();
+  }
+);
 
 Then('the public-to-private share panel does not show {string}', async ({ page }, aliasValue: string) => {
   const email = accountEmail(aliasValue);
@@ -316,7 +348,9 @@ function sharePersonRow(page: Page, email: string) {
 }
 
 function sharePeopleRows(page: Page) {
-  return ShareSelectors.sharePopover(page).locator('.group').filter({ hasText: /@appflowy\.local/ });
+  return ShareSelectors.sharePopover(page)
+    .locator('.group')
+    .filter({ hasText: /@appflowy\.local/ });
 }
 
 function parseAccountAliases(aliasesValue: string): SeededAccountAlias[] {
@@ -349,9 +383,8 @@ async function cleanupTemporaryViews(request: APIRequestContext, state: Scenario
 
   const viewIds = [
     state.movablePage?.pageId,
-    state.privateTarget?.pageId,
     state.movablePage?.spaceId,
-    state.privateTarget?.spaceId,
+    ...(state.privateTargetIsSeeded ? [] : [state.privateTarget?.pageId, state.privateTarget?.spaceId]),
   ].filter((viewId): viewId is string => Boolean(viewId));
 
   for (const viewId of viewIds) {
@@ -364,11 +397,52 @@ async function cleanupTemporaryViews(request: APIRequestContext, state: Scenario
   }
 }
 
-async function getApi<T>(
+async function cleanupStaleTemporaryViews(
   request: APIRequestContext,
-  token: string,
-  path: string
-): Promise<T> {
+  ownerToken: string,
+  workspaceId: string
+): Promise<void> {
+  const root = await getApi<FolderView>(
+    request,
+    ownerToken,
+    `/api/workspace/${workspaceId}/view/${workspaceId}?depth=50`
+  );
+  const staleViewIds = collectTemporaryViewIds(root);
+
+  for (const viewId of staleViewIds) {
+    await postVoidApiAllowFailure(
+      request,
+      ownerToken,
+      `/api/workspace/${workspaceId}/page-view/${viewId}/move-to-trash`,
+      `move stale public-to-private view ${viewId} to trash`
+    );
+  }
+}
+
+function collectTemporaryViewIds(view: FolderView): string[] {
+  const childIds = (view.children ?? []).flatMap(collectTemporaryViewIds);
+
+  if (isTemporaryView(view)) {
+    return [...childIds, view.view_id];
+  }
+
+  return childIds;
+}
+
+function isTemporaryView(view: FolderView): boolean {
+  if (view.view_id === SEEDED_PRIVATE_SPACE_ID || view.view_id === SEEDED_PRIVATE_TARGET_PAGE_ID) {
+    return false;
+  }
+
+  return [
+    'ptp0527 BDD Public Space ',
+    'ptp0527 BDD Movable Public Page ',
+    'ptp0527 BDD Private Space ',
+    'ptp0527 BDD Private Target Page ',
+  ].some((prefix) => view.name.startsWith(prefix));
+}
+
+async function getApi<T>(request: APIRequestContext, token: string, path: string): Promise<T> {
   const response = await request.get(`${TestConfig.apiUrl}${path}`, {
     headers: {
       Authorization: `Bearer ${token}`,


### PR DESCRIPTION
## Summary
- update the public-to-private BDD scenario to use the seeded private target page
- clean stale temporary ptp0527 views before creating new test pages
- assert the share panel and sidebar state after moving the public page under the private target

## Tests
- PUBLIC_TO_PRIVATE_WEB_PREFIX=ptp0527 LOCALHOST_GOTRUE=http://127.0.0.1:9999 cargo test --test public_to_private_access_seed public_to_private_move_web_accounts_are_seeded -- --ignored --nocapture
- pnpm run test:e2e:bdd:headed --grep @public-to-private-move-access

## Summary by Sourcery

Update public-to-private move access BDD flow to reuse seeded private target data and ensure clean test state before and after scenarios.

Enhancements:
- Reuse a seeded private target page instead of creating a new private target in the public-to-private move access scenario.
- Add cleanup logic to detect and trash stale public-to-private temporary views while preserving seeded fixtures.
- Refine share panel and sidebar expectations after moving the public page under the private target to validate access state more precisely.

Tests:
- Adjust the public-to-private move access feature description and steps to reflect usage of the seeded private target page rather than a temporary one.