### PR TITLE
Fix read-only enforcement from object permissions

### DIFF
--- a/playwright/bdd/features/page/full-access-share-management.feature
+++ b/playwright/bdd/features/page/full-access-share-management.feature
@@ -70,6 +70,59 @@ Feature: FullAccess private page share panel controls
     Then the full access seeded page title is visible
     And the full access page title cannot be edited to "fa0522 Read Guest Rename Probe"
 
+  # Expected result: a guest who already has the page open as Can view receives the permission
+  # update, becomes editable without relogin/reopen, and can persist a title change.
+  Scenario: Read guest can edit after owner upgrades open page access
+    Given I sign in as full access seeded "read guest"
+    When I open the full access seeded "guest read only private page"
+    Then the full access seeded page title is visible
+    And the full access page title is read-only
+    When the full access owner grants seeded "read guest" "Can edit" on the current page
+    Then the full access page title is editable
+    When I rename the full access page title to "fa0522 Read Guest Upgrade Rename Probe"
+    Then the full access page title is "fa0522 Read Guest Upgrade Rename Probe"
+
+  # Expected result: a guest who already has an editable page open receives the downgrade,
+  # loses edit controls, and stale local typing does not persist.
+  Scenario: Edit guest loses write access after owner downgrades open page access
+    Given I sign in as full access seeded "edit guest"
+    When I open the full access seeded "guest edit private page"
+    Then the full access seeded page title is visible
+    And the full access page title is editable
+    When the full access owner grants seeded "edit guest" "Can view" on the current page
+    Then the full access page title is read-only
+    And the full access page title cannot be edited to "fa0522 Downgraded Guest Stale Rename Probe"
+
+  # Expected result: revocation of an already-open page removes document access and clears the editor
+  # instead of allowing cached client state to keep rendering private content.
+  Scenario: Edit guest loses open page after owner revokes access
+    Given I sign in as full access seeded "edit guest"
+    When I open the full access seeded "guest edit private page"
+    Then the full access seeded page title is visible
+    When the full access owner revokes seeded "edit guest" on the current page
+    Then the full access no access page is shown
+
+  # Expected result: database permission uses the database object, not just the page shell.
+  # A Can view guest can open the database but cannot add rows/properties or edit cells.
+  Scenario: Read guest cannot mutate a database shared as Can view
+    Given I sign in as full access seeded "owner"
+    And I create a temporary full access grid database shared with seeded "read guest" as "Can view"
+    Given I sign in as full access seeded "read guest"
+    And I open the temporary full access database
+    Then the temporary full access database is read-only
+    And typing in the temporary full access database first cell has no effect
+
+  # Expected result: row document permission follows the database permission. A Can view guest can
+  # inspect the first row document but cannot mutate its embedded document body.
+  Scenario: Read guest cannot mutate a database row document shared as Can view
+    Given I sign in as full access seeded "owner"
+    And I create a temporary full access grid database shared with seeded "read guest" as "Can view"
+    Given I sign in as full access seeded "read guest"
+    And I open the temporary full access database
+    When I open the temporary full access database first row document
+    Then the temporary full access database row document is read-only
+    And typing in the temporary full access database row document has no effect
+
   # Expected result: a guest with Can edit can change the private page title.
   Scenario: Edit guest can edit a private page title
     Given I sign in as full access seeded "edit guest"

--- a/playwright/bdd/features/page/public-to-private-move-access.feature
+++ b/playwright/bdd/features/page/public-to-private-move-access.feature
@@ -37,3 +37,37 @@ Feature: Public page moved under private page access
     When I sign in as seeded public-to-private "member 2"
     And I open the temporary public-to-private movable page
     Then the public-to-private no access page is shown
+
+  # Expected result: moving a page between private subtrees stops using the old subtree's
+  # inherited access and starts using the new subtree's inherited access.
+  Scenario: Moving a page between differently shared private spaces swaps access
+    Given I sign in as seeded public-to-private "owner"
+    And I create a temporary private source shared with "member 1" and private target shared with "member 2"
+    When I sign in as seeded public-to-private "member 1"
+    And I open the temporary public-to-private movable page
+    Then the temporary public-to-private movable page title is visible
+    And the temporary public-to-private movable page editor is read-only
+    When I sign in as seeded public-to-private "member 2"
+    And I open the temporary public-to-private movable page
+    Then the public-to-private no access page is shown
+    When I move the temporary public-to-private page under the private target page
+    And I sign in as seeded public-to-private "member 1"
+    And I open the temporary public-to-private movable page
+    Then the public-to-private no access page is shown
+    When I sign in as seeded public-to-private "member 2"
+    And I open the temporary public-to-private movable page
+    Then the temporary public-to-private movable page title is visible
+    And the temporary public-to-private movable page editor is read-only
+
+  # Expected result: changing a private space to Public refreshes the client so a workspace
+  # member without an explicit share can open and edit the page.
+  Scenario: Member gains access when a private space becomes public
+    Given I sign in as seeded public-to-private "owner"
+    And I create a temporary private source shared with "member 1" and private target shared with "member 2"
+    When I sign in as seeded public-to-private "member 2"
+    And I open the temporary public-to-private movable page
+    Then the public-to-private no access page is shown
+    When I change the temporary private source space permission to "Public"
+    And I open the temporary public-to-private movable page
+    Then the temporary public-to-private movable page title is visible
+    And the temporary public-to-private movable page title is editable

--- a/playwright/bdd/steps/full-access-share-management.steps.ts
+++ b/playwright/bdd/steps/full-access-share-management.steps.ts
@@ -1,15 +1,24 @@
 import { APIRequestContext, expect, Page } from '@playwright/test';
 import { createBdd } from 'playwright-bdd';
 
+import { createDatabaseView, waitForGridReady } from '../../support/database-ui-helpers';
 import { signInWithPasswordViaUi } from '../../support/auth-flow-helpers';
-import { PageSelectors, ShareSelectors, SidebarSelectors } from '../../support/selectors';
+import {
+  DatabaseGridSelectors,
+  PageSelectors,
+  PropertyMenuSelectors,
+  RowDetailSelectors,
+  ShareSelectors,
+  SidebarSelectors,
+} from '../../support/selectors';
 import { setupPageErrorHandling, TestConfig } from '../../support/test-config';
 
 const { Given, When, Then, Before, After } = createBdd();
 
 const PASSWORD = 'AppFlowy!@123';
-const WORKSPACE_ID = '2b64f8c8-22d2-4e35-8deb-8a7e85bba4d4';
 const INVITE_PROBE_EMAIL = 'fa0522-out@appflowy.local';
