### PR TITLE
Fix stale Slate selection after link edits

### DIFF
--- a/src/application/slate-yjs/__tests__/transformSelection.test.ts
+++ b/src/application/slate-yjs/__tests__/transformSelection.test.ts
@@ -1,0 +1,31 @@
+import { expect } from '@jest/globals';
+import { createEditor, Editor, Range } from 'slate';
+
+import { ensureValidSelection, isValidSelection } from '@/application/slate-yjs/utils/transformSelection';
+
+describe('ensureValidSelection', () => {
+  it('clamps a stale selection offset to the current text length', () => {
+    const editor = createEditor();
+
+    editor.children = [
+      {
+        type: 'paragraph',
+        children: [{ text: 'Hi' }],
+      },
+    ] as Editor['children'];
+    editor.selection = {
+      anchor: { path: [0, 0], offset: 47 },
+      focus: { path: [0, 0], offset: 47 },
+    };
+
+    expect(isValidSelection(editor, editor.selection)).toBe(false);
+
+    ensureValidSelection(editor);
+
+    expect(editor.selection).not.toBeNull();
+    expect(Range.isCollapsed(editor.selection!)).toBe(true);
+    expect(isValidSelection(editor, editor.selection!)).toBe(true);
+    expect(editor.selection!.anchor.offset).toBe(2);
+    expect(editor.selection!.focus.offset).toBe(2);
+  });
+});

--- a/src/application/slate-yjs/command/index.ts
+++ b/src/application/slate-yjs/command/index.ts
@@ -43,7 +43,7 @@ import {
   reorderRow,
   updateTableData,
 } from '@/application/slate-yjs/utils/simple-table-operations';
-import { findNearestValidSelection, isValidSelection } from '@/application/slate-yjs/utils/transformSelection';
+import { ensureValidSelection, findNearestValidSelection, isValidSelection } from '@/application/slate-yjs/utils/transformSelection';
 import {
   dataStringTOJson,
   deepCopyBlock,
@@ -470,6 +470,8 @@ export const CustomEditor = {
   },
 
   toggleToggleList(editor: YjsEditor, blockId: string) {
+    ensureValidSelection(editor);
+
     // The published view renders with a static Slate editor that has no Yjs
     // shared root. Toggle the collapsed state directly on the Slate node so the
     // block can still be expanded/collapsed in read-only mode.

--- a/src/application/slate-yjs/utils/transformSelection.ts
+++ b/src/application/slate-yjs/utils/transformSelection.ts
@@ -1,4 +1,4 @@
-import { Editor, Element as SlateElement, Operation, Point, Range, Text } from 'slate';
+import { Editor, Element as SlateElement, Operation, Point, Range, Text, Transforms } from 'slate';
 
 import { Log } from '@/utils/log';
 
@@ -89,6 +89,29 @@ export function isValidSelection(editor: Editor, selection: Range): boolean {
   } catch (error) {
     return false;
   }
+}
+
+/**
+ * Clamp or clear the current editor selection if it points outside the current
+ * Slate tree. This prevents slate-react from trying to resolve a stale offset
+ * into a DOM point after inline content is replaced.
+ */
+export function ensureValidSelection(editor: Editor): boolean {
+  const { selection } = editor;
+
+  if (!selection || isValidSelection(editor, selection)) {
+    return true;
+  }
+
+  const nearestSelection = findNearestValidSelection(editor, selection);
+
+  if (nearestSelection) {
+    Transforms.select(editor, nearestSelection);
+  } else {
+    Transforms.deselect(editor);
+  }
+
+  return false;
 }
 
 /**

--- a/src/components/editor/CollaborativeEditor.tsx
+++ b/src/components/editor/CollaborativeEditor.tsx
@@ -7,6 +7,7 @@ import * as Y from 'yjs';
 import { CustomEditor } from '@/application/slate-yjs/command';
 import { withYHistory } from '@/application/slate-yjs/plugins/withHistory';
 import { withYjs, YjsEditor } from '@/application/slate-yjs/plugins/withYjs';
+import { ensureValidSelection } from '@/application/slate-yjs/utils/transformSelection';
 import { BlockType, CollabOrigin, YDoc } from '@/application/types';
 import { FindReplaceProvider } from '@/components/editor/components/find-replace/FindReplaceContext';
 import EditorEditable from '@/components/editor/Editable';
@@ -251,6 +252,7 @@ function CollaborativeEditor({
   );
 
   const handleSlateChange = useCallback(() => {
+    ensureValidSelection(editor);
     handleDatabaseBlockLifecycle(editor);
   }, [editor, handleDatabaseBlockLifecycle]);
 

--- a/src/components/editor/components/blocks/todo-list/CheckboxIcon.tsx
+++ b/src/components/editor/components/blocks/todo-list/CheckboxIcon.tsx
@@ -4,6 +4,7 @@ import { useReadOnly, useSlateStatic } from 'slate-react';
 
 import { YjsEditor } from '@/application/slate-yjs';
 import { CustomEditor } from '@/application/slate-yjs/command';
+import { ensureValidSelection } from '@/application/slate-yjs/utils/transformSelection';
 import { ReactComponent as CheckboxCheckSvg } from '@/assets/icons/check_filled.svg';
 import { ReactComponent as CheckboxUncheckSvg } from '@/assets/icons/uncheck.svg';
 import { TodoListNode } from '@/components/editor/editor.type';
@@ -21,6 +22,7 @@ function CheckboxIcon({ block, className }: { block: TodoListNode; className: st
 
       e.stopPropagation();
       e.preventDefault();
+      ensureValidSelection(editor);
       editor.collapse({
         edge: 'end',
       });


### PR DESCRIPTION
## Summary
- add an offset-aware Slate selection guard that clamps or clears stale selections
- run the guard on Slate changes and before todo/toggle list marker interactions
- add a regression test for stale selection offsets like the reported link-in-checkbox crash

## Testing
- pnpm exec jest src/application/slate-yjs/__tests__/transformSelection.test.ts src/application/slate-yjs/__tests__/withYjs.selection.test.ts --no-coverage --runInBand
- pnpm run type-check

## Summary by Sourcery

Guard and normalize Slate selections to prevent crashes when selections become stale after content changes.

Bug Fixes:
- Clamp or clear invalid Slate selections before editing operations to avoid crashes caused by stale offsets, such as after inline link edits in checkboxes.

Tests:
- Add regression tests covering selection transformation and stale selection offsets to ensure invalid selections are safely corrected or cleared.