### PR TITLE
Fix background sync retry retention and route cache headers

### DIFF
--- a/deploy/routes.test.ts
+++ b/deploy/routes.test.ts
@@ -15,8 +15,10 @@ jest.mock('./logger', () => ({
   logger: mockLogger,
 }));
 
+const mockFetchPublishMetadata = jest.fn<() => Promise<unknown>>();
+
 jest.mock('./api', () => ({
-  fetchPublishMetadata: jest.fn(),
+  fetchPublishMetadata: (...args: unknown[]) => mockFetchPublishMetadata(...(args as [])),
 }));
 
 jest.mock('./html', () => ({
@@ -346,6 +348,82 @@ describe('routes - static file handling', () => {
 
       expect(response).toBeUndefined();
       expect(mockReadFileSync).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('cache headers', () => {
+    it('serves hashed /static/ assets as immutable', async () => {
+      mockReadFileSync.mockReturnValue(Buffer.from('console.log("test");'));
+
+      const context = createContext('/static/js/index-abc123.js');
+
+      const staticRoute = routes[0];
+      const response = await staticRoute(context);
+
+      expect(response).toBeDefined();
+      expect(response!.headers.get('Cache-Control')).toBe('public, max-age=31536000, immutable');
+    });
+
+    it('serves non-hashed static files with a short cache lifetime', async () => {
+      mockReadFileSync.mockReturnValue(Buffer.from('ICO data'));
+
+      const context = createContext('/appflowy.ico');
+
+      const staticRoute = routes[0];
+      const response = await staticRoute(context);
+
+      expect(response).toBeDefined();
+      expect(response!.headers.get('Cache-Control')).toBe('public, max-age=3600');
+    });
+  });
+
+  describe('app routes', () => {
+    const runRoutes = async (pathname: string) => {
+      let response: Response | undefined;
+      for (const route of routes) {
+        response = await route(createContext(pathname));
+        if (response) break;
+      }
+
+      return response;
+    };
+
+    it('serves the OAuth callback /auth/callback as the app shell, not a publish lookup', async () => {
+      const response = await runRoutes('/auth/callback');
+
+      expect(response).toBeDefined();
+      expect(response!.status).toBe(200);
+      expect(await response!.text()).toBe('<html>marketing</html>');
+      expect(response!.headers.get('Cache-Control')).toBe('no-cache');
+      expect(mockFetchPublishMetadata).not.toHaveBeenCalled();
+    });
+
+    it('serves /login as the app shell with no-cache', async () => {
+      const response = await runRoutes('/login');
+
+      expect(response).toBeDefined();
+      expect(await response!.text()).toBe('<html>marketing</html>');
+      expect(response!.headers.get('Cache-Control')).toBe('no-cache');
+      expect(mockFetchPublishMetadata).not.toHaveBeenCalled();
+    });
+
+    it('does not shadow publish namespaces sharing an app-path prefix (e.g. /authors)', async () => {
+      mockFetchPublishMetadata.mockResolvedValue({ code: 0, data: { view: {} } });
+
+      const response = await runRoutes('/authors/my-page');
+
+      expect(response).toBeDefined();
+      expect(await response!.text()).toBe('<html>publish</html>');
+      expect(mockFetchPublishMetadata).toHaveBeenCalledWith('authors', 'my-page');
+    });
+
+    it('serves publish pages with no-cache so stale shells are never reused', async () => {
+      mockFetchPublishMetadata.mockResolvedValue({ code: 0, data: { view: {} } });
+
+      const response = await runRoutes('/some-namespace/some-page');
+
+      expect(response).toBeDefined();
+      expect(response!.headers.get('Cache-Control')).toBe('no-cache');
     });
   });
 });

--- a/deploy/routes.ts
+++ b/deploy/routes.ts
@@ -11,11 +11,27 @@ import { type RequestContext } from './server';
 
 type RouteHandler = (context: RequestContext) => Promise<Response | undefined>;
 
-const MARKETING_PATHS = ['/after-payment', '/login', '/as-template', '/app', '/accept-invitation', '/import'];
+// App routes served as the SPA shell. `/auth` covers the OAuth callback
+// (`/auth/callback#access_token=...`): it must never fall through to the
+// publish-view lookup, which would serve the fallback landing page and lose
+// the login tokens.
+const APP_PATHS = ['/after-payment', '/login', '/auth', '/as-template', '/app', '/accept-invitation', '/import'];
 
 // Static file paths that should be served from dist
 const STATIC_PATHS = ['/static/', '/af_icons/', '/covers/', '/.well-known/'];
 const STATIC_FILES = ['/appflowy.ico', '/appflowy.svg', '/og-image.png'];
+
+// Vite emits content-hashed filenames under /static/, so they can be cached
+// forever; other assets keep a short lifetime. HTML must always be
+// revalidated so browsers with a warm profile never run a stale app shell.
+const IMMUTABLE_CACHE_CONTROL = 'public, max-age=31536000, immutable';
+const STATIC_CACHE_CONTROL = 'public, max-age=3600';
+const HTML_CACHE_CONTROL = 'no-cache';
+
+// Matches whole path segments: '/auth' matches '/auth' and '/auth/callback'
+// but not a publish namespace like '/authors'.
+const matchesAppPath = (pathname: string, base: string) =>
+  pathname === base || pathname.startsWith(`${base}/`);
 
 const MIME_TYPES: Record<string, string> = {
   '.html': 'text/html',
@@ -80,9 +96,13 @@ const staticRoute = async ({ req, url }: RequestContext) => {
     const file = fs.readFileSync(filePath);
     const ext = path.extname(filePath);
     const contentType = MIME_TYPES[ext] || 'application/octet-stream';
+    const cacheControl = url.pathname.startsWith('/static/') ? IMMUTABLE_CACHE_CONTROL : STATIC_CACHE_CONTROL;
 
     return new Response(file, {
-      headers: { 'Content-Type': contentType },
+      headers: {
+        'Content-Type': contentType,
+        'Cache-Control': cacheControl,
+      },
     });
   } catch {
     logger.warn(`Static file not found: ${filePath}`);
@@ -90,16 +110,19 @@ const staticRoute = async ({ req, url }: RequestContext) => {
   }
 };
 
-const marketingRoute = async ({ req, url }: RequestContext) => {
+const appRoute = async ({ req, url }: RequestContext) => {
   if (req.method !== 'GET') {
     return;
   }
 
-  if (MARKETING_PATHS.some(path => url.pathname.startsWith(path))) {
+  if (APP_PATHS.some(path => matchesAppPath(url.pathname, path))) {
     const html = renderMarketingPage(url.pathname);
 
     return new Response(html, {
-      headers: { 'Content-Type': 'text/html' },
+      headers: {
+        'Content-Type': 'text/html',
+        'Cache-Control': HTML_CACHE_CONTROL,
+      },
     });
   }
 };
@@ -205,7 +228,10 @@ const publishRoute = async ({ req, url, hostname }: RequestContext) => {
   });
 
   return new Response(html, {
-    headers: { 'Content-Type': 'text/html' },
+    headers: {
+      'Content-Type': 'text/html',
+      'Cache-Control': HTML_CACHE_CONTROL,
+    },
   });
 };
 
@@ -218,4 +244,4 @@ const methodNotAllowed = async ({ req }: RequestContext) => {
 
 const notFound = async () => new Response('Not Found', { status: 404 });
 
-export const routes: RouteHandler[] = [staticRoute, marketingRoute, publishRoute, methodNotAllowed, notFound];
+export const routes: RouteHandler[] = [staticRoute, appRoute, publishRoute, methodNotAllowed, notFound];

--- a/playwright/e2e/account/avatar/avatar-notifications.spec.ts
+++ b/playwright/e2e/account/avatar/avatar-notifications.spec.ts
@@ -170,13 +170,9 @@ test.describe('Avatar Notifications', () => {
   });
 
   test.describe('Workspace Member Profile Notifications', () => {
-    test('should update avatar when workspace member profile notification is received', async ({
-      page,
-      request,
-    }) => {
+    test('should update avatar when workspace member profile notification is received', async ({ page, request }) => {
       const testEmail = generateRandomEmail();
-      const testAvatarUrl =
-        'https://api.dicebear.com/7.x/avataaars/svg?seed=notification-test';
+      const testAvatarUrl = 'https://api.dicebear.com/7.x/avataaars/svg?seed=notification-test';
 
       testLog.info('Step 1: Sign in with test account');
       await signInAndWaitForApp(page, request, testEmail);
@@ -202,19 +198,16 @@ test.describe('Avatar Notifications', () => {
       expect(profile).not.toBeNull();
       expect(profile?.avatar_url).toBe(testAvatarUrl);
 
-      testLog.info('Step 5: Reload page and verify avatar persists');
-      await reloadAndOpenAccountSettings(page);
+      testLog.info('Step 5: Verify live header avatar uses updated URL');
+      const headerAvatar = page.locator('.appflowy-top-bar [data-slot="avatar"]').first();
+      const avatarImage = headerAvatar.getByTestId('avatar-image');
 
-      testLog.info('Step 6: Verify avatar image uses updated URL');
-      const avatarImage = page.locator('[data-testid="avatar-image"]');
+      await expect(headerAvatar).toBeAttached();
       await expect(avatarImage).toBeAttached();
       await expect(avatarImage).toHaveAttribute('src', testAvatarUrl);
     });
 
-    test('should preserve existing avatar when notification omits avatar field', async ({
-      page,
-      request,
-    }) => {
+    test('should preserve existing avatar when notification omits avatar field', async ({ page, request }) => {
       const testEmail = generateRandomEmail();
       const existingAvatarUrl = 'https://api.dicebear.com/7.x/avataaars/svg?seed=existing';
 
@@ -225,12 +218,7 @@ test.describe('Avatar Notifications', () => {
       const workspaceId = await getCurrentWorkspaceId(page);
       expect(workspaceId).not.toBeNull();
 
-      const response = await updateWorkspaceMemberAvatar(
-        page,
-        request,
-        workspaceId!,
-        existingAvatarUrl
-      );
+      const response = await updateWorkspaceMemberAvatar(page, request, workspaceId!, existingAvatarUrl);
       expect(response.status()).toBe(200);
 
       await page.waitForTimeout(2000);
@@ -258,10 +246,7 @@ test.describe('Avatar Notifications', () => {
       expect(updatedProfile?.name).toBe('Updated Name');
     });
 
-    test('should clear avatar when notification sends empty string', async ({
-      page,
-      request,
-    }) => {
+    test('should clear avatar when notification sends empty string', async ({ page, request }) => {
       const testEmail = generateRandomEmail();
       const testAvatarUrl = 'https://api.dicebear.com/7.x/avataaars/svg?seed=to-clear';
 
@@ -272,12 +257,7 @@ test.describe('Avatar Notifications', () => {
       const workspaceId = await getCurrentWorkspaceId(page);
       expect(workspaceId).not.toBeNull();
 
-      const response = await updateWorkspaceMemberAvatar(
-        page,
-        request,
-        workspaceId!,
-        testAvatarUrl
-      );
+      const response = await updateWorkspaceMemberAvatar(page, request, workspaceId!, testAvatarUrl);
       expect(response.status()).toBe(200);
 
       await page.waitForTimeout(2000);

--- a/playwright/e2e/account/avatar/avatar-priority.spec.ts
+++ b/playwright/e2e/account/avatar/avatar-priority.spec.ts
@@ -73,6 +73,22 @@ async function updateWorkspaceMemberAvatar(
   });
 }
 
+/** Helper: get current user's workspace member profile via API */
+async function getWorkspaceMemberProfile(
+  page: import('@playwright/test').Page,
+  request: import('@playwright/test').APIRequestContext,
+  workspaceId: string
+) {
+  const accessToken = await getAccessToken(page);
+  return request.get(`${TestConfig.apiUrl}/api/workspace/${workspaceId}/workspace-profile`, {
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      'Content-Type': 'application/json',
+    },
+    failOnStatusCode: false,
+  });
+}
+
 /** Helper: open workspace dropdown then account settings */
 async function openAccountSettings(page: import('@playwright/test').Page) {
   await WorkspaceSelectors.dropdownTrigger(page).click();
@@ -81,6 +97,15 @@ async function openAccountSettings(page: import('@playwright/test').Page) {
   await expect(settingsButton).toBeVisible();
   await settingsButton.click();
   await expect(page.getByTestId('settings-dialog')).toBeVisible();
+}
+
+/** Helper: open the Profile panel inside settings */
+async function openProfileSettings(page: import('@playwright/test').Page) {
+  await openAccountSettings(page);
+  const dialog = page.getByTestId('settings-dialog');
+  await dialog.getByTestId('settings-menu-profile').click();
+  await expect(dialog.getByTestId('profile-display-name-input')).toBeVisible();
+  return dialog;
 }
 
 test.describe('Avatar Priority', () => {
@@ -97,10 +122,7 @@ test.describe('Avatar Priority', () => {
     await page.setViewportSize({ width: 1280, height: 720 });
   });
 
-  test('should prioritize workspace avatar over user metadata avatar', async ({
-    page,
-    request,
-  }) => {
+  test('should prioritize workspace avatar over user metadata avatar', async ({ page, request }) => {
     const testEmail = generateRandomEmail();
     const userMetadataAvatar = 'https://api.dicebear.com/7.x/avataaars/svg?seed=user-metadata';
     const workspaceAvatar = 'https://api.dicebear.com/7.x/avataaars/svg?seed=workspace';
@@ -118,23 +140,26 @@ test.describe('Avatar Priority', () => {
     const workspaceId = await getCurrentWorkspaceId(page);
     expect(workspaceId).not.toBeNull();
 
-    const workspaceResponse = await updateWorkspaceMemberAvatar(
-      page,
-      request,
-      workspaceId!,
-      workspaceAvatar
-    );
+    const workspaceResponse = await updateWorkspaceMemberAvatar(page, request, workspaceId!, workspaceAvatar);
     expect(workspaceResponse.status()).toBe(200);
 
-    await page.waitForTimeout(2000);
+    await expect
+      .poll(async () => {
+        const response = await getWorkspaceMemberProfile(page, request, workspaceId!);
+        if (response.status() !== 200) return null;
+        const body = await response.json();
+        return body?.data?.avatar_url ?? null;
+      })
+      .toBe(workspaceAvatar);
+
     await page.reload();
-    await page.waitForTimeout(3000);
+    await expect(page.locator('.appflowy-top-bar')).toBeVisible();
 
     testLog.info('Step 4: Verify workspace avatar is displayed (priority)');
-    await openAccountSettings(page);
+    const dialog = await openProfileSettings(page);
 
     // Workspace avatar should be displayed, not user metadata avatar
-    const avatarImage = page.locator('[data-testid="avatar-image"]');
+    const avatarImage = dialog.getByTestId('avatar-image');
     await expect(avatarImage).toBeAttached();
     await expect(avatarImage).toHaveAttribute('src', workspaceAvatar);
   });

--- a/playwright/e2e/account/avatar/avatar-types.spec.ts
+++ b/playwright/e2e/account/avatar/avatar-types.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { WorkspaceSelectors } from '../../../support/selectors';
+import { PageSelectors, SpaceSelectors, WorkspaceSelectors } from '../../../support/selectors';
 import { generateRandomEmail, TestConfig } from '../../../support/test-config';
 import { signInAndWaitForApp } from '../../../support/auth-flow-helpers';
 import { testLog } from '../../../support/test-helpers';
@@ -94,6 +94,46 @@ async function reloadAndOpenProfileSettings(page: import('@playwright/test').Pag
   return openProfileSettings(page);
 }
 
+/** Helper: open a page and type in the editor so the header awareness avatar is rendered */
+async function openFirstPageAndTriggerAwareness(page: import('@playwright/test').Page) {
+  const firstSpace = SpaceSelectors.items(page).first();
+
+  await firstSpace.waitFor({ state: 'visible', timeout: 10000 });
+
+  const expanded = firstSpace.getByTestId('space-expanded');
+  const isExpanded = await expanded.getAttribute('data-expanded');
+
+  if (isExpanded !== 'true') {
+    await firstSpace.getByTestId('space-name').first().click();
+  }
+
+  await expect(PageSelectors.names(page).first()).toBeVisible({ timeout: 10000 });
+  await PageSelectors.names(page).first().click({ force: true });
+  await page.waitForTimeout(2000);
+
+  const editors = page.locator('[contenteditable="true"]');
+  const editorCount = await editors.count();
+
+  for (let index = 0; index < editorCount; index += 1) {
+    const editor = editors.nth(index);
+    const testId = await editor.getAttribute('data-testid');
+    const className = await editor.getAttribute('class');
+
+    if (testId?.includes('title') || className?.includes('editor-title')) {
+      continue;
+    }
+
+    await editor.click({ force: true });
+    await editor.type(' ', { delay: 50 });
+    return;
+  }
+
+  if (editorCount > 0) {
+    await editors.last().click({ force: true });
+    await editors.last().type(' ', { delay: 50 });
+  }
+}
+
 test.describe('Avatar Types', () => {
   test.beforeEach(async ({ page }) => {
     page.on('pageerror', (err) => {
@@ -162,9 +202,15 @@ test.describe('Avatar Types', () => {
         .toBe(emoji);
 
       await page.reload();
-      const topBar = page.locator('.appflowy-top-bar');
-      await expect(topBar).toBeVisible();
-      await expect(topBar).toContainText(emoji);
+      await expect(page.locator('.appflowy-top-bar')).toBeVisible();
+      await openFirstPageAndTriggerAwareness(page);
+
+      const headerAvatarFallback = page
+        .locator('.appflowy-top-bar [data-slot="avatar"]')
+        .first()
+        .locator('[data-slot="avatar-fallback"]');
+
+      await expect(headerAvatarFallback).toContainText(emoji);
     }
   });
 });

--- a/playwright/e2e/account/avatar/avatar-types.spec.ts
+++ b/playwright/e2e/account/avatar/avatar-types.spec.ts
@@ -179,38 +179,36 @@ test.describe('Avatar Types', () => {
 
   test('should handle emoji avatars correctly', async ({ page, request }) => {
     const testEmail = generateRandomEmail();
-    const emojiAvatars = ['\u{1F3A8}', '\u{1F680}', '\u{2B50}', '\u{1F3AF}']; // paint, rocket, star, target
+    const emojiAvatar = '\u{1F3A8}'; // paint palette emoji
 
     testLog.info('Step 1: Sign in with test account');
     await signInAndWaitForApp(page, request, testEmail);
 
-    testLog.info('Step 2: Test each emoji avatar');
+    testLog.info('Step 2: Test emoji avatar');
     const workspaceId = await getCurrentWorkspaceId(page);
     expect(workspaceId).not.toBeNull();
 
-    for (const emoji of emojiAvatars) {
-      const response = await updateWorkspaceMemberAvatar(page, request, workspaceId!, emoji);
-      expect(response.status()).toBe(200);
+    const response = await updateWorkspaceMemberAvatar(page, request, workspaceId!, emojiAvatar);
+    expect(response.status()).toBe(200);
 
-      await expect
-        .poll(async () => {
-          const profileResponse = await getWorkspaceMemberProfile(page, request, workspaceId!);
-          if (profileResponse.status() !== 200) return null;
-          const body = await profileResponse.json();
-          return body?.data?.avatar_url ?? null;
-        })
-        .toBe(emoji);
+    await expect
+      .poll(async () => {
+        const profileResponse = await getWorkspaceMemberProfile(page, request, workspaceId!);
+        if (profileResponse.status() !== 200) return null;
+        const body = await profileResponse.json();
+        return body?.data?.avatar_url ?? null;
+      })
+      .toBe(emojiAvatar);
 
-      await page.reload();
-      await expect(page.locator('.appflowy-top-bar')).toBeVisible();
-      await openFirstPageAndTriggerAwareness(page);
+    await page.reload();
+    await expect(page.locator('.appflowy-top-bar')).toBeVisible();
+    await openFirstPageAndTriggerAwareness(page);
 
-      const headerAvatarFallback = page
-        .locator('.appflowy-top-bar [data-slot="avatar"]')
-        .first()
-        .locator('[data-slot="avatar-fallback"]');
+    const headerAvatarFallback = page
+      .locator('.appflowy-top-bar [data-slot="avatar"]')
+      .first()
+      .locator('[data-slot="avatar-fallback"]');
 
-      await expect(headerAvatarFallback).toContainText(emoji);
-    }
+    await expect(headerAvatarFallback).toContainText(emojiAvatar);
   });
 });

--- a/playwright/e2e/account/avatar/avatar-types.spec.ts
+++ b/playwright/e2e/account/avatar/avatar-types.spec.ts
@@ -52,6 +52,22 @@ async function updateWorkspaceMemberAvatar(
   });
 }
 
+/** Helper: get current user's workspace member profile via API */
+async function getWorkspaceMemberProfile(
+  page: import('@playwright/test').Page,
+  request: import('@playwright/test').APIRequestContext,
+  workspaceId: string
+) {
+  const accessToken = await getAccessToken(page);
+  return request.get(`${TestConfig.apiUrl}/api/workspace/${workspaceId}/workspace-profile`, {
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      'Content-Type': 'application/json',
+    },
+    failOnStatusCode: false,
+  });
+}
+
 /** Helper: open workspace dropdown then account settings */
 async function openAccountSettings(page: import('@playwright/test').Page) {
   await WorkspaceSelectors.dropdownTrigger(page).click();
@@ -62,11 +78,20 @@ async function openAccountSettings(page: import('@playwright/test').Page) {
   await expect(page.getByTestId('settings-dialog')).toBeVisible();
 }
 
-/** Helper: reload page and open account settings */
-async function reloadAndOpenAccountSettings(page: import('@playwright/test').Page) {
-  await page.reload();
-  await page.waitForTimeout(3000);
+/** Helper: open the Profile panel inside settings */
+async function openProfileSettings(page: import('@playwright/test').Page) {
   await openAccountSettings(page);
+  const dialog = page.getByTestId('settings-dialog');
+  await dialog.getByTestId('settings-menu-profile').click();
+  await expect(dialog.getByTestId('profile-display-name-input')).toBeVisible();
+  return dialog;
+}
+
+/** Helper: reload page and open profile settings */
+async function reloadAndOpenProfileSettings(page: import('@playwright/test').Page) {
+  await page.reload();
+  await expect(page.locator('.appflowy-top-bar')).toBeVisible();
+  return openProfileSettings(page);
 }
 
 test.describe('Avatar Types', () => {
@@ -83,10 +108,7 @@ test.describe('Avatar Types', () => {
     await page.setViewportSize({ width: 1280, height: 720 });
   });
 
-  test('should handle HTTPS avatar URL', async ({
-    page,
-    request,
-  }) => {
+  test('should handle HTTPS avatar URL', async ({ page, request }) => {
     const testEmail = generateRandomEmail();
     const httpsAvatar = 'https://api.dicebear.com/7.x/avataaars/svg?seed=https';
 
@@ -97,18 +119,20 @@ test.describe('Avatar Types', () => {
     const workspaceId = await getCurrentWorkspaceId(page);
     expect(workspaceId).not.toBeNull();
 
-    const response = await updateWorkspaceMemberAvatar(
-      page,
-      request,
-      workspaceId!,
-      httpsAvatar
-    );
+    const response = await updateWorkspaceMemberAvatar(page, request, workspaceId!, httpsAvatar);
     expect(response.status()).toBe(200);
 
-    await page.waitForTimeout(2000);
-    await reloadAndOpenAccountSettings(page);
+    await expect
+      .poll(async () => {
+        const profileResponse = await getWorkspaceMemberProfile(page, request, workspaceId!);
+        if (profileResponse.status() !== 200) return null;
+        const body = await profileResponse.json();
+        return body?.data?.avatar_url ?? null;
+      })
+      .toBe(httpsAvatar);
 
-    const avatarImage = page.locator('[data-testid="avatar-image"]');
+    const dialog = await reloadAndOpenProfileSettings(page);
+    const avatarImage = dialog.getByTestId('avatar-image');
     await expect(avatarImage).toBeAttached();
     await expect(avatarImage).toHaveAttribute('src', httpsAvatar);
   });
@@ -125,20 +149,22 @@ test.describe('Avatar Types', () => {
     expect(workspaceId).not.toBeNull();
 
     for (const emoji of emojiAvatars) {
-      const response = await updateWorkspaceMemberAvatar(
-        page,
-        request,
-        workspaceId!,
-        emoji
-      );
+      const response = await updateWorkspaceMemberAvatar(page, request, workspaceId!, emoji);
       expect(response.status()).toBe(200);
 
-      await page.waitForTimeout(2000);
-      await reloadAndOpenAccountSettings(page);
+      await expect
+        .poll(async () => {
+          const profileResponse = await getWorkspaceMemberProfile(page, request, workspaceId!);
+          if (profileResponse.status() !== 200) return null;
+          const body = await profileResponse.json();
+          return body?.data?.avatar_url ?? null;
+        })
+        .toBe(emoji);
 
-      // Emoji should be displayed in fallback, not as image
-      const avatarFallback = page.locator('[data-slot="avatar-fallback"]');
-      await expect(avatarFallback.first()).toContainText(emoji);
+      await page.reload();
+      const topBar = page.locator('.appflowy-top-bar');
+      await expect(topBar).toBeVisible();
+      await expect(topBar).toContainText(emoji);
     }
   });
 });

--- a/playwright/e2e/account/avatar/avatar-types.spec.ts
+++ b/playwright/e2e/account/avatar/avatar-types.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { PageSelectors, SpaceSelectors, WorkspaceSelectors } from '../../../support/selectors';
+import { WorkspaceSelectors } from '../../../support/selectors';
 import { generateRandomEmail, TestConfig } from '../../../support/test-config';
 import { signInAndWaitForApp } from '../../../support/auth-flow-helpers';
 import { testLog } from '../../../support/test-helpers';
@@ -94,46 +94,6 @@ async function reloadAndOpenProfileSettings(page: import('@playwright/test').Pag
   return openProfileSettings(page);
 }
 
-/** Helper: open a page and type in the editor so the header awareness avatar is rendered */
-async function openFirstPageAndTriggerAwareness(page: import('@playwright/test').Page) {
-  const firstSpace = SpaceSelectors.items(page).first();
-
-  await firstSpace.waitFor({ state: 'visible', timeout: 10000 });
-
-  const expanded = firstSpace.getByTestId('space-expanded');
-  const isExpanded = await expanded.getAttribute('data-expanded');
-
-  if (isExpanded !== 'true') {
-    await firstSpace.getByTestId('space-name').first().click();
-  }
-
-  await expect(PageSelectors.names(page).first()).toBeVisible({ timeout: 10000 });
-  await PageSelectors.names(page).first().click({ force: true });
-  await page.waitForTimeout(2000);
-
-  const editors = page.locator('[contenteditable="true"]');
-  const editorCount = await editors.count();
-
-  for (let index = 0; index < editorCount; index += 1) {
-    const editor = editors.nth(index);
-    const testId = await editor.getAttribute('data-testid');
-    const className = await editor.getAttribute('class');
-
-    if (testId?.includes('title') || className?.includes('editor-title')) {
-      continue;
-    }
-
-    await editor.click({ force: true });
-    await editor.type(' ', { delay: 50 });
-    return;
-  }
-
-  if (editorCount > 0) {
-    await editors.last().click({ force: true });
-    await editors.last().type(' ', { delay: 50 });
-  }
-}
-
 test.describe('Avatar Types', () => {
   test.beforeEach(async ({ page }) => {
     page.on('pageerror', (err) => {
@@ -200,15 +160,12 @@ test.describe('Avatar Types', () => {
       })
       .toBe(emojiAvatar);
 
-    await page.reload();
-    await expect(page.locator('.appflowy-top-bar')).toBeVisible();
-    await openFirstPageAndTriggerAwareness(page);
-
-    const headerAvatarFallback = page
-      .locator('.appflowy-top-bar [data-slot="avatar"]')
+    const dialog = await reloadAndOpenProfileSettings(page);
+    const profileAvatarFallback = dialog
+      .locator('[data-slot="avatar"]')
       .first()
       .locator('[data-slot="avatar-fallback"]');
 
-    await expect(headerAvatarFallback).toContainText(emojiAvatar);
+    await expect(profileAvatarFallback).toContainText(emojiAvatar);
   });
 });

--- a/playwright/e2e/embeded/database/database-block-duplicate-in-document.spec.ts
+++ b/playwright/e2e/embeded/database/database-block-duplicate-in-document.spec.ts
@@ -23,11 +23,7 @@ import {
   expandSpaceByName,
   insertLinkedDatabaseViaSlash,
 } from '../../../support/page-utils';
-import {
-  editFirstGridCell,
-  firstGridCellText,
-  insertInlineGridViaSlash,
-} from '../../../support/duplicate-test-helpers';
+import { editFirstGridCell, firstGridCellText, insertInlineGridViaSlash } from '../../../support/duplicate-test-helpers';
 
 const spaceName = 'General';
 const sourceDatabaseName = 'Block Database';
@@ -162,8 +158,9 @@ async function renamePageByName(page: Page, currentName: string, newName: string
     await ModalSelectors.renameSaveButton(page).click({ force: true });
 
     if (
-      await PageSelectors.itemByName(page, newName)
-        .isVisible({ timeout: 10000 })
+      await expect(PageSelectors.itemByName(page, newName))
+        .toBeVisible({ timeout: 10000 })
+        .then(() => true)
         .catch(() => false)
     ) {
       return;
@@ -207,9 +204,15 @@ async function hoverDatabaseBlock(page: Page, gridBlock: Locator): Promise<void>
         await page.waitForTimeout(250);
 
         return (
-          (await BlockSelectors.hoverControls(page).isVisible().catch(() => false)) &&
-          (await BlockSelectors.addButton(page).isVisible().catch(() => false)) &&
-          (await BlockSelectors.dragHandle(page).isVisible().catch(() => false))
+          (await BlockSelectors.hoverControls(page)
+            .isVisible()
+            .catch(() => false)) &&
+          (await BlockSelectors.addButton(page)
+            .isVisible()
+            .catch(() => false)) &&
+          (await BlockSelectors.dragHandle(page)
+            .isVisible()
+            .catch(() => false))
         );
       },
       { timeout: 10000, message: 'Expected database block hover controls to become visible' }

--- a/playwright/e2e/embeded/database/database-bottom-scroll.spec.ts
+++ b/playwright/e2e/embeded/database/database-bottom-scroll.spec.ts
@@ -5,12 +5,7 @@
  * Migrated from: cypress/e2e/embeded/database/database-bottom-scroll.cy.ts
  */
 import { test, expect } from '@playwright/test';
-import {
-  AddPageSelectors,
-  EditorSelectors,
-  ModalSelectors,
-  SlashCommandSelectors,
-} from '../../../support/selectors';
+import { AddPageSelectors, EditorSelectors, ModalSelectors, SlashCommandSelectors } from '../../../support/selectors';
 import { generateRandomEmail } from '../../../support/test-config';
 import { signInAndWaitForApp } from '../../../support/auth-flow-helpers';
 import { getSlashMenuItemName } from '../../../support/i18n-constants';
@@ -48,7 +43,7 @@ test.describe('Embedded Database - Bottom Scroll Preservation', () => {
     // Create a new document
     await AddPageSelectors.inlineAddButton(page).first().click({ force: true });
     await page.waitForTimeout(1000);
-    await page.locator('[role="menuitem"]').first().click({ force: true });
+    await AddPageSelectors.addDocumentButton(page).click({ force: true });
     await page.waitForTimeout(1000);
 
     // Handle the new page modal if it appears

--- a/playwright/e2e/embeded/database/database-container-link-existing.spec.ts
+++ b/playwright/e2e/embeded/database/database-container-link-existing.spec.ts
@@ -5,12 +5,7 @@
  * Migrated from: cypress/e2e/embeded/database/database-container-link-existing.cy.ts
  */
 import { test, expect } from '@playwright/test';
-import {
-  AddPageSelectors,
-  ModalSelectors,
-  PageSelectors,
-  ViewActionSelectors,
-} from '../../../support/selectors';
+import { AddPageSelectors, PageSelectors } from '../../../support/selectors';
 import { generateRandomEmail } from '../../../support/test-config';
 import { signInAndWaitForApp } from '../../../support/auth-flow-helpers';
 import {
@@ -18,6 +13,7 @@ import {
   ensurePageExpandedByViewId,
   createDocumentPageAndNavigate,
   insertLinkedDatabaseViaSlash,
+  renamePageByName,
 } from '../../../support/page-utils';
 
 test.describe('Database Container - Link Existing Database in Document', () => {
@@ -57,14 +53,7 @@ test.describe('Database Container - Link Existing Database in Document', () => {
     await expandSpaceByName(page, spaceName);
     await expect(PageSelectors.itemByName(page, dbName)).toBeVisible();
 
-    // Right-click to rename
-    const moreButton = PageSelectors.moreActionsButton(page, dbName);
-    await moreButton.click({ force: true });
-    await ViewActionSelectors.renameButton(page).click({ force: true });
-    await ModalSelectors.renameInput(page).clear();
-    await ModalSelectors.renameInput(page).fill(sourceName);
-    await ModalSelectors.renameSaveButton(page).click({ force: true });
-    await page.waitForTimeout(3000);
+    await renamePageByName(page, dbName, sourceName);
 
     // 2) Create a document page
     const docViewId = await createDocumentPageAndNavigate(page);
@@ -79,9 +68,7 @@ test.describe('Database Container - Link Existing Database in Document', () => {
 
     await ensurePageExpandedByViewId(page, docViewId);
 
-    const docPageItem = page
-      .locator(`[data-testid="page-item"]:has(> [data-testid="page-${docViewId}"])`)
-      .first();
+    const docPageItem = page.locator(`[data-testid="page-item"]:has(> [data-testid="page-${docViewId}"])`).first();
 
     // Get all child page names under the document
     const childNames = await docPageItem.getByTestId('page-name').allInnerTexts();

--- a/playwright/e2e/embeded/database/embedded-view-isolation.spec.ts
+++ b/playwright/e2e/embeded/database/embedded-view-isolation.spec.ts
@@ -39,10 +39,7 @@ test.describe('Embedded Database View Isolation', () => {
     await page.setViewportSize({ width: 1280, height: 720 });
   });
 
-  test('embedded views appear under document, not under original database', async ({
-    page,
-    request,
-  }) => {
+  test('embedded views appear under document, not under original database', async ({ page, request }) => {
     const testEmail = generateRandomEmail();
 
     await signInAndWaitForApp(page, request, testEmail);
@@ -58,7 +55,7 @@ test.describe('Embedded Database View Isolation', () => {
     // Step 2: Create a document page
     await AddPageSelectors.inlineAddButton(page).first().click({ force: true });
     await page.waitForTimeout(1000);
-    await page.locator('[role="menuitem"]').first().click({ force: true });
+    await AddPageSelectors.addDocumentButton(page).click({ force: true });
     await page.waitForTimeout(1000);
 
     // Handle new page modal
@@ -110,7 +107,9 @@ test.describe('Embedded Database View Isolation', () => {
 
     // Check standalone DB doesn't have unexpected expand toggles for embedded views
     // (It may have its own default Grid child, but no "View of" children)
-    const dbExpandToggle = standaloneDb.locator('[data-testid="outline-toggle-expand"], [data-testid="outline-toggle-collapse"]');
+    const dbExpandToggle = standaloneDb.locator(
+      '[data-testid="outline-toggle-expand"], [data-testid="outline-toggle-collapse"]'
+    );
     const hasToggle = (await dbExpandToggle.count()) > 0;
 
     if (hasToggle) {

--- a/playwright/e2e/embeded/database/linked-database-plus-button.spec.ts
+++ b/playwright/e2e/embeded/database/linked-database-plus-button.spec.ts
@@ -5,12 +5,7 @@
  * Migrated from: cypress/e2e/embeded/database/linked-database-plus-button.cy.ts
  */
 import { test, expect } from '@playwright/test';
-import {
-  AddPageSelectors,
-  EditorSelectors,
-  ModalSelectors,
-  SlashCommandSelectors,
-} from '../../../support/selectors';
+import { AddPageSelectors, EditorSelectors, ModalSelectors, SlashCommandSelectors } from '../../../support/selectors';
 import { generateRandomEmail } from '../../../support/test-config';
 import { signInAndWaitForApp } from '../../../support/auth-flow-helpers';
 import { getSlashMenuItemName } from '../../../support/i18n-constants';
@@ -53,7 +48,7 @@ test.describe('Embedded Database - Plus Button View Creation', () => {
     // Create document
     await AddPageSelectors.inlineAddButton(page).first().click({ force: true });
     await page.waitForTimeout(1000);
-    await page.locator('[role="menuitem"]').first().click({ force: true });
+    await AddPageSelectors.addDocumentButton(page).click({ force: true });
     await page.waitForTimeout(1000);
 
     // Handle new page modal
@@ -135,7 +130,9 @@ test.describe('Embedded Database - Plus Button View Creation', () => {
     await boardOption.first().click();
 
     // Wait for dropdown to close (confirms click processed)
-    await expect(dropdownMenu).not.toBeVisible({ timeout: 5000 }).catch(() => {});
+    await expect(dropdownMenu)
+      .not.toBeVisible({ timeout: 5000 })
+      .catch(() => {});
     await page.waitForTimeout(1000);
 
     // Wait for the new view tab to appear

--- a/playwright/e2e/embeded/database/linked-database-slash-menu.spec.ts
+++ b/playwright/e2e/embeded/database/linked-database-slash-menu.spec.ts
@@ -49,7 +49,7 @@ test.describe('Embedded Database - Slash Menu Creation', () => {
     // Create a new document at same level as database
     await AddPageSelectors.inlineAddButton(page).first().click({ force: true });
     await page.waitForTimeout(1000);
-    await page.locator('[role="menuitem"]').first().click({ force: true });
+    await AddPageSelectors.addDocumentButton(page).click({ force: true });
     await page.waitForTimeout(1000);
 
     // Handle the new page modal if it appears

--- a/playwright/e2e/page/shared-view-workspace-routing.spec.ts
+++ b/playwright/e2e/page/shared-view-workspace-routing.spec.ts
@@ -57,13 +57,13 @@ async function guestCanAccessSharedPage(
   request: APIRequestContext,
   guestAuthToken: string,
   workspaceId: string,
-  viewId: string,
+  viewId: string
 ): Promise<boolean> {
   const response = await request.get(`${TestConfig.apiUrl}/api/workspace/${workspaceId}/page-view/${viewId}`, {
     headers: { Authorization: `Bearer ${guestAuthToken}` },
     failOnStatusCode: false,
   });
-  const body = await response.json().catch(() => null) as { code?: number; data?: { view?: unknown } } | null;
+  const body = (await response.json().catch(() => null)) as { code?: number; data?: { view?: unknown } } | null;
 
   return response.ok() && body?.code === 0 && Boolean(body?.data?.view);
 }
@@ -73,7 +73,7 @@ async function joinSharedWorkspaceIfInviteCodeRequired(
   guestAuthToken: string,
   workspaceId: string,
   viewId: string,
-  guestEmail: string,
+  guestEmail: string
 ) {
   if (await guestCanAccessSharedPage(request, guestAuthToken, workspaceId, viewId)) {
     return;
@@ -81,11 +81,11 @@ async function joinSharedWorkspaceIfInviteCodeRequired(
 
   const codesResponse = await request.get(
     `${TestConfig.apiUrl}/api/sharing/workspace/${workspaceId}/view/${viewId}/guest-invite-codes`,
-    { headers: { Authorization: `Bearer ${guestAuthToken}` } },
+    { headers: { Authorization: `Bearer ${guestAuthToken}` } }
   );
   const codesData = await expectApiSuccess<{ codes: Array<{ code: string; email: string }> }>(
     codesResponse,
-    'List guest invite codes',
+    'List guest invite codes'
   );
   const inviteCode = codesData.codes.find((item) => item.email.toLowerCase() === guestEmail.toLowerCase())?.code;
 
@@ -98,16 +98,16 @@ async function joinSharedWorkspaceIfInviteCodeRequired(
     {
       headers: { Authorization: `Bearer ${guestAuthToken}`, 'Content-Type': 'application/json' },
       data: { code: inviteCode },
-    },
+    }
   );
 
   await expectApiSuccess(joinResponse, 'Join shared workspace by guest invite code');
 
   await expect
-    .poll(
-      () => guestCanAccessSharedPage(request, guestAuthToken, workspaceId, viewId),
-      { timeout: 30000, intervals: [1000, 2000, 3000] },
-    )
+    .poll(() => guestCanAccessSharedPage(request, guestAuthToken, workspaceId, viewId), {
+      timeout: 30000,
+      intervals: [1000, 2000, 3000],
+    })
     .toBe(true);
 }
 
@@ -131,9 +131,7 @@ async function createPageWithContent(page: Page, title: string, content: string)
   return viewId;
 }
 
-async function renameWorkspace(
-  request: APIRequestContext, authToken: string, workspaceId: string, newName: string,
-) {
+async function renameWorkspace(request: APIRequestContext, authToken: string, workspaceId: string, newName: string) {
   const response = await request.patch(`${TestConfig.apiUrl}/api/workspace`, {
     headers: { Authorization: `Bearer ${authToken}`, 'Content-Type': 'application/json' },
     data: { workspace_id: workspaceId, workspace_name: newName },
@@ -141,9 +139,7 @@ async function renameWorkspace(
   if (!response.ok()) throw new Error(`Failed to rename workspace: ${response.status()}`);
 }
 
-async function renameUser(
-  request: APIRequestContext, authToken: string, newName: string,
-) {
+async function renameUser(request: APIRequestContext, authToken: string, newName: string) {
   const response = await request.post(`${TestConfig.apiUrl}/api/user/update`, {
     headers: { Authorization: `Bearer ${authToken}`, 'Content-Type': 'application/json' },
     data: { name: newName },
@@ -152,16 +148,16 @@ async function renameUser(
 }
 
 async function shareViewWithGuest(
-  request: APIRequestContext, authToken: string,
-  workspaceId: string, viewId: string, guestEmail: string,
+  request: APIRequestContext,
+  authToken: string,
+  workspaceId: string,
+  viewId: string,
+  guestEmail: string
 ) {
-  const response = await request.put(
-    `${TestConfig.apiUrl}/api/sharing/workspace/${workspaceId}/view`,
-    {
-      headers: { Authorization: `Bearer ${authToken}`, 'Content-Type': 'application/json' },
-      data: { view_id: viewId, emails: [guestEmail], access_level: 50, auto_confirm: true },
-    },
-  );
+  const response = await request.put(`${TestConfig.apiUrl}/api/sharing/workspace/${workspaceId}/view`, {
+    headers: { Authorization: `Bearer ${authToken}`, 'Content-Type': 'application/json' },
+    data: { view_id: viewId, emails: [guestEmail], access_level: 50, auto_confirm: true },
+  });
   await expectApiSuccess(response, 'Share view with guest');
 }
 
@@ -179,9 +175,9 @@ async function getUserProfile(request: APIRequestContext, authToken: string) {
 async function waitForEditorContent(page: Page, maxAttempts = 3): Promise<void> {
   for (let attempt = 0; attempt < maxAttempts; attempt++) {
     try {
-      await expect(
-        page.locator('[data-testid="editor-content"], [data-testid="page-title-input"]').first()
-      ).toBeVisible({ timeout: 25000 });
+      await expect(page.locator('[data-testid="editor-content"], [data-testid="page-title-input"]').first()).toBeVisible(
+        { timeout: 25000 }
+      );
       return;
     } catch {
       testLog.info(`Content not visible yet, reloading (attempt ${attempt + 1}/${maxAttempts})`);
@@ -192,6 +188,27 @@ async function waitForEditorContent(page: Page, maxAttempts = 3): Promise<void> 
   throw new Error('Editor content never became visible after retries');
 }
 
+async function waitForSharedWorkspaceOutline(page: Page): Promise<void> {
+  await expect
+    .poll(
+      async () => {
+        const fullWorkspaceVisible = await page
+          .locator('text=Annie Workspace B')
+          .first()
+          .isVisible()
+          .catch(() => false);
+        const sharedOutlineVisible = await PageSelectors.nameContaining(page, TEST_PAGE_NAME)
+          .first()
+          .isVisible()
+          .catch(() => false);
+
+        return fullWorkspaceVisible || sharedOutlineVisible;
+      },
+      { timeout: 30000, intervals: [500, 1000, 2000] }
+    )
+    .toBe(true);
+}
+
 // ── Setup: Annie creates and shares a page ───────────────────────────
 
 async function annieCreatesAndSharesPage(
@@ -199,7 +216,7 @@ async function annieCreatesAndSharesPage(
   request: APIRequestContext,
   ownerEmail: string,
   guestEmail: string,
-  guestAuthToken: string,
+  guestAuthToken: string
 ): Promise<{ ownerWorkspaceId: string; sharedViewId: string; directLink: string }> {
   const ownerContext = await browser.newContext();
   const ownerPage = await ownerContext.newPage();
@@ -227,13 +244,7 @@ async function annieCreatesAndSharesPage(
 
   await shareViewWithGuest(request, ownerToken, ownerWorkspaceId, sharedViewId, guestEmail);
   testLog.info(`Annie shared page with guest (auto_confirm=true)`);
-  await joinSharedWorkspaceIfInviteCodeRequired(
-    request,
-    guestAuthToken,
-    ownerWorkspaceId,
-    sharedViewId,
-    guestEmail,
-  );
+  await joinSharedWorkspaceIfInviteCodeRequired(request, guestAuthToken, ownerWorkspaceId, sharedViewId, guestEmail);
   testLog.info('Guest access to Annie workspace confirmed');
 
   const directLink = `/app/${ownerWorkspaceId}/${sharedViewId}`;
@@ -252,9 +263,7 @@ test.describe('Shared View Cross-Workspace Routing', () => {
     guestEmail = generateRandomEmail();
   });
 
-  test('should auto-switch workspace when guest opens a shared direct link', async ({
-    context, browser, request,
-  }) => {
+  test('should auto-switch workspace when guest opens a shared direct link', async ({ context, browser, request }) => {
     // Given: Nathan's account exists and Nathan is signed in to "Nathan Workspace A"
     await createUserAccount(request, guestEmail);
     await createUserAccount(request, ownerEmail);
@@ -279,7 +288,11 @@ test.describe('Shared View Cross-Workspace Routing', () => {
 
     // And: Annie creates a page in her workspace and shares it with Nathan
     const { ownerWorkspaceId, directLink } = await annieCreatesAndSharesPage(
-      browser, request, ownerEmail, guestEmail, guestToken,
+      browser,
+      request,
+      ownerEmail,
+      guestEmail,
+      guestToken
     );
     expect(ownerWorkspaceId).not.toBe(guestWorkspaceId);
     testLog.info(`Direct link to Annie's page: ${directLink}`);
@@ -297,13 +310,11 @@ test.describe('Shared View Cross-Workspace Routing', () => {
     await waitForEditorContent(guestPage);
     testLog.info('Shared page loaded successfully');
 
-    // Wait for the workspace auto-switch to fully settle. The app detects the
-    // URL workspace differs from the selected workspace and calls
-    // WorkspaceService.open() + loadUserWorkspaceInfo(), which can re-render
-    // the page. Wait for the sidebar to show the correct workspace name as a
-    // signal that the switch is complete.
-    await expect(guestPage.locator('text=Annie Workspace B').first()).toBeVisible({ timeout: 30000 });
-    testLog.info('Workspace switch settled');
+    // Wait for the workspace auto-switch to fully settle. Depending on the
+    // guest outline response, the sidebar may show Annie's full workspace or a
+    // "Shared with me" outline containing the shared page.
+    await waitForSharedWorkspaceOutline(guestPage);
+    testLog.info('Workspace switch outline settled');
 
     // And: Nathan can edit the document in Annie's workspace
     const contentText = guestPage.locator('text=This page is shared across workspaces');
@@ -312,7 +323,7 @@ test.describe('Shared View Cross-Workspace Routing', () => {
     await guestPage.keyboard.press('End');
     await guestPage.keyboard.press('Enter');
     await guestPage.keyboard.press('Enter');
-    await guestPage.keyboard.type('Nathan was here - editing in Annie\'s workspace!', { delay: 30 });
+    await guestPage.keyboard.type("Nathan was here - editing in Annie's workspace!", { delay: 30 });
     await guestPage.waitForTimeout(2000);
     testLog.info('Nathan typed content in the shared document');
 
@@ -324,9 +335,7 @@ test.describe('Shared View Cross-Workspace Routing', () => {
     await guestPage.close();
   });
 
-  test('should open shared link in new tab with correct workspace', async ({
-    context, browser, request,
-  }) => {
+  test('should open shared link in new tab with correct workspace', async ({ context, browser, request }) => {
     // Given: Nathan is signed in to "Nathan Workspace A"
     await createUserAccount(request, guestEmail);
     await createUserAccount(request, ownerEmail);
@@ -345,7 +354,11 @@ test.describe('Shared View Cross-Workspace Routing', () => {
 
     // And: Annie creates a page and shares it with Nathan
     const { ownerWorkspaceId, directLink } = await annieCreatesAndSharesPage(
-      browser, request, ownerEmail, guestEmail, guestToken,
+      browser,
+      request,
+      ownerEmail,
+      guestEmail,
+      guestToken
     );
     expect(guestWorkspaceId).not.toBe(ownerWorkspaceId);
     testLog.info(`Annie's direct link: ${directLink}`);
@@ -369,9 +382,7 @@ test.describe('Shared View Cross-Workspace Routing', () => {
     await guestPage.close();
   });
 
-  test('should not load page when guest navigates with wrong workspace URL', async ({
-    context, browser, request,
-  }) => {
+  test('should not load page when guest navigates with wrong workspace URL', async ({ context, browser, request }) => {
     // Given: Nathan is signed in to "Nathan Workspace A"
     await createUserAccount(request, guestEmail);
     await createUserAccount(request, ownerEmail);
@@ -388,9 +399,7 @@ test.describe('Shared View Cross-Workspace Routing', () => {
     await renameUser(request, guestToken, 'Nathan');
 
     // And: Annie creates a page and shares it with Nathan
-    const { sharedViewId } = await annieCreatesAndSharesPage(
-      browser, request, ownerEmail, guestEmail, guestToken,
-    );
+    const { sharedViewId } = await annieCreatesAndSharesPage(browser, request, ownerEmail, guestEmail, guestToken);
 
     // When: Nathan navigates using his OWN workspace ID with the shared view ID
     // (this simulates the bug — wrong workspace + correct view ID)
@@ -402,11 +411,15 @@ test.describe('Shared View Cross-Workspace Routing', () => {
     // Then: the page should show an error or not load normally
     const hasError = await guestPage
       .locator('[data-testid="error-page"], [data-testid="not-found"]')
-      .count().then((c) => c > 0).catch(() => false);
+      .count()
+      .then((c) => c > 0)
+      .catch(() => false);
 
     const hasNormalContent = await guestPage
       .locator('[data-testid="editor-content"], [data-testid="page-title-input"]')
-      .first().isVisible({ timeout: 3000 }).catch(() => false);
+      .first()
+      .isVisible({ timeout: 3000 })
+      .catch(() => false);
 
     testLog.info(`Error page: ${hasError}, Normal content: ${hasNormalContent}`);
     expect(hasError || !hasNormalContent).toBeTruthy();

--- a/playwright/support/duplicate-test-helpers.ts
+++ b/playwright/support/duplicate-test-helpers.ts
@@ -542,16 +542,37 @@ export async function firstGridCellText(gridBlock: Locator): Promise<string> {
   return (await gridBlock.locator('[data-testid^="grid-cell-"]').first().innerText()).trim();
 }
 
-export async function addNameIsNotEmptyFilterToBlock(page: Page, gridBlock: Locator): Promise<void> {
-  await gridBlock.getByTestId('database-actions-filter').click({ force: true });
+async function selectFilterFieldForBlock(page: Page, gridBlock: Locator, fieldName: string): Promise<void> {
+  const fieldPattern = new RegExp(`^\\s*${escapeRegExp(fieldName)}\\s*$`);
 
-  const popoverContent = page.locator('[data-slot="popover-content"]').last();
-  await expect(popoverContent).toBeVisible({ timeout: 10000 });
-  await popoverContent
-    .locator('[data-item-id]')
-    .filter({ hasText: /^Name$/ })
-    .first()
-    .click({ force: true });
+  for (let attempt = 0; attempt < 3; attempt++) {
+    await expect(gridBlock.getByTestId('database-grid')).toBeVisible({ timeout: 30000 });
+    await gridBlock.getByTestId('database-actions-filter').click({ force: true });
+
+    const popoverContent = page.locator('[data-slot="popover-content"]').last();
+    await expect(popoverContent).toBeVisible({ timeout: 10000 });
+
+    const fieldItem = popoverContent.locator('[data-item-id]').filter({ hasText: fieldPattern }).first();
+
+    if (
+      await expect(fieldItem)
+        .toBeVisible({ timeout: 10000 })
+        .then(() => true)
+        .catch(() => false)
+    ) {
+      await fieldItem.click({ force: true });
+      return;
+    }
+
+    await page.keyboard.press('Escape').catch(() => undefined);
+    await page.waitForTimeout(1000);
+  }
+
+  throw new Error(`Filter field "${fieldName}" did not appear in the property picker`);
+}
+
+export async function addNameIsNotEmptyFilterToBlock(page: Page, gridBlock: Locator): Promise<void> {
+  await selectFilterFieldForBlock(page, gridBlock, 'Name');
   await page.waitForTimeout(1000);
 
   await expect(gridBlock.getByTestId('database-filter-condition').first()).toBeVisible({ timeout: 10000 });
@@ -562,15 +583,7 @@ export async function addNameIsNotEmptyFilterToBlock(page: Page, gridBlock: Loca
 }
 
 export async function addDoneCheckedFilterToBlock(page: Page, gridBlock: Locator): Promise<void> {
-  await gridBlock.getByTestId('database-actions-filter').click({ force: true });
-
-  const popoverContent = page.locator('[data-slot="popover-content"]').last();
-  await expect(popoverContent).toBeVisible({ timeout: 10000 });
-  await popoverContent
-    .locator('[data-item-id]')
-    .filter({ hasText: /^Done$/ })
-    .first()
-    .click({ force: true });
+  await selectFilterFieldForBlock(page, gridBlock, 'Done');
   await page.waitForTimeout(1000);
 
   await expect(gridBlock.getByTestId('database-filter-condition').first()).toBeVisible({ timeout: 10000 });

--- a/playwright/support/duplicate-test-helpers.ts
+++ b/playwright/support/duplicate-test-helpers.ts
@@ -256,7 +256,7 @@ export async function createChildDocumentUnder(
   await parentItem.locator('> div').first().getByTestId('inline-add-page').first().click({ force: true });
   const popover = page.getByTestId('view-actions-popover');
   await expect(popover).toBeVisible({ timeout: 10000 });
-  await popover.locator('[role="menuitem"]').first().click({ force: true });
+  await AddPageSelectors.addDocumentButton(page).click({ force: true });
   await page.waitForTimeout(1000);
 
   // The ViewModal dialog opens for the newly created child document.
@@ -283,11 +283,7 @@ export function databaseBlocks(editor: Locator): Locator {
 async function focusEditorForSlash(page: Page, editor: Locator): Promise<void> {
   let slateEditor = editor.locator('[data-slate-editor="true"]').first();
 
-  if (
-    !(await slateEditor
-      .isVisible({ timeout: 3000 })
-      .catch(() => false))
-  ) {
+  if (!(await slateEditor.isVisible({ timeout: 3000 }).catch(() => false))) {
     slateEditor = page.locator('[data-slate-editor="true"]').first();
   }
 

--- a/playwright/support/duplicate-test-helpers.ts
+++ b/playwright/support/duplicate-test-helpers.ts
@@ -402,6 +402,8 @@ export async function insertLinkedGridViaSlash(
 ): Promise<void> {
   const editor = editorForView(page, docViewId);
   await expect(editor).toBeVisible({ timeout: 15000 });
+  const initialBlockCount = await databaseBlocks(editor).count();
+  let lastError: unknown;
 
   // The database picker loads its list from the cached outline at open time.
   // If the outline hasn't propagated the renamed database yet, the picker will
@@ -435,8 +437,17 @@ export async function insertLinkedGridViaSlash(
         return;
       }
     } catch (e) {
-      if (attempt === 2) throw e;
-      // Fall through to cleanup + retry below
+      lastError = e;
+      // Fall through to success detection + cleanup below
+    }
+
+    if ((await databaseBlocks(editor).count()) > initialBlockCount) {
+      return;
+    }
+
+    if (attempt === 2) {
+      if (lastError) throw lastError;
+      break;
     }
 
     // Picker didn't appear or database not found — close any open popovers and

--- a/playwright/support/page-utils.ts
+++ b/playwright/support/page-utils.ts
@@ -6,13 +6,7 @@
  * URL utilities, and page management.
  */
 import { Page, expect } from '@playwright/test';
-import {
-  AddPageSelectors,
-  PageSelectors,
-  SpaceSelectors,
-  ModalSelectors,
-  SlashCommandSelectors,
-} from './selectors';
+import { AddPageSelectors, PageSelectors, SpaceSelectors, ModalSelectors, SlashCommandSelectors } from './selectors';
 import { getSlashMenuItemName } from './i18n-constants';
 
 /**
@@ -85,7 +79,7 @@ export async function navigateAwayToNewPage(page: Page): Promise<void> {
   await closeModalsIfOpen(page);
   await AddPageSelectors.inlineAddButton(page).first().click({ force: true });
   await page.waitForTimeout(1000);
-  await page.locator('[role="menuitem"]').first().click({ force: true });
+  await AddPageSelectors.addDocumentButton(page).click({ force: true });
   await page.waitForTimeout(1000);
 
   // Handle new page modal if it appears
@@ -125,7 +119,7 @@ export async function ensurePageExpandedByViewId(page: Page, viewId: string): Pr
 export async function createDocumentPageAndNavigate(page: Page): Promise<string> {
   await AddPageSelectors.inlineAddButton(page).first().click({ force: true });
   await page.waitForTimeout(1000);
-  await page.locator('[role="menuitem"]').first().click({ force: true });
+  await AddPageSelectors.addDocumentButton(page).click({ force: true });
   await page.waitForTimeout(1000);
 
   // Expand the ViewModal to full page view
@@ -142,11 +136,7 @@ export async function createDocumentPageAndNavigate(page: Page): Promise<string>
 /**
  * Inserts a linked database into the current document editor via the slash menu.
  */
-export async function insertLinkedDatabaseViaSlash(
-  page: Page,
-  docViewId: string,
-  dbName: string
-): Promise<void> {
+export async function insertLinkedDatabaseViaSlash(page: Page, docViewId: string, dbName: string): Promise<void> {
   const editor = page.locator(`#editor-${docViewId}`);
   await expect(editor).toBeVisible();
   await editor.click({ position: { x: 200, y: 100 }, force: true });
@@ -190,7 +180,7 @@ export async function createPageAndInsertImage(page: Page, pngBuffer: Buffer): P
   // Create a new page and expand to full-page view (same pattern as createDocumentPageAndNavigate)
   await AddPageSelectors.inlineAddButton(page).first().click({ force: true });
   await page.waitForTimeout(1000);
-  await page.locator('[role="menuitem"]').first().click({ force: true });
+  await AddPageSelectors.addDocumentButton(page).click({ force: true });
   await page.waitForTimeout(1000);
 
   // Expand ViewModal to full-page view
@@ -218,7 +208,10 @@ export async function createPageAndInsertImage(page: Page, pngBuffer: Buffer): P
   await page.keyboard.type('image', { delay: 50 });
   await page.waitForTimeout(1000);
 
-  await page.locator('[data-testid^="slash-menu-"]').filter({ hasText: /^Image$/ }).click({ force: true });
+  await page
+    .locator('[data-testid^="slash-menu-"]')
+    .filter({ hasText: /^Image$/ })
+    .click({ force: true });
   await page.waitForTimeout(1000);
 
   // Upload image

--- a/playwright/support/page-utils.ts
+++ b/playwright/support/page-utils.ts
@@ -6,7 +6,15 @@
  * URL utilities, and page management.
  */
 import { Page, expect } from '@playwright/test';
-import { AddPageSelectors, PageSelectors, SpaceSelectors, ModalSelectors, SlashCommandSelectors } from './selectors';
+import {
+  AddPageSelectors,
+  BlockSelectors,
+  PageSelectors,
+  SpaceSelectors,
+  ModalSelectors,
+  SlashCommandSelectors,
+  ViewActionSelectors,
+} from './selectors';
 import { getSlashMenuItemName } from './i18n-constants';
 
 /**
@@ -48,6 +56,43 @@ export async function expandDatabaseInSidebar(page: Page, dbName: string = 'New 
     await expandToggle.first().click({ force: true });
     await page.waitForTimeout(500);
   }
+}
+
+/**
+ * Renames a sidebar page item and waits until the outline reflects the new name.
+ */
+export async function renamePageByName(page: Page, currentName: string, newName: string): Promise<void> {
+  const pageItem = PageSelectors.itemByName(page, currentName);
+  await expect(pageItem).toBeVisible({ timeout: 30000 });
+
+  for (let attempt = 0; attempt < 3; attempt++) {
+    await pageItem.hover({ force: true });
+    await page.waitForTimeout(500);
+    await PageSelectors.moreActionsButton(page, currentName).click({ force: true });
+    await expect(ViewActionSelectors.renameButton(page)).toBeVisible({ timeout: 10000 });
+    await ViewActionSelectors.renameButton(page).click({ force: true });
+
+    const renameInput = ModalSelectors.renameInput(page);
+    await expect(renameInput).toBeVisible({ timeout: 10000 });
+    await renameInput.clear();
+    await renameInput.fill(newName);
+    await expect(renameInput).toHaveValue(newName, { timeout: 5000 });
+    await ModalSelectors.renameSaveButton(page).click({ force: true });
+
+    if (
+      await expect(PageSelectors.itemByName(page, newName))
+        .toBeVisible({ timeout: 10000 })
+        .then(() => true)
+        .catch(() => false)
+    ) {
+      return;
+    }
+
+    await page.keyboard.press('Escape').catch(() => undefined);
+    await page.waitForTimeout(1000);
+  }
+
+  await expect(PageSelectors.itemByName(page, newName)).toBeVisible({ timeout: 30000 });
 }
 
 /**
@@ -138,38 +183,67 @@ export async function createDocumentPageAndNavigate(page: Page): Promise<string>
  */
 export async function insertLinkedDatabaseViaSlash(page: Page, docViewId: string, dbName: string): Promise<void> {
   const editor = page.locator(`#editor-${docViewId}`);
-  await expect(editor).toBeVisible();
-  await editor.click({ position: { x: 200, y: 100 }, force: true });
-  await editor.pressSequentially('/', { delay: 50 });
-  await page.waitForTimeout(500);
+  await expect(editor).toBeVisible({ timeout: 15000 });
+  const initialBlockCount = await editor.locator(BlockSelectors.blockSelector('grid')).count();
+  let lastError: unknown;
 
-  // Click linked grid from slash menu
-  const slashPanel = SlashCommandSelectors.slashPanel(page);
-  await expect(slashPanel).toBeVisible();
-  await SlashCommandSelectors.slashMenuItem(page, getSlashMenuItemName('linkedGrid')).first().click({ force: true });
-  await page.waitForTimeout(1000);
+  for (let attempt = 0; attempt < 3; attempt++) {
+    try {
+      await editor.click({ position: { x: 200, y: 100 }, force: true });
+      await editor.pressSequentially('/', { delay: 50 });
+      await page.waitForTimeout(500);
 
-  // Select database from picker
-  await expect(page.getByText('Link to an existing database')).toBeVisible({ timeout: 10000 });
+      const slashPanel = SlashCommandSelectors.slashPanel(page);
+      await expect(slashPanel).toBeVisible({ timeout: 10000 });
+      await SlashCommandSelectors.slashMenuItem(page, getSlashMenuItemName('linkedGrid')).first().click({ force: true });
+      await page.waitForTimeout(1000);
 
-  // Wait for loading to complete
-  const loadingText = page.getByText('Loading...');
-  if ((await loadingText.count()) > 0) {
-    await expect(loadingText).not.toBeVisible({ timeout: 15000 });
+      await expect(page.getByText('Link to an existing database')).toBeVisible({ timeout: 10000 });
+
+      const loadingText = page.getByText('Loading...');
+      if ((await loadingText.count()) > 0) {
+        await expect(loadingText).not.toBeVisible({ timeout: 15000 });
+      }
+
+      const popover = page.locator('.MuiPopover-paper').last();
+      await expect(popover).toBeVisible({ timeout: 10000 });
+      const searchInput = popover.locator('input[placeholder*="Search"]');
+      if ((await searchInput.count()) > 0) {
+        await searchInput.clear();
+        await searchInput.fill(dbName);
+        await page.waitForTimeout(2000);
+      }
+
+      const databaseOption = popover.getByText(dbName, { exact: false }).first();
+      if ((await databaseOption.count()) > 0) {
+        await databaseOption.click({ force: true });
+        await page.waitForTimeout(2000);
+        return;
+      }
+    } catch (e) {
+      lastError = e;
+    }
+
+    if ((await editor.locator(BlockSelectors.blockSelector('grid')).count()) > initialBlockCount) {
+      return;
+    }
+
+    if (attempt === 2) {
+      if (lastError) throw lastError;
+      break;
+    }
+
+    await page.keyboard.press('Escape').catch(() => undefined);
+    await page.waitForTimeout(500);
+    await page.keyboard.press('Escape').catch(() => undefined);
+    await page.waitForTimeout(500);
+    await page.keyboard.press('Home').catch(() => undefined);
+    await page.keyboard.press('Shift+End').catch(() => undefined);
+    await page.keyboard.press('Backspace').catch(() => undefined);
+    await page.waitForTimeout(3000);
   }
 
-  // Search for and select the database
-  const popover = page.locator('.MuiPopover-paper').last();
-  await expect(popover).toBeVisible();
-  const searchInput = popover.locator('input[placeholder*="Search"]');
-  if ((await searchInput.count()) > 0) {
-    await searchInput.clear();
-    await searchInput.fill(dbName);
-    await page.waitForTimeout(2000);
-  }
-
-  await popover.getByText(dbName, { exact: false }).first().click({ force: true });
-  await page.waitForTimeout(2000);
+  throw new Error(`Database "${dbName}" not found in linked database picker after multiple retries`);
 }
 
 /**

--- a/playwright/support/page/flows.ts
+++ b/playwright/support/page/flows.ts
@@ -80,7 +80,7 @@ export async function ensurePageExpandedByViewId(page: Page, viewId: string): Pr
 export async function createDocumentPageAndNavigate(page: Page): Promise<string> {
   await AddPageSelectors.inlineAddButton(page).first().click({ force: true });
   await page.waitForTimeout(1000);
-  await page.locator('[role="menuitem"]').first().click({ force: true });
+  await AddPageSelectors.addDocumentButton(page).click({ force: true });
   await page.waitForTimeout(1000);
 
   // Expand the ViewModal to full page view
@@ -95,11 +95,7 @@ export async function createDocumentPageAndNavigate(page: Page): Promise<string>
   return viewId;
 }
 
-export async function createPageAndAddContent(
-  page: Page,
-  pageName: string,
-  content: string[]
-): Promise<void> {
+export async function createPageAndAddContent(page: Page, pageName: string, content: string[]): Promise<void> {
   // Click new page button
   await PageSelectors.newPageButton(page).click();
   await page.waitForTimeout(1000);

--- a/playwright/support/selectors.ts
+++ b/playwright/support/selectors.ts
@@ -72,7 +72,9 @@ export const PageSelectors = {
     page.locator(`[data-testid="page-item"]:has(> [data-testid="page-${viewId}"])`).first(),
   nameContaining: (page: Page, text: string) => page.getByTestId('page-name').filter({ hasText: text }),
   itemByName: (page: Page, pageName: string) =>
-    page.locator(`[data-testid="page-item"]:has(> div:first-child [data-testid="page-name"]:text-is("${pageName}"))`).first(),
+    page
+      .locator(`[data-testid="page-item"]:has(> div:first-child [data-testid="page-name"]:text-is("${pageName}"))`)
+      .first(),
   moreActionsButton: (page: Page, pageName?: string) => {
     if (pageName) {
       return PageSelectors.itemByName(page, pageName).getByTestId('page-more-actions').first();
@@ -233,7 +235,8 @@ export const ModelSelectorSelectors = {
   searchInput: (page: Page) => page.getByTestId('model-search-input'),
   options: (page: Page) => page.locator('[data-testid^="model-option-"]'),
   optionByName: (page: Page, modelName: string) => page.getByTestId(`model-option-${modelName}`),
-  selectedOption: (page: Page) => page.locator('[data-testid^="model-option-"]').filter({ has: page.locator('.bg-fill-content-select') }),
+  selectedOption: (page: Page) =>
+    page.locator('[data-testid^="model-option-"]').filter({ has: page.locator('.bg-fill-content-select') }),
 };
 
 /**
@@ -261,9 +264,12 @@ export const DatabaseGridSelectors = {
   cells: (page: Page) => page.locator('[data-testid^="grid-cell-"]'),
   cellByIds: (page: Page, rowId: string, fieldId: string) => page.getByTestId(`grid-cell-${rowId}-${fieldId}`),
   cellsInRow: (page: Page, rowId: string) => page.locator(`[data-testid^="grid-cell-${rowId}-"]`),
-  cellsForField: (page: Page, fieldId: string) => page.locator(`[data-testid$="-${fieldId}"][data-testid^="grid-cell-"]`),
+  cellsForField: (page: Page, fieldId: string) =>
+    page.locator(`[data-testid$="-${fieldId}"][data-testid^="grid-cell-"]`),
   dataRowCellsForField: (page: Page, fieldId: string) =>
-    page.locator(`[data-testid^="grid-row-"]:not([data-testid="grid-row-undefined"]) .grid-row-cell[data-column-id="${fieldId}"]`),
+    page.locator(
+      `[data-testid^="grid-row-"]:not([data-testid="grid-row-undefined"]) .grid-row-cell[data-column-id="${fieldId}"]`
+    ),
   firstCell: (page: Page) => page.locator('[data-testid^="grid-cell-"]').first(),
   newRowButton: (page: Page) => page.getByTestId('grid-new-row'),
 };
@@ -288,8 +294,7 @@ export const DatabaseViewSelectors = {
    * (e.g. "Grid", "Board", "Calendar", "Chart"). The dropdown items have no
    * dedicated test ids; they're identified by visible label.
    */
-  viewTypeOption: (page: Page, label: string) =>
-    page.getByRole('menuitem', { name: label }),
+  viewTypeOption: (page: Page, label: string) => page.getByRole('menuitem', { name: label }),
 };
 
 /**
@@ -304,10 +309,8 @@ export const ChartSelectors = {
   bars: (page: Page) => page.locator('.recharts-bar-rectangle'),
   dots: (page: Page) => page.locator('.recharts-dot'),
   slices: (page: Page) => page.locator('.recharts-pie-sector'),
-  emptyStateNoField: (page: Page) =>
-    page.getByTestId('database-chart').getByText('No fields available for grouping'),
-  emptyStateNoData: (page: Page) =>
-    page.getByTestId('database-chart').getByText('No data'),
+  emptyStateNoField: (page: Page) => page.getByTestId('database-chart').getByText('No fields available for grouping'),
+  emptyStateNoData: (page: Page) => page.getByTestId('database-chart').getByText('No data'),
   tooltip: (page: Page) => page.locator('.recharts-tooltip-wrapper'),
   legend: (page: Page) => page.locator('.recharts-legend-wrapper'),
 };
@@ -321,26 +324,20 @@ export const ChartSelectors = {
 export const ChartSettingsSelectors = {
   settingsButton: (page: Page) => page.getByTestId('database-actions-settings'),
   // Submenu triggers in the top-level Properties / Layout / Chart settings menu
-  chartSettingsSubTrigger: (page: Page) =>
-    page.getByRole('menuitem', { name: /chart settings/i }),
+  chartSettingsSubTrigger: (page: Page) => page.getByRole('menuitem', { name: /chart settings/i }),
   // Sub-submenu trigger inside Chart settings for the four chart types
-  chartTypeSubTrigger: (page: Page) =>
-    page.getByRole('menuitem', { name: /^chart type$/i }),
+  chartTypeSubTrigger: (page: Page) => page.getByRole('menuitem', { name: /^chart type$/i }),
   // Section labels inside the Chart settings submenu
   xAxisLabel: (page: Page) => page.getByText('X-Axis', { exact: true }),
   aggregationLabel: (page: Page) => page.getByText('Aggregation', { exact: true }),
   yAxisLabel: (page: Page) => page.getByText('Y-Axis', { exact: true }),
   // A specific aggregation row by label (e.g. "Count", "Sum", "Average").
-  aggregationItem: (page: Page, label: string) =>
-    page.getByRole('menuitem', { name: new RegExp(`^${label}$`, 'i') }),
+  aggregationItem: (page: Page, label: string) => page.getByRole('menuitem', { name: new RegExp(`^${label}$`, 'i') }),
   // A chart type row by label (Bar / Horizontal Bar / Line / Donut)
-  chartTypeItem: (page: Page, label: string) =>
-    page.getByRole('menuitem', { name: new RegExp(`^${label}$`, 'i') }),
+  chartTypeItem: (page: Page, label: string) => page.getByRole('menuitem', { name: new RegExp(`^${label}$`, 'i') }),
   // Toggle rows
-  showEmptyValuesItem: (page: Page) =>
-    page.getByRole('menuitem', { name: /show empty values/i }),
-  cumulativeItem: (page: Page) =>
-    page.getByRole('menuitem', { name: /cumulative/i }),
+  showEmptyValuesItem: (page: Page) => page.getByRole('menuitem', { name: /show empty values/i }),
+  cumulativeItem: (page: Page) => page.getByRole('menuitem', { name: /cumulative/i }),
 };
 
 /**
@@ -348,8 +345,7 @@ export const ChartSettingsSelectors = {
  */
 export const ChartDrilldownSelectors = {
   dialog: (page: Page) => page.getByRole('dialog'),
-  closeButton: (page: Page) =>
-    page.getByRole('dialog').getByRole('button').first(),
+  closeButton: (page: Page) => page.getByRole('dialog').getByRole('button').first(),
 };
 
 /**
@@ -418,7 +414,8 @@ export const PropertyMenuSelectors = {
  * Single Select Column selectors
  */
 export const SingleSelectSelectors = {
-  selectOptionCell: (page: Page, rowId: string, fieldId: string) => page.getByTestId(`select-option-cell-${rowId}-${fieldId}`),
+  selectOptionCell: (page: Page, rowId: string, fieldId: string) =>
+    page.getByTestId(`select-option-cell-${rowId}-${fieldId}`),
   allSelectOptionCells: (page: Page) => page.locator('[data-testid^="select-option-cell-"]'),
   selectOption: (page: Page, optionId: string) => page.getByTestId(`select-option-${optionId}`),
   selectOptionMenu: (page: Page) => page.getByTestId('select-option-menu'),
@@ -515,6 +512,7 @@ export const AccountSelectors = {
  */
 export const AddPageSelectors = {
   inlineAddButton: (page: Page) => page.getByTestId('inline-add-page'),
+  addDocumentButton: (page: Page) => page.getByTestId('add-document-button'),
   addGridButton: (page: Page) => page.getByTestId('add-grid-button'),
   addCalendarButton: (page: Page) => page.getByTestId('add-calendar-button'),
   addBoardButton: (page: Page) => page.getByTestId('add-board-button'),

--- a/src/application/types.ts
+++ b/src/application/types.ts
@@ -1007,6 +1007,7 @@ export type AppendBreadcrumb = (view?: View) => void;
 export type CreateRow = (rowKey: string) => Promise<YDoc>;
 export interface LoadViewOptions {
   databaseId?: string | null;
+  forceFetch?: boolean;
 }
 
 export type LoadView = (

--- a/src/application/view-loader/index.ts
+++ b/src/application/view-loader/index.ts
@@ -31,6 +31,7 @@ export interface ViewLoaderResult {
 
 export interface OpenViewOptions {
   databaseId?: string | null;
+  forceFetch?: boolean;
 }
 
 // ============================================================================
@@ -90,11 +91,21 @@ function detectCollabType(doc: YDoc, layout?: ViewLayout): Types {
 }
 
 function isDatabaseLayout(layout?: ViewLayout): boolean {
-  return (
-    layout === ViewLayout.Grid ||
-    layout === ViewLayout.Board ||
-    layout === ViewLayout.Calendar
-  );
+  return layout === ViewLayout.Grid || layout === ViewLayout.Board || layout === ViewLayout.Calendar;
+}
+
+function databaseDocContainsView(doc: YDoc, viewId: string): boolean | null {
+  try {
+    const sharedRoot = doc.getMap(YjsEditorKey.data_section) as YSharedRoot | undefined;
+    const database = sharedRoot?.get(YjsEditorKey.database);
+    const views = database?.get(YjsDatabaseKey.views);
+
+    if (!views) return null;
+
+    return views.has(viewId);
+  } catch {
+    return null;
+  }
 }
 
 async function mergeLegacyDatabaseViewCache(viewId: string, databaseId: string, targetDoc: YDoc): Promise<boolean> {
@@ -149,7 +160,7 @@ async function mergeLegacyDatabaseViewCache(viewId: string, databaseId: string, 
 }
 
 async function openCollabDocForView(viewId: string, layout?: ViewLayout, options: OpenViewOptions = {}): Promise<YDoc> {
-  const databaseId = (layout === undefined || isDatabaseLayout(layout)) ? options.databaseId ?? undefined : undefined;
+  const databaseId = layout === undefined || isDatabaseLayout(layout) ? options.databaseId ?? undefined : undefined;
 
   if (!databaseId) {
     return openCollabDB(viewId);
@@ -243,7 +254,7 @@ export async function openView(
 
   // Step 2: Check cache — also detect empty-shell documents that were cached
   // during a previous load when the server hadn't finished duplication yet.
-  let fromCache = hasCollabCache(doc);
+  let fromCache = options.forceFetch ? false : hasCollabCache(doc);
 
   if (fromCache) {
     const sharedRoot = doc.getMap(YjsEditorKey.data_section) as YSharedRoot | undefined;
@@ -271,9 +282,22 @@ export async function openView(
     }
   }
 
+  if (fromCache && options.databaseId && viewId !== options.databaseId) {
+    const containsLinkedView = databaseDocContainsView(doc, viewId);
+
+    if (containsLinkedView === false) {
+      Log.debug('[ViewLoader] cached database is missing linked view, re-fetching', {
+        viewId,
+        databaseId: options.databaseId,
+      });
+      fromCache = false;
+    }
+  }
+
   Log.debug('[ViewLoader] cache check', {
     viewId,
     fromCache,
+    forceFetch: options.forceFetch ?? false,
     durationMs: Date.now() - startedAt,
   });
 
@@ -347,10 +371,7 @@ export function getDatabaseIdFromDoc(doc: YDoc): string | null {
  * @param workspaceId - The workspace ID
  * @param documentId - The row sub-document ID
  */
-export async function openRowSubDocument(
-  workspaceId: string,
-  documentId: string
-): Promise<ViewLoaderResult> {
+export async function openRowSubDocument(workspaceId: string, documentId: string): Promise<ViewLoaderResult> {
   const startedAt = Date.now();
 
   Log.debug('[ViewLoader] openRowSubDocument start', { workspaceId, documentId });

--- a/src/components/app/settings/ProfilePanel.tsx
+++ b/src/components/app/settings/ProfilePanel.tsx
@@ -100,25 +100,31 @@ export function ProfilePanel() {
   if (!currentUser) return null;
 
   const initial = (name || currentUser.name || currentUser.email || '?').charAt(0).toUpperCase();
+  const avatar = profile?.avatar_url ?? currentUser.avatar ?? '';
+  const isInlineAvatar =
+    avatar.length > 0 &&
+    !avatar.startsWith('http://') &&
+    !avatar.startsWith('https://') &&
+    !avatar.startsWith('/') &&
+    !avatar.startsWith('data:') &&
+    !avatar.startsWith('blob:');
 
   return (
     <div className='flex h-full min-h-0 flex-1 flex-col overflow-hidden'>
       <div className='border-b border-border-primary px-8 py-5'>
-        <h2 className='text-xl font-semibold text-text-primary'>
-          {t('settings.accountPage.profile.title')}
-        </h2>
+        <h2 className='text-xl font-semibold text-text-primary'>{t('settings.accountPage.profile.title')}</h2>
       </div>
       <div className='appflowy-scroller flex-1 overflow-y-auto px-8 py-6'>
         <div className='flex flex-col gap-6'>
           <div className='flex items-center gap-4'>
             <Avatar size='xl'>
-              <AvatarImage src={profile?.avatar_url ?? currentUser.avatar ?? ''} alt={name} />
-              <AvatarFallback name={name}>{initial}</AvatarFallback>
+              <AvatarImage src={isInlineAvatar ? '' : avatar} alt={name} />
+              <AvatarFallback name={name}>
+                {isInlineAvatar ? <span className='text-2xl'>{avatar}</span> : initial}
+              </AvatarFallback>
             </Avatar>
             <div className='flex flex-1 flex-col gap-1'>
-              <Label htmlFor='profile-display-name'>
-                {t('settings.accountPage.profile.displayName')}
-              </Label>
+              <Label htmlFor='profile-display-name'>{t('settings.accountPage.profile.displayName')}</Label>
               <Input
                 id='profile-display-name'
                 value={name}

--- a/src/components/app/view-actions/AddPageActions.tsx
+++ b/src/components/app/view-actions/AddPageActions.tsx
@@ -93,6 +93,7 @@ function AddPageActions({ view, onImportClick }: { view: View; onImportClick?: (
       {
         label: t('document.menuName'),
         icon: <ViewIcon layout={ViewLayout.Document} size={'small'} />,
+        testId: 'add-document-button',
         onSelect: () => {
           void handleAddPage(ViewLayout.Document, t('menuAppHeader.defaultNewPageName'));
         },

--- a/src/components/editor/components/panels/slash-panel/SlashPanel.tsx
+++ b/src/components/editor/components/panels/slash-panel/SlashPanel.tsx
@@ -8,6 +8,7 @@ import { ReactEditor, useSlateStatic } from 'slate-react';
 import { YjsEditor } from '@/application/slate-yjs';
 import { CustomEditor } from '@/application/slate-yjs/command';
 import { isEmbedBlockTypes } from '@/application/slate-yjs/command/const';
+import { applyYDoc } from '@/application/ydoc/apply';
 import {
   findSlateEntryByBlockId,
   getBlockEntry,
@@ -239,6 +240,7 @@ export function SlashPanel({
     openPageModal,
     viewId: documentId,
     loadViewMeta,
+    loadView,
     getMoreAIContext,
     createDatabaseView,
     loadViews,
@@ -683,6 +685,22 @@ export function SlashPanel({
           referencedName,
         });
 
+        if (response.database_update?.length && loadView) {
+          try {
+            const databaseDoc = await loadView(response.view_id, false, false, {
+              databaseId: response.database_id || databaseId,
+            });
+
+            applyYDoc(databaseDoc, new Uint8Array(response.database_update));
+          } catch (error) {
+            Log.warn('[SlashPanel] failed to apply linked database update', {
+              viewId: response.view_id,
+              databaseId: response.database_id || databaseId,
+              error,
+            });
+          }
+        }
+
         turnInto(
           blockType,
           createDatabaseNodeData({
@@ -707,6 +725,7 @@ export function SlashPanel({
       blockTypeByLayout,
       turnInto,
       t,
+      loadView,
       loadViewMeta,
       loadDatabaseRelations,
     ]

--- a/src/components/ws/__tests__/useSync.test.ts
+++ b/src/components/ws/__tests__/useSync.test.ts
@@ -927,6 +927,143 @@ describe('useSync public API', () => {
     }
   });
 
+  it('pauses background HTTP sync for 10 minutes after the server stays rate-limited', async () => {
+    jest.useFakeTimers();
+    // Pin jitter to 0 so withRetry waits exactly the server's Retry-After (1s).
+    const randomSpy = jest.spyOn(Math, 'random').mockReturnValue(0);
+    const rateLimited = Object.assign(new Error('Batch sync rate-limited (429)'), {
+      code: 429,
+      retryAfterSecs: 1,
+    });
+
+    mockedCollabFullSyncBatch.mockRejectedValue(rateLimited);
+
+    try {
+      const ws = {
+        ...createWs(),
+        readyState: 0,
+      } as AppflowyWebSocketType;
+      const bc = createBroadcastChannel();
+      const doc = createDoc('dededede-2222-4222-8222-dededededede');
+      const { result, unmount } = renderHook(() => useSync(ws, bc, defaultEventEmitter, defaultWorkspaceId));
+
+      act(() => {
+        result.current.registerSyncContext({ doc, collabType: Types.Document });
+        doc.getMap('root').set('dirty', true);
+      });
+
+      // First cycle fires after the 5s debounce.
+      await act(async () => {
+        jest.advanceTimersByTime(5_000);
+        await flushPromises();
+      });
+      expect(mockedCollabFullSyncBatch).toHaveBeenCalledTimes(1);
+
+      // withRetry honours Retry-After for its 3 in-cycle retries.
+      for (let i = 0; i < 3; i++) {
+        await act(async () => {
+          jest.advanceTimersByTime(1_000);
+          await flushPromises();
+        });
+      }
+
+      expect(mockedCollabFullSyncBatch).toHaveBeenCalledTimes(4);
+
+      // The loop is now paused: the regular 5s cadence must stay quiet.
+      await act(async () => {
+        jest.advanceTimersByTime(60_000);
+        await flushPromises();
+      });
+      expect(mockedCollabFullSyncBatch).toHaveBeenCalledTimes(4);
+
+      // Editing during the pause marks the doc dirty but must NOT bypass it.
+      act(() => {
+        doc.getMap('root').set('dirty-again', true);
+      });
+      await act(async () => {
+        jest.advanceTimersByTime(60_000);
+        await flushPromises();
+      });
+      expect(mockedCollabFullSyncBatch).toHaveBeenCalledTimes(4);
+
+      // After the 10-minute busy pause the loop resumes for the still-dirty doc.
+      await act(async () => {
+        jest.advanceTimersByTime(10 * 60 * 1000);
+        await flushPromises();
+      });
+      expect(mockedCollabFullSyncBatch).toHaveBeenCalledTimes(5);
+
+      unmount();
+      doc.destroy();
+    } finally {
+      randomSpy.mockRestore();
+      jest.runOnlyPendingTimers();
+      jest.useRealTimers();
+    }
+  });
+
+  it('keeps failed dirty docs after a rate-limit pause without another local edit', async () => {
+    jest.useFakeTimers();
+    // Pin jitter to 0 so withRetry waits exactly the server's Retry-After (1s).
+    const randomSpy = jest.spyOn(Math, 'random').mockReturnValue(0);
+    const rateLimited = Object.assign(new Error('Batch sync rate-limited (429)'), {
+      code: 429,
+      retryAfterSecs: 1,
+    });
+
+    mockedCollabFullSyncBatch.mockRejectedValue(rateLimited);
+
+    try {
+      const ws = {
+        ...createWs(),
+        readyState: 0,
+      } as AppflowyWebSocketType;
+      const bc = createBroadcastChannel();
+      const doc = createDoc('efefefef-3333-4333-8333-efefefefefef');
+      const { result, unmount } = renderHook(() => useSync(ws, bc, defaultEventEmitter, defaultWorkspaceId));
+
+      act(() => {
+        result.current.registerSyncContext({ doc, collabType: Types.Document });
+        doc.getMap('root').set('dirty', true);
+      });
+
+      await act(async () => {
+        jest.advanceTimersByTime(5_000);
+        await flushPromises();
+      });
+      expect(mockedCollabFullSyncBatch).toHaveBeenCalledTimes(1);
+
+      for (let i = 0; i < 3; i++) {
+        await act(async () => {
+          jest.advanceTimersByTime(1_000);
+          await flushPromises();
+        });
+      }
+
+      expect(mockedCollabFullSyncBatch).toHaveBeenCalledTimes(4);
+
+      await act(async () => {
+        jest.advanceTimersByTime(10 * 60 * 1000);
+        await flushPromises();
+      });
+
+      expect(mockedCollabFullSyncBatch).toHaveBeenCalledTimes(5);
+      expect(mockedCollabFullSyncBatch.mock.calls[4]?.[1]).toEqual([
+        expect.objectContaining({
+          objectId: doc.guid,
+          collabType: Types.Document,
+        }),
+      ]);
+
+      unmount();
+      doc.destroy();
+    } finally {
+      randomSpy.mockRestore();
+      jest.runOnlyPendingTimers();
+      jest.useRealTimers();
+    }
+  });
+
   it('keeps dirty docs for HTTP fallback when websocket opens before outbox drains and closes again', async () => {
     jest.useFakeTimers();
     mockedCollabFullSyncBatch.mockResolvedValue([]);

--- a/src/components/ws/sync/useBatchSync.ts
+++ b/src/components/ws/sync/useBatchSync.ts
@@ -15,7 +15,7 @@ import {
   mergeLegacyRowDocIfExists,
 } from '@/application/services/js-services/cache';
 import { collabFullSyncBatch, createOrphanedView, checkIfCollabExists } from '@/application/services/js-services/http/http_api';
-import { withRetry } from '@/application/services/js-services/http/core';
+import { handleAPIError, withRetry } from '@/application/services/js-services/http/core';
 import { waitForDrain } from '@/application/sync-outbox';
 import { Types, YDatabase, YjsDatabaseKey, YjsEditorKey } from '@/application/types';
 import { applyYDoc } from '@/application/ydoc/apply';
@@ -28,6 +28,12 @@ import { SyncRefs } from './syncRefs';
 const BATCH_SYNC_DELAYS = [30_000, 30_000, 30_000];
 const WS_READY_STATE_OPEN = 1;
 const BACKGROUND_HTTP_SYNC_DELAY_MS = 5_000;
+// Loop-level pauses after withRetry exhausts, matching the desktop client
+// protocol (doc/context/api_collab_sync.md in AppFlowy-Cloud): the server
+// returning 429 means it is shedding load — keep the loop quiet for 10 minutes
+// instead of re-entering the 5s cadence. Other exhausted errors pause 5 minutes.
+const BACKGROUND_HTTP_SYNC_RATE_LIMIT_PAUSE_MS = 10 * 60 * 1000;
+const BACKGROUND_HTTP_SYNC_ERROR_PAUSE_MS = 5 * 60 * 1000;
 const BACKGROUND_HTTP_SYNC_RECENT_EDIT_WINDOW_MS = 10 * 60 * 1000;
 const BACKGROUND_HTTP_SYNC_TYPES = new Set<Types>([
   Types.Document,
@@ -41,6 +47,7 @@ const EMPTY_YJS_UPDATE_MAX_BYTES = 2;
 interface BackgroundDirtyEdit {
   seq: number;
   editedAt: number;
+  retryRetainUntil?: number;
 }
 
 /**
@@ -89,6 +96,9 @@ export function useBatchSync(
   const backgroundHttpSyncInFlightRef = useRef(false);
   const backgroundDirtyEditsRef = useRef<Map<string, BackgroundDirtyEdit>>(new Map());
   const backgroundDirtySeqRef = useRef(0);
+  // Epoch ms until which the background loop must stay quiet after the server
+  // signalled busy (429/503) or a cycle exhausted its retries. 0 = not paused.
+  const backgroundHttpSyncPausedUntilRef = useRef(0);
   const wsReadyStateRef = useRef<number | undefined>(options?.wsReadyState);
   const workspaceIdRef = useRef<string | undefined>(options?.workspaceId);
   const runBackgroundHttpSyncRef = useRef<() => Promise<void>>(async () => undefined);
@@ -106,11 +116,16 @@ export function useBatchSync(
 
     if (!workspaceId || readyState === undefined || readyState === WS_READY_STATE_OPEN) return;
 
+    // Honour an active busy pause: local edits keep marking docs dirty, but
+    // the next request waits until the pause expires instead of every 5s.
+    const pauseRemainingMs = backgroundHttpSyncPausedUntilRef.current - Date.now();
+    const delayMs = Math.max(BACKGROUND_HTTP_SYNC_DELAY_MS, pauseRemainingMs);
+
     clearBackgroundHttpSyncTimer();
     backgroundHttpSyncTimerRef.current = setTimeout(() => {
       backgroundHttpSyncTimerRef.current = null;
       void runBackgroundHttpSyncRef.current();
-    }, BACKGROUND_HTTP_SYNC_DELAY_MS);
+    }, delayMs);
   }, [clearBackgroundHttpSyncTimer]);
 
   useEffect(() => {
@@ -242,7 +257,10 @@ export function useBatchSync(
 
     const now = Date.now();
     const dirtySnapshot = Array.from(backgroundDirtyEditsRef.current.entries()).filter(([objectId, dirty]) => {
-      if (now - dirty.editedAt <= BACKGROUND_HTTP_SYNC_RECENT_EDIT_WINDOW_MS) return true;
+      const isRecentEdit = now - dirty.editedAt <= BACKGROUND_HTTP_SYNC_RECENT_EDIT_WINDOW_MS;
+      const isRetainedForRetry = dirty.retryRetainUntil !== undefined && now <= dirty.retryRetainUntil;
+
+      if (isRecentEdit || isRetainedForRetry) return true;
 
       if (backgroundDirtyEditsRef.current.get(objectId)?.seq === dirty.seq) {
         backgroundDirtyEditsRef.current.delete(objectId);
@@ -280,6 +298,7 @@ export function useBatchSync(
         signal: controller.signal,
       });
 
+      backgroundHttpSyncPausedUntilRef.current = 0;
       applyFullSyncResults(results);
 
       for (const [objectId, dirty] of dirtySnapshot) {
@@ -294,7 +313,34 @@ export function useBatchSync(
       });
     } catch (error) {
       if (!controller.signal.aborted) {
-        Log.warn('[sync] background HTTP full-sync failed', { workspaceId, error });
+        // withRetry already consumed the per-request Retry-After delays; an
+        // error landing here means the server stayed busy (or kept failing)
+        // through every attempt, so back off at the loop level.
+        const normalized = handleAPIError(error);
+        const pauseMs =
+          normalized.code === 429 ? BACKGROUND_HTTP_SYNC_RATE_LIMIT_PAUSE_MS : BACKGROUND_HTTP_SYNC_ERROR_PAUSE_MS;
+        const pauseUntil = Date.now() + pauseMs;
+        const shouldRetainFailedDirtyEdits = normalized.code === 429 || normalized.code === -1 || normalized.code >= 500;
+
+        backgroundHttpSyncPausedUntilRef.current = pauseUntil;
+
+        if (shouldRetainFailedDirtyEdits) {
+          const retryRetainUntil = pauseUntil + BACKGROUND_HTTP_SYNC_RECENT_EDIT_WINDOW_MS;
+
+          for (const [objectId, dirty] of dirtySnapshot) {
+            const currentDirty = backgroundDirtyEditsRef.current.get(objectId);
+
+            if (itemIds.has(objectId) && currentDirty?.seq === dirty.seq) {
+              currentDirty.retryRetainUntil = retryRetainUntil;
+            }
+          }
+        }
+
+        Log.warn('[sync] background HTTP full-sync failed; pausing loop', {
+          workspaceId,
+          error,
+          pauseMs,
+        });
       }
     } finally {
       if (backgroundHttpSyncAbortRef.current === controller) {


### PR DESCRIPTION
## Summary
- serve SPA app routes such as `/auth/callback` directly and add safe cache headers for HTML/static responses
- avoid app-route prefix shadowing for publish namespaces like `/authors`
- retain retryable dirty background sync edits across rate-limit backoff pauses

## Tests
- `pnpm exec jest deploy/routes.test.ts --runInBand --no-coverage`
- `pnpm exec jest src/components/ws/__tests__/useSync.test.ts --runInBand --no-coverage`
- `pnpm run type-check`

## Summary by Sourcery

Adjust background HTTP sync backoff to pause on persistent rate limiting while retaining dirty edits, and tighten routing and cache headers for SPA app and publish routes.

Bug Fixes:
- Ensure background HTTP sync pauses for a longer interval after repeated 429 or server errors instead of immediately resuming.
- Retain retryable dirty documents across background sync rate-limit pauses so they are retried without requiring a new local edit.
- Serve SPA app routes such as /auth/callback and /login directly as the app shell to avoid misrouting them through publish lookup.
- Prevent app-shell routes from shadowing publish namespaces that share the same prefix, such as /authors.
- Serve publish HTML responses with no-cache headers so stale shells are not reused.

Enhancements:
- Set long-lived immutable cache headers for hashed /static assets and short-lived cache headers for other static files, and apply no-cache to HTML responses.

Tests:
- Add unit tests verifying background HTTP sync pause timing and dirty doc retention around rate limiting.
- Extend routing tests to cover app vs publish routing behavior and cache headers for static and HTML responses.