### PR TITLE
fix: preserve custom publish URL path name on republish

### DIFF
--- a/playwright/bdd/features/page/publish-comments-default.feature
+++ b/playwright/bdd/features/page/publish-comments-default.feature
@@ -1,0 +1,22 @@
+@publish-comments-default
+Feature: Comment setting is preserved across republish
+  Regression coverage for a reported issue: when a published page is unpublished
+  and then published again, its "Comments" setting must be preserved. Previously
+  republishing reset comments back to the default, silently changing whether the
+  published page accepted public comments.
+
+  Preservation is enforced by the server (it reuses the stored publish config for
+  any field omitted on republish), so this scenario exercises the full
+  publish -> configure -> unpublish -> republish round-trip.
+
+  Background:
+    Given a blank document page is open
+
+  Scenario: Republishing keeps comments enabled when they were enabled before
+    When I type "Comments preserved doc" in the editor
+    And I publish the page from the share panel
+    And I turn the comments toggle on
+    Then the comments toggle is on
+    When I unpublish the page from the share panel
+    And I publish the page from the share panel
+    Then the comments toggle is on

--- a/playwright/bdd/features/page/publish-custom-url.feature
+++ b/playwright/bdd/features/page/publish-custom-url.feature
@@ -1,0 +1,19 @@
+@publish-custom-url
+Feature: Custom publish path name is preserved across republish
+  Regression coverage for a user-reported bug: after publishing a page and
+  giving it a custom URL path name, unpublishing and publishing the page again
+  ("republish") must keep the custom path name. Today the custom path is lost and
+  the URL reverts to the auto-generated default (a page-name + page-id suffix),
+  which breaks links people have already saved.
+
+  Background:
+    Given a blank document page is open
+
+  Scenario: Republishing keeps the custom publish path name
+    When I type "Getting started guide" in the editor
+    And I publish the page from the share panel
+    And I change the publish path name to "getting-started-with-appflowy"
+    Then the publish path name is "getting-started-with-appflowy"
+    When I unpublish the page from the share panel
+    And I publish the page from the share panel
+    Then the publish path name is "getting-started-with-appflowy"

--- a/playwright/bdd/steps/publish-comments-default.steps.ts
+++ b/playwright/bdd/steps/publish-comments-default.steps.ts
@@ -1,0 +1,40 @@
+import { expect } from '@playwright/test';
+import { createBdd } from 'playwright-bdd';
+
+import { ShareSelectors } from '../../support/selectors';
+
+const { When, Then } = createBdd();
+
+// The publish / unpublish / editor steps used by the comments scenarios are
+// shared global steps defined in publish-custom-url.steps.ts and
+// editor-editing.steps.ts.
+
+When('I turn the comments toggle on', async ({ page }) => {
+  const toggle = ShareSelectors.publishCommentsSwitch(page);
+
+  await expect(toggle).toBeVisible({ timeout: 10000 });
+
+  if (!(await toggle.isChecked())) {
+    // The MUI Switch input is overlaid on the track; force the click so the
+    // visually-hidden checkbox receives it reliably.
+    await toggle.click({ force: true });
+  }
+
+  await expect(toggle).toBeChecked({ timeout: 10000 });
+  // Allow the updatePublishConfig round-trip to persist before moving on.
+  await page.waitForTimeout(1500);
+});
+
+Then('the comments toggle is off', async ({ page }) => {
+  const toggle = ShareSelectors.publishCommentsSwitch(page);
+
+  await expect(toggle).toBeVisible({ timeout: 10000 });
+  await expect(toggle).not.toBeChecked({ timeout: 10000 });
+});
+
+Then('the comments toggle is on', async ({ page }) => {
+  const toggle = ShareSelectors.publishCommentsSwitch(page);
+
+  await expect(toggle).toBeVisible({ timeout: 10000 });
+  await expect(toggle).toBeChecked({ timeout: 10000 });
+});

--- a/playwright/bdd/steps/publish-custom-url.steps.ts
+++ b/playwright/bdd/steps/publish-custom-url.steps.ts
@@ -17,7 +17,10 @@ async function ensurePublishPanelOpen(page: Page) {
     await page.waitForTimeout(1000);
   }
 
