### PR TITLE
fix(database): preserve cell data when converting field types

### DIFF
--- a/src/application/database-yjs/__tests__/cell.transform.test.ts
+++ b/src/application/database-yjs/__tests__/cell.transform.test.ts
@@ -1,3 +1,4 @@
+import dayjs from 'dayjs';
 import * as Y from 'yjs';
 
 jest.mock('@/utils/runtime-config', () => ({
@@ -126,8 +127,18 @@ Item 2`, FieldType.Checklist, FieldType.RichText);
           { id: 'opt1', name: 'Red', color: 0 },
           { id: 'opt2', name: 'Blue', color: 0 }
         ];
-        const field = createField(FieldType.Checklist, { options }); // Checklist field now holds the options
-  
+        // After converting MultiSelect -> Checklist, the select options remain
+        // under the source (MultiSelect) type-option key (the switch adds the
+        // new type-option without deleting the old one). The read path resolves
+        // them by the cell's source type, not the field's current type.
+        const field = createField(FieldType.Checklist);
+        const typeOptionMap = new Y.Map();
+        const option = new Y.Map();
+
+        option.set(YjsDatabaseKey.content, JSON.stringify({ options }));
+        typeOptionMap.set(String(FieldType.MultiSelect), option);
+        field.set(YjsDatabaseKey.type_option, typeOptionMap);
+
         const cell = createCell('opt1,opt2', FieldType.Checklist, FieldType.MultiSelect);
         
         const parsed = parseYDatabaseCellToCell(cell, field) as unknown as ChecklistCell;
@@ -139,6 +150,55 @@ Item 2`, FieldType.Checklist, FieldType.RichText);
         expect(parsedData.options[1].name).toBe('Blue');
         expect(parsedData.selected_option_ids).toHaveLength(2);
       });
