### PR TITLE
fix: hydrate sidebar outline for notification targets

### DIFF
--- a/playwright/e2e/app/outline-navigation-notification.spec.ts
+++ b/playwright/e2e/app/outline-navigation-notification.spec.ts
@@ -1,0 +1,367 @@
+import { test, expect, type Page, type Route } from '@playwright/test';
+import { readFileSync } from 'node:fs';
+
+import { signInAndWaitForApp } from '../../support/auth-flow-helpers';
+import { PageSelectors, SpaceSelectors } from '../../support/selectors';
+import { generateRandomEmail } from '../../support/test-config';
+
+const VIEW_LAYOUT_DOCUMENT = 0;
+const spaceId = '11111111-1111-4111-8111-111111111111';
+const rootId = '22222222-2222-4222-8222-222222222222';
+const parentId = '33333333-3333-4333-8333-333333333333';
+const targetId = '44444444-4444-4444-8444-444444444444';
+const rootSiblingId = '55555555-5555-4555-8555-555555555555';
+const targetSiblingId = '66666666-6666-4666-8666-666666666666';
+const initialViewId = '77777777-7777-4777-8777-777777777777';
+
+type SidebarView = {
+  folder_rid?: string;
+  view_id: string;
+  name: string;
+  icon: null;
+  layout: number;
+  extra: Record<string, unknown> | null;
+  children: SidebarView[];
+  has_children?: boolean;
+  is_published: boolean;
+  is_private: boolean;
+  parent_view_id?: string;
+};
+
+const simpleDocument = JSON.parse(readFileSync(new URL('../../fixtures/simple_doc.json', import.meta.url), 'utf8')) as {
+  data: {
+    doc_state: number[];
+  };
+};
+
+function createView(viewId: string, overrides: Partial<SidebarView> = {}): SidebarView {
+  return {
+    view_id: viewId,
+    name: overrides.name ?? viewId,
+    icon: null,
+    layout: VIEW_LAYOUT_DOCUMENT,
+    extra: overrides.extra ?? null,
+    children: overrides.children ?? [],
+    has_children: overrides.has_children,
+    is_published: false,
+    is_private: false,
+    parent_view_id: overrides.parent_view_id,
+    ...overrides,
+  };
+}
+
+function apiResponse(data: unknown) {
+  return {
+    code: 0,
+    data,
+    message: 'success',
+  };
+}
+
+async function fulfillJson(route: Route, data: unknown) {
+  await route.fulfill({
+    status: 200,
+    contentType: 'application/json',
+    body: JSON.stringify(apiResponse(data)),
+  });
+}
+
+function extractWorkspaceId(page: Page): string {
+  const match = new URL(page.url()).pathname.match(/\/app\/([^/?#]+)/);
+
+  if (!match?.[1]) {
+    throw new Error(`Unable to extract workspace id from URL: ${page.url()}`);
+  }
+
+  return match[1];
+}
+
+async function installNavigationFixture(page: Page, workspaceId: string, options: { denyTargetAccess?: boolean } = {}) {
+  const targetView = createView(targetId, {
+    name: 'Mention target',
+    parent_view_id: parentId,
+  });
+  const initialView = createView(initialViewId, {
+    name: 'Initial cached page',
+    parent_view_id: spaceId,
+  });
+
+  const shallowWorkspaceRoot = createView(workspaceId, {
+    folder_rid: 'outline-navigation-playwright-1',
+    children: [
+      createView(spaceId, {
+        name: 'Navigation fixture space',
+        extra: {
+          is_space: true,
+          space_icon: '',
+          space_icon_color: '',
+        },
+        has_children: true,
+        children: [initialView],
+      }),
+    ],
+  });
+
+  const navigationRoot = createView(spaceId, {
+    name: 'Navigation fixture space',
+    extra: {
+      is_space: true,
+      space_icon: '',
+      space_icon_color: '',
+    },
+    has_children: true,
+    children: [
+      createView(rootId, {
+        name: 'Root view',
+        has_children: true,
+        parent_view_id: spaceId,
+        children: [
+          createView(parentId, {
+            name: 'Parent view',
+            has_children: true,
+            parent_view_id: rootId,
+            children: [
+              targetView,
+              createView(targetSiblingId, {
+                name: 'Target sibling',
+                parent_view_id: parentId,
+              }),
+            ],
+          }),
+        ],
+      }),
+      createView(rootSiblingId, {
+        name: 'Root sibling',
+        has_children: true,
+        parent_view_id: spaceId,
+      }),
+    ],
+  });
+  const mentionNotification = {
+    id: 'outline-navigation-mention-notification',
+    workspace_id: workspaceId,
+    type: 'mention',
+    view_id: targetId,
+    actor_uid: 1,
+    metadata: {
+      actor_name: 'Navigation Tester',
+      page_name: 'Mention target',
+      page_path: 'Root view / Parent view / Mention target',
+    },
+    is_read: false,
+    is_archived: false,
+    created_at: new Date().toISOString(),
+    read_at: null,
+  };
+
+  await page.route('**/api/workspace/**', async (route) => {
+    const request = route.request();
+    const url = new URL(request.url());
+    const pathname = url.pathname;
+
+    if (request.method() === 'GET' && pathname === `/api/workspace/${workspaceId}/view/${workspaceId}`) {
+      await fulfillJson(route, shallowWorkspaceRoot);
+      return;
+    }
+
+    if (request.method() === 'GET' && pathname === `/api/workspace/${workspaceId}/notifications/unread-count`) {
+      await fulfillJson(route, {
+        unread_count: 1,
+      });
+      return;
+    }
+
+    if (request.method() === 'GET' && pathname === `/api/workspace/${workspaceId}/notifications`) {
+      await fulfillJson(route, {
+        notifications: url.searchParams.get('archived') === 'true' ? [] : [mentionNotification],
+        has_more: false,
+      });
+      return;
+    }
+
+    if (request.method() === 'GET' && pathname === `/api/workspace/${workspaceId}/view/${targetId}/navigation`) {
+      if (options.denyTargetAccess) {
+        await route.fulfill({
+          status: 403,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            code: 403,
+            message: 'not enough permissions',
+          }),
+        });
+        return;
+      }
+
+      await fulfillJson(route, navigationRoot);
+      return;
+    }
+
+    if (request.method() === 'GET' && pathname === `/api/workspace/${workspaceId}/view/${targetId}`) {
+      if (options.denyTargetAccess) {
+        await route.fulfill({
+          status: 403,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            code: 403,
+            message: 'not enough permissions',
+          }),
+        });
+        return;
+      }
+
+      await fulfillJson(route, targetView);
+      return;
+    }
+
+    if (request.method() === 'GET' && pathname === `/api/workspace/${workspaceId}/view/${initialViewId}`) {
+      await fulfillJson(route, initialView);
+      return;
+    }
+
+    if (request.method() === 'GET' && pathname === `/api/workspace/${workspaceId}/page-view/${targetId}`) {
+      await fulfillJson(route, {
+        view: targetView,
+        data: {
+          encoded_collab: simpleDocument.data.doc_state,
+          row_data: {},
+        },
+      });
+      return;
+    }
+
+    if (request.method() === 'GET' && pathname === `/api/workspace/${workspaceId}/page-view/${initialViewId}`) {
+      await fulfillJson(route, {
+        view: initialView,
+        data: {
+          encoded_collab: simpleDocument.data.doc_state,
+          row_data: {},
+        },
+      });
+      return;
+    }
+
+    if (request.method() === 'POST' && pathname === `/api/workspace/${workspaceId}/add-recent-pages`) {
+      await fulfillJson(route, null);
+      return;
+    }
+
+    if (request.method() === 'POST' && pathname === `/api/workspace/${workspaceId}/notifications/read`) {
+      await fulfillJson(route, null);
+      return;
+    }
+
+    await route.continue();
+  });
+}
+
+test.describe('Outline navigation from notification', () => {
+  test.beforeEach(async ({ page }) => {
+    page.on('pageerror', (err) => {
+      if (
+        err.message.includes('No workspace or service found') ||
+        err.message.includes('View not found') ||
+        err.message.includes('WebSocket') ||
+        err.message.includes('connection') ||
+        err.message.includes('ResizeObserver loop') ||
+        err.message.includes('Non-Error promise rejection')
+      ) {
+        return;
+      }
+
+      throw err;
+    });
+  });
+
+  async function openMentionNotification(page: Page, workspaceId: string) {
+    await page.goto(`/app/${workspaceId}/${initialViewId}`, { waitUntil: 'domcontentloaded' });
+    await expect(SpaceSelectors.names(page).filter({ hasText: 'Navigation fixture space' })).toBeVisible({
+      timeout: 30000,
+    });
+    await expect(PageSelectors.nameContaining(page, 'Mention target')).toHaveCount(0);
+
+    await page
+      .getByRole('button', {
+        name: /notifications|settings\.notifications\.titles\.notifications/i,
+      })
+      .click();
+    await expect(page.getByText('Mentioned You')).toBeVisible({ timeout: 30000 });
+
+    const navigationRequest = page.waitForRequest((request) => {
+      const url = new URL(request.url());
+
+      return request.method() === 'GET' && url.pathname === `/api/workspace/${workspaceId}/view/${targetId}/navigation`;
+    });
+
+    await page.getByRole('button').filter({ hasText: 'Mention target' }).first().click();
+    await navigationRequest;
+  }
+
+  test('opens a deep target from a mention notification and expands sidebar context', async ({ page, request }) => {
+    await signInAndWaitForApp(page, request, generateRandomEmail());
+
+    const workspaceId = extractWorkspaceId(page);
+
+    await installNavigationFixture(page, workspaceId);
+    await page.evaluate(() => {
+      window.localStorage.removeItem('outline_expanded');
+    });
+
+    await openMentionNotification(page, workspaceId);
+    await expect(page).toHaveURL(new RegExp(`/app/${workspaceId}/${targetId}`));
+
+    await expect(PageSelectors.nameContaining(page, 'Mention target')).toBeVisible({ timeout: 30000 });
+    await expect(PageSelectors.nameContaining(page, 'Parent view')).toBeVisible();
+    await expect(PageSelectors.nameContaining(page, 'Target sibling')).toBeVisible();
+    await expect(PageSelectors.nameContaining(page, 'Root sibling')).toBeVisible();
+    await expect(PageSelectors.pageByViewId(page, targetId)).toHaveAttribute('data-selected', 'true');
+
+    await expect
+      .poll(async () => {
+        return page.evaluate(
+          ([spaceViewId, rootViewId, parentViewId]) => {
+            const expanded = JSON.parse(window.localStorage.getItem('outline_expanded') || '{}') as Record<
+              string,
+              boolean
+            >;
+
+            return [expanded[spaceViewId], expanded[rootViewId], expanded[parentViewId]];
+          },
+          [spaceId, rootId, parentId]
+        );
+      })
+      .toEqual([true, true, true]);
+  });
+
+  test('keeps the sidebar closed when the notification target is denied by navigation API', async ({
+    page,
+    request,
+  }) => {
+    await signInAndWaitForApp(page, request, generateRandomEmail());
+
+    const workspaceId = extractWorkspaceId(page);
+
+    await installNavigationFixture(page, workspaceId, { denyTargetAccess: true });
+    await page.evaluate(() => {
+      window.localStorage.removeItem('outline_expanded');
+    });
+
+    await openMentionNotification(page, workspaceId);
+
+    await expect(PageSelectors.nameContaining(page, 'Mention target')).toHaveCount(0);
+    await expect
+      .poll(async () => {
+        return page.evaluate(
+          ([spaceViewId, rootViewId, parentViewId]) => {
+            const expanded = JSON.parse(window.localStorage.getItem('outline_expanded') || '{}') as Record<
+              string,
+              boolean
+            >;
+
+            return [expanded[spaceViewId], expanded[rootViewId], expanded[parentViewId]];
+          },
+          [spaceId, rootId, parentId]
+        );
+      })
+      .toEqual([undefined, undefined, undefined]);
+  });
+});