+const ACCESS_LEVEL_READ_ONLY = 10;
+const ACCESS_LEVEL_READ_AND_WRITE = 30;
 const modKey = process.platform === 'darwin' ? 'Meta' : 'Control';
 
 const FULL_ACCESS_ACCOUNTS = {
@@ -53,19 +62,54 @@ const FULL_ACCESS_PAGES = {
 
 type FullAccessAccountAlias = keyof typeof FULL_ACCESS_ACCOUNTS;
 type FullAccessPageAlias = keyof typeof FULL_ACCESS_PAGES;
-type FullAccessPage = (typeof FULL_ACCESS_PAGES)[FullAccessPageAlias];
+type FullAccessPageDefinition = (typeof FULL_ACCESS_PAGES)[FullAccessPageAlias];
+type FullAccessPage = FullAccessPageDefinition & {
+  workspaceId: string;
+};
 
 type ScenarioState = {
+  workspaceId?: string;
+  fixturePages?: Partial<Record<FullAccessPageAlias, FullAccessPage>>;
   currentPage?: FullAccessPage;
   pagesToRestore: FullAccessPage[];
+  accessLevelsToRestore: AccessLevelRestore[];
+  temporaryDatabase?: TemporaryDatabase;
 };
 
 const stateByPage = new WeakMap<Page, ScenarioState>();
 
+type AccessLevelRestore = {
+  page: FullAccessPage;
+  email: string;
+  accessLevel: number;
+};
+
+type TemporaryDatabase = {
+  workspaceId: string;
+  viewId: string;
+};
+
+type Workspace = {
+  workspace_id: string;
+  role?: string;
+};
+
+type FolderView = {
+  view_id: string;
+  name: string;
+  children?: FolderView[];
+};
+
+type ApiResponse<T> = {
+  code?: number;
+  message?: string;
+  data?: T;
+};
+
 Before(async ({ page }) => {
   setupPageErrorHandling(page);
   await page.setViewportSize({ width: 1440, height: 900 });
-  stateByPage.set(page, { pagesToRestore: [] });
+  stateByPage.set(page, { pagesToRestore: [], accessLevelsToRestore: [] });
 });
 
 After(async ({ page, request }) => {
@@ -73,6 +117,14 @@ After(async ({ page, request }) => {
 
   for (const seededPage of state.pagesToRestore) {
     await restoreFullAccessSeededPageTitle(request, page, seededPage);
+  }
+
+  for (const restore of state.accessLevelsToRestore) {
+    await restoreFullAccessSeededPageAccess(request, restore);
+  }
+
+  if (state.temporaryDatabase) {
+    await cleanupTemporaryDatabase(request, state.temporaryDatabase);
   }
 });
 
@@ -82,17 +134,58 @@ Given('the seeded fa0522 full access share-management fixture exists', async () 
 });
 
 Given('I sign in as full access seeded {string}', async ({ page }, accountAliasValue: string) => {
+  await resetBrowserSession(page);
   await signInWithPasswordViaUi(page, accountEmail(accountAliasValue), PASSWORD, 2000);
   await expect(page).toHaveURL(/\/app/, { timeout: 30000 });
   await expect(SidebarSelectors.pageHeader(page)).toBeVisible({ timeout: 30000 });
 });
 
-When('I open the full access seeded {string}', async ({ page }, pageAliasValue: string) => {
-  const seededPage = pageDefinition(pageAliasValue);
+When('I open the full access seeded {string}', async ({ page, request }, pageAliasValue: string) => {
+  const seededPage = await resolveFullAccessPage(request, getState(page), pageAliasValue);
 
   getState(page).currentPage = seededPage;
-  await page.goto(`/app/${WORKSPACE_ID}/${seededPage.viewId}`, { waitUntil: 'domcontentloaded' });
+  await page.goto(`/app/${seededPage.workspaceId}/${seededPage.viewId}`, { waitUntil: 'domcontentloaded' });
   await page.waitForTimeout(1500);
+});
+
+Given(
+  'I create a temporary full access grid database shared with seeded {string} as {string}',
+  async ({ page, request }, accountAliasValue: string, accessText: string) => {
+    const state = getState(page);
+    const email = accountEmail(accountAliasValue);
+    const ownerToken = await getAuthToken(page);
+
+    if (!ownerToken) {
+      throw new Error('Cannot create temporary full access database: no owner auth token in browser storage');
+    }
+
+    const workspaceId = await ensureFullAccessWorkspaceId(request, state);
+
+    await createDatabaseView(page, 'Grid', 7000);
+    await waitForGridReady(page);
+    await waitForTemporaryDatabaseCellsLoaded(page);
+
+    const viewId = currentViewIdFromUrl(page.url());
+
+    state.temporaryDatabase = { workspaceId, viewId };
+
+    await putVoidApi(request, ownerToken, `/api/sharing/workspace/${workspaceId}/view`, {
+      view_id: viewId,
+      emails: [email],
+      access_level: accessLevelFromText(accessText),
+    });
+  }
+);
+
+When('I open the temporary full access database', async ({ page }) => {
+  const temporaryDatabase = requireTemporaryDatabase(getState(page));
+
+  await page.goto(`/app/${temporaryDatabase.workspaceId}/${temporaryDatabase.viewId}`, {
+    waitUntil: 'domcontentloaded',
+  });
+  await page.waitForTimeout(1500);
+  await waitForGridReady(page);
+  await waitForTemporaryDatabaseCellsLoaded(page);
 });
 
 Then(
@@ -198,6 +291,58 @@ When('I rename the full access page title to {string}', async ({ page }, newTitl
   await page.waitForTimeout(1500);
 });
 
+When(
+  'the full access owner grants seeded {string} {string} on the current page',
+  async ({ page, request }, accountAliasValue: string, accessText: string) => {
+    const state = getState(page);
+    const seededPage = requireCurrentPage(state);
+    const email = accountEmail(accountAliasValue);
+    const nextAccessLevel = accessLevelFromText(accessText);
+    const ownerToken = await getPasswordAuthToken(request, FULL_ACCESS_ACCOUNTS.owner);
+
+    state.accessLevelsToRestore.push({
+      page: seededPage,
+      email,
+      accessLevel: originalAccessLevelFor(seededPage, email),
+    });
+
+    await putVoidApi(request, ownerToken, `/api/sharing/workspace/${seededPage.workspaceId}/view`, {
+      view_id: seededPage.viewId,
+      emails: [email],
+      access_level: nextAccessLevel,
+    });
+
+    await page.waitForTimeout(1500);
+  }
+);
+
+When(
+  'the full access owner revokes seeded {string} on the current page',
+  async ({ page, request }, accountAliasValue: string) => {
+    const state = getState(page);
+    const seededPage = requireCurrentPage(state);
+    const email = accountEmail(accountAliasValue);
+    const ownerToken = await getPasswordAuthToken(request, FULL_ACCESS_ACCOUNTS.owner);
+
+    state.accessLevelsToRestore.push({
+      page: seededPage,
+      email,
+      accessLevel: originalAccessLevelFor(seededPage, email),
+    });
+
+    await postVoidApi(
+      request,
+      ownerToken,
+      `/api/sharing/workspace/${seededPage.workspaceId}/view/${seededPage.viewId}/revoke-access`,
+      {
+        emails: [email],
+      }
+    );
+
+    await page.waitForTimeout(1500);
+  }
+);
+
 Then('the full access page title is {string}', async ({ page }, expectedTitle: string) => {
   const editableTitle = PageSelectors.titleInput(page).first();
 
@@ -207,6 +352,100 @@ Then('the full access page title is {string}', async ({ page }, expectedTitle: s
   }
 
   await expect(page.getByText(expectedTitle, { exact: true }).first()).toBeVisible({ timeout: 15000 });
+});
+
+Then('the full access page title is read-only', async ({ page }) => {
+  await expect(PageSelectors.titleInput(page)).toHaveCount(0);
+});
+
+Then('the full access no access page is shown', async ({ page }) => {
+  await expect(page.getByText('No access to this page', { exact: true }).first()).toBeVisible({ timeout: 30000 });
+  await expect(page.getByRole('button', { name: 'Request access' }).first()).toBeVisible({ timeout: 15000 });
+  await expect(PageSelectors.titleInput(page)).toHaveCount(0);
+  await expect(ShareSelectors.shareButton(page)).toHaveCount(0);
+});
+
+Then('the temporary full access database is read-only', async ({ page }) => {
+  await waitForGridReady(page);
+  await expect(DatabaseGridSelectors.newRowButton(page)).toHaveCount(0);
+  await expect(PropertyMenuSelectors.newPropertyButton(page)).toHaveCount(0);
+});
+
+Then('typing in the temporary full access database first cell has no effect', async ({ page }) => {
+  await waitForTemporaryDatabaseCellsLoaded(page);
+
+  const firstCell = DatabaseGridSelectors.cells(page).first();
+
+  await expect(firstCell).toBeVisible({ timeout: 30000 });
+
+  const before = (await firstCell.innerText()).trim();
+  const wrapperHandle = await firstCell.evaluateHandle((element) => element.closest('.grid-row-cell') ?? element);
+  const wrapper = wrapperHandle.asElement();
+
+  if (wrapper) {
+    await wrapper.click({ force: true });
+  } else {
+    await firstCell.click({ force: true });
+  }
+
+  await page.keyboard.type('fa0522 readonly database stale edit');
+  await page.keyboard.press('Enter').catch(() => undefined);
+  await page.waitForTimeout(1000);
+
+  await expect(firstCell.locator('textarea')).toHaveCount(0);
+  await expect.poll(async () => (await firstCell.innerText()).trim()).toBe(before);
+});
+
+When('I open the temporary full access database first row document', async ({ page }) => {
+  await waitForGridReady(page);
+  await waitForTemporaryDatabaseCellsLoaded(page);
+  await openTemporaryDatabaseRowDocument(page, 0);
+});
+
+Then('the temporary full access database row document is read-only', async ({ page }) => {
+  await scrollRowDocumentIntoView(page);
+
+  const titleInput = RowDetailSelectors.titleInput(page);
+  const editor = rowDocumentEditor(page);
+
+  await expect(titleInput).toBeVisible({ timeout: 15000 });
+  await expect(titleInput).toHaveJSProperty('readOnly', true);
+
+  if ((await editor.count()) > 0) {
+    await expect(editor).toBeVisible({ timeout: 15000 });
+    await expect(editor).toHaveAttribute('contenteditable', 'false');
+  }
+});
+
+Then('typing in the temporary full access database row document has no effect', async ({ page }) => {
+  await scrollRowDocumentIntoView(page);
+
+  const titleInput = RowDetailSelectors.titleInput(page);
+  const editor = rowDocumentEditor(page);
+  const sentinel = 'fa0522 readonly row document stale edit';
+
+  await expect(titleInput).toBeVisible({ timeout: 15000 });
+
+  if ((await editor.count()) === 0) {
+    const beforeTitle = await titleInput.inputValue();
+
+    await titleInput.click({ force: true }).catch(() => undefined);
+    await page.keyboard.type(sentinel);
+    await page.waitForTimeout(1000);
+
+    await expect(titleInput).toHaveValue(beforeTitle);
+    await expect(page.getByText(sentinel, { exact: true })).toHaveCount(0);
+    return;
+  }
+
+  const before = (await editor.textContent()) ?? '';
+
+  await editor.click({ force: true }).catch(() => undefined);
+  await page.keyboard.type(sentinel);
+  await page.waitForTimeout(1000);
+
+  await expect(editor).not.toContainText(sentinel);
+  await expect(editor).toHaveText(before);
 });
 
 Then(
@@ -246,7 +485,7 @@ function accountEmail(aliasValue: string): string {
   return email;
 }
 
-function pageDefinition(aliasValue: string): (typeof FULL_ACCESS_PAGES)[FullAccessPageAlias] {
+function pageDefinition(aliasValue: string): FullAccessPageDefinition {
   const alias = aliasValue as FullAccessPageAlias;
   const seededPage = FULL_ACCESS_PAGES[alias];
 
@@ -255,6 +494,70 @@ function pageDefinition(aliasValue: string): (typeof FULL_ACCESS_PAGES)[FullAcce
   }
 
   return seededPage;
+}
+
+async function resolveFullAccessPage(
+  request: APIRequestContext,
+  state: ScenarioState,
+  aliasValue: string
+): Promise<FullAccessPage> {
+  const alias = aliasValue as FullAccessPageAlias;
+  const seededPage = pageDefinition(aliasValue);
+  const cachedPage = state.fixturePages?.[alias];
+
+  if (cachedPage) {
+    return cachedPage;
+  }
+
+  const workspaceId = await ensureFullAccessWorkspaceId(request, state);
+  const ownerToken = await getPasswordAuthToken(request, FULL_ACCESS_ACCOUNTS.owner);
+  const root = await getApi<FolderView>(
+    request,
+    ownerToken,
+    `/api/workspace/${workspaceId}/view/${workspaceId}?depth=50`
+  );
+  const viewId = findViewIdByTitle(root, seededPage.title);
+  const resolvedPage = { ...seededPage, viewId, workspaceId };
+
+  state.fixturePages = {
+    ...state.fixturePages,
+    [alias]: resolvedPage,
+  };
+
+  return resolvedPage;
+}
+
+async function ensureFullAccessWorkspaceId(request: APIRequestContext, state: ScenarioState): Promise<string> {
+  if (state.workspaceId) {
+    return state.workspaceId;
+  }
+
+  const ownerToken = await getPasswordAuthToken(request, FULL_ACCESS_ACCOUNTS.owner);
+  const workspaces = await getApi<Workspace[]>(request, ownerToken, '/api/workspace?include_member_count=true');
+  const workspace = workspaces.find((candidate) => candidate.role === 'Owner') ?? workspaces[0];
+
+  if (!workspace?.workspace_id) {
+    throw new Error('FullAccess seeded owner has no workspace');
+  }
+
+  state.workspaceId = workspace.workspace_id;
+  return state.workspaceId;
+}
+
+function findViewIdByTitle(view: FolderView, title: string): string {
+  if (view.name === title) {
+    return view.view_id;
+  }
+
+  for (const child of view.children ?? []) {
+    try {
+      return findViewIdByTitle(child, title);
+    } catch {
+      // Continue searching siblings.
+    }
+  }
+
+  throw new Error(`Unable to find full access seeded view title: ${title}`);
 }
 
 function getState(page: Page): ScenarioState {
@@ -275,8 +578,107 @@ function requireCurrentPage(state: ScenarioState): FullAccessPage {
   return state.currentPage;
 }
 
+function requireTemporaryDatabase(state: ScenarioState): TemporaryDatabase {
+  if (!state.temporaryDatabase) {
+    throw new Error('No temporary full access database has been created for this scenario');
+  }
+
+  return state.temporaryDatabase;
+}
+
 function inviteInput(page: Page) {
   return ShareSelectors.emailTagInput(page).locator('input[type="text"]');
+}
+
+function rowDocumentEditor(page: Page) {
+  return page.getByTestId('editor-content').first();
+}
+
+async function waitForTemporaryDatabaseCellsLoaded(page: Page) {
+  const firstCell = DatabaseGridSelectors.cells(page).first();
+
+  await expect(firstCell).toBeVisible({ timeout: 30000 });
+  await expect(firstCell.locator('[data-testid^="primary-cell-loading-"]')).toHaveCount(0, {
+    timeout: 30000,
+  });
+}
+
+async function scrollRowDocumentIntoView(page: Page) {
+  const modalScrollContainer = RowDetailSelectors.modal(page)
+    .locator('.appflowy-scroll-container')
+    .first();
+  const scrollContainer = (await modalScrollContainer.count()) > 0
+    ? modalScrollContainer
+    : page.locator('.appflowy-scroll-container').first();
+
+  if ((await scrollContainer.count()) === 0) {
+    return;
+  }
+
+  await scrollContainer.evaluate((element) => element.scrollTo(0, element.scrollHeight));
+  await page.waitForTimeout(500);
+}
+
+async function openTemporaryDatabaseRowDocument(page: Page, rowIndex: number) {
+  const row = DatabaseGridSelectors.dataRows(page).nth(rowIndex);
+
+  await row.scrollIntoViewIfNeeded();
+  await row.hover();
+  await page.waitForTimeout(500);
+
+  const expandButton = page.getByTestId('row-expand-button').first();
+
+  await expect(expandButton).toBeVisible({ timeout: 5000 });
+  await expandButton.click({ force: true });
+
+  await expect
+    .poll(
+      async () =>
+        (await RowDetailSelectors.modal(page).count()) > 0 ||
+        (await RowDetailSelectors.titleInput(page).count()) > 0,
+      {
+        timeout: 15000,
+      }
+    )
+    .toBe(true);
+}
+
+function accessLevelFromText(accessText: string): number {
+  switch (accessText) {
+    case 'Can view':
+      return ACCESS_LEVEL_READ_ONLY;
+    case 'Can edit':
+      return ACCESS_LEVEL_READ_AND_WRITE;
+    default:
+      throw new Error(`Unsupported full access seeded access level: ${accessText}`);
+  }
+}
+
+function originalAccessLevelFor(page: FullAccessPage, email: string): number {
+  if (page.title === FULL_ACCESS_PAGES['guest read only private page'].title) {
+    return ACCESS_LEVEL_READ_ONLY;
+  }
+
+  if (
+    page.title === FULL_ACCESS_PAGES['guest edit private page'].title &&
+    email === FULL_ACCESS_ACCOUNTS['edit guest']
+  ) {
+    return ACCESS_LEVEL_READ_AND_WRITE;
+  }
+
+  throw new Error(`No original access level mapping for ${email} on ${page.viewId}`);
+}
+
+function currentViewIdFromUrl(url: string): string {
+  const parsed = new URL(url);
+  const segments = parsed.pathname.split('/').filter(Boolean);
+  const viewId = segments[2];
+
+  if (!viewId) {
+    throw new Error(`Unable to parse view id from current URL: ${url}`);
+  }
+
+  return viewId;
 }
 
 function sharePersonRow(page: Page, email: string) {
@@ -291,7 +693,7 @@ async function restoreFullAccessSeededPageTitle(request: APIRequestContext, page
   }
 
   const response = await request.post(
-    `${TestConfig.apiUrl}/api/workspace/${WORKSPACE_ID}/page-view/${seededPage.viewId}/update-name`,
+    `${TestConfig.apiUrl}/api/workspace/${seededPage.workspaceId}/page-view/${seededPage.viewId}/update-name`,
     {
       headers: {
         Authorization: `Bearer ${token}`,
@@ -305,9 +707,159 @@ async function restoreFullAccessSeededPageTitle(request: APIRequestContext, page
 
   if (!response.ok() || body?.code !== 0) {
     throw new Error(
-      `Failed to restore full access seeded page ${seededPage.viewId}: HTTP ${response.status()} ${JSON.stringify(body)}`
+      `Failed to restore full access seeded page ${seededPage.viewId}: ` +
+        `HTTP ${response.status()} ${JSON.stringify(body)}`
     );
   }
+}
+
+async function restoreFullAccessSeededPageAccess(request: APIRequestContext, restore: AccessLevelRestore) {
+  const ownerToken = await getPasswordAuthToken(request, FULL_ACCESS_ACCOUNTS.owner);
+
+  await putVoidApi(request, ownerToken, `/api/sharing/workspace/${restore.page.workspaceId}/view`, {
+    view_id: restore.page.viewId,
+    emails: [restore.email],
+    access_level: restore.accessLevel,
+  });
+}
+
+async function cleanupTemporaryDatabase(request: APIRequestContext, temporaryDatabase: TemporaryDatabase) {
+  const ownerToken = await getPasswordAuthToken(request, FULL_ACCESS_ACCOUNTS.owner);
+
+  await postVoidApiAllowFailure(
+    request,
+    ownerToken,
+    `/api/workspace/${temporaryDatabase.workspaceId}/page-view/${temporaryDatabase.viewId}/move-to-trash`,
+    `move temporary full access database ${temporaryDatabase.viewId} to trash`
+  );
+}
+
+async function getApi<T>(request: APIRequestContext, token: string, path: string): Promise<T> {
+  const response = await request.get(`${TestConfig.apiUrl}${path}`, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    },
+    failOnStatusCode: false,
+  });
+  const body = (await response.json().catch(() => null)) as ApiResponse<T> | null;
+
+  if (!response.ok() || body?.code !== 0 || body.data === undefined) {
+    throw new Error(`API request failed for ${path}: HTTP ${response.status()} ${JSON.stringify(body)}`);
+  }
+
+  return body.data;
+}
+
+async function putVoidApi(
+  request: APIRequestContext,
+  token: string,
+  path: string,
+  data: Record<string, unknown>
+): Promise<void> {
+  const response = await request.put(`${TestConfig.apiUrl}${path}`, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    },
+    data,
+    failOnStatusCode: false,
+  });
+  const body = (await response.json().catch(() => null)) as { code?: number; message?: string } | null;
+
+  if (!response.ok() || body?.code !== 0) {
+    throw new Error(`API request failed for ${path}: HTTP ${response.status()} ${JSON.stringify(body)}`);
+  }
+}
+
+async function postVoidApi(
+  request: APIRequestContext,
+  token: string,
+  path: string,
+  data: Record<string, unknown>
+): Promise<void> {
+  const response = await request.post(`${TestConfig.apiUrl}${path}`, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    },
+    data,
+    failOnStatusCode: false,
+  });
+  const body = (await response.json().catch(() => null)) as { code?: number; message?: string } | null;
+
+  if (!response.ok() || body?.code !== 0) {
+    throw new Error(`API request failed for ${path}: HTTP ${response.status()} ${JSON.stringify(body)}`);
+  }
+}
+
+async function postVoidApiAllowFailure(
+  request: APIRequestContext,
+  token: string,
+  path: string,
+  label: string
+): Promise<void> {
+  const response = await request.post(`${TestConfig.apiUrl}${path}`, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    },
+    failOnStatusCode: false,
+  });
+
+  if (!response.ok()) {
+    console.warn(`Failed to ${label}: HTTP ${response.status()} ${await response.text()}`);
+  }
+}
+
+async function getPasswordAuthToken(request: APIRequestContext, email: string): Promise<string> {
+  const response = await request.post(`${TestConfig.gotrueUrl}/token?grant_type=password`, {
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    data: {
+      email,
+      password: PASSWORD,
+    },
+    failOnStatusCode: false,
+  });
+  const body = (await response.json().catch(() => null)) as { access_token?: string; error?: string } | null;
+
+  if (!response.ok() || !body?.access_token) {
+    throw new Error(`Failed to sign in ${email} for API token: HTTP ${response.status()} ${JSON.stringify(body)}`);
+  }
+
+  return body.access_token;
+}
+
+async function resetBrowserSession(page: Page) {
+  await page.goto('/', { waitUntil: 'domcontentloaded' }).catch(() => undefined);
+  await page.evaluate(async () => {
+    localStorage.clear();
+    sessionStorage.clear();
+
+    const indexedDatabase = indexedDB as IDBFactory & { databases?: () => Promise<Array<{ name?: string }>> };
+
+    if (!indexedDatabase.databases) return;
+
+    const databases = await indexedDatabase.databases();
+    await Promise.all(
+      databases
+        .map((database) => database.name)
+        .filter((name): name is string => Boolean(name))
+        .map(
+          (name) =>
+            new Promise<void>((resolve) => {
+              const request = indexedDB.deleteDatabase(name);
+
+              request.onsuccess = () => resolve();
+              request.onerror = () => resolve();
+              request.onblocked = () => resolve();
+            })
+        )
+    );
+  });
+  await page.context().clearCookies();
 }
 
 async function getAuthToken(page: Page): Promise<string> {

--- a/playwright/bdd/steps/public-to-private-move-access.steps.ts
+++ b/playwright/bdd/steps/public-to-private-move-access.steps.ts
@@ -31,6 +31,7 @@ type ScenarioState = {
   workspaceId?: string;
   ownerToken?: string;
   movablePage?: TemporaryView;
+  privateSource?: TemporaryView;
   privateTarget?: TemporaryView;
   privateTargetIsSeeded?: boolean;
 };
@@ -196,6 +197,99 @@ Given(
   }
 );
 
+Given(
+  'I create a temporary private source shared with {string} and private target shared with {string}',
+  async ({ page, request }, sourceAliasValue: string, targetAliasValue: string) => {
+    const state = getState(page);
+    const workspaceId = requireWorkspaceId(state);
+    const ownerToken = requireOwnerToken(state);
+    const sourceEmail = accountEmail(sourceAliasValue);
+    const targetEmail = accountEmail(targetAliasValue);
+    const sourceSpaceName = `ptp0527 BDD Private Source Space ${state.runId}`;
+    const sourcePageTitle = `ptp0527 BDD Private Source Page ${state.runId}`;
+    const targetSpaceName = `ptp0527 BDD Private Target Space ${state.runId}`;
+    const targetPageTitle = `ptp0527 BDD Private Target Page ${state.runId}`;
+    const movableTitle = `ptp0527 BDD Private Movable Page ${state.runId}`;
+
+    await cleanupStaleTemporaryViews(request, ownerToken, workspaceId);
+
+    const sourceSpace = await postApi<{ view_id: string }>(request, ownerToken, `/api/workspace/${workspaceId}/space`, {
+      name: sourceSpaceName,
+      space_icon: 'lock',
+      space_icon_color: '#555555',
+      space_permission: SPACE_PERMISSION_PRIVATE,
+    });
+    const sourcePage = await postApi<{ view_id: string }>(
+      request,
+      ownerToken,
+      `/api/workspace/${workspaceId}/page-view`,
+      {
+        parent_view_id: sourceSpace.view_id,
+        layout: VIEW_LAYOUT_DOCUMENT,
+        name: sourcePageTitle,
+      }
+    );
+
+    const targetSpace = await postApi<{ view_id: string }>(request, ownerToken, `/api/workspace/${workspaceId}/space`, {
+      name: targetSpaceName,
+      space_icon: 'lock',
+      space_icon_color: '#555555',
+      space_permission: SPACE_PERMISSION_PRIVATE,
+    });
+    const targetPage = await postApi<{ view_id: string }>(
+      request,
+      ownerToken,
+      `/api/workspace/${workspaceId}/page-view`,
+      {
+        parent_view_id: targetSpace.view_id,
+        layout: VIEW_LAYOUT_DOCUMENT,
+        name: targetPageTitle,
+      }
+    );
+    const movablePage = await postApi<{ view_id: string }>(
+      request,
+      ownerToken,
+      `/api/workspace/${workspaceId}/page-view`,
+      {
+        parent_view_id: sourcePage.view_id,
+        layout: VIEW_LAYOUT_DOCUMENT,
+        name: movableTitle,
+      }
+    );
+
+    await putVoidApi(request, ownerToken, `/api/sharing/workspace/${workspaceId}/view`, {
+      view_id: sourcePage.view_id,
+      emails: [sourceEmail],
+      access_level: ACCESS_LEVEL_READ_ONLY,
+    });
+    await putVoidApi(request, ownerToken, `/api/sharing/workspace/${workspaceId}/view`, {
+      view_id: targetPage.view_id,
+      emails: [targetEmail],
+      access_level: ACCESS_LEVEL_READ_ONLY,
+    });
+
+    state.privateSource = {
+      spaceId: sourceSpace.view_id,
+      spaceName: sourceSpaceName,
+      pageId: sourcePage.view_id,
+      pageTitle: sourcePageTitle,
+    };
+    state.privateTarget = {
+      spaceId: targetSpace.view_id,
+      spaceName: targetSpaceName,
+      pageId: targetPage.view_id,
+      pageTitle: targetPageTitle,
+    };
+    state.privateTargetIsSeeded = false;
+    state.movablePage = {
+      spaceId: sourceSpace.view_id,
+      spaceName: sourceSpaceName,
+      pageId: movablePage.view_id,
+      pageTitle: movableTitle,
+    };
+  }
+);
+
 When('I open the temporary public-to-private movable page', async ({ page }) => {
   const state = getState(page);
   const workspaceId = requireWorkspaceId(state);
@@ -229,10 +323,38 @@ When('I move the temporary public-to-private page under the private target page'
   await expect(SidebarSelectors.pageHeader(page)).toBeVisible({ timeout: 30000 });
 });
 
+When(
+  'I change the temporary private source space permission to {string}',
+  async ({ page, request }, permission: string) => {
+    const state = getState(page);
+    const workspaceId = requireWorkspaceId(state);
+    const ownerToken = requireOwnerToken(state);
+    const privateSource = requirePrivateSource(state);
+    const nextPermission = permission === 'Public' ? SPACE_PERMISSION_PUBLIC : SPACE_PERMISSION_PRIVATE;
+
+    if (permission !== 'Public' && permission !== 'Private') {
+      throw new Error(`Unsupported public-to-private source space permission: ${permission}`);
+    }
+
+    await patchVoidApi(request, ownerToken, `/api/workspace/${workspaceId}/space/${privateSource.spaceId}`, {
+      name: privateSource.spaceName,
+      space_icon: 'lock',
+      space_icon_color: '#555555',
+      space_permission: nextPermission,
+    });
+
+    await page.waitForTimeout(1500);
+  }
+);
+
 Then('the temporary public-to-private movable page title is visible', async ({ page }) => {
   const movablePage = requireMovablePage(getState(page));
 
   await expect(page.getByText(movablePage.pageTitle, { exact: true }).first()).toBeVisible({ timeout: 30000 });
+});
+
+Then('the temporary public-to-private movable page title is editable', async ({ page }) => {
+  await expect(PageSelectors.titleInput(page).first()).toBeVisible({ timeout: 15000 });
 });
 
 Then('the temporary public-to-private movable page editor is read-only', async ({ page }) => {
@@ -363,6 +485,14 @@ function requireMovablePage(state: ScenarioState): TemporaryView {
   return state.movablePage;
 }
 
+function requirePrivateSource(state: ScenarioState): TemporaryView {
+  if (!state.privateSource) {
+    throw new Error('No temporary public-to-private private source page has been created for this scenario');
+  }
+
+  return state.privateSource;
+}
+
 function requirePrivateTarget(state: ScenarioState): TemporaryView {
   if (!state.privateTarget) {
     throw new Error('No temporary public-to-private private target page has been created for this scenario');
@@ -409,11 +539,17 @@ async function cleanupTemporaryViews(request: APIRequestContext, state: Scenario
     return;
   }
 
-  const viewIds = [
-    state.movablePage?.pageId,
-    state.movablePage?.spaceId,
-    ...(state.privateTargetIsSeeded ? [] : [state.privateTarget?.pageId, state.privateTarget?.spaceId]),
-  ].filter((viewId): viewId is string => Boolean(viewId));
+  const viewIds = Array.from(
+    new Set(
+      [
+        state.movablePage?.pageId,
+        state.movablePage?.spaceId,
+        state.privateSource?.pageId,
+        state.privateSource?.spaceId,
+        ...(state.privateTargetIsSeeded ? [] : [state.privateTarget?.pageId, state.privateTarget?.spaceId]),
+      ].filter((viewId): viewId is string => Boolean(viewId))
+    )
+  );
 
   for (const viewId of viewIds) {
     await postVoidApiAllowFailure(
@@ -465,8 +601,12 @@ function isTemporaryView(view: FolderView): boolean {
   return [
     'ptp0527 BDD Public Space ',
     'ptp0527 BDD Movable Public Page ',
+    'ptp0527 BDD Private Source Space ',
+    'ptp0527 BDD Private Source Page ',
+    'ptp0527 BDD Private Movable Page ',
     'ptp0527 BDD Private Space ',
     'ptp0527 BDD Private Target Page ',
+    'ptp0527 BDD Private Target Space ',
   ].some((prefix) => view.name.startsWith(prefix));
 }
 
@@ -538,6 +678,27 @@ async function putVoidApi(
   data: Record<string, unknown>
 ): Promise<void> {
   const response = await request.put(`${TestConfig.apiUrl}${path}`, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    },
+    data,
+    failOnStatusCode: false,
+  });
+  const body = (await response.json().catch(() => null)) as ApiResponse<unknown> | null;
+
+  if (!response.ok() || body?.code !== 0) {
+    throw new Error(`API request failed for ${path}: HTTP ${response.status()} ${JSON.stringify(body)}`);
+  }
+}
+
+async function patchVoidApi(
+  request: APIRequestContext,
+  token: string,
+  path: string,
+  data: Record<string, unknown>
+): Promise<void> {
+  const response = await request.patch(`${TestConfig.apiUrl}${path}`, {
     headers: {
       Authorization: `Bearer ${token}`,
       'Content-Type': 'application/json',

--- a/playwright/e2e/database/legacy-database-owner-edit.spec.ts
+++ b/playwright/e2e/database/legacy-database-owner-edit.spec.ts
@@ -1,0 +1,224 @@
+import { test, expect, type APIRequestContext, type Locator, type Page } from '@playwright/test';
+
+import { signInWithPasswordViaUi } from '../../support/auth-flow-helpers';
+import { waitForGridReady } from '../../support/database-ui-helpers';
+import { getCurrentDatabaseInfo } from '../../support/relation-test-helpers';
+import { DatabaseGridSelectors } from '../../support/selectors';
+import { setupPageErrorHandling, TestConfig } from '../../support/test-config';
+
+const LEGACY_DB_OWNER_EMAIL = process.env.LEGACY_DB_OWNER_EMAIL || 'legacy_db_user@appflowy.io';
+const LEGACY_DB_OWNER_PASSWORD = process.env.LEGACY_DB_OWNER_PASSWORD || 'AppFlowy!@123';
+const LEGACY_DB_WORKSPACE_ID = process.env.LEGACY_DB_WORKSPACE_ID;
+const LEGACY_DB_VIEW_ID = process.env.LEGACY_DB_VIEW_ID;
+
+const GRID_LAYOUT = 1;
+
+type Workspace = {
+  workspace_id: string;
+  role?: string;
+};
+
+type FolderView = {
+  view_id: string;
+  name: string;
+  layout?: number | string | null;
+  extra?: {
+    database_id?: string;
+    is_database_container?: boolean;
+  } | null;
+  children?: FolderView[];
+};
+
+type ApiResponse<T> = {
+  code?: number;
+  message?: string;
+  data?: T;
+};
+
+type LegacyDatabaseView = {
+  workspaceId: string;
+  viewId: string;
+  name: string;
+};
+
+test.describe('Legacy database owner permissions', () => {
+  test.beforeEach(async ({ page }) => {
+    setupPageErrorHandling(page);
+    await page.setViewportSize({ width: 1440, height: 960 });
+  });
+
+  test('owner can edit a legacy grid database without a database container', async ({ page, request }) => {
+    const legacyDatabase = await resolveLegacyGridDatabase(request);
+
+    test.info().annotations.push({
+      type: 'legacy database',
+      description: `${legacyDatabase.name} (${legacyDatabase.workspaceId}/${legacyDatabase.viewId})`,
+    });
+
+    await signInWithPasswordViaUi(page, LEGACY_DB_OWNER_EMAIL, LEGACY_DB_OWNER_PASSWORD);
+    await page.goto(`/app/${legacyDatabase.workspaceId}/${legacyDatabase.viewId}`, {
+      waitUntil: 'domcontentloaded',
+    });
+
+    await waitForGridReady(page);
+    await ensureAtLeastOneRow(page);
+
+    const { primaryFieldId } = await getCurrentDatabaseInfo(page);
+    const probeText = `legacy-owner-edit-${Date.now()}`;
+    const firstPrimaryCell = DatabaseGridSelectors.dataRowCellsForField(page, primaryFieldId).first();
+    const originalText = await normalizedText(firstPrimaryCell);
+
+    try {
+      await replaceCellText(page, firstPrimaryCell, probeText);
+      await expect(firstPrimaryCell).toContainText(probeText, { timeout: 15000 });
+
+      await page.reload({ waitUntil: 'domcontentloaded' });
+      await waitForGridReady(page);
+      await expect(DatabaseGridSelectors.grid(page)).toContainText(probeText, { timeout: 30000 });
+    } finally {
+      await restoreProbeCell(page, primaryFieldId, probeText, originalText);
+    }
+  });
+});
+
+async function resolveLegacyGridDatabase(request: APIRequestContext): Promise<LegacyDatabaseView> {
+  if (LEGACY_DB_WORKSPACE_ID && LEGACY_DB_VIEW_ID) {
+    return {
+      workspaceId: LEGACY_DB_WORKSPACE_ID,
+      viewId: LEGACY_DB_VIEW_ID,
+      name: 'env override legacy database',
+    };
+  }
+
+  const token = await getPasswordAuthToken(request);
+  const workspaces = await getApi<Workspace[]>(request, token, '/api/workspace?include_member_count=true');
+  const ownerWorkspaces = [
+    ...workspaces.filter((workspace) => workspace.role === 'Owner'),
+    ...workspaces.filter((workspace) => workspace.role !== 'Owner'),
+  ];
+
+  for (const workspace of ownerWorkspaces) {
+    const workspaceId = workspace.workspace_id;
+    const root = await getApi<FolderView>(request, token, `/api/workspace/${workspaceId}/view/${workspaceId}?depth=50`);
+    const legacyView = findLegacyGridDatabase(root);
+
+    if (legacyView) {
+      return {
+        workspaceId,
+        viewId: legacyView.view_id,
+        name: legacyView.name,
+      };
+    }
+  }
+
+  throw new Error(`No legacy grid database was found for ${LEGACY_DB_OWNER_EMAIL}`);
+}
+
+function findLegacyGridDatabase(root: FolderView): FolderView | null {
+  const visit = (view: FolderView, underDatabaseContainer: boolean): FolderView | null => {
+    const isDatabaseContainer = view.extra?.is_database_container === true;
+    const isLegacyGrid = Number(view.layout) === GRID_LAYOUT && !isDatabaseContainer && !underDatabaseContainer;
+
+    if (isLegacyGrid) {
+      return view;
+    }
+
+    for (const child of view.children ?? []) {
+      const match = visit(child, underDatabaseContainer || isDatabaseContainer);
+
+      if (match) {
+        return match;
+      }
+    }
+
+    return null;
+  };
+
+  return visit(root, false);
+}
+
+async function ensureAtLeastOneRow(page: Page): Promise<void> {
+  if ((await DatabaseGridSelectors.dataRows(page).count()) > 0) {
+    return;
+  }
+
+  await DatabaseGridSelectors.newRowButton(page).click({ force: true });
+  await expect(DatabaseGridSelectors.dataRows(page).first()).toBeVisible({ timeout: 15000 });
+}
+
+async function replaceCellText(page: Page, cell: Locator, text: string): Promise<void> {
+  await cell.scrollIntoViewIfNeeded();
+  await cell.evaluate((element) => (element as HTMLElement).click());
+
+  const textarea = page.locator('textarea:visible').first();
+
+  await expect(textarea).toBeVisible({ timeout: 8000 });
+  await textarea.clear();
+
+  if (text.length > 0) {
+    await textarea.pressSequentially(text, { delay: 20 });
+  }
+
+  await page.keyboard.press('Enter');
+  await page.waitForTimeout(800);
+}
+
+async function restoreProbeCell(
+  page: Page,
+  primaryFieldId: string,
+  probeText: string,
+  originalText: string
+): Promise<void> {
+  const probeCell = DatabaseGridSelectors.dataRowCellsForField(page, primaryFieldId)
+    .filter({ hasText: probeText })
+    .first();
+
+  if ((await probeCell.count()) === 0) {
+    return;
+  }
+
+  await replaceCellText(page, probeCell, originalText);
+}
+
+async function normalizedText(locator: Locator): Promise<string> {
+  return ((await locator.textContent()) || '').trim();
+}
+
+async function getApi<T>(request: APIRequestContext, token: string, path: string): Promise<T> {
+  const response = await request.get(`${TestConfig.apiUrl}${path}`, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    },
+    failOnStatusCode: false,
+  });
+  const body = (await response.json().catch(() => null)) as ApiResponse<T> | null;
+
+  if (!response.ok() || body?.code !== 0 || body.data === undefined) {
+    throw new Error(`API request failed for ${path}: HTTP ${response.status()} ${JSON.stringify(body)}`);
+  }
+
+  return body.data;
+}
+
+async function getPasswordAuthToken(request: APIRequestContext): Promise<string> {
+  const response = await request.post(`${TestConfig.gotrueUrl}/token?grant_type=password`, {
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    data: {
+      email: LEGACY_DB_OWNER_EMAIL,
+      password: LEGACY_DB_OWNER_PASSWORD,
+    },
+    failOnStatusCode: false,
+  });
+  const body = (await response.json().catch(() => null)) as { access_token?: string; error?: string } | null;
+
+  if (!response.ok() || !body?.access_token) {
+    throw new Error(
+      `Failed to sign in ${LEGACY_DB_OWNER_EMAIL} for API token: HTTP ${response.status()} ${JSON.stringify(body)}`
+    );
+  }
+
+  return body.access_token;
+}

--- a/src/application/database-yjs/selector.ts
+++ b/src/application/database-yjs/selector.ts
@@ -1897,7 +1897,7 @@ export function useCellSelector({ rowId, fieldId }: { rowId: string; fieldId: st
     return () => {
       cell?.unobserveDeep(observerEvent);
     };
-  }, [cell, field, rowId, fieldId]);
+  }, [cell, field, fieldClock, rowId, fieldId]);
 
   useEffect(() => {
     if (!cells) return;
@@ -1920,7 +1920,7 @@ export function useCellSelector({ rowId, fieldId }: { rowId: string; fieldId: st
     return () => {
       cells.unobserve(observerEvent);
     };
-  }, [cells, fieldId, field, rowId]);
+  }, [cells, fieldId, field, fieldClock, rowId]);
 
   if (fieldType === FieldType.Rollup) {
     return rollupCell;

--- a/src/application/services/domains/collab.ts
+++ b/src/application/services/domains/collab.ts
@@ -1,6 +1,7 @@
 export {
   updateCollab as update,
   getCollab as get,
+  getObjectPermission,
   getPageCollab,
   collabFullSyncBatch as fullSyncBatch,
   databaseBlobDiff,

--- a/src/application/services/js-services/__tests__/sync.test.ts
+++ b/src/application/services/js-services/__tests__/sync.test.ts
@@ -96,6 +96,80 @@ const mockSync = (clientCount: number, tracer = defaultTracer): SyncContext[] =>
   return clients;
 };
 
+describe('database row hydration sync', () => {
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('responds to row sync requests with full row state', () => {
+    const doc = new Y.Doc({ guid: random.uuidv4() });
+    const text = doc.getText('cell');
+    const emit = jest.fn();
+    const context: SyncContext = {
+      doc,
+      emit,
+      collabType: Types.DatabaseRow,
+    };
+
+    text.insert(0, 'row-value');
+
+    handleMessage(context, {
+      objectId: doc.guid,
+      collabType: Types.DatabaseRow,
+      syncRequest: {
+        stateVector: Y.encodeStateVector(doc),
+        lastMessageId: { timestamp: 0, counter: 0 },
+      },
+    });
+
+    const payload = emit.mock.calls[0]?.[0].collabMessage?.update?.payload;
+    const mirror = new Y.Doc();
+
+    Y.applyUpdate(mirror, payload);
+    expect(mirror.getText('cell').toString()).toBe('row-value');
+  });
+
+  it('sends follow-up sync requests for rendered database rows', () => {
+    jest.useFakeTimers();
+
+    const doc = new Y.Doc({ guid: random.uuidv4() });
+    const emit = jest.fn();
+    const context: SyncContext = {
+      doc,
+      emit,
+      collabType: Types.DatabaseRow,
+    };
+
+    const { cleanup } = initSync(context);
+
+    expect(emit).toHaveBeenCalledTimes(1);
+    expect(emit.mock.calls[0]?.[0]).toEqual(
+      expect.objectContaining({
+        collabMessage: expect.objectContaining({
+          objectId: doc.guid,
+          collabType: Types.DatabaseRow,
+          syncRequest: expect.any(Object),
+        }),
+      })
+    );
+
+    jest.advanceTimersByTime(749);
+    expect(emit).toHaveBeenCalledTimes(1);
+
+    jest.advanceTimersByTime(1);
+    expect(emit).toHaveBeenCalledTimes(2);
+
+    jest.advanceTimersByTime(1750);
+    expect(emit).toHaveBeenCalledTimes(3);
+
+    cleanup();
+    jest.advanceTimersByTime(5000);
+    expect(emit).toHaveBeenCalledTimes(3);
+
+    doc.destroy();
+  });
+});
+
 interface QueuedSyncBus {
   clients: SyncContext[];
   online: boolean[];

--- a/src/application/services/js-services/cache/__tests__/cache.test.ts
+++ b/src/application/services/js-services/cache/__tests__/cache.test.ts
@@ -290,6 +290,6 @@ describe('collabTypeToDBType', () => {
     expect(collabTypeToDBType(Types.WorkspaceDatabase)).toBe('databases');
     expect(collabTypeToDBType(Types.DatabaseRow)).toBe('database_row');
     expect(collabTypeToDBType(Types.UserAwareness)).toBe('user_awareness');
-    expect(collabTypeToDBType(Types.Empty)).toBe('');
+    expect(collabTypeToDBType(Types.Unknown)).toBe('');
   });
 });

--- a/src/application/services/js-services/cache/index.ts
+++ b/src/application/services/js-services/cache/index.ts
@@ -57,7 +57,6 @@ const collabSharedRootKeyMap = {
   [Types.WorkspaceDatabase]: YjsEditorKey.workspace_database,
   [Types.DatabaseRow]: YjsEditorKey.database_row,
   [Types.UserAwareness]: YjsEditorKey.user_awareness,
-  [Types.Empty]: YjsEditorKey.empty,
 };
 
 export function hasCollabCache(doc: YDoc) {

--- a/src/application/services/js-services/http/__tests__/collab-api.test.ts
+++ b/src/application/services/js-services/http/__tests__/collab-api.test.ts
@@ -1,7 +1,8 @@
 import { collab } from '@/proto/messages';
-import { getAxios } from '@/application/services/js-services/http/core';
+import { executeAPIRequest, getAxios } from '@/application/services/js-services/http/core';
+import { Types } from '@/application/types';
 
-import { collabFullSyncBatch } from '../collab-api';
+import { collabFullSyncBatch, getObjectPermission } from '../collab-api';
 
 jest.mock('@/application/services/js-services/device-id', () => ({
   getOrCreateDeviceId: jest.fn(() => 'test-device-id'),
@@ -15,6 +16,7 @@ jest.mock('@/application/services/js-services/http/core', () => ({
 }));
 
 const mockGetAxios = getAxios as unknown as jest.Mock;
+const mockExecuteAPIRequest = executeAPIRequest as unknown as jest.Mock;
 
 describe('collabFullSyncBatch', () => {
   beforeEach(() => {
@@ -50,5 +52,40 @@ describe('collabFullSyncBatch', () => {
     expect(ArrayBuffer.isView(requestBody)).toBe(true);
     expect(requestBody.byteLength).toBeLessThan(requestBody.buffer.byteLength);
     expect(config.transformRequest[0](requestBody)).toBe(requestBody);
+  });
+});
+
+describe('getObjectPermission', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('sends collab_type for view permission queries', async () => {
+    const get = jest.fn();
+
+    mockGetAxios.mockReturnValue({ get });
+    mockExecuteAPIRequest.mockImplementation(async (request: () => unknown) => {
+      request();
+      return {
+        object_id: 'view-id',
+        collab_type: Types.Document,
+        governing_view_id: 'view-id',
+        access_level: null,
+        can_read: true,
+        can_write: false,
+        can_comment: false,
+        can_share: false,
+      };
+    });
+
+    const permission = await getObjectPermission('workspace-id', 'view-id', Types.Document);
+
+    expect(permission.can_write).toBe(false);
+    expect(get).toHaveBeenCalledWith('/api/workspace/workspace-id/collab/view-id/permission', {
+      params: {
+        collab_type: Types.Document,
+      },
+      signal: undefined,
+    });
   });
 });

--- a/src/application/services/js-services/http/__tests__/collab-api.test.ts
+++ b/src/application/services/js-services/http/__tests__/collab-api.test.ts
@@ -105,7 +105,7 @@ describe('collab history APIs', () => {
     mockWithRetry.mockImplementation((fn: () => unknown) => fn());
   });
 
-  it('retries permission-backpressured history mutations through the shared retry wrapper', async () => {
+  it('does not retry non-idempotent history mutations', async () => {
     const post = jest.fn();
     const deleteRequest = jest.fn();
 
@@ -132,7 +132,7 @@ describe('collab history APIs', () => {
     await deleteCollabVersion('workspace-id', 'object-id', 'version-id');
     await revertCollabVersion('workspace-id', 'object-id', Types.Document, 'version-id');
 
-    expect(mockWithRetry).toHaveBeenCalledTimes(3);
+    expect(mockWithRetry).not.toHaveBeenCalled();
     expect(post).toHaveBeenCalledWith('/api/workspace/workspace-id/collab/object-id/history', {
       snapshot: expect.any(String),
       name: 'snapshot',

--- a/src/application/services/js-services/http/__tests__/collab-api.test.ts
+++ b/src/application/services/js-services/http/__tests__/collab-api.test.ts
@@ -1,8 +1,14 @@
 import { collab } from '@/proto/messages';
-import { executeAPIRequest, getAxios } from '@/application/services/js-services/http/core';
+import { executeAPIRequest, executeAPIVoidRequest, getAxios, withRetry } from '@/application/services/js-services/http/core';
 import { Types } from '@/application/types';
 
-import { collabFullSyncBatch, getObjectPermission } from '../collab-api';
+import {
+  collabFullSyncBatch,
+  createCollabVersion,
+  deleteCollabVersion,
+  getObjectPermission,
+  revertCollabVersion,
+} from '../collab-api';
 
 jest.mock('@/application/services/js-services/device-id', () => ({
   getOrCreateDeviceId: jest.fn(() => 'test-device-id'),
@@ -13,10 +19,13 @@ jest.mock('@/application/services/js-services/http/core', () => ({
   executeAPIVoidRequest: jest.fn(),
   getAxios: jest.fn(),
   parseRetryAfterSecs: jest.fn(),
+  withRetry: jest.fn((fn: () => unknown) => fn()),
 }));
 
 const mockGetAxios = getAxios as unknown as jest.Mock;
 const mockExecuteAPIRequest = executeAPIRequest as unknown as jest.Mock;
+const mockExecuteAPIVoidRequest = executeAPIVoidRequest as unknown as jest.Mock;
+const mockWithRetry = withRetry as unknown as jest.Mock;
 
 describe('collabFullSyncBatch', () => {
   beforeEach(() => {
@@ -41,7 +50,7 @@ describe('collabFullSyncBatch', () => {
     await collabFullSyncBatch('workspace-id', [
       {
         objectId: 'object-id',
-        collabType: 0,
+        collabType: Types.Document,
         stateVector: new Uint8Array([1]),
         docState: new Uint8Array([2]),
       },
@@ -86,6 +95,58 @@ describe('getObjectPermission', () => {
         collab_type: Types.Document,
       },
       signal: undefined,
+    });
+  });
+});
+
+describe('collab history APIs', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockWithRetry.mockImplementation((fn: () => unknown) => fn());
+  });
+
+  it('retries permission-backpressured history mutations through the shared retry wrapper', async () => {
+    const post = jest.fn();
+    const deleteRequest = jest.fn();
+
+    mockGetAxios.mockReturnValue({ post, delete: deleteRequest });
+    mockExecuteAPIRequest
+      .mockImplementationOnce(async (request: () => unknown) => {
+        request();
+        return 'version-id';
+      })
+      .mockImplementationOnce(async (request: () => unknown) => {
+        request();
+        return {
+          state_vector: [1],
+          doc_state: [2],
+          collab_version: 'restored-version',
+          version: 0,
+        };
+      });
+    mockExecuteAPIVoidRequest.mockImplementationOnce(async (request: () => unknown) => {
+      request();
+    });
+
+    await createCollabVersion('workspace-id', 'object-id', Types.Document, 'snapshot', new Uint8Array([1]));
+    await deleteCollabVersion('workspace-id', 'object-id', 'version-id');
+    await revertCollabVersion('workspace-id', 'object-id', Types.Document, 'version-id');
+
+    expect(mockWithRetry).toHaveBeenCalledTimes(3);
+    expect(post).toHaveBeenCalledWith('/api/workspace/workspace-id/collab/object-id/history', {
+      snapshot: expect.any(String),
+      name: 'snapshot',
+      collab_type: Types.Document,
+    });
+    expect(deleteRequest).toHaveBeenCalledWith('/api/workspace/workspace-id/collab/object-id/history', {
+      data: JSON.stringify('version-id'),
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    });
+    expect(post).toHaveBeenCalledWith('/api/workspace/workspace-id/collab/object-id/revert', {
+      version: 'version-id',
+      collab_type: Types.Document,
     });
   });
 });

--- a/src/application/services/js-services/http/__tests__/core.test.ts
+++ b/src/application/services/js-services/http/__tests__/core.test.ts
@@ -1,0 +1,31 @@
+import { ERROR_CODE } from '@/application/constants';
+
+import { withRetry } from '../core';
+
+describe('withRetry', () => {
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.restoreAllMocks();
+  });
+
+  it('retries AppFlowy TooManyRequests API errors', async () => {
+    jest.useFakeTimers();
+    jest.spyOn(Math, 'random').mockReturnValue(0);
+
+    const request = jest
+      .fn()
+      .mockRejectedValueOnce({
+        code: ERROR_CODE.TOO_MANY_REQUESTS,
+        message: 'permission resolver is busy',
+      })
+      .mockResolvedValueOnce('ok');
+
+    const promise = withRetry(request, { delays: [1] });
+
+    await Promise.resolve();
+    jest.advanceTimersByTime(1);
+
+    await expect(promise).resolves.toBe('ok');
+    expect(request).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/application/services/js-services/http/collab-api.ts
+++ b/src/application/services/js-services/http/collab-api.ts
@@ -2,6 +2,7 @@ import { toBase64 } from 'lib0/buffer';
 
 import { getOrCreateDeviceId } from '@/application/services/js-services/device-id';
 import {
+  ObjectPermission,
   RowId,
   Types,
   User,
@@ -168,6 +169,24 @@ export async function getCollab(workspaceId: string, objectId: string, collabTyp
   return {
     data: new Uint8Array(data.doc_state),
   };
+}
+
+export async function getObjectPermission(
+  workspaceId: string,
+  objectId: string,
+  collabType: Types = Types.Document,
+  signal?: AbortSignal
+) {
+  const url = `/api/workspace/${workspaceId}/collab/${objectId}/permission`;
+
+  return executeAPIRequest<ObjectPermission>(() =>
+    getAxios()?.get<APIResponse<ObjectPermission>>(url, {
+      params: {
+        collab_type: collabType,
+      },
+      signal,
+    })
+  );
 }
 
 export async function getPageCollab(workspaceId: string, viewId: string) {

--- a/src/application/services/js-services/http/collab-api.ts
+++ b/src/application/services/js-services/http/collab-api.ts
@@ -12,7 +12,7 @@ import { database_blob } from '@/proto/database_blob';
 import { collab } from '@/proto/messages';
 import { Log } from '@/utils/log';
 
-import { APIResponse, APIError, executeAPIRequest, executeAPIVoidRequest, getAxios, parseRetryAfterSecs } from './core';
+import { APIResponse, APIError, executeAPIRequest, executeAPIVoidRequest, getAxios, parseRetryAfterSecs, withRetry } from './core';
 
 export interface CollabFullSyncBatchResult {
   objectId: string;
@@ -337,45 +337,51 @@ export async function createCollabVersion(
   const snapshot = toBase64(ySnapshot);
   const url = `/api/workspace/${workspaceId}/collab/${objectId}/history`;
 
-  return executeAPIRequest<string>(() =>
-    getAxios()?.post<APIResponse<string>>(url, {
-      snapshot,
-      name,
-      collab_type: collabType,
-    })
+  return withRetry(() =>
+    executeAPIRequest<string>(() =>
+      getAxios()?.post<APIResponse<string>>(url, {
+        snapshot,
+        name,
+        collab_type: collabType,
+      })
+    )
   );
 }
 
 export async function deleteCollabVersion(workspaceId: string, objectId: string, version: string) {
   const url = `/api/workspace/${workspaceId}/collab/${objectId}/history`;
 
-  return executeAPIVoidRequest(() =>
-    getAxios()?.delete<APIResponse>(url, {
-      data: JSON.stringify(version),
-      headers: {
-        'Content-Type': 'application/json',
-      },
-    })
+  return withRetry(() =>
+    executeAPIVoidRequest(() =>
+      getAxios()?.delete<APIResponse>(url, {
+        data: JSON.stringify(version),
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      })
+    )
   );
 }
 
 export async function revertCollabVersion(workspaceId: string, objectId: string, collabType: Types, version: string) {
   const url = `/api/workspace/${workspaceId}/collab/${objectId}/revert`;
-  const data = await executeAPIRequest<{
-    state_vector: number[];
-    doc_state: number[];
-    collab_version: string | null;
-    version: number; // this is encoder version (lib0 v1 encoding is 0, while lib0 v2 encoding is 1, we only use 0 atm.)
-  }>(() =>
-    getAxios()?.post<APIResponse<{
+  const data = await withRetry(() =>
+    executeAPIRequest<{
       state_vector: number[];
       doc_state: number[];
       collab_version: string | null;
       version: number;
-    }>>(url, {
-      version,
-      collab_type: collabType,
-    })
+    }>(() =>
+      getAxios()?.post<APIResponse<{
+        state_vector: number[];
+        doc_state: number[];
+        collab_version: string | null;
+        version: number;
+      }>>(url, {
+        version,
+        collab_type: collabType,
+      })
+    )
   );
 
   return {

--- a/src/application/services/js-services/http/collab-api.ts
+++ b/src/application/services/js-services/http/collab-api.ts
@@ -12,7 +12,7 @@ import { database_blob } from '@/proto/database_blob';
 import { collab } from '@/proto/messages';
 import { Log } from '@/utils/log';
 
-import { APIResponse, APIError, executeAPIRequest, executeAPIVoidRequest, getAxios, parseRetryAfterSecs, withRetry } from './core';
+import { APIResponse, APIError, executeAPIRequest, executeAPIVoidRequest, getAxios, parseRetryAfterSecs } from './core';
 
 export interface CollabFullSyncBatchResult {
   objectId: string;
@@ -337,51 +337,45 @@ export async function createCollabVersion(
   const snapshot = toBase64(ySnapshot);
   const url = `/api/workspace/${workspaceId}/collab/${objectId}/history`;
 
-  return withRetry(() =>
-    executeAPIRequest<string>(() =>
-      getAxios()?.post<APIResponse<string>>(url, {
-        snapshot,
-        name,
-        collab_type: collabType,
-      })
-    )
+  return executeAPIRequest<string>(() =>
+    getAxios()?.post<APIResponse<string>>(url, {
+      snapshot,
+      name,
+      collab_type: collabType,
+    })
   );
 }
 
 export async function deleteCollabVersion(workspaceId: string, objectId: string, version: string) {
   const url = `/api/workspace/${workspaceId}/collab/${objectId}/history`;
 
-  return withRetry(() =>
-    executeAPIVoidRequest(() =>
-      getAxios()?.delete<APIResponse>(url, {
-        data: JSON.stringify(version),
-        headers: {
-          'Content-Type': 'application/json',
-        },
-      })
-    )
+  return executeAPIVoidRequest(() =>
+    getAxios()?.delete<APIResponse>(url, {
+      data: JSON.stringify(version),
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    })
   );
 }
 
 export async function revertCollabVersion(workspaceId: string, objectId: string, collabType: Types, version: string) {
   const url = `/api/workspace/${workspaceId}/collab/${objectId}/revert`;
-  const data = await withRetry(() =>
-    executeAPIRequest<{
+  const data = await executeAPIRequest<{
+    state_vector: number[];
+    doc_state: number[];
+    collab_version: string | null;
+    version: number;
+  }>(() =>
+    getAxios()?.post<APIResponse<{
       state_vector: number[];
       doc_state: number[];
       collab_version: string | null;
       version: number;
-    }>(() =>
-      getAxios()?.post<APIResponse<{
-        state_vector: number[];
-        doc_state: number[];
-        collab_version: string | null;
-        version: number;
-      }>>(url, {
-        version,
-        collab_type: collabType,
-      })
-    )
+    }>>(url, {
+      version,
+      collab_type: collabType,
+    })
   );
 
   return {

--- a/src/application/services/js-services/http/core.ts
+++ b/src/application/services/js-services/http/core.ts
@@ -1,6 +1,7 @@
 import axios, { AxiosError, AxiosInstance, AxiosResponse } from 'axios';
 import dayjs from 'dayjs';
 
+import { ERROR_CODE } from '@/application/constants';
 import { AFCloudConfig } from '@/application/services/services.type';
 import { getTokenParsed, invalidToken } from '@/application/session/token';
 import { Log } from '@/utils/log';
@@ -248,7 +249,11 @@ export async function withRetry<T>(
       // handleAPIError handles AxiosError (string codes like "ERR_NETWORK"),
       // raw Error, and unknown shapes — always returns { code, message }.
       const normalized = handleAPIError(error);
-      const isRetryable = normalized.code === -1 || normalized.code >= 500 || normalized.code === 429;
+      const isRetryable =
+        normalized.code === -1 ||
+        normalized.code >= 500 ||
+        normalized.code === 429 ||
+        normalized.code === ERROR_CODE.TOO_MANY_REQUESTS;
 
       if (!isRetryable) break;
 

--- a/src/application/services/js-services/sync-protocol.ts
+++ b/src/application/services/js-services/sync-protocol.ts
@@ -76,7 +76,9 @@ export enum UpdateFlags {
 const handleSyncRequest = (ctx: SyncContext, message: collab.ISyncRequest): void => {
   const { doc, emit } = ctx;
   const stateVector = message.stateVector && message.stateVector.length > 0 ? message.stateVector : undefined;
-  const update = Y.encodeStateAsUpdate(doc, stateVector);
+  const update = ctx.collabType === Types.DatabaseRow
+    ? Y.encodeStateAsUpdate(doc)
+    : Y.encodeStateAsUpdate(doc, stateVector);
 
   Log.debug('[sync] responding to sync request from server', {
     objectId: doc.guid,
@@ -97,6 +99,20 @@ const handleSyncRequest = (ctx: SyncContext, message: collab.ISyncRequest): void
     },
   });
   ctx.onManifestSync?.(doc.guid);
+};
+
+const emitSyncRequest = (ctx: SyncContext): void => {
+  ctx.emit({
+    collabMessage: {
+      objectId: ctx.doc.guid,
+      collabType: ctx.collabType,
+      syncRequest: {
+        stateVector: Y.encodeStateVector(ctx.doc),
+        lastMessageId: ctx.lastMessageId || { timestamp: 0, counter: 0 },
+        version: ctx.doc.version,
+      },
+    },
+  });
 };
 
 const handleAccessChanged = (ctx: SyncContext, message: collab.IAccessChanged): void => {
@@ -185,6 +201,8 @@ export const initSync = (ctx: SyncContext) => {
   }
 
   let onAwarenessChange: ((event: AwarenessEvent, origin: string) => void) | undefined;
+  const rowHydrationTimers: ReturnType<typeof setTimeout>[] = [];
+  let disposed = false;
 
   // Persist every local update synchronously to the sync_outbox, then let the
   // background drain loop push it over the WebSocket. Survives refresh, tab
@@ -221,17 +239,24 @@ export const initSync = (ctx: SyncContext) => {
 
   // emit initial sync request to the server
   Log.debug('[Version] initSync sending initial syncRequest: objectId=%s, version=%s', ctx.doc.guid, ctx.doc.version);
-  emit({
-    collabMessage: {
-      objectId: ctx.doc.guid,
-      collabType: ctx.collabType,
-      syncRequest: {
-        stateVector: Y.encodeStateVector(ctx.doc),
-        lastMessageId: lastMessageId || { timestamp: 0, counter: 0 },
-        version: ctx.doc.version,
-      },
-    },
-  });
+  ctx.lastMessageId = lastMessageId || ctx.lastMessageId;
+  emitSyncRequest(ctx);
+
+  if (collabType === Types.DatabaseRow) {
+    for (const delayMs of [750, 2500]) {
+      rowHydrationTimers.push(
+        setTimeout(() => {
+          if (disposed) return;
+
+          Log.debug('[Database] row hydration sync retry', {
+            rowId: doc.guid,
+            delayMs,
+          });
+          emitSyncRequest(ctx);
+        }, delayMs)
+      );
+    }
+  }
 
   if (awareness) {
     onAwarenessChange = ({ added, updated, removed }: AwarenessEvent, _: string) => {
@@ -270,8 +295,10 @@ export const initSync = (ctx: SyncContext) => {
   // detaches listeners. Outbox deletion is caller-driven via
   // discardPendingUpdates() (version reset/revert paths only).
   const cleanup = () => {
+    disposed = true;
     doc.off('update', onUpdate);
     doc.off('destroy', onDestroy);
+    rowHydrationTimers.forEach((timer) => clearTimeout(timer));
     if (awareness && onAwarenessChange) {
       awareness.off('change', onAwarenessChange);
     }

--- a/src/application/slate-yjs/__tests__/database-block-live-sync.test.ts
+++ b/src/application/slate-yjs/__tests__/database-block-live-sync.test.ts
@@ -1,0 +1,91 @@
+import { expect } from '@jest/globals';
+import { createEditor, Element } from 'slate';
+import * as Y from 'yjs';
+
+import { yDocToSlateContent } from '@/application/slate-yjs/utils/convert';
+import { BlockType, YBlocks, YjsEditorKey } from '@/application/types';
+
+import {
+  generateId,
+  getTestingDocData,
+  insertBlock,
+  withTestingYDoc,
+  withTestingYjsEditor,
+} from './withTestingYjsEditor';
+
+jest.mock('nanoid');
+jest.mock('lodash-es', () => jest.requireActual('lodash'));
+jest.mock('lodash-es/isEqual', () => jest.requireActual('lodash/isEqual'));
+
+function buildSyncedParagraph(blockId: string) {
+  const pageId = generateId();
+  const remoteDoc = withTestingYDoc(pageId);
+  const remoteBlock = insertBlock({
+    doc: remoteDoc,
+    blockObject: {
+      id: blockId,
+      ty: BlockType.Paragraph,
+      relation_id: blockId,
+      text_id: blockId,
+      data: '{}',
+    },
+  });
+
+  remoteBlock.applyDelta([{ insert: '/grid' }]);
+
+  const localDoc = new Y.Doc();
+
+  Y.applyUpdateV2(localDoc, Y.encodeStateAsUpdateV2(remoteDoc));
+
+  return { remoteDoc, localDoc };
+}
+
+function shipRemoteBlockUpdate(remoteDoc: Y.Doc, localDoc: Y.Doc, blockId: string) {
+  const before = Y.encodeStateVector(localDoc);
+  const { blocks } = getTestingDocData(remoteDoc);
+  const block = (blocks as YBlocks).get(blockId);
+  const viewId = generateId();
+  const databaseId = generateId();
+
+  expect(block).toBeDefined();
+
+  block.set(YjsEditorKey.block_type, BlockType.GridBlock);
+  block.set(YjsEditorKey.block_external_id, '');
+  block.set(
+    YjsEditorKey.block_data,
+    JSON.stringify({
+      view_id: viewId,
+      view_ids: [viewId],
+      database_id: databaseId,
+      parent_id: blockId,
+    })
+  );
+
+  Y.applyUpdateV2(localDoc, Y.encodeStateAsUpdateV2(remoteDoc, before));
+}
+
+describe('database block live sync', () => {
+  it('updates an existing paragraph into a grid block when the remote block type changes', () => {
+    const blockId = generateId();
+    const { remoteDoc, localDoc } = buildSyncedParagraph(blockId);
+    const editor = withTestingYjsEditor(createEditor(), localDoc);
+
+    editor.connect();
+
+    const initialNode = editor.children[0] as Element;
+
+    expect(initialNode.type).toBe(BlockType.Paragraph);
+
+    shipRemoteBlockUpdate(remoteDoc, localDoc, blockId);
+
+    const fullRebuildNode = yDocToSlateContent(localDoc)?.children[0] as Element;
+
+    expect(fullRebuildNode.type).toBe(BlockType.GridBlock);
+
+    const liveNode = editor.children[0] as Element;
+
+    expect(liveNode.type).toBe(BlockType.GridBlock);
+    expect(liveNode.data).toEqual(fullRebuildNode.data);
+    expect(liveNode.children).toEqual(fullRebuildNode.children);
+  });
+});

--- a/src/application/slate-yjs/utils/applyToSlate.ts
+++ b/src/application/slate-yjs/utils/applyToSlate.ts
@@ -5,7 +5,7 @@ import { YEvent, YMapEvent, YTextEvent } from 'yjs';
 import { YjsEditor } from '@/application/slate-yjs';
 import { BlockJson } from '@/application/slate-yjs/types';
 import { applyTextYEvent } from '@/application/slate-yjs/utils/applyTextToSlate';
-import { blockToSlateNode, deltaInsertToSlateNode } from '@/application/slate-yjs/utils/convert';
+import { blockToSlateNode, deltaInsertToSlateNode, traverseBlock } from '@/application/slate-yjs/utils/convert';
 import { findSlateEntryByBlockId } from '@/application/slate-yjs/utils/editor';
 import { dataStringTOJson, getBlock, getChildrenArray, getPageId, getText } from '@/application/slate-yjs/utils/yjs';
 import { YBlock, YjsEditorKey } from '@/application/types';
@@ -77,6 +77,8 @@ function applyUpdateBlockYEvent(editor: YjsEditor, blockId: string, event: YMapE
   const { target } = event;
   const block = target as YBlock;
   const newData = dataStringTOJson(block.get(YjsEditorKey.block_data));
+  const newType = block.get(YjsEditorKey.block_type);
+  const newRelationId = block.get(YjsEditorKey.block_children);
   const entry = findSlateEntryByBlockId(editor, blockId);
 
   if (!entry) {
@@ -89,22 +91,58 @@ function applyUpdateBlockYEvent(editor: YjsEditor, blockId: string, event: YMapE
   }
 
   const [node, path] = entry;
-  const oldData = node.data as Record<string, unknown>;
+  const oldData = (node.data || {}) as Record<string, unknown>;
+  const oldType = node.type;
+  const oldRelationId = node.relationId;
+  const structuralUpdate =
+    event.keysChanged.has(YjsEditorKey.block_type) ||
+    event.keysChanged.has(YjsEditorKey.block_children) ||
+    event.keysChanged.has(YjsEditorKey.block_external_id);
 
-  Log.debug(`✅ Updating block data for blockId: ${blockId}`, {
+  Log.debug(`✅ Updating block for blockId: ${blockId}`, {
     path,
+    oldType,
+    newType,
     oldDataKeys: Object.keys(oldData),
     newDataKeys: Object.keys(newData),
   });
+
+  if (structuralUpdate) {
+    const replacement = traverseBlock(blockId, editor.sharedRoot);
+
+    if (!replacement) {
+      Log.error(`❌ Failed to rebuild structurally updated block: ${blockId}`);
+      return [];
+    }
+
+    Editor.withoutNormalizing(editor, () => {
+      editor.apply({
+        type: 'remove_node',
+        path,
+        node,
+      });
+      editor.apply({
+        type: 'insert_node',
+        path,
+        node: replacement,
+      });
+    });
+
+    return;
+  }
 
   editor.apply({
     type: 'set_node',
     path,
     newProperties: {
       data: newData,
+      relationId: newRelationId,
+      type: newType,
     },
     properties: {
       data: oldData,
+      relationId: oldRelationId,
+      type: oldType,
     },
   });
 }

--- a/src/application/types.ts
+++ b/src/application/types.ts
@@ -929,7 +929,7 @@ export enum Types {
   Folder = 3,
   DatabaseRow = 4,
   UserAwareness = 5,
-  Empty = 6,
+  Unknown = 6,
 }
 
 export enum CollabOrigin {

--- a/src/application/types.ts
+++ b/src/application/types.ts
@@ -1216,6 +1216,17 @@ export interface View {
   workspace_id?: string;
 }
 
+export interface ObjectPermission {
+  object_id: string;
+  collab_type: Types;
+  governing_view_id: string;
+  access_level?: AccessLevel | null;
+  can_read: boolean;
+  can_write: boolean;
+  can_comment: boolean;
+  can_share: boolean;
+}
+
 export interface UpdatePublishConfigPayload {
   comments_enabled?: boolean;
   duplicate_enabled?: boolean;

--- a/src/components/app/ViewModal.tsx
+++ b/src/components/app/ViewModal.tsx
@@ -25,7 +25,7 @@ import {
 } from '@/components/app/app.hooks';
 import DatabaseView from '@/components/app/DatabaseView';
 import MoreActions from '@/components/app/header/MoreActions';
-import { useViewOperations } from '@/components/app/hooks/useViewOperations';
+import { useViewReadOnlyStatus } from '@/components/app/hooks/useViewOperations';
 import MovePagePopover from '@/components/app/view-actions/MovePagePopover';
 import { Document } from '@/components/document';
 import RecordNotFound from '@/components/error/RecordNotFound';
@@ -71,7 +71,6 @@ function ViewModal({ viewId, open, onClose }: { viewId?: string; open: boolean; 
 
   const outline = useAppOutline();
   const requestInstance = getAxiosInstance();
-  const { getViewReadOnlyStatus } = useViewOperations();
 
   // Document state
   const [doc, setDoc] = useState<{ id: string; doc: YDoc } | undefined>(undefined);
@@ -324,13 +323,7 @@ function ViewModal({ viewId, open, onClose }: { viewId?: string; open: boolean; 
     );
   }, [effectiveViewId, handleClose, movePageOpen, outline, t, toView]);
 
-  // Check if view is in shareWithMe and determine readonly status.
-  // `resolvedView` includes the server-fetched fallback, so locked pages opened
-  // before their outline branch is loaded still flip the editor to read-only.
-  const isReadOnly = useMemo(() => {
-    if (!effectiveViewId) return false;
-    return getViewReadOnlyStatus(effectiveViewId, outline, resolvedView);
-  }, [getViewReadOnlyStatus, effectiveViewId, outline, resolvedView]);
+  const isReadOnly = useViewReadOnlyStatus(effectiveViewId, outline, resolvedView);
 
   const View = useMemo(() => {
     switch (layout) {

--- a/src/components/app/hooks/__tests__/ViewItem.databaseContainer.test.tsx
+++ b/src/components/app/hooks/__tests__/ViewItem.databaseContainer.test.tsx
@@ -30,7 +30,15 @@ jest.mock('@/components/_shared/cutsom-icon', () => ({
   CustomIconPopover: ({ children }: { children: React.ReactNode }) => children,
 }));
 
-jest.mock('@/components/_shared/outline/OutlineIcon', () => () => null);
+jest.mock('@/components/_shared/outline/OutlineIcon', () => ({
+  __esModule: true,
+  default: ({ isExpanded, setIsExpanded }: { isExpanded: boolean; setIsExpanded: (isExpanded: boolean) => void }) => (
+    <button
+      data-testid={isExpanded ? 'outline-toggle-collapse' : 'outline-toggle-expand'}
+      onClick={() => setIsExpanded(!isExpanded)}
+    />
+  ),
+}));
 jest.mock('@/components/_shared/view-icon/PageIcon', () => () => null);
 
 describe('ViewItem database container', () => {
@@ -197,5 +205,35 @@ describe('ViewItem database container', () => {
     expect(within(screen.getByTestId(`page-${containerView.view_id}`)).queryByTestId('page-icon')).not.toBeNull();
     expect(within(screen.getByTestId(`page-${firstChildView.view_id}`)).queryByTestId('page-icon')).toBeNull();
     expect(within(screen.getByTestId(`page-${secondChildView.view_id}`)).queryByTestId('page-icon')).toBeNull();
+  });
+
+  it('keeps an expanded unloaded row retryable when children are still absent', () => {
+    const documentView: View = {
+      view_id: 'document-view-id',
+      name: 'Untitled',
+      icon: null,
+      layout: ViewLayout.Document,
+      extra: null,
+      children: [],
+      has_children: true,
+      is_published: false,
+      is_private: false,
+    };
+    const toggleExpand = jest.fn();
+
+    render(
+      <ViewItem
+        view={documentView}
+        width={240}
+        expandIds={[documentView.view_id]}
+        toggleExpand={toggleExpand}
+        onClickView={jest.fn()}
+        loadedViewIds={new Set()}
+      />
+    );
+
+    fireEvent.click(within(screen.getByTestId(`page-${documentView.view_id}`)).getByTestId('outline-toggle-expand'));
+
+    expect(toggleExpand).toHaveBeenCalledWith(documentView.view_id, true);
   });
 });

--- a/src/components/app/hooks/__tests__/useViewReadOnlyStatus.permissionApi.test.tsx
+++ b/src/components/app/hooks/__tests__/useViewReadOnlyStatus.permissionApi.test.tsx
@@ -2,6 +2,7 @@ import EventEmitter from 'events';
 
 import { act, renderHook, waitFor } from '@testing-library/react';
 
+import { ERROR_CODE } from '@/application/constants';
 import { AccessLevel, ObjectPermission, Types, View, ViewExtra, ViewLayout } from '@/application/types';
 import { AuthInternalContext, AuthInternalContextType } from '@/components/app/contexts/AuthInternalContext';
 import { SyncInternalContext, SyncInternalContextType } from '@/components/app/contexts/SyncInternalContext';
@@ -113,11 +114,11 @@ describe('useViewReadOnlyStatus permission API', () => {
     expect(getObjectPermission).toHaveBeenCalledWith('workspace-id', 'view-id', 0, expect.any(AbortSignal));
   });
 
-  it('queries database views by database collab identity', async () => {
+  it('queries database views by folder view permission identity', async () => {
     getObjectPermission.mockResolvedValue(
       createPermission({
-        object_id: 'database-id',
-        collab_type: Types.Database,
+        object_id: 'database-view-id',
+        collab_type: Types.Document,
         governing_view_id: 'database-view-id',
       })
     );
@@ -134,8 +135,8 @@ describe('useViewReadOnlyStatus permission API', () => {
     await waitFor(() => {
       expect(getObjectPermission).toHaveBeenCalledWith(
         'workspace-id',
-        'database-id',
-        Types.Database,
+        'database-view-id',
+        Types.Document,
         expect.any(AbortSignal)
       );
     });
@@ -172,7 +173,7 @@ describe('useViewReadOnlyStatus permission API', () => {
     expect(getObjectPermission).toHaveBeenCalledTimes(2);
   });
 
-  it('refetches database permission when notification targets the database object', async () => {
+  it('refetches database view permission when notification targets the folder view', async () => {
     const eventEmitter = new EventEmitter();
     const databaseView = createView({
       view_id: 'database-view-id',
@@ -183,15 +184,15 @@ describe('useViewReadOnlyStatus permission API', () => {
     getObjectPermission
       .mockResolvedValueOnce(
         createPermission({
-          object_id: 'database-id',
-          collab_type: Types.Database,
+          object_id: 'database-view-id',
+          collab_type: Types.Document,
           governing_view_id: 'database-view-id',
         })
       )
       .mockResolvedValueOnce(
         createPermission({
-          object_id: 'database-id',
-          collab_type: Types.Database,
+          object_id: 'database-view-id',
+          collab_type: Types.Document,
           governing_view_id: 'database-view-id',
           access_level: AccessLevel.ReadOnly,
           can_write: false,
@@ -208,18 +209,20 @@ describe('useViewReadOnlyStatus permission API', () => {
     });
 
     act(() => {
-      eventEmitter.emit('permission-changed', { objectId: 'database-id' });
+      eventEmitter.emit('permission-changed', { objectId: 'database-view-id' });
     });
 
-    expect(result.current).toBe(true);
+    await waitFor(() => {
+      expect(result.current).toBe(true);
+    });
 
     await waitFor(() => {
       expect(getObjectPermission).toHaveBeenCalledTimes(2);
     });
     expect(getObjectPermission).toHaveBeenLastCalledWith(
       'workspace-id',
-      'database-id',
-      Types.Database,
+      'database-view-id',
+      Types.Document,
       expect.any(AbortSignal)
     );
     expect(result.current).toBe(true);
@@ -247,7 +250,61 @@ describe('useViewReadOnlyStatus permission API', () => {
     await waitFor(() => {
       expect(getObjectPermission).toHaveBeenCalledTimes(2);
     });
-    expect(result.current).toBe(true);
+    await waitFor(() => {
+      expect(result.current).toBe(true);
+    });
+  });
+
+  it('retries a permission refresh after the server returns too many requests', async () => {
+    const eventEmitter = new EventEmitter();
+
+    getObjectPermission
+      .mockResolvedValueOnce(createPermission())
+      .mockRejectedValueOnce({
+        code: ERROR_CODE.TOO_MANY_REQUESTS,
+        message: 'permission resolver is busy',
+        retryAfterSecs: 1,
+      })
+      .mockResolvedValueOnce(createPermission());
+
+    const { result } = renderHook(() => useViewReadOnlyStatus('view-id', []), {
+      wrapper: wrapper(eventEmitter),
+    });
+
+    await waitFor(() => {
+      expect(result.current).toBe(false);
+    });
+
+    jest.useFakeTimers();
+    try {
+      act(() => {
+        eventEmitter.emit('permission-changed', { objectId: 'view-id' });
+      });
+
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      await waitFor(() => {
+        expect(result.current).toBe(true);
+      });
+      expect(getObjectPermission).toHaveBeenCalledTimes(2);
+
+      act(() => {
+        jest.advanceTimersByTime(999);
+      });
+      expect(getObjectPermission).toHaveBeenCalledTimes(2);
+
+      await act(async () => {
+        jest.advanceTimersByTime(1);
+        await Promise.resolve();
+      });
+
+      expect(getObjectPermission).toHaveBeenCalledTimes(3);
+      expect(result.current).toBe(false);
+    } finally {
+      jest.useRealTimers();
+    }
   });
 
   it('ignores older permission responses after a newer refresh resolves', async () => {
@@ -265,7 +322,9 @@ describe('useViewReadOnlyStatus permission API', () => {
       eventEmitter.emit('permission-changed', { objectId: 'view-id' });
     });
 
-    expect(result.current).toBe(true);
+    await waitFor(() => {
+      expect(result.current).toBe(true);
+    });
 
     await act(async () => {
       second.resolve(
@@ -314,7 +373,9 @@ describe('useViewReadOnlyStatus permission API', () => {
       eventEmitter.emit('permission-changed', { objectId: 'parent-view-id' });
     });
 
-    expect(result.current).toBe(true);
+    await waitFor(() => {
+      expect(result.current).toBe(true);
+    });
 
     await waitFor(() => {
       expect(getObjectPermission).toHaveBeenCalledTimes(2);

--- a/src/components/app/hooks/__tests__/useViewReadOnlyStatus.permissionApi.test.tsx
+++ b/src/components/app/hooks/__tests__/useViewReadOnlyStatus.permissionApi.test.tsx
@@ -1,0 +1,324 @@
+import EventEmitter from 'events';
+
+import { act, renderHook, waitFor } from '@testing-library/react';
+
+import { AccessLevel, ObjectPermission, Types, View, ViewExtra, ViewLayout } from '@/application/types';
+import { AuthInternalContext, AuthInternalContextType } from '@/components/app/contexts/AuthInternalContext';
+import { SyncInternalContext, SyncInternalContextType } from '@/components/app/contexts/SyncInternalContext';
+import { getPlatform } from '@/utils/platform';
+
+import { useViewReadOnlyStatus } from '../useViewOperations';
+
+const getObjectPermission = jest.fn();
+
+jest.mock('@/application/services/domains', () => ({
+  CollabService: {
+    getObjectPermission: (...args: unknown[]) => getObjectPermission(...args),
+  },
+  ViewService: {},
+  WorkspaceService: {},
+}));
+jest.mock('@/application/view-loader', () => ({ openView: jest.fn() }));
+jest.mock('@/utils/platform', () => ({ getPlatform: jest.fn(() => ({ isMobile: false })) }));
+
+const mockGetPlatform = getPlatform as jest.MockedFunction<typeof getPlatform>;
+
+function createPermission(overrides: Partial<ObjectPermission> = {}): ObjectPermission {
+  return {
+    object_id: 'view-id',
+    collab_type: Types.Document,
+    governing_view_id: 'view-id',
+    access_level: AccessLevel.ReadAndWrite,
+    can_read: true,
+    can_write: true,
+    can_comment: true,
+    can_share: false,
+    ...overrides,
+  };
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+
+  return { promise, resolve, reject };
+}
+
+function createView(overrides: Partial<View>): View {
+  return {
+    view_id: 'view-id',
+    name: 'View',
+    icon: null,
+    layout: ViewLayout.Document,
+    extra: null,
+    children: [],
+    is_published: false,
+    is_private: false,
+    ...overrides,
+  };
+}
+
+function shareWithMeOutline(...children: View[]): View[] {
+  return [
+    createView({
+      view_id: 'share-with-me-space',
+      extra: { is_space: true, is_hidden_space: true } as ViewExtra,
+      children,
+    }),
+  ];
+}
+
+function wrapper(eventEmitter = new EventEmitter()) {
+  const authContextValue: AuthInternalContextType = {
+    currentWorkspaceId: 'workspace-id',
+    isAuthenticated: true,
+    onChangeWorkspace: () => Promise.resolve(),
+  };
+  const syncContextValue: SyncInternalContextType = {
+    registerSyncContext: () => ({ doc: {} as never }),
+    eventEmitter,
+    awarenessMap: {},
+  } as unknown as SyncInternalContextType;
+
+  return ({ children }: { children: React.ReactNode }) => (
+    <AuthInternalContext.Provider value={authContextValue}>
+      <SyncInternalContext.Provider value={syncContextValue}>{children}</SyncInternalContext.Provider>
+    </AuthInternalContext.Provider>
+  );
+}
+
+describe('useViewReadOnlyStatus permission API', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetPlatform.mockReturnValue({ isMobile: false } as ReturnType<typeof getPlatform>);
+  });
+
+  it('uses server write permission instead of the old outline fallback', async () => {
+    getObjectPermission.mockResolvedValue(createPermission());
+    const outline = shareWithMeOutline(createView({ view_id: 'view-id', access_level: AccessLevel.ReadOnly }));
+
+    const { result } = renderHook(() => useViewReadOnlyStatus('view-id', outline), {
+      wrapper: wrapper(),
+    });
+
+    expect(result.current).toBe(true);
+
+    await waitFor(() => {
+      expect(result.current).toBe(false);
+    });
+    expect(getObjectPermission).toHaveBeenCalledWith('workspace-id', 'view-id', 0, expect.any(AbortSignal));
+  });
+
+  it('queries database views by database collab identity', async () => {
+    getObjectPermission.mockResolvedValue(
+      createPermission({
+        object_id: 'database-id',
+        collab_type: Types.Database,
+        governing_view_id: 'database-view-id',
+      })
+    );
+    const databaseView = createView({
+      view_id: 'database-view-id',
+      layout: ViewLayout.Grid,
+      extra: { database_id: 'database-id' } as ViewExtra,
+    });
+
+    renderHook(() => useViewReadOnlyStatus('database-view-id', [], databaseView), {
+      wrapper: wrapper(),
+    });
+
+    await waitFor(() => {
+      expect(getObjectPermission).toHaveBeenCalledWith(
+        'workspace-id',
+        'database-id',
+        Types.Database,
+        expect.any(AbortSignal)
+      );
+    });
+  });
+
+  it('refetches when permission change notification targets the view', async () => {
+    const eventEmitter = new EventEmitter();
+
+    getObjectPermission.mockResolvedValueOnce(createPermission()).mockResolvedValueOnce(
+      createPermission({
+        access_level: AccessLevel.ReadOnly,
+        can_write: false,
+        can_comment: false,
+      })
+    );
+
+    const { result } = renderHook(() => useViewReadOnlyStatus('view-id', []), {
+      wrapper: wrapper(eventEmitter),
+    });
+
+    await waitFor(() => {
+      expect(result.current).toBe(false);
+    });
+
+    act(() => {
+      eventEmitter.emit('permission-changed', { objectId: 'view-id' });
+    });
+
+    expect(result.current).toBe(true);
+
+    await waitFor(() => {
+      expect(result.current).toBe(true);
+    });
+    expect(getObjectPermission).toHaveBeenCalledTimes(2);
+  });
+
+  it('refetches database permission when notification targets the database object', async () => {
+    const eventEmitter = new EventEmitter();
+    const databaseView = createView({
+      view_id: 'database-view-id',
+      layout: ViewLayout.Grid,
+      extra: { database_id: 'database-id' } as ViewExtra,
+    });
+
+    getObjectPermission
+      .mockResolvedValueOnce(
+        createPermission({
+          object_id: 'database-id',
+          collab_type: Types.Database,
+          governing_view_id: 'database-view-id',
+        })
+      )
+      .mockResolvedValueOnce(
+        createPermission({
+          object_id: 'database-id',
+          collab_type: Types.Database,
+          governing_view_id: 'database-view-id',
+          access_level: AccessLevel.ReadOnly,
+          can_write: false,
+          can_comment: false,
+        })
+      );
+
+    const { result } = renderHook(() => useViewReadOnlyStatus('database-view-id', [], databaseView), {
+      wrapper: wrapper(eventEmitter),
+    });
+
+    await waitFor(() => {
+      expect(result.current).toBe(false);
+    });
+
+    act(() => {
+      eventEmitter.emit('permission-changed', { objectId: 'database-id' });
+    });
+
+    expect(result.current).toBe(true);
+
+    await waitFor(() => {
+      expect(getObjectPermission).toHaveBeenCalledTimes(2);
+    });
+    expect(getObjectPermission).toHaveBeenLastCalledWith(
+      'workspace-id',
+      'database-id',
+      Types.Database,
+      expect.any(AbortSignal)
+    );
+    expect(result.current).toBe(true);
+  });
+
+  it('stays read-only when a notification-triggered permission refresh fails', async () => {
+    const eventEmitter = new EventEmitter();
+
+    getObjectPermission.mockResolvedValueOnce(createPermission()).mockRejectedValueOnce(new Error('network'));
+
+    const { result } = renderHook(() => useViewReadOnlyStatus('view-id', []), {
+      wrapper: wrapper(eventEmitter),
+    });
+
+    await waitFor(() => {
+      expect(result.current).toBe(false);
+    });
+
+    act(() => {
+      eventEmitter.emit('permission-changed', { objectId: 'view-id' });
+    });
+
+    expect(result.current).toBe(true);
+
+    await waitFor(() => {
+      expect(getObjectPermission).toHaveBeenCalledTimes(2);
+    });
+    expect(result.current).toBe(true);
+  });
+
+  it('ignores older permission responses after a newer refresh resolves', async () => {
+    const eventEmitter = new EventEmitter();
+    const first = deferred<ObjectPermission>();
+    const second = deferred<ObjectPermission>();
+
+    getObjectPermission.mockReturnValueOnce(first.promise).mockReturnValueOnce(second.promise);
+
+    const { result } = renderHook(() => useViewReadOnlyStatus('view-id', []), {
+      wrapper: wrapper(eventEmitter),
+    });
+
+    act(() => {
+      eventEmitter.emit('permission-changed', { objectId: 'view-id' });
+    });
+
+    expect(result.current).toBe(true);
+
+    await act(async () => {
+      second.resolve(
+        createPermission({
+          access_level: AccessLevel.ReadOnly,
+          can_write: false,
+          can_comment: false,
+        })
+      );
+      await second.promise;
+    });
+
+    expect(result.current).toBe(true);
+
+    await act(async () => {
+      first.resolve(createPermission());
+      await first.promise;
+    });
+
+    expect(result.current).toBe(true);
+  });
+
+  it('refetches when a permission change targets the governing view', async () => {
+    const eventEmitter = new EventEmitter();
+
+    getObjectPermission
+      .mockResolvedValueOnce(createPermission({ governing_view_id: 'parent-view-id' }))
+      .mockResolvedValueOnce(
+        createPermission({
+          governing_view_id: 'parent-view-id',
+          access_level: AccessLevel.ReadOnly,
+          can_write: false,
+          can_comment: false,
+        })
+      );
+
+    const { result } = renderHook(() => useViewReadOnlyStatus('view-id', []), {
+      wrapper: wrapper(eventEmitter),
+    });
+
+    await waitFor(() => {
+      expect(result.current).toBe(false);
+    });
+
+    act(() => {
+      eventEmitter.emit('permission-changed', { objectId: 'parent-view-id' });
+    });
+
+    expect(result.current).toBe(true);
+
+    await waitFor(() => {
+      expect(getObjectPermission).toHaveBeenCalledTimes(2);
+    });
+    expect(result.current).toBe(true);
+  });
+});

--- a/src/components/app/hooks/__tests__/useWorkspaceData.sidebarRevalidation.test.tsx
+++ b/src/components/app/hooks/__tests__/useWorkspaceData.sidebarRevalidation.test.tsx
@@ -391,7 +391,7 @@ describe('useWorkspaceData sidebar outline revalidation', () => {
     expect(result.current.outline?.[0]?.name).toBe('server space');
   });
 
-  it('repairs relaxed outline patches with same-rid root revalidation', async () => {
+  it('loads the target subtree instead of relaxed-applying out-of-bounds child patches', async () => {
     const eventEmitter = new EventEmitter();
     const root = createView('space-id', {
       children: [],
@@ -399,14 +399,15 @@ describe('useWorkspaceData sidebar outline revalidation', () => {
     });
     const childA = createView('child-a');
     const childB = createView('child-b');
-    const serverRoot = createView('space-id', {
-      children: [childA, childB],
-      has_children: true,
-    });
 
-    (ViewService.getOutline as jest.Mock)
-      .mockResolvedValueOnce({ outline: [root], folderRid: '1-1' })
-      .mockResolvedValueOnce({ outline: [serverRoot], folderRid: '2-1' });
+    (ViewService.getOutline as jest.Mock).mockResolvedValueOnce({ outline: [root], folderRid: '1-1' });
+    (ViewService.getMultiple as jest.Mock).mockResolvedValueOnce([
+      createView('space-id', {
+        children: [childA, childB],
+        folder_rid: '2-1',
+        has_children: true,
+      }),
+    ]);
 
     const { result } = renderHook(() => useWorkspaceData(), {
       wrapper: createWrapper(eventEmitter),
@@ -429,16 +430,74 @@ describe('useWorkspaceData sidebar outline revalidation', () => {
       });
     });
 
-    expect(result.current.outline?.[0]?.children.map((view) => view.view_id)).toEqual(['child-b']);
+    await waitFor(() => {
+      expect(ViewService.getMultiple).toHaveBeenCalledWith(workspaceId, ['space-id'], 1);
+      expect(result.current.outline?.[0]?.children.map((view) => view.view_id)).toEqual(['child-a', 'child-b']);
+    });
+  });
 
-    let revalidationResult: string | undefined;
-
-    await act(async () => {
-      revalidationResult = await result.current.revalidateSidebarOutline?.([]);
+  it('loads the target subtree when a patch addresses unloaded nested children', async () => {
+    const eventEmitter = new EventEmitter();
+    const documentId = 'document-id';
+    const existingEmbeddedA = createView('existing-embedded-a');
+    const existingEmbeddedB = createView('existing-embedded-b');
+    const newEmbedded = createView('new-embedded', {
+      extra: {
+        database_id: 'database-id',
+        embedded: true,
+        is_database_container: true,
+      },
+      has_children: true,
+      name: 'New Database',
+    });
+    const root = createView('space-id', {
+      children: [
+        createView(documentId, {
+          children: [],
+          has_children: true,
+        }),
+      ],
+      has_children: true,
     });
 
-    expect(revalidationResult).toBe('changed');
-    expect(result.current.outline?.[0]?.children.map((view) => view.view_id)).toEqual(['child-a', 'child-b']);
+    (ViewService.getOutline as jest.Mock).mockResolvedValueOnce({ outline: [root], folderRid: '1-1' });
+    (ViewService.getMultiple as jest.Mock).mockResolvedValueOnce([
+      createView(documentId, {
+        children: [existingEmbeddedA, existingEmbeddedB, newEmbedded],
+        folder_rid: '2-1',
+        has_children: true,
+      }),
+    ]);
+
+    const { result } = renderHook(() => useWorkspaceData(), {
+      wrapper: createWrapper(eventEmitter),
+    });
+
+    await waitFor(() => {
+      expect(result.current.outline?.[0]?.children[0]?.view_id).toBe(documentId);
+    });
+
+    await act(async () => {
+      eventEmitter.emit(APP_EVENTS.FOLDER_OUTLINE_CHANGED, {
+        folderRid: '2-1',
+        outlineDiffJson: JSON.stringify([
+          {
+            op: 'add',
+            path: '/outline/0/children/0/children/2',
+            value: newEmbedded,
+          },
+        ]),
+      });
+    });
+
+    await waitFor(() => {
+      expect(ViewService.getMultiple).toHaveBeenCalledWith(workspaceId, [documentId], 1);
+      expect(result.current.outline?.[0]?.children[0]?.children.map((view) => view.view_id)).toEqual([
+        existingEmbeddedA.view_id,
+        existingEmbeddedB.view_id,
+        newEmbedded.view_id,
+      ]);
+    });
   });
 
   it('resets root folder rid state when the workspace changes', async () => {

--- a/src/components/app/hooks/useViewOperations.ts
+++ b/src/components/app/hooks/useViewOperations.ts
@@ -3,7 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import { Awareness } from 'y-protocols/awareness';
 import * as Y from 'yjs';
 
-import { APP_EVENTS } from '@/application/constants';
+import { APP_EVENTS, ERROR_CODE } from '@/application/constants';
 import { CollabService, ViewService, WorkspaceService } from '@/application/services/domains';
 import {
   AccessLevel,
@@ -31,6 +31,40 @@ import { useAuthInternal } from '../contexts/AuthInternalContext';
 import { useSyncInternal } from '../contexts/SyncInternalContext';
 
 import { useDatabaseIdentity } from './useDatabaseIdentity';
+
+const PERMISSION_RETRY_BASE_DELAY_MS = 5_000;
+const PERMISSION_RETRY_MAX_DELAY_MS = 60_000;
+const PERMISSION_RETRY_MAX_ATTEMPTS = 5;
+
+function readNumber(error: unknown, key: string): number | undefined {
+  if (typeof error === 'object' && error !== null && key in error) {
+    const value = (error as Record<string, unknown>)[key];
+
+    if (typeof value === 'number') return value;
+  }
+
+  return undefined;
+}
+
+// Respect the server's `Retry-After` when present; otherwise back off
+// exponentially from the base delay, capped so retries never loop too tightly.
+function permissionRetryDelayMs(error: unknown, attempt: number) {
+  const retryAfterSecs = readNumber(error, 'retryAfterSecs');
+
+  if (retryAfterSecs !== undefined && retryAfterSecs > 0) {
+    return Math.min(retryAfterSecs * 1000, PERMISSION_RETRY_MAX_DELAY_MS);
+  }
+
+  const backoff = PERMISSION_RETRY_BASE_DELAY_MS * 2 ** attempt;
+
+  return Math.min(backoff, PERMISSION_RETRY_MAX_DELAY_MS);
+}
+
+function isTooManyRequests(error: unknown) {
+  const code = readNumber(error, 'code');
+
+  return code === 429 || code === ERROR_CODE.TOO_MANY_REQUESTS;
+}
 
 /**
  * Determine whether the editor should be read-only for the given view.
@@ -119,6 +153,12 @@ export function useViewReadOnlyStatus(viewId: string | undefined, outline?: View
   });
   const permissionRequestSeqRef = useRef(0);
   const permissionAbortRef = useRef<AbortController | null>(null);
+  const permissionRetryTimeoutRef = useRef<number | null>(null);
+  const clearPermissionRetryTimeout = useCallback(() => {
+    if (permissionRetryTimeoutRef.current === null) return;
+    window.clearTimeout(permissionRetryTimeoutRef.current);
+    permissionRetryTimeoutRef.current = null;
+  }, []);
   const fallbackReadOnly = useMemo(() => {
     if (!viewId) return false;
     return getViewReadOnlyStatus(viewId, outline, fallbackView);
@@ -135,12 +175,15 @@ export function useViewReadOnlyStatus(viewId: string | undefined, outline?: View
   const permissionCollabType = permissionIdentity?.collabType;
 
   const fetchPermission = useCallback(
-    async (options?: { failClosed?: boolean }) => {
+    async (options?: { failClosed?: boolean; attempt?: number }) => {
       if (!currentWorkspaceId || !viewId || !permissionObjectId || permissionCollabType === undefined) return;
+
+      const attempt = options?.attempt ?? 0;
 
       const key = `${currentWorkspaceId}:${permissionCollabType}:${permissionObjectId}`;
       const requestSeq = permissionRequestSeqRef.current + 1;
 
+      clearPermissionRetryTimeout();
       permissionRequestSeqRef.current = requestSeq;
       permissionAbortRef.current?.abort();
 
@@ -181,13 +224,23 @@ export function useViewReadOnlyStatus(viewId: string | undefined, outline?: View
           permission: null,
           failClosed: options?.failClosed ?? false,
         });
+
+        if (isTooManyRequests(error) && attempt < PERMISSION_RETRY_MAX_ATTEMPTS) {
+          const retryDelayMs = permissionRetryDelayMs(error, attempt);
+
+          permissionRetryTimeoutRef.current = window.setTimeout(() => {
+            permissionRetryTimeoutRef.current = null;
+            void fetchPermission({ failClosed: options?.failClosed ?? false, attempt: attempt + 1 });
+          }, retryDelayMs);
+        }
       }
     },
-    [currentWorkspaceId, permissionCollabType, permissionObjectId, viewId]
+    [clearPermissionRetryTimeout, currentWorkspaceId, permissionCollabType, permissionObjectId, viewId]
   );
 
   useEffect(() => {
     if (!currentWorkspaceId || !viewId || !permissionObjectId || permissionCollabType === undefined) {
+      clearPermissionRetryTimeout();
       permissionAbortRef.current?.abort();
       setPermissionState({
         key: null,
@@ -199,8 +252,11 @@ export function useViewReadOnlyStatus(viewId: string | undefined, outline?: View
 
     void fetchPermission({ failClosed: false });
 
-    return () => permissionAbortRef.current?.abort();
-  }, [currentWorkspaceId, viewId, permissionObjectId, permissionCollabType, fetchPermission]);
+    return () => {
+      clearPermissionRetryTimeout();
+      permissionAbortRef.current?.abort();
+    };
+  }, [clearPermissionRetryTimeout, currentWorkspaceId, viewId, permissionObjectId, permissionCollabType, fetchPermission]);
 
   const activePermissionKey =
     permissionObjectId && permissionCollabType !== undefined
@@ -447,7 +503,7 @@ export function useViewOperations() {
       const objectId = docWithMeta.object_id;
       const viewId = docWithMeta.view_id ?? objectId;
 
-      // Use explicit undefined check for collabType since Types.Document = 0 is falsy
+      // Use explicit undefined check so zero-valued collab types remain valid.
       if (collabType === undefined || !objectId || !viewId) {
         console.warn('[useViewOperations] bindViewSync failed - missing metadata', {
           hasCollabType: collabType !== undefined,

--- a/src/components/app/hooks/useViewOperations.ts
+++ b/src/components/app/hooks/useViewOperations.ts
@@ -99,21 +99,10 @@ type PermissionObjectIdentity = {
   collabType: Types;
 };
 
-function getPermissionObjectIdentity(
-  viewId: string,
-  outline?: View[],
-  fallbackView?: View | null
-): PermissionObjectIdentity {
-  const view =
-    (fallbackView?.view_id === viewId ? fallbackView : undefined) ?? (outline ? findView(outline, viewId) : undefined);
-
-  if (view && isDatabaseLayout(view.layout)) {
-    return {
-      objectId: getDatabaseIdFromExtra(view) ?? viewId,
-      collabType: Types.Database,
-    };
-  }
-
+function getPermissionObjectIdentity(viewId: string): PermissionObjectIdentity {
+  // Page UI permission is scoped to the opened folder view. Database data still
+  // syncs through the canonical database collab id, but one database can have
+  // multiple folder views with different inherited access.
   return {
     objectId: viewId,
     collabType: Types.Document,
@@ -140,8 +129,8 @@ export function useViewReadOnlyStatus(viewId: string | undefined, outline?: View
   }, [viewId, outline, fallbackView]);
   const permissionIdentity = useMemo(() => {
     if (!viewId) return null;
-    return getPermissionObjectIdentity(viewId, outline, fallbackView);
-  }, [viewId, outline, fallbackView]);
+    return getPermissionObjectIdentity(viewId);
+  }, [viewId]);
   const permissionObjectId = permissionIdentity?.objectId;
   const permissionCollabType = permissionIdentity?.collabType;
 

--- a/src/components/app/hooks/useViewOperations.ts
+++ b/src/components/app/hooks/useViewOperations.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Awareness } from 'y-protocols/awareness';
 import * as Y from 'yjs';
@@ -8,6 +8,7 @@ import { CollabService, ViewService, WorkspaceService } from '@/application/serv
 import {
   AccessLevel,
   LoadViewOptions,
+  ObjectPermission,
   Types,
   View,
   ViewLayout,
@@ -15,7 +16,12 @@ import {
   YDocWithMeta,
 } from '@/application/types';
 import { openView } from '@/application/view-loader';
-import { getDatabaseIdFromExtra, getFirstChildView, isDatabaseContainer, isDatabaseLayout } from '@/application/view-utils';
+import {
+  getDatabaseIdFromExtra,
+  getFirstChildView,
+  isDatabaseContainer,
+  isDatabaseLayout,
+} from '@/application/view-utils';
 import { findSharedAccessLevel, findView } from '@/components/_shared/outline/utils';
 import { CollabDocResetPayload } from '@/components/ws/sync/types';
 import { Log } from '@/utils/log';
@@ -66,6 +72,190 @@ export function getViewReadOnlyStatus(viewId: string, outline?: View[], fallback
 
   // If not part of the shared-with-me space, default is false (editable)
   return false;
+}
+
+function getViewLocalReadOnlyStatus(viewId: string, outline?: View[], fallbackView?: View | null) {
+  const isMobile = getPlatform().isMobile;
+
+  if (isMobile) return true;
+
+  if (fallbackView?.view_id === viewId && fallbackView.is_locked) return true;
+
+  if (!outline) return false;
+
+  const view = findView(outline, viewId);
+
+  return Boolean(view?.is_locked);
+}
+
+type PermissionReadOnlyState = {
+  key: string | null;
+  permission: ObjectPermission | null;
+  failClosed: boolean;
+};
+
+type PermissionObjectIdentity = {
+  objectId: string;
+  collabType: Types;
+};
+
+function getPermissionObjectIdentity(
+  viewId: string,
+  outline?: View[],
+  fallbackView?: View | null
+): PermissionObjectIdentity {
+  const view =
+    (fallbackView?.view_id === viewId ? fallbackView : undefined) ?? (outline ? findView(outline, viewId) : undefined);
+
+  if (view && isDatabaseLayout(view.layout)) {
+    return {
+      objectId: getDatabaseIdFromExtra(view) ?? viewId,
+      collabType: Types.Database,
+    };
+  }
+
+  return {
+    objectId: viewId,
+    collabType: Types.Document,
+  };
+}
+
+export function useViewReadOnlyStatus(viewId: string | undefined, outline?: View[], fallbackView?: View | null) {
+  const { currentWorkspaceId } = useAuthInternal();
+  const { eventEmitter } = useSyncInternal();
+  const [permissionState, setPermissionState] = useState<PermissionReadOnlyState>({
+    key: null,
+    permission: null,
+    failClosed: false,
+  });
+  const permissionRequestSeqRef = useRef(0);
+  const permissionAbortRef = useRef<AbortController | null>(null);
+  const fallbackReadOnly = useMemo(() => {
+    if (!viewId) return false;
+    return getViewReadOnlyStatus(viewId, outline, fallbackView);
+  }, [viewId, outline, fallbackView]);
+  const localReadOnly = useMemo(() => {
+    if (!viewId) return false;
+    return getViewLocalReadOnlyStatus(viewId, outline, fallbackView);
+  }, [viewId, outline, fallbackView]);
+  const permissionIdentity = useMemo(() => {
+    if (!viewId) return null;
+    return getPermissionObjectIdentity(viewId, outline, fallbackView);
+  }, [viewId, outline, fallbackView]);
+  const permissionObjectId = permissionIdentity?.objectId;
+  const permissionCollabType = permissionIdentity?.collabType;
+
+  const fetchPermission = useCallback(
+    async (options?: { failClosed?: boolean }) => {
+      if (!currentWorkspaceId || !viewId || !permissionObjectId || permissionCollabType === undefined) return;
+
+      const key = `${currentWorkspaceId}:${permissionCollabType}:${permissionObjectId}`;
+      const requestSeq = permissionRequestSeqRef.current + 1;
+
+      permissionRequestSeqRef.current = requestSeq;
+      permissionAbortRef.current?.abort();
+
+      const controller = new AbortController();
+
+      permissionAbortRef.current = controller;
+      setPermissionState({
+        key,
+        permission: null,
+        failClosed: options?.failClosed ?? false,
+      });
+
+      try {
+        const nextPermission = await CollabService.getObjectPermission(
+          currentWorkspaceId,
+          permissionObjectId,
+          permissionCollabType,
+          controller.signal
+        );
+
+        if (controller.signal.aborted || requestSeq !== permissionRequestSeqRef.current) return;
+        setPermissionState({
+          key,
+          permission: nextPermission,
+          failClosed: false,
+        });
+      } catch (error) {
+        if (controller.signal.aborted || requestSeq !== permissionRequestSeqRef.current) return;
+        Log.debug('[useViewReadOnlyStatus] failed to fetch object permission', {
+          workspaceId: currentWorkspaceId,
+          viewId,
+          objectId: permissionObjectId,
+          collabType: permissionCollabType,
+          error,
+        });
+        setPermissionState({
+          key,
+          permission: null,
+          failClosed: options?.failClosed ?? false,
+        });
+      }
+    },
+    [currentWorkspaceId, permissionCollabType, permissionObjectId, viewId]
+  );
+
+  useEffect(() => {
+    if (!currentWorkspaceId || !viewId || !permissionObjectId || permissionCollabType === undefined) {
+      permissionAbortRef.current?.abort();
+      setPermissionState({
+        key: null,
+        permission: null,
+        failClosed: false,
+      });
+      return;
+    }
+
+    void fetchPermission({ failClosed: false });
+
+    return () => permissionAbortRef.current?.abort();
+  }, [currentWorkspaceId, viewId, permissionObjectId, permissionCollabType, fetchPermission]);
+
+  const activePermissionKey =
+    permissionObjectId && permissionCollabType !== undefined
+      ? `${currentWorkspaceId}:${permissionCollabType}:${permissionObjectId}`
+      : null;
+  const activePermission = permissionState.key === activePermissionKey ? permissionState.permission : null;
+  const shouldRefreshPermission = useCallback(
+    (changedObjectId?: string | null) => {
+      return (
+        !changedObjectId ||
+        changedObjectId === viewId ||
+        changedObjectId === permissionObjectId ||
+        changedObjectId === activePermission?.governing_view_id
+      );
+    },
+    [activePermission?.governing_view_id, permissionObjectId, viewId]
+  );
+
+  useEffect(() => {
+    if (!viewId) return;
+
+    const handlePermissionChanged = (payload?: { objectId?: string | null }) => {
+      if (!shouldRefreshPermission(payload?.objectId)) return;
+      void fetchPermission({ failClosed: true });
+    };
+
+    const handleShareViewsChanged = (payload?: { viewId?: string | null }) => {
+      if (!shouldRefreshPermission(payload?.viewId)) return;
+      void fetchPermission({ failClosed: true });
+    };
+
+    eventEmitter.on(APP_EVENTS.PERMISSION_CHANGED, handlePermissionChanged);
+    eventEmitter.on(APP_EVENTS.SHARE_VIEWS_CHANGED, handleShareViewsChanged);
+
+    return () => {
+      eventEmitter.off(APP_EVENTS.PERMISSION_CHANGED, handlePermissionChanged);
+      eventEmitter.off(APP_EVENTS.SHARE_VIEWS_CHANGED, handleShareViewsChanged);
+    };
+  }, [eventEmitter, fetchPermission, shouldRefreshPermission, viewId]);
+
+  if (localReadOnly) return true;
+  if (permissionState.key === activePermissionKey && permissionState.failClosed) return true;
+  if (activePermission) return !activePermission.can_write;
+  return fallbackReadOnly;
 }
 
 // Hook for managing view-related operations
@@ -174,20 +364,13 @@ export function useViewOperations() {
         const layout = isSubDocument ? ViewLayout.Document : view?.layout;
         const databaseIdHint = !isSubDocument
           ? options?.databaseId ??
-            (
-              layout !== undefined && isDatabaseLayout(layout)
-                ? getDatabaseIdFromExtra(view)
-                : undefined
-            )
+            (layout !== undefined && isDatabaseLayout(layout) ? getDatabaseIdFromExtra(view) : undefined)
           : undefined;
 
         // Use view-loader to open document (handles cache vs fetch)
-        let { doc, collabType: detectedCollabType } = await openView(
-          currentWorkspaceId,
-          viewId,
-          layout,
-          { databaseId: databaseIdHint }
-        );
+        let { doc, collabType: detectedCollabType } = await openView(currentWorkspaceId, viewId, layout, {
+          databaseId: databaseIdHint,
+        });
 
         // Use detected collab type, or override for sub-documents
         let collabType = isSubDocument ? Types.Document : detectedCollabType;
@@ -458,17 +641,14 @@ export function useViewOperations() {
 
           doc.version = versionId;
 
-          Y.transact(
-            doc,
-            () => {
-              try {
-                Y.applyUpdate(doc, docState);
-              } catch (e) {
-                Log.error('Error applying Yjs update for document version preview', e);
-                throw e;
-              }
+          Y.transact(doc, () => {
+            try {
+              Y.applyUpdate(doc, docState);
+            } catch (e) {
+              Log.error('Error applying Yjs update for document version preview', e);
+              throw e;
             }
-          );
+          });
 
           return doc;
         }

--- a/src/components/app/hooks/useWorkspaceData.ts
+++ b/src/components/app/hooks/useWorkspaceData.ts
@@ -178,6 +178,71 @@ function isOnlyNonVisualOutlineChange(patch: JsonPatchOperation[]): boolean {
   });
 }
 
+function decodeJsonPointerSegment(segment: string): string {
+  return segment.replace(/~1/g, '/').replace(/~0/g, '~');
+}
+
+function getViewAtOutlinePath(outline: View[], pathSegments: string[]): View | null {
+  let cursor: View[] | View | undefined = outline;
+
+  for (const segment of pathSegments) {
+    const key = decodeJsonPointerSegment(segment);
+
+    if (key === 'outline') {
+      cursor = outline;
+      continue;
+    }
+
+    if (key === 'children') {
+      if (!cursor || Array.isArray(cursor)) return null;
+      cursor = cursor.children ?? [];
+      continue;
+    }
+
+    const index = Number(key);
+
+    if (!Number.isInteger(index) || index < 0 || !Array.isArray(cursor)) {
+      return null;
+    }
+
+    cursor = cursor[index];
+  }
+
+  return cursor && !Array.isArray(cursor) ? cursor : null;
+}
+
+function findPatchParentsRequiringChildReload(outline: View[], patch: JsonPatchOperation[]): string[] {
+  const parentIds = new Set<string>();
+
+  for (const op of patch) {
+    if (op.op !== 'add' || !op.path) continue;
+
+    const segments = op.path.split('/').slice(1);
+    const childrenSegmentIndex = segments.length - 2;
+
+    if (childrenSegmentIndex < 0 || segments[childrenSegmentIndex] !== 'children') continue;
+
+    const childIndexRaw = decodeJsonPointerSegment(segments[segments.length - 1]);
+    const childIndex = Number(childIndexRaw);
+
+    if (!Number.isInteger(childIndex) || childIndex < 0) continue;
+
+    const parentView = getViewAtOutlinePath(outline, segments.slice(0, childrenSegmentIndex));
+
+    if (!parentView) continue;
+
+    const childCount = parentView.children?.length ?? 0;
+    const childrenAreUnloaded = parentView.has_children === true && childCount === 0;
+    const patchSkipsLocalChildren = childIndex > childCount;
+
+    if (childrenAreUnloaded || patchSkipsLocalChildren) {
+      parentIds.add(parentView.view_id);
+    }
+  }
+
+  return Array.from(parentIds);
+}
+
 // Hook for managing workspace data (outline, favorites, recent, trash)
 export function useWorkspaceData() {
   const { currentWorkspaceId, userWorkspaceInfo } = useAuthInternal();
@@ -882,6 +947,20 @@ export function useWorkspaceData() {
 
       const baseOutline = stableOutlineRef.current.filter((view) => !view.extra?.is_hidden_space);
       const baseDocument = { outline: baseOutline };
+      const childReloadParentIds = findPatchParentsRequiringChildReload(baseOutline, patch);
+
+      if (childReloadParentIds.length > 0) {
+        Log.debug('[Outline] [FolderOutlineChanged] patch targets unloaded children, loading parent subtrees', {
+          parentViewIds: childReloadParentIds,
+        });
+        updateLastFolderRid(patchRid);
+        void loadViewChildrenBatch(childReloadParentIds).catch((error) => {
+          Log.warn('[Outline] [FolderOutlineChanged] Failed to load patch target subtrees, reloading outline', error);
+          void loadOutline(currentWorkspaceId, false);
+        });
+        return;
+      }
+
       let patchedOutline: View[] | null = null;
       let usedRelaxedPatch = false;
 
@@ -967,6 +1046,7 @@ export function useWorkspaceData() {
   }, [
     currentWorkspaceId,
     eventEmitter,
+    loadViewChildrenBatch,
     loadOutline,
     refreshTrashListInBackground,
     replaceOutlinePreservingChildren,

--- a/src/components/app/outline/ViewItem.tsx
+++ b/src/components/app/outline/ViewItem.tsx
@@ -102,6 +102,12 @@ function ViewItem({
     enabled: Boolean(reorderChildren) && (visibleChildren?.length ?? 0) > 1,
     errorMessage: 'Failed to reorder pages',
   });
+  const isLoaded = loadedViewIds?.has(viewId) ?? false;
+  const isLoading = loadingViewIds?.has(viewId) ?? false;
+  // If a previous lazy-load failed, the row can remain expanded with no
+  // children. Keep the toggle in "expand" mode so clicking it retries.
+  const childrenPresent = orderedChildren.length > 0;
+  const showExpandedToggle = isExpanded && (childrenPresent || isLoaded || isLoading);
 
   const handleChangeIcon = useCallback(
     async (icon: { ty: ViewIconType; value: string }) => {
@@ -129,14 +135,14 @@ function ViewItem({
       <span className={'flex h-full w-5 items-center justify-end text-sm'}>
         <OutlineIcon
           level={level}
-          isExpanded={isExpanded}
+          isExpanded={showExpandedToggle}
           setIsExpanded={(status) => {
             toggleExpand(viewId, status);
           }}
         />
       </span>
     );
-  }, [isExpanded, level, toggleExpand, viewId]);
+  }, [level, showExpandedToggle, toggleExpand, viewId]);
 
   // Dot icon for referenced database views (like desktop)
   const getDotIcon = useCallback(() => {
@@ -164,7 +170,6 @@ function ViewItem({
     // Determine which left icon to show
     // Use the utility function which properly handles database containers
     const isRefDatabaseView = isRefDbView(view, parentView);
-    const isLoaded = loadedViewIds?.has(view.view_id) ?? false;
     const hasConfirmedChildren = Boolean(visibleChildren?.length);
     // Use server-provided has_children when available; fall back to heuristic for old servers
     const hasChildren =
@@ -267,6 +272,7 @@ function ViewItem({
     aiEnabled,
     view,
     visibleChildren,
+    isLoaded,
     selected,
     level,
     getIcon,
@@ -280,7 +286,6 @@ function ViewItem({
     onClickView,
     viewId,
     handleChangeIcon,
-    loadedViewIds,
     dragState,
     shouldSuppressClick,
   ]);
@@ -288,8 +293,6 @@ function ViewItem({
   // Children are present in the DOM only once the lazy load has populated them.
   // Gate the open animation on actual presence (not a loading flag) so the
   // Collapse opens against real content and animates on the first expand.
-  const childrenPresent = orderedChildren.length > 0;
-
   const renderChildren = useMemo(() => {
     if (!aiEnabled && view.layout === ViewLayout.AIChat) return null;
 

--- a/src/components/database/Database.tsx
+++ b/src/components/database/Database.tsx
@@ -293,13 +293,24 @@ function Database(props: Database2Props) {
       }
 
       syncedRowKeysRef.current.add(rowKey);
-      void createRow(rowKey).catch((e) => {
-        console.error('[Database] registerRowSync failed', rowKey, e);
-        // Remove from set so it can be retried
-        syncedRowKeysRef.current.delete(rowKey);
-      });
+      void createRow(rowKey)
+        .then((rowDoc) => {
+          const [rowKeyDatabaseId, rowId] = rowKey.split('_rows_');
+
+          if (!rowDoc || !rowId || rowKeyDatabaseId !== getDatabaseId()) return;
+
+          setRowMap((prev) => {
+            if (prev[rowId]) return prev;
+            return { ...prev, [rowId]: rowDoc };
+          });
+        })
+        .catch((e) => {
+          console.error('[Database] registerRowSync failed', rowKey, e);
+          // Remove from set so it can be retried
+          syncedRowKeysRef.current.delete(rowKey);
+        });
     },
-    [createRow]
+    [createRow, getDatabaseId]
   );
 
   const bindRowSync = useCallback(

--- a/src/components/database/components/cell/checkbox/CheckboxCell.test.tsx
+++ b/src/components/database/components/cell/checkbox/CheckboxCell.test.tsx
@@ -1,0 +1,44 @@
+import { render, screen } from '@testing-library/react';
+
+import { FieldType } from '@/application/database-yjs';
+import { CheckboxCell as CheckboxCellType } from '@/application/database-yjs/cell.type';
+import { CheckboxCell } from '@/components/database/components/cell/checkbox/CheckboxCell';
+
+jest.mock('@/application/database-yjs/dispatch', () => ({
+  useUpdateCellDispatch: () => jest.fn(),
+}));
+
+function makeCell(data: string): CheckboxCellType {
+  return {
+    createdAt: 0,
+    data,
+    fieldType: FieldType.Checkbox,
+    lastModified: 0,
+  };
+}
+
+describe('CheckboxCell', () => {
+  it('rerenders from remote cell data changes', () => {
+    const { rerender } = render(
+      <CheckboxCell
+        cell={makeCell('No')}
+        fieldId="done-field"
+        rowId="row-1"
+      />
+    );
+
+    expect(screen.getByTestId('checkbox-cell-row-1-done-field').getAttribute('data-checked')).toBe('false');
+    expect(screen.getByTestId('checkbox-unchecked-icon')).not.toBeNull();
+
+    rerender(
+      <CheckboxCell
+        cell={makeCell('Yes')}
+        fieldId="done-field"
+        rowId="row-1"
+      />
+    );
+
+    expect(screen.getByTestId('checkbox-cell-row-1-done-field').getAttribute('data-checked')).toBe('true');
+    expect(screen.getByTestId('checkbox-checked-icon')).not.toBeNull();
+  });
+});

--- a/src/components/database/components/cell/checkbox/CheckboxCell.tsx
+++ b/src/components/database/components/cell/checkbox/CheckboxCell.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react';
+import { useEffect } from 'react';
 
 import { CellProps, CheckboxCell as CheckboxCellType } from '@/application/database-yjs/cell.type';
 import { useUpdateCellDispatch } from '@/application/database-yjs/dispatch';
@@ -17,17 +17,12 @@ export function CheckboxCell({
   setEditing,
 }: CellProps<CheckboxCellType>) {
   const onUpdateCell = useUpdateCellDispatch(rowId, fieldId);
-
-  const checkedRef = useRef<boolean>(getChecked(cell?.data));
-
-  useEffect(() => {
-    checkedRef.current = getChecked(cell?.data);
-  }, [cell?.data]);
+  const checked = getChecked(cell?.data);
 
   useEffect(() => {
     if (readOnly) return;
     if (editing) {
-      if (checkedRef.current) {
+      if (checked) {
         onUpdateCell('No');
       } else {
         onUpdateCell('Yes');
@@ -35,15 +30,15 @@ export function CheckboxCell({
 
       setEditing?.(false);
     }
-  }, [editing, onUpdateCell, setEditing, readOnly]);
+  }, [checked, editing, onUpdateCell, setEditing, readOnly]);
   return (
     <div
       style={style}
       data-testid={`checkbox-cell-${rowId}-${fieldId}`}
-      data-checked={checkedRef.current}
+      data-checked={checked}
       className={cn('relative flex h-full w-full text-lg text-text-action', readOnly ? '' : 'cursor-pointer')}
     >
-      {checkedRef.current ? (
+      {checked ? (
         <CheckboxCheckSvg className={'h-5 w-5'} data-testid="checkbox-checked-icon" />
       ) : (
         <CheckboxUncheckSvg className={'h-5 w-5 text-border-primary hover:text-border-primary-hover'} data-testid="checkbox-unchecked-icon" />

--- a/src/components/database/components/grid/grid-row/GridVirtualRow.tsx
+++ b/src/components/database/components/grid/grid-row/GridVirtualRow.tsx
@@ -5,7 +5,7 @@ import { VirtualItem } from '@tanstack/react-virtual';
 import { uniqBy } from 'lodash-es';
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
-import { useReadOnly, useRowData, useSortsSelector } from '@/application/database-yjs';
+import { useDatabaseContext, useReadOnly, useRowData, useSortsSelector } from '@/application/database-yjs';
 import { YjsDatabaseKey } from '@/application/types';
 import { DropRowIndicator } from '@/components/database/components/drag-and-drop/DropRowIndicator';
 import {
@@ -48,6 +48,7 @@ function GridVirtualRow({
   const rowId = data[rowIndex].rowId as string;
   const rowType = data[rowIndex].type;
   const { setHoverRowId, setResizeRow } = useGridContext();
+  const { bindRowSync } = useDatabaseContext();
   const databaseRow = useRowData(rowId);
   const cells = databaseRow?.get(YjsDatabaseKey.cells);
   const cellsCount = cells?.size;
@@ -68,6 +69,12 @@ function GridVirtualRow({
   );
 
   const isRegularRow = rowType === RenderRowType.Row;
+
+  useEffect(() => {
+    if (!isRegularRow) return;
+
+    bindRowSync?.(rowId);
+  }, [bindRowSync, isRegularRow, rowId]);
 
   useEffect(() => {
     const element = innerRef.current;

--- a/src/components/database/components/tabs/DatabaseTabs.tsx
+++ b/src/components/database/components/tabs/DatabaseTabs.tsx
@@ -64,6 +64,8 @@ export const DatabaseTabs = forwardRef<HTMLDivElement, DatabaseTabBarProps>(
     const [deleteConfirmOpen, setDeleteConfirmOpen] = useState<string | null>(null);
     const [renameViewId, setRenameViewId] = useState<string | null>(null);
     const [menuViewId, setMenuViewId] = useState<string | null>(null);
+    const embeddedTitle = context.isDocumentBlock && meta ? (meta.name || _viewName || '').trim() : '';
+    const embeddedTitleViewId = context.isDocumentBlock ? meta?.view_id : undefined;
 
     // Used to trigger a scroll in the child component
     const [pendingScrollToViewId, setPendingScrollToViewId] = useState<string | null>(null);
@@ -233,6 +235,24 @@ export const DatabaseTabs = forwardRef<HTMLDivElement, DatabaseTabBarProps>(
           paddingRight: scrollLeftPadding === undefined ? 96 : scrollLeftPadding,
         }}
       >
+        {embeddedTitle ? (
+          <div className={'mb-2 flex min-h-8 w-full items-center'}>
+            <button
+              type={'button'}
+              disabled={readOnly || !embeddedTitleViewId}
+              className={
+                'max-w-full truncate rounded px-0 py-1 text-left text-xl font-semibold leading-8 text-text-title outline-none hover:text-text-primary disabled:cursor-default disabled:text-text-title'
+              }
+              onClick={() => {
+                if (!embeddedTitleViewId) return;
+                setRenameViewId(embeddedTitleViewId);
+              }}
+            >
+              {embeddedTitle}
+            </button>
+          </div>
+        ) : null}
+
         <div className={`database-tabs flex w-full items-center gap-1.5 overflow-hidden border-b border-border-primary`}>
           <DatabaseViewTabs
             viewIds={viewIds}

--- a/src/components/database/components/tabs/DatabaseTabs.tsx
+++ b/src/components/database/components/tabs/DatabaseTabs.tsx
@@ -3,7 +3,7 @@ import { forwardRef, useCallback, useEffect, useMemo, useState } from 'react';
 import { APP_EVENTS } from '@/application/constants';
 import { useDatabase, useDatabaseContext } from '@/application/database-yjs';
 import { useUpdateDatabaseView } from '@/application/database-yjs/dispatch';
-import { DatabaseViewLayout, View, ViewLayout, YDatabaseView, YjsDatabaseKey } from '@/application/types';
+import { DatabaseViewLayout, UpdatePagePayload, View, ViewLayout, YDatabaseView, YjsDatabaseKey } from '@/application/types';
 import { isDatabaseContainer } from '@/application/view-utils';
 import { findView } from '@/components/_shared/outline/utils';
 import { type ReorderResult } from '@/components/_shared/reorder/useReorderMonitor';
@@ -57,8 +57,8 @@ export const DatabaseTabs = forwardRef<HTMLDivElement, DatabaseTabBarProps>(
   ) => {
     const views = useDatabase()?.get(YjsDatabaseKey.views);
     const context = useDatabaseContext();
-    const { loadViewMeta, navigateToView, readOnly, showActions = true, eventEmitter } = context;
-    const updatePage = useUpdateDatabaseView();
+    const { loadViewMeta, navigateToView, readOnly, showActions = true, eventEmitter, updatePage } = context;
+    const updateDatabaseView = useUpdateDatabaseView();
     const [meta, setMeta] = useState<View | null>(null);
     const scrollLeftPadding = context.paddingStart;
     const [deleteConfirmOpen, setDeleteConfirmOpen] = useState<string | null>(null);
@@ -66,6 +66,7 @@ export const DatabaseTabs = forwardRef<HTMLDivElement, DatabaseTabBarProps>(
     const [menuViewId, setMenuViewId] = useState<string | null>(null);
     const embeddedTitle = context.isDocumentBlock && meta ? (meta.name || _viewName || '').trim() : '';
     const embeddedTitleViewId = context.isDocumentBlock ? meta?.view_id : undefined;
+    const embeddedTitleUsesPageUpdate = Boolean(context.isDocumentBlock && meta && isDatabaseContainer(meta));
 
     // Used to trigger a scroll in the child component
     const [pendingScrollToViewId, setPendingScrollToViewId] = useState<string | null>(null);
@@ -197,6 +198,23 @@ export const DatabaseTabs = forwardRef<HTMLDivElement, DatabaseTabBarProps>(
       };
     }, [meta]);
 
+    const handleRenameView = useCallback(
+      async (viewId: string, payload: UpdatePagePayload) => {
+        if (embeddedTitleUsesPageUpdate && viewId === embeddedTitleViewId) {
+          if (!updatePage) {
+            throw new Error('Page update is unavailable');
+          }
+
+          await updatePage(viewId, payload);
+        } else {
+          await updateDatabaseView(viewId, payload);
+        }
+
+        void reloadView();
+      },
+      [embeddedTitleUsesPageUpdate, embeddedTitleViewId, reloadView, updateDatabaseView, updatePage]
+    );
+
     useEffect(() => {
       void reloadView();
     }, [reloadView]);
@@ -239,7 +257,7 @@ export const DatabaseTabs = forwardRef<HTMLDivElement, DatabaseTabBarProps>(
           <div className={'mb-2 flex min-h-8 w-full items-center'}>
             <button
               type={'button'}
-              disabled={readOnly || !embeddedTitleViewId}
+              disabled={readOnly || !embeddedTitleViewId || (embeddedTitleUsesPageUpdate && !updatePage)}
               className={
                 'max-w-full truncate rounded px-0 py-1 text-left text-xl font-semibold leading-8 text-text-title outline-none hover:text-text-primary disabled:cursor-default disabled:text-text-title'
               }
@@ -315,10 +333,7 @@ export const DatabaseTabs = forwardRef<HTMLDivElement, DatabaseTabBarProps>(
               setRenameViewId(null);
             }}
             view={renameView}
-            updatePage={async (viewId, payload) => {
-              await updatePage(viewId, payload);
-              void reloadView();
-            }}
+            updatePage={handleRenameView}
             viewId={renameViewId || ''}
           />
         )}

--- a/src/components/database/components/tabs/__tests__/DatabaseTabs.embeddedTitle.test.tsx
+++ b/src/components/database/components/tabs/__tests__/DatabaseTabs.embeddedTitle.test.tsx
@@ -31,10 +31,31 @@ jest.mock('@/components/database/components/conditions', () => ({
 
 jest.mock('@/components/app/view-actions/RenameModal', () => ({
   __esModule: true,
-  default: ({ open, view, viewId }: { open: boolean; view: View; viewId: string }) =>
+  default: ({
+    open,
+    view,
+    viewId,
+    updatePage,
+  }: {
+    open: boolean;
+    view: View;
+    viewId: string;
+    updatePage: (viewId: string, payload: { name: string; icon: unknown; extra: unknown }) => Promise<void>;
+  }) =>
     open ? (
       <div data-testid='rename-modal'>
         {viewId}:{view.name}
+        <button
+          type='button'
+          data-testid='rename-modal-save'
+          onClick={() =>
+            updatePage(viewId, {
+              name: 'Renamed Database',
+              icon: view.icon,
+              extra: view.extra,
+            })
+          }
+        />
       </div>
     ) : null,
 }));
@@ -64,10 +85,11 @@ describe('DatabaseTabs embedded title', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockUseDatabase.mockReturnValue({ get: jest.fn() } as never);
-    mockUseUpdateDatabaseView.mockReturnValue(jest.fn() as never);
   });
 
   it('renders the database container name for document blocks', async () => {
+    const updateDatabaseView = jest.fn();
+    const updatePage = jest.fn();
     const childView = createView({
       view_id: 'grid-view-id',
       name: 'Grid',
@@ -91,12 +113,14 @@ describe('DatabaseTabs embedded title', () => {
       return null;
     });
 
+    mockUseUpdateDatabaseView.mockReturnValue(updateDatabaseView as never);
     mockUseDatabaseContext.mockReturnValue({
       readOnly: false,
       databasePageId: childView.view_id,
       activeViewId: childView.view_id,
       workspaceId: 'workspace-id',
       loadViewMeta,
+      updatePage,
       isDocumentBlock: true,
       showActions: false,
     } as never);
@@ -120,5 +144,17 @@ describe('DatabaseTabs embedded title', () => {
     await waitFor(() => {
       expect(screen.getByTestId('rename-modal').textContent).toBe('container-view-id:New Database');
     });
+
+    fireEvent.click(screen.getByTestId('rename-modal-save'));
+
+    await waitFor(() => {
+      expect(updatePage).toHaveBeenCalledWith(
+        containerView.view_id,
+        expect.objectContaining({
+          name: 'Renamed Database',
+        })
+      );
+    });
+    expect(updateDatabaseView).not.toHaveBeenCalled();
   });
 });

--- a/src/components/database/components/tabs/__tests__/DatabaseTabs.embeddedTitle.test.tsx
+++ b/src/components/database/components/tabs/__tests__/DatabaseTabs.embeddedTitle.test.tsx
@@ -1,0 +1,124 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+import { useDatabase, useDatabaseContext } from '@/application/database-yjs';
+import { useUpdateDatabaseView } from '@/application/database-yjs/dispatch';
+import { View, ViewLayout } from '@/application/types';
+
+import { DatabaseTabs } from '../DatabaseTabs';
+
+jest.mock('@/application/database-yjs', () => ({
+  useDatabase: jest.fn(),
+  useDatabaseContext: jest.fn(),
+}));
+
+jest.mock('@/application/database-yjs/dispatch', () => ({
+  useUpdateDatabaseView: jest.fn(),
+}));
+
+jest.mock('@/components/database/components/tabs/DatabaseViewTabs', () => ({
+  DatabaseViewTabs: ({ viewIds, viewNameById }: { viewIds: string[]; viewNameById?: Record<string, string> }) => (
+    <div data-testid='database-view-tabs'>
+      {viewIds.map((viewId) => (
+        <span key={viewId}>{viewNameById?.[viewId] ?? viewId}</span>
+      ))}
+    </div>
+  ),
+}));
+
+jest.mock('@/components/database/components/conditions', () => ({
+  DatabaseActions: () => <div data-testid='database-actions' />,
+}));
+
+jest.mock('@/components/app/view-actions/RenameModal', () => ({
+  __esModule: true,
+  default: ({ open, view, viewId }: { open: boolean; view: View; viewId: string }) =>
+    open ? (
+      <div data-testid='rename-modal'>
+        {viewId}:{view.name}
+      </div>
+    ) : null,
+}));
+
+jest.mock('@/components/database/components/tabs/DeleteViewConfirm', () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+const mockUseDatabase = useDatabase as jest.MockedFunction<typeof useDatabase>;
+const mockUseDatabaseContext = useDatabaseContext as jest.MockedFunction<typeof useDatabaseContext>;
+const mockUseUpdateDatabaseView = useUpdateDatabaseView as jest.MockedFunction<typeof useUpdateDatabaseView>;
+
+const createView = (overrides: Partial<View> & Pick<View, 'view_id' | 'name'>): View => ({
+  view_id: overrides.view_id,
+  name: overrides.name,
+  icon: null,
+  layout: ViewLayout.Grid,
+  extra: null,
+  children: [],
+  is_published: false,
+  is_private: false,
+  ...overrides,
+});
+
+describe('DatabaseTabs embedded title', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseDatabase.mockReturnValue({ get: jest.fn() } as never);
+    mockUseUpdateDatabaseView.mockReturnValue(jest.fn() as never);
+  });
+
+  it('renders the database container name for document blocks', async () => {
+    const childView = createView({
+      view_id: 'grid-view-id',
+      name: 'Grid',
+      parent_view_id: 'container-view-id',
+      extra: {
+        database_id: 'database-id',
+      },
+    });
+    const containerView = createView({
+      view_id: 'container-view-id',
+      name: 'New Database',
+      children: [childView],
+      extra: {
+        database_id: 'database-id',
+        is_database_container: true,
+      },
+    });
+    const loadViewMeta = jest.fn(async (viewId: string) => {
+      if (viewId === childView.view_id) return childView;
+      if (viewId === containerView.view_id) return containerView;
+      return null;
+    });
+
+    mockUseDatabaseContext.mockReturnValue({
+      readOnly: false,
+      databasePageId: childView.view_id,
+      activeViewId: childView.view_id,
+      workspaceId: 'workspace-id',
+      loadViewMeta,
+      isDocumentBlock: true,
+      showActions: false,
+    } as never);
+
+    render(
+      <DatabaseTabs
+        databasePageId={childView.view_id}
+        selectedViewId={childView.view_id}
+        viewIds={[childView.view_id]}
+      />
+    );
+
+    const title = await screen.findByRole('button', { name: 'New Database' });
+
+    expect(loadViewMeta).toHaveBeenCalledWith(childView.view_id);
+    expect(loadViewMeta).toHaveBeenCalledWith(containerView.view_id);
+    expect(screen.getByTestId('database-view-tabs').textContent).toContain('Grid');
+
+    fireEvent.click(title);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('rename-modal').textContent).toBe('container-view-id:New Database');
+    });
+  });
+});

--- a/src/components/database/hooks/useBindViewSync.ts
+++ b/src/components/database/hooks/useBindViewSync.ts
@@ -35,7 +35,7 @@ export function useBindViewSync() {
       const objectId = docWithMeta.object_id;
       const viewId = docWithMeta.view_id ?? objectId;
 
-      // Use explicit undefined check for collabType since Types.Document = 0 is falsy
+      // Use explicit undefined check so zero-valued collab types remain valid.
       if (collabType === undefined || !objectId || !viewId) {
         Log.warn('[useBindViewSync] failed - missing metadata', {
           hasCollabType: collabType !== undefined,

--- a/src/components/editor/components/blocks/database/DatabaseBlock.tsx
+++ b/src/components/editor/components/blocks/database/DatabaseBlock.tsx
@@ -391,10 +391,18 @@ export const DatabaseBlock = memo(
   (prevProps, nextProps) => {
     const prevViewIds = getViewIds(prevProps.node.data);
     const nextViewIds = getViewIds(nextProps.node.data);
+    const prevData = prevProps.node.data || {};
+    const nextData = nextProps.node.data || {};
+    const hasSameViewIds =
+      prevViewIds.length === nextViewIds.length &&
+      prevViewIds.every((id, index) => id === nextViewIds[index]);
 
     return (
-      prevViewIds.length === nextViewIds.length &&
-      prevViewIds.every((id, index) => id === nextViewIds[index])
+      prevProps.node.type === nextProps.node.type &&
+      prevData.view_id === nextData.view_id &&
+      prevData.database_id === nextData.database_id &&
+      prevData.parent_id === nextData.parent_id &&
+      hasSameViewIds
     );
   }
 );

--- a/src/components/editor/components/blocks/database/components/DatabaseContent.tsx
+++ b/src/components/editor/components/blocks/database/components/DatabaseContent.tsx
@@ -6,8 +6,6 @@ import { getPublishedDatabaseRenderRowMap } from '@/application/publish-snapshot
 import { LoadView, LoadViewMeta, UIVariant, YDoc } from '@/application/types';
 import { Database } from '@/components/database';
 
-const EMBEDDED_DATABASE_FIXED_HEIGHT = 600;
-
 interface DatabaseContentProps {
   /**
    * The base/primary view ID for the embedded database.
@@ -64,7 +62,7 @@ export const DatabaseContent = ({
   onViewAdded,
   onViewIdsChanged,
   context,
-  fixedHeight = EMBEDDED_DATABASE_FIXED_HEIGHT,
+  fixedHeight,
   onRendered,
 }: DatabaseContentProps) => {
   const { t } = useTranslation();
@@ -124,14 +122,8 @@ export const DatabaseContent = ({
   const showError = notFound || deletionStatus === 'inTrash' || deletionStatus === 'deleted';
 
   return (
-    <div className="flex h-full w-full flex-col items-center justify-center gap-2 rounded bg-background-primary px-16 py-10 text-text-secondary max-md:px-4">
-      {showError ? (
-        <div className="text-base font-medium">
-          {getNotFoundMessage()}
-        </div>
-      ) : (
-        <CircularProgress size={20} />
-      )}
+    <div className='flex h-full w-full flex-col items-center justify-center gap-2 rounded bg-background-primary px-16 py-10 text-text-secondary max-md:px-4'>
+      {showError ? <div className='text-base font-medium'>{getNotFoundMessage()}</div> : <CircularProgress size={20} />}
     </div>
   );
 };

--- a/src/components/editor/components/blocks/database/components/__tests__/DatabaseContent.test.tsx
+++ b/src/components/editor/components/blocks/database/components/__tests__/DatabaseContent.test.tsx
@@ -10,7 +10,7 @@ import { Database } from '@/components/database';
 import { DatabaseContent } from '../DatabaseContent';
 
 jest.mock('@/components/database', () => ({
-  Database: jest.fn(() => <div data-testid="database" />),
+  Database: jest.fn(() => <div data-testid='database' />),
 }));
 
 jest.mock('react-i18next', () => ({
@@ -48,12 +48,12 @@ describe('DatabaseContent', () => {
         selectedViewId={snapshot.database.activeViewId}
         hasDatabase={true}
         notFound={false}
-        deletionStatus="none"
+        deletionStatus='none'
         paddingStart={0}
         paddingEnd={0}
         width={800}
         doc={doc}
-        workspaceId="publish"
+        workspaceId='publish'
         onOpenRowPage={jest.fn()}
         loadViewMeta={jest.fn()}
         databaseName={snapshot.view.name}
@@ -67,9 +67,57 @@ describe('DatabaseContent', () => {
     expect((Database as jest.Mock).mock.calls[0][0]).toEqual(
       expect.objectContaining({
         doc,
+        embeddedHeight: undefined,
         initialRowMap: rowMap,
         activeViewId: snapshot.database.activeViewId,
         variant: UIVariant.Publish,
+      })
+    );
+  });
+
+  it('passes an embedded height only when the caller provides one', () => {
+    const snapshot = normalizePublishedPageSnapshot(publishedDatabasePayload);
+
+    if (snapshot.kind !== 'database') {
+      throw new Error('Expected database snapshot fixture');
+    }
+
+    const { doc } = createDatabaseYjsRenderDocsFromSnapshot(snapshot);
+    const context = {
+      readOnly: true,
+      databaseDoc: doc,
+      databasePageId: snapshot.view.viewId,
+      activeViewId: snapshot.database.activeViewId,
+      rowMap: null,
+      workspaceId: 'publish',
+      variant: UIVariant.Publish,
+    } as DatabaseContextState;
+
+    render(
+      <DatabaseContent
+        baseViewId={snapshot.view.viewId}
+        selectedViewId={snapshot.database.activeViewId}
+        hasDatabase={true}
+        notFound={false}
+        deletionStatus='none'
+        paddingStart={0}
+        paddingEnd={0}
+        width={800}
+        doc={doc}
+        workspaceId='publish'
+        onOpenRowPage={jest.fn()}
+        loadViewMeta={jest.fn()}
+        databaseName={snapshot.view.name}
+        visibleViewIds={snapshot.database.visibleViewIds}
+        onChangeView={jest.fn()}
+        context={context}
+        fixedHeight={420}
+      />
+    );
+
+    expect((Database as jest.Mock).mock.calls[0][0]).toEqual(
+      expect.objectContaining({
+        embeddedHeight: 420,
       })
     );
   });

--- a/src/components/ws/__tests__/useSync.test.ts
+++ b/src/components/ws/__tests__/useSync.test.ts
@@ -380,6 +380,50 @@ describe('useSync deferred cleanup', () => {
     outboxMock.clearDrainConfig();
     unmount();
   });
+
+  it('replays unknown-typed row update received before the row context registers', async () => {
+    const ws = createWs();
+    const bc = createBroadcastChannel();
+    const databaseId = '33333333-3333-4333-8333-333333333334';
+    const rowId = '33333333-3333-4333-8333-333333333335';
+    const serverDoc = createDatabaseRowDoc(rowId, databaseId, { field_a: 'desktop value' });
+    const localDoc = createDoc(rowId);
+    const update = Y.encodeStateAsUpdate(serverDoc);
+    const message = {
+      objectId: rowId,
+      collabType: Types.Unknown,
+      update: {
+        flags: 0,
+        payload: update,
+      },
+    };
+
+    const { result, rerender, unmount } = renderHook(() =>
+      useSync(ws, bc, defaultEventEmitter, defaultWorkspaceId)
+    );
+
+    act(() => {
+      ws.lastMessage = { collabMessage: message } as AppflowyWebSocketType['lastMessage'];
+      rerender();
+    });
+
+    await flushPromises();
+    expect(mockedHandleMessage).not.toHaveBeenCalled();
+
+    act(() => {
+      result.current.registerSyncContext({ doc: localDoc, collabType: Types.DatabaseRow });
+    });
+
+    await waitFor(() => {
+      expect(mockedHandleMessage).toHaveBeenCalledTimes(1);
+    });
+    expect(mockedHandleMessage.mock.calls[0]?.[0].doc).toBe(localDoc);
+    expect(mockedHandleMessage.mock.calls[0]?.[1]).toBe(message);
+
+    unmount();
+    serverDoc.destroy();
+    localDoc.destroy();
+  });
 });
 
 describe('useSync version-gated message handling', () => {
@@ -468,6 +512,41 @@ describe('useSync version-gated message handling', () => {
     unmount();
     doc.destroy();
     nextDoc.destroy();
+  });
+
+  it('does not reset unknown local version on sync request without remote version', async () => {
+    const ws = createWs();
+    const bc = createBroadcastChannel();
+    const objectId = '55555555-5555-4555-8555-555555555554';
+    const doc = createDoc(objectId) as Y.Doc & { version?: string };
+    const { result, rerender, unmount } = renderHook(() =>
+      useSync(ws, bc, defaultEventEmitter, defaultWorkspaceId)
+    );
+
+    act(() => {
+      result.current.registerSyncContext({ doc, collabType: Types.DatabaseRow });
+    });
+
+    const message = {
+      objectId,
+      collabType: Types.DatabaseRow,
+      syncRequest: {},
+    };
+
+    act(() => {
+      ws.lastMessage = { collabMessage: message } as AppflowyWebSocketType['lastMessage'];
+      rerender();
+    });
+
+    await waitFor(() => {
+      expect(mockedHandleMessage).toHaveBeenCalledTimes(1);
+    });
+    expect(mockedHandleMessage.mock.calls[0]?.[0].doc).toBe(doc);
+    expect(mockedHandleMessage.mock.calls[0]?.[1]).toBe(message);
+    expect(mockedOpenCollabDB).not.toHaveBeenCalled();
+
+    unmount();
+    doc.destroy();
   });
 
   it('resets unknown local version on sync request with known remote version', async () => {

--- a/src/components/ws/__tests__/useSync.test.ts
+++ b/src/components/ws/__tests__/useSync.test.ts
@@ -424,6 +424,44 @@ describe('useSync deferred cleanup', () => {
     serverDoc.destroy();
     localDoc.destroy();
   });
+
+  it('does not replay access changes received before a context registers', async () => {
+    const ws = createWs();
+    const bc = createBroadcastChannel();
+    const objectId = '33333333-3333-4333-8333-333333333336';
+    const doc = createDoc(objectId);
+    const message = {
+      objectId,
+      collabType: Types.Document,
+      accessChanged: {
+        canRead: false,
+        canWrite: false,
+        reason: 0,
+      },
+    };
+
+    const { result, rerender, unmount } = renderHook(() =>
+      useSync(ws, bc, defaultEventEmitter, defaultWorkspaceId)
+    );
+
+    act(() => {
+      ws.lastMessage = { collabMessage: message } as AppflowyWebSocketType['lastMessage'];
+      rerender();
+    });
+
+    await flushPromises();
+    expect(mockedHandleMessage).not.toHaveBeenCalled();
+
+    act(() => {
+      result.current.registerSyncContext({ doc, collabType: Types.Document });
+    });
+
+    await flushPromises();
+    expect(mockedHandleMessage).not.toHaveBeenCalled();
+
+    unmount();
+    doc.destroy();
+  });
 });
 
 describe('useSync version-gated message handling', () => {

--- a/src/components/ws/sync/syncRefs.ts
+++ b/src/components/ws/sync/syncRefs.ts
@@ -137,6 +137,16 @@ export type SyncRefs = {
   queuedMessagesDuringReset: React.MutableRefObject<Map<string, ICollabMessage[]>>;
 
   /**
+   * Database-row messages received before the row's sync context exists.
+   *
+   * The database collab can reveal a new row before Web has mounted and
+   * registered that row's own collab context. Without this short-lived queue,
+   * the row-content update is lost and the grid keeps rendering the loading
+   * placeholder until a reload or blob refresh rehydrates the row.
+   */
+  queuedMessagesBeforeContext: React.MutableRefObject<Map<string, ICollabMessage[]>>;
+
+  /**
    * Transient per-tab "latest seen" incoming version, keyed by `objectId`.
    *
    * Updated at the top of `applyCollabMessage` for every message that carries a
@@ -177,6 +187,15 @@ export type SyncRefs = {
   processingObjectIdsRef: React.MutableRefObject<Set<string>>;
 
   /**
+   * Optional callback installed by `useCollabMessageHandler`.
+   *
+   * `useSyncContextLifecycle` calls this after registering a context so any
+   * messages queued in `queuedMessagesBeforeContext` can be replayed through
+   * the normal per-object FIFO processor.
+   */
+  onContextRegisteredRef: React.MutableRefObject<((objectId: string) => void) | undefined>;
+
+  /**
    * Snapshot of the latest `currentUser` value from React context.
    *
    * Kept in a ref so that async callbacks (e.g. the message queue processor)
@@ -211,11 +230,13 @@ export function useSyncRefs(): SyncRefs {
   const pendingCleanups = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map());
   const resettingObjectIds = useRef<Set<string>>(new Set());
   const queuedMessagesDuringReset = useRef<Map<string, ICollabMessage[]>>(new Map());
+  const queuedMessagesBeforeContext = useRef<Map<string, ICollabMessage[]>>(new Map());
   const latestIncomingVersionRef = useRef<Map<string, string>>(new Map());
 
   // ── 4. Message queue & lifecycle ─────────────────────────────────────
   const incomingMessageQueuesRef = useRef<Map<string, ICollabMessage[]>>(new Map());
   const processingObjectIdsRef = useRef<Set<string>>(new Set());
+  const onContextRegisteredRef = useRef<((objectId: string) => void) | undefined>(undefined);
   const latestUserRef = useRef<User | undefined>(undefined);
   const isDisposedRef = useRef(false);
 
@@ -232,9 +253,11 @@ export function useSyncRefs(): SyncRefs {
     pendingCleanups,
     resettingObjectIds,
     queuedMessagesDuringReset,
+    queuedMessagesBeforeContext,
     latestIncomingVersionRef,
     incomingMessageQueuesRef,
     processingObjectIdsRef,
+    onContextRegisteredRef,
     latestUserRef,
     isDisposedRef,
   }), []);

--- a/src/components/ws/sync/useCollabMessageHandler.ts
+++ b/src/components/ws/sync/useCollabMessageHandler.ts
@@ -5,7 +5,7 @@ import * as Y from 'yjs';
 
 import { deleteCollabDB, openCollabDB } from '@/application/db';
 import { handleMessage, SyncContext } from '@/application/services/js-services/sync-protocol';
-import { User, YDoc } from '@/application/types';
+import { Types, User, YDoc } from '@/application/types';
 import { collab } from '@/proto/messages';
 import { Log } from '@/utils/log';
 
@@ -17,6 +17,13 @@ import { isCollabVersionId, RegisterSyncContext, SyncDocMeta, versionChanged } f
 import ICollabMessage = collab.ICollabMessage;
 
 const MAX_QUEUED_MESSAGES_BEFORE_CONTEXT = 50;
+
+function shouldQueueMessageBeforeContext(message: ICollabMessage) {
+  const hasStateMessage = Boolean(message.update || message.syncRequest);
+  const isRowMessage = message.collabType === Types.DatabaseRow || message.collabType === Types.Unknown;
+
+  return Boolean(message.objectId && hasStateMessage && isRowMessage);
+}
 
 export function useCollabMessageHandler(
   refs: SyncRefs,
@@ -32,7 +39,7 @@ export function useCollabMessageHandler(
   const queueMessageBeforeContext = useCallback((message: ICollabMessage) => {
     const objectId = message.objectId;
 
-    if (!objectId) {
+    if (!objectId || !shouldQueueMessageBeforeContext(message)) {
       return false;
     }
 

--- a/src/components/ws/sync/useCollabMessageHandler.ts
+++ b/src/components/ws/sync/useCollabMessageHandler.ts
@@ -16,6 +16,8 @@ import { isCollabVersionId, RegisterSyncContext, SyncDocMeta, versionChanged } f
 
 import ICollabMessage = collab.ICollabMessage;
 
+const MAX_QUEUED_MESSAGES_BEFORE_CONTEXT = 50;
+
 export function useCollabMessageHandler(
   refs: SyncRefs,
   wsCollabMessage: ICollabMessage | undefined | null,
@@ -26,6 +28,31 @@ export function useCollabMessageHandler(
 ) {
   const lastHandledWsMessageRef = useRef<ICollabMessage | null>(null);
   const lastHandledBcMessageRef = useRef<ICollabMessage | null>(null);
+
+  const queueMessageBeforeContext = useCallback((message: ICollabMessage) => {
+    const objectId = message.objectId;
+
+    if (!objectId) {
+      return false;
+    }
+
+    const queued = refs.queuedMessagesBeforeContext.current.get(objectId) ?? [];
+
+    queued.push(message);
+    while (queued.length > MAX_QUEUED_MESSAGES_BEFORE_CONTEXT) {
+      queued.shift();
+    }
+
+    refs.queuedMessagesBeforeContext.current.set(objectId, queued);
+    Log.debug('[sync] queued collab message until context registers', {
+      objectId,
+      collabType: message.collabType,
+      queueLength: queued.length,
+      hasUpdate: Boolean(message.update),
+      hasSyncRequest: Boolean(message.syncRequest),
+    });
+    return true;
+  }, [refs]);
 
   const applyCollabMessage = useCallback(
     async (
@@ -62,6 +89,18 @@ export function useCollabMessageHandler(
       }
 
       Log.debug(`[Version] context lookup: objectId=${objectId}, hasContext=${!!context}, docVersion=${JSON.stringify(context?.doc?.version)}, isCollabVersionId(docVersion)=${context ? isCollabVersionId(context.doc.version) : 'N/A'}`);
+
+      if (!context) {
+        if (queueMessageBeforeContext(message)) {
+          return;
+        }
+
+        Log.debug('[sync] skipped collab message without active context', {
+          objectId,
+          collabType: message.collabType,
+        });
+        return;
+      }
 
       if (context) {
         let messageHandled = false;
@@ -238,7 +277,7 @@ export function useCollabMessageHandler(
 
       Log.debug('Received collab message:', message.collabType, message);
     },
-    [refs, eventEmitter, registerSyncContext, scheduleDeferredCleanup]
+    [refs, eventEmitter, registerSyncContext, scheduleDeferredCleanup, queueMessageBeforeContext]
   );
 
   const processIncomingMessageQueueForObject = useCallback(async (objectId: string) => {
@@ -311,6 +350,35 @@ export function useCollabMessageHandler(
     },
     [refs, processIncomingMessageQueueForObject]
   );
+
+  const replayMessagesQueuedBeforeContext = useCallback((objectId: string) => {
+    const queued = refs.queuedMessagesBeforeContext.current.get(objectId);
+
+    if (!queued || queued.length === 0) {
+      return;
+    }
+
+    refs.queuedMessagesBeforeContext.current.delete(objectId);
+    const pending = refs.incomingMessageQueuesRef.current.get(objectId) ?? [];
+
+    refs.incomingMessageQueuesRef.current.set(objectId, [...queued, ...pending]);
+    Log.debug('[sync] replaying collab messages queued before context registration', {
+      objectId,
+      queued: queued.length,
+      pending: pending.length,
+    });
+    void processIncomingMessageQueueForObject(objectId);
+  }, [refs, processIncomingMessageQueueForObject]);
+
+  useEffect(() => {
+    refs.onContextRegisteredRef.current = replayMessagesQueuedBeforeContext;
+
+    return () => {
+      if (refs.onContextRegisteredRef.current === replayMessagesQueuedBeforeContext) {
+        refs.onContextRegisteredRef.current = undefined;
+      }
+    };
+  }, [refs, replayMessagesQueuedBeforeContext]);
 
   useEffect(() => {
     const message = wsCollabMessage;

--- a/src/components/ws/sync/useSyncContextLifecycle.ts
+++ b/src/components/ws/sync/useSyncContextLifecycle.ts
@@ -224,6 +224,7 @@ export function useSyncContextLifecycle(
       const refCount = incrementContextRefCount(syncContext.doc.guid);
 
       Log.debug(`Registered sync context for objectId ${syncContext.doc.guid}; owner count=${refCount}`);
+      refs.onContextRegisteredRef.current?.(syncContext.doc.guid);
 
       return syncContext;
     },

--- a/src/pages/AppPage.tsx
+++ b/src/pages/AppPage.tsx
@@ -26,7 +26,7 @@ import {
   useScheduleDeferredCleanup,
 } from '@/components/app/app.hooks';
 import DatabaseView from '@/components/app/DatabaseView';
-import { getViewReadOnlyStatus } from '@/components/app/hooks/useViewOperations';
+import { useViewReadOnlyStatus } from '@/components/app/hooks/useViewOperations';
 import { RevertedDialog } from '@/components/app/RevertedDialog';
 import { Document } from '@/components/document';
 import RecordNotFound from '@/components/error/RecordNotFound';
@@ -454,13 +454,7 @@ function AppPage() {
 
   const requestInstance = getAxiosInstance();
 
-  // Check if view is in shareWithMe and determine readonly status.
-  // `view` is the merged outline-or-fallback object, so the lock check honors
-  // pages opened by direct URL before the outline branch has loaded.
-  const isReadOnly = useMemo(() => {
-    if (!viewId) return false;
-    return getViewReadOnlyStatus(viewId, outline, view);
-  }, [viewId, outline, view]);
+  const permissionReadOnly = useViewReadOnlyStatus(viewId, outline, view);
 
   const viewDom = useMemo(() => {
     // Check if doc belongs to current viewId (handles race condition when doc from old view arrives after navigation)
@@ -492,7 +486,7 @@ function AppPage() {
           requestInstance={requestInstance}
           workspaceId={workspaceId}
           doc={docForCurrentView}
-          readOnly={isReadOnly}
+          readOnly={permissionReadOnly}
           viewMeta={viewMeta}
           navigateToView={toView}
           loadViewMeta={loadViewMeta}
@@ -536,7 +530,7 @@ function AppPage() {
         requestInstance={requestInstance}
         workspaceId={workspaceId}
         doc={docForCurrentView}
-        readOnly={isReadOnly}
+        readOnly={permissionReadOnly}
         viewMeta={viewMeta}
         navigateToView={toView}
         loadViewMeta={loadViewMeta}
@@ -579,7 +573,7 @@ function AppPage() {
     viewMeta,
     workspaceId,
     requestInstance,
-    isReadOnly,
+    permissionReadOnly,
     toView,
     loadViewMeta,
     createRow,

--- a/src/pages/__tests__/AppPage.databaseContainer.test.tsx
+++ b/src/pages/__tests__/AppPage.databaseContainer.test.tsx
@@ -37,6 +37,7 @@ jest.mock('@/components/app/app.hooks', () => {
 
 jest.mock('@/components/app/hooks/useViewOperations', () => ({
   getViewReadOnlyStatus: () => false,
+  useViewReadOnlyStatus: () => false,
   useViewOperations: () => ({
     getViewReadOnlyStatus: () => false,
   }),


### PR DESCRIPTION
## Summary
- add collab object permission API support and wire page/modal read-only state through it
- query database layouts with the database collab object id and Types.Database
- keep permission refreshes fail-closed and add regression coverage for database permission identities

## Tests
- pnpm exec jest src/components/app/hooks/__tests__/useViewReadOnlyStatus.permissionApi.test.tsx src/application/services/js-services/http/__tests__/collab-api.test.ts src/pages/__tests__/AppPage.databaseContainer.test.tsx --no-coverage --runInBand

## Summary by Sourcery

Integrate server-side collab object permissions to determine view read-only status for documents and databases, and wire this through page and modal rendering.

New Features:
- Add a hook that derives view read-only status from collab object permissions, including database layouts using their database collab identity.
- Introduce an HTTP API helper for fetching object permissions with collab_type support.

Bug Fixes:
- Ensure read-only enforcement refreshes and fails closed on permission change or share events, covering document and database permission identities.

Enhancements:
- Update app pages and view modal to rely on permission-based read-only state instead of outline-only fallbacks.
- Propagate collab permission utilities through the collab domain service exports.

Tests:
- Add unit tests for the permission-based read-only hook, including notification-driven refresh, failure handling, race conditions, and database identities.
- Extend collab API tests to validate object permission requests include collab_type and expected parameters.
- Adjust AppPage database container tests to accommodate the new read-only hook.