+  });
+
+  describe('SingleSelect <-> MultiSelect (desktop parity: keep option IDs)', () => {
+    const options: SelectOption[] = [
+      { id: 'opt1', name: 'Red', color: 0 },
+      { id: 'opt2', name: 'Blue', color: 0 },
+    ];
+
+    it('SingleSelect -> MultiSelect: preserves the selected option ID', () => {
+      // Options are copied 1:1 on switch, so the field's current (MultiSelect)
+      // type-option holds them.
+      const field = createField(FieldType.MultiSelect, { options });
+      const cell = createCell('opt1', FieldType.MultiSelect, FieldType.SingleSelect);
+
+      const parsed = parseYDatabaseCellToCell(cell, field) as unknown as SelectOptionCell;
+
+      expect(parsed.data).toBe('opt1');
+    });
+
+    it('MultiSelect -> SingleSelect: preserves all stored option IDs', () => {
+      const field = createField(FieldType.SingleSelect, { options });
+      const cell = createCell('opt1,opt2', FieldType.SingleSelect, FieldType.MultiSelect);
+
+      const parsed = parseYDatabaseCellToCell(cell, field) as unknown as SelectOptionCell;
+
+      expect(parsed.data).toBe('opt1,opt2');
+    });
+  });
+
+  describe('RichText -> DateTime (desktop parity: parse text to timestamp)', () => {
+    it('parses a date string into a unix-seconds timestamp', () => {
+      const field = createField(FieldType.DateTime);
+      const cell = createCell('2026-05-14', FieldType.DateTime, FieldType.RichText);
+
+      const parsed = parseYDatabaseCellToCell(cell, field);
+
+      // data is a unix-seconds string that round-trips back to the same date
+      expect(typeof parsed.data).toBe('string');
+      expect(dayjs.unix(Number(parsed.data)).format('YYYY-MM-DD')).toBe('2026-05-14');
+    });
+
+    it('returns empty for unparseable text', () => {
+      const field = createField(FieldType.DateTime);
+      const cell = createCell('not a date', FieldType.DateTime, FieldType.RichText);
+
+      const parsed = parseYDatabaseCellToCell(cell, field);
+
+      expect(parsed.data).toBe('');
+    });
   });
 
   describe('Other Transformations', () => {

--- a/src/application/database-yjs/__tests__/field-type-conversion.test.tsx
+++ b/src/application/database-yjs/__tests__/field-type-conversion.test.tsx
@@ -1,0 +1,347 @@
+import { act, renderHook } from '@testing-library/react';
+import * as Y from 'yjs';
+
+import { DatabaseContext, DatabaseContextState, FieldType } from '@/application/database-yjs';
+import { getCellDataText, parseYDatabaseCellToCell } from '@/application/database-yjs/cell.parse';
+import { useSwitchPropertyType } from '@/application/database-yjs/dispatch';
+import {
+  YDatabase,
+  YDatabaseCell,
+  YDatabaseField,
+  YDatabaseFields,
+  YDatabaseRow,
+  YDatabaseView,
+  YDatabaseViews,
+  YDoc,
+  YjsDatabaseKey,
+  YjsEditorKey,
+} from '@/application/types';
+
+import { createRowDoc } from './test-helpers';
+
+import type React from 'react';
+
+jest.mock('@/utils/runtime-config', () => ({
+  getConfigValue: (_key: string, fallback: string) => fallback,
+}));
+
+const databaseId = 'database-id';
+const viewId = 'view-id';
+const rowId = 'row-id';
+const fieldId = 'measurements-field-id';
+
+// Mirrors what the buggy import produced: a MultiSelect field whose options are
+// named after the original text values, with the cell storing option IDs.
+const OPTIONS = [
+  { id: 'opt_a', name: '0', color: 'Purple' },
+  { id: 'opt_b', name: '60', color: 'Pink' },
+  { id: 'opt_c', name: '82', color: 'Orange' },
+];
+const CELL_DATA = 'opt_a,opt_b,opt_c'; // option IDs, renders as "0,60,82"
+
+function createMultiSelectField(): YDatabaseField {
+  const field = new Y.Map() as YDatabaseField;
+  const now = '1000';
+
+  field.set(YjsDatabaseKey.id, fieldId);
+  field.set(YjsDatabaseKey.name, 'Rsh measurements');
+  field.set(YjsDatabaseKey.type, FieldType.MultiSelect);
+  // created_at !== last_modified so the hook does not auto-rename the field.
+  field.set(YjsDatabaseKey.created_at, now);
+  field.set(YjsDatabaseKey.last_modified, '2000');
+
+  const typeOptionMap = new Y.Map();
+  const option = new Y.Map();
+
+  option.set(YjsDatabaseKey.content, JSON.stringify({ disable_color: false, options: OPTIONS }));
+  typeOptionMap.set(String(FieldType.MultiSelect), option);
+  field.set(YjsDatabaseKey.type_option, typeOptionMap);
+
+  return field;
+}
+
+function createDatabaseDoc(): YDoc {
+  const doc = new Y.Doc({ guid: databaseId }) as YDoc;
+  const sharedRoot = doc.getMap(YjsEditorKey.data_section);
+  const database = new Y.Map() as YDatabase;
+  const fields = new Y.Map<YDatabaseField>() as YDatabaseFields;
+  const views = new Y.Map<YDatabaseView>() as YDatabaseViews;
+  const view = new Y.Map() as YDatabaseView;
+
+  fields.set(fieldId, createMultiSelectField());
+  views.set(viewId, view);
+  database.set(YjsDatabaseKey.id, databaseId);
+  database.set(YjsDatabaseKey.fields, fields);
+  database.set(YjsDatabaseKey.views, views);
+  sharedRoot.set(YjsEditorKey.database, database);
+
+  return doc;
+}
+
+function getField(databaseDoc: YDoc): YDatabaseField {
+  const database = databaseDoc.getMap(YjsEditorKey.data_section).get(YjsEditorKey.database) as YDatabase;
+
+  return database.get(YjsDatabaseKey.fields).get(fieldId);
+}
+
+function getCell(rowDoc: YDoc): YDatabaseCell {
+  const row = rowDoc.getMap(YjsEditorKey.data_section).get(YjsEditorKey.database_row) as YDatabaseRow;
+
+  return row.get(YjsDatabaseKey.cells).get(fieldId);
+}
+
+function setup() {
+  const databaseDoc = createDatabaseDoc();
+  const rowDoc = createRowDoc(rowId, databaseId, {
+    [fieldId]: { fieldType: FieldType.MultiSelect, data: CELL_DATA },
+  });
+  const contextValue = {
+    readOnly: false,
+    databaseDoc,
+    databasePageId: viewId,
+    activeViewId: viewId,
+    rowMap: { [rowId]: rowDoc },
+    workspaceId: 'workspace-id',
+  } as unknown as DatabaseContextState;
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <DatabaseContext.Provider value={contextValue}>{children}</DatabaseContext.Provider>
+  );
+  const { result } = renderHook(() => useSwitchPropertyType(), { wrapper });
+
+  return { databaseDoc, rowDoc, switchType: result.current };
+}
+
+describe('Bug B (fixed) — field-type conversion preserves select values', () => {
+  it('baseline: MultiSelect cell renders its option names', () => {
+    const { databaseDoc, rowDoc } = setup();
+
+    expect(getCellDataText(getCell(rowDoc), getField(databaseDoc))).toBe('0,60,82');
+  });
+
+  it('MultiSelect -> Text: renders the option names as text (resolved by source type)', () => {
+    const { databaseDoc, rowDoc, switchType } = setup();
+
+    act(() => {
+      switchType(fieldId, FieldType.RichText);
+    });
+
+    const cell = getCell(rowDoc);
+    const field = getField(databaseDoc);
+
+    // Raw data is preserved...
+    expect(cell.get(YjsDatabaseKey.data)).toBe(CELL_DATA);
+
+    // ...and now renders, because options are resolved by the cell's source
+    // type (MultiSelect) rather than the field's current type (RichText).
+    expect(getCellDataText(cell, field)).toBe('0,60,82');
+    expect(parseYDatabaseCellToCell(cell, field).data as string).toBe('0,60,82');
+  });
+
+  it('round-trip MultiSelect -> Text -> MultiSelect: values stay visible', () => {
+    const { databaseDoc, rowDoc, switchType } = setup();
+
+    act(() => {
+      switchType(fieldId, FieldType.RichText);
+    });
+    act(() => {
+      switchType(fieldId, FieldType.MultiSelect);
+    });
+
+    const cell = getCell(rowDoc);
+    const field = getField(databaseDoc);
+
+    // Raw data survived the round-trip...
+    expect(cell.get(YjsDatabaseKey.data)).toBe(CELL_DATA);
+
+    // ...and the chips render again: the origin type was preserved (not
+    // overwritten with the intermediate RichText hop), so the cell is native
+    // MultiSelect once more.
+    expect(cell.get(YjsDatabaseKey.source_field_type)).toBeUndefined();
+    expect(getCellDataText(cell, field)).toBe('0,60,82');
+  });
+});
+
+describe('Created/LastEditedTime -> DateTime (desktop parity: materialize timestamp)', () => {
+  const TIMESTAMP = '1747180800'; // unix seconds
+
+  function createTimestampField(type: FieldType): YDatabaseField {
+    const field = new Y.Map() as YDatabaseField;
+
+    field.set(YjsDatabaseKey.id, fieldId);
+    field.set(YjsDatabaseKey.name, 'Created');
+    field.set(YjsDatabaseKey.type, type);
+    field.set(YjsDatabaseKey.created_at, '1000');
+    field.set(YjsDatabaseKey.last_modified, '2000');
+
+    return field;
+  }
+
+  function setupTimestamp(type: FieldType, meta: { createdAt?: string; lastModified?: string }) {
+    const doc = new Y.Doc({ guid: databaseId }) as YDoc;
+    const sharedRoot = doc.getMap(YjsEditorKey.data_section);
+    const database = new Y.Map() as YDatabase;
+    const fields = new Y.Map<YDatabaseField>() as YDatabaseFields;
+    const views = new Y.Map<YDatabaseView>() as YDatabaseViews;
+
+    fields.set(fieldId, createTimestampField(type));
+    views.set(viewId, new Y.Map() as YDatabaseView);
+    database.set(YjsDatabaseKey.id, databaseId);
+    database.set(YjsDatabaseKey.fields, fields);
+    database.set(YjsDatabaseKey.views, views);
+    sharedRoot.set(YjsEditorKey.database, database);
+
+    // Row carries the timestamp on its meta and has NO cell for the field
+    // (created/last-edited time has no cell data of its own).
+    const rowDoc = createRowDoc(rowId, databaseId, {}, meta.createdAt ?? '0', meta.lastModified ?? '0');
+    const contextValue = {
+      readOnly: false,
+      databaseDoc: doc,
+      databasePageId: viewId,
+      activeViewId: viewId,
+      rowMap: { [rowId]: rowDoc },
+      workspaceId: 'workspace-id',
+    } as unknown as DatabaseContextState;
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <DatabaseContext.Provider value={contextValue}>{children}</DatabaseContext.Provider>
+    );
+    const { result } = renderHook(() => useSwitchPropertyType(), { wrapper });
+
+    return { databaseDoc: doc, rowDoc, switchType: result.current };
+  }
+
+  it('CreatedTime -> DateTime: materializes row.created_at into the cell and renders a date', () => {
+    const { databaseDoc, rowDoc, switchType } = setupTimestamp(FieldType.CreatedTime, { createdAt: TIMESTAMP });
+
+    act(() => {
+      switchType(fieldId, FieldType.DateTime);
+    });
+
+    const cell = getCell(rowDoc);
+    const field = getField(databaseDoc);
+
+    expect(cell.get(YjsDatabaseKey.data)).toBe(TIMESTAMP);
+    expect(getCellDataText(cell, field).length).toBeGreaterThan(0);
+  });
+
+  it('LastEditedTime -> DateTime: materializes row.last_modified into the cell', () => {
+    const { rowDoc, switchType } = setupTimestamp(FieldType.LastEditedTime, { lastModified: TIMESTAMP });
+
+    act(() => {
+      switchType(fieldId, FieldType.DateTime);
+    });
+
+    expect(getCell(rowDoc).get(YjsDatabaseKey.data)).toBe(TIMESTAMP);
+  });
+});
+
+// Mirrors desktop's real_data_transform_test.rs: A -> B -> A must restore the
+// original displayed value AND leave the raw cell data untouched (only a user
+// edit may change it). Each case is fully isolated (unique ids) to avoid any
+// cross-case state bleed.
+describe('round-trip A -> B -> A preserves cell data (desktop parity)', () => {
+  let seq = 0;
+
+  const selectContent = {
+    disable_color: false,
+    options: [
+      { id: 'o1', name: 'Red', color: 'Purple' },
+      { id: 'o2', name: 'Blue', color: 'Pink' },
+    ],
+  };
+  const checklistData = JSON.stringify({
+    options: [{ id: 'c1', name: 'Task', color: 0 }],
+    selected_option_ids: ['c1'],
+  });
+
+  function setup(type: FieldType, typeOptionContent: unknown, cellData: string) {
+    seq += 1;
+    const guid = `rt-db-${seq}`;
+    const fid = `rt-field-${seq}`;
+    const rid = `rt-row-${seq}`;
+    const vid = `rt-view-${seq}`;
+
+    const field = new Y.Map() as YDatabaseField;
+
+    field.set(YjsDatabaseKey.id, fid);
+    field.set(YjsDatabaseKey.name, 'F');
+    field.set(YjsDatabaseKey.type, type);
+    field.set(YjsDatabaseKey.created_at, '1000');
+    field.set(YjsDatabaseKey.last_modified, '2000');
+
+    if (typeOptionContent !== undefined) {
+      const typeOptionMap = new Y.Map();
+      const option = new Y.Map();
+
+      option.set(YjsDatabaseKey.content, JSON.stringify(typeOptionContent));
+      typeOptionMap.set(String(type), option);
+      field.set(YjsDatabaseKey.type_option, typeOptionMap);
+    }
+
+    const doc = new Y.Doc({ guid }) as YDoc;
+    const sharedRoot = doc.getMap(YjsEditorKey.data_section);
+    const database = new Y.Map() as YDatabase;
+    const fields = new Y.Map<YDatabaseField>() as YDatabaseFields;
+    const views = new Y.Map<YDatabaseView>() as YDatabaseViews;
+
+    fields.set(fid, field);
+    views.set(vid, new Y.Map() as YDatabaseView);
+    database.set(YjsDatabaseKey.id, guid);
+    database.set(YjsDatabaseKey.fields, fields);
+    database.set(YjsDatabaseKey.views, views);
+    sharedRoot.set(YjsEditorKey.database, database);
+
+    const rowDoc = createRowDoc(rid, guid, { [fid]: { fieldType: type, data: cellData } });
+    const contextValue = {
+      readOnly: false,
+      databaseDoc: doc,
+      databasePageId: vid,
+      activeViewId: vid,
+      rowMap: { [rid]: rowDoc },
+      workspaceId: 'workspace-id',
+    } as unknown as DatabaseContextState;
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <DatabaseContext.Provider value={contextValue}>{children}</DatabaseContext.Provider>
+    );
+    const { result } = renderHook(() => useSwitchPropertyType(), { wrapper });
+
+    const cellOf = () =>
+      (rowDoc.getMap(YjsEditorKey.data_section).get(YjsEditorKey.database_row) as YDatabaseRow)
+        .get(YjsDatabaseKey.cells)
+        .get(fid);
+    const fieldOf = () =>
+      (doc.getMap(YjsEditorKey.data_section).get(YjsEditorKey.database) as YDatabase)
+        .get(YjsDatabaseKey.fields)
+        .get(fid);
+
+    return { fid, result, cellOf, fieldOf };
+  }
+
+  const cases: Array<[string, FieldType, unknown, string, FieldType]> = [
+    ['SingleSelect <-> MultiSelect', FieldType.SingleSelect, selectContent, 'o1', FieldType.MultiSelect],
+    ['SingleSelect <-> RichText', FieldType.SingleSelect, selectContent, 'o1', FieldType.RichText],
+    ['MultiSelect <-> RichText', FieldType.MultiSelect, selectContent, 'o1,o2', FieldType.RichText],
+    ['Checkbox <-> RichText', FieldType.Checkbox, undefined, 'Yes', FieldType.RichText],
+    ['Number <-> RichText', FieldType.Number, { format: 0 }, '42', FieldType.RichText],
+    ['URL <-> RichText', FieldType.URL, undefined, 'http://example.com', FieldType.RichText],
+    ['Checklist <-> RichText', FieldType.Checklist, undefined, checklistData, FieldType.RichText],
+    ['DateTime <-> RichText', FieldType.DateTime, {}, '1747180800', FieldType.RichText],
+  ];
+
+  it.each(cases)('%s: round-trip restores value and keeps raw data', (_name, typeA, typeOpt, cellData, typeB) => {
+    const { fid, result, cellOf, fieldOf } = setup(typeA, typeOpt, cellData);
+
+    const before = getCellDataText(cellOf(), fieldOf());
+
+    expect(before.length).toBeGreaterThan(0);
+
+    act(() => {
+      result.current(fid, typeB);
+    });
+    act(() => {
+      result.current(fid, typeA);
+    });
+
+    expect(getCellDataText(cellOf(), fieldOf())).toBe(before);
+    expect(cellOf().get(YjsDatabaseKey.data)).toBe(cellData);
+  });
+});

