### PR TITLE
Fix realtime sync reconnect stability

### DIFF
--- a/src/application/services/js-services/http/__tests__/gotrue-refresh-dedup.test.ts
+++ b/src/application/services/js-services/http/__tests__/gotrue-refresh-dedup.test.ts
@@ -1,0 +1,167 @@
+const mockGrantClient = {
+  interceptors: {
+    request: {
+      use: jest.fn(),
+    },
+  },
+  post: jest.fn(),
+};
+
+const mockAxiosCreate = jest.fn(() => mockGrantClient);
+
+jest.mock('axios', () => ({
+  __esModule: true,
+  default: {
+    create: mockAxiosCreate,
+  },
+  create: mockAxiosCreate,
+}));
+
+jest.mock('@/application/session/token', () => ({
+  getTokenParsed: jest.fn(),
+  saveGoTrueAuth: jest.fn(),
+}));
+
+jest.mock('../cloud-auth', () => ({
+  verifyToken: jest.fn(),
+}));
+
+jest.mock('@/utils/log', () => ({
+  Log: {
+    debug: jest.fn(),
+    error: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+  },
+}));
+
+const { initGrantService, refreshToken } = require('../gotrue') as typeof import('../gotrue');
+const { saveGoTrueAuth } = require('@/application/session/token') as { saveGoTrueAuth: jest.Mock };
+
+function createDeferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((promiseResolve, promiseReject) => {
+    resolve = promiseResolve;
+    reject = promiseReject;
+  });
+
+  return { promise, resolve, reject };
+}
+
+const refreshedToken = {
+  access_token: 'refreshed-access-token',
+  expires_at: 456,
+  refresh_token: 'refreshed-refresh-token',
+};
+
+describe('refreshToken concurrent deduplication', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGrantClient.post.mockReset();
+    initGrantService('http://localhost/gotrue');
+  });
+
+  // Reproduces the refresh stampede: when the access token expires, every
+  // concurrent in-flight API request independently triggers a refresh. With a
+  // token-rotating server, the second POST sends an already-consumed refresh
+  // token and gets rejected, forcing a logout. All concurrent callers must
+  // share a single network request.
+  it('shares one network request among concurrent calls with the same refresh token', async () => {
+    const deferred = createDeferred<{ data: typeof refreshedToken }>();
+
+    mockGrantClient.post.mockReturnValue(deferred.promise);
+
+    const first = refreshToken('stored-refresh-token');
+    const second = refreshToken('stored-refresh-token');
+
+    deferred.resolve({ data: refreshedToken });
+
+    const [firstToken, secondToken] = await Promise.all([first, second]);
+
+    expect(mockGrantClient.post).toHaveBeenCalledTimes(1);
+    expect(firstToken).toEqual(refreshedToken);
+    expect(secondToken).toEqual(refreshedToken);
+    expect(saveGoTrueAuth).toHaveBeenCalledTimes(1);
+  });
+
+  it('issues a new request once the previous refresh has settled', async () => {
+    mockGrantClient.post.mockResolvedValue({ data: refreshedToken });
+
+    await refreshToken('stored-refresh-token');
+    await refreshToken('stored-refresh-token');
+
+    expect(mockGrantClient.post).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not dedupe calls made with different refresh tokens', async () => {
+    mockGrantClient.post.mockResolvedValue({ data: refreshedToken });
+
+    await Promise.all([refreshToken('token-A'), refreshToken('token-B')]);
+
+    expect(mockGrantClient.post).toHaveBeenCalledTimes(2);
+  });
+
+  it('keeps dedupe entries for earlier tokens when a different token refresh interleaves', async () => {
+    const deferredA = createDeferred<{ data: typeof refreshedToken }>();
+    const deferredB = createDeferred<{ data: typeof refreshedToken }>();
+    const tokenARefresh = {
+      ...refreshedToken,
+      access_token: 'token-A-access-token',
+      refresh_token: 'token-A-next-refresh-token',
+    };
+    const tokenBRefresh = {
+      ...refreshedToken,
+      access_token: 'token-B-access-token',
+      refresh_token: 'token-B-next-refresh-token',
+    };
+
+    mockGrantClient.post.mockImplementation((_url: string, body: { refresh_token: string }) => {
+      if (body.refresh_token === 'token-A') return deferredA.promise;
+      if (body.refresh_token === 'token-B') return deferredB.promise;
+      return Promise.reject(new Error(`unexpected refresh token: ${body.refresh_token}`));
+    });
+
+    const firstA = refreshToken('token-A');
+    const firstB = refreshToken('token-B');
+    const secondA = refreshToken('token-A');
+
+    expect(mockGrantClient.post).toHaveBeenCalledTimes(2);
+    expect(mockGrantClient.post).toHaveBeenNthCalledWith(1, '/token?grant_type=refresh_token', {
+      refresh_token: 'token-A',
+    });
+    expect(mockGrantClient.post).toHaveBeenNthCalledWith(2, '/token?grant_type=refresh_token', {
+      refresh_token: 'token-B',
+    });
+
+    deferredA.resolve({ data: tokenARefresh });
+    deferredB.resolve({ data: tokenBRefresh });
+
+    await expect(firstA).resolves.toEqual(tokenARefresh);
+    await expect(secondA).resolves.toEqual(tokenARefresh);
+    await expect(firstB).resolves.toEqual(tokenBRefresh);
+    expect(saveGoTrueAuth).toHaveBeenCalledTimes(2);
+  });
+
+  it('propagates a shared failure to all concurrent callers and allows a retry', async () => {
+    const deferred = createDeferred<never>();
+
+    mockGrantClient.post.mockReturnValueOnce(deferred.promise);
+
+    const first = refreshToken('stored-refresh-token');
+    const second = refreshToken('stored-refresh-token');
+
+    const failure = new Error('refresh failed');
+
+    deferred.reject(failure);
+
+    await expect(first).rejects.toBe(failure);
+    await expect(second).rejects.toBe(failure);
+    expect(mockGrantClient.post).toHaveBeenCalledTimes(1);
+
+    // The failed in-flight entry must be cleared so a later call can retry.
+    mockGrantClient.post.mockResolvedValueOnce({ data: refreshedToken });
+    await expect(refreshToken('stored-refresh-token')).resolves.toEqual(refreshedToken);
+    expect(mockGrantClient.post).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/application/services/js-services/http/gotrue.ts
+++ b/src/application/services/js-services/http/gotrue.ts
@@ -43,35 +43,62 @@ export function initGrantService(baseURL: string) {
   });
 }
 
