### PR TITLE
fix: anchor slash menu at caret inside empty checklist items

### DIFF
--- a/src/components/editor/components/toolbar/selection-toolbar/__tests__/utils.test.ts
+++ b/src/components/editor/components/toolbar/selection-toolbar/__tests__/utils.test.ts
@@ -1,0 +1,100 @@
+import { getRangeRect } from '../utils';
+
+/**
+ * Helper: build a DOMRect-like object. jsdom does not run layout, so every real
+ * `getBoundingClientRect()` would otherwise return all zeros — which is exactly the
+ * shape we want to control here.
+ */
+function rect(top: number, left: number, width: number, height: number): DOMRect {
+  return {
+    top,
+    left,
+    width,
+    height,
+    right: left + width,
+    bottom: top + height,
+    x: left,
+    y: top,
+    toJSON: () => ({}),
+  } as DOMRect;
+}
+
+/**
+ * Mock `window.getSelection()` to return a single collapsed range whose
+ * `getBoundingClientRect()` and `startContainer` are fully under our control.
+ */
+function mockSelection(rangeRect: DOMRect, startContainer: Node) {
+  const domRange = {
+    getBoundingClientRect: () => rangeRect,
+    startContainer,
+  } as unknown as Range;
+
+  const selection = {
+    rangeCount: 1,
+    getRangeAt: () => domRange,
+  } as unknown as Selection;
+
+  jest.spyOn(window, 'getSelection').mockReturnValue(selection);
+}
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe('getRangeRect', () => {
+  it('returns the range rect when it has a real layout box', () => {
+    const valid = rect(120, 240, 0, 18);
+
+    mockSelection(valid, document.createElement('span'));
+
+    expect(getRangeRect()).toEqual(valid);
+  });
+
+  // Regression: typing "/" inside an empty checklist/to-do item.
+  //
+  // In Chrome, a collapsed selection at an empty text node that sits next to a
+  // `contentEditable=false` element (the checklist icon AND the block placeholder)
+  // returns a degenerate {0,0,0,0} rect. Because that rect is a truthy object, the
+  // slash panel used to anchor at the viewport's top-left corner instead of at the
+  // caret. getRangeRect() must instead fall back to the nearest ancestor element that
+  // has a real layout box.
+  it('falls back to the nearest laid-out ancestor when the caret rect is degenerate', () => {
+    // <span class="text-element">                 (flex row, has real box)
+    //   <span contenteditable=false>icon</span>
+    //   <span class="text-content">               (real box at the caret position)
+    //     <span contenteditable=false placeholder></span>
+    //     <span class="leaf">{""}</span>          (empty leaf, degenerate box)
+    //   </span>
+    // </span>
+    const textElement = document.createElement('span');
+    const textContent = document.createElement('span');
+    const leaf = document.createElement('span');
+    const emptyText = document.createTextNode('');
+
+    leaf.appendChild(emptyText);
+    textContent.appendChild(leaf);
+    textElement.appendChild(textContent);
+
+    // Empty leaf has no usable box (mirrors Chrome for the empty editable span).
+    leaf.getBoundingClientRect = () => rect(0, 0, 0, 0);
+    // The content wrapper is where the caret actually sits.
+    textContent.getBoundingClientRect = () => rect(300, 220, 0, 24);
+    textElement.getBoundingClientRect = () => rect(300, 180, 400, 24);
+
+    // The collapsed caret lives in the empty text node and reports a degenerate rect.
+    mockSelection(rect(0, 0, 0, 0), emptyText);
+
+    const result = getRangeRect();
+
+    // Must NOT be the {0,0,0,0} rect that anchors the panel to the top-left corner.
+    expect(result).not.toBeNull();
+    expect(result!.top).toBe(300);
+    expect(result!.left).toBe(220);
+  });
+
+  it('returns null when there is no selection range', () => {
+    jest.spyOn(window, 'getSelection').mockReturnValue({ rangeCount: 0 } as unknown as Selection);
+
+    expect(getRangeRect()).toBeNull();
+  });
+});

--- a/src/components/editor/components/toolbar/selection-toolbar/utils.ts
+++ b/src/components/editor/components/toolbar/selection-toolbar/utils.ts
@@ -1,5 +1,14 @@
 import { ReactEditor } from 'slate-react';
 
