### PR TITLE
[Fix] To use parseInt best practices after static analysis process

### DIFF
--- a/api/_lib/unfurl.ts
+++ b/api/_lib/unfurl.ts
@@ -273,7 +273,7 @@ function decodeEntities(value: string): string {
   return value.replace(/&(#x?[0-9a-fA-F]+|[a-zA-Z]+);/g, (match, entity: string) => {
     if (entity[0] === '#') {
       const isHex = entity[1] === 'x' || entity[1] === 'X';
-      const code = isHex ? parseInt(entity.slice(2), 16) : parseInt(entity.slice(1), 10);
+      const code = isHex ? Number.parseInt(entity.slice(2), 16) : Number.parseInt(entity.slice(1), 10);
 
       return Number.isFinite(code) ? String.fromCodePoint(code) : match;
     }

--- a/deploy/html.ts
+++ b/deploy/html.ts
@@ -146,9 +146,13 @@ export const renderPublishPage = ({ hostname, pathname, metaData, publishError }
 };
 
 const appendPublishErrorScript = ($: CheerioAPI, error: PublishErrorPayload) => {
-  const serialized = JSON.stringify(error).replace(/</g, '\\u003c').replace(/>/g, '\\u003e');
+  const serialized = JSON.stringify(error)
+    .replace(/</g, '\\u003c')
+    .replace(/>/g, '\\u003e');
 
-  $('head').append(`<script id="appflowy-publish-error">window.__APPFLOWY_PUBLISH_ERROR__ = ${serialized};</script>`);
+  $('head').append(
+    `<script id="appflowy-publish-error">window.__APPFLOWY_PUBLISH_ERROR__ = ${serialized};</script>`
+  );
 };
 
 const setOrUpdateMetaTag = ($: CheerioAPI, selector: string, attribute: string, content: string) => {

--- a/deploy/html.ts
+++ b/deploy/html.ts
@@ -146,13 +146,9 @@ export const renderPublishPage = ({ hostname, pathname, metaData, publishError }
 };
 
 const appendPublishErrorScript = ($: CheerioAPI, error: PublishErrorPayload) => {
-  const serialized = JSON.stringify(error)
-    .replace(/</g, '\\u003c')
-    .replace(/>/g, '\\u003e');
+  const serialized = JSON.stringify(error).replace(/</g, '\\u003c').replace(/>/g, '\\u003e');
 
-  $('head').append(
-    `<script id="appflowy-publish-error">window.__APPFLOWY_PUBLISH_ERROR__ = ${serialized};</script>`
-  );
+  $('head').append(`<script id="appflowy-publish-error">window.__APPFLOWY_PUBLISH_ERROR__ = ${serialized};</script>`);
 };
 
 const setOrUpdateMetaTag = ($: CheerioAPI, selector: string, attribute: string, content: string) => {
@@ -184,10 +180,10 @@ const argbToRgba = (color: string): string => {
     return color.replace('0x', '#');
   }
 
-  const r = parseInt(hex.slice(2, 4), 16);
-  const g = parseInt(hex.slice(4, 6), 16);
-  const b = parseInt(hex.slice(6, 8), 16);
-  const a = hasAlpha ? parseInt(hex.slice(0, 2), 16) / 255 : 1;
+  const r = Number.parseInt(hex.slice(2, 4), 16);
+  const g = Number.parseInt(hex.slice(4, 6), 16);
+  const b = Number.parseInt(hex.slice(6, 8), 16);
+  const a = hasAlpha ? Number.parseInt(hex.slice(0, 2), 16) / 255 : 1;
 
   return `rgba(${r}, ${g}, ${b}, ${a})`;
 };

--- a/src/application/database-yjs/cell.parse.ts
+++ b/src/application/database-yjs/cell.parse.ts
@@ -27,7 +27,9 @@ export function parseYDatabaseCommonCellToCell(cell: YDatabaseCell): Cell {
 
 export function parseYDatabaseCellToCell(cell: YDatabaseCell, field?: YDatabaseField): Cell {
   const cellType = Number.parseInt(cell.get(YjsDatabaseKey.field_type));
-  const sourceType = Number(cell.get(YjsDatabaseKey.source_field_type) ?? cellType) as FieldType;
+  const sourceType = Number(
+    cell.get(YjsDatabaseKey.source_field_type) ?? cellType
+  ) as FieldType;
 
   let value = parseYDatabaseCommonCellToCell(cell);
 
@@ -86,7 +88,10 @@ function transformCellData(
         return stringifyChecklistStruct(parsed);
       }
 
-      if ((sourceType === FieldType.SingleSelect || sourceType === FieldType.MultiSelect) && field) {
+      if (
+        (sourceType === FieldType.SingleSelect || sourceType === FieldType.MultiSelect) &&
+        field
+      ) {
         // Resolve options by the source select type — the field's current type
         // is Checklist here, so its own type-option holds no select options.
         const typeOption = parseSelectOptionTypeOptions(field, sourceType);
@@ -146,16 +151,15 @@ function transformCellData(
 
       if (sourceType === FieldType.RichText && typeof data === 'string') {
         const names = data.split(',').map((s) => s.trim());
-        const ids = names.map((name) => options.find((o) => o.name === name)?.id).filter(Boolean);
+        const ids = names
+          .map((name) => options.find((o) => o.name === name)?.id)
+          .filter(Boolean);
 
         return ids.join(',');
       }
 
       // Checkbox → SingleSelect/MultiSelect: map "Yes"/"No" to option IDs
-      if (
-        sourceType === FieldType.Checkbox &&
-        (typeof data === 'string' || typeof data === 'number' || typeof data === 'boolean')
-      ) {
+      if (sourceType === FieldType.Checkbox && (typeof data === 'string' || typeof data === 'number' || typeof data === 'boolean')) {
         const isChecked = parseCheckboxValue(data);
         const targetName = isChecked ? 'Yes' : 'No';
         const matchingOption = options.find((o) => o.name === targetName);

--- a/src/application/database-yjs/cell.parse.ts
+++ b/src/application/database-yjs/cell.parse.ts
@@ -20,16 +20,14 @@ export function parseYDatabaseCommonCellToCell(cell: YDatabaseCell): Cell {
   return {
     createdAt: Number(cell.get(YjsDatabaseKey.created_at)),
     lastModified: Number(cell.get(YjsDatabaseKey.last_modified)),
-    fieldType: parseInt(cell.get(YjsDatabaseKey.field_type)) as FieldType,
+    fieldType: Number.parseInt(cell.get(YjsDatabaseKey.field_type)) as FieldType,
     data: cell.get(YjsDatabaseKey.data),
   };
 }
 
 export function parseYDatabaseCellToCell(cell: YDatabaseCell, field?: YDatabaseField): Cell {
-  const cellType = parseInt(cell.get(YjsDatabaseKey.field_type));
-  const sourceType = Number(
-    cell.get(YjsDatabaseKey.source_field_type) ?? cellType
-  ) as FieldType;
+  const cellType = Number.parseInt(cell.get(YjsDatabaseKey.field_type));
+  const sourceType = Number(cell.get(YjsDatabaseKey.source_field_type) ?? cellType) as FieldType;
 
   let value = parseYDatabaseCommonCellToCell(cell);
 
@@ -88,10 +86,7 @@ function transformCellData(
         return stringifyChecklistStruct(parsed);
       }
 
-      if (
-        (sourceType === FieldType.SingleSelect || sourceType === FieldType.MultiSelect) &&
-        field
-      ) {
+      if ((sourceType === FieldType.SingleSelect || sourceType === FieldType.MultiSelect) && field) {
         // Resolve options by the source select type — the field's current type
         // is Checklist here, so its own type-option holds no select options.
         const typeOption = parseSelectOptionTypeOptions(field, sourceType);
@@ -151,15 +146,16 @@ function transformCellData(
 
       if (sourceType === FieldType.RichText && typeof data === 'string') {
         const names = data.split(',').map((s) => s.trim());
-        const ids = names
-          .map((name) => options.find((o) => o.name === name)?.id)
-          .filter(Boolean);
+        const ids = names.map((name) => options.find((o) => o.name === name)?.id).filter(Boolean);
 
         return ids.join(',');
       }
 
       // Checkbox → SingleSelect/MultiSelect: map "Yes"/"No" to option IDs
-      if (sourceType === FieldType.Checkbox && (typeof data === 'string' || typeof data === 'number' || typeof data === 'boolean')) {
+      if (
+        sourceType === FieldType.Checkbox &&
+        (typeof data === 'string' || typeof data === 'number' || typeof data === 'boolean')
+      ) {
         const isChecked = parseCheckboxValue(data);
         const targetName = isChecked ? 'Yes' : 'No';
         const matchingOption = options.find((o) => o.name === targetName);

--- a/src/application/database-yjs/fields/date/utils.ts
+++ b/src/application/database-yjs/fields/date/utils.ts
@@ -83,15 +83,7 @@ export function getFieldDateTimeFormats(typeOption: YMapFieldTypeOption | undefi
   };
 }
 
-export function getDateCellStr({
-  cell,
-  field,
-  currentUser,
-}: {
-  cell: DateTimeCell;
-  field: YDatabaseField;
-  currentUser?: User;
-}) {
+export function getDateCellStr({ cell, field, currentUser }: { cell: DateTimeCell; field: YDatabaseField; currentUser?: User }) {
   const typeOptionMap = field.get(YjsDatabaseKey.type_option);
   const typeOption = typeOptionMap?.get(String(cell.fieldType));
 

--- a/src/application/database-yjs/fields/date/utils.ts
+++ b/src/application/database-yjs/fields/date/utils.ts
@@ -71,19 +71,27 @@ export function getFieldDateTimeFormats(typeOption: YMapFieldTypeOption | undefi
   const dateFormat =
     parsedDateFormat === undefined || Number.isNaN(parsedDateFormat)
       ? fallbackDateFormat ?? DateFormat.Local
-      : parsedDateFormat as DateFormat;
+      : (parsedDateFormat as DateFormat);
   const timeFormat =
     parsedTimeFormat === undefined || Number.isNaN(parsedTimeFormat)
       ? fallbackTimeFormat ?? TimeFormat.TwelveHour
-      : parsedTimeFormat as TimeFormat;
+      : (parsedTimeFormat as TimeFormat);
 
   return {
     dateFormat,
     timeFormat,
-  }
+  };
 }
 
-export function getDateCellStr({ cell, field, currentUser }: { cell: DateTimeCell; field: YDatabaseField, currentUser?: User }) {
+export function getDateCellStr({
+  cell,
+  field,
+  currentUser,
+}: {
+  cell: DateTimeCell;
+  field: YDatabaseField;
+  currentUser?: User;
+}) {
   const typeOptionMap = field.get(YjsDatabaseKey.type_option);
   const typeOption = typeOptionMap?.get(String(cell.fieldType));
 
@@ -105,10 +113,10 @@ export function getDateCellStr({ cell, field, currentUser }: { cell: DateTimeCel
   const endDateTime =
     endTimestamp && isRange
       ? getDateTimeStr({
-        timeStamp: endTimestamp,
-        includeTime,
-        typeOptionValue,
-      })
+          timeStamp: endTimestamp,
+          includeTime,
+          typeOptionValue,
+        })
       : null;
 
   return [startDateTime, endDateTime].filter(Boolean).join(` ${RIGHTWARDS_ARROW} `);
@@ -123,9 +131,9 @@ export function isDate(input: string) {
 export function safeParseTimestamp(input: string) {
   if (/^\d+$/.test(input)) {
     if (input.length >= 9 && input.length <= 10) {
-      return dayjs.unix(parseInt(input, 10));
+      return dayjs.unix(Number.parseInt(input, 10));
     } else if (input.length >= 12 && input.length <= 13) {
-      return dayjs(parseInt(input, 10));
+      return dayjs(Number.parseInt(input, 10));
     }
   }
 

--- a/src/application/database-yjs/fields/number/EnhancedBigStats.ts
+++ b/src/application/database-yjs/fields/number/EnhancedBigStats.ts
@@ -14,9 +14,9 @@ export class EnhancedBigStats {
    * Create a new statistics calculator instance
    * @param data - Array of number strings
    */
-  constructor (data: string[] = []) {
+  constructor(data: string[] = []) {
     this.validateData(data);
-    this.data = data.map(str => new Big(str));
+    this.data = data.map((str) => new Big(str));
   }
 
   /**
@@ -25,13 +25,15 @@ export class EnhancedBigStats {
    * @param format - Optional number format to apply to the output
    * @returns Expanded decimal string without scientific notation, or null if parsing fails
    */
-  static parse (input: string | number, format?: NumberFormat): string | null {
+  static parse(input: string | number, format?: NumberFormat): string | null {
     if (!input || (typeof input !== 'string' && typeof input !== 'number')) {
       return null;
     }
 
     // Trim whitespace and remove currency symbols and separators
-    const cleaned = input.toString().trim()
+    const cleaned = input
+      .toString()
+      .trim()
       // Remove all currency symbols, thousand separators, and other non-numeric characters
       // except for digits, period, plus, minus, and 'e' for scientific notation
       .replace(/[^0-9.e+-]/gi, '')
@@ -51,7 +53,7 @@ export class EnhancedBigStats {
       if (scientificMatch) {
         // Input is in scientific notation
         const base = scientificMatch[1];
-        const exponent = parseInt(scientificMatch[2], 10);
+        const exponent = Number.parseInt(scientificMatch[2], 10);
 
         // Create Big instance from scientific notation
         bigNumber = new Big(`${base}e${exponent}`);
@@ -117,7 +119,7 @@ export class EnhancedBigStats {
    * @param format - The number format to use
    * @returns Formatted string representation
    */
-  static formatValue (numberValue: string | Big | number, format: NumberFormat = NumberFormat.Num): string {
+  static formatValue(numberValue: string | Big | number, format: NumberFormat = NumberFormat.Num): string {
     // Convert input to string for processing
     const valueStr = numberValue.toString();
 
@@ -130,16 +132,13 @@ export class EnhancedBigStats {
 
     try {
       // Check if the value is an integer (no decimal point or all zeros after decimal)
-      const isInteger = !valueStr.includes('.') ||
-        new Big(valueStr).mod(1).eq(0);
+      const isInteger = !valueStr.includes('.') || new Big(valueStr).mod(1).eq(0);
 
       if (isInteger) {
         try {
           // For integers, try to use BigInt for maximum precision
           // Remove any decimal part that is all zeros
-          const cleanedInt = valueStr.includes('.')
-            ? valueStr.slice(0, valueStr.indexOf('.'))
-            : valueStr;
+          const cleanedInt = valueStr.includes('.') ? valueStr.slice(0, valueStr.indexOf('.')) : valueStr;
 
           return formatter(BigInt(cleanedInt));
         } catch (e) {
@@ -163,7 +162,7 @@ export class EnhancedBigStats {
    * @param b - Second number string
    * @returns Comparison result: -1 if a < b, 1 if a > b, 0 if equal
    */
-  static compare (a: string, b: string): number {
+  static compare(a: string, b: string): number {
     const numA = new Big(a);
     const numB = new Big(b);
 
@@ -177,7 +176,7 @@ export class EnhancedBigStats {
    * @param data - Data to be validated
    * @private
    */
-  private validateData (data: string[]): void {
+  private validateData(data: string[]): void {
     if (!Array.isArray(data)) {
       throw new Error('Data must be an array');
     }
@@ -197,7 +196,7 @@ export class EnhancedBigStats {
    * Calculate sum of the data
    * @returns Total sum
    */
-  sum (): Big {
+  sum(): Big {
     if (this.data.length === 0) return new Big(0);
 
     return this.data.reduce((acc, val) => acc.plus(val), new Big(0));
@@ -207,7 +206,7 @@ export class EnhancedBigStats {
    * Calculate average of the data
    * @returns Average value
    */
-  average (): Big {
+  average(): Big {
     if (this.data.length === 0) {
       throw new Error('Cannot calculate average of empty dataset');
     }
@@ -221,7 +220,7 @@ export class EnhancedBigStats {
    * Find maximum value in the data
    * @returns Maximum value
    */
-  max (): Big {
+  max(): Big {
     if (this.data.length === 0) {
       throw new Error('Cannot find maximum of empty dataset');
     }
@@ -233,7 +232,7 @@ export class EnhancedBigStats {
    * Find minimum value in the data
    * @returns Minimum value
    */
-  min (): Big {
+  min(): Big {
     if (this.data.length === 0) {
       throw new Error('Cannot find minimum of empty dataset');
     }
@@ -245,7 +244,7 @@ export class EnhancedBigStats {
    * Calculate median of the data
    * @returns Median value
    */
-  median (): Big {
+  median(): Big {
     if (this.data.length === 0) {
       throw new Error('Cannot calculate median of empty dataset');
     }
@@ -275,13 +274,13 @@ export class EnhancedBigStats {
    * Calculate variance of the data
    * @returns Variance
    */
-  variance (): Big {
+  variance(): Big {
     if (this.data.length <= 1) {
       throw new Error('Need at least two data points to calculate variance');
     }
 
     const avg = this.average();
-    const squaredDiffs = this.data.map(val => {
+    const squaredDiffs = this.data.map((val) => {
       const diff = val.minus(avg);
 
       return diff.times(diff);
@@ -296,7 +295,7 @@ export class EnhancedBigStats {
    * Calculate standard deviation of the data
    * @returns Standard deviation
    */
-  standardDeviation (): Big {
+  standardDeviation(): Big {
     const variance = this.variance();
 
     // Initial guess
@@ -316,7 +315,10 @@ export class EnhancedBigStats {
    * @param format - Number format to use for formatted values
    * @returns All statistical values with both raw and formatted representations
    */
-  getStats (decimalPlaces: number = 4, format: NumberFormat = NumberFormat.Num): {
+  getStats(
+    decimalPlaces: number = 4,
+    format: NumberFormat = NumberFormat.Num
+  ): {
     count: number;
     sum: { raw: string; formatted: string };
     average: { raw: string; formatted: string };
@@ -374,14 +376,18 @@ export class EnhancedBigStats {
           raw: range.toString(),
           formatted: EnhancedBigStats.formatValue(range, format),
         },
-        variance: variance ? {
-          raw: variance.toString(),
-          formatted: EnhancedBigStats.formatValue(variance, format),
-        } : null,
-        standardDeviation: standardDeviation ? {
-          raw: standardDeviation.toString(),
-          formatted: EnhancedBigStats.formatValue(standardDeviation, format),
-        } : null,
+        variance: variance
+          ? {
+              raw: variance.toString(),
+              formatted: EnhancedBigStats.formatValue(variance, format),
+            }
+          : null,
+        standardDeviation: standardDeviation
+          ? {
+              raw: standardDeviation.toString(),
+              formatted: EnhancedBigStats.formatValue(standardDeviation, format),
+            }
+          : null,
       };
     } finally {
       // Restore original precision setting
@@ -395,7 +401,7 @@ export class EnhancedBigStats {
    * @param format - Number format to use
    * @returns Formatted string representation of the statistic
    */
-  formatStat (statMethod: () => Big, format: NumberFormat): string {
+  formatStat(statMethod: () => Big, format: NumberFormat): string {
     try {
       const value = statMethod.call(this);
 
@@ -410,7 +416,7 @@ export class EnhancedBigStats {
    * @param format - Number format to use
    * @returns Formatted sum
    */
-  formattedSum (format: NumberFormat = NumberFormat.Num): string {
+  formattedSum(format: NumberFormat = NumberFormat.Num): string {
     return this.formatStat(() => this.sum(), format);
   }
 
@@ -419,7 +425,7 @@ export class EnhancedBigStats {
    * @param format - Number format to use
    * @returns Formatted average
    */
-  formattedAverage (format: NumberFormat = NumberFormat.Num): string {
+  formattedAverage(format: NumberFormat = NumberFormat.Num): string {
     return this.formatStat(() => this.average(), format);
   }
 
@@ -428,7 +434,7 @@ export class EnhancedBigStats {
    * @param format - Number format to use
    * @returns Formatted median
    */
-  formattedMedian (format: NumberFormat = NumberFormat.Num): string {
+  formattedMedian(format: NumberFormat = NumberFormat.Num): string {
     return this.formatStat(() => this.median(), format);
   }
 
@@ -437,7 +443,7 @@ export class EnhancedBigStats {
    * @param format - Number format to use
    * @returns Formatted minimum
    */
-  formattedMin (format: NumberFormat = NumberFormat.Num): string {
+  formattedMin(format: NumberFormat = NumberFormat.Num): string {
     return this.formatStat(() => this.min(), format);
   }
 
@@ -446,7 +452,7 @@ export class EnhancedBigStats {
    * @param format - Number format to use
    * @returns Formatted maximum
    */
-  formattedMax (format: NumberFormat = NumberFormat.Num): string {
+  formattedMax(format: NumberFormat = NumberFormat.Num): string {
     return this.formatStat(() => this.max(), format);
   }
 
@@ -454,7 +460,7 @@ export class EnhancedBigStats {
    * Add a new data point
    * @param value - Number string to be added
    */
-  addDataPoint (value: string): void {
+  addDataPoint(value: string): void {
     try {
       const bigValue = new Big(value);
 
@@ -469,7 +475,7 @@ export class EnhancedBigStats {
    * @param input - User input string to parse and add
    * @returns Boolean indicating if the addition was successful
    */
-  addParsedDataPoint (input: string): boolean {
+  addParsedDataPoint(input: string): boolean {
     const parsedValue = EnhancedBigStats.parse(input);
 
     if (parsedValue === null) {
@@ -487,7 +493,7 @@ export class EnhancedBigStats {
   /**
    * Clear the dataset
    */
-  clearData (): void {
+  clearData(): void {
     this.data = [];
   }
 
@@ -495,9 +501,9 @@ export class EnhancedBigStats {
    * Set a new dataset
    * @param data - New dataset
    */
-  setData (data: string[]): void {
+  setData(data: string[]): void {
     this.validateData(data);
-    this.data = data.map(str => new Big(str));
+    this.data = data.map((str) => new Big(str));
   }
 
   /**
@@ -505,7 +511,7 @@ export class EnhancedBigStats {
    * @param inputs - Array of user input strings
    * @returns Number of successfully parsed values
    */
-  setParsedData (inputs: string[]): number {
+  setParsedData(inputs: string[]): number {
     if (!Array.isArray(inputs)) {
       return 0;
     }
@@ -533,7 +539,7 @@ export class EnhancedBigStats {
    * Get the raw data as Big instances
    * @returns Array of Big numbers
    */
-  getRawData (): Big[] {
+  getRawData(): Big[] {
     return [...this.data];
   }
 
@@ -542,10 +548,9 @@ export class EnhancedBigStats {
    * @param format - Number format to use
    * @returns Array of formatted values
    */
-  getFormattedData (format: NumberFormat = NumberFormat.Num): string[] {
-    return this.data.map(value => EnhancedBigStats.formatValue(value, format));
+  getFormattedData(format: NumberFormat = NumberFormat.Num): string[] {
+    return this.data.map((value) => EnhancedBigStats.formatValue(value, format));
   }
-
 }
 
 export default EnhancedBigStats;

--- a/src/application/database-yjs/fields/number/EnhancedBigStats.ts
+++ b/src/application/database-yjs/fields/number/EnhancedBigStats.ts
@@ -31,9 +31,7 @@ export class EnhancedBigStats {
     }
 
     // Trim whitespace and remove currency symbols and separators
-    const cleaned = input
-      .toString()
-      .trim()
+    const cleaned = input.toString().trim()
       // Remove all currency symbols, thousand separators, and other non-numeric characters
       // except for digits, period, plus, minus, and 'e' for scientific notation
       .replace(/[^0-9.e+-]/gi, '')
@@ -315,10 +313,7 @@ export class EnhancedBigStats {
    * @param format - Number format to use for formatted values
    * @returns All statistical values with both raw and formatted representations
    */
-  getStats(
-    decimalPlaces: number = 4,
-    format: NumberFormat = NumberFormat.Num
-  ): {
+  getStats(decimalPlaces: number = 4, format: NumberFormat = NumberFormat.Num): {
     count: number;
     sum: { raw: string; formatted: string };
     average: { raw: string; formatted: string };

--- a/src/application/database-yjs/fields/number/parse.ts
+++ b/src/application/database-yjs/fields/number/parse.ts
@@ -4,7 +4,7 @@ import { getTypeOptions } from '../type_option';
 
 import { NumberFormat } from './number.type';
 
-export function parseNumberTypeOptions (field: YDatabaseField) {
+export function parseNumberTypeOptions(field: YDatabaseField) {
   const numberTypeOption = getTypeOptions(field)?.toJSON();
 
   if (!numberTypeOption) {
@@ -14,6 +14,6 @@ export function parseNumberTypeOptions (field: YDatabaseField) {
   }
 
   return {
-    format: parseInt(numberTypeOption.format) as NumberFormat,
+    format: Number.parseInt(numberTypeOption.format) as NumberFormat,
   };
 }

--- a/src/application/database-yjs/selector.ts
+++ b/src/application/database-yjs/selector.ts
@@ -718,9 +718,7 @@ export function useAdvancedFilterSelector(filterId: string) {
       // Handle both Yjs Y.Array (with .get() method) and plain JavaScript array (from desktop sync)
       const isYArray = typeof (children as { get?: unknown }).get === 'function';
       const childrenArray = children as { length: number; get?: (index: number) => unknown } | unknown[];
-      const childCount = Array.isArray(childrenArray)
-        ? childrenArray.length
-        : (childrenArray as { length: number }).length;
+      const childCount = Array.isArray(childrenArray) ? childrenArray.length : (childrenArray as { length: number }).length;
 
       let foundFilter: unknown = null;
 
@@ -1023,7 +1021,9 @@ export function useGroup(groupId: string) {
         .map(normalizeGroupColumn)
         .filter((column): column is GroupColumn => Boolean(column));
 
-      setColumns(persistedColumns.length > 0 ? persistedColumns : getFallbackGroupColumns(fields?.get(groupFieldId)));
+      setColumns(
+        persistedColumns.length > 0 ? persistedColumns : getFallbackGroupColumns(fields?.get(groupFieldId))
+      );
     };
 
     observerEvent();
@@ -1966,8 +1966,7 @@ export function useCalendarEventsSelector() {
     if (!field || !rowOrders || !filedId) return;
     const fieldType = Number(field?.get(YjsDatabaseKey.type)) as FieldType;
 
-    if (![FieldType.DateTime, FieldType.LastEditedTime, FieldType.CreatedTime].includes(fieldType) || !primaryFieldId)
-      return;
+    if (![FieldType.DateTime, FieldType.LastEditedTime, FieldType.CreatedTime].includes(fieldType) || !primaryFieldId) return;
 
     const observerEvent = () => {
       const newEvents: CalendarEvent[] = [];
@@ -2047,10 +2046,7 @@ export function useCalendarEventsSelector() {
             id: `${row.id}`,
             start: getDate(value.data),
             isRange: value.isRange || false,
-            end:
-              value.endTimestamp && value.isRange
-                ? getDate(value.endTimestamp)
-                : dayjs(getDate(value.data)).add(30, 'minute').toDate(),
+            end: value.endTimestamp && value.isRange ? getDate(value.endTimestamp) : dayjs(getDate(value.data)).add(30, 'minute').toDate(),
             title,
             allDay,
             rowId: row.id,

--- a/src/application/database-yjs/selector.ts
+++ b/src/application/database-yjs/selector.ts
@@ -37,8 +37,8 @@ import {
   readRollupCell,
   readRollupCellSync,
   RollupCellValue,
-  subscribeRollupCell,
   subscribeRollupCache,
+  subscribeRollupCell,
 } from '@/application/database-yjs/rollup/cache';
 import { getMetaJSON, getRowKey } from '@/application/database-yjs/row_meta';
 import { sortBy } from '@/application/database-yjs/sort';
@@ -65,7 +65,16 @@ import { useCurrentUser } from '@/components/main/app.hooks';
 import { getDateFormat, getTimeFormat, renderDate } from '@/utils/time';
 
 import { ChartLayoutSettings } from './chart.type';
-import { CalendarLayoutSetting, DateGroupCondition, FieldType, FieldVisibility, Filter, FilterType, RowMeta, SortCondition } from './database.type';
+import {
+  CalendarLayoutSetting,
+  DateGroupCondition,
+  FieldType,
+  FieldVisibility,
+  Filter,
+  FilterType,
+  RowMeta,
+  SortCondition,
+} from './database.type';
 
 export interface Column {
   fieldId: string;
@@ -107,11 +116,14 @@ const defaultVisible = [FieldVisibility.AlwaysShown, FieldVisibility.HideWhenEmp
 type ConditionReference = { id: string; fieldId: string };
 
 function areConditionReferencesEqual(left: ConditionReference[], right: ConditionReference[]) {
-  return left.length === right.length && left.every((item, index) => {
-    const rightItem = right[index];
+  return (
+    left.length === right.length &&
+    left.every((item, index) => {
+      const rightItem = right[index];
 
-    return item.id === rightItem?.id && item.fieldId === rightItem.fieldId;
-  });
+      return item.id === rightItem?.id && item.fieldId === rightItem.fieldId;
+    })
+  );
 }
 
 /**
@@ -276,7 +288,7 @@ export function useFieldsSelector(visibilitys: FieldVisibility[] = defaultVisibl
           return {
             fieldId,
             isPrimary: field?.get(YjsDatabaseKey.is_primary),
-            width: parseInt(setting?.get(YjsDatabaseKey.width)) || MIN_COLUMN_WIDTH,
+            width: Number.parseInt(setting?.get(YjsDatabaseKey.width)) || MIN_COLUMN_WIDTH,
             visibility: Number(
               setting?.get(YjsDatabaseKey.visibility) || FieldVisibility.AlwaysShown
             ) as FieldVisibility,
@@ -471,7 +483,7 @@ export function useFiltersSelector() {
     const observerEvent = () => {
       const nextFilters = getFilters();
 
-      setFilters((prevFilters) => areConditionReferencesEqual(prevFilters, nextFilters) ? prevFilters : nextFilters);
+      setFilters((prevFilters) => (areConditionReferencesEqual(prevFilters, nextFilters) ? prevFilters : nextFilters));
     };
 
     observerEvent();
@@ -706,7 +718,9 @@ export function useAdvancedFilterSelector(filterId: string) {
       // Handle both Yjs Y.Array (with .get() method) and plain JavaScript array (from desktop sync)
       const isYArray = typeof (children as { get?: unknown }).get === 'function';
       const childrenArray = children as { length: number; get?: (index: number) => unknown } | unknown[];
-      const childCount = Array.isArray(childrenArray) ? childrenArray.length : (childrenArray as { length: number }).length;
+      const childCount = Array.isArray(childrenArray)
+        ? childrenArray.length
+        : (childrenArray as { length: number }).length;
 
       let foundFilter: unknown = null;
 
@@ -805,7 +819,7 @@ export function useSortsSelector() {
     const observerEvent = () => {
       const nextSorts = getSorts();
 
-      setSorts((prevSorts) => areConditionReferencesEqual(prevSorts, nextSorts) ? prevSorts : nextSorts);
+      setSorts((prevSorts) => (areConditionReferencesEqual(prevSorts, nextSorts) ? prevSorts : nextSorts));
     };
 
     setSorts(getSorts());
@@ -1009,9 +1023,7 @@ export function useGroup(groupId: string) {
         .map(normalizeGroupColumn)
         .filter((column): column is GroupColumn => Boolean(column));
 
-      setColumns(
-        persistedColumns.length > 0 ? persistedColumns : getFallbackGroupColumns(fields?.get(groupFieldId))
-      );
+      setColumns(persistedColumns.length > 0 ? persistedColumns : getFallbackGroupColumns(fields?.get(groupFieldId)));
     };
 
     observerEvent();
@@ -1954,7 +1966,8 @@ export function useCalendarEventsSelector() {
     if (!field || !rowOrders || !filedId) return;
     const fieldType = Number(field?.get(YjsDatabaseKey.type)) as FieldType;
 
-    if (![FieldType.DateTime, FieldType.LastEditedTime, FieldType.CreatedTime].includes(fieldType) || !primaryFieldId) return;
+    if (![FieldType.DateTime, FieldType.LastEditedTime, FieldType.CreatedTime].includes(fieldType) || !primaryFieldId)
+      return;
 
     const observerEvent = () => {
       const newEvents: CalendarEvent[] = [];
@@ -1999,9 +2012,10 @@ export function useCalendarEventsSelector() {
         const rowCreatedTime = databbaseRow.get(YjsDatabaseKey.created_at).toString();
         const rowLastEditedTime = databbaseRow.get(YjsDatabaseKey.last_modified).toString();
 
-        const value = cell ? parseYDatabaseCellToCell(cell, field) as DateTimeCell : undefined;
+        const value = cell ? (parseYDatabaseCellToCell(cell, field) as DateTimeCell) : undefined;
 
-        if ((!value?.data && fieldType !== FieldType.CreatedTime && fieldType !== FieldType.LastEditedTime) ||
+        if (
+          (!value?.data && fieldType !== FieldType.CreatedTime && fieldType !== FieldType.LastEditedTime) ||
           (fieldType === FieldType.CreatedTime && !rowCreatedTime) ||
           (fieldType === FieldType.LastEditedTime && !rowLastEditedTime)
         ) {
@@ -2020,7 +2034,6 @@ export function useCalendarEventsSelector() {
           return dayjsResult.toDate();
         };
 
-
         if ([FieldType.CreatedTime, FieldType.LastEditedTime].includes(fieldType)) {
           newEvents.push({
             id: `${row.id}`,
@@ -2034,19 +2047,20 @@ export function useCalendarEventsSelector() {
             id: `${row.id}`,
             start: getDate(value.data),
             isRange: value.isRange || false,
-            end: value.endTimestamp && value.isRange ? getDate(value.endTimestamp) : dayjs(getDate(value.data)).add(30, 'minute').toDate(),
+            end:
+              value.endTimestamp && value.isRange
+                ? getDate(value.endTimestamp)
+                : dayjs(getDate(value.data)).add(30, 'minute').toDate(),
             title,
             allDay,
             rowId: row.id,
           });
         }
-
-
       });
 
       setEvents(newEvents);
       setEmptyEvents(emptyEvents);
-    }
+    };
 
     observerEvent();
 
@@ -2072,7 +2086,6 @@ export function useCalendarEventsSelector() {
         rowDoc.getMap(YjsEditorKey.data_section).unobserveDeep(debouncedObserverEvent);
       });
     };
-
   }, [field, rowOrders, rows, filedId, primaryFieldId, ensureRow]);
 
   return { events, emptyEvents };
@@ -2092,7 +2105,10 @@ export function useCalendarLayoutSetting() {
     const view = database.get(YjsDatabaseKey.views)?.get(viewId);
     const observerHandler = () => {
       const layoutSetting = view?.get(YjsDatabaseKey.layout_settings)?.get('2');
-      const firstDayOfWeek = layoutSetting?.get(YjsDatabaseKey.first_day_of_week) === undefined ? startWeekOn : Number(layoutSetting?.get(YjsDatabaseKey.first_day_of_week) || 0);
+      const firstDayOfWeek =
+        layoutSetting?.get(YjsDatabaseKey.first_day_of_week) === undefined
+          ? startWeekOn
+          : Number(layoutSetting?.get(YjsDatabaseKey.first_day_of_week) || 0);
 
       setSetting({
         fieldId: layoutSetting?.get(YjsDatabaseKey.field_id),
@@ -2155,15 +2171,17 @@ export const useRowMetaSelector = (rowId: string) => {
       const promise = ensureRow(rowId);
 
       if (promise) {
-        promise.then((doc) => {
-          if (!cancelled && doc) {
-            setRowDoc(doc);
-          }
-        }).catch((error: unknown) => {
-          if (!cancelled) {
-            console.error('[useRowMetaSelector] Failed to ensure row doc:', error);
-          }
-        });
+        promise
+          .then((doc) => {
+            if (!cancelled && doc) {
+              setRowDoc(doc);
+            }
+          })
+          .catch((error: unknown) => {
+            if (!cancelled) {
+              console.error('[useRowMetaSelector] Failed to ensure row doc:', error);
+            }
+          });
       }
     }
 
@@ -2512,10 +2530,7 @@ export function useRowPrimaryContentSelector(rowDoc: YDoc | null, primaryFieldId
   return primaryContent;
 }
 
-function chartSettingsEqual(
-  a: ChartLayoutSettings | null,
-  b: ChartLayoutSettings | null
-): boolean {
+function chartSettingsEqual(a: ChartLayoutSettings | null, b: ChartLayoutSettings | null): boolean {
   if (a === b) return true;
   if (!a || !b) return false;
   return (
@@ -2580,11 +2595,9 @@ export function useChartLayoutSetting(): ChartLayoutSettings | null {
         aggregationType: Number(chartSettingMap.get('aggregationType') || 0) as ChartLayoutSettings['aggregationType'],
         yFieldId: chartSettingMap.get('yFieldId') ? String(chartSettingMap.get('yFieldId')) : undefined,
         cumulative: Boolean(chartSettingMap.get('cumulative')),
-        dateCondition: (
-          dateConditionRaw === undefined || dateConditionRaw === null
-            ? DateGroupCondition.Month
-            : Number(dateConditionRaw)
-        ) as ChartLayoutSettings['dateCondition'],
+        dateCondition: (dateConditionRaw === undefined || dateConditionRaw === null
+          ? DateGroupCondition.Month
+          : Number(dateConditionRaw)) as ChartLayoutSettings['dateCondition'],
       };
 
       setSetting((prev) => (chartSettingsEqual(prev, next) ? prev : next));

--- a/src/application/services/js-services/http/core.ts
+++ b/src/application/services/js-services/http/core.ts
@@ -41,7 +41,7 @@ export function parseRetryAfterSecs(headers: Record<string, unknown> | undefined
   const raw = headers['retry-after'];
 
   if (typeof raw === 'string') {
-    const parsed = parseInt(raw.trim(), 10);
+    const parsed = Number.parseInt(raw.trim(), 10);
 
     return Number.isFinite(parsed) && parsed >= 0 ? parsed : undefined;
   }
@@ -123,15 +123,22 @@ export async function executeAPIRequest<TResponseData = unknown>(
     }
 
     // Get the actual URL that was requested
-    const requestUrl = response.request?.responseURL
-      || (response.config?.baseURL && response.config?.url
+    const requestUrl =
+      response.request?.responseURL ||
+      (response.config?.baseURL && response.config?.url
         ? `${response.config.baseURL}${response.config.url}`
-        : response.config?.url)
-      || 'unknown';
+        : response.config?.url) ||
+      'unknown';
 
     const method = response.config?.method?.toUpperCase() || 'UNKNOWN';
 
-    Log.debug('[executeAPIRequest]', { method, url: requestUrl, response_data: response.data?.data, response_code: response.data?.code, response_message: response.data?.message });
+    Log.debug('[executeAPIRequest]', {
+      method,
+      url: requestUrl,
+      response_data: response.data?.data,
+      response_code: response.data?.code,
+      response_message: response.data?.message,
+    });
 
     if (!response.data) {
       console.error('[executeAPIRequest] No response data received', response);
@@ -266,7 +273,11 @@ export async function withRetry<T>(
         delay = Math.round(delays[attempt] * (1.0 + Math.random()));
       }
 
-      Log.debug(`[withRetry] Attempt ${attempt + 1}/${delays.length} failed (code=${normalized.code}, retryAfter=${normalized.retryAfterSecs ?? 'none'}), retrying in ${delay}ms`);
+      Log.debug(
+        `[withRetry] Attempt ${attempt + 1}/${delays.length} failed (code=${normalized.code}, retryAfter=${
+          normalized.retryAfterSecs ?? 'none'
+        }), retrying in ${delay}ms`
+      );
 
       // Wait for backoff, but abort early if signal fires
       await new Promise<void>((resolve) => {
@@ -277,10 +288,14 @@ export async function withRetry<T>(
 
         const timer = setTimeout(resolve, delay);
 
-        signal?.addEventListener('abort', () => {
-          clearTimeout(timer);
-          resolve();
-        }, { once: true });
+        signal?.addEventListener(
+          'abort',
+          () => {
+            clearTimeout(timer);
+            resolve();
+          },
+          { once: true }
+        );
       });
     }
   }

--- a/src/application/services/js-services/http/gotrue-error.ts
+++ b/src/application/services/js-services/http/gotrue-error.ts
@@ -131,9 +131,9 @@ export function parseGoTrueError(errorData: {
 
   // Try to get code from explicit field
   if (errorData.code) {
-    code = typeof errorData.code === 'number' ? errorData.code : parseInt(errorData.code);
+    code = typeof errorData.code === 'number' ? errorData.code : Number.parseInt(errorData.code);
   } else if (errorData.errorCode) {
-    code = parseInt(errorData.errorCode);
+    code = Number.parseInt(errorData.errorCode);
   } else if (errorData.status) {
     code = errorData.status;
   }
@@ -143,7 +143,7 @@ export function parseGoTrueError(errorData: {
     const codeMatch = errorMessage.match(/^(\d{3}):/);
 
     if (codeMatch) {
-      code = parseInt(codeMatch[1]);
+      code = Number.parseInt(codeMatch[1]);
     }
   }
 

--- a/src/components/_shared/color-picker/CustomColorPicker.tsx
+++ b/src/components/_shared/color-picker/CustomColorPicker.tsx
@@ -79,13 +79,13 @@ function rgbaToArgb(color: string): string {
     return '';
   }
 
-  const r = parseInt(match[1].substring(0, 2), 16);
-  const g = parseInt(match[1].substring(2, 4), 16);
-  const b = parseInt(match[1].substring(4, 6), 16);
+  const r = Number.parseInt(match[1].substring(0, 2), 16);
+  const g = Number.parseInt(match[1].substring(2, 4), 16);
+  const b = Number.parseInt(match[1].substring(4, 6), 16);
   let a = 255;
 
   if (typeof match[2] !== 'undefined') {
-    a = parseInt(match[2], 16);
+    a = Number.parseInt(match[2], 16);
   }
 
   const hex = (v: number) => Math.max(0, Math.min(255, v)).toString(16).padStart(2, '0');
@@ -117,13 +117,13 @@ function argbToHtmlHex(color: string): string {
     b = 0;
 
   if (match[1].length === 8) {
-    r = parseInt(match[1].substring(2, 4), 16);
-    g = parseInt(match[1].substring(4, 6), 16);
-    b = parseInt(match[1].substring(6, 8), 16);
+    r = Number.parseInt(match[1].substring(2, 4), 16);
+    g = Number.parseInt(match[1].substring(4, 6), 16);
+    b = Number.parseInt(match[1].substring(6, 8), 16);
   } else if (match[1].length === 6) {
-    r = parseInt(match[1].substring(0, 2), 16);
-    g = parseInt(match[1].substring(2, 4), 16);
-    b = parseInt(match[1].substring(4, 6), 16);
+    r = Number.parseInt(match[1].substring(0, 2), 16);
+    g = Number.parseInt(match[1].substring(2, 4), 16);
+    b = Number.parseInt(match[1].substring(4, 6), 16);
   }
 
   const hex = (v: number) => Math.max(0, Math.min(255, v)).toString(16).padStart(2, '0');

--- a/src/components/_shared/outline/outline.hooks.ts
+++ b/src/components/_shared/outline/outline.hooks.ts
@@ -74,7 +74,7 @@ export function useOutlinePopover ({
 
 export function useOutlineDrawer () {
   const [drawerWidth, setDrawerWidth] = React.useState(() => {
-    return parseInt(localStorage.getItem('outline_width') || '268', 10);
+    return Number.parseInt(localStorage.getItem('outline_width') || '268', 10);
   });
 
   const [drawerOpened, setDrawerOpened] = React.useState(() => {

--- a/src/components/as-template/category/CategoryForm.tsx
+++ b/src/components/as-template/category/CategoryForm.tsx
@@ -7,24 +7,20 @@ import { TemplateCategoryFormValues } from '@/application/template.type';
 import BgColorPicker from '@/components/as-template/category/BgColorPicker';
 import IconPicker from '@/components/as-template/category/IconPicker';
 
-const CategoryForm = forwardRef<HTMLInputElement, {
-  defaultValues: TemplateCategoryFormValues;
-  onSubmit: (data: TemplateCategoryFormValues) => void;
-}>(({
-  defaultValues,
-  onSubmit,
-}, ref) => {
+const CategoryForm = forwardRef<
+  HTMLInputElement,
+  {
+    defaultValues: TemplateCategoryFormValues;
+    onSubmit: (data: TemplateCategoryFormValues) => void;
+  }
+>(({ defaultValues, onSubmit }, ref) => {
   const { t } = useTranslation();
-  const {
-    control,
-    handleSubmit,
-  } = useForm<TemplateCategoryFormValues>({
+  const { control, handleSubmit } = useForm<TemplateCategoryFormValues>({
     defaultValues,
   });
 
   return (
-    <form className={'flex flex-col gap-4 py-2'} onSubmit={handleSubmit(onSubmit)}
-    >
+    <form className={'flex flex-col gap-4 py-2'} onSubmit={handleSubmit(onSubmit)}>
       <Controller
         control={control}
         rules={{
@@ -32,15 +28,16 @@ const CategoryForm = forwardRef<HTMLInputElement, {
             field: t('template.category.name'),
           }),
         }}
-
         render={({ field, fieldState }) => (
           <TextField
             error={!!fieldState.error}
-            helperText={fieldState.error?.message} required {...field}
+            helperText={fieldState.error?.message}
+            required
+            {...field}
             label={t('template.category.name')}
           />
         )}
-        name="name"
+        name='name'
       />
 
       <Controller
@@ -50,17 +47,18 @@ const CategoryForm = forwardRef<HTMLInputElement, {
             field: t('template.category.desc'),
           }),
         }}
-
         render={({ field, fieldState }) => (
           <TextField
             multiline
             minRows={3}
             error={!!fieldState.error}
-            helperText={fieldState.error?.message} required {...field}
+            helperText={fieldState.error?.message}
+            required
+            {...field}
             label={t('template.category.desc')}
           />
         )}
-        name="description"
+        name='description'
       />
 
       <Controller
@@ -70,13 +68,8 @@ const CategoryForm = forwardRef<HTMLInputElement, {
             field: t('template.category.icon'),
           }),
         }}
-
-        render={({ field }) => (
-          <IconPicker
-            {...field}
-          />
-        )}
-        name="icon"
+        render={({ field }) => <IconPicker {...field} />}
+        name='icon'
       />
 
       <Controller
@@ -86,13 +79,8 @@ const CategoryForm = forwardRef<HTMLInputElement, {
             field: t('template.category.bgColor'),
           }),
         }}
-
-        render={({ field }) => (
-          <BgColorPicker
-            {...field}
-          />
-        )}
-        name="bg_color"
+        render={({ field }) => <BgColorPicker {...field} />}
+        name='bg_color'
       />
       <Controller
         control={control}
@@ -101,7 +89,7 @@ const CategoryForm = forwardRef<HTMLInputElement, {
             field: t('template.category.type'),
           }),
         }}
-        name="category_type"
+        name='category_type'
         render={({ field }) => (
           <FormControl>
             <FormLabel>{t('template.category.type')}</FormLabel>
@@ -109,7 +97,7 @@ const CategoryForm = forwardRef<HTMLInputElement, {
               row
               value={field.value}
               onChange={(e) => {
-                field.onChange(parseInt(e.target.value, 10));
+                field.onChange(Number.parseInt(e.target.value, 10));
               }}
             >
               <FormControlLabel value={0} control={<Radio />} label={t('template.category.byUseCase')} />
@@ -117,7 +105,6 @@ const CategoryForm = forwardRef<HTMLInputElement, {
             </RadioGroup>
           </FormControl>
         )}
-
       />
       <Controller
         control={control}
@@ -126,23 +113,22 @@ const CategoryForm = forwardRef<HTMLInputElement, {
             field: t('template.category.priority'),
           }),
         }}
-
         render={({ field, fieldState }) => (
           <TextField
-            type="number"
+            type='number'
             error={!!fieldState.error}
             helperText={fieldState.error?.message}
             required
             label={t('template.category.priority')}
             {...field}
             onChange={(e) => {
-              field.onChange(parseInt(e.target.value, 10));
+              field.onChange(Number.parseInt(e.target.value, 10));
             }}
           />
         )}
-        name="priority"
+        name='priority'
       />
-      <input type="submit" ref={ref} style={{ display: 'none' }} />
+      <input type='submit' ref={ref} style={{ display: 'none' }} />
     </form>
   );
 });

--- a/src/components/database/components/grid/grid-calculation-cell/CalculationCell.tsx
+++ b/src/components/database/components/grid/grid-calculation-cell/CalculationCell.tsx
@@ -19,7 +19,7 @@ export interface CalculationCellProps {
   cell?: ICalculationCell;
 }
 
-export function CalculationCell ({ cell }: CalculationCellProps) {
+export function CalculationCell({ cell }: CalculationCellProps) {
   const { t } = useTranslation();
 
   const fieldId = cell?.fieldId || '';
@@ -34,7 +34,7 @@ export function CalculationCell ({ cell }: CalculationCellProps) {
         ? parseNumberTypeOptions(field).format
         : undefined,
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [field, clock],
+    [field, clock]
   );
   const [num, setNum] = useState<string>();
 
@@ -98,7 +98,7 @@ export function CalculationCell ({ cell }: CalculationCellProps) {
     const readValue = () => {
       const value = cell?.value;
 
-      if (value === undefined || isNaN(parseInt(value))) return '0';
+      if (value === undefined || isNaN(Number.parseInt(value))) return '0';
 
       const data = EnhancedBigStats.parse(value) || '0';
 
@@ -112,7 +112,10 @@ export function CalculationCell ({ cell }: CalculationCellProps) {
         return data.toString();
       }
 
-      const res = parseFloat(data).toFixed(2).replace(/(\.[0-9]*[1-9])0+$/, '$1').replace(/\.0+$/, '');
+      const res = parseFloat(data)
+        .toFixed(2)
+        .replace(/(\.[0-9]*[1-9])0+$/, '$1')
+        .replace(/\.0+$/, '');
 
       if (format && currencyFormaterMap[format] && !isCount) {
         return currencyFormaterMap[format](parseFloat(res));
@@ -127,9 +130,13 @@ export function CalculationCell ({ cell }: CalculationCellProps) {
   return (
     <Tooltip delayDuration={1500}>
       <TooltipTrigger asChild>
-        <div className={'h-full text-sm w-full overflow-hidden items-center px-2 text-right flex gap-[10px] uppercase leading-[36px] text-text-secondary'}>
+        <div
+          className={
+            'flex h-full w-full items-center gap-[10px] overflow-hidden px-2 text-right text-sm uppercase leading-[36px] text-text-secondary'
+          }
+        >
           <span className={'flex-1 text-xs'}>{prefix}</span>
-          <span className={'font-medium text-text-primary truncate'}>{num}</span>
+          <span className={'truncate font-medium text-text-primary'}>{num}</span>
         </div>
       </TooltipTrigger>
       <TooltipContent>

--- a/src/components/editor/parsers/block-converters.ts
+++ b/src/components/editor/parsers/block-converters.ts
@@ -1,4 +1,3 @@
-
 import { BlockData, BlockType, HeadingBlockData, ImageBlockData, ImageType } from '@/application/types';
 
 import { extractInlineFormatsFromHAST, extractTextFromHAST } from './inline-converters';
@@ -177,7 +176,11 @@ function extractParagraphSegments(node: HastElement): ParagraphSegment[] {
     });
   };
 
-  const walkNode = (child: HastElement | { type: string; value?: string }, activeFormats: ActiveInlineFormat[], isRoot = false) => {
+  const walkNode = (
+    child: HastElement | { type: string; value?: string },
+    activeFormats: ActiveInlineFormat[],
+    isRoot = false
+  ) => {
     if (child.type === 'text') {
       appendText(child.value ?? '', activeFormats);
       return;
@@ -281,7 +284,7 @@ export function isParagraph(tagName: string): boolean {
  * Converts a heading element to ParsedBlock
  */
 export function parseHeading(node: HastElement): ParsedBlock {
-  const level = parseInt(node.tagName[1]) as 1 | 2 | 3 | 4 | 5 | 6;
+  const level = Number.parseInt(node.tagName[1]) as 1 | 2 | 3 | 4 | 5 | 6;
 
   return {
     type: BlockType.HeadingBlock,
@@ -331,7 +334,7 @@ export function parseBlockquote(node: HastElement): ParsedBlock {
 export function parseCodeBlock(node: HastElement): ParsedBlock | null {
   // Look for code element inside pre
   const codeElement = node.children.find((child) => {
-    return child.type === 'element' && (child).tagName === 'code';
+    return child.type === 'element' && child.tagName === 'code';
   }) as HastElement | undefined;
 
   // Only treat as code block if there's a code element
@@ -379,7 +382,7 @@ export function parseList(node: HastElement): ParsedBlock[] {
       if (elem.tagName === 'li') {
         // Check for checkbox (todo list)
         const input = elem.children.find((c) => {
-          return c.type === 'element' && (c).tagName === 'input';
+          return c.type === 'element' && c.tagName === 'input';
         }) as HastElement | undefined;
 
         if (input && input.properties?.type === 'checkbox') {

--- a/src/components/editor/parsers/inline-converters.ts
+++ b/src/components/editor/parsers/inline-converters.ts
@@ -1,4 +1,3 @@
-
 import { InlineFormat } from './types';
 
 import type { Element as HastElement, Text as HastText } from 'hast';
@@ -65,7 +64,7 @@ export function extractInlineFormatsFromHAST(node: HastElement, baseOffset = 0):
         if (styles['font-weight']) {
           const weight = styles['font-weight'];
 
-          if (weight === 'bold' || weight === 'bolder' || parseInt(weight) >= 700) {
+          if (weight === 'bold' || weight === 'bolder' || Number.parseInt(weight) >= 700) {
             newFormats.add('bold');
           }
         }

--- a/src/components/editor/utils/fragment.ts
+++ b/src/components/editor/utils/fragment.ts
@@ -93,7 +93,7 @@ function deserializeNode(node: Node, parentBlock: YBlock, sharedRoot: YSharedRoo
           element.textContent = textContent.replace(/^(-)?\[(x| )?\]\s/, '');
         } else if (/^\d+\.\s/.test(textContent)) {
           blockType = BlockType.NumberedListBlock;
-          (blockData as NumberedListBlockData).number = parseInt(textContent.split('.')[0]);
+          (blockData as NumberedListBlockData).number = Number.parseInt(textContent.split('.')[0]);
           element.textContent = textContent.replace(/^\d+\.\s/, '');
         } else if (/^- /.test(textContent)) {
           blockType = BlockType.BulletedListBlock;

--- a/src/components/editor/utils/markdown.ts
+++ b/src/components/editor/utils/markdown.ts
@@ -265,7 +265,7 @@ const rules: Rule[] = [
     match: /^(\d+)\.\s/,
     format: BlockType.NumberedListBlock,
     filter: (editor, match) => {
-      const start = parseInt(match[1]);
+      const start = Number.parseInt(match[1]);
       const blockType = getNodeType(editor);
       const blockData = getBlockData(editor);
 
@@ -275,7 +275,7 @@ const rules: Rule[] = [
       );
     },
     transform: (editor, match) => {
-      const start = parseInt(match[1]);
+      const start = Number.parseInt(match[1]);
 
       const entry = getBlockEntry(editor);
 

--- a/src/components/ui/textarea-autosize.tsx
+++ b/src/components/ui/textarea-autosize.tsx
@@ -90,7 +90,9 @@ const TextareaAutosize = forwardRef<HTMLTextAreaElement, TextareaAutosizeProps>(
       const styles = window.getComputedStyle(textarea);
 
       contentMirror.style.width = `${
-        textarea.getBoundingClientRect().width - parseInt(styles.paddingLeft) - parseInt(styles.paddingRight)
+        textarea.getBoundingClientRect().width -
+        Number.parseInt(styles.paddingLeft) -
+        Number.parseInt(styles.paddingRight)
       }px`;
       contentMirror.style.fontFamily = styles.fontFamily;
       contentMirror.style.fontSize = styles.fontSize;
@@ -127,9 +129,9 @@ const TextareaAutosize = forwardRef<HTMLTextAreaElement, TextareaAutosizeProps>(
       const style = window.getComputedStyle(innerRef.current);
 
       return {
-        lineHeight: parseInt(style.lineHeight) || 20,
-        paddingTop: parseInt(style.paddingTop) || 0,
-        paddingBottom: parseInt(style.paddingBottom) || 0,
+        lineHeight: Number.parseInt(style.lineHeight) || 20,
+        paddingTop: Number.parseInt(style.paddingTop) || 0,
+        paddingBottom: Number.parseInt(style.paddingBottom) || 0,
       };
     }, []);
 

--- a/src/utils/color.ts
+++ b/src/utils/color.ts
@@ -357,10 +357,10 @@ function argbToRgba(color: string): string {
     return color.replace('0x', '#');
   }
 
-  const r = parseInt(hex.slice(2, 4), 16);
-  const g = parseInt(hex.slice(4, 6), 16);
-  const b = parseInt(hex.slice(6, 8), 16);
-  const a = hasAlpha ? parseInt(hex.slice(0, 2), 16) / 255 : 1;
+  const r = Number.parseInt(hex.slice(2, 4), 16);
+  const g = Number.parseInt(hex.slice(4, 6), 16);
+  const b = Number.parseInt(hex.slice(6, 8), 16);
+  const a = hasAlpha ? Number.parseInt(hex.slice(0, 2), 16) / 255 : 1;
 
   return `rgba(${r}, ${g}, ${b}, ${a})`;
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -177,7 +177,7 @@ export default defineConfig({
   clearScreen: false,
   server: {
     host: '0.0.0.0', // Listen on all network interfaces (both IPv4 and IPv6)
-    port: process.env.PORT ? parseInt(process.env.PORT) : 3000,
+    port: process.env.PORT ? Number.parseInt(process.env.PORT) : 3000,
     strictPort: true,
     watch: {
       ignored: ['node_modules'],


### PR DESCRIPTION
### **Description**

After running static analysis on the project a few impovements were suggested to improve the code.
This pull request replaces the use of `parseInt()` function in favor of `Number.parseInt()` static function.
This improves reliablity of the code but has low impact on maintainablity.
Improves formatting and code readability in some places due to changes with Prettier plugin

---

### **Checklist**

#### **General**
- [x] I've tested the changes in multiple environments (e.g., different browsers, operating systems).

#### **Testing**
- [x] I've run unit test to verify that nothing of the existing functionality was broken.
