### PR TITLE
Fix sidebar outline revalidation

### DIFF
--- a/playwright/e2e/app/outline-lazy-loading.spec.ts
+++ b/playwright/e2e/app/outline-lazy-loading.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect, type Request } from '@playwright/test';
 import { PageSelectors } from '../../support/selectors';
 import { generateRandomEmail } from '../../support/test-config';
 import { signInAndWaitForApp } from '../../support/auth-flow-helpers';
@@ -16,6 +16,48 @@ function extractViewId(testId: string | null | undefined, prefix: string): strin
 async function waitForSidebarReady(page: import('@playwright/test').Page) {
   await expect(page.locator('[data-testid="space-item"]').first()).toBeVisible({ timeout: 60000 });
   await expect(PageSelectors.items(page).first()).toBeVisible({ timeout: 60000 });
+}
+
+function extractBatchViewRequest(request: Request): { depth: string | null; viewIds: string[] } {
+  const url = new URL(request.url());
+  let depth = url.searchParams.get('depth');
+  let viewIds =
+    url.searchParams
+      .get('view_ids')
+      ?.split(',')
+      .map((id: string) => id.trim())
+      .filter(Boolean) ?? [];
+
+  if (request.method() !== 'POST') {
+    return { depth, viewIds };
+  }
+
+  let body: unknown;
+
+  try {
+    body = request.postDataJSON();
+  } catch {
+    return { depth, viewIds };
+  }
+
+  if (!body || typeof body !== 'object') {
+    return { depth, viewIds };
+  }
+
+  const payload = body as { depth?: unknown; view_ids?: unknown };
+
+  if (payload.depth !== undefined && payload.depth !== null) {
+    depth = String(payload.depth);
+  }
+
+  if (Array.isArray(payload.view_ids)) {
+    viewIds = payload.view_ids
+      .filter((id): id is string => typeof id === 'string')
+      .map((id) => id.trim())
+      .filter(Boolean);
+  }
+
+  return { depth, viewIds };
 }
 
 /**
@@ -169,14 +211,7 @@ test.describe('Outline Lazy Loading', () => {
 
     // Intercept batch view requests
     await page.route('**/api/workspace/*/views*', async (route) => {
-      const url = new URL(route.request().url());
-      const depth = url.searchParams.get('depth');
-      const viewIds =
-        url.searchParams
-          .get('view_ids')
-          ?.split(',')
-          .map((id: string) => id.trim())
-          .filter(Boolean) ?? [];
+      const { depth, viewIds } = extractBatchViewRequest(route.request());
 
       seenBatchRequests.push({ depth, viewIds });
       await route.continue();

--- a/src/application/services/js-services/http/view-api.ts
+++ b/src/application/services/js-services/http/view-api.ts
@@ -3,12 +3,13 @@ import { View } from '@/application/types';
 
 import { APIResponse, executeAPIRequest, getAxios } from './core';
 
+const MAX_WORKSPACE_VIEW_SUBTREES_GET_URL_BYTES = 4096;
+const WORKSPACE_VIEW_SUBTREES_BATCH_CHUNK_SIZE = 100;
+
 export async function getAppOutline(workspaceId: string): Promise<AppOutlineResponse> {
   const url = `/api/workspace/${workspaceId}/view/${workspaceId}?depth=2`;
 
-  return executeAPIRequest<View>(() =>
-    getAxios()?.get<APIResponse<View>>(url)
-  ).then((data) => ({
+  return executeAPIRequest<View>(() => getAxios()?.get<APIResponse<View>>(url)).then((data) => ({
     outline: Array.isArray(data.children) ? data.children : [],
     folderRid: data.folder_rid,
   }));
@@ -17,47 +18,135 @@ export async function getAppOutline(workspaceId: string): Promise<AppOutlineResp
 export async function getView(workspaceId: string, viewId: string, depth: number = 1) {
   const url = `/api/workspace/${workspaceId}/view/${viewId}?depth=${depth}`;
 
-  return executeAPIRequest<View>(() =>
-    getAxios()?.get<APIResponse<View>>(url)
-  );
+  return executeAPIRequest<View>(() => getAxios()?.get<APIResponse<View>>(url));
 }
 
 export async function getViews(workspaceId: string, viewIds: string[], depth: number = 2) {
   if (viewIds.length === 0) return [];
 
-  const query = new URLSearchParams({
-    depth: String(depth),
-    view_ids: viewIds.join(','),
-  });
-  const url = `/api/workspace/${workspaceId}/views?${query.toString()}`;
+  const url = `/api/workspace/${workspaceId}/views`;
+  const views: View[] = [];
+
+  for (const chunk of chunkViewIds(viewIds, WORKSPACE_VIEW_SUBTREES_BATCH_CHUNK_SIZE)) {
+    const data = await getViewsChunk(url, chunk, depth);
+
+    views.push(...data);
+  }
+
+  return views;
+}
+
+async function getViewsChunk(url: string, viewIds: string[], depth: number): Promise<View[]> {
+  if (workspaceViewSubtreesQueryFitsGet(url, viewIds, depth)) {
+    return getViewsByGet(url, viewIds, depth);
+  }
+
+  try {
+    return await getViewsByPost(url, viewIds, depth);
+  } catch (error) {
+    if (!isUnsupportedPostRouteError(error)) {
+      throw error;
+    }
+
+    const views: View[] = [];
+
+    for (const chunk of workspaceViewSubtreesGetChunks(url, viewIds, depth)) {
+      views.push(...(await getViewsByGet(url, chunk, depth)));
+    }
+
+    return views;
+  }
+}
+
+async function getViewsByGet(url: string, viewIds: string[], depth: number): Promise<View[]> {
+  const query = workspaceViewSubtreesQuery(viewIds, depth);
 
   return executeAPIRequest<{ views: View[] }>(() =>
-    getAxios()?.get<APIResponse<{ views: View[] }>>(url)
+    getAxios()?.get<APIResponse<{ views: View[] }>>(`${url}?${query}`)
   ).then((data) => data.views ?? []);
+}
+
+async function getViewsByPost(url: string, viewIds: string[], depth: number): Promise<View[]> {
+  return executeAPIRequest<{ views: View[] }>(() =>
+    getAxios()?.post<APIResponse<{ views: View[] }>>(url, {
+      depth,
+      view_ids: viewIds,
+    })
+  ).then((data) => data.views ?? []);
+}
+
+function workspaceViewSubtreesQuery(viewIds: string[], depth: number): string {
+  const params = new URLSearchParams();
+
+  params.set('depth', String(depth));
+  params.set('view_ids', viewIds.join(','));
+
+  return params.toString();
+}
+
+function workspaceViewSubtreesQueryFitsGet(url: string, viewIds: string[], depth: number): boolean {
+  return `${url}?${workspaceViewSubtreesQuery(viewIds, depth)}`.length <= MAX_WORKSPACE_VIEW_SUBTREES_GET_URL_BYTES;
+}
+
+function workspaceViewSubtreesGetChunks(url: string, viewIds: string[], depth: number): string[][] {
+  const chunks: string[][] = [];
+  let start = 0;
+
+  while (start < viewIds.length) {
+    let end = Math.min(viewIds.length, start + WORKSPACE_VIEW_SUBTREES_BATCH_CHUNK_SIZE);
+
+    while (end > start + 1 && !workspaceViewSubtreesQueryFitsGet(url, viewIds.slice(start, end), depth)) {
+      end = start + Math.floor((end - start) / 2);
+    }
+
+    chunks.push(viewIds.slice(start, end));
+    start = end;
+  }
+
+  return chunks;
+}
+
+function chunkViewIds(viewIds: string[], chunkSize: number): string[][] {
+  const chunks: string[][] = [];
+
+  for (let index = 0; index < viewIds.length; index += chunkSize) {
+    chunks.push(viewIds.slice(index, index + chunkSize));
+  }
+
+  return chunks;
+}
+
+function isUnsupportedPostRouteError(error: unknown): boolean {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    'code' in error &&
+    ((error as { code: unknown }).code === 404 || (error as { code: unknown }).code === 405)
+  );
 }
 
 export async function getAppFavorites(workspaceId: string) {
   const url = `/api/workspace/${workspaceId}/favorite`;
 
-  return executeAPIRequest<{ views: View[] }>(() =>
-    getAxios()?.get<APIResponse<{ views: View[] }>>(url)
-  ).then((data) => data.views);
+  return executeAPIRequest<{ views: View[] }>(() => getAxios()?.get<APIResponse<{ views: View[] }>>(url)).then(
+    (data) => data.views
+  );
 }
 
 export async function getAppRecent(workspaceId: string) {
   const url = `/api/workspace/${workspaceId}/recent`;
 
-  return executeAPIRequest<{ views: View[] }>(() =>
-    getAxios()?.get<APIResponse<{ views: View[] }>>(url)
-  ).then((data) => data.views);
+  return executeAPIRequest<{ views: View[] }>(() => getAxios()?.get<APIResponse<{ views: View[] }>>(url)).then(
+    (data) => data.views
+  );
 }
 
 export async function getAppTrash(workspaceId: string) {
   const url = `/api/workspace/${workspaceId}/trash`;
 
-  return executeAPIRequest<{ views: View[] }>(() =>
-    getAxios()?.get<APIResponse<{ views: View[] }>>(url)
-  ).then((data) => data.views);
+  return executeAPIRequest<{ views: View[] }>(() => getAxios()?.get<APIResponse<{ views: View[] }>>(url)).then(
+    (data) => data.views
+  );
 }
 
 export async function createOrphanedView(workspaceId: string, payload: { document_id: string }): Promise<Uint8Array> {

--- a/src/application/services/js-services/http/view-api.ts
+++ b/src/application/services/js-services/http/view-api.ts
@@ -4,7 +4,7 @@ import { View } from '@/application/types';
 import { APIResponse, executeAPIRequest, getAxios } from './core';
 
 const MAX_WORKSPACE_VIEW_SUBTREES_GET_URL_BYTES = 4096;
-const WORKSPACE_VIEW_SUBTREES_BATCH_CHUNK_SIZE = 100;
+const WORKSPACE_VIEW_SUBTREES_BATCH_CHUNK_SIZE = 50;
 
 export async function getAppOutline(workspaceId: string): Promise<AppOutlineResponse> {
   const url = `/api/workspace/${workspaceId}/view/${workspaceId}?depth=2`;
@@ -25,15 +25,11 @@ export async function getViews(workspaceId: string, viewIds: string[], depth: nu
   if (viewIds.length === 0) return [];
 
   const url = `/api/workspace/${workspaceId}/views`;
-  const views: View[] = [];
+  const viewChunks = await Promise.all(
+    chunkViewIds(viewIds, WORKSPACE_VIEW_SUBTREES_BATCH_CHUNK_SIZE).map((chunk) => getViewsChunk(url, chunk, depth))
+  );
 
-  for (const chunk of chunkViewIds(viewIds, WORKSPACE_VIEW_SUBTREES_BATCH_CHUNK_SIZE)) {
-    const data = await getViewsChunk(url, chunk, depth);
-
-    views.push(...data);
-  }
-
-  return views;
+  return viewChunks.flat();
 }
 
 async function getViewsChunk(url: string, viewIds: string[], depth: number): Promise<View[]> {
@@ -48,13 +44,11 @@ async function getViewsChunk(url: string, viewIds: string[], depth: number): Pro
       throw error;
     }
 
-    const views: View[] = [];
+    const viewChunks = await Promise.all(
+      workspaceViewSubtreesGetChunks(url, viewIds, depth).map((chunk) => getViewsByGet(url, chunk, depth))
+    );
 
-    for (const chunk of workspaceViewSubtreesGetChunks(url, viewIds, depth)) {
-      views.push(...(await getViewsByGet(url, chunk, depth)));
-    }
-
-    return views;
+    return viewChunks.flat();
   }
 }
 

--- a/src/components/app/app.hooks.tsx
+++ b/src/components/app/app.hooks.tsx
@@ -328,6 +328,17 @@ export function useMarkViewChildrenStale() {
   return context.markViewChildrenStale;
 }
 
+/** Revalidate the root sidebar outline and refresh currently expanded sidebar subtrees. */
+export function useRevalidateSidebarOutline() {
+  const context = useContext(AppOutlineContext);
+
+  if (!context) {
+    throw new Error('useRevalidateSidebarOutline must be used within an AppProvider');
+  }
+
+  return context.revalidateSidebarOutline;
+}
+
 /** Memoized `{ loadFavoriteViews, favoriteViews }`. Only re-renders when favorites change. */
 export function useAppFavorites() {
   const context = useContext(AppOutlineContext);

--- a/src/components/app/contexts/AppOutlineContext.ts
+++ b/src/components/app/contexts/AppOutlineContext.ts
@@ -1,6 +1,7 @@
 import { createContext } from 'react';
 
 import { DatabaseRelations, MentionablePerson, UIVariant, View } from '@/application/types';
+import type { SidebarOutlineRevalidationResult } from '@/components/app/outline/sidebarRevalidation';
 
 /**
  * Outline / sidebar state context — changes on folder mutations, not on page navigation.
@@ -47,6 +48,8 @@ export interface AppOutlineContextType {
   loadViewChildrenBatch?: (viewIds: string[]) => Promise<View[]>;
   /** Mark a view's cached children as stale so the next access re-fetches them. */
   markViewChildrenStale?: (viewId: string) => void;
+  /** Revalidate the root sidebar outline and refresh currently expanded sidebar subtrees. */
+  revalidateSidebarOutline?: (expandedViewIds?: string[]) => Promise<SidebarOutlineRevalidationResult>;
   /** Fetch the user's favorite views. */
   loadFavoriteViews?: () => Promise<View[] | undefined>;
   /** Fetch the user's recently visited views. */

--- a/src/components/app/hooks/__tests__/useWorkspaceData.sidebarRevalidation.test.tsx
+++ b/src/components/app/hooks/__tests__/useWorkspaceData.sidebarRevalidation.test.tsx
@@ -153,6 +153,35 @@ describe('useWorkspaceData sidebar outline revalidation', () => {
     expect(ViewService.invalidateCache).not.toHaveBeenCalled();
   });
 
+  it('skips revalidation when folder rid is missing and the root outline is unchanged', async () => {
+    const eventEmitter = new EventEmitter();
+    const root = createView('space-id', {
+      has_children: true,
+    });
+
+    (ViewService.getOutline as jest.Mock)
+      .mockResolvedValueOnce({ outline: [root] })
+      .mockResolvedValueOnce({ outline: [createView('space-id', { has_children: true })] });
+
+    const { result } = renderHook(() => useWorkspaceData(), {
+      wrapper: createWrapper(eventEmitter),
+    });
+
+    await waitFor(() => {
+      expect(result.current.outline?.map((view) => view.view_id)).toEqual(['space-id']);
+    });
+
+    let revalidationResult: string | undefined;
+
+    await act(async () => {
+      revalidationResult = await result.current.revalidateSidebarOutline?.(['space-id']);
+    });
+
+    expect(revalidationResult).toBe('unchanged');
+    expect(ViewService.getMultiple).not.toHaveBeenCalled();
+    expect(ViewService.invalidateCache).not.toHaveBeenCalled();
+  });
+
   it('marks cached subtrees stale and refreshes only 20 expanded roots', async () => {
     const eventEmitter = new EventEmitter();
     const root = createView('space-id', {

--- a/src/components/app/hooks/__tests__/useWorkspaceData.sidebarRevalidation.test.tsx
+++ b/src/components/app/hooks/__tests__/useWorkspaceData.sidebarRevalidation.test.tsx
@@ -114,6 +114,21 @@ function createWrapper(eventEmitter: EventEmitter, getWorkspaceId = () => worksp
   };
 }
 
+function createDeferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+
+  return {
+    promise,
+    reject,
+    resolve,
+  };
+}
+
 describe('useWorkspaceData sidebar outline revalidation', () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -426,6 +441,70 @@ describe('useWorkspaceData sidebar outline revalidation', () => {
 
     expect(revalidationResult).toBe('changed');
     expect(result.current.outline?.[0]?.name).toBe('workspace b new');
+  });
+
+  it('ignores stale revalidation results after the workspace changes', async () => {
+    const eventEmitter = new EventEmitter();
+    const workspaceA = 'workspace-a';
+    const workspaceB = 'workspace-b';
+    const staleWorkspaceAResponse = createDeferred<{ outline: View[]; folderRid: string }>();
+    let activeWorkspaceId = workspaceA;
+    let workspaceAOutlineCalls = 0;
+
+    (ViewService.getOutline as jest.Mock).mockImplementation(async (requestedWorkspaceId: string) => {
+      if (requestedWorkspaceId === workspaceA) {
+        workspaceAOutlineCalls += 1;
+
+        if (workspaceAOutlineCalls === 1) {
+          return {
+            outline: [createView('space-a', { name: 'workspace a' })],
+            folderRid: '1-1',
+          };
+        }
+
+        return staleWorkspaceAResponse.promise;
+      }
+
+      return {
+        outline: [createView('space-b', { name: 'workspace b' })],
+        folderRid: '1-1',
+      };
+    });
+
+    const { result, rerender } = renderHook(() => useWorkspaceData(), {
+      wrapper: createWrapper(eventEmitter, () => activeWorkspaceId),
+    });
+
+    await waitFor(() => {
+      expect(result.current.outline?.[0]?.name).toBe('workspace a');
+    });
+
+    let revalidationPromise: Promise<string | undefined> = Promise.resolve(undefined);
+
+    act(() => {
+      revalidationPromise = result.current.revalidateSidebarOutline?.([]) ?? Promise.resolve(undefined);
+    });
+
+    activeWorkspaceId = workspaceB;
+    rerender();
+
+    await waitFor(() => {
+      expect(result.current.outline?.[0]?.name).toBe('workspace b');
+    });
+
+    let revalidationResult: string | undefined;
+
+    await act(async () => {
+      staleWorkspaceAResponse.resolve({
+        outline: [createView('space-a', { name: 'stale workspace a' })],
+        folderRid: '2-1',
+      });
+      revalidationResult = await revalidationPromise;
+    });
+
+    expect(revalidationResult).toBe('unchanged');
+    expect(result.current.outline?.[0]?.name).toBe('workspace b');
+    expect(result.current.outline?.[0]?.view_id).toBe('space-b');
   });
 
   it('invalidates loaded subtree caches that are dropped by a changed root outline', async () => {

--- a/src/components/app/hooks/__tests__/useWorkspaceData.sidebarRevalidation.test.tsx
+++ b/src/components/app/hooks/__tests__/useWorkspaceData.sidebarRevalidation.test.tsx
@@ -391,6 +391,56 @@ describe('useWorkspaceData sidebar outline revalidation', () => {
     expect(result.current.outline?.[0]?.name).toBe('server space');
   });
 
+  it('repairs relaxed outline patches with same-rid root revalidation', async () => {
+    const eventEmitter = new EventEmitter();
+    const root = createView('space-id', {
+      children: [],
+      has_children: true,
+    });
+    const childA = createView('child-a');
+    const childB = createView('child-b');
+    const serverRoot = createView('space-id', {
+      children: [childA, childB],
+      has_children: true,
+    });
+
+    (ViewService.getOutline as jest.Mock)
+      .mockResolvedValueOnce({ outline: [root], folderRid: '1-1' })
+      .mockResolvedValueOnce({ outline: [serverRoot], folderRid: '2-1' });
+
+    const { result } = renderHook(() => useWorkspaceData(), {
+      wrapper: createWrapper(eventEmitter),
+    });
+
+    await waitFor(() => {
+      expect(result.current.outline?.[0]?.view_id).toBe('space-id');
+    });
+
+    await act(async () => {
+      eventEmitter.emit(APP_EVENTS.FOLDER_OUTLINE_CHANGED, {
+        folderRid: '2-1',
+        outlineDiffJson: JSON.stringify([
+          {
+            op: 'add',
+            path: '/outline/0/children/1',
+            value: childB,
+          },
+        ]),
+      });
+    });
+
+    expect(result.current.outline?.[0]?.children.map((view) => view.view_id)).toEqual(['child-b']);
+
+    let revalidationResult: string | undefined;
+
+    await act(async () => {
+      revalidationResult = await result.current.revalidateSidebarOutline?.([]);
+    });
+
+    expect(revalidationResult).toBe('changed');
+    expect(result.current.outline?.[0]?.children.map((view) => view.view_id)).toEqual(['child-a', 'child-b']);
+  });
+
   it('resets root folder rid state when the workspace changes', async () => {
     const eventEmitter = new EventEmitter();
     const workspaceA = 'workspace-a';

--- a/src/components/app/hooks/__tests__/useWorkspaceData.sidebarRevalidation.test.tsx
+++ b/src/components/app/hooks/__tests__/useWorkspaceData.sidebarRevalidation.test.tsx
@@ -1,0 +1,518 @@
+import EventEmitter from 'events';
+
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { type ReactNode } from 'react';
+import { MemoryRouter } from 'react-router-dom';
+
+import { APP_EVENTS } from '@/application/constants';
+import { AccessService, ViewService } from '@/application/services/domains';
+import { Role, View, ViewLayout } from '@/application/types';
+import { AuthInternalContext, AuthInternalContextType } from '@/components/app/contexts/AuthInternalContext';
+import { SyncInternalContext, SyncInternalContextType } from '@/components/app/contexts/SyncInternalContext';
+import { MAX_SIDEBAR_OUTLINE_REVALIDATION_EXPANDED_IDS } from '@/components/app/outline/sidebarRevalidation';
+
+import { useWorkspaceData } from '../useWorkspaceData';
+
+jest.mock('lodash-es', () => ({
+  sortBy: (items: Record<string, unknown>[], key: string) =>
+    [...items].sort((a, b) => String(a[key] ?? '').localeCompare(String(b[key] ?? ''))),
+  uniqBy: (items: Record<string, unknown>[], key: string) => {
+    const seen = new Set<unknown>();
+
+    return items.filter((item) => {
+      const value = item[key];
+
+      if (seen.has(value)) return false;
+      seen.add(value);
+      return true;
+    });
+  },
+}));
+
+jest.mock('@/application/services/domains', () => ({
+  AccessService: {
+    getShareWithMe: jest.fn(),
+  },
+  ViewService: {
+    get: jest.fn(),
+    getDatabaseRelations: jest.fn(),
+    getMultiple: jest.fn(),
+    getOutline: jest.fn(),
+    getTrash: jest.fn(),
+    invalidateCache: jest.fn(),
+  },
+  WorkspaceService: {
+    getMentionableUsers: jest.fn(),
+  },
+}));
+
+const workspaceId = 'workspace-id';
+
+const createView = (viewId: string, overrides: Partial<View> = {}): View => ({
+  view_id: viewId,
+  name: overrides.name ?? viewId,
+  icon: overrides.icon ?? null,
+  layout: overrides.layout ?? ViewLayout.Document,
+  extra: overrides.extra ?? null,
+  children: overrides.children ?? [],
+  has_children: overrides.has_children,
+  is_published: overrides.is_published ?? false,
+  is_private: overrides.is_private ?? false,
+  ...overrides,
+});
+
+function createWrapper(eventEmitter: EventEmitter, getWorkspaceId = () => workspaceId) {
+  const authContext: AuthInternalContextType = {
+    currentWorkspaceId: getWorkspaceId(),
+    isAuthenticated: true,
+    onChangeWorkspace: jest.fn(),
+    userWorkspaceInfo: {
+      userId: 'user-id',
+      selectedWorkspace: {
+        id: getWorkspaceId(),
+        databaseStorageId: 'database-storage-id',
+        role: Role.Owner,
+      },
+    } as AuthInternalContextType['userWorkspaceInfo'],
+  };
+
+  const syncContext = {
+    eventEmitter,
+    awarenessMap: {},
+    broadcastChannel: {},
+    flushAllSync: jest.fn(),
+    registerSyncContext: jest.fn(),
+    revertCollabVersion: jest.fn(),
+    scheduleDeferredCleanup: jest.fn(),
+    syncAllToServer: jest.fn(),
+    webSocket: {},
+  } as unknown as SyncInternalContextType;
+
+  return function Wrapper({ children }: { children: ReactNode }) {
+    const activeWorkspaceId = getWorkspaceId();
+    const activeAuthContext = {
+      ...authContext,
+      currentWorkspaceId: activeWorkspaceId,
+      userWorkspaceInfo: authContext.userWorkspaceInfo
+        ? {
+            ...authContext.userWorkspaceInfo,
+            selectedWorkspace: {
+              ...authContext.userWorkspaceInfo.selectedWorkspace,
+              id: activeWorkspaceId,
+            },
+          }
+        : authContext.userWorkspaceInfo,
+    };
+
+    return (
+      <MemoryRouter future={{ v7_relativeSplatPath: true, v7_startTransition: true }}>
+        <AuthInternalContext.Provider value={activeAuthContext}>
+          <SyncInternalContext.Provider value={syncContext}>{children}</SyncInternalContext.Provider>
+        </AuthInternalContext.Provider>
+      </MemoryRouter>
+    );
+  };
+}
+
+describe('useWorkspaceData sidebar outline revalidation', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    (AccessService.getShareWithMe as jest.Mock).mockResolvedValue(null);
+    (ViewService.getDatabaseRelations as jest.Mock).mockResolvedValue({});
+    (ViewService.getMultiple as jest.Mock).mockResolvedValue([]);
+    (ViewService.getTrash as jest.Mock).mockResolvedValue([]);
+  });
+
+  it('skips revalidation when the root folder rid is unchanged', async () => {
+    const eventEmitter = new EventEmitter();
+    const root = createView('space-id', {
+      has_children: true,
+    });
+
+    (ViewService.getOutline as jest.Mock)
+      .mockResolvedValueOnce({ outline: [root], folderRid: '1-1' })
+      .mockResolvedValueOnce({ outline: [root], folderRid: '1-1' });
+
+    const { result } = renderHook(() => useWorkspaceData(), {
+      wrapper: createWrapper(eventEmitter),
+    });
+
+    await waitFor(() => {
+      expect(result.current.outline?.map((view) => view.view_id)).toEqual(['space-id']);
+    });
+
+    let revalidationResult: string | undefined;
+
+    await act(async () => {
+      revalidationResult = await result.current.revalidateSidebarOutline?.(['space-id']);
+    });
+
+    expect(revalidationResult).toBe('unchanged');
+    expect(ViewService.getMultiple).not.toHaveBeenCalled();
+    expect(ViewService.invalidateCache).not.toHaveBeenCalled();
+  });
+
+  it('marks cached subtrees stale and refreshes only 20 expanded roots', async () => {
+    const eventEmitter = new EventEmitter();
+    const root = createView('space-id', {
+      has_children: true,
+    });
+
+    (ViewService.getOutline as jest.Mock)
+      .mockResolvedValueOnce({ outline: [root], folderRid: '1-1' })
+      .mockResolvedValueOnce({ outline: [root], folderRid: '2-1' });
+
+    (ViewService.getMultiple as jest.Mock)
+      .mockResolvedValueOnce([
+        createView('space-id', {
+          children: [createView('child-id')],
+          has_children: true,
+        }),
+      ])
+      .mockResolvedValueOnce([]);
+
+    const { result } = renderHook(() => useWorkspaceData(), {
+      wrapper: createWrapper(eventEmitter),
+    });
+
+    await waitFor(() => {
+      expect(result.current.outline?.map((view) => view.view_id)).toEqual(['space-id']);
+    });
+
+    await act(async () => {
+      await result.current.loadViewChildrenBatch?.(['space-id']);
+    });
+
+    await waitFor(() => {
+      expect(result.current.loadedViewIds?.has('space-id')).toBe(true);
+    });
+
+    const expandedViewIds = [...Array.from({ length: 25 }, (_, index) => `view-${index}`), '', 'view-0'];
+
+    let revalidationResult: string | undefined;
+
+    await act(async () => {
+      revalidationResult = await result.current.revalidateSidebarOutline?.(expandedViewIds);
+    });
+
+    expect(revalidationResult).toBe('changed');
+    expect(ViewService.invalidateCache).toHaveBeenCalledWith(workspaceId, 'space-id');
+    expect(ViewService.getMultiple).toHaveBeenLastCalledWith(
+      workspaceId,
+      Array.from({ length: MAX_SIDEBAR_OUTLINE_REVALIDATION_EXPANDED_IDS }, (_, index) => `view-${index}`),
+      1
+    );
+  });
+
+  it('does not let lazy child folder rid hide unapplied root outline changes', async () => {
+    const eventEmitter = new EventEmitter();
+    const root = createView('space-id', {
+      has_children: true,
+      name: 'old space',
+    });
+    const updatedRoot = createView('space-id', {
+      has_children: true,
+      name: 'new space',
+    });
+
+    (ViewService.getOutline as jest.Mock)
+      .mockResolvedValueOnce({ outline: [root], folderRid: '1-1' })
+      .mockResolvedValueOnce({ outline: [updatedRoot], folderRid: '2-1' });
+
+    (ViewService.getMultiple as jest.Mock).mockResolvedValueOnce([
+      createView('space-id', {
+        children: [createView('child-id')],
+        folder_rid: '2-1',
+        has_children: true,
+      }),
+    ]);
+
+    const { result } = renderHook(() => useWorkspaceData(), {
+      wrapper: createWrapper(eventEmitter),
+    });
+
+    await waitFor(() => {
+      expect(result.current.outline?.[0]?.name).toBe('old space');
+    });
+
+    await act(async () => {
+      await result.current.loadViewChildrenBatch?.(['space-id']);
+    });
+
+    let revalidationResult: string | undefined;
+
+    await act(async () => {
+      revalidationResult = await result.current.revalidateSidebarOutline?.([]);
+    });
+
+    expect(revalidationResult).toBe('changed');
+    expect(result.current.outline?.[0]?.name).toBe('new space');
+  });
+
+  it('does not let granular folder changes hide unapplied root outline changes', async () => {
+    const eventEmitter = new EventEmitter();
+    const root = createView('space-id', {
+      has_children: true,
+      name: 'old space',
+    });
+    const granularRoot = createView('space-id', {
+      has_children: true,
+      name: 'granular space',
+    });
+    const serverRoot = createView('space-id', {
+      has_children: true,
+      name: 'server space',
+    });
+
+    (ViewService.getOutline as jest.Mock)
+      .mockResolvedValueOnce({ outline: [root], folderRid: '1-1' })
+      .mockResolvedValueOnce({ outline: [serverRoot], folderRid: '2-1' });
+
+    const { result } = renderHook(() => useWorkspaceData(), {
+      wrapper: createWrapper(eventEmitter),
+    });
+
+    await waitFor(() => {
+      expect(result.current.outline?.[0]?.name).toBe('old space');
+    });
+
+    await act(async () => {
+      eventEmitter.emit(APP_EVENTS.FOLDER_VIEW_CHANGED, {
+        changeType: 0,
+        folderRid: '2-1',
+        viewJson: JSON.stringify(granularRoot),
+      });
+    });
+
+    expect(result.current.outline?.[0]?.name).toBe('granular space');
+
+    let revalidationResult: string | undefined;
+
+    await act(async () => {
+      revalidationResult = await result.current.revalidateSidebarOutline?.([]);
+    });
+
+    expect(revalidationResult).toBe('changed');
+    expect(result.current.outline?.[0]?.name).toBe('server space');
+  });
+
+  it('does not let skipped non-visual outline diffs hide unapplied root outline changes', async () => {
+    const eventEmitter = new EventEmitter();
+    const root = createView('space-id', {
+      has_children: true,
+      last_edited_time: 1,
+      name: 'old space',
+    });
+    const serverRoot = createView('space-id', {
+      has_children: true,
+      last_edited_time: 2,
+      name: 'server space',
+    });
+
+    (ViewService.getOutline as jest.Mock)
+      .mockResolvedValueOnce({ outline: [root], folderRid: '1-1' })
+      .mockResolvedValueOnce({ outline: [serverRoot], folderRid: '2-1' });
+
+    const { result } = renderHook(() => useWorkspaceData(), {
+      wrapper: createWrapper(eventEmitter),
+    });
+
+    await waitFor(() => {
+      expect(result.current.outline?.[0]?.name).toBe('old space');
+    });
+
+    await act(async () => {
+      eventEmitter.emit(APP_EVENTS.FOLDER_OUTLINE_CHANGED, {
+        folderRid: '2-1',
+        outlineDiffJson: JSON.stringify([
+          {
+            op: 'replace',
+            path: '/outline/0/last_edited_time',
+            value: 2,
+          },
+        ]),
+      });
+    });
+
+    expect(result.current.outline?.[0]?.name).toBe('old space');
+
+    let revalidationResult: string | undefined;
+
+    await act(async () => {
+      revalidationResult = await result.current.revalidateSidebarOutline?.([]);
+    });
+
+    expect(revalidationResult).toBe('changed');
+    expect(result.current.outline?.[0]?.name).toBe('server space');
+  });
+
+  it('resets root folder rid state when the workspace changes', async () => {
+    const eventEmitter = new EventEmitter();
+    const workspaceA = 'workspace-a';
+    const workspaceB = 'workspace-b';
+    let activeWorkspaceId = workspaceA;
+    let workspaceBOutlineCalls = 0;
+
+    (ViewService.getOutline as jest.Mock).mockImplementation(async (requestedWorkspaceId: string) => {
+      if (requestedWorkspaceId === workspaceA) {
+        return {
+          outline: [createView('space-a', { name: 'workspace a' })],
+          folderRid: '9-1',
+        };
+      }
+
+      workspaceBOutlineCalls += 1;
+
+      return {
+        outline: [
+          createView('space-b', {
+            name: workspaceBOutlineCalls < 3 ? 'workspace b old' : 'workspace b new',
+          }),
+        ],
+        folderRid: workspaceBOutlineCalls < 3 ? '1-1' : '2-1',
+      };
+    });
+
+    const { result, rerender } = renderHook(() => useWorkspaceData(), {
+      wrapper: createWrapper(eventEmitter, () => activeWorkspaceId),
+    });
+
+    await waitFor(() => {
+      expect(result.current.outline?.[0]?.name).toBe('workspace a');
+    });
+
+    activeWorkspaceId = workspaceB;
+    rerender();
+
+    await waitFor(() => {
+      expect(result.current.outline?.[0]?.name).toBe('workspace b old');
+    });
+
+    let revalidationResult: string | undefined;
+
+    await act(async () => {
+      revalidationResult = await result.current.revalidateSidebarOutline?.([]);
+    });
+
+    expect(revalidationResult).toBe('changed');
+    expect(result.current.outline?.[0]?.name).toBe('workspace b new');
+  });
+
+  it('invalidates loaded subtree caches that are dropped by a changed root outline', async () => {
+    const eventEmitter = new EventEmitter();
+    const root = createView('space-id', {
+      has_children: true,
+    });
+    const emptyRoot = createView('space-id', {
+      has_children: false,
+    });
+
+    (ViewService.getOutline as jest.Mock)
+      .mockResolvedValueOnce({ outline: [root], folderRid: '1-1' })
+      .mockResolvedValueOnce({ outline: [emptyRoot], folderRid: '2-1' });
+
+    (ViewService.getMultiple as jest.Mock)
+      .mockResolvedValueOnce([
+        createView('space-id', {
+          children: [
+            createView('child-id', {
+              has_children: true,
+            }),
+          ],
+          has_children: true,
+        }),
+      ])
+      .mockResolvedValueOnce([
+        createView('child-id', {
+          children: [createView('grandchild-id')],
+          has_children: true,
+        }),
+      ]);
+
+    const { result } = renderHook(() => useWorkspaceData(), {
+      wrapper: createWrapper(eventEmitter),
+    });
+
+    await waitFor(() => {
+      expect(result.current.outline?.map((view) => view.view_id)).toEqual(['space-id']);
+    });
+
+    await act(async () => {
+      await result.current.loadViewChildrenBatch?.(['space-id']);
+    });
+
+    await act(async () => {
+      await result.current.loadViewChildrenBatch?.(['child-id']);
+    });
+
+    await waitFor(() => {
+      expect(result.current.loadedViewIds?.has('space-id')).toBe(true);
+      expect(result.current.loadedViewIds?.has('child-id')).toBe(true);
+    });
+
+    (ViewService.invalidateCache as jest.Mock).mockClear();
+
+    await act(async () => {
+      await result.current.revalidateSidebarOutline?.([]);
+    });
+
+    expect(ViewService.invalidateCache).toHaveBeenCalledWith(workspaceId, 'space-id');
+    expect(ViewService.invalidateCache).toHaveBeenCalledWith(workspaceId, 'child-id');
+  });
+
+  it('keeps root revalidation retryable when expanded refresh fails', async () => {
+    const eventEmitter = new EventEmitter();
+    const refreshError = new Error('subtree refresh failed');
+    const root = createView('space-id', {
+      has_children: true,
+    });
+    const updatedRoot = createView('space-id', {
+      has_children: true,
+      name: 'new space',
+    });
+
+    (ViewService.getOutline as jest.Mock)
+      .mockResolvedValueOnce({ outline: [root], folderRid: '1-1' })
+      .mockResolvedValueOnce({ outline: [updatedRoot], folderRid: '2-1' })
+      .mockResolvedValueOnce({ outline: [updatedRoot], folderRid: '2-1' });
+
+    (ViewService.getMultiple as jest.Mock).mockRejectedValueOnce(refreshError).mockResolvedValueOnce([
+      createView('space-id', {
+        children: [createView('child-id')],
+        folder_rid: '2-1',
+        has_children: true,
+      }),
+    ]);
+
+    const { result } = renderHook(() => useWorkspaceData(), {
+      wrapper: createWrapper(eventEmitter),
+    });
+
+    await waitFor(() => {
+      expect(result.current.outline?.map((view) => view.view_id)).toEqual(['space-id']);
+    });
+
+    let thrown: unknown;
+
+    await act(async () => {
+      try {
+        await result.current.revalidateSidebarOutline?.(['space-id']);
+      } catch (error) {
+        thrown = error;
+      }
+    });
+
+    expect(thrown).toBe(refreshError);
+
+    let revalidationResult: string | undefined;
+
+    await act(async () => {
+      revalidationResult = await result.current.revalidateSidebarOutline?.(['space-id']);
+    });
+
+    expect(revalidationResult).toBe('changed');
+    expect(ViewService.getMultiple).toHaveBeenCalledTimes(2);
+    expect(ViewService.getMultiple).toHaveBeenLastCalledWith(workspaceId, ['space-id'], 1);
+  });
+});

--- a/src/components/app/hooks/__tests__/useWorkspaceData.trashRefresh.test.tsx
+++ b/src/components/app/hooks/__tests__/useWorkspaceData.trashRefresh.test.tsx
@@ -159,6 +159,49 @@ describe('useWorkspaceData trash refresh', () => {
     });
   });
 
+  it('refreshes stale trash state when polling applies a changed outline', async () => {
+    const eventEmitter = new EventEmitter();
+    const restoredView = createView(restoredViewId);
+    let trashResponse: View[] = [restoredView];
+
+    (ViewService.getOutline as jest.Mock)
+      .mockResolvedValueOnce({
+        outline: [],
+        folderRid: '1-1',
+      })
+      .mockResolvedValueOnce({
+        outline: [createView('space-id')],
+        folderRid: '2-1',
+      });
+
+    (ViewService.getTrash as jest.Mock).mockImplementation(async () => trashResponse);
+
+    const { result } = renderHook(() => useWorkspaceData(), {
+      wrapper: createWrapper(eventEmitter),
+    });
+
+    await waitFor(() => {
+      expect(result.current.trashList?.map((view) => view.view_id)).toEqual([restoredViewId]);
+    });
+
+    const initialTrashRequestCount = (ViewService.getTrash as jest.Mock).mock.calls.length;
+
+    trashResponse = [];
+
+    let revalidationResult: string | undefined;
+
+    await act(async () => {
+      revalidationResult = await result.current.revalidateSidebarOutline?.([]);
+    });
+
+    expect(revalidationResult).toBe('changed');
+
+    await waitFor(() => {
+      expect(ViewService.getTrash).toHaveBeenCalledTimes(initialTrashRequestCount + 1);
+      expect(result.current.trashList).toEqual([]);
+    });
+  });
+
   it('ignores stale trash refresh responses from overlapping folder notifications', async () => {
     const eventEmitter = new EventEmitter();
     const restoredView = createView(restoredViewId);

--- a/src/components/app/hooks/useWorkspaceData.ts
+++ b/src/components/app/hooks/useWorkspaceData.ts
@@ -880,6 +880,7 @@ export function useWorkspaceData() {
       const baseOutline = stableOutlineRef.current.filter((view) => !view.extra?.is_hidden_space);
       const baseDocument = { outline: baseOutline };
       let patchedOutline: View[] | null = null;
+      let usedRelaxedPatch = false;
 
       const firstOp = patch[0];
       const fastReplace = patch.length === 1 && firstOp?.op === 'replace' && firstOp?.path === '/outline';
@@ -911,6 +912,7 @@ export function useWorkspaceData() {
 
             if (Array.isArray(nextOutline)) {
               patchedOutline = nextOutline as View[];
+              usedRelaxedPatch = true;
             }
           } catch (retryError) {
             Log.warn('[Outline] [FolderOutlineChanged] Relaxed patch also failed, reloading outline', retryError);
@@ -939,7 +941,11 @@ export function useWorkspaceData() {
 
       const mergedOutline = replaceOutlinePreservingChildren(nextOutline);
 
-      updateAppliedRootOutlineSnapshot(patchRid, nextOutline);
+      if (usedRelaxedPatch) {
+        updateLastFolderRid(patchRid);
+      } else {
+        updateAppliedRootOutlineSnapshot(patchRid, nextOutline);
+      }
 
       if (eventEmitter) {
         eventEmitter.emit(APP_EVENTS.OUTLINE_LOADED, mergedOutline || []);

--- a/src/components/app/hooks/useWorkspaceData.ts
+++ b/src/components/app/hooks/useWorkspaceData.ts
@@ -191,6 +191,8 @@ export function useWorkspaceData() {
   const lastFolderRidRef = useRef<FolderRid | null>(null);
   const lastAppliedRootOutlineRidRef = useRef<FolderRid | null>(null);
   const lastAppliedRootOutlineFingerprintRef = useRef<string | null>(null);
+  const currentWorkspaceIdRef = useRef(currentWorkspaceId);
+  const workspaceRevisionRef = useRef(0);
   const [favoriteViews, setFavoriteViews] = useState<View[]>();
   const [recentViews, setRecentViews] = useState<View[]>();
   const [trashList, setTrashList] = useState<View[]>();
@@ -200,6 +202,11 @@ export function useWorkspaceData() {
   const trashRequestSeqRef = useRef(0);
 
   const mentionableUsersRef = useRef<MentionablePerson[]>([]);
+
+  if (currentWorkspaceIdRef.current !== currentWorkspaceId) {
+    currentWorkspaceIdRef.current = currentWorkspaceId;
+    workspaceRevisionRef.current += 1;
+  }
 
   // Lazy-loading state: tracks which views have had their children fetched.
   // Uses a stable ref + revision counter to avoid creating new Set references
@@ -264,6 +271,10 @@ export function useWorkspaceData() {
     },
     [updateAppliedRootOutlineRid]
   );
+
+  const isStaleWorkspaceRequest = useCallback((workspaceId: string, workspaceRevision: number) => {
+    return currentWorkspaceIdRef.current !== workspaceId || workspaceRevisionRef.current !== workspaceRevision;
+  }, []);
 
   const loadOutline = useCallback(
     async (workspaceId: string, force = true) => {
@@ -441,10 +452,13 @@ export function useWorkspaceData() {
     async (viewId: string): Promise<View[]> => {
       if (!currentWorkspaceId) return [];
 
+      const workspaceId = currentWorkspaceId;
+      const workspaceRevision = workspaceRevisionRef.current;
+
       // Dedup concurrent fetches
       if (loadingViewIdsRef.current.has(viewId)) {
         Log.debug('[Outline] [loadViewChildren] skip in-flight request', {
-          workspaceId: currentWorkspaceId,
+          workspaceId,
           viewId,
         });
         return [];
@@ -454,16 +468,19 @@ export function useWorkspaceData() {
 
       try {
         Log.debug('[Outline] [loadViewChildren] requesting single subtree', {
-          workspaceId: currentWorkspaceId,
+          workspaceId,
           viewId,
           depth: 1,
         });
 
-        const viewData = await ViewService.get(currentWorkspaceId, viewId);
+        const viewData = await ViewService.get(workspaceId, viewId);
+        const children = viewData?.children ?? [];
+
+        if (isStaleWorkspaceRequest(workspaceId, workspaceRevision)) {
+          return children;
+        }
 
         updateLastFolderRid(parseFolderRid(viewData?.folder_rid));
-
-        const children = viewData?.children ?? [];
 
         // Merge into outline
         const nextOutline = mergeChildrenIntoOutline(stableOutlineRef.current, viewId, children, viewData?.has_children);
@@ -483,19 +500,27 @@ export function useWorkspaceData() {
 
         return children;
       } catch (e) {
+        if (isStaleWorkspaceRequest(workspaceId, workspaceRevision)) {
+          return [];
+        }
+
         Log.error('[Outline] [loadViewChildren] Failed to load children for', viewId, e);
         return [];
       } finally {
-        loadingViewIdsRef.current.delete(viewId);
+        if (!isStaleWorkspaceRequest(workspaceId, workspaceRevision)) {
+          loadingViewIdsRef.current.delete(viewId);
+        }
       }
     },
-    [currentWorkspaceId, stableOutlineRef, eventEmitter, updateLastFolderRid]
+    [currentWorkspaceId, stableOutlineRef, eventEmitter, isStaleWorkspaceRequest, updateLastFolderRid]
   );
 
   const loadViewChildrenBatch = useCallback(
     async (viewIds: string[]): Promise<View[]> => {
       if (!currentWorkspaceId || viewIds.length === 0) return [];
 
+      const workspaceId = currentWorkspaceId;
+      const workspaceRevision = workspaceRevisionRef.current;
       const uniqueIds = Array.from(new Set(viewIds)).filter((viewId) => !loadingViewIdsRef.current.has(viewId));
 
       if (uniqueIds.length === 0) return [];
@@ -513,12 +538,16 @@ export function useWorkspaceData() {
         });
 
         Log.debug('[Outline] [loadViewChildrenBatch] requesting subtree views', {
-          workspaceId: currentWorkspaceId,
+          workspaceId,
           depth: 1,
           requestViewMeta,
         });
 
-        const views = await ViewService.getMultiple(currentWorkspaceId, uniqueIds, 1);
+        const views = await ViewService.getMultiple(workspaceId, uniqueIds, 1);
+
+        if (isStaleWorkspaceRequest(workspaceId, workspaceRevision)) {
+          return views;
+        }
 
         views.forEach((view) => {
           updateLastFolderRid(parseFolderRid(view?.folder_rid));
@@ -558,13 +587,19 @@ export function useWorkspaceData() {
 
         return views;
       } catch (e) {
+        if (isStaleWorkspaceRequest(workspaceId, workspaceRevision)) {
+          return [];
+        }
+
         Log.error('[Outline] [loadViewChildrenBatch] Failed to load children for', uniqueIds, e);
         throw e;
       } finally {
-        uniqueIds.forEach((viewId) => loadingViewIdsRef.current.delete(viewId));
+        if (!isStaleWorkspaceRequest(workspaceId, workspaceRevision)) {
+          uniqueIds.forEach((viewId) => loadingViewIdsRef.current.delete(viewId));
+        }
       }
     },
-    [currentWorkspaceId, stableOutlineRef, eventEmitter, updateLastFolderRid]
+    [currentWorkspaceId, stableOutlineRef, eventEmitter, isStaleWorkspaceRequest, updateLastFolderRid]
   );
 
   const markViewChildrenStale = useCallback(
@@ -671,10 +706,18 @@ export function useWorkspaceData() {
       if (!currentWorkspaceId) return 'unchanged';
 
       const workspaceId = currentWorkspaceId;
+      const workspaceRevision = workspaceRevisionRef.current;
       const res = await ViewService.getOutline(workspaceId);
 
       if (!res) {
         throw new Error('App outline not found');
+      }
+
+      if (isStaleWorkspaceRequest(workspaceId, workspaceRevision)) {
+        Log.debug('[Outline] [periodic-revalidate] skipped stale workspace response', {
+          workspaceId,
+        });
+        return 'unchanged';
       }
 
       const nextFolderRid = parseFolderRid(res.folderRid);
@@ -726,6 +769,14 @@ export function useWorkspaceData() {
       try {
         await loadViewChildrenBatch(refreshViewIds);
       } catch (error) {
+        if (isStaleWorkspaceRequest(workspaceId, workspaceRevision)) {
+          Log.debug('[Outline] [periodic-revalidate] skipped stale expanded refresh error', {
+            workspaceId,
+            refreshViewIds,
+          });
+          return 'unchanged';
+        }
+
         Log.warn('[Outline] [periodic-revalidate] failed to refresh expanded sidebar roots', {
           workspaceId,
           refreshViewIds,
@@ -734,12 +785,21 @@ export function useWorkspaceData() {
         throw error;
       }
 
+      if (isStaleWorkspaceRequest(workspaceId, workspaceRevision)) {
+        Log.debug('[Outline] [periodic-revalidate] skipped stale expanded refresh response', {
+          workspaceId,
+          refreshViewIds,
+        });
+        return 'unchanged';
+      }
+
       updateAppliedRootOutlineSnapshot(nextFolderRid, nextOutline);
       return 'changed';
     },
     [
       currentWorkspaceId,
       eventEmitter,
+      isStaleWorkspaceRequest,
       loadViewChildrenBatch,
       markCachedFolderSubtreesStale,
       replaceOutlinePreservingChildren,

--- a/src/components/app/hooks/useWorkspaceData.ts
+++ b/src/components/app/hooks/useWorkspaceData.ts
@@ -17,6 +17,10 @@ import {
   updateViewInOutline,
 } from '@/components/_shared/outline/mergeOutline';
 import { findView, findViewByLayout } from '@/components/_shared/outline/utils';
+import {
+  limitSidebarOutlineExpandedViewIds,
+  type SidebarOutlineRevalidationResult,
+} from '@/components/app/outline/sidebarRevalidation';
 import { notification } from '@/proto/messages';
 import { createDeduplicatedNoArgsRequest, createDeduplicatedRequest } from '@/utils/deduplicateRequest';
 import { Log } from '@/utils/log';
@@ -57,7 +61,7 @@ function buildViewIndex(views: View[]): Map<string, View> {
 export function preserveLoadedChildren(
   newOutline: View[],
   oldOutline: View[],
-  prevLoadedIds: Set<string>,
+  prevLoadedIds: Set<string>
 ): { outline: View[]; loadedIds: Set<string> } {
   if (prevLoadedIds.size === 0) {
     return { outline: newOutline, loadedIds: new Set() };
@@ -91,12 +95,7 @@ export function preserveLoadedChildren(
     }
 
     // Graft old children back into the new shallow tree
-    finalOutline = mergeChildrenIntoOutline(
-      finalOutline,
-      loadedId,
-      oldView.children,
-      oldView.has_children,
-    );
+    finalOutline = mergeChildrenIntoOutline(finalOutline, loadedId, oldView.children, oldView.has_children);
     nextLoadedIds.add(loadedId);
   }
 
@@ -162,7 +161,10 @@ export function useWorkspaceData() {
 
   const [outline, setOutline] = useState<View[]>();
   const stableOutlineRef = useRef<View[]>([]);
+  // Global folder ordering can advance from lazy subtree fetches. Root polling
+  // must compare against the root/sidebar outline snapshot we actually applied.
   const lastFolderRidRef = useRef<FolderRid | null>(null);
+  const lastAppliedRootOutlineRidRef = useRef<FolderRid | null>(null);
   const [favoriteViews, setFavoriteViews] = useState<View[]>();
   const [recentViews, setRecentViews] = useState<View[]>();
   const [trashList, setTrashList] = useState<View[]>();
@@ -192,7 +194,7 @@ export function useWorkspaceData() {
     const { outline: mergedOutline, loadedIds: nextLoadedIds } = preserveLoadedChildren(
       newOutline,
       prevOutline,
-      prevLoadedIds,
+      prevLoadedIds
     );
 
     stableOutlineRef.current = mergedOutline;
@@ -214,6 +216,21 @@ export function useWorkspaceData() {
     }
   }, []);
 
+  const updateAppliedRootOutlineRid = useCallback(
+    (next: FolderRid | null) => {
+      if (!next) return;
+
+      updateLastFolderRid(next);
+
+      const current = lastAppliedRootOutlineRidRef.current;
+
+      if (!current || compareFolderRid(next, current) > 0) {
+        lastAppliedRootOutlineRidRef.current = next;
+      }
+    },
+    [updateLastFolderRid]
+  );
+
   const loadOutline = useCallback(
     async (workspaceId: string, force = true) => {
       try {
@@ -233,8 +250,6 @@ export function useWorkspaceData() {
         // Append shareWithMe data as hidden space if available
         const nextFolderRid = parseFolderRid(res.folderRid);
 
-        updateLastFolderRid(nextFolderRid);
-
         let outlineWithShareWithMe = res.outline;
 
         if (shareWithMeResult && shareWithMeResult.children && shareWithMeResult.children.length > 0) {
@@ -252,6 +267,8 @@ export function useWorkspaceData() {
         }
 
         const mergedOutline = replaceOutlinePreservingChildren(outlineWithShareWithMe);
+
+        updateAppliedRootOutlineRid(nextFolderRid);
 
         if (eventEmitter) {
           eventEmitter.emit(APP_EVENTS.OUTLINE_LOADED, mergedOutline || []);
@@ -315,9 +332,7 @@ export function useWorkspaceData() {
 
           // With shallow outlines, fetch all visible spaces in one batch and
           // search for a navigable child in original space order.
-          const spaces = outlineWithShareWithMe.filter(
-            (v) => v.extra?.is_space && !v.extra?.is_hidden_space
-          );
+          const spaces = outlineWithShareWithMe.filter((v) => v.extra?.is_space && !v.extra?.is_hidden_space);
 
           if (spaces.length > 0) {
             try {
@@ -378,7 +393,7 @@ export function useWorkspaceData() {
         }
       }
     },
-    [navigate, eventEmitter, updateLastFolderRid, userWorkspaceInfo?.userId, replaceOutlinePreservingChildren]
+    [navigate, eventEmitter, updateAppliedRootOutlineRid, userWorkspaceInfo?.userId, replaceOutlinePreservingChildren]
   );
 
   // Load children for a single view (lazy expand)
@@ -411,12 +426,7 @@ export function useWorkspaceData() {
         const children = viewData?.children ?? [];
 
         // Merge into outline
-        const nextOutline = mergeChildrenIntoOutline(
-          stableOutlineRef.current,
-          viewId,
-          children,
-          viewData?.has_children
-        );
+        const nextOutline = mergeChildrenIntoOutline(stableOutlineRef.current, viewId, children, viewData?.has_children);
 
         if (nextOutline !== stableOutlineRef.current) {
           stableOutlineRef.current = nextOutline;
@@ -446,9 +456,7 @@ export function useWorkspaceData() {
     async (viewIds: string[]): Promise<View[]> => {
       if (!currentWorkspaceId || viewIds.length === 0) return [];
 
-      const uniqueIds = Array.from(new Set(viewIds)).filter(
-        (viewId) => !loadingViewIdsRef.current.has(viewId)
-      );
+      const uniqueIds = Array.from(new Set(viewIds)).filter((viewId) => !loadingViewIdsRef.current.has(viewId));
 
       if (uniqueIds.length === 0) return [];
 
@@ -486,12 +494,7 @@ export function useWorkspaceData() {
           if (!viewId) continue;
 
           const children = viewData.children ?? [];
-          const mergedOutline = mergeChildrenIntoOutline(
-            nextOutline,
-            viewId,
-            children,
-            viewData?.has_children
-          );
+          const mergedOutline = mergeChildrenIntoOutline(nextOutline, viewId, children, viewData?.has_children);
 
           if (mergedOutline !== nextOutline) {
             nextOutline = mergedOutline;
@@ -524,70 +527,94 @@ export function useWorkspaceData() {
     [currentWorkspaceId, stableOutlineRef, eventEmitter, updateLastFolderRid]
   );
 
-  const markViewChildrenStale = useCallback((viewId: string) => {
-    const subtreeRoot = findView(stableOutlineRef.current, viewId);
-    const subtreeIds: string[] = [];
+  const markViewChildrenStale = useCallback(
+    (viewId: string) => {
+      const subtreeRoot = findView(stableOutlineRef.current, viewId);
+      const subtreeIds: string[] = [];
 
-    if (subtreeRoot) {
-      const stack: View[] = [subtreeRoot];
+      if (subtreeRoot) {
+        const stack: View[] = [subtreeRoot];
 
-      while (stack.length > 0) {
-        const current = stack.pop();
+        while (stack.length > 0) {
+          const current = stack.pop();
 
-        if (!current) continue;
-        subtreeIds.push(current.view_id);
-        current.children?.forEach((child) => stack.push(child));
-      }
-    } else {
-      subtreeIds.push(viewId);
-    }
-
-    let changed = false;
-
-    subtreeIds.forEach((id) => {
-      if (loadedViewIdsRef.current.delete(id)) {
-        changed = true;
+          if (!current) continue;
+          subtreeIds.push(current.view_id);
+          current.children?.forEach((child) => stack.push(child));
+        }
+      } else {
+        subtreeIds.push(viewId);
       }
 
-      loadingViewIdsRef.current.delete(id);
-    });
+      let changed = false;
 
-    if (!changed) return;
-
-    // Also invalidate the HTTP cache for the root view so the next
-    // loadViewChildren call makes a fresh API request instead of
-    // returning stale cached data.
-    if (currentWorkspaceId) {
-      ViewService.invalidateCache(currentWorkspaceId, viewId);
-    }
-
-    Log.debug('[Outline] [cache] Marked view subtree stale', { viewId, clearedIds: subtreeIds.length });
-    setLoadedViewIdsRevision((r) => r + 1);
-  }, [stableOutlineRef, currentWorkspaceId]);
-
-  // Load trash list
-  const loadTrash = useCallback(
-    async (currentWorkspaceId: string) => {
-      const requestSeq = ++trashRequestSeqRef.current;
-
-      try {
-        const res = await ViewService.getTrash(currentWorkspaceId);
-
-        if (!res) {
-          throw new Error('App trash not found');
+      subtreeIds.forEach((id) => {
+        if (loadedViewIdsRef.current.delete(id)) {
+          changed = true;
         }
 
-        if (requestSeq !== trashRequestSeqRef.current) {
-          return;
-        }
+        loadingViewIdsRef.current.delete(id);
+      });
 
-        setTrashList(sortBy(uniqBy(res, 'view_id') as unknown as View[], 'last_edited_time').reverse());
-      } catch (e) {
-        return Promise.reject('App trash not found');
+      if (!changed) return;
+
+      // Also invalidate the HTTP cache for the root view so the next
+      // loadViewChildren call makes a fresh API request instead of
+      // returning stale cached data.
+      if (currentWorkspaceId) {
+        ViewService.invalidateCache(currentWorkspaceId, viewId);
       }
+
+      Log.debug('[Outline] [cache] Marked view subtree stale', { viewId, clearedIds: subtreeIds.length });
+      setLoadedViewIdsRevision((r) => r + 1);
+    },
+    [stableOutlineRef, currentWorkspaceId]
+  );
+
+  const markCachedFolderSubtreesStale = useCallback(
+    (workspaceId: string, staleViewIds = Array.from(loadedViewIdsRef.current), resetLoadedState = true) => {
+      if (staleViewIds.length === 0) return 0;
+
+      for (const viewId of staleViewIds) {
+        ViewService.invalidateCache(workspaceId, viewId);
+        loadingViewIdsRef.current.delete(viewId);
+      }
+
+      if (resetLoadedState) {
+        loadedViewIdsRef.current = new Set();
+        setLoadedViewIdsRevision((r) => r + 1);
+      }
+
+      Log.debug('[Outline] [periodic-revalidate] marked cached subtrees stale', {
+        workspaceId,
+        staleCount: staleViewIds.length,
+      });
+
+      return staleViewIds.length;
     },
     []
   );
+
+  // Load trash list
+  const loadTrash = useCallback(async (currentWorkspaceId: string) => {
+    const requestSeq = ++trashRequestSeqRef.current;
+
+    try {
+      const res = await ViewService.getTrash(currentWorkspaceId);
+
+      if (!res) {
+        throw new Error('App trash not found');
+      }
+
+      if (requestSeq !== trashRequestSeqRef.current) {
+        return;
+      }
+
+      setTrashList(sortBy(uniqBy(res, 'view_id') as unknown as View[], 'last_edited_time').reverse());
+    } catch (e) {
+      return Promise.reject('App trash not found');
+    }
+  }, []);
 
   // Remote delete/restore arrives as folder changes. Keep the app-level trash
   // state fresh because deleted-page routing is derived from `trashList`.
@@ -598,6 +625,80 @@ export function useWorkspaceData() {
       Log.warn('[Trash] Failed to refresh trash list after folder change', error);
     });
   }, [currentWorkspaceId, loadTrash]);
+
+  const revalidateSidebarOutline = useCallback(
+    async (expandedViewIds: string[] = []): Promise<SidebarOutlineRevalidationResult> => {
+      if (!currentWorkspaceId) return 'unchanged';
+
+      const workspaceId = currentWorkspaceId;
+      const res = await ViewService.getOutline(workspaceId);
+
+      if (!res) {
+        throw new Error('App outline not found');
+      }
+
+      const nextFolderRid = parseFolderRid(res.folderRid);
+      const currentRid = lastAppliedRootOutlineRidRef.current;
+
+      if (nextFolderRid && currentRid && compareFolderRid(nextFolderRid, currentRid) <= 0) {
+        Log.debug('[Outline] [periodic-revalidate] skipped unchanged outline', {
+          workspaceId,
+          folderRid: res.folderRid,
+        });
+        return 'unchanged';
+      }
+
+      const existingShareWithMe = stableOutlineRef.current.find((view) => view.extra?.is_hidden_space);
+      const nextOutline = existingShareWithMe ? [...res.outline, existingShareWithMe] : res.outline;
+      const staleLoadedViewIds = Array.from(loadedViewIdsRef.current);
+
+      markCachedFolderSubtreesStale(workspaceId, staleLoadedViewIds, false);
+
+      const mergedOutline = replaceOutlinePreservingChildren(nextOutline);
+
+      if (staleLoadedViewIds.length > 0) {
+        loadedViewIdsRef.current = new Set();
+        setLoadedViewIdsRevision((r) => r + 1);
+      }
+
+      refreshTrashListInBackground();
+
+      if (eventEmitter) {
+        eventEmitter.emit(APP_EVENTS.OUTLINE_LOADED, mergedOutline || []);
+      }
+
+      const refreshViewIds = limitSidebarOutlineExpandedViewIds(expandedViewIds);
+
+      if (refreshViewIds.length === 0 || !loadViewChildrenBatch) {
+        updateAppliedRootOutlineRid(nextFolderRid);
+        return 'changed';
+      }
+
+      try {
+        await loadViewChildrenBatch(refreshViewIds);
+      } catch (error) {
+        Log.warn('[Outline] [periodic-revalidate] failed to refresh expanded sidebar roots', {
+          workspaceId,
+          refreshViewIds,
+          error,
+        });
+        throw error;
+      }
+
+      updateAppliedRootOutlineRid(nextFolderRid);
+      return 'changed';
+    },
+    [
+      currentWorkspaceId,
+      eventEmitter,
+      loadViewChildrenBatch,
+      markCachedFolderSubtreesStale,
+      replaceOutlinePreservingChildren,
+      refreshTrashListInBackground,
+      stableOutlineRef,
+      updateAppliedRootOutlineRid,
+    ]
+  );
 
   useEffect(() => {
     const handleShareViewsChanged = () => {
@@ -672,8 +773,7 @@ export function useWorkspaceData() {
       let patchedOutline: View[] | null = null;
 
       const firstOp = patch[0];
-      const fastReplace =
-        patch.length === 1 && firstOp?.op === 'replace' && firstOp?.path === '/outline';
+      const fastReplace = patch.length === 1 && firstOp?.op === 'replace' && firstOp?.path === '/outline';
 
       if (fastReplace && firstOp?.op === 'replace') {
         const replaceOp = firstOp as ReplaceOperation<View[]>;
@@ -725,16 +825,12 @@ export function useWorkspaceData() {
       // JSON-patch (computed against the old server state) then inserts it again.
       patchedOutline = deduplicateOutlineChildren(patchedOutline);
 
-      const existingShareWithMe = stableOutlineRef.current.find(
-        (view) => view.extra?.is_hidden_space
-      );
-      const nextOutline = existingShareWithMe
-        ? [...patchedOutline, existingShareWithMe]
-        : patchedOutline;
+      const existingShareWithMe = stableOutlineRef.current.find((view) => view.extra?.is_hidden_space);
+      const nextOutline = existingShareWithMe ? [...patchedOutline, existingShareWithMe] : patchedOutline;
 
       const mergedOutline = replaceOutlinePreservingChildren(nextOutline);
 
-      updateLastFolderRid(patchRid);
+      updateAppliedRootOutlineRid(patchRid);
 
       if (eventEmitter) {
         eventEmitter.emit(APP_EVENTS.OUTLINE_LOADED, mergedOutline || []);
@@ -757,6 +853,7 @@ export function useWorkspaceData() {
     refreshTrashListInBackground,
     replaceOutlinePreservingChildren,
     stableOutlineRef,
+    updateAppliedRootOutlineRid,
     updateLastFolderRid,
   ]);
 
@@ -942,30 +1039,33 @@ export function useWorkspaceData() {
   }, []);
 
   // Internal helper to fetch and update database relations
-  const fetchAndUpdateDatabaseRelations = useCallback(async (silent = false) => {
-    if (!currentWorkspaceId) {
-      return;
-    }
-
-    const selectedWorkspace = userWorkspaceInfo?.selectedWorkspace;
-
-    if (!selectedWorkspace) return;
-
-    try {
-      const res = await ViewService.getDatabaseRelations(currentWorkspaceId, selectedWorkspace.databaseStorageId);
-
-      if (res) {
-        workspaceDatabasesRef.current = res;
-        setWorkspaceDatabases(res);
+  const fetchAndUpdateDatabaseRelations = useCallback(
+    async (silent = false) => {
+      if (!currentWorkspaceId) {
+        return;
       }
 
-      return res;
-    } catch (e) {
-      if (!silent) {
-        console.error(e);
+      const selectedWorkspace = userWorkspaceInfo?.selectedWorkspace;
+
+      if (!selectedWorkspace) return;
+
+      try {
+        const res = await ViewService.getDatabaseRelations(currentWorkspaceId, selectedWorkspace.databaseStorageId);
+
+        if (res) {
+          workspaceDatabasesRef.current = res;
+          setWorkspaceDatabases(res);
+        }
+
+        return res;
+      } catch (e) {
+        if (!silent) {
+          console.error(e);
+        }
       }
-    }
-  }, [currentWorkspaceId, userWorkspaceInfo?.selectedWorkspace]);
+    },
+    [currentWorkspaceId, userWorkspaceInfo?.selectedWorkspace]
+  );
 
   // Load database relations (returns cached if available, fetches otherwise).
   // Pass `{ refresh: true }` to bypass the cache — needed by flows like the
@@ -1070,6 +1170,8 @@ export function useWorkspaceData() {
   // Load data when workspace changes
   useEffect(() => {
     if (!currentWorkspaceId) return;
+    lastFolderRidRef.current = null;
+    lastAppliedRootOutlineRidRef.current = null;
     setOutline([]);
     loadedViewIdsRef.current = new Set();
     setLoadedViewIdsRevision((r) => r + 1);
@@ -1118,7 +1220,6 @@ export function useWorkspaceData() {
     void enhancedLoadDatabaseRelations();
   }, [enhancedLoadDatabaseRelations]);
 
-
   return {
     outline,
     favoriteViews,
@@ -1141,5 +1242,6 @@ export function useWorkspaceData() {
     loadViewChildren,
     loadViewChildrenBatch,
     markViewChildrenStale,
+    revalidateSidebarOutline,
   };
 }

--- a/src/components/app/hooks/useWorkspaceData.ts
+++ b/src/components/app/hooks/useWorkspaceData.ts
@@ -142,6 +142,31 @@ function compareFolderRid(a: FolderRid, b: FolderRid): number {
   return a.seqNo - b.seqNo;
 }
 
+function normalizeRootOutlineForComparison(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(normalizeRootOutlineForComparison);
+  }
+
+  if (value && typeof value === 'object') {
+    const source = value as Record<string, unknown>;
+    const normalized: Record<string, unknown> = {};
+
+    for (const key of Object.keys(source).sort()) {
+      if (key === 'folder_rid' || source[key] === undefined) continue;
+
+      normalized[key] = normalizeRootOutlineForComparison(source[key]);
+    }
+
+    return normalized;
+  }
+
+  return value;
+}
+
+function createRootOutlineFingerprint(views: View[]): string {
+  return JSON.stringify(normalizeRootOutlineForComparison(views));
+}
+
 const OUTLINE_NON_VISUAL_FIELDS = new Set(['/last_edited_time', '/last_edited_by']);
 
 function isOnlyNonVisualOutlineChange(patch: JsonPatchOperation[]): boolean {
@@ -165,6 +190,7 @@ export function useWorkspaceData() {
   // must compare against the root/sidebar outline snapshot we actually applied.
   const lastFolderRidRef = useRef<FolderRid | null>(null);
   const lastAppliedRootOutlineRidRef = useRef<FolderRid | null>(null);
+  const lastAppliedRootOutlineFingerprintRef = useRef<string | null>(null);
   const [favoriteViews, setFavoriteViews] = useState<View[]>();
   const [recentViews, setRecentViews] = useState<View[]>();
   const [trashList, setTrashList] = useState<View[]>();
@@ -231,6 +257,14 @@ export function useWorkspaceData() {
     [updateLastFolderRid]
   );
 
+  const updateAppliedRootOutlineSnapshot = useCallback(
+    (nextRid: FolderRid | null, nextOutline: View[]) => {
+      updateAppliedRootOutlineRid(nextRid);
+      lastAppliedRootOutlineFingerprintRef.current = createRootOutlineFingerprint(nextOutline);
+    },
+    [updateAppliedRootOutlineRid]
+  );
+
   const loadOutline = useCallback(
     async (workspaceId: string, force = true) => {
       try {
@@ -268,7 +302,7 @@ export function useWorkspaceData() {
 
         const mergedOutline = replaceOutlinePreservingChildren(outlineWithShareWithMe);
 
-        updateAppliedRootOutlineRid(nextFolderRid);
+        updateAppliedRootOutlineSnapshot(nextFolderRid, outlineWithShareWithMe);
 
         if (eventEmitter) {
           eventEmitter.emit(APP_EVENTS.OUTLINE_LOADED, mergedOutline || []);
@@ -393,7 +427,13 @@ export function useWorkspaceData() {
         }
       }
     },
-    [navigate, eventEmitter, updateAppliedRootOutlineRid, userWorkspaceInfo?.userId, replaceOutlinePreservingChildren]
+    [
+      navigate,
+      eventEmitter,
+      updateAppliedRootOutlineSnapshot,
+      userWorkspaceInfo?.userId,
+      replaceOutlinePreservingChildren,
+    ]
   );
 
   // Load children for a single view (lazy expand)
@@ -650,6 +690,15 @@ export function useWorkspaceData() {
 
       const existingShareWithMe = stableOutlineRef.current.find((view) => view.extra?.is_hidden_space);
       const nextOutline = existingShareWithMe ? [...res.outline, existingShareWithMe] : res.outline;
+      const nextRootOutlineFingerprint = createRootOutlineFingerprint(nextOutline);
+
+      if (!nextFolderRid && lastAppliedRootOutlineFingerprintRef.current === nextRootOutlineFingerprint) {
+        Log.debug('[Outline] [periodic-revalidate] skipped unchanged outline without folder rid', {
+          workspaceId,
+        });
+        return 'unchanged';
+      }
+
       const staleLoadedViewIds = Array.from(loadedViewIdsRef.current);
 
       markCachedFolderSubtreesStale(workspaceId, staleLoadedViewIds, false);
@@ -670,7 +719,7 @@ export function useWorkspaceData() {
       const refreshViewIds = limitSidebarOutlineExpandedViewIds(expandedViewIds);
 
       if (refreshViewIds.length === 0 || !loadViewChildrenBatch) {
-        updateAppliedRootOutlineRid(nextFolderRid);
+        updateAppliedRootOutlineSnapshot(nextFolderRid, nextOutline);
         return 'changed';
       }
 
@@ -685,7 +734,7 @@ export function useWorkspaceData() {
         throw error;
       }
 
-      updateAppliedRootOutlineRid(nextFolderRid);
+      updateAppliedRootOutlineSnapshot(nextFolderRid, nextOutline);
       return 'changed';
     },
     [
@@ -696,7 +745,7 @@ export function useWorkspaceData() {
       replaceOutlinePreservingChildren,
       refreshTrashListInBackground,
       stableOutlineRef,
-      updateAppliedRootOutlineRid,
+      updateAppliedRootOutlineSnapshot,
     ]
   );
 
@@ -830,7 +879,7 @@ export function useWorkspaceData() {
 
       const mergedOutline = replaceOutlinePreservingChildren(nextOutline);
 
-      updateAppliedRootOutlineRid(patchRid);
+      updateAppliedRootOutlineSnapshot(patchRid, nextOutline);
 
       if (eventEmitter) {
         eventEmitter.emit(APP_EVENTS.OUTLINE_LOADED, mergedOutline || []);
@@ -853,7 +902,7 @@ export function useWorkspaceData() {
     refreshTrashListInBackground,
     replaceOutlinePreservingChildren,
     stableOutlineRef,
-    updateAppliedRootOutlineRid,
+    updateAppliedRootOutlineSnapshot,
     updateLastFolderRid,
   ]);
 
@@ -1172,6 +1221,7 @@ export function useWorkspaceData() {
     if (!currentWorkspaceId) return;
     lastFolderRidRef.current = null;
     lastAppliedRootOutlineRidRef.current = null;
+    lastAppliedRootOutlineFingerprintRef.current = null;
     setOutline([]);
     loadedViewIdsRef.current = new Set();
     setLoadedViewIdsRevision((r) => r + 1);

--- a/src/components/app/layers/AppBusinessLayer.tsx
+++ b/src/components/app/layers/AppBusinessLayer.tsx
@@ -106,6 +106,7 @@ export const AppBusinessLayer: FC<AppBusinessLayerProps> = ({ children }) => {
     loadViewChildren,
     loadViewChildrenBatch,
     markViewChildrenStale,
+    revalidateSidebarOutline,
   } = useWorkspaceData();
 
   const breadcrumbViewId = useMemo(() => {
@@ -496,6 +497,7 @@ export const AppBusinessLayer: FC<AppBusinessLayerProps> = ({ children }) => {
       loadViewChildren,
       loadViewChildrenBatch,
       markViewChildrenStale,
+      revalidateSidebarOutline,
       loadFavoriteViews,
       loadRecentViews,
       loadTrash,
@@ -507,7 +509,7 @@ export const AppBusinessLayer: FC<AppBusinessLayerProps> = ({ children }) => {
     }),
     [
       outline, favoriteViews, recentViews, trashList, loadedViewIds,
-      loadViewChildren, loadViewChildrenBatch, markViewChildrenStale,
+      loadViewChildren, loadViewChildrenBatch, markViewChildrenStale, revalidateSidebarOutline,
       loadFavoriteViews, loadRecentViews, loadTrash, loadViews,
       refreshOutline, loadDatabaseRelations, getMentionUser, loadMentionableUsers,
     ]

--- a/src/components/app/outline/Outline.tsx
+++ b/src/components/app/outline/Outline.tsx
@@ -15,10 +15,18 @@ import {
   useLoadViewChildrenBatch,
   useLoadViewChildren,
   useMarkViewChildrenStale,
+  useRevalidateSidebarOutline,
   useUserWorkspaceInfo,
 } from '@/components/app/app.hooks';
 import { Favorite } from '@/components/app/favorite';
 import { useReorderableSidebarList } from '@/components/app/outline/reorder/useReorderableSidebarList';
+import {
+  createSidebarOutlineRevalidationScheduleState,
+  getSidebarOutlineRevalidationDelayMs,
+  limitSidebarOutlineExpandedViewIds,
+  nextSidebarOutlineRevalidationStateAfterFailure,
+  nextSidebarOutlineRevalidationStateAfterResult,
+} from '@/components/app/outline/sidebarRevalidation';
 import SpaceItem from '@/components/app/outline/SpaceItem';
 import { ShareWithMe } from '@/components/app/share-with-me';
 import ViewActionsPopover from '@/components/app/view-actions/ViewActionsPopover';
@@ -56,6 +64,7 @@ export function Outline({ width }: { width: number }) {
   const loadViewChildren = useLoadViewChildren();
   const loadViewChildrenBatch = useLoadViewChildrenBatch();
   const markViewChildrenStale = useMarkViewChildrenStale();
+  const revalidateSidebarOutline = useRevalidateSidebarOutline();
   const userWorkspaceInfo = useUserWorkspaceInfo();
   const canReorderSpaces = userWorkspaceInfo?.selectedWorkspace.role === Role.Owner;
   const spaceListRef = useRef<HTMLDivElement>(null);
@@ -107,6 +116,18 @@ export function Outline({ width }: { width: number }) {
   const loadingViewIds = useMemo(() => loadingViewIdsRef.current, [loadingRevision]); // eslint-disable-line react-hooks/exhaustive-deps
   const [expandViewIds, setExpandViewIds] = React.useState<string[]>(Object.keys(getOutlineExpands()));
   const [pendingAutoLoadIds, setPendingAutoLoadIds] = useState<string[]>(Object.keys(getOutlineExpands()));
+  const expandViewIdsRef = useRef(expandViewIds);
+  const sidebarRevalidationStateRef = useRef(createSidebarOutlineRevalidationScheduleState());
+  const rescheduleSidebarRevalidationRef = useRef<() => void>(() => undefined);
+
+  useEffect(() => {
+    expandViewIdsRef.current = expandViewIds;
+  }, [expandViewIds]);
+
+  useEffect(() => {
+    sidebarRevalidationStateRef.current = createSidebarOutlineRevalidationScheduleState();
+    rescheduleSidebarRevalidationRef.current();
+  }, [outline]);
 
   useEffect(() => {
     const restoredExpandedIds = Object.keys(getOutlineExpands());
@@ -119,6 +140,98 @@ export function Outline({ width }: { width: number }) {
     validatedExistingRestoreIdsRef.current = new Set();
     setLoadingRevision((r) => r + 1);
   }, [currentWorkspaceId]);
+
+  useEffect(() => {
+    if (!currentWorkspaceId || !revalidateSidebarOutline) return;
+
+    let stopped = false;
+    let timer: number | undefined;
+    let inFlight = false;
+
+    const clearPendingTimer = () => {
+      if (timer !== undefined) {
+        window.clearTimeout(timer);
+        timer = undefined;
+      }
+    };
+
+    const scheduleNextTick = () => {
+      clearPendingTimer();
+      timer = window.setTimeout(() => {
+        void tick();
+      }, getSidebarOutlineRevalidationDelayMs(sidebarRevalidationStateRef.current));
+    };
+
+    const tick = async () => {
+      if (stopped || inFlight) return;
+
+      inFlight = true;
+      try {
+        const result = await revalidateSidebarOutline(limitSidebarOutlineExpandedViewIds(expandViewIdsRef.current));
+
+        sidebarRevalidationStateRef.current = nextSidebarOutlineRevalidationStateAfterResult(
+          sidebarRevalidationStateRef.current,
+          result
+        );
+      } catch (error) {
+        sidebarRevalidationStateRef.current = nextSidebarOutlineRevalidationStateAfterFailure(
+          sidebarRevalidationStateRef.current
+        );
+        Log.warn('[Outline] [periodic-revalidate] failed', {
+          workspaceId: currentWorkspaceId,
+          error,
+        });
+      } finally {
+        inFlight = false;
+        if (!stopped) {
+          scheduleNextTick();
+        }
+      }
+    };
+
+    const resetSchedule = () => {
+      sidebarRevalidationStateRef.current = createSidebarOutlineRevalidationScheduleState();
+    };
+
+    const rescheduleFromFastInterval = () => {
+      if (stopped) return;
+
+      resetSchedule();
+      scheduleNextTick();
+    };
+
+    const runNow = () => {
+      if (stopped) return;
+
+      resetSchedule();
+      clearPendingTimer();
+      if (!inFlight) {
+        void tick();
+      }
+    };
+
+    const runNowWhenVisible = () => {
+      if (document.visibilityState === 'visible') {
+        runNow();
+      }
+    };
+
+    rescheduleSidebarRevalidationRef.current = rescheduleFromFastInterval;
+    document.addEventListener('visibilitychange', runNowWhenVisible);
+    window.addEventListener('online', runNow);
+
+    scheduleNextTick();
+
+    return () => {
+      stopped = true;
+      clearPendingTimer();
+      document.removeEventListener('visibilitychange', runNowWhenVisible);
+      window.removeEventListener('online', runNow);
+      if (rescheduleSidebarRevalidationRef.current === rescheduleFromFastInterval) {
+        rescheduleSidebarRevalidationRef.current = () => undefined;
+      }
+    };
+  }, [currentWorkspaceId, revalidateSidebarOutline]);
 
   // Validate restored expanded IDs that are not in the current tree and prune only truly stale IDs.
   // This avoids keeping deleted/moved IDs forever, while preserving valid deep IDs.
@@ -185,7 +298,7 @@ export function Outline({ width }: { width: number }) {
   // Auto-load only the restored expanded ids from startup state.
   // Manual expand clicks should use single-view loading path only.
   const autoLoadState = useMemo(() => {
-    if (!outline || outline.length === 0 || !loadViewChildren) {
+    if (!outline || outline.length === 0 || (!loadViewChildrenBatch && !loadViewChildren)) {
       return {
         fetchableAutoLoadIds: [] as string[],
         nextRetryAt: null as number | null,
@@ -215,7 +328,7 @@ export function Outline({ width }: { width: number }) {
       fetchableAutoLoadIds,
       nextRetryAt,
     };
-  }, [pendingAutoLoadIds, outline, loadViewChildren, loadedViewIds, nowMs]);
+  }, [pendingAutoLoadIds, outline, loadViewChildren, loadViewChildrenBatch, loadedViewIds, nowMs]);
   const { fetchableAutoLoadIds, nextRetryAt } = autoLoadState;
 
   // Schedule a wake-up at nearest retry time so blocked ids can refetch.
@@ -235,7 +348,7 @@ export function Outline({ width }: { width: number }) {
   // Startup/outline restore: fetch expanded nodes that are currently in tree.
   // As deeper expanded nodes appear after parent fetches, this effect runs again.
   useEffect(() => {
-    if (fetchableAutoLoadIds.length === 0 || !loadViewChildren) return;
+    if (fetchableAutoLoadIds.length === 0) return;
 
     for (const id of fetchableAutoLoadIds) {
       loadingViewIdsRef.current.add(id);
@@ -244,7 +357,7 @@ export function Outline({ width }: { width: number }) {
 
     setLoadingRevision((r) => r + 1);
 
-    if (loadViewChildrenBatch && fetchableAutoLoadIds.length > 1) {
+    if (loadViewChildrenBatch) {
       void loadViewChildrenBatch(fetchableAutoLoadIds)
         .catch(() => {
           // No-op: retry scheduling is driven by retryAfter timestamps.
@@ -258,6 +371,8 @@ export function Outline({ width }: { width: number }) {
         });
       return;
     }
+
+    if (!loadViewChildren) return;
 
     void Promise.allSettled(fetchableAutoLoadIds.map((id) => loadViewChildren(id))).then(() => {
       for (const id of fetchableAutoLoadIds) {
@@ -287,6 +402,8 @@ export function Outline({ width }: { width: number }) {
       });
 
       if (isExpanded) {
+        sidebarRevalidationStateRef.current = createSidebarOutlineRevalidationScheduleState();
+        rescheduleSidebarRevalidationRef.current();
         setOutlineExpands(id, true);
         setExpandViewIds((prev) => (prev.includes(id) ? prev : [...prev, id]));
       } else {

--- a/src/components/app/outline/Outline.tsx
+++ b/src/components/app/outline/Outline.tsx
@@ -114,8 +114,8 @@ export function Outline({ width }: { width: number }) {
   const [loadingRevision, setLoadingRevision] = useState(0);
   const [nowMs, setNowMs] = useState(() => Date.now());
   const loadingViewIds = useMemo(() => loadingViewIdsRef.current, [loadingRevision]); // eslint-disable-line react-hooks/exhaustive-deps
-  const [expandViewIds, setExpandViewIds] = React.useState<string[]>(Object.keys(getOutlineExpands()));
-  const [pendingAutoLoadIds, setPendingAutoLoadIds] = useState<string[]>(Object.keys(getOutlineExpands()));
+  const [expandViewIds, setExpandViewIds] = React.useState<string[]>(() => Object.keys(getOutlineExpands()));
+  const [pendingAutoLoadIds, setPendingAutoLoadIds] = useState<string[]>(() => Object.keys(getOutlineExpands()));
   const expandViewIdsRef = useRef(expandViewIds);
   const sidebarRevalidationStateRef = useRef(createSidebarOutlineRevalidationScheduleState());
   const rescheduleSidebarRevalidationRef = useRef<() => void>(() => undefined);

--- a/src/components/app/outline/__tests__/sidebarRevalidation.test.ts
+++ b/src/components/app/outline/__tests__/sidebarRevalidation.test.ts
@@ -1,0 +1,56 @@
+import {
+  createSidebarOutlineRevalidationScheduleState,
+  getSidebarOutlineRevalidationDelayMs,
+  nextSidebarOutlineRevalidationStateAfterFailure,
+  nextSidebarOutlineRevalidationStateAfterResult,
+  SIDEBAR_OUTLINE_REVALIDATION_FAILURE_BASE_MS,
+  SIDEBAR_OUTLINE_REVALIDATION_FAILURE_MAX_MS,
+  SIDEBAR_OUTLINE_REVALIDATION_INTERVAL_MS,
+  SIDEBAR_OUTLINE_REVALIDATION_QUIET_INTERVAL_MS,
+  SIDEBAR_OUTLINE_REVALIDATION_SLOW_INTERVAL_MS,
+} from '@/components/app/outline/sidebarRevalidation';
+
+describe('sidebar outline revalidation schedule', () => {
+  it('slows down after repeated unchanged checks and resets after changes', () => {
+    let state = createSidebarOutlineRevalidationScheduleState();
+
+    expect(getSidebarOutlineRevalidationDelayMs(state, () => 0)).toBe(SIDEBAR_OUTLINE_REVALIDATION_INTERVAL_MS);
+
+    state = nextSidebarOutlineRevalidationStateAfterResult(state, 'unchanged');
+    state = nextSidebarOutlineRevalidationStateAfterResult(state, 'unchanged');
+    expect(getSidebarOutlineRevalidationDelayMs(state, () => 0)).toBe(SIDEBAR_OUTLINE_REVALIDATION_INTERVAL_MS);
+
+    state = nextSidebarOutlineRevalidationStateAfterResult(state, 'unchanged');
+    expect(getSidebarOutlineRevalidationDelayMs(state, () => 0)).toBe(SIDEBAR_OUTLINE_REVALIDATION_QUIET_INTERVAL_MS);
+
+    state = nextSidebarOutlineRevalidationStateAfterResult(state, 'unchanged');
+    state = nextSidebarOutlineRevalidationStateAfterResult(state, 'unchanged');
+    state = nextSidebarOutlineRevalidationStateAfterResult(state, 'unchanged');
+    expect(getSidebarOutlineRevalidationDelayMs(state, () => 0)).toBe(SIDEBAR_OUTLINE_REVALIDATION_SLOW_INTERVAL_MS);
+
+    state = nextSidebarOutlineRevalidationStateAfterResult(state, 'changed');
+    expect(getSidebarOutlineRevalidationDelayMs(state, () => 0)).toBe(SIDEBAR_OUTLINE_REVALIDATION_INTERVAL_MS);
+  });
+
+  it('uses capped failure backoff separately from unchanged checks', () => {
+    let state = createSidebarOutlineRevalidationScheduleState();
+
+    state = nextSidebarOutlineRevalidationStateAfterResult(state, 'unchanged');
+    state = nextSidebarOutlineRevalidationStateAfterResult(state, 'unchanged');
+    state = nextSidebarOutlineRevalidationStateAfterResult(state, 'unchanged');
+    state = nextSidebarOutlineRevalidationStateAfterFailure(state);
+    expect(getSidebarOutlineRevalidationDelayMs(state, () => 0)).toBe(SIDEBAR_OUTLINE_REVALIDATION_FAILURE_BASE_MS);
+
+    state = nextSidebarOutlineRevalidationStateAfterFailure(state);
+    expect(getSidebarOutlineRevalidationDelayMs(state, () => 0)).toBe(SIDEBAR_OUTLINE_REVALIDATION_FAILURE_BASE_MS * 2);
+
+    for (let index = 0; index < 8; index += 1) {
+      state = nextSidebarOutlineRevalidationStateAfterFailure(state);
+    }
+
+    expect(getSidebarOutlineRevalidationDelayMs(state, () => 0)).toBe(SIDEBAR_OUTLINE_REVALIDATION_FAILURE_MAX_MS);
+
+    state = nextSidebarOutlineRevalidationStateAfterResult(state, 'changed');
+    expect(getSidebarOutlineRevalidationDelayMs(state, () => 0)).toBe(SIDEBAR_OUTLINE_REVALIDATION_INTERVAL_MS);
+  });
+});

--- a/src/components/app/outline/sidebarRevalidation.ts
+++ b/src/components/app/outline/sidebarRevalidation.ts
@@ -1,0 +1,105 @@
+export const SIDEBAR_OUTLINE_REVALIDATION_INTERVAL_MS = 30_000;
+export const SIDEBAR_OUTLINE_REVALIDATION_JITTER_MS = 30_000;
+export const SIDEBAR_OUTLINE_REVALIDATION_QUIET_AFTER = 3;
+export const SIDEBAR_OUTLINE_REVALIDATION_SLOW_AFTER = 6;
+export const SIDEBAR_OUTLINE_REVALIDATION_QUIET_INTERVAL_MS = 120_000;
+export const SIDEBAR_OUTLINE_REVALIDATION_QUIET_JITTER_MS = 60_000;
+export const SIDEBAR_OUTLINE_REVALIDATION_SLOW_INTERVAL_MS = 300_000;
+export const SIDEBAR_OUTLINE_REVALIDATION_SLOW_JITTER_MS = 120_000;
+export const SIDEBAR_OUTLINE_REVALIDATION_FAILURE_BASE_MS = 30_000;
+export const SIDEBAR_OUTLINE_REVALIDATION_FAILURE_MAX_MS = 300_000;
+export const MAX_SIDEBAR_OUTLINE_REVALIDATION_EXPANDED_IDS = 20;
+
+export type SidebarOutlineRevalidationResult = 'changed' | 'unchanged';
+
+export interface SidebarOutlineRevalidationScheduleState {
+  unchangedCount: number;
+  failureCount: number;
+}
+
+export function createSidebarOutlineRevalidationScheduleState(): SidebarOutlineRevalidationScheduleState {
+  return {
+    unchangedCount: 0,
+    failureCount: 0,
+  };
+}
+
+export function nextSidebarOutlineRevalidationStateAfterResult(
+  state: SidebarOutlineRevalidationScheduleState,
+  result: SidebarOutlineRevalidationResult
+): SidebarOutlineRevalidationScheduleState {
+  return {
+    unchangedCount: result === 'changed' ? 0 : state.unchangedCount + 1,
+    failureCount: 0,
+  };
+}
+
+export function nextSidebarOutlineRevalidationStateAfterFailure(
+  state: SidebarOutlineRevalidationScheduleState
+): SidebarOutlineRevalidationScheduleState {
+  return {
+    unchangedCount: state.unchangedCount,
+    failureCount: state.failureCount + 1,
+  };
+}
+
+export function getSidebarOutlineRevalidationDelayMs(
+  state: SidebarOutlineRevalidationScheduleState = createSidebarOutlineRevalidationScheduleState(),
+  random = Math.random
+) {
+  const { intervalMs, jitterMs } = getSidebarOutlineRevalidationWindowMs(state);
+
+  return intervalMs + Math.floor(random() * (jitterMs + 1));
+}
+
+function getSidebarOutlineRevalidationWindowMs(state: SidebarOutlineRevalidationScheduleState) {
+  if (state.failureCount > 0) {
+    return {
+      intervalMs: Math.min(
+        SIDEBAR_OUTLINE_REVALIDATION_FAILURE_BASE_MS * 2 ** Math.min(state.failureCount - 1, 30),
+        SIDEBAR_OUTLINE_REVALIDATION_FAILURE_MAX_MS
+      ),
+      jitterMs: 0,
+    };
+  }
+
+  if (state.unchangedCount >= SIDEBAR_OUTLINE_REVALIDATION_SLOW_AFTER) {
+    return {
+      intervalMs: SIDEBAR_OUTLINE_REVALIDATION_SLOW_INTERVAL_MS,
+      jitterMs: SIDEBAR_OUTLINE_REVALIDATION_SLOW_JITTER_MS,
+    };
+  }
+
+  if (state.unchangedCount >= SIDEBAR_OUTLINE_REVALIDATION_QUIET_AFTER) {
+    return {
+      intervalMs: SIDEBAR_OUTLINE_REVALIDATION_QUIET_INTERVAL_MS,
+      jitterMs: SIDEBAR_OUTLINE_REVALIDATION_QUIET_JITTER_MS,
+    };
+  }
+
+  return {
+    intervalMs: SIDEBAR_OUTLINE_REVALIDATION_INTERVAL_MS,
+    jitterMs: SIDEBAR_OUTLINE_REVALIDATION_JITTER_MS,
+  };
+}
+
+export function limitSidebarOutlineExpandedViewIds(
+  viewIds: string[],
+  maxViewIds = MAX_SIDEBAR_OUTLINE_REVALIDATION_EXPANDED_IDS
+) {
+  const seen = new Set<string>();
+  const limited: string[] = [];
+
+  for (const viewId of viewIds) {
+    if (!viewId || seen.has(viewId)) continue;
+
+    seen.add(viewId);
+    limited.push(viewId);
+
+    if (limited.length >= maxViewIds) {
+      break;
+    }
+  }
+
+  return limited;
+}


### PR DESCRIPTION
## Summary
- add periodic sidebar outline revalidation with adaptive scheduling and visibility/online refresh triggers
- separate applied root outline folder RID tracking from lazy subtree updates so root changes are not skipped
- invalidate stale subtree caches, refresh expanded sidebar roots, and refresh trash state when a changed outline is applied
- support POST/fallback chunking for large batched view subtree requests and update Playwright request parsing

## Tests
- pnpm exec jest src/components/app/outline/__tests__/sidebarRevalidation.test.ts src/components/app/hooks/__tests__/useWorkspaceData.sidebarRevalidation.test.tsx src/components/app/hooks/__tests__/useWorkspaceData.trashRefresh.test.tsx --runInBand --no-coverage
- pnpm run type-check
- pnpm exec eslint --quiet --ext .ts,.tsx src/application/services/js-services/http/view-api.ts src/components/app/app.hooks.tsx src/components/app/contexts/AppOutlineContext.ts src/components/app/hooks/__tests__/useWorkspaceData.sidebarRevalidation.test.tsx src/components/app/hooks/__tests__/useWorkspaceData.trashRefresh.test.tsx src/components/app/hooks/useWorkspaceData.ts src/components/app/layers/AppBusinessLayer.tsx src/components/app/outline/Outline.tsx src/components/app/outline/__tests__/sidebarRevalidation.test.ts src/components/app/outline/sidebarRevalidation.ts

## Summary by Sourcery

Add periodic sidebar outline revalidation with adaptive scheduling, ensure root outline changes are applied reliably, and support robust batched subtree loading for large view requests.

New Features:
- Introduce sidebar outline revalidation scheduling with visibility/online triggers and expanded-subtree refresh.
- Expose a hook and context API for revalidating the sidebar outline from UI components.
- Add support for POST-based and chunked GET batched view subtree requests to handle large payloads.

Bug Fixes:
- Prevent stale or unapplied root outline changes from being skipped due to lazy subtree folder RID updates or granular folder patches.
- Ensure cached sidebar subtrees and trash state are invalidated and refreshed when the root outline changes.
- Keep root outline revalidation retryable when expanded subtree refresh fails and handle workspace changes correctly.

Enhancements:
- Refine outline auto-loading logic to better handle batch loading availability and retry scheduling.
- Centralize and limit expanded view IDs considered during sidebar outline revalidation to avoid excessive batch requests.

Tests:
- Add unit tests for sidebar outline revalidation behavior in useWorkspaceData, including RID tracking, cache invalidation, and failure handling.
- Extend trash refresh tests to cover periodic outline-driven trash updates.
- Update Playwright outline lazy-loading tests to parse both GET and POST batch view requests.