+// A DOMRect is "degenerate" when every value is 0. Chrome returns such a rect for a
+// collapsed range positioned at an empty text node or directly next to a
+// contentEditable=false element (e.g. a checklist/toggle start icon, or a block
+// placeholder). Treating it as a valid position anchors popovers at the viewport's
+// top-left corner instead of at the caret.
+function isDegenerateRect (rect: DOMRect | undefined | null): boolean {
+  return !rect || (rect.top === 0 && rect.left === 0 && rect.width === 0 && rect.height === 0);
+}
+
 export function getRangeRect () {
   const domSelection = window.getSelection();
   const rangeCount = domSelection?.rangeCount;
@@ -8,7 +17,25 @@ export function getRangeRect () {
 
   const domRange = rangeCount > 0 ? domSelection.getRangeAt(0) : undefined;
 
-  return domRange?.getBoundingClientRect();
+  if (!domRange) return null;
+
+  const rect = domRange.getBoundingClientRect();
+
+  if (!isDegenerateRect(rect)) return rect;
+
+  // Fall back to the nearest ancestor element that has a real layout box so the caret
+  // position can still be resolved (e.g. inside an empty checklist/to-do item).
+  const startNode = domRange.startContainer;
+  let el: Element | null = startNode.nodeType === Node.ELEMENT_NODE ? (startNode as Element) : startNode.parentElement;
+
+  while (el) {
+    const elRect = el.getBoundingClientRect();
+
+    if (!isDegenerateRect(elRect)) return elRect;
+    el = el.parentElement;
+  }
+
+  return rect;
 }
 
 export function getSelectionPosition (editor: ReactEditor) {


### PR DESCRIPTION
## Problem

On Chrome, typing `/` inside an empty checklist/to-do item opened the slash menu at the **viewport's top-left corner** instead of next to the cursor (user-reported).

![bug](https://github.com/AppFlowy-IO/AppFlowy-Web)

## Root cause

The panel position comes from `getRangeRect()` (`selection-toolbar/utils.ts`), which calls `getBoundingClientRect()` on the collapsed caret selection.

In Chrome, a collapsed range at an **empty text node sitting next to a `contentEditable=false` element** returns a degenerate `{0,0,0,0}` rect. A to-do line hits this exactly: the empty editable leaf sits right after two `contentEditable=false` elements — the checkbox icon (`CheckboxIcon.tsx`) and the block placeholder (`Placeholder.tsx`). A plain paragraph usually has the typed `/` already painted, so its rect is valid — which is why this only reproduces on checklists.

Because a zero `DOMRect` is still a **truthy object**, the existing fallback chain in `getPanelPosition` (`if (rect) …`) never fired and the panel anchored to `{top:0, left:0}`.

## Fix

`getRangeRect()` now detects a degenerate rect and falls back to the nearest ancestor element that has a real layout box, so the caret position resolves correctly.

Because all panels (slash / mention `@` / page-reference `[[`,`+` / paste-as) and the selection toolbar share `getRangeRect()`, this single change fixes them all.

> Note: the `vertical: -30` value in `SlashPanel.tsx` is **not** a bug — MUI's `PopoverOrigin` accepts numbers as pixel offsets.

## Testing

Added a regression test (`selection-toolbar/__tests__/utils.test.ts`) that simulates the degenerate-rect caret in a checklist-like DOM and asserts the fallback resolves the caret position.

| Code version | Result |
|---|---|
| Original | ❌ returns `top:0` (reproduces the misplacement) |
| Fixed | ✅ returns the real caret position |

Verified the test **fails on the original code** and **passes with the fix**. Also confirmed the underlying Chrome quirk live in a real browser with the editor's exact DOM structure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Fix caret-based popover positioning in the editor when Chrome returns a degenerate selection rect, and add regression coverage for this behavior.

Bug Fixes:
- Correct popover anchoring so slash and related panels appear at the caret inside empty checklist/to-do items instead of at the viewport origin.

Tests:
- Add unit tests for getRangeRect() covering valid rects, degenerate caret rect fallbacks to laid-out ancestors, and the no-selection case.