--- a/src/application/services/domains/view.ts
+++ b/src/application/services/domains/view.ts
@@ -1,5 +1,6 @@
 export {
   getAppOutline as getOutline,
+  getViewNavigation as getNavigation,
   getViews as getMultiple,
   getAppFavorites as getFavorites,
   getAppRecent as getRecent,

--- a/src/application/services/js-services/http/view-api.ts
+++ b/src/application/services/js-services/http/view-api.ts
@@ -21,6 +21,12 @@ export async function getView(workspaceId: string, viewId: string, depth: number
   return executeAPIRequest<View>(() => getAxios()?.get<APIResponse<View>>(url));
 }
 
+export async function getViewNavigation(workspaceId: string, viewId: string, depth: number = 0) {
+  const url = `/api/workspace/${workspaceId}/view/${viewId}/navigation?depth=${depth}`;
+
+  return executeAPIRequest<View>(() => getAxios()?.get<APIResponse<View>>(url));
+}
+
 export async function getViews(workspaceId: string, viewIds: string[], depth: number = 2) {
   if (viewIds.length === 0) return [];
 

--- a/src/components/app/app.hooks.tsx
+++ b/src/components/app/app.hooks.tsx
@@ -328,6 +328,17 @@ export function useMarkViewChildrenStale() {
   return context.markViewChildrenStale;
 }
 
+/** Hydrate missing parent/sibling context for a view and return ancestor IDs to expand. */
+export function useEnsureViewVisibleInOutline() {
+  const context = useContext(AppOutlineContext);
+
+  if (!context) {
+    throw new Error('useEnsureViewVisibleInOutline must be used within an AppProvider');
+  }
+
+  return context.ensureViewVisibleInOutline;
+}
+
 /** Revalidate the root sidebar outline and refresh currently expanded sidebar subtrees. */
 export function useRevalidateSidebarOutline() {
   const context = useContext(AppOutlineContext);

--- a/src/components/app/contexts/AppOutlineContext.ts
+++ b/src/components/app/contexts/AppOutlineContext.ts
@@ -22,6 +22,7 @@ import type { SidebarOutlineRevalidationResult } from '@/components/app/outline/
  * - `useLoadViewChildren(viewId)` — fetch children of a view
  * - `useLoadViewChildrenBatch(viewIds)` — fetch children of multiple views
  * - `useMarkViewChildrenStale(viewId)` — invalidate cached children
+ * - `useEnsureViewVisibleInOutline(viewId)` — hydrate missing parent/sibling context
  * - `useAppFavorites()` — memoized `{ loadFavoriteViews, favoriteViews }`
  * - `useAppRecent()` — memoized `{ loadRecentViews, recentViews }`
  * - `useAppTrash()` — memoized `{ loadTrash, trashList }`
@@ -48,6 +49,8 @@ export interface AppOutlineContextType {
   loadViewChildrenBatch?: (viewIds: string[]) => Promise<View[]>;
   /** Mark a view's cached children as stale so the next access re-fetches them. */
   markViewChildrenStale?: (viewId: string) => void;
+  /** Fetch server-authoritative parent/sibling context and merge it into the sidebar outline. */
+  ensureViewVisibleInOutline?: (viewId: string) => Promise<string[]>;
   /** Revalidate the root sidebar outline and refresh currently expanded sidebar subtrees. */
   revalidateSidebarOutline?: (expandedViewIds?: string[]) => Promise<SidebarOutlineRevalidationResult>;
   /** Fetch the user's favorite views. */

--- a/src/components/app/hooks/__tests__/useWorkspaceData.preserveLoadedChildren.test.ts
+++ b/src/components/app/hooks/__tests__/useWorkspaceData.preserveLoadedChildren.test.ts
@@ -1,6 +1,6 @@
-import { View, ViewLayout } from '@/application/types';
+import { AccessLevel, View, ViewLayout } from '@/application/types';
 
-import { preserveLoadedChildren } from '../useWorkspaceData';
+import { mergeNavigationTreeIntoOutline, preserveLoadedChildren } from '../useWorkspaceData';
 
 const createView = (viewId: string, overrides: Partial<View> = {}): View => ({
   view_id: viewId,
@@ -38,5 +38,120 @@ describe('preserveLoadedChildren', () => {
 
     expect(result.outline[0]?.children.map((child) => child.view_id)).toEqual([oldChild.view_id]);
     expect(result.loadedIds.has(parentId)).toBe(true);
+  });
+});
+
+describe('mergeNavigationTreeIntoOutline', () => {
+  it('hydrates the target path and preserves server sibling order', () => {
+    const otherSpace = createView('99999999-9999-4999-8999-999999999999', {
+      extra: { is_space: true },
+    });
+    const spaceId = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+    const rootId = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb';
+    const parentId = 'cccccccc-cccc-4ccc-8ccc-cccccccccccc';
+    const targetId = 'dddddddd-dddd-4ddd-8ddd-dddddddddddd';
+    const siblingId = 'eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee';
+    const rootSiblingId = 'ffffffff-ffff-4fff-8fff-ffffffffffff';
+
+    const outline = [
+      createView(spaceId, {
+        extra: { is_space: true },
+        children: [],
+        has_children: true,
+      }),
+      otherSpace,
+    ];
+    const navigationTree = createView(spaceId, {
+      extra: { is_space: true },
+      children: [
+        createView(rootId, {
+          children: [
+            createView(parentId, {
+              children: [createView(targetId), createView(siblingId, { has_children: true })],
+              has_children: true,
+            }),
+          ],
+          has_children: true,
+        }),
+        createView(rootSiblingId, { has_children: true }),
+      ],
+      has_children: true,
+    });
+
+    const result = mergeNavigationTreeIntoOutline(outline, navigationTree, targetId, new Set());
+    const hydratedSpace = result.find((view) => view.view_id === spaceId);
+    const root = hydratedSpace?.children.find((view) => view.view_id === rootId);
+    const parent = root?.children.find((view) => view.view_id === parentId);
+
+    expect(result.map((view) => view.view_id)).toEqual([spaceId, otherSpace.view_id]);
+    expect(hydratedSpace?.children.map((view) => view.view_id)).toEqual([rootId, rootSiblingId]);
+    expect(parent?.children.map((view) => view.view_id)).toEqual([targetId, siblingId]);
+  });
+
+  it('keeps children for sibling branches already loaded locally', () => {
+    const spaceId = '11111111-1111-4111-8111-111111111111';
+    const rootId = '22222222-2222-4222-8222-222222222222';
+    const loadedSiblingId = '33333333-3333-4333-8333-333333333333';
+    const loadedSiblingChild = createView('44444444-4444-4444-8444-444444444444');
+    const targetId = '55555555-5555-4555-8555-555555555555';
+
+    const outline = [
+      createView(spaceId, {
+        extra: { is_space: true },
+        children: [
+          createView(rootId),
+          createView(loadedSiblingId, {
+            children: [loadedSiblingChild],
+            has_children: true,
+          }),
+        ],
+      }),
+    ];
+    const navigationTree = createView(spaceId, {
+      extra: { is_space: true },
+      children: [
+        createView(rootId, {
+          children: [createView(targetId)],
+          has_children: true,
+        }),
+        createView(loadedSiblingId, {
+          children: [],
+          has_children: true,
+        }),
+      ],
+    });
+
+    const result = mergeNavigationTreeIntoOutline(outline, navigationTree, targetId, new Set([loadedSiblingId]));
+    const loadedSibling = result[0]?.children.find((view) => view.view_id === loadedSiblingId);
+
+    expect(loadedSibling?.children.map((view) => view.view_id)).toEqual([loadedSiblingChild.view_id]);
+  });
+
+  it('attaches a shared private navigation root under the hidden shared-with-me space', () => {
+    const workspaceSpace = createView('66666666-6666-4666-8666-666666666666', {
+      extra: { is_space: true },
+    });
+    const sharedSpaceId = '77777777-7777-4777-8777-777777777777';
+    const sharedRootId = '88888888-8888-4888-8888-888888888888';
+    const targetId = '99999999-9999-4999-8999-999999999999';
+    const sharedWithMe = createView(sharedSpaceId, {
+      extra: {
+        is_space: true,
+        is_hidden_space: true,
+      },
+      children: [],
+      has_children: true,
+    });
+    const navigationTree = createView(sharedRootId, {
+      access_level: AccessLevel.ReadOnly,
+      is_private: true,
+      children: [createView(targetId)],
+    });
+
+    const result = mergeNavigationTreeIntoOutline([workspaceSpace, sharedWithMe], navigationTree, targetId, new Set());
+    const updatedSharedWithMe = result.find((view) => view.view_id === sharedSpaceId);
+
+    expect(result.map((view) => view.view_id)).toEqual([workspaceSpace.view_id, sharedSpaceId]);
+    expect(updatedSharedWithMe?.children.map((view) => view.view_id)).toEqual([sharedRootId]);
   });
 });

--- a/src/components/app/hooks/__tests__/useWorkspaceData.sidebarRevalidation.test.tsx
+++ b/src/components/app/hooks/__tests__/useWorkspaceData.sidebarRevalidation.test.tsx
@@ -37,6 +37,7 @@ jest.mock('@/application/services/domains', () => ({
     get: jest.fn(),
     getDatabaseRelations: jest.fn(),
     getMultiple: jest.fn(),
+    getNavigation: jest.fn(),
     getOutline: jest.fn(),
     getTrash: jest.fn(),
     invalidateCache: jest.fn(),
@@ -136,7 +137,73 @@ describe('useWorkspaceData sidebar outline revalidation', () => {
     (AccessService.getShareWithMe as jest.Mock).mockResolvedValue(null);
     (ViewService.getDatabaseRelations as jest.Mock).mockResolvedValue({});
     (ViewService.getMultiple as jest.Mock).mockResolvedValue([]);
+    (ViewService.getNavigation as jest.Mock).mockResolvedValue(createView('navigation-root'));
     (ViewService.getTrash as jest.Mock).mockResolvedValue([]);
+  });
+
+  it('hydrates missing selected view path from navigation context', async () => {
+    const eventEmitter = new EventEmitter();
+    const spaceId = 'space-id';
+    const rootId = 'root-id';
+    const parentId = 'parent-id';
+    const targetId = 'target-id';
+    const targetSiblingId = 'target-sibling-id';
+    const rootSiblingId = 'root-sibling-id';
+
+    const initialSpace = createView(spaceId, {
+      extra: { is_space: true },
+      children: [],
+      has_children: true,
+    });
+    const navigationTree = createView(spaceId, {
+      extra: { is_space: true },
+      children: [
+        createView(rootId, {
+          children: [
+            createView(parentId, {
+              children: [createView(targetId), createView(targetSiblingId)],
+              has_children: true,
+            }),
+          ],
+          has_children: true,
+        }),
+        createView(rootSiblingId, { has_children: true }),
+      ],
+      has_children: true,
+    });
+
+    (ViewService.getOutline as jest.Mock).mockResolvedValue({
+      outline: [initialSpace],
+      folderRid: '1-1',
+    });
+    (ViewService.getNavigation as jest.Mock).mockResolvedValue(navigationTree);
+
+    const { result } = renderHook(() => useWorkspaceData(), {
+      wrapper: createWrapper(eventEmitter),
+    });
+
+    await waitFor(() => {
+      expect(result.current.outline?.map((view) => view.view_id)).toEqual([spaceId]);
+    });
+
+    let ancestors: string[] = [];
+
+    await act(async () => {
+      ancestors = (await result.current.ensureViewVisibleInOutline?.(targetId)) ?? [];
+    });
+
+    expect(ViewService.getNavigation).toHaveBeenCalledWith(workspaceId, targetId, 0);
+    expect(ancestors).toEqual([spaceId, rootId, parentId]);
+    expect(result.current.loadedViewIds?.has(spaceId)).toBe(true);
+    expect(result.current.loadedViewIds?.has(rootId)).toBe(true);
+    expect(result.current.loadedViewIds?.has(parentId)).toBe(true);
+
+    const space = result.current.outline?.[0];
+    const root = space?.children.find((view) => view.view_id === rootId);
+    const parent = root?.children.find((view) => view.view_id === parentId);
+
+    expect(space?.children.map((view) => view.view_id)).toEqual([rootId, rootSiblingId]);
+    expect(parent?.children.map((view) => view.view_id)).toEqual([targetId, targetSiblingId]);
   });
 
   it('skips revalidation when the root folder rid is unchanged', async () => {

--- a/src/components/app/hooks/useWorkspaceData.ts
+++ b/src/components/app/hooks/useWorkspaceData.ts
@@ -16,7 +16,7 @@ import {
   reorderChildrenInOutline,
   updateViewInOutline,
 } from '@/components/_shared/outline/mergeOutline';
-import { findView, findViewByLayout } from '@/components/_shared/outline/utils';
+import { findShareWithMeSpace, findView, findViewByLayout } from '@/components/_shared/outline/utils';
 import {
   limitSidebarOutlineExpandedViewIds,
   type SidebarOutlineRevalidationResult,
@@ -56,6 +56,130 @@ function buildViewIndex(views: View[]): Map<string, View> {
 
   walk(views);
   return index;
+}
+
+function collectViewPath(root: View, targetViewId: string): View[] | null {
+  const path: View[] = [];
+
+  const walk = (view: View): boolean => {
+    path.push(view);
+
+    if (view.view_id === targetViewId) {
+      return true;
+    }
+
+    for (const child of view.children ?? []) {
+      if (walk(child)) {
+        return true;
+      }
+    }
+
+    path.pop();
+    return false;
+  };
+
+  return walk(root) ? path : null;
+}
+
+function replaceViewInOutline(outline: View[], replacement: View): { outline: View[]; replaced: boolean } {
+  let replaced = false;
+
+  const nextOutline = outline.map((view) => {
+    if (view.view_id === replacement.view_id) {
+      replaced = true;
+      return replacement;
+    }
+
+    if (view.children && view.children.length > 0) {
+      const childResult = replaceViewInOutline(view.children, replacement);
+
+      if (childResult.replaced) {
+        replaced = true;
+        return { ...view, children: childResult.outline };
+      }
+    }
+
+    return view;
+  });
+
+  return { outline: replaced ? nextOutline : outline, replaced };
+}
+
+function upsertSiblingView(siblings: View[], replacement: View): View[] {
+  const index = siblings.findIndex((view) => view.view_id === replacement.view_id);
+
+  if (index === -1) {
+    return [...siblings, replacement];
+  }
+
+  const next = [...siblings];
+
+  next[index] = replacement;
+  return next;
+}
+
+function shouldAttachNavigationRootToShareWithMe(outline: View[], navigationRoot: View): boolean {
+  if (!findShareWithMeSpace(outline)) return false;
+  if (navigationRoot.extra?.is_hidden_space) return false;
+
+  return navigationRoot.access_level !== undefined || navigationRoot.is_private;
+}
+
+function upsertNavigationRoot(outline: View[], navigationRoot: View): View[] {
+  const replaced = replaceViewInOutline(outline, navigationRoot);
+
+  if (replaced.replaced) {
+    return replaced.outline;
+  }
+
+  if (shouldAttachNavigationRootToShareWithMe(outline, navigationRoot)) {
+    return outline.map((view) => {
+      if (!view.extra?.is_hidden_space) return view;
+
+      return {
+        ...view,
+        children: upsertSiblingView(view.children ?? [], navigationRoot),
+        has_children: true,
+      };
+    });
+  }
+
+  return upsertSiblingView(outline, navigationRoot);
+}
+
+function mergeNavigationView(
+  view: View,
+  targetViewId: string,
+  cachedById: Map<string, View>,
+  loadedViewIds: Set<string>
+): View {
+  const cached = cachedById.get(view.view_id);
+  const navigationChildren = view.children ?? [];
+  const preserveCachedChildren =
+    navigationChildren.length === 0 &&
+    cached?.children &&
+    cached.children.length > 0 &&
+    (view.view_id === targetViewId || loadedViewIds.has(view.view_id));
+
+  return {
+    ...cached,
+    ...view,
+    children: preserveCachedChildren
+      ? cached.children
+      : navigationChildren.map((child) => mergeNavigationView(child, targetViewId, cachedById, loadedViewIds)),
+  };
+}
+
+export function mergeNavigationTreeIntoOutline(
+  outline: View[],
+  navigationRoot: View,
+  targetViewId: string,
+  loadedViewIds: Set<string>
+): View[] {
+  const cachedById = buildViewIndex(outline);
+  const mergedRoot = mergeNavigationView(navigationRoot, targetViewId, cachedById, loadedViewIds);
+
+  return upsertNavigationRoot(outline, mergedRoot);
 }
 
 export function preserveLoadedChildren(
@@ -647,6 +771,55 @@ export function useWorkspaceData() {
       setLoadedViewIdsRevision((r) => r + 1);
     },
     [stableOutlineRef, currentWorkspaceId]
+  );
+
+  const ensureViewVisibleInOutline = useCallback(
+    async (viewId: string): Promise<string[]> => {
+      if (!currentWorkspaceId) return [];
+
+      const workspaceId = currentWorkspaceId;
+      const workspaceRevision = workspaceRevisionRef.current;
+      const navigationRoot = await ViewService.getNavigation(workspaceId, viewId, 0);
+      const path = collectViewPath(navigationRoot, viewId);
+
+      if (!path || isStaleWorkspaceRequest(workspaceId, workspaceRevision)) {
+        return [];
+      }
+
+      updateLastFolderRid(parseFolderRid(navigationRoot.folder_rid));
+
+      const nextOutline = mergeNavigationTreeIntoOutline(
+        stableOutlineRef.current,
+        navigationRoot,
+        viewId,
+        loadedViewIdsRef.current
+      );
+
+      if (nextOutline !== stableOutlineRef.current) {
+        stableOutlineRef.current = nextOutline;
+        setOutline(nextOutline);
+        if (eventEmitter) {
+          eventEmitter.emit(APP_EVENTS.OUTLINE_LOADED, nextOutline || []);
+        }
+      }
+
+      const ancestorIds = path.slice(0, -1).map((view) => view.view_id);
+      let loadedChanged = false;
+
+      for (const ancestorId of ancestorIds) {
+        if (!loadedViewIdsRef.current.has(ancestorId)) {
+          loadedViewIdsRef.current.add(ancestorId);
+          loadedChanged = true;
+        }
+      }
+
+      if (loadedChanged) {
+        setLoadedViewIdsRevision((r) => r + 1);
+      }
+
+      return ancestorIds;
+    },
+    [currentWorkspaceId, eventEmitter, isStaleWorkspaceRequest, updateLastFolderRid]
   );
 
   const markCachedFolderSubtreesStale = useCallback(
@@ -1368,6 +1541,7 @@ export function useWorkspaceData() {
     loadViewChildren,
     loadViewChildrenBatch,
     markViewChildrenStale,
+    ensureViewVisibleInOutline,
     revalidateSidebarOutline,
   };
 }

--- a/src/components/app/layers/AppBusinessLayer.tsx
+++ b/src/components/app/layers/AppBusinessLayer.tsx
@@ -106,6 +106,7 @@ export const AppBusinessLayer: FC<AppBusinessLayerProps> = ({ children }) => {
     loadViewChildren,
     loadViewChildrenBatch,
     markViewChildrenStale,
+    ensureViewVisibleInOutline,
     revalidateSidebarOutline,
   } = useWorkspaceData();
 
@@ -497,6 +498,7 @@ export const AppBusinessLayer: FC<AppBusinessLayerProps> = ({ children }) => {
       loadViewChildren,
       loadViewChildrenBatch,
       markViewChildrenStale,
+      ensureViewVisibleInOutline,
       revalidateSidebarOutline,
       loadFavoriteViews,
       loadRecentViews,
@@ -509,7 +511,7 @@ export const AppBusinessLayer: FC<AppBusinessLayerProps> = ({ children }) => {
     }),
     [
       outline, favoriteViews, recentViews, trashList, loadedViewIds,
-      loadViewChildren, loadViewChildrenBatch, markViewChildrenStale, revalidateSidebarOutline,
+      loadViewChildren, loadViewChildrenBatch, markViewChildrenStale, ensureViewVisibleInOutline, revalidateSidebarOutline,
       loadFavoriteViews, loadRecentViews, loadTrash, loadViews,
       refreshOutline, loadDatabaseRelations, getMentionUser, loadMentionableUsers,
     ]

--- a/src/components/app/outline/Outline.tsx
+++ b/src/components/app/outline/Outline.tsx
@@ -15,7 +15,9 @@ import {
   useLoadViewChildrenBatch,
   useLoadViewChildren,
   useMarkViewChildrenStale,
+  useEnsureViewVisibleInOutline,
   useRevalidateSidebarOutline,
+  useSidebarSelectedViewId,
   useUserWorkspaceInfo,
 } from '@/components/app/app.hooks';
 import { Favorite } from '@/components/app/favorite';
@@ -64,7 +66,9 @@ export function Outline({ width }: { width: number }) {
   const loadViewChildren = useLoadViewChildren();
   const loadViewChildrenBatch = useLoadViewChildrenBatch();
   const markViewChildrenStale = useMarkViewChildrenStale();
+  const ensureViewVisibleInOutline = useEnsureViewVisibleInOutline();
   const revalidateSidebarOutline = useRevalidateSidebarOutline();
+  const selectedViewId = useSidebarSelectedViewId();
   const userWorkspaceInfo = useUserWorkspaceInfo();
   const canReorderSpaces = userWorkspaceInfo?.selectedWorkspace.role === Role.Owner;
   const spaceListRef = useRef<HTMLDivElement>(null);
@@ -108,6 +112,11 @@ export function Outline({ width }: { width: number }) {
   }, []);
 
   const loadingViewIdsRef = useRef<Set<string>>(new Set());
+  const navigationHydrationInFlightRef = useRef<Set<string>>(new Set());
+  // Selected views that navigation hydration could not place in the outline
+  // (not found server-side, or access denied). Tracked so we don't re-fetch
+  // navigation on every subsequent `outline` change for an unresolvable id.
+  const navigationHydrationUnresolvedRef = useRef<Set<string>>(new Set());
   const autoLoadRetryAfterRef = useRef<Map<string, number>>(new Map());
   const validatingRestoreIdsRef = useRef<Set<string>>(new Set());
   const validatedExistingRestoreIdsRef = useRef<Set<string>>(new Set());
@@ -125,6 +134,50 @@ export function Outline({ width }: { width: number }) {
   }, [expandViewIds]);
 
   useEffect(() => {
+    if (!selectedViewId || !outline || !ensureViewVisibleInOutline) return;
+    if (findView(outline, selectedViewId)) return;
+    if (navigationHydrationInFlightRef.current.has(selectedViewId)) return;
+    if (navigationHydrationUnresolvedRef.current.has(selectedViewId)) return;
+
+    navigationHydrationInFlightRef.current.add(selectedViewId);
+
+    void ensureViewVisibleInOutline(selectedViewId)
+      .then((ancestorIds) => {
+        if (ancestorIds.length === 0) {
+          // Either the view resolved at the sidebar root (it's now in the
+          // outline, so findView short-circuits on the next run) or it could
+          // not be resolved. Mark it so we don't re-fetch on every outline
+          // change while it stays selected.
+          navigationHydrationUnresolvedRef.current.add(selectedViewId);
+          return;
+        }
+
+        ancestorIds.forEach((id) => setOutlineExpands(id, true));
+        setExpandViewIds((prev) => {
+          const next = new Set(prev);
+
+          ancestorIds.forEach((id) => next.add(id));
+          return next.size === prev.length ? prev : Array.from(next);
+        });
+        setPendingAutoLoadIds((prev) => {
+          const filtered = prev.filter((id) => !ancestorIds.includes(id));
+
+          return filtered.length === prev.length ? prev : filtered;
+        });
+      })
+      .catch((error) => {
+        navigationHydrationUnresolvedRef.current.add(selectedViewId);
+        Log.warn('[Outline] [navigation-context] failed to hydrate selected view', {
+          viewId: selectedViewId,
+          error,
+        });
+      })
+      .finally(() => {
+        navigationHydrationInFlightRef.current.delete(selectedViewId);
+      });
+  }, [ensureViewVisibleInOutline, outline, selectedViewId]);
+
+  useEffect(() => {
     sidebarRevalidationStateRef.current = createSidebarOutlineRevalidationScheduleState();
     rescheduleSidebarRevalidationRef.current();
   }, [outline]);
@@ -135,6 +188,8 @@ export function Outline({ width }: { width: number }) {
     setExpandViewIds(restoredExpandedIds);
     setPendingAutoLoadIds(restoredExpandedIds);
     loadingViewIdsRef.current = new Set();
+    navigationHydrationInFlightRef.current = new Set();
+    navigationHydrationUnresolvedRef.current = new Set();
     autoLoadRetryAfterRef.current = new Map();
     validatingRestoreIdsRef.current = new Set();
     validatedExistingRestoreIdsRef.current = new Set();

--- a/src/components/app/outline/__tests__/Outline.navigationContext.test.tsx
+++ b/src/components/app/outline/__tests__/Outline.navigationContext.test.tsx
@@ -1,0 +1,258 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import React, { useMemo, useState } from 'react';
+
+import { View, ViewLayout } from '@/application/types';
+import Outline from '@/components/app/outline/Outline';
+
+declare global {
+  // eslint-disable-next-line no-var
+  var __outlineNavigationTestOutline: View[] | undefined;
+  // eslint-disable-next-line no-var
+  var __outlineNavigationTestSelectedViewId: string | undefined;
+  // eslint-disable-next-line no-var
+  var __outlineNavigationTestEnsureViewVisible: jest.Mock<Promise<string[]>, [viewId: string]> | undefined;
+  // eslint-disable-next-line no-var
+  var __outlineNavigationTestToView: jest.Mock<Promise<void>, [viewId: string]> | undefined;
+}
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+jest.mock('@/components/app/app.hooks', () => ({
+  useAIEnabled: () => true,
+  useAppOperations: () => ({
+    updatePage: jest.fn(),
+    uploadFile: jest.fn(),
+  }),
+  useAppOutline: () => global.__outlineNavigationTestOutline,
+  useCurrentWorkspaceId: () => 'workspace-id',
+  useCurrentWorkspaceIdOptional: () => 'workspace-id',
+  useEnsureViewVisibleInOutline: () => global.__outlineNavigationTestEnsureViewVisible,
+  useLoadedViewIds: () => new Set<string>(),
+  useLoadViewChildren: () => jest.fn().mockResolvedValue([]),
+  useLoadViewChildrenBatch: () => jest.fn().mockResolvedValue([]),
+  useMarkViewChildrenStale: () => jest.fn(),
+  useRevalidateSidebarOutline: () => undefined,
+  useSidebarHighlightedViewIds: () =>
+    global.__outlineNavigationTestSelectedViewId ? [global.__outlineNavigationTestSelectedViewId] : [],
+  useSidebarSelectedViewId: () => global.__outlineNavigationTestSelectedViewId,
+  useToView: () => global.__outlineNavigationTestToView,
+  useUserWorkspaceInfo: () => ({
+    selectedWorkspace: {
+      id: 'workspace-id',
+      role: 'Owner',
+    },
+  }),
+}));
+
+jest.mock('@/components/app/favorite', () => ({
+  Favorite: () => null,
+}));
+
+jest.mock('@/components/app/share-with-me', () => ({
+  ShareWithMe: () => null,
+}));
+
+jest.mock('@/components/app/view-actions/ViewActionsPopover', () => ({
+  __esModule: true,
+  default: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+jest.mock('@/components/app/import/ImportDialog', () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+jest.mock('@/components/app/outline/AnimatedCollapse', () => ({
+  __esModule: true,
+  AnimatedCollapse: ({ expanded, children }: { expanded: boolean; children: React.ReactNode }) =>
+    expanded ? <div>{children}</div> : null,
+  default: ({ expanded, children }: { expanded: boolean; children: React.ReactNode }) =>
+    expanded ? <div>{children}</div> : null,
+}));
+
+jest.mock('@/components/app/outline/reorder/useReorderableSidebarList', () => ({
+  useReorderableSidebarList: ({ items }: { items: View[] }) => ({
+    instanceId: Symbol('outline-navigation-test'),
+    orderedItems: items,
+  }),
+}));
+
+jest.mock('@/components/_shared/reorder/useReorderableItem', () => ({
+  useReorderableItem: () => ({
+    dragState: { type: 'idle' },
+    shouldSuppressClick: () => false,
+  }),
+}));
+
+jest.mock('@/components/_shared/cutsom-icon', () => ({
+  CustomIconPopover: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+jest.mock('@/components/_shared/outline/OutlineIcon', () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+jest.mock('@/components/_shared/view-icon/PageIcon', () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+jest.mock('@/components/_shared/view-icon/SpaceIcon', () => ({
+  __esModule: true,
+  default: () => <span data-testid='space-icon' />,
+}));
+
+jest.mock('@/components/_shared/skeleton/DirectoryStructure', () => ({
+  __esModule: true,
+  default: () => <div data-testid='outline-skeleton' />,
+}));
+
+jest.mock('@/components/database/components/drag-and-drop/DropRowLine', () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+const spaceId = 'space-id';
+const rootId = 'root-id';
+const parentId = 'parent-id';
+const targetId = 'target-id';
+const rootSiblingId = 'root-sibling-id';
+const targetSiblingId = 'target-sibling-id';
+
+function createView(viewId: string, overrides: Partial<View> = {}): View {
+  return {
+    view_id: viewId,
+    name: overrides.name ?? viewId,
+    icon: overrides.icon ?? null,
+    layout: overrides.layout ?? ViewLayout.Document,
+    extra: overrides.extra ?? null,
+    children: overrides.children ?? [],
+    has_children: overrides.has_children,
+    is_published: overrides.is_published ?? false,
+    is_private: overrides.is_private ?? false,
+    parent_view_id: overrides.parent_view_id,
+    ...overrides,
+  };
+}
+
+const shallowOutline = [
+  createView(spaceId, {
+    name: 'Space',
+    extra: { is_space: true },
+    has_children: true,
+  }),
+];
+
+const hydratedOutline = [
+  createView(spaceId, {
+    name: 'Space',
+    extra: { is_space: true },
+    has_children: true,
+    children: [
+      createView(rootId, {
+        name: 'Root view',
+        has_children: true,
+        parent_view_id: spaceId,
+        children: [
+          createView(parentId, {
+            name: 'Parent view',
+            has_children: true,
+            parent_view_id: rootId,
+            children: [
+              createView(targetId, {
+                name: 'Mention target',
+                parent_view_id: parentId,
+              }),
+              createView(targetSiblingId, {
+                name: 'Target sibling',
+                parent_view_id: parentId,
+              }),
+            ],
+          }),
+        ],
+      }),
+      createView(rootSiblingId, {
+        name: 'Root sibling',
+        has_children: true,
+        parent_view_id: spaceId,
+      }),
+    ],
+  }),
+];
+
+function OutlineNavigationHarness({ ensureRejects = false }: { ensureRejects?: boolean }) {
+  const [outline, setOutline] = useState<View[]>(shallowOutline);
+  const ensureViewVisible = useMemo(
+    () =>
+      jest.fn(async (viewId: string) => {
+        if (ensureRejects) {
+          throw new Error('not enough permissions');
+        }
+
+        if (viewId === targetId) {
+          setOutline(hydratedOutline);
+          return [spaceId, rootId, parentId];
+        }
+
+        return [];
+      }),
+    [ensureRejects]
+  );
+
+  global.__outlineNavigationTestOutline = outline;
+  global.__outlineNavigationTestEnsureViewVisible = ensureViewVisible;
+  global.__outlineNavigationTestSelectedViewId = targetId;
+  global.__outlineNavigationTestToView = jest.fn().mockResolvedValue(undefined);
+
+  return <Outline width={280} />;
+}
+
+describe('Outline navigation context hydration', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    global.__outlineNavigationTestOutline = undefined;
+    global.__outlineNavigationTestEnsureViewVisible = undefined;
+    global.__outlineNavigationTestSelectedViewId = undefined;
+    global.__outlineNavigationTestToView = undefined;
+  });
+
+  it('hydrates and expands a notification target path when the selected view is missing locally', async () => {
+    render(<OutlineNavigationHarness />);
+
+    await waitFor(() => {
+      expect(global.__outlineNavigationTestEnsureViewVisible).toHaveBeenCalledWith(targetId);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('Mention target')).toBeTruthy();
+    });
+
+    expect(screen.getByText('Parent view')).toBeTruthy();
+    expect(screen.getByText('Target sibling')).toBeTruthy();
+    expect(screen.getByText('Root sibling')).toBeTruthy();
+    expect(screen.getByTestId(`page-${targetId}`).getAttribute('data-selected')).toBe('true');
+    expect(JSON.parse(localStorage.getItem('outline_expanded') || '{}')).toEqual({
+      [spaceId]: true,
+      [rootId]: true,
+      [parentId]: true,
+    });
+  });
+
+  it('keeps the sidebar closed when navigation hydration denies access', async () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+    render(<OutlineNavigationHarness ensureRejects />);
+
+    await waitFor(() => {
+      expect(global.__outlineNavigationTestEnsureViewVisible).toHaveBeenCalledWith(targetId);
+    });
+
+    expect(screen.queryByText('Mention target')).toBeNull();
+    expect(JSON.parse(localStorage.getItem('outline_expanded') || '{}')).toEqual({});
+
+    warnSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
- Fetch server navigation context when a selected notification target is missing from the local sidebar outline
- Merge the hydrated path and siblings into cached outline state, then expand the ancestor chain
- Add unit coverage and a Playwright fixture for successful hydration and denied-access behavior

## Tests
- pnpm exec jest src/components/app/hooks/__tests__/useWorkspaceData.preserveLoadedChildren.test.ts src/components/app/hooks/__tests__/useWorkspaceData.sidebarRevalidation.test.tsx src/components/app/outline/__tests__/Outline.navigationContext.test.tsx --runInBand --no-coverage
- pnpm run type-check

## Summary by Sourcery

Hydrate and expand sidebar outline context for notification-selected views by merging server-provided navigation trees into the cached outline, and add automated coverage for navigation hydration and access-denied behavior.

New Features:
- Add ensureViewVisibleInOutline workspace hook and Outline wiring to hydrate missing parent/sibling context for a selected view using server navigation data.
- Introduce a view navigation API client and domain wrapper to fetch server-authoritative navigation trees for individual views.

Enhancements:
- Extend outline merging logic to integrate server navigation subtrees into the cached outline while preserving locally loaded child branches and sibling order, including support for attaching shared private roots under the hidden Share With Me space.

Tests:
- Add unit tests for navigation tree merging and sidebar navigation context hydration, and Playwright end-to-end tests covering successful hydration and access-denied scenarios when opening notification targets.