### PR TITLE
fix: attach sidebar reorder auto-scroll to the scroll container

### DIFF
--- a/src/components/_shared/reorder/useReorderMonitor.ts
+++ b/src/components/_shared/reorder/useReorderMonitor.ts
@@ -6,6 +6,28 @@ import { extractClosestEdge } from '@atlaskit/pragmatic-drag-and-drop-hitbox/clo
 import { getReorderDestinationIndex } from '@atlaskit/pragmatic-drag-and-drop-hitbox/util/get-reorder-destination-index';
 import React, { useEffect, useRef } from 'react';
 
+const SCROLLABLE_OVERFLOW = /(auto|scroll|overlay)/;
+
+/**
+ * Walk up from `element` to the nearest ancestor that is actually a scroll
+ * container. `autoScrollForElements` warns ("attached to an element that appears
+ * not to be scrollable") and does nothing when handed an element with
+ * `overflow: visible`. A reorderable list is typically a non-scrolling flex
+ * column whose scrolling is owned by an ancestor (e.g. the sidebar's AFScroller),
+ * so resolve that ancestor here. Returns null when nothing scrollable is found.
+ */
+function getClosestScrollableElement(element: HTMLElement | null): HTMLElement | null {
+  for (let node: HTMLElement | null = element; node; node = node.parentElement) {
+    const { overflowX, overflowY } = window.getComputedStyle(node);
+
+    if (SCROLLABLE_OVERFLOW.test(overflowY) || SCROLLABLE_OVERFLOW.test(overflowX)) {
+      return node;
+    }
+  }
+
+  return null;
+}
+
 export interface ReorderResult {
   /** The dragged item's id. */
   movedId: string;
@@ -102,7 +124,7 @@ export function useReorderMonitor({
       }),
     ];
 
-    const autoScrollElement = autoScrollElementRef?.current;
+    const autoScrollElement = getClosestScrollableElement(autoScrollElementRef?.current ?? null);
 
     if (autoScrollElement) {
       cleanups.push(


### PR DESCRIPTION
## Summary

Fixes the console warning:
> Auto scrolling has been attached to an element that appears not to be scrollable
> `{element: div.folder-views…, overflowX: 'visible', overflowY: 'visible'}`

## Root cause

`useReorderMonitor` (sidebar space reordering) passed the Outline's `folder-views` element to `autoScrollForElements`. That element is a non-scrolling `flex-1 flex-col` (`overflow: visible`) — the actual scroll container is its ancestor, the sidebar's `AFScroller` view (`overflow: auto`). `@atlaskit/pragmatic-drag-and-drop-auto-scroll` warns and **skips** a non-scrollable element, so dragging a space near the top/bottom of the list never auto-scrolled.

## Fix

Resolve the nearest scrollable ancestor of the provided element (via computed `overflow`) before attaching auto-scroll; attach nothing if none is found. The sidebar Outline is the only caller that passes `autoScrollElementRef` (`DatabaseViewTabs` and the other `useReorderMonitor` users don't), so no other reorderable list changes behavior.

This both **silences the warning** and **makes sidebar drag auto-scroll actually work**.

## Verification

- `tsc --noEmit` passes.
- Live DOM: walking up from `div.folder-views` (overflow `visible`) resolves to `div.appflowy-custom-scroller` (overflow `auto`) in 3 steps — the correct scroll container.
- Console clean (no warning) after reload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bug Fixes:
- Resolve the nearest scrollable ancestor before enabling auto-scroll to prevent warnings and make sidebar drag auto-scroll functional.