--- a/src/application/database-yjs/cell.parse.ts
+++ b/src/application/database-yjs/cell.parse.ts
@@ -8,6 +8,7 @@ import {
   getDateCellStr,
   parseChecklistFlexible,
   parseSelectOptionTypeOptions,
+  safeParseTimestamp,
   stringifyChecklist,
 } from '@/application/database-yjs/fields';
 import { parseCheckboxValue, parseTimeStringToMs } from '@/application/database-yjs/fields/text/utils';
@@ -91,7 +92,9 @@ function transformCellData(
         (sourceType === FieldType.SingleSelect || sourceType === FieldType.MultiSelect) &&
         field
       ) {
-        const typeOption = parseSelectOptionTypeOptions(field);
+        // Resolve options by the source select type — the field's current type
+        // is Checklist here, so its own type-option holds no select options.
+        const typeOption = parseSelectOptionTypeOptions(field, sourceType);
         const options = typeOption?.options || [];
         const selectedIds = data.split(',');
         const checklistOptions: SelectOption[] = [];
@@ -118,6 +121,15 @@ function transformCellData(
     case FieldType.SingleSelect:
     case FieldType.MultiSelect: {
       if (!field) return '';
+
+      // SingleSelect <-> MultiSelect: the switch copies the options 1:1, so the
+      // stored option IDs stay valid — keep them (desktop parity:
+      // SelectOptionIds::from(cell)). Without this the data would be dropped.
+      // Early-return before parsing options (which this path does not need).
+      if (sourceType === FieldType.SingleSelect || sourceType === FieldType.MultiSelect) {
+        return typeof data === 'string' ? data : '';
+      }
+
       const typeOption = parseSelectOptionTypeOptions(field);
       const options = typeOption?.options || [];
 
@@ -165,6 +177,20 @@ function transformCellData(
 
       return '';
 
+    case FieldType.DateTime: {
+      // text -> DateTime: parse a free-text date into a unix timestamp in
+      // SECONDS (desktop parity: cast_string_to_timestamp). A materialized
+      // Created/LastEditedTime timestamp (numeric seconds/ms) normalizes through
+      // safeParseTimestamp to seconds as well.
+      if (typeof data !== 'string' && typeof data !== 'number') return '';
+      const raw = String(data).trim();
+
+      if (!raw) return '';
+      const parsed = safeParseTimestamp(raw);
+
+      return parsed.isValid() ? String(parsed.unix()) : '';
+    }
+
     case FieldType.Checkbox:
       if (sourceType === FieldType.RichText) {
         if (typeof data === 'string' || typeof data === 'number' || typeof data === 'boolean') {
@@ -178,8 +204,9 @@ function transformCellData(
       if (sourceType === FieldType.SingleSelect || sourceType === FieldType.MultiSelect) {
         if (typeof data === 'string' && data) {
           const selectedIds = data.split(',');
-          // First, try to look up option names from field type_option (if still available)
-          const typeOption = field ? parseSelectOptionTypeOptions(field) : null;
+          // First, try to look up option names from field type_option (if still available).
+          // Resolve by the source select type: the field's current type is Checkbox here.
+          const typeOption = field ? parseSelectOptionTypeOptions(field, sourceType) : null;
           const options = typeOption?.options || [];
           // Check if any selected option has name "Yes" (either by option lookup or direct ID match)
           const hasYes = selectedIds.some((id) => {
@@ -415,7 +442,9 @@ function stringifyFromSource(
     case FieldType.SingleSelect:
     case FieldType.MultiSelect: {
       if (!field) return '';
-      const options = parseSelectOptionTypeOptions(field)?.options || [];
+      // The field's current type is no longer a select (we are stringifying a
+      // converted-to-text cell), so resolve options by the source select type.
+      const options = parseSelectOptionTypeOptions(field, sourceType)?.options || [];
 
       if (typeof data === 'string') {
         return data

--- a/src/application/database-yjs/dispatch.ts
+++ b/src/application/database-yjs/dispatch.ts
@@ -2367,13 +2367,56 @@ export function useSwitchPropertyType() {
                 const cells = row.get(YjsDatabaseKey.cells);
                 const cell = cells.get(fieldId);
 
+                // Created/LastEditedTime fields have no cell data of their own —
+                // the timestamp lives on the row meta. Materialize it into the
+                // cell so the value survives the switch (desktop parity:
+                // switch_to_field_type writes row.created_at / row.modified_at
+                // into the cell before transforming).
+                if (oldFieldType === FieldType.CreatedTime || oldFieldType === FieldType.LastEditedTime) {
+                  const timestamp =
+                    oldFieldType === FieldType.CreatedTime
+                      ? row.get(YjsDatabaseKey.created_at)
+                      : row.get(YjsDatabaseKey.last_modified);
+                  const materialized = cell ?? (new Y.Map() as YDatabaseCell);
+
+                  if (!cell) {
+                    cells.set(fieldId, materialized);
+                  }
+
+                  materialized.set(YjsDatabaseKey.source_field_type, String(oldFieldType));
+                  materialized.set(YjsDatabaseKey.field_type, fieldType);
+                  materialized.set(
+                    YjsDatabaseKey.data,
+                    timestamp !== undefined && timestamp !== null ? String(timestamp) : ''
+                  );
+                  materialized.set(YjsDatabaseKey.last_modified, String(dayjs().unix()));
+
+                  return;
+                }
+
                 // Update each cell lazily: preserve existing data, record source type, update target type only.
                 if (cell) {
                   const data = cell.get(YjsDatabaseKey.data);
                   const oldCellType = Number(cell.get(YjsDatabaseKey.field_type));
 
-                  // Remember the original type so rendering can decode on demand.
-                  cell.set(YjsDatabaseKey.source_field_type, String(oldCellType));
+                  // Preserve the TRUE origin type across chained conversions
+                  // (mirrors desktop, where a cell's written-at type is never
+                  // overwritten by a switch). The data is still in the origin
+                  // type's format, so the origin is the existing source_field_type
+                  // if present, otherwise the cell's current type.
+                  const existingSource = cell.get(YjsDatabaseKey.source_field_type);
+                  const originType = existingSource !== undefined ? Number(existingSource) : oldCellType;
+
+                  if (originType === fieldType) {
+                    // Switched back to the type the data was written at — the
+                    // cell is native again, so drop the source marker.
+                    cell.delete(YjsDatabaseKey.source_field_type);
+                  } else if (existingSource === undefined) {
+                    // First divergence from the written-at type: record the origin.
+                    cell.set(YjsDatabaseKey.source_field_type, String(oldCellType));
+                  }
+                  // else: keep the already-recorded origin (do NOT overwrite it
+                  // with the intermediate hop — that is what hid the values).
 
                   // Move the cell to the new type without mutating data.
                   cell.set(YjsDatabaseKey.field_type, fieldType);

--- a/src/application/database-yjs/dispatch/cell.ts
+++ b/src/application/database-yjs/dispatch/cell.ts
@@ -186,6 +186,11 @@ function writeCellToRow({
       }
 
       cell.set(YjsDatabaseKey.field_type, fieldType);
+      // The data is now written in the current field type's format, so any
+      // lingering source-type marker from an earlier conversion is stale.
+      // Clearing it makes the cell native again (mirrors desktop, where a real
+      // write updates the cell's written-at type).
+      cell.delete(YjsDatabaseKey.source_field_type);
       cell.set(YjsDatabaseKey.last_modified, String(dayjs().unix()));
     }
 

--- a/src/application/database-yjs/fields/select-option/parse.ts
+++ b/src/application/database-yjs/fields/select-option/parse.ts
@@ -1,11 +1,12 @@
+import { FieldType } from '@/application/database-yjs/database.type';
 import { YDatabaseField, YjsDatabaseKey } from '@/application/types';
 
 import { getTypeOptions } from '../type_option';
 
 import { SelectTypeOption } from './select_option.type';
 
-export function parseSelectOptionTypeOptions(field: YDatabaseField) {
-  const content = getTypeOptions(field)?.get(YjsDatabaseKey.content);
+export function parseSelectOptionTypeOptions(field: YDatabaseField, fieldType?: FieldType) {
+  const content = getTypeOptions(field, fieldType)?.get(YjsDatabaseKey.content);
 
   if (!content)
     return {

--- a/src/application/database-yjs/fields/type_option.ts
+++ b/src/application/database-yjs/fields/type_option.ts
@@ -1,8 +1,16 @@
 import { FieldType } from '@/application/database-yjs/database.type';
 import { YDatabaseField, YMapFieldTypeOption, YjsDatabaseKey } from '@/application/types';
 
-export function getTypeOptions(field?: YDatabaseField): YMapFieldTypeOption | undefined {
-  const fieldType = Number(field?.get(YjsDatabaseKey.type)) as FieldType;
+export function getTypeOptions(
+  field?: YDatabaseField,
+  fieldType?: FieldType
+): YMapFieldTypeOption | undefined {
+  // Resolve the type-option entry for an explicit field type when provided.
+  // A converted cell keeps its data in the *source* type's format, and the
+  // field retains the source type's type-option, so callers rendering such a
+  // cell must look it up by the source type rather than the field's current
+  // type (which would otherwise miss the options and drop the value).
+  const type = (fieldType ?? Number(field?.get(YjsDatabaseKey.type))) as FieldType;
 
-  return field?.get(YjsDatabaseKey.type_option)?.get(String(fieldType));
+  return field?.get(YjsDatabaseKey.type_option)?.get(String(type));
 }


### PR DESCRIPTION
## Problem

Converting a field type in the grid could **hide or drop** cell values:

- **MultiSelect → Text**: values disappeared. Switching back to MultiSelect left them hidden — the data was still in the doc, just unrenderable.
- This is the recovery path for columns mis-imported as MultiSelect (see the backend fix in AppFlowy-Cloud PR #711).

## Root cause

The web uses a lazy conversion model (keep the raw data, record `source_field_type`, transform on read), but:

1. Select option resolution used the field's **current** type (`getTypeOptions`), so after a switch the lookup missed the (retained) source options and the stored option IDs no longer mapped to names → blank.
2. `useSwitchPropertyType` overwrote the cell's recorded origin with the **intermediate** hop on each switch, so a round-trip (A → B → A) misread the data.

## Fix — mirror desktop's (`flowy-database2`) lazy-conversion model

- Resolve select options by the cell's **source** field type, not the current type (`cell.parse.ts`).
- Preserve the **true origin** type across chained switches; clear it only when the cell returns to its written-at type (`useSwitchPropertyType`).
- Clear `source_field_type` on a genuine edit so an edited cell becomes native (`writeCellToRow`).

## Desktop-parity gaps also closed

- **SingleSelect ↔ MultiSelect** — keep the option IDs instead of dropping them (`SelectOptionIds::from(cell)`).
- **RichText → DateTime** — parse the text into a unix-seconds timestamp (`cast_string_to_timestamp`).
- **Created/LastEditedTime → DateTime** — materialize the row timestamp into the cell before switching.

## Tests

- Hook-driven conversion tests (`field-type-conversion.test.tsx`) incl. MultiSelect↔Text and the timestamp materialization cases.
- Parameterized **round-trip** suite over 8 type pairs asserting `A → B → A` restores the displayed value **and** leaves raw cell data untouched — mirroring desktop's `real_data_transform_test.rs` (the "data stays unless the user edits it" invariant).
- Updated `cell.transform.test.ts` (select↔select parity, RichText→DateTime, MS→Checklist fixture corrected to real post-switch layout).
- Full `database-yjs` suite: **481 passing**; changed source lint/type clean.

> Pairs with the backend import fix: AppFlowy-Cloud-Premium#711 (stops new imports from mis-typing the column); this PR lets users recover existing data and fixes conversion in general.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Preserve database cell values when converting field types by aligning the web field-type conversion and parsing behavior with the desktop lazy-conversion model.

Enhancements:
- Resolve select options using the cell's source field type so converted select/checklist/checkbox cells retain their stored option values.
- Maintain the original source_field_type across chained field-type switches and clear it only when a cell returns to its native type or is actively edited.
- Normalize RichText and timestamp-like values into DateTime cells, including converting Created/LastEditedTime row metadata into materialized DateTime cell data.
- Allow SingleSelect and MultiSelect conversions to keep stored option IDs intact instead of dropping them.
- Extend type-option lookup utilities to support resolving options for an explicitly provided field type to support lazy conversions.

Tests:
- Add hook-driven field-type conversion tests for MultiSelect↔Text, RichText→DateTime, and Created/LastEditedTime→DateTime recovery paths.
- Add a round-trip test suite over multiple field-type pairs to assert A→B→A conversions preserve both displayed values and raw cell data.
- Update existing cell transform tests to cover select-to-select parity and checklist/select conversion scenarios under the new lazy-conversion behavior.