### PR TITLE
fix: render desktop row comment mentions

### DIFF
--- a/src/components/database/components/database-row/comment/RowCommentItem.tsx
+++ b/src/components/database/components/database-row/comment/RowCommentItem.tsx
@@ -1,5 +1,6 @@
 import dayjs from 'dayjs';
 import { memo, useCallback, useEffect, useMemo, useState } from 'react';
+import type { ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { RowComment } from '@/application/row-comment.type';
@@ -21,6 +22,47 @@ import DeleteCommentConfirm from './DeleteCommentConfirm';
 import MemberAvatar, { getMemberDisplayName } from './MemberAvatar';
 import { useRowCommentDispatch, useRowCommentState } from './RowCommentContext';
 import RowCommentReactions from './RowCommentReactions';
+
+const DESKTOP_PERSON_MENTION_PATTERN = /@\[([^\]\n]+)\]\(([^)\s]+)\)/g;
+
+function renderCommentContent(content: string): ReactNode {
+  const parts: ReactNode[] = [];
+  let lastIndex = 0;
+  let match: RegExpExecArray | null;
+
+  DESKTOP_PERSON_MENTION_PATTERN.lastIndex = 0;
+
+  while ((match = DESKTOP_PERSON_MENTION_PATTERN.exec(content)) !== null) {
+    const [raw, name, personId] = match;
+
+    if (match.index > lastIndex) {
+      parts.push(content.slice(lastIndex, match.index));
+    }
+
+    parts.push(
+      <span
+        key={`${personId}-${match.index}`}
+        data-mention-id={personId}
+        className={'inline-flex max-w-full items-baseline align-baseline'}
+      >
+        <span className={'mr-0.5 text-text-tertiary'}>@</span>
+        <span className={'truncate text-text-secondary'}>{name}</span>
+      </span>
+    );
+
+    lastIndex = match.index + raw.length;
+  }
+
+  if (parts.length === 0) {
+    return content;
+  }
+
+  if (lastIndex < content.length) {
+    parts.push(content.slice(lastIndex));
+  }
+
+  return parts;
+}
 
 function RowCommentItem({ comment, isFirst = false, isLast = false }: { comment: RowComment; isFirst?: boolean; isLast?: boolean }) {
   const { t } = useTranslation();
@@ -59,6 +101,7 @@ function RowCommentItem({ comment, isFirst = false, isLast = false }: { comment:
   const isParent = !comment.parentCommentId;
   const isReplying = replyingCommentId === comment.id;
   const wasEdited = comment.updatedAt > comment.createdAt;
+  const renderedContent = useMemo(() => renderCommentContent(comment.content), [comment.content]);
 
   const relativeTime = useMemo(() => {
     const now = dayjs();
@@ -147,7 +190,7 @@ function RowCommentItem({ comment, isFirst = false, isLast = false }: { comment:
               onCancel={handleCancelEdit}
             />
           ) : (
-            <p data-testid={'row-comment-content'} className={'whitespace-pre-wrap break-words text-sm text-text-primary'}>{comment.content}</p>
+            <p data-testid={'row-comment-content'} className={'whitespace-pre-wrap break-words text-sm text-text-primary'}>{renderedContent}</p>
           )}
 
           {/* Reactions */}

--- a/src/components/database/components/database-row/comment/__tests__/RowCommentItem.test.tsx
+++ b/src/components/database/components/database-row/comment/__tests__/RowCommentItem.test.tsx
@@ -1,0 +1,88 @@
+import { render, screen } from '@testing-library/react';
+
+import { RowComment } from '@/application/row-comment.type';
+
+import RowCommentItem from '../RowCommentItem';
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: { count?: number }) => options?.count ?? key,
+  }),
+}));
+
+jest.mock('@/components/_shared/emoji-picker', () => ({
+  EmojiPicker: () => null,
+}));
+
+jest.mock('../RowCommentContext', () => ({
+  useRowCommentState: () => ({
+    editingCommentId: null,
+    replyingCommentId: null,
+    currentUserId: 'author-id',
+    currentUserUid: 'author-uid',
+    members: new Map([['author-id', { name: 'Lucas Xu' }]]),
+  }),
+  useRowCommentDispatch: () => ({
+    setEditingCommentId: jest.fn(),
+    updateComment: jest.fn(),
+    deleteComment: jest.fn(),
+    resolveComment: jest.fn(),
+    toggleReaction: jest.fn(),
+  }),
+}));
+
+jest.mock('../MemberAvatar', () => ({
+  __esModule: true,
+  default: ({ uid }: { uid: string }) => <div data-testid='member-avatar'>{uid}</div>,
+  getMemberDisplayName: (_members: Map<string, { name?: string }>, authorId: string) => authorId,
+}));
+
+jest.mock('../RowCommentReactions', () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+jest.mock('../AddCommentInput', () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+jest.mock('../DeleteCommentConfirm', () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+const baseComment: RowComment = {
+  id: 'comment-id',
+  parentCommentId: null,
+  content: '',
+  authorId: 'author-id',
+  createdAt: 1_700_000_000,
+  updatedAt: 1_700_000_000,
+  isResolved: false,
+  resolvedBy: null,
+  resolvedAt: null,
+  reactions: {},
+  attachments: [],
+};
+
+describe('RowCommentItem', () => {
+  it('renders desktop-created person mentions as inline mention chips', () => {
+    render(
+      <RowCommentItem
+        comment={{
+          ...baseComment,
+          content: 'Yes, I can receive it. @[Lucas Xu](6dd44664-b739-4aa5-bfd7-4fbc6677d435) 编辑被人的',
+        }}
+      />
+    );
+
+    const content = screen.getByTestId('row-comment-content');
+    const mention = content.querySelector('[data-mention-id="6dd44664-b739-4aa5-bfd7-4fbc6677d435"]');
+
+    expect(mention).not.toBeNull();
+    expect(mention?.textContent).toBe('@Lucas Xu');
+    expect(content.textContent).toBe('Yes, I can receive it. @Lucas Xu 编辑被人的');
+    expect(content.textContent).not.toContain('@[Lucas Xu](6dd44664-b739-4aa5-bfd7-4fbc6677d435)');
+  });
+});


### PR DESCRIPTION
<!---
Thank you for submitting a pull request to the AppFlowy Web! The team will dedicate their best efforts to reviewing and approving your PR. If you have any questions or feedback, feel free to join our [Discord](https://discord.gg/wdjWUXXhtw).
-->


### **Description**
<!---
Provide a clear and concise description of the changes introduced in this pull request for AppFlowy Web. What problem does it solve? What value does it add?
-->

---

### **Checklist**
<!---
Before marking your pull request as ready for review, ensure the following checklist is complete.
-->

#### **General**
- [ ] I've included relevant documentation or comments for the changes introduced.
- [ ] I've tested the changes in multiple environments (e.g., different browsers, operating systems).

#### **Testing**
- [ ] I've added or updated tests to validate the changes introduced for AppFlowy Web.

#### **Feature-Specific**
- [ ] For feature additions, I've added a preview (video, screenshot, or demo) in the "Feature Preview" section.
- [ ] I've verified that this feature integrates seamlessly with existing functionality.

## Summary by Sourcery

Render desktop-created person mentions in row comments as inline mention chips and add coverage for this behavior.

Bug Fixes:
- Ensure row comment content correctly renders desktop-formatted person mentions instead of showing raw markup.

Tests:
- Add a unit test verifying that desktop-created person mentions in row comments are rendered as inline mention chips with the expected text content.