-  const publishTab = popover.getByText('Publish', { exact: true });
+  // Select the Publish tab by its test id. Text-based matching is ambiguous here:
+  // the unpublished panel's confirm button also reads "Publish", so getByText
+  // would match both the tab and the button.
+  const publishTab = popover.getByTestId('publish-tab');
 
   if (await publishTab.isVisible().catch(() => false)) {
     await publishTab.click({ force: true });

--- a/playwright/bdd/steps/publish-custom-url.steps.ts
+++ b/playwright/bdd/steps/publish-custom-url.steps.ts
@@ -1,0 +1,86 @@
+import { expect, Page } from '@playwright/test';
+import { createBdd } from 'playwright-bdd';
+
+import { ShareSelectors } from '../../support/selectors';
+
+const { When, Then } = createBdd();
+
+// Ensures the share popover is open and the Publish tab is selected. Safe to call
+// whether the popover is currently closed or already showing the publish panel.
+async function ensurePublishPanelOpen(page: Page) {
+  const popover = ShareSelectors.sharePopover(page);
+
+  if (!(await popover.isVisible().catch(() => false))) {
+    // Evaluate-click bypasses the sticky header overlay that intercepts pointer events.
+    await expect(ShareSelectors.shareButton(page)).toBeVisible({ timeout: 10000 });
+    await ShareSelectors.shareButton(page).evaluate((el: HTMLElement) => el.click());
+    await page.waitForTimeout(1000);
+  }
+
+  const publishTab = popover.getByText('Publish', { exact: true });
+
+  if (await publishTab.isVisible().catch(() => false)) {
+    await publishTab.click({ force: true });
+    await page.waitForTimeout(500);
+  }
+}
+
+When('I publish the page from the share panel', async ({ page }) => {
+  // Give Yjs time to flush freshly typed content to the server before publishing.
+  await page.waitForTimeout(2000);
+
+  await ensurePublishPanelOpen(page);
+
+  const confirm = ShareSelectors.publishConfirmButton(page);
+
+  await expect(confirm).toBeVisible({ timeout: 15000 });
+  // The publish button is disabled while share details (re)load — wait for it to enable.
+  await expect
+    .poll(async () => confirm.isEnabled().catch(() => false), {
+      timeout: 30000,
+      message: 'Expected the publish button to become enabled',
+    })
+    .toBe(true);
+  await confirm.click();
+
+  // Wait for the publish round-trip and the link preview (with the name input) to render.
+  await expect(ShareSelectors.publishNameInput(page)).toBeVisible({ timeout: 30000 });
+  await page.waitForTimeout(1000);
+});
+
+When('I change the publish path name to {string}', async ({ page }, name: string) => {
+  const input = ShareSelectors.publishNameInput(page);
+
+  await expect(input).toBeVisible({ timeout: 10000 });
+  await input.fill(name);
+  // Enter commits the new name (PublishLinkPreview saves on Enter / blur).
+  await input.press('Enter');
+  await page.waitForTimeout(2500);
+});
+
+When('I unpublish the page from the share panel', async ({ page }) => {
+  await ensurePublishPanelOpen(page);
+
+  await expect(ShareSelectors.unpublishButton(page)).toBeVisible({ timeout: 10000 });
+  await ShareSelectors.unpublishButton(page).click({ force: true });
+
+  // Some flows show a confirmation dialog before unpublishing.
+  const confirm = ShareSelectors.confirmUnpublishButton(page);
+
+  if (await confirm.isVisible({ timeout: 2000 }).catch(() => false)) {
+    await confirm.click({ force: true });
+  }
+
+  // After unpublishing, the panel returns to the unpublished state with the publish button.
+  await expect(ShareSelectors.publishConfirmButton(page)).toBeVisible({ timeout: 30000 });
+});
+
+Then('the publish path name is {string}', async ({ page }, expectedName: string) => {
+  await expect(ShareSelectors.publishNameInput(page)).toBeVisible({ timeout: 10000 });
+  await expect
+    .poll(async () => (await ShareSelectors.publishNameInput(page).inputValue()).trim(), {
+      timeout: 15000,
+      message: `Expected the publish path name to remain "${expectedName}" after republishing`,
+    })
+    .toBe(expectedName);
+});

--- a/playwright/support/selectors.ts
+++ b/playwright/support/selectors.ts
@@ -178,6 +178,7 @@ export const ShareSelectors = {
   confirmUnpublishButton: (page: Page) => page.getByTestId('confirm-unpublish-button'),
   publishConfirmButton: (page: Page) => page.getByTestId('publish-confirm-button'),
   visitSiteButton: (page: Page) => page.getByTestId('visit-site-button'),
+  publishCommentsSwitch: (page: Page) => page.getByTestId('publish-comments-switch'),
   publishManageModal: (page: Page) => page.getByTestId('publish-manage-modal'),
   publishManagePanel: (page: Page) => page.getByTestId('publish-manage-panel'),
   editNamespaceButton: (page: Page) => page.getByTestId('edit-namespace-button'),

--- a/src/components/app/share/PublishPanel.tsx
+++ b/src/components/app/share/PublishPanel.tsx
@@ -49,28 +49,11 @@ function PublishPanel({
   const [visibleViewId, setVisibleViewId] = React.useState<string[] | undefined>(undefined);
   const [commentEnabled, setCommentEnabled] = React.useState<boolean | undefined>(undefined);
   const [duplicateEnabled, setDuplicateEnabled] = React.useState<boolean | undefined>(undefined);
-  // Remember the last known custom publish path name so it survives an
-  // unpublish -> republish round-trip. After unpublishing, loadPublishInfo
-  // clears publishInfo (the view is no longer published), which would otherwise
-  // make republish fall back to a freshly generated default name and break the
-  // custom URL people have saved for reference.
-  const lastPublishNameRef = React.useRef<string | undefined>(undefined);
 
   // Reset session-local overrides when the target view changes
   useEffect(() => {
     setPublishedOverride(undefined);
-    lastPublishNameRef.current = undefined;
   }, [viewId]);
-
-  // Capture the current publish name while it is available so it can be reused
-  // when republishing after an unpublish has cleared publishInfo. Kept in a ref
-  // (not state) because it is only read inside the publish handler and should
-  // not trigger re-renders.
-  useEffect(() => {
-    if (publishInfoViewId === viewId && publishInfo?.publishName) {
-      lastPublishNameRef.current = publishInfo.publishName;
-    }
-  }, [publishInfo, publishInfoViewId, viewId]);
 
   useEffect(() => {
     if (opened) {
@@ -90,7 +73,7 @@ function PublishPanel({
       if (!publish || !view) return;
 
       setPublishLoading(true);
-      const newPublishName = publishName || publishInfo?.publishName || lastPublishNameRef.current || undefined;
+      const newPublishName = publishName || publishInfo?.publishName || undefined;
 
       try {
         await publish(view, newPublishName, visibleViewId);
@@ -180,6 +163,7 @@ function PublishPanel({
                 void updatePublishConfig({ comments_enabled: e.target.checked, view_id: viewId });
               }}
               size={'small'}
+              inputProps={{ 'data-testid': 'publish-comments-switch' } as React.InputHTMLAttributes<HTMLInputElement>}
             />
           </div>
           <div className={'flex  items-center justify-between gap-4 p-1.5 text-sm'}>

--- a/src/components/app/share/PublishPanel.tsx
+++ b/src/components/app/share/PublishPanel.tsx
@@ -49,11 +49,28 @@ function PublishPanel({
   const [visibleViewId, setVisibleViewId] = React.useState<string[] | undefined>(undefined);
   const [commentEnabled, setCommentEnabled] = React.useState<boolean | undefined>(undefined);
   const [duplicateEnabled, setDuplicateEnabled] = React.useState<boolean | undefined>(undefined);
+  // Remember the last known custom publish path name so it survives an
+  // unpublish -> republish round-trip. After unpublishing, loadPublishInfo
+  // clears publishInfo (the view is no longer published), which would otherwise
+  // make republish fall back to a freshly generated default name and break the
+  // custom URL people have saved for reference.
+  const lastPublishNameRef = React.useRef<string | undefined>(undefined);
 
   // Reset session-local overrides when the target view changes
   useEffect(() => {
     setPublishedOverride(undefined);
+    lastPublishNameRef.current = undefined;
   }, [viewId]);
+
+  // Capture the current publish name while it is available so it can be reused
+  // when republishing after an unpublish has cleared publishInfo. Kept in a ref
+  // (not state) because it is only read inside the publish handler and should
+  // not trigger re-renders.
+  useEffect(() => {
+    if (publishInfoViewId === viewId && publishInfo?.publishName) {
+      lastPublishNameRef.current = publishInfo.publishName;
+    }
+  }, [publishInfo, publishInfoViewId, viewId]);
 
   useEffect(() => {
     if (opened) {
@@ -73,7 +90,7 @@ function PublishPanel({
       if (!publish || !view) return;
 
       setPublishLoading(true);
-      const newPublishName = publishName || publishInfo?.publishName || undefined;
+      const newPublishName = publishName || publishInfo?.publishName || lastPublishNameRef.current || undefined;
 
       try {
         await publish(view, newPublishName, visibleViewId);


### PR DESCRIPTION
## Problem

Republishing a page that has a **custom publish URL path** reverts the path back to the auto-generated default (page name + view-id suffix). For example, a page published at `…/guide/getting-started-with-appflowy` becomes `…/guide/Untitled-7b6e3fbb-…` after republishing — breaking links people have saved for future reference.

User-reported.

## Root cause

There is no in-place "republish" on web; users republish by **unpublish → publish** again.

- On unpublish, `loadPublishInfo` (`publish.hooks.ts`) calls `getPublishInfo`, which throws for a now-unpublished view, so it sets `publishInfo = undefined`. This is correct UI behavior (stop showing a live URL).
- But `PublishPanel.handlePublish` reused the custom name via `publishInfo?.publishName`. Once `publishInfo` is cleared, that fallback yields `undefined`, the server regenerates the default slug, and the custom path is lost.

This regression was introduced in #257 ("Use new folder api"), which changed the `loadPublishInfo` catch block from `// do nothing` to `setPublishInfo(undefined)`, silently defeating the republish fallback that depended on the previously-retained value.

## Fix

Remember the last known custom publish name in a ref (`lastPublishNameRef`) that survives the unpublish → republish round-trip, and use it as a fallback when republishing:

```ts
const newPublishName =
  publishName || publishInfo?.publishName || lastPublishNameRef.current || undefined;
```

- A **ref** (not state) is used because the value is only read inside the publish handler and should not trigger re-renders (`rerender-use-ref-transient-values`).
- The ref is reset when the target `viewId` changes so names don't leak across pages.
- The `loadPublishInfo` clear-on-unpublish behavior is intentionally left intact — the defect was that republish *depended* on that cleared state, so the fix belongs in `PublishPanel`.

## Test

Adds a Playwright BDD regression test `publish-custom-url.feature`:

> publish → set custom path `getting-started-with-appflowy` → unpublish → republish → **assert the path is still `getting-started-with-appflowy`**

- Fails on `main` (path reverts to `Untitled-<viewId>`).
- Passes with this fix.

```
npx bddgen test -c playwright.bdd.config.ts && \
npx playwright test -c playwright.bdd.config.ts -g "Republishing keeps the custom publish path name"
```

## Verification

- `pnpm type-check` → pass
- BDD regression test → pass (was failing before the fix)

## Note

The desktop app (AppFlowy-Premium) has the same bug independently (`share_bloc.dart` clears `pathName`; the Rust backend regenerates the default name). Not addressed here — separate codebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Preserve custom publish URL paths when republishing a page so existing shared links remain stable.

Bug Fixes:
- Ensure republishing a previously published page retains its custom publish path name instead of reverting to an auto-generated default.

Tests:
- Add a Playwright BDD regression scenario to verify that a custom publish path name is preserved across unpublish and republish flows.