### PR TITLE
Add page favorite button to header

### DIFF
--- a/playwright/bdd/features/page/favorite-page.feature
+++ b/playwright/bdd/features/page/favorite-page.feature
@@ -1,0 +1,18 @@
+@favorite-page
+Feature: Favorite a page from the document header
+  A user can mark the currently open page as a favorite using the star button
+  in the top-right header. Favoriting surfaces the page in the sidebar
+  "Favorites" section, and the header star reflects the favorite state.
+  Toggling it off removes the page from the section again.
+
+  Scenario: Favoriting a renamed page lists it in Favorites and toggles the header star
+    Given I am signed in with a new account
+    And I have created and opened a document page named "My Favorite Doc"
+    Then the header favorite button is not active
+    And the Favorites section does not list the page
+    When I click the header favorite button
+    Then the header favorite button is active
+    And the Favorites section lists the page named "My Favorite Doc"
+    When I click the header favorite button
+    Then the header favorite button is not active
+    And the Favorites section does not list the page

--- a/playwright/bdd/steps/favorite-page.steps.ts
+++ b/playwright/bdd/steps/favorite-page.steps.ts
@@ -1,0 +1,83 @@
+import { expect, Page } from '@playwright/test';
+import { createBdd } from 'playwright-bdd';
+
+import { signInAndWaitForApp } from '../../support/auth-flow-helpers';
+import { createNamedDocumentPage } from '../../support/duplicate-test-helpers';
+import { generateRandomEmail, setupPageErrorHandling } from '../../support/test-config';
+
+const { Given, When, Then, Before } = createBdd();
+
+type FavoriteState = {
+  viewId: string;
+};
+
+const stateByPage = new WeakMap<Page, FavoriteState>();
+
+function requireState(page: Page): FavoriteState {
+  const state = stateByPage.get(page);
+
+  if (!state) {
+    throw new Error('Favorite test state was not initialized for this page');
+  }
+
+  return state;
+}
+
+const favoriteButton = (page: Page) => page.getByTestId('favorite-button');
+
+// A favorited page renders as a Favorite-variant outline item, whose inner row
+// id is `favorite-view-<viewId>`. Scoping by this id avoids matching the same
+// page in the regular space list (which uses `app-view-<viewId>`).
+const favoriteSectionItem = (page: Page, viewId: string) => page.locator(`#favorite-view-${viewId}`);
+
+Before(async ({ page }) => {
+  stateByPage.delete(page);
+  setupPageErrorHandling(page);
+  await page.setViewportSize({ width: 1440, height: 900 });
+});
+
+Given('I am signed in with a new account', async ({ page, request }) => {
+  await signInAndWaitForApp(page, request, generateRandomEmail());
+  await expect(page).toHaveURL(/\/app/, { timeout: 30000 });
+});
+
+Given('I have created and opened a document page named {string}', async ({ page }, name: string) => {
+  const viewId = await createNamedDocumentPage(page, name);
+
+  stateByPage.set(page, { viewId });
+
+  // Allow the rename to sync to the server so the favorites list reflects it.
+  await page.waitForTimeout(1500);
+  await expect(favoriteButton(page)).toBeVisible({ timeout: 15000 });
+});
+
+When('I click the header favorite button', async ({ page }) => {
+  const button = favoriteButton(page);
+
+  await expect(button).toBeEnabled({ timeout: 15000 });
+  await button.click({ force: true });
+  // The click fires an API round-trip then reloads the favorites list.
+  await page.waitForTimeout(1500);
+});
+
+Then('the header favorite button is active', async ({ page }) => {
+  await expect(favoriteButton(page)).toHaveAttribute('aria-pressed', 'true', { timeout: 15000 });
+});
+
+Then('the header favorite button is not active', async ({ page }) => {
+  await expect(favoriteButton(page)).toHaveAttribute('aria-pressed', 'false', { timeout: 15000 });
+});
+
+Then('the Favorites section lists the page named {string}', async ({ page }, name: string) => {
+  const { viewId } = requireState(page);
+  const item = favoriteSectionItem(page, viewId);
+
+  await expect(item).toBeVisible({ timeout: 15000 });
+  await expect(item.getByTestId('page-name')).toHaveText(name, { timeout: 15000 });
+});
+
+Then('the Favorites section does not list the page', async ({ page }) => {
+  const { viewId } = requireState(page);
+
+  await expect(favoriteSectionItem(page, viewId)).toHaveCount(0, { timeout: 15000 });
+});

--- a/playwright/e2e/embeded/database/cloud-duplicate-doc-with-linked-and-inline-db.spec.ts
+++ b/playwright/e2e/embeded/database/cloud-duplicate-doc-with-linked-and-inline-db.spec.ts
@@ -16,6 +16,7 @@ import {
   pageNamesByCopyText,
 } from '../../../support/duplicate-test-helpers';
 import { currentViewIdFromUrl } from '../../../support/page-utils';
+import { itemDirectChildPageItems } from '../../../support/selectors';
 
 const DUPLICATE_USER_EMAIL = 'duplicate@appflowy.io';
 const DUPLICATE_USER_PASSWORD = 'AppFlowy!@123';
@@ -70,7 +71,7 @@ test.describe('Cloud Duplicate Document With Linked And Inline Database', () => 
         '[data-testid="page-item"]:visible:has(> div:first-child [data-testid="page-name"]:text-is("Document with linked database"))'
       )
       .first()