+interface RefreshedToken {
+  access_token: string;
+  expires_at: number;
+  refresh_token: string;
+}
+
+// In-flight refreshes shared by concurrent callers with the same refresh token
+// (axios request interceptor, 401 retry handler, WebSocket reconnect). This
+// must be keyed by token: different sessions/tokens may refresh concurrently,
+// but duplicate requests for one rotating refresh token must join the same
+// promise or the later request can consume an already-used token.
+const refreshInFlightByToken = new Map<string, Promise<RefreshedToken>>();
+
 export async function refreshToken(refresh_token: string) {
-  Log.info('[Auth] refreshToken: requesting new token');
-  const response = await axiosInstance?.post<{
-    access_token: string;
-    expires_at: number;
-    refresh_token: string;
-  }>('/token?grant_type=refresh_token', {
-    refresh_token,
-  });
+  const inFlight = refreshInFlightByToken.get(refresh_token);
 
-  const newToken = response?.data;
-
-  if (newToken) {
-    Log.info('[Auth] refreshToken: success, saving token');
-    saveGoTrueAuth(JSON.stringify(newToken));
-  } else {
-    Log.error('[Auth] refreshToken: no token data in response');
-    return Promise.reject('Failed to refresh token');
+  if (inFlight) {
+    Log.debug('[Auth] refreshToken: joining in-flight refresh');
+    return inFlight;
   }
 
-  return newToken;
+  Log.info('[Auth] refreshToken: requesting new token');
+
+  const promise = (async (): Promise<RefreshedToken> => {
+    const response = await axiosInstance?.post<RefreshedToken>('/token?grant_type=refresh_token', {
+      refresh_token,
+    });
+
+    const newToken = response?.data;
+
+    if (newToken) {
+      Log.info('[Auth] refreshToken: success, saving token');
+      saveGoTrueAuth(JSON.stringify(newToken));
+    } else {
+      Log.error('[Auth] refreshToken: no token data in response');
+      return Promise.reject('Failed to refresh token');
+    }
+
+    return newToken;
+  })();
+
+  refreshInFlightByToken.set(refresh_token, promise);
+
+  try {
+    return await promise;
+  } finally {
+    if (refreshInFlightByToken.get(refresh_token) === promise) {
+      refreshInFlightByToken.delete(refresh_token);
+    }
+  }
 }
 
 function normalizeAuthFlowError(error: unknown, fallbackMessage: string, useErrorMessage: boolean) {
   const err = error as { message?: string; code?: number };
   const message =
-    useErrorMessage && typeof err?.message === 'string'
-      ? err.message.replace(/\s*\[.*\]$/, '')
-      : fallbackMessage;
+    useErrorMessage && typeof err?.message === 'string' ? err.message.replace(/\s*\[.*\]$/, '') : fallbackMessage;
 
   return {
     code: err?.code ?? -1,
@@ -155,7 +182,11 @@ export async function signInWithPassword(params: { email: string; password: stri
       message: e.response?.data?.message || 'Incorrect password. Please try again.',
     });
 
-    Log.error('[Auth] signInWithPassword: failed', { status: e.response?.status, code: error.code, message: error.message });
+    Log.error('[Auth] signInWithPassword: failed', {
+      status: e.response?.status,
+      code: error.code,
+      message: error.message,
+    });
 
     return Promise.reject({
       code: error.code,
@@ -244,7 +275,11 @@ export async function signUpWithPassword(params: { email: string; password: stri
       message: e.response?.data?.message || 'Failed to sign up with password.',
     });
 
-    Log.error('[Auth] signUpWithPassword: failed', { status: e.response?.status, code: error.code, message: error.message });
+    Log.error('[Auth] signUpWithPassword: failed', {
+      status: e.response?.status,
+      code: error.code,
+      message: error.message,
+    });
 
     return Promise.reject({
       code: error.code,
@@ -321,7 +356,10 @@ export async function changePassword(params: { password: string }) {
     return;
     // eslint-disable-next-line
   } catch (e: any) {
-    Log.error('[Auth] changePassword: failed', { status: e.response?.status, message: e.response?.data?.msg || e.message });
+    Log.error('[Auth] changePassword: failed', {
+      status: e.response?.status,
+      message: e.response?.data?.msg || e.message,
+    });
     emit(EventType.SESSION_INVALID);
     return Promise.reject({
       code: -1,
@@ -381,7 +419,11 @@ export async function signInOTP({
     }
     // eslint-disable-next-line
   } catch (e: any) {
-    Log.error('[Auth] signInOTP: failed', { status: e.response?.status, code: e.response?.data?.code, message: e.response?.data?.msg || e.message });
+    Log.error('[Auth] signInOTP: failed', {
+      status: e.response?.status,
+      code: e.response?.data?.code,
+      message: e.response?.data?.msg || e.message,
+    });
     return Promise.reject({
       code: e.response?.data?.code || e.response?.status,
       message: e.response?.data?.msg || e.message,

--- a/src/components/app/contexts/SyncInternalContext.ts
+++ b/src/components/app/contexts/SyncInternalContext.ts
@@ -4,15 +4,15 @@ import { createContext, useContext } from 'react';
 import { Awareness } from 'y-protocols/awareness';
 
 import { SyncContext } from '@/application/services/js-services/sync-protocol';
-import { AppflowyWebSocketType } from '@/components/ws/useAppflowyWebSocket';
-import { BroadcastChannelType } from '@/components/ws/useBroadcastChannel';
 import { RegisterSyncContext } from '@/components/ws/useSync';
 
 // Internal context for synchronization layer
 // This context is only used within the app provider layers
+// Note: the WebSocket/BroadcastChannel transports are deliberately NOT exposed
+// here — their identity changes whenever a message arrives, which would
+// re-render every consumer per message. Message routing happens in useSync,
+// which receives the transports directly in AppSyncLayer.
 export interface SyncInternalContextType {
-  webSocket: AppflowyWebSocketType; // WebSocket connection from useAppflowyWebSocket
-  broadcastChannel: BroadcastChannelType; // BroadcastChannel from useBroadcastChannel
   registerSyncContext: (params: RegisterSyncContext) => SyncContext;
   revertCollabVersion: (viewId: string, version: string) => Promise<void>;
   eventEmitter: EventEmitter;

--- a/src/components/app/layers/AppSyncLayer.tsx
+++ b/src/components/app/layers/AppSyncLayer.tsx
@@ -1,6 +1,6 @@
 import EventEmitter from 'events';
 
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { Awareness } from 'y-protocols/awareness';
 
 import { APP_EVENTS } from '@/application/constants';
@@ -60,28 +60,30 @@ export const AppSyncLayer: React.FC<AppSyncLayerProps> = ({ children }) => {
     currentWorkspaceId!
   );
 
-  // Handle WebSocket reconnection
-  const reconnectWebSocket = useCallback(() => {
-    webSocket.reconnect();
-  }, [webSocket]);
+  // Handle WebSocket reconnection. Depend on the stable `reconnect` function,
+  // not the webSocket container whose identity changes per incoming message.
+  const webSocketReconnect = webSocket.reconnect;
 
   // Set up WebSocket reconnection event listener
   useEffect(() => {
     const currentEventEmitter = eventEmitterRef.current;
 
-    currentEventEmitter.on(APP_EVENTS.RECONNECT_WEBSOCKET, reconnectWebSocket);
+    currentEventEmitter.on(APP_EVENTS.RECONNECT_WEBSOCKET, webSocketReconnect);
 
     return () => {
-      currentEventEmitter.off(APP_EVENTS.RECONNECT_WEBSOCKET, reconnectWebSocket);
+      currentEventEmitter.off(APP_EVENTS.RECONNECT_WEBSOCKET, webSocketReconnect);
     };
-  }, [reconnectWebSocket]);
+  }, [webSocketReconnect]);
 
-  // Emit WebSocket status changes
+  // Emit WebSocket status on actual readyState transitions only — not on every
+  // webSocket identity change (which happens for each incoming message).
+  const webSocketReadyState = webSocket.readyState;
+
   useEffect(() => {
     const currentEventEmitter = eventEmitterRef.current;
 
-    currentEventEmitter.emit(APP_EVENTS.WEBSOCKET_STATUS, webSocket.readyState);
-  }, [webSocket]);
+    currentEventEmitter.emit(APP_EVENTS.WEBSOCKET_STATUS, webSocketReadyState);
+  }, [webSocketReadyState]);
 
   // Wire the persistent sync_outbox drain to this WebSocket. The drain loop
   // runs whenever a record is enqueued AND the socket is OPEN. The drain is
@@ -109,10 +111,7 @@ export const AppSyncLayer: React.FC<AppSyncLayerProps> = ({ children }) => {
   // unrelated re-render (e.g. WS status, BC message, child remount) just
   // burns a localStorage read + JSON.parse. Token-refresh still flows in
   // because `isAuthenticated` gates AppSyncLayer's mount via the auth layer.
-  const currentUserId = useMemo(
-    () => (isAuthenticated ? getTokenParsed()?.user?.id ?? null : null),
-    [isAuthenticated]
-  );
+  const currentUserId = useMemo(() => (isAuthenticated ? getTokenParsed()?.user?.id ?? null : null), [isAuthenticated]);
 
   useEffect(() => {
     if (currentUserId && currentWorkspaceId) {
@@ -227,9 +226,7 @@ export const AppSyncLayer: React.FC<AppSyncLayerProps> = ({ children }) => {
       }
     };
 
-    const handleWorkspaceMemberProfileChange = async (
-      profileChange: notification.IWorkspaceMemberProfileChanged
-    ) => {
+    const handleWorkspaceMemberProfileChange = async (profileChange: notification.IWorkspaceMemberProfileChanged) => {
       if (!currentWorkspaceId) {
         console.warn('No current workspace ID available');
         return;
@@ -298,9 +295,7 @@ export const AppSyncLayer: React.FC<AppSyncLayerProps> = ({ children }) => {
                   ...baseProfile,
                   name: profileChange.name ?? baseProfile.name,
                   avatar_url:
-                    profileChange.avatarUrl !== undefined
-                      ? profileChange.avatarUrl || null
-                      : baseProfile.avatar_url,
+                    profileChange.avatarUrl !== undefined ? profileChange.avatarUrl || null : baseProfile.avatar_url,
                   cover_image_url:
                     profileChange.coverImageUrl !== undefined
                       ? profileChange.coverImageUrl || null
@@ -378,11 +373,12 @@ export const AppSyncLayer: React.FC<AppSyncLayerProps> = ({ children }) => {
     };
   }, [isAuthenticated, currentWorkspaceId]);
 
-  // Context value for synchronization layer
+  // Context value for synchronization layer. The webSocket/broadcastChannel
+  // transports are intentionally excluded: their identity changes on every
+  // incoming message and would re-render all consumers per message. Everything
+  // exposed here is referentially stable across messages.
   const syncContextValue: SyncInternalContextType = useMemo(
     () => ({
-      webSocket,
-      broadcastChannel,
       registerSyncContext,
       revertCollabVersion,
       eventEmitter: eventEmitterRef.current,
@@ -391,7 +387,7 @@ export const AppSyncLayer: React.FC<AppSyncLayerProps> = ({ children }) => {
       syncAllToServer,
       scheduleDeferredCleanup,
     }),
-    [webSocket, broadcastChannel, registerSyncContext, revertCollabVersion, awarenessMap, flushAllSync, syncAllToServer, scheduleDeferredCleanup]
+    [registerSyncContext, revertCollabVersion, awarenessMap, flushAllSync, syncAllToServer, scheduleDeferredCleanup]
   );
 
   return <SyncInternalContext.Provider value={syncContextValue}>{children}</SyncInternalContext.Provider>;

--- a/src/components/app/layers/__tests__/AppSyncLayer.test.tsx
+++ b/src/components/app/layers/__tests__/AppSyncLayer.test.tsx
@@ -1,0 +1,173 @@
+import { render } from '@testing-library/react';
+import { memo, useEffect } from 'react';
+
+import { APP_EVENTS } from '@/application/constants';
+import { AuthInternalContext, type AuthInternalContextType } from '@/components/app/contexts/AuthInternalContext';
+import { useSyncInternal } from '@/components/app/contexts/SyncInternalContext';
+import { AppSyncLayer } from '@/components/app/layers/AppSyncLayer';
+import { useAppflowyWebSocket, useBroadcastChannel, useSync } from '@/components/ws';
+import type { AppflowyWebSocketType } from '@/components/ws/useAppflowyWebSocket';
+import type { BroadcastChannelType } from '@/components/ws/useBroadcastChannel';
+import type { messages } from '@/proto/messages';
+
+jest.mock('@/components/ws', () => ({
+  useAppflowyWebSocket: jest.fn(),
+  useBroadcastChannel: jest.fn(),
+  useSync: jest.fn(),
+}));
+
+jest.mock('@/application/services/domains', () => ({
+  CollabService: {
+    getClientId: jest.fn(() => 7),
+    getDeviceId: jest.fn(() => 'device-1'),
+  },
+  UserService: {
+    getWorkspaceMemberProfile: jest.fn(),
+  },
+}));
+
+jest.mock('@/application/session/token', () => ({
+  getTokenParsed: jest.fn(() => ({ user: { id: 'user-1' } })),
+}));
+
+jest.mock('@/application/sync-outbox', () => ({
+  clearDrainConfig: jest.fn(),
+  configureDrain: jest.fn(),
+  setCurrentSession: jest.fn(),
+  startDrainAll: jest.fn(),
+}));
+
+jest.mock('@/application/db', () => ({
+  db: {
+    users: { get: jest.fn(), put: jest.fn() },
+    workspace_member_profiles: { put: jest.fn() },
+  },
+}));
+
+const mockUseAppflowyWebSocket = useAppflowyWebSocket as jest.Mock;
+const mockUseBroadcastChannel = useBroadcastChannel as jest.Mock;
+const mockUseSync = useSync as jest.Mock;
+
+// Stable per-connection pieces, matching the real (memoized) hook behaviour:
+// these keep their identity across messages — only the container object and
+// lastMessage change when a message arrives.
+const stableWsSendMessage = jest.fn();
+const stableWsReconnect = jest.fn();
+const stableBcValue: BroadcastChannelType = {
+  lastBroadcastMessage: null,
+  postMessage: jest.fn(),
+};
+const stableSyncValue = {
+  registerSyncContext: jest.fn(),
+  revertCollabVersion: jest.fn(),
+  flushAllSync: jest.fn(),
+  syncAllToServer: jest.fn(),
+  scheduleDeferredCleanup: jest.fn(),
+};
+
+const createWsValue = (lastMessage: messages.Message | null): AppflowyWebSocketType =>
+  ({
+    lastMessage,
+    sendMessage: stableWsSendMessage,
+    readyState: 1,
+    options: { workspaceId: 'workspace-1' },
+    reconnectAttempt: 0,
+    reconnect: stableWsReconnect,
+  } as AppflowyWebSocketType);
+
+const authContextValue = {
+  currentWorkspaceId: 'workspace-1',
+  isAuthenticated: true,
+} as unknown as AuthInternalContextType;
+
+let consumerRenderCount = 0;
+let websocketStatusEmits = 0;
+
+const ContextConsumer = memo(function ContextConsumer() {
+  const { eventEmitter } = useSyncInternal();
+
+  consumerRenderCount += 1;
+
+  useEffect(() => {
+    const handleStatus = () => {
+      websocketStatusEmits += 1;
+    };
+
+    eventEmitter.on(APP_EVENTS.WEBSOCKET_STATUS, handleStatus);
+
+    return () => {
+      eventEmitter.off(APP_EVENTS.WEBSOCKET_STATUS, handleStatus);
+    };
+  }, [eventEmitter]);
+
+  return <div data-testid='consumer' />;
+});
+
+const renderLayer = () =>
+  render(
+    <AuthInternalContext.Provider value={authContextValue}>
+      <AppSyncLayer>
+        <ContextConsumer />
+      </AppSyncLayer>
+    </AuthInternalContext.Provider>
+  );
+
+const rerenderLayer = (rerender: ReturnType<typeof render>['rerender']) =>
+  rerender(
+    <AuthInternalContext.Provider value={authContextValue}>
+      <AppSyncLayer>
+        <ContextConsumer />
+      </AppSyncLayer>
+    </AuthInternalContext.Provider>
+  );
+
+describe('AppSyncLayer per-message churn', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    consumerRenderCount = 0;
+    websocketStatusEmits = 0;
+    mockUseBroadcastChannel.mockReturnValue(stableBcValue);
+    mockUseSync.mockReturnValue(stableSyncValue);
+    mockUseAppflowyWebSocket.mockReturnValue(createWsValue(null));
+  });
+
+  // Reproduces the fan-out bug: an incoming collab message produces a new
+  // webSocket value (new lastMessage), which must NOT rebuild the sync context
+  // value — otherwise every context consumer re-renders on every message.
+  it('does not re-render context consumers when a websocket message arrives', () => {
+    const { rerender } = renderLayer();
+
+    const rendersAfterMount = consumerRenderCount;
+
+    // Simulate a message arriving: same connection (stable functions and
+    // readyState), new container identity with a new lastMessage.
+    mockUseAppflowyWebSocket.mockReturnValue(createWsValue({ collabMessage: {} } as unknown as messages.Message));
+    rerenderLayer(rerender);
+
+    expect(consumerRenderCount).toBe(rendersAfterMount);
+  });
+
+  // Reproduces the spurious status broadcast: WEBSOCKET_STATUS must be emitted
+  // on readyState transitions, not re-emitted for every incoming message.
+  it('does not re-emit WEBSOCKET_STATUS when a message arrives without a readyState change', () => {
+    const { rerender } = renderLayer();
+
+    const emitsAfterMount = websocketStatusEmits;
+
+    mockUseAppflowyWebSocket.mockReturnValue(createWsValue({ collabMessage: {} } as unknown as messages.Message));
+    rerenderLayer(rerender);
+
+    expect(websocketStatusEmits).toBe(emitsAfterMount);
+  });
+
+  it('emits WEBSOCKET_STATUS when the readyState actually changes', () => {
+    const { rerender } = renderLayer();
+
+    const emitsAfterMount = websocketStatusEmits;
+
+    mockUseAppflowyWebSocket.mockReturnValue({ ...createWsValue(null), readyState: 3 });
+    rerenderLayer(rerender);
+
+    expect(websocketStatusEmits).toBe(emitsAfterMount + 1);
+  });
+});

--- a/src/components/ws/__tests__/useAppflowyWebSocket.test.ts
+++ b/src/components/ws/__tests__/useAppflowyWebSocket.test.ts
@@ -1,0 +1,157 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+
+import { getTokenParsed } from '@/application/session/token';
+
+import { useAppflowyWebSocket, Options } from '../useAppflowyWebSocket';
+
+// Stable return value: useWebSocket must hand back the same object/functions
+// across renders, like the real library does for an unchanged connection.
+const stableSendMessage = jest.fn();
+const stableGetWebSocket = jest.fn(() => null);
+const mockUseWebSocket = jest.fn(() => ({
+  lastMessage: null,
+  sendMessage: stableSendMessage,
+  readyState: 1,
+  getWebSocket: stableGetWebSocket,
+}));
+
+jest.mock('react-use-websocket', () => ({
+  __esModule: true,
+  default: (...args: unknown[]) => mockUseWebSocket(...(args as [])),
+}));
+
+jest.mock('@/application/session/token', () => ({
+  getTokenParsed: jest.fn(),
+  invalidToken: jest.fn(),
+}));
+
+jest.mock('@/application/services/js-services/http/gotrue', () => ({
+  refreshToken: jest.fn(),
+}));
+
+const mockGetTokenParsed = getTokenParsed as jest.Mock;
+
+const futureExpiry = () => Math.floor(Date.now() / 1000) + 3600;
+
+const setStoredToken = (accessToken: string) => {
+  mockGetTokenParsed.mockReturnValue({
+    access_token: accessToken,
+    refresh_token: 'refresh-token',
+    expires_at: futureExpiry(),
+  });
+};
+
+const lastSocketUrl = (): string => {
+  const calls = mockUseWebSocket.mock.calls as unknown as [string][];
+
+  return calls[calls.length - 1][0];
+};
+
+const lastSocketOptions = () => {
+  const calls = mockUseWebSocket.mock.calls as unknown as [
+    string,
+    { shouldReconnect?: (event: CloseEvent) => boolean }
+  ][];
+
+  return calls[calls.length - 1][1];
+};
+
+const baseOptions: Options = {
+  workspaceId: 'workspace-1',
+  clientId: 7,
+  deviceId: 'device-1',
+};
+
+describe('useAppflowyWebSocket', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    setStoredToken('token-A');
+  });
+
+  it('connects with the session token in the socket URL', () => {
+    renderHook(() => useAppflowyWebSocket(baseOptions));
+
+    expect(lastSocketUrl()).toContain('token=token-A');
+    expect(lastSocketUrl()).toContain('/workspace-1/');
+  });
+
+  // Reproduces the silent-reconnect bug: the HTTP layer refreshing the stored
+  // token must NOT change the socket URL on the next render — a URL change
+  // makes react-use-websocket tear down and reopen the connection, bypassing
+  // the throttled nonce reconnect path entirely.
+  it('keeps the socket URL stable when the stored token is refreshed mid-session', () => {
+    const { rerender } = renderHook(() => useAppflowyWebSocket(baseOptions));
+
+    const initialUrl = lastSocketUrl();
+
+    setStoredToken('token-B');
+    rerender();
+
+    expect(lastSocketUrl()).toBe(initialUrl);
+  });
+
+  // Guards the load-bearing counterpart of the test above: an explicit
+  // reconnect MUST pick up the freshest stored token, since the old one may
+  // have been rotated or expired while the socket was down.
+  it('uses the freshest stored token when a reconnect is triggered', async () => {
+    const { result } = renderHook(() => useAppflowyWebSocket(baseOptions));
+
+    setStoredToken('token-B');
+
+    act(() => {
+      result.current.reconnect();
+    });
+
+    await waitFor(() => {
+      expect(lastSocketUrl()).toContain('_rc=1');
+    });
+
+    expect(lastSocketUrl()).toContain('token=token-B');
+  });
+
+  it('uses the freshest stored token when react-use-websocket schedules an automatic retry', async () => {
+    renderHook(() => useAppflowyWebSocket(baseOptions));
+
+    setStoredToken('token-B');
+
+    act(() => {
+      expect(lastSocketOptions().shouldReconnect?.({ code: 1006, reason: 'abnormal close' } as CloseEvent)).toBe(true);
+    });
+
+    await waitFor(() => {
+      expect(lastSocketUrl()).toContain('token=token-B');
+    });
+
+    expect(lastSocketUrl()).not.toContain('_rc=');
+  });
+
+  // Reproduces the per-message fan-out amplifier: the hook returned a fresh
+  // object literal every render, so every consumer of the hook value (and the
+  // SyncInternalContext built from it) re-rendered even when nothing changed.
+  it('returns a referentially stable value across re-renders with equivalent options', () => {
+    const { result, rerender } = renderHook(({ options }) => useAppflowyWebSocket(options), {
+      initialProps: { options: { ...baseOptions } },
+    });
+
+    const first = result.current;
+
+    // New options object with identical values, as produced by an inline
+    // object literal in the calling component.
+    rerender({ options: { ...baseOptions } });
+
+    expect(result.current).toBe(first);
+  });
+
+  it('keeps sendMessage and reconnect referentially stable across re-renders', () => {
+    const { result, rerender } = renderHook(({ options }) => useAppflowyWebSocket(options), {
+      initialProps: { options: { ...baseOptions } },
+    });
+
+    const { sendMessage, reconnect } = result.current;
+
+    rerender({ options: { ...baseOptions } });
+
+    expect(result.current.sendMessage).toBe(sendMessage);
+    expect(result.current.reconnect).toBe(reconnect);
+  });
+});

--- a/src/components/ws/__tests__/useBroadcastChannel.test.ts
+++ b/src/components/ws/__tests__/useBroadcastChannel.test.ts
@@ -1,0 +1,168 @@
+import { act, renderHook } from '@testing-library/react';
+
+import { messages } from '@/proto/messages';
+
+import { useBroadcastChannel } from '../useBroadcastChannel';
+
+// jsdom does not implement BroadcastChannel; install a recording mock so the
+// tests can assert on channel lifecycle (create/post/close) per instance.
+class MockBroadcastChannel {
+  static instances: MockBroadcastChannel[] = [];
+
+  name: string;
+  closed = false;
+  postMessage = jest.fn((data: unknown) => {
+    if (this.closed) {
+      const error = new Error('Channel is closed');
+
+      error.name = 'InvalidStateError';
+      throw error;
+    }
+
+    void data;
+  });
+
+  private listeners = new Map<string, Set<(event: MessageEvent) => void>>();
+
+  constructor(name: string) {
+    this.name = name;
+    MockBroadcastChannel.instances.push(this);
+  }
+
+  addEventListener(type: string, listener: (event: MessageEvent) => void) {
+    if (!this.listeners.has(type)) {
+      this.listeners.set(type, new Set());
+    }
+
+    this.listeners.get(type)!.add(listener);
+  }
+
+  removeEventListener(type: string, listener: (event: MessageEvent) => void) {
+    this.listeners.get(type)?.delete(listener);
+  }
+
+  close() {
+    this.closed = true;
+  }
+
+  emitMessage(data: ArrayBuffer | Uint8Array) {
+    for (const listener of this.listeners.get('message') ?? []) {
+      listener({ data } as MessageEvent);
+    }
+  }
+}
+
+describe('useBroadcastChannel', () => {
+  const originalBroadcastChannel = (globalThis as { BroadcastChannel?: unknown }).BroadcastChannel;
+
+  beforeEach(() => {
+    MockBroadcastChannel.instances = [];
+    (globalThis as { BroadcastChannel?: unknown }).BroadcastChannel = MockBroadcastChannel;
+  });
+
+  afterAll(() => {
+    (globalThis as { BroadcastChannel?: unknown }).BroadcastChannel = originalBroadcastChannel;
+  });
+
+  const message: messages.IMessage = {};
+
+  it('posts messages on the active channel', () => {
+    const { result } = renderHook(({ name }) => useBroadcastChannel(name), {
+      initialProps: { name: 'workspace:A' },
+    });
+
+    act(() => {
+      result.current.postMessage(message);
+    });
+
+    expect(MockBroadcastChannel.instances).toHaveLength(1);
+    expect(MockBroadcastChannel.instances[0].postMessage).toHaveBeenCalledTimes(1);
+    // protobufjs may emit Buffer (a Uint8Array subclass from another realm in
+    // jsdom), so assert on shape rather than constructor identity.
+    const payload = MockBroadcastChannel.instances[0].postMessage.mock.calls[0][0] as Uint8Array;
+
+    expect(typeof payload.byteLength).toBe('number');
+  });
+
+  it('exposes received messages as lastBroadcastMessage', () => {
+    const { result } = renderHook(({ name }) => useBroadcastChannel(name), {
+      initialProps: { name: 'workspace:A' },
+    });
+
+    const encoded = messages.Message.encode(message).finish();
+
+    act(() => {
+      MockBroadcastChannel.instances[0].emitMessage(encoded);
+    });
+
+    expect(result.current.lastBroadcastMessage).toBeInstanceOf(messages.Message);
+  });
+
+  it('closes the previous channel when the channel name changes', () => {
+    const { rerender } = renderHook(({ name }) => useBroadcastChannel(name), {
+      initialProps: { name: 'workspace:A' },
+    });
+
+    rerender({ name: 'workspace:B' });
+
+    const [first, second] = MockBroadcastChannel.instances;
+
+    expect(MockBroadcastChannel.instances).toHaveLength(2);
+    expect(first.closed).toBe(true);
+    expect(second.closed).toBe(false);
+  });
+
+  // Reproduces the workspace-switch bug: the closed flag set during the old
+  // channel's cleanup must not leak into the replacement channel, otherwise
+  // every cross-tab broadcast after a workspace switch is silently dropped.
+  it('keeps posting messages after switching to a new channel', () => {
+    const { result, rerender } = renderHook(({ name }) => useBroadcastChannel(name), {
+      initialProps: { name: 'workspace:A' },
+    });
+
+    act(() => {
+      result.current.postMessage(message);
+    });
+
+    rerender({ name: 'workspace:B' });
+
+    act(() => {
+      result.current.postMessage(message);
+    });
+
+    const [first, second] = MockBroadcastChannel.instances;
+
+    expect(first.postMessage).toHaveBeenCalledTimes(1);
+    expect(second.postMessage).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps postMessage referentially stable across channel switches and sends', () => {
+    const { result, rerender } = renderHook(({ name }) => useBroadcastChannel(name), {
+      initialProps: { name: 'workspace:A' },
+    });
+
+    const initialPostMessage = result.current.postMessage;
+
+    act(() => {
+      result.current.postMessage(message);
+    });
+
+    rerender({ name: 'workspace:B' });
+
+    expect(result.current.postMessage).toBe(initialPostMessage);
+  });
+
+  it('drops sends without throwing after the channel is closed underneath', () => {
+    const { result } = renderHook(({ name }) => useBroadcastChannel(name), {
+      initialProps: { name: 'workspace:A' },
+    });
+
+    MockBroadcastChannel.instances[0].close();
+
+    expect(() => {
+      act(() => {
+        result.current.postMessage(message);
+      });
+    }).not.toThrow();
+  });
+});

--- a/src/components/ws/useAppflowyWebSocket.ts
+++ b/src/components/ws/useAppflowyWebSocket.ts
@@ -184,7 +184,11 @@ export interface Options {
 
 export const useAppflowyWebSocket = (options: Options): AppflowyWebSocketType => {
   const wsUrl = options.url || wsURL;
-  const token = options.token || getTokenParsed()?.access_token;
+  // The token is captured in state rather than read from the session on every
+  // render: a mid-session refresh by the HTTP layer must not change the socket
+  // URL (which would force a silent reconnect outside the throttled nonce
+  // path). Reconnects re-read the freshest token in bumpReconnectNonce.
+  const [token, setToken] = useState(() => options.token || getTokenParsed()?.access_token);
   // Stable across re-renders: generate once via lazy initializer, not on every render.
   const [clientId] = useState(() => options.clientId || random.uint32());
   const [deviceId] = useState(() => options.deviceId || random.uuidv4());
@@ -211,6 +215,12 @@ export const useAppflowyWebSocket = (options: Options): AppflowyWebSocketType =>
   const tokenRefreshInFlightRef = useRef<Promise<ReconnectAuthStatus> | null>(null);
   const isMountedRef = useRef(true);
 
+  const syncTokenForReconnect = useCallback(() => {
+    const nextToken = options.token || getTokenParsed()?.access_token;
+
+    setToken((currentToken) => (currentToken === nextToken ? currentToken : nextToken));
+  }, [options.token]);
+
   const clearSlowPollRecovery = useCallback(() => {
     reconnectStoppedRef.current = false;
     if (slowPollTimerRef.current) {
@@ -231,8 +241,12 @@ export const useAppflowyWebSocket = (options: Options): AppflowyWebSocketType =>
     }
 
     lastNonceBumpRef.current = now;
+    // The stored token may have been rotated (e.g. refreshed by
+    // ensureFreshTokenForReconnect or the HTTP layer) while the socket was
+    // down; the new connection must authenticate with the freshest one.
+    syncTokenForReconnect();
     setReconnectNonce((n) => n + 1);
-  }, []);
+  }, [syncTokenForReconnect]);
 
   const ensureFreshTokenForReconnect = useCallback(async (): Promise<ReconnectAuthStatus> => {
     // If token is explicitly provided by caller, we can't refresh it from session state.
@@ -350,6 +364,10 @@ export const useAppflowyWebSocket = (options: Options): AppflowyWebSocketType =>
         return false;
       }
 
+      // Automatic react-use-websocket retries reuse the current URL prop. If
+      // the HTTP layer rotated the stored token while this socket was open,
+      // refresh our URL token before the scheduled retry starts.
+      syncTokenForReconnect();
       return true;
     },
 
@@ -492,17 +510,30 @@ export const useAppflowyWebSocket = (options: Options): AppflowyWebSocketType =>
     [lastMessage]
   );
 
+  // Depend on the primitive fields, not the options object identity: callers
+  // typically pass an inline object literal, which would defeat the memo.
   const resolvedOptions = useMemo<Options>(
-    () => ({ ...options, url: wsUrl, clientId, deviceId }),
-    [options, wsUrl, clientId, deviceId]
+    () => ({
+      workspaceId: options.workspaceId,
+      token: options.token,
+      url: wsUrl,
+      clientId,
+      deviceId,
+    }),
+    [options.workspaceId, options.token, wsUrl, clientId, deviceId]
   );
 
-  return {
-    lastMessage: lastProtobufMessage,
-    sendMessage: sendProtobufMessage,
-    readyState,
-    options: resolvedOptions,
-    reconnectAttempt,
-    reconnect: manualReconnect,
-  };
+  // Memoized so consumers (and context values built from this) only re-render
+  // when something actually changed, not on every render of the host component.
+  return useMemo(
+    () => ({
+      lastMessage: lastProtobufMessage,
+      sendMessage: sendProtobufMessage,
+      readyState,
+      options: resolvedOptions,
+      reconnectAttempt,
+      reconnect: manualReconnect,
+    }),
+    [lastProtobufMessage, sendProtobufMessage, readyState, resolvedOptions, reconnectAttempt, manualReconnect]
+  );
 };

--- a/src/components/ws/useBroadcastChannel.ts
+++ b/src/components/ws/useBroadcastChannel.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
 import { messages } from '@/proto/messages';
 import { Log } from '@/utils/log';
@@ -10,32 +10,38 @@ export type BroadcastChannelType = {
 
 /**
  * Hook for cross-tab synchronization using BroadcastChannel API
- * 
+ *
  * Purpose: Enables communication between multiple browser tabs of the same workspace
  * to ensure consistent real-time updates across all tabs.
- * 
+ *
  * Multi-tab Architecture:
  * - Only one tab per workspace maintains active WebSocket connection
  * - That "active" tab receives server notifications directly
  * - Active tab broadcasts messages to other tabs via BroadcastChannel
  * - Other tabs receive and process broadcasted messages identically
- * 
+ *
  * Example: User profile change notification
  * 1. Server → WebSocket → Tab A (active)
  * 2. Tab A processes notification + updates its UI
  * 3. Tab A broadcasts message to BroadcastChannel
  * 4. Tab B & C receive broadcast + update their UI
  * 5. Result: All tabs show updated profile simultaneously
- * 
+ *
  * @param channelName - Unique channel identifier (typically workspace-scoped)
  * @returns Object with lastBroadcastMessage and postMessage function
  */
 export const useBroadcastChannel = (channelName: string): BroadcastChannelType => {
-  const channel = useMemo(() => new BroadcastChannel(channelName), [channelName]);
+  // The live channel for the current channelName. Closed-ness is tracked per
+  // channel instance (not React state) so a workspace switch can never leak a
+  // stale "closed" flag into the replacement channel and silently drop sends.
+  const channelRef = useRef<BroadcastChannel | null>(null);
   const [lastMessage, setLastMessage] = useState<messages.Message | null>(null);
-  const [isChannelClosed, setIsChannelClosed] = useState(false);
 
   useEffect(() => {
+    const channel = new BroadcastChannel(channelName);
+
+    channelRef.current = channel;
+
     const handleMessage = (event: MessageEvent) => {
       const message = messages.Message.decode(new Uint8Array(event.data));
 
@@ -46,32 +52,38 @@ export const useBroadcastChannel = (channelName: string): BroadcastChannelType =
 
     return () => {
       channel.removeEventListener('message', handleMessage);
-      setIsChannelClosed(true);
+
+      if (channelRef.current === channel) {
+        channelRef.current = null;
+      }
+
       channel.close();
     };
-  }, [channel]);
+  }, [channelName]);
 
-  const sendMessage = useCallback(
-    (msg: messages.IMessage) => {
-      if (isChannelClosed) {
-        // Fail silently instead of showing warning - this is normal during cleanup
-        Log.debug('BroadcastChannel closed, skipping message send');
-        return;
-      }
+  const sendMessage = useCallback((msg: messages.IMessage) => {
+    const channel = channelRef.current;
 
-      try {
-        channel.postMessage(messages.Message.encode(msg).finish());
-      } catch (error) {
-        if (error instanceof Error && error.name === 'InvalidStateError') {
-          setIsChannelClosed(true);
-          Log.debug('BroadcastChannel closed during send operation');
-        } else {
-          console.error('Failed to send message to BroadcastChannel:', error);
+    if (!channel) {
+      // Fail silently instead of showing warning - this is normal during cleanup
+      Log.debug('BroadcastChannel closed, skipping message send');
+      return;
+    }
+
+    try {
+      channel.postMessage(messages.Message.encode(msg).finish());
+    } catch (error) {
+      if (error instanceof Error && error.name === 'InvalidStateError') {
+        if (channelRef.current === channel) {
+          channelRef.current = null;
         }
+
+        Log.debug('BroadcastChannel closed during send operation');
+      } else {
+        console.error('Failed to send message to BroadcastChannel:', error);
       }
-    },
-    [channel, isChannelClosed]
-  );
+    }
+  }, []);
 
   return { lastBroadcastMessage: lastMessage, postMessage: sendMessage };
 };


### PR DESCRIPTION
## Summary
- avoid per-message sync context churn and duplicate websocket status emits
- keep websocket automatic retries on the freshest stored auth token without resetting retry counters
- fix BroadcastChannel lifecycle across channel switches
- deduplicate GoTrue refresh requests per refresh token, including interleaved rotating-token refreshes

## Tests
- pnpm exec jest src/application/services/js-services/http/__tests__/gotrue-refresh-dedup.test.ts src/components/ws/__tests__/useAppflowyWebSocket.test.ts src/components/ws/__tests__/useBroadcastChannel.test.ts src/components/app/layers/__tests__/AppSyncLayer.test.tsx --runInBand --no-coverage
- pnpm run type-check

## Summary by Sourcery

Improve realtime sync stability by deduplicating auth refreshes, fixing cross-tab broadcast lifecycle, and stabilizing WebSocket reconnect behavior and sync context updates.

Bug Fixes:
- Deduplicate concurrent GoTrue refreshToken calls per refresh token to avoid rotating-token failures and shared refresh stampedes.
- Prevent BroadcastChannel sends from being dropped after workspace/channel switches by managing channel lifecycle via refs instead of closed flags.
- Ensure WebSocket reconnects and automatic retries always use the freshest stored auth token without causing unintended URL-based reconnects.
- Stop emitting WEBSOCKET_STATUS and rebuilding sync context on every WebSocket message by memoizing WebSocket options and sync context values.

Enhancements:
- Stabilize useAppflowyWebSocket return value and callbacks across renders to reduce unnecessary rerenders in consumers.
- Refine AppSyncLayer wiring to depend on stable WebSocket reconnect handlers and readyState, decoupling transport identity from sync context.
- Add targeted tests covering GoTrue token refresh deduplication, BroadcastChannel lifecycle, WebSocket token/URL behavior, and sync layer render behavior.