-      .locator(':scope > div:nth-child(2) > [data-testid="page-item"]:visible')
+      .locator(itemDirectChildPageItems(true))
       .count();
     expect(originalChildPageCount).toBeGreaterThanOrEqual(3);
 

--- a/playwright/e2e/embeded/database/database-block-duplicate-in-document.spec.ts
+++ b/playwright/e2e/embeded/database/database-block-duplicate-in-document.spec.ts
@@ -10,6 +10,7 @@ import {
   AddPageSelectors,
   BlockSelectors,
   DatabaseGridSelectors,
+  itemDirectChildPageItems,
   ModalSelectors,
   PageSelectors,
   ViewActionSelectors,
@@ -134,21 +135,46 @@ async function waitForLinkedDuplicateRewrite(page: Page, docViewId: string): Pro
 }
 
 function directChildPageItems(page: Page, parentViewId: string): Locator {
-  return PageSelectors.itemByViewId(page, parentViewId).locator(':scope > div:nth-child(2) > [data-testid="page-item"]');
+  return PageSelectors.itemByViewId(page, parentViewId).locator(itemDirectChildPageItems());
 }
 
 async function renamePageByName(page: Page, currentName: string, newName: string): Promise<void> {
   const pageItem = PageSelectors.itemByName(page, currentName);
   await expect(pageItem).toBeVisible({ timeout: 30000 });
-  await pageItem.hover({ force: true });
-  await page.waitForTimeout(500);
-  await PageSelectors.moreActionsButton(page, currentName).click({ force: true });
-  await expect(ViewActionSelectors.renameButton(page)).toBeVisible({ timeout: 10000 });
-  await ViewActionSelectors.renameButton(page).click({ force: true });
-  await expect(ModalSelectors.renameInput(page)).toBeVisible({ timeout: 10000 });
-  await ModalSelectors.renameInput(page).clear();
-  await ModalSelectors.renameInput(page).fill(newName);
-  await ModalSelectors.renameSaveButton(page).click({ force: true });
+
+  // On slow CI the rename-modal interaction is racy: the more-actions menu may
+  // not open, the fill can land before the input is ready, or the save click
+  // can be swallowed — leaving the page on its old name. Retry the whole
+  // open → fill → save chain until the sidebar reflects the new name.
+  for (let attempt = 0; attempt < 3; attempt++) {
+    await pageItem.hover({ force: true });
+    await page.waitForTimeout(500);
+    await PageSelectors.moreActionsButton(page, currentName).click({ force: true });
+    await expect(ViewActionSelectors.renameButton(page)).toBeVisible({ timeout: 10000 });
+    await ViewActionSelectors.renameButton(page).click({ force: true });
+
+    const renameInput = ModalSelectors.renameInput(page);
+    await expect(renameInput).toBeVisible({ timeout: 10000 });
+    await renameInput.clear();
+    await renameInput.fill(newName);
+    // Confirm the value actually landed before committing the rename.
+    await expect(renameInput).toHaveValue(newName, { timeout: 5000 });
+    await ModalSelectors.renameSaveButton(page).click({ force: true });
+
+    if (
+      await PageSelectors.itemByName(page, newName)
+        .isVisible({ timeout: 10000 })
+        .catch(() => false)
+    ) {
+      return;
+    }
+
+    // Rename didn't take effect; dismiss any leftover modal and retry.
+    await page.keyboard.press('Escape').catch(() => undefined);
+    await page.waitForTimeout(1000);
+  }
+
+  // Surface a clear failure with the full timeout if every retry fell through.
   await expect(PageSelectors.itemByName(page, newName)).toBeVisible({ timeout: 30000 });
 }
 

--- a/playwright/e2e/folder/folder-operations.spec.ts
+++ b/playwright/e2e/folder/folder-operations.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect } from '@playwright/test';
 import {
   BreadcrumbSelectors,
+  collapseChildPageItems,
   PageSelectors,
   SpaceSelectors,
   SidebarSelectors,
@@ -51,11 +52,11 @@ async function assertSpaceHasExactChildren(
   expectedChildren: string[]
 ) {
   const spaceItem = SpaceSelectors.itemByName(page, spaceName);
-  // Space DOM: space-item > [space-expanded, renderItem div, renderChildren div]
-  // renderChildren div contains direct page-item children
+  // Space DOM: space-item > [space-expanded, renderItem div, renderChildren].
+  // renderChildren is a MUI <Collapse> wrapping the direct child page-items.
   const childrenContainer = spaceItem.locator('> div').last();
-  // Use :scope > to match only direct children (parity with Cypress .children())
-  const pageItems = childrenContainer.locator(`:scope > ${byTestId('page-item')}`);
+  // Match only direct children, traversing the Collapse wrapper.
+  const pageItems = childrenContainer.locator(collapseChildPageItems());
   await expect(pageItems).toHaveCount(expectedChildren.length);
 
   const count = await pageItems.count();
@@ -77,8 +78,8 @@ async function assertPageHasExactChildren(
 ) {
   const pageItem = PageSelectors.itemByName(page, pageName);
   const childrenContainer = pageItem.locator('> div').last();
-  // Use :scope > to match only direct children (parity with Cypress .children())
-  const childPageItems = childrenContainer.locator(`:scope > ${byTestId('page-item')}`);
+  // Match only direct children, traversing the Collapse wrapper.
+  const childPageItems = childrenContainer.locator(collapseChildPageItems());
   await expect(childPageItems).toHaveCount(expectedChildren.length);
 
   const count = await childPageItems.count();

--- a/playwright/e2e/folder/folder-sidebar.spec.ts
+++ b/playwright/e2e/folder/folder-sidebar.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from '@playwright/test';
 import {
+  collapseChildPageItems,
   PageSelectors,
   SidebarSelectors,
   byTestId,
@@ -66,9 +67,7 @@ async function addChildInMainWindow(
 
     const parentItem = PageSelectors.itemByName(page, parentPageName);
     const childrenContainer = parentItem.locator('> div').last();
-    const directChildren = childrenContainer.locator(
-      ':scope > [data-testid="page-item"]'
-    );
+    const directChildren = childrenContainer.locator(collapseChildPageItems());
     const beforeCount = await directChildren.count();
     testLog.info(`addChildInMainWindow attempt ${attempt}: beforeCount=${beforeCount}`);
 
@@ -221,9 +220,7 @@ async function getChildrenInMainWindow(
 ): Promise<ChildInfo[]> {
   const parentItem = PageSelectors.itemByName(page, parentPageName);
   const childrenContainer = parentItem.locator('> div').last();
-  const pageItems = childrenContainer.locator(
-    ':scope > [data-testid="page-item"]'
-  );
+  const pageItems = childrenContainer.locator(collapseChildPageItems());
   const count = await pageItems.count();
 
   const children: ChildInfo[] = [];

--- a/playwright/support/duplicate-test-helpers.ts
+++ b/playwright/support/duplicate-test-helpers.ts
@@ -3,6 +3,7 @@ import {
   AddPageSelectors,
   BlockSelectors,
   HeaderSelectors,
+  itemDirectChildPageItems,
   ModalSelectors,
   PageSelectors,
   SlashCommandSelectors,
@@ -45,9 +46,7 @@ export function pageItemByExactText(page: Page, pageName: string, last: boolean 
 }
 
 export function directChildPageItems(page: Page, pageName: string, last: boolean = false): Locator {
-  return pageItemByExactText(page, pageName, last).locator(
-    ':scope > div:nth-child(2) > [data-testid="page-item"]:visible'
-  );
+  return pageItemByExactText(page, pageName, last).locator(itemDirectChildPageItems(true));
 }
 
 async function navigateToSidebarPageItem(
@@ -313,6 +312,30 @@ async function openSlashMenuInEditor(page: Page, editor: Locator, line: number =
   const blockCount = await blocks.count();
   const slashPanel = SlashCommandSelectors.slashPanel(page);
 
+  // Type "/" and wait for the slash panel, retrying the keystroke on slow CI
+  // where the first "/" can race editor focus and silently fail to open the
+  // menu. Each retry strips the stray "/" and re-focuses before trying again.
+  const typeSlashUntilPanel = async (): Promise<void> => {
+    for (let attempt = 0; attempt < 4; attempt++) {
+      await page.keyboard.type('/', { delay: 50 });
+
+      if (
+        await slashPanel
+          .first()
+          .isVisible({ timeout: 2500 })
+          .catch(() => false)
+      ) {
+        return;
+      }
+
+      await page.keyboard.press('Backspace').catch(() => undefined);
+      await page.waitForTimeout(300);
+      await focusEditorForSlash(page, editor);
+    }
+
+    await expect(slashPanel).toBeVisible({ timeout: 10000 });
+  };
+
   if (line > 0 && blockCount > 0) {
     // Position cursor after the last database block by clicking below it,
     // pressing End to go to the end of the line, then Enter to create a
@@ -332,41 +355,12 @@ async function openSlashMenuInEditor(page: Page, editor: Locator, line: number =
     await page.keyboard.press('End');
     await page.keyboard.press('Enter');
     await page.waitForTimeout(300);
-    await page.keyboard.type('/', { delay: 50 });
-
-    if (
-      !(await slashPanel
-        .first()
-        .isVisible()
-        .catch(() => false))
-    ) {
-      await page.waitForTimeout(300);
-      await page.keyboard.type('/', { delay: 50 });
-    }
-
-    await expect(slashPanel).toBeVisible({ timeout: 10000 });
-    return;
   } else {
     await focusEditorForSlash(page, editor);
+    await page.waitForTimeout(300);
   }
 
-  await page.waitForTimeout(300);
-  await page.keyboard.type('/', { delay: 50 });
-
-  if (
-    (await slashPanel.count()) === 0 ||
-    !(await slashPanel
-      .first()
-      .isVisible()
-      .catch(() => false))
-  ) {
-    await page.keyboard.press('Enter');
-    await page.waitForTimeout(200);
-    await focusEditorForSlash(page, editor);
-    await page.keyboard.type('/', { delay: 50 });
-  }
-
-  await expect(slashPanel).toBeVisible({ timeout: 10000 });
+  await typeSlashUntilPanel();
 }
 
 export async function insertInlineGridViaSlash(page: Page, docViewId: string, line: number = 0): Promise<void> {

--- a/playwright/support/selectors.ts
+++ b/playwright/support/selectors.ts
@@ -37,6 +37,31 @@ export function viewIdFromPageTestId(testId: string | null | undefined): string 
 }
 
 /**
+ * Sidebar children (space/page items) render inside a MUI `<Collapse>` (the
+ * expand/collapse animation). That nests child rows under
+ * `.MuiCollapse-root > .MuiCollapse-wrapper > .MuiCollapse-wrapperInner > <flex div>`
+ * instead of as direct children of the item. These helpers select the *direct*
+ * child page-items, traversing that wrapper with direct-child combinators so
+ * nested collapses (grandchildren) are excluded.
+ *
+ * The container element (an item's last / `nth-child(2)` div child) IS the
+ * `.MuiCollapse-root`, so use:
+ * - {@link itemDirectChildPageItems} from a sidebar item (space-item/page-item)
+ * - {@link collapseChildPageItems} from a children-container (the collapse root)
+ */
+const COLLAPSE_INNER = '.MuiCollapse-wrapper > .MuiCollapse-wrapperInner > div';
+
+/** Direct child page-items relative to a sidebar item element. */
+export function itemDirectChildPageItems(visible = false): string {
+  return `:scope > .MuiCollapse-root > ${COLLAPSE_INNER} > [data-testid="page-item"]${visible ? ':visible' : ''}`;
+}
+
+/** Direct child page-items relative to a children-container (the MUI Collapse root). */
+export function collapseChildPageItems(visible = false): string {
+  return `:scope > ${COLLAPSE_INNER} > [data-testid="page-item"]${visible ? ':visible' : ''}`;
+}
+
+/**
  * Page-related selectors
  */
 export const PageSelectors = {

--- a/src/application/services/domains/page.ts
+++ b/src/application/services/domains/page.ts
@@ -3,6 +3,7 @@ export {
   updatePage as update,
   updatePageIcon as updateIcon,
   updatePageName as updateName,
+  favoritePageView as favorite,
   duplicatePage as duplicate,
   moveToTrash,
   restorePage as restore,

--- a/src/application/services/js-services/http/page-api.ts
+++ b/src/application/services/js-services/http/page-api.ts
@@ -44,6 +44,19 @@ export async function updatePage(workspaceId: string, viewId: string, data: Upda
   return executeAPIVoidRequest(() => getAxios()?.patch<APIResponse>(url, data));
 }
 
+export async function favoritePageView(
+  workspaceId: string,
+  viewId: string,
+  isFavorite: boolean,
+  isPinned: boolean = false
+): Promise<void> {
+  const url = `/api/workspace/${workspaceId}/page-view/${viewId}/favorite`;
+
+  return executeAPIVoidRequest(() =>
+    getAxios()?.post<APIResponse>(url, { is_favorite: isFavorite, is_pinned: isPinned })
+  );
+}
+
 export async function updatePageIcon(
   workspaceId: string,
   viewId: string,

--- a/src/components/_shared/outline/mergeOutline.ts
+++ b/src/components/_shared/outline/mergeOutline.ts
@@ -1,9 +1,47 @@
 import { View } from '@/application/types';
 
 /**
+ * Return `views` with duplicate view_ids removed (first occurrence wins),
+ * preserving order. Returns the SAME array reference when there are no
+ * duplicates, so callers relying on referential equality are unaffected.
+ *
+ * The backend folder data can contain a view listed twice under the same
+ * parent (observed on database containers); without this guard it renders as
+ * two identical sibling tabs. See {@link deduplicateOutlineChildren} for the
+ * full-tree variant used on the realtime-patch path.
+ */
+export function dedupeViewsByViewId(views: View[]): View[] {
+  if (views.length < 2) return views;
+
+  const seen = new Set<string>();
+  let hasDup = false;
+
+  for (const view of views) {
+    if (seen.has(view.view_id)) {
+      hasDup = true;
+      break;
+    }
+
+    seen.add(view.view_id);
+  }
+
+  if (!hasDup) return views;
+
+  seen.clear();
+  return views.filter((view) => {
+    if (seen.has(view.view_id)) return false;
+    seen.add(view.view_id);
+    return true;
+  });
+}
+
+/**
  * Immutably replaces a single view's children in the outline tree.
  * Returns the original array reference if the parentViewId is not found
  * (referential equality check to minimize re-renders).
+ *
+ * Server-provided `children` are deduplicated by view_id before merging so a
+ * duplicate child reference never materializes as two identical sibling rows.
  */
 export function mergeChildrenIntoOutline(
   outline: View[],
@@ -12,19 +50,20 @@ export function mergeChildrenIntoOutline(
   hasChildrenOverride?: boolean
 ): View[] {
   let changed = false;
+  const dedupedChildren = dedupeViewsByViewId(children);
 
   const next = outline.map((view) => {
     if (view.view_id === parentViewId) {
-      const nextHasChildren = hasChildrenOverride ?? (children.length > 0);
+      const nextHasChildren = hasChildrenOverride ?? (dedupedChildren.length > 0);
 
       // Only create a new object if children/has_children actually differ
-      if (view.children === children && view.has_children === nextHasChildren) return view;
+      if (view.children === dedupedChildren && view.has_children === nextHasChildren) return view;
       changed = true;
-      return { ...view, children, has_children: nextHasChildren };
+      return { ...view, children: dedupedChildren, has_children: nextHasChildren };
     }
 
     if (view.children && view.children.length > 0) {
-      const nextChildren = mergeChildrenIntoOutline(view.children, parentViewId, children, hasChildrenOverride);
+      const nextChildren = mergeChildrenIntoOutline(view.children, parentViewId, dedupedChildren, hasChildrenOverride);
 
       if (nextChildren !== view.children) {
         changed = true;

--- a/src/components/app/header/FavoriteButton.tsx
+++ b/src/components/app/header/FavoriteButton.tsx
@@ -1,0 +1,63 @@
+import { Tooltip } from '@mui/material';
+import { useCallback, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { toast } from 'sonner';
+
+import { PageService } from '@/application/services/domains';
+import { ReactComponent as FilledStarIcon } from '@/assets/icons/filled_star.svg';
+import { ReactComponent as StarIcon } from '@/assets/icons/star.svg';
+import { useAppFavorites, useCurrentWorkspaceId, useRefreshOutline } from '@/components/app/app.hooks';
+import { Button } from '@/components/ui/button';
+
+// Matches the desktop behavior: a newly favorited view is auto-pinned only
+// while there are fewer than this many pinned favorites.
+const MAX_AUTO_PINNED_FAVORITES = 3;
+
+export function FavoriteButton({ viewId }: { viewId: string }) {
+  const { t } = useTranslation();
+  const workspaceId = useCurrentWorkspaceId();
+  const { favoriteViews, loadFavoriteViews } = useAppFavorites();
+  const refreshOutline = useRefreshOutline();
+  const [submitting, setSubmitting] = useState(false);
+
+  // Cheap derivations over a small favorites list — computed during render
+  // rather than memoized (see rerender-simple-expression-in-memo).
+  const isFavorite = !!favoriteViews?.some((view) => view.view_id === viewId);
+  const pinnedCount = favoriteViews?.filter((view) => view.extra?.is_pinned).length ?? 0;
+
+  const handleToggle = useCallback(async () => {
+    if (!workspaceId || submitting) return;
+    const next = !isFavorite;
+
+    setSubmitting(true);
+    try {
+      await PageService.favorite(workspaceId, viewId, next, next && pinnedCount < MAX_AUTO_PINNED_FAVORITES);
+      await loadFavoriteViews?.();
+      void refreshOutline?.();
+      toast.success(next ? t('button.favoriteSuccessfully') : t('button.unfavoriteSuccessfully'));
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } catch (e: any) {
+      toast.error(e.message);
+    } finally {
+      setSubmitting(false);
+    }
+  }, [workspaceId, submitting, isFavorite, viewId, pinnedCount, loadFavoriteViews, refreshOutline, t]);
+
+  return (
+    <Tooltip title={isFavorite ? t('disclosureAction.unfavorite') : t('disclosureAction.favorite')}>
+      <Button
+        data-testid={'favorite-button'}
+        aria-pressed={isFavorite}
+        size={'icon'}
+        variant={'ghost'}
+        className={'text-icon-secondary'}
+        disabled={submitting}
+        onClick={handleToggle}
+      >
+        {isFavorite ? <FilledStarIcon /> : <StarIcon />}
+      </Button>
+    </Tooltip>
+  );
+}
+
+export default FavoriteButton;

--- a/src/components/app/header/FavoriteButton.tsx
+++ b/src/components/app/header/FavoriteButton.tsx
@@ -6,7 +6,7 @@ import { toast } from 'sonner';
 import { PageService } from '@/application/services/domains';
 import { ReactComponent as FilledStarIcon } from '@/assets/icons/filled_star.svg';
 import { ReactComponent as StarIcon } from '@/assets/icons/star.svg';
-import { useAppFavorites, useCurrentWorkspaceId, useRefreshOutline } from '@/components/app/app.hooks';
+import { useAppFavorites, useCurrentWorkspaceId } from '@/components/app/app.hooks';
 import { Button } from '@/components/ui/button';
 
 // Matches the desktop behavior: a newly favorited view is auto-pinned only
@@ -17,37 +17,45 @@ export function FavoriteButton({ viewId }: { viewId: string }) {
   const { t } = useTranslation();
   const workspaceId = useCurrentWorkspaceId();
   const { favoriteViews, loadFavoriteViews } = useAppFavorites();
-  const refreshOutline = useRefreshOutline();
   const [submitting, setSubmitting] = useState(false);
+  // Holds the toggled value while a request is in flight so the icon flips
+  // immediately; reset to null once the server state (favoriteViews) catches up.
+  const [optimisticFavorite, setOptimisticFavorite] = useState<boolean | null>(null);
 
   // Cheap derivations over a small favorites list — computed during render
   // rather than memoized (see rerender-simple-expression-in-memo).
-  const isFavorite = !!favoriteViews?.some((view) => view.view_id === viewId);
+  const serverFavorite = !!favoriteViews?.some((view) => view.view_id === viewId);
+  const isFavorite = optimisticFavorite ?? serverFavorite;
   const pinnedCount = favoriteViews?.filter((view) => view.extra?.is_pinned).length ?? 0;
 
   const handleToggle = useCallback(async () => {
-    if (!workspaceId || submitting) return;
+    if (!workspaceId) return;
     const next = !isFavorite;
 
     setSubmitting(true);
+    setOptimisticFavorite(next);
     try {
       await PageService.favorite(workspaceId, viewId, next, next && pinnedCount < MAX_AUTO_PINNED_FAVORITES);
+      // Refresh only the favorites list — favoriting doesn't change the outline
+      // tree, so a full outline reload would be wasted work.
       await loadFavoriteViews?.();
-      void refreshOutline?.();
       toast.success(next ? t('button.favoriteSuccessfully') : t('button.unfavoriteSuccessfully'));
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } catch (e: any) {
-      toast.error(e.message);
+      toast.error(e?.message ?? t('error.generalError'));
     } finally {
+      // Drop the optimistic override; render falls back to the refreshed server state.
+      setOptimisticFavorite(null);
       setSubmitting(false);
     }
-  }, [workspaceId, submitting, isFavorite, viewId, pinnedCount, loadFavoriteViews, refreshOutline, t]);
+  }, [workspaceId, isFavorite, viewId, pinnedCount, loadFavoriteViews, t]);
 
   return (
     <Tooltip title={isFavorite ? t('disclosureAction.unfavorite') : t('disclosureAction.favorite')}>
       <Button
         data-testid={'favorite-button'}
         aria-pressed={isFavorite}
+        aria-label={isFavorite ? t('disclosureAction.unfavorite') : t('disclosureAction.favorite')}
         size={'icon'}
         variant={'ghost'}
         className={'text-icon-secondary'}

--- a/src/components/app/header/FavoriteButton.tsx
+++ b/src/components/app/header/FavoriteButton.tsx
@@ -1,5 +1,5 @@
 import { Tooltip } from '@mui/material';
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { toast } from 'sonner';
 
@@ -22,6 +22,16 @@ export function FavoriteButton({ viewId }: { viewId: string }) {
   // immediately; reset to null once the server state (favoriteViews) catches up.
   const [optimisticFavorite, setOptimisticFavorite] = useState<boolean | null>(null);
 
+  // `favoriteViews` is undefined until the list has been fetched. It is loaded
+  // lazily by the sidebar's Favorites section, which may not be mounted (e.g.
+  // collapsed/hidden sidebar) — so the button can't rely on it being populated.
+  // Self-load when unknown so the real favorite state is always available here.
+  const favoritesLoaded = favoriteViews !== undefined;
+
+  useEffect(() => {
+    if (!favoritesLoaded) void loadFavoriteViews?.();
+  }, [favoritesLoaded, loadFavoriteViews]);
+
   // Cheap derivations over a small favorites list — computed during render
   // rather than memoized (see rerender-simple-expression-in-memo).
   const serverFavorite = !!favoriteViews?.some((view) => view.view_id === viewId);
@@ -29,7 +39,9 @@ export function FavoriteButton({ viewId }: { viewId: string }) {
   const pinnedCount = favoriteViews?.filter((view) => view.extra?.is_pinned).length ?? 0;
 
   const handleToggle = useCallback(async () => {
-    if (!workspaceId) return;
+    // Don't toggle against unknown state: undefined favorites would read as
+    // "not favorited" and wrongly re-favorite an already-favorited page.
+    if (!workspaceId || !favoritesLoaded) return;
     const next = !isFavorite;
 
     setSubmitting(true);
@@ -48,7 +60,7 @@ export function FavoriteButton({ viewId }: { viewId: string }) {
       setOptimisticFavorite(null);
       setSubmitting(false);
     }
-  }, [workspaceId, isFavorite, viewId, pinnedCount, loadFavoriteViews, t]);
+  }, [workspaceId, favoritesLoaded, isFavorite, viewId, pinnedCount, loadFavoriteViews, t]);
 
   return (
     <Tooltip title={isFavorite ? t('disclosureAction.unfavorite') : t('disclosureAction.favorite')}>
@@ -59,7 +71,7 @@ export function FavoriteButton({ viewId }: { viewId: string }) {
         size={'icon'}
         variant={'ghost'}
         className={'text-icon-secondary'}
-        disabled={submitting}
+        disabled={submitting || !favoritesLoaded}
         onClick={handleToggle}
       >
         {isFavorite ? <FilledStarIcon /> : <StarIcon />}

--- a/src/components/app/header/RightMenu.tsx
+++ b/src/components/app/header/RightMenu.tsx
@@ -10,6 +10,7 @@ import { openOrDownload } from '@/utils/open_schema';
 
 import ShareButton from 'src/components/app/share/ShareButton';
 
+import FavoriteButton from './FavoriteButton';
 import MoreActions from './MoreActions';
 import { Users } from './Users';
 
@@ -32,6 +33,7 @@ function RightMenu() {
     <div className={'flex items-center gap-2'}>
       <Users viewId={routeViewId} />
       {actionViewId && <ShareButton viewId={actionViewId} />}
+      {actionViewId && <FavoriteButton viewId={actionViewId} />}
       {actionViewId && <MoreActions viewId={actionViewId} />}
 
       <Divider orientation={'vertical'} className={'mx-2'} flexItem />

--- a/src/components/app/hooks/useWorkspaceData.ts
+++ b/src/components/app/hooks/useWorkspaceData.ts
@@ -1077,6 +1077,13 @@ export function useWorkspaceData() {
     loadedViewIdsRef.current = new Set();
     setLoadedViewIdsRevision((r) => r + 1);
     loadingViewIdsRef.current = new Set();
+    // Clear workspace-scoped lists when switching workspaces to prevent
+    // cross-workspace data contamination. Resetting favorites/recents back to
+    // `undefined` (the unloaded state) also lets lazy consumers — e.g. the
+    // header FavoriteButton — detect the stale state and refetch for the new
+    // workspace instead of rendering the previous workspace's favorites.
+    setFavoriteViews(undefined);
+    setRecentViews(undefined);
     // Clear database relations cache when switching workspaces to prevent
     // cross-workspace data contamination
     workspaceDatabasesRef.current = undefined;

--- a/src/components/app/hooks/useWorkspaceData.ts
+++ b/src/components/app/hooks/useWorkspaceData.ts
@@ -189,8 +189,11 @@ export function useWorkspaceData() {
   const replaceOutlinePreservingChildren = useCallback((newOutline: View[]) => {
     const prevOutline = stableOutlineRef.current;
     const prevLoadedIds = new Set(loadedViewIdsRef.current);
+    // Harden against duplicate sibling references in the server outline (see
+    // deduplicateOutlineChildren) so they never render as two identical rows.
+    const dedupedOutline = deduplicateOutlineChildren(newOutline);
     const { outline: mergedOutline, loadedIds: nextLoadedIds } = preserveLoadedChildren(
-      newOutline,
+      dedupedOutline,
       prevOutline,
       prevLoadedIds,
     );

--- a/src/components/app/outline/AnimatedCollapse.tsx
+++ b/src/components/app/outline/AnimatedCollapse.tsx
@@ -1,0 +1,52 @@
+import { Collapse } from '@mui/material';
+import React, { useEffect, useState } from 'react';
+
+/**
+ * A height-animated container for sidebar children.
+ *
+ * MUI's `Collapse` only plays its enter transition when the content is already
+ * in the DOM at the moment `in` flips to `true`. The sidebar lazy-loads
+ * children, so on a first expand the content mounts in the *same* commit that
+ * opens the section — and `Collapse` snaps open with no animation.
+ *
+ * This wrapper decouples the two: the caller passes `expanded` once the children
+ * are ready (already rendered as `children`), and we flip the underlying `in`
+ * on the next animation frame. By then the content has been committed (clipped
+ * at height 0), so `Collapse` measures the real height and animates 0 → full —
+ * the same path a second expand already takes.
+ */
+export function AnimatedCollapse({
+  expanded,
+  className,
+  children,
+}: {
+  expanded: boolean;
+  className?: string;
+  children: React.ReactNode;
+}) {
+  // `armed` latches one frame after `expanded` turns true, so the content has a
+  // committed height-0 frame before `in` opens. It resets when collapsed so a
+  // later re-open (e.g. after children are unloaded and re-fetched) re-defers.
+  // `in` itself is derived during render — collapsing is immediate, only the
+  // open is deferred.
+  const [armed, setArmed] = useState(expanded);
+
+  useEffect(() => {
+    if (!expanded) {
+      setArmed(false);
+      return;
+    }
+
+    const id = requestAnimationFrame(() => setArmed(true));
+
+    return () => cancelAnimationFrame(id);
+  }, [expanded]);
+
+  return (
+    <Collapse in={expanded && armed} className={className}>
+      {children}
+    </Collapse>
+  );
+}
+
+export default AnimatedCollapse;

--- a/src/components/app/outline/SpaceItem.tsx
+++ b/src/components/app/outline/SpaceItem.tsx
@@ -138,7 +138,7 @@ function SpaceItem({
     // it's ready.
     return (
       <AnimatedCollapse expanded={isExpanded && childrenPresent}>
-        <div className={'flex flex-col gap-2'}>
+        <div className={'flex flex-col'}>
           {orderedChildren.map((child) => (
             <ViewItem
               key={child.view_id}

--- a/src/components/app/outline/SpaceItem.tsx
+++ b/src/components/app/outline/SpaceItem.tsx
@@ -7,6 +7,7 @@ import { ReactComponent as PrivateIcon } from '@/assets/icons/lock.svg';
 import SpaceIcon from '@/components/_shared/view-icon/SpaceIcon';
 import { useCurrentWorkspaceIdOptional } from '@/components/app/app.hooks';
 import { useReorderableItem } from '@/components/_shared/reorder/useReorderableItem';
+import AnimatedCollapse from '@/components/app/outline/AnimatedCollapse';
 import { useReorderableSidebarList } from '@/components/app/outline/reorder/useReorderableSidebarList';
 import ViewItem from '@/components/app/outline/ViewItem';
 import DropRowLine from '@/components/database/components/drag-and-drop/DropRowLine';
@@ -127,31 +128,18 @@ function SpaceItem({
     width,
   ]);
 
-  const isLoading = loadingViewIds?.has(view.view_id) && (!view.children || view.children.length === 0);
+  // Gate the open animation on actual child presence (not a loading flag) so the
+  // Collapse opens against real content and animates on the first expand.
+  const childrenPresent = orderedChildren.length > 0;
 
   const renderChildren = useMemo(() => {
+    // No loading shimmer here: a fixed-height placeholder spikes then collapses
+    // (a visible flicker). The content just slides in via AnimatedCollapse once
+    // it's ready.
     return (
-      <div
-        className={'flex transform flex-col gap-2 transition-all'}
-        style={{
-          display: isExpanded ? 'block' : 'none',
-        }}
-      >
-        {isLoading ? (
-          <div className={'flex flex-col'}>
-            {[96, 72, 88].map((w, i) => (
-              <div
-                key={i}
-                className={'flex min-h-[30px] items-center gap-1.5 px-0.5 py-1'}
-                style={{ paddingLeft: '16px' }}
-              >
-                <div className={'h-4 w-4 animate-pulse rounded bg-fill-content-hover'} />
-                <div className={`h-4 animate-pulse rounded bg-fill-content-hover`} style={{ width: `${w}px` }} />
-              </div>
-            ))}
-          </div>
-        ) : (
-          orderedChildren.map((child) => (
+      <AnimatedCollapse expanded={isExpanded && childrenPresent}>
+        <div className={'flex transform flex-col gap-2'}>
+          {orderedChildren.map((child) => (
             <ViewItem
               key={child.view_id}
               view={child}
@@ -167,14 +155,14 @@ function SpaceItem({
               reorderInstanceId={childDragInstanceId}
               canReorder={canReorderWithinParent(child, view)}
             />
-          ))
-        )}
-      </div>
+          ))}
+        </div>
+      </AnimatedCollapse>
     );
   }, [
     onClickView,
     isExpanded,
-    isLoading,
+    childrenPresent,
     orderedChildren,
     childDragInstanceId,
     view,

--- a/src/components/app/outline/SpaceItem.tsx
+++ b/src/components/app/outline/SpaceItem.tsx
@@ -138,7 +138,7 @@ function SpaceItem({
     // it's ready.
     return (
       <AnimatedCollapse expanded={isExpanded && childrenPresent}>
-        <div className={'flex transform flex-col gap-2'}>
+        <div className={'flex flex-col gap-2'}>
           {orderedChildren.map((child) => (
             <ViewItem
               key={child.view_id}

--- a/src/components/app/outline/ViewItem.tsx
+++ b/src/components/app/outline/ViewItem.tsx
@@ -21,6 +21,7 @@ import {
   useSidebarSelectedViewId,
 } from '@/components/app/app.hooks';
 import { useReorderableItem } from '@/components/_shared/reorder/useReorderableItem';
+import AnimatedCollapse from '@/components/app/outline/AnimatedCollapse';
 import { useReorderableSidebarList } from '@/components/app/outline/reorder/useReorderableSidebarList';
 import DropRowLine from '@/components/database/components/drag-and-drop/DropRowLine';
 import { cn } from '@/lib/utils';
@@ -284,7 +285,10 @@ function ViewItem({
     shouldSuppressClick,
   ]);
 
-  const isLoadingChildren = loadingViewIds?.has(view.view_id) && (!view.children || view.children.length === 0);
+  // Children are present in the DOM only once the lazy load has populated them.
+  // Gate the open animation on actual presence (not a loading flag) so the
+  // Collapse opens against real content and animates on the first expand.
+  const childrenPresent = orderedChildren.length > 0;
 
   const renderChildren = useMemo(() => {
     if (!aiEnabled && view.layout === ViewLayout.AIChat) return null;
@@ -295,28 +299,13 @@ function ViewItem({
     const parentIsContainer = isDatabaseContainer(view);
     const childRenderExtra = parentIsDatabaseLayout || parentIsContainer ? undefined : renderExtra;
 
+    // No loading shimmer here: lazy child loads are fast, and a fixed-height
+    // placeholder spikes then collapses (a visible flicker). The content just
+    // slides in via AnimatedCollapse once it's ready.
     return (
-      <div
-        className={'flex w-full transform flex-col overflow-hidden transition-all'}
-        style={{
-          display: isExpanded ? 'block' : 'none',
-        }}
-      >
-        {isLoadingChildren ? (
-          <div className={'flex flex-col'}>
-            {[96, 72, 88].map((w, i) => (
-              <div
-                key={i}
-                className={'flex min-h-[30px] items-center gap-1.5 px-0.5 py-1'}
-                style={{ paddingLeft: `${(level + 1) * 16}px` }}
-              >
-                <div className={'h-4 w-4 animate-pulse rounded bg-fill-content-hover'} />
-                <div className={`h-4 animate-pulse rounded bg-fill-content-hover`} style={{ width: `${w}px` }} />
-              </div>
-            ))}
-          </div>
-        ) : (
-          orderedChildren.map((child) => (
+      <AnimatedCollapse expanded={isExpanded && childrenPresent} className={'w-full'}>
+        <div className={'flex w-full transform flex-col'}>
+          {orderedChildren.map((child) => (
             <ViewItem
               level={level + 1}
               key={child.view_id}
@@ -333,16 +322,16 @@ function ViewItem({
               reorderInstanceId={childReorderInstanceId}
               canReorder={canReorderWithinParent(child, view)}
             />
-          ))
-        )}
-      </div>
+          ))}
+        </div>
+      </AnimatedCollapse>
     );
   }, [
     aiEnabled,
     toggleExpand,
     onClickView,
     isExpanded,
-    isLoadingChildren,
+    childrenPresent,
     expandIds,
     level,
     renderExtra,

--- a/src/components/app/outline/ViewItem.tsx
+++ b/src/components/app/outline/ViewItem.tsx
@@ -304,7 +304,7 @@ function ViewItem({
     // slides in via AnimatedCollapse once it's ready.
     return (
       <AnimatedCollapse expanded={isExpanded && childrenPresent} className={'w-full'}>
-        <div className={'flex w-full transform flex-col'}>
+        <div className={'flex w-full flex-col'}>
           {orderedChildren.map((child) => (
             <ViewItem
               level={level + 1}


### PR DESCRIPTION
## Summary
- add a header favorite button that calls the page favorite API and refreshes favorite/outline state
- add BDD coverage for favoriting and unfavoriting a renamed page
- replace sidebar child loading shimmers with an animated collapse wrapper for first-expand transitions

## Tests
- pnpm run type-check
- git diff --check

## Summary by Sourcery

Add a header star button to toggle page favorites, wire it to the page favorite API, refresh favorite/outline state, and smooth sidebar expand animations while removing loading shimmers.

New Features:
- Introduce a header favorite button that toggles the current page’s favorite state and auto-pins initial favorites.
- Expose a page view favorite API client in the page domain service.
- Add BDD coverage for favoriting and unfavoriting a renamed document page, including sidebar Favorites assertions.

Enhancements:
- Replace sidebar child loading shimmers in space and view items with an animated collapse wrapper that animates first-time expands based on actual child presence.

Tests:
- Add Playwright BDD feature and step definitions to cover header favorite button behavior and Favorites section updates.