### PR TITLE
[codex] Scope sidebar view cache by user

### DIFF
--- a/playwright/bdd/features/app/outline-cache.feature
+++ b/playwright/bdd/features/app/outline-cache.feature
@@ -1,0 +1,12 @@
+@outline-cache
+Feature: Sidebar outline disk cache
+  The sidebar should use locally cached subtree data while server refresh is slow.
+
+  Scenario: Expanding a cached sidebar view renders local children before refresh completes
+    Given I am signed in for sidebar outline cache testing
+    And a temporary sidebar space has disk cached children
+    And the temporary sidebar space subtree refresh is delayed
+    When I expand the cached sidebar space
+    Then the sidebar shows the disk cached child before the server refresh completes
+    When the delayed sidebar refresh completes
+    Then the sidebar shows the refreshed child from the server

--- a/playwright/bdd/steps/outline-cache.steps.ts
+++ b/playwright/bdd/steps/outline-cache.steps.ts
@@ -1,0 +1,413 @@
+import { APIRequestContext, expect, Page, Route } from '@playwright/test';
+import { createBdd } from 'playwright-bdd';
+
+import { signInAndWaitForApp } from '../../support/auth-flow-helpers';
+import { generateRandomEmail, setupPageErrorHandling, TestConfig } from '../../support/test-config';
+
+const { Given, When, Then, Before } = createBdd();
+
+const CACHED_CHILD_ID = 'bdd-disk-cached-child-id';
+const CACHED_CHILD_NAME = 'Disk cached child';
+const REFRESHED_CHILD_ID = 'bdd-refreshed-child-id';
+const REFRESHED_CHILD_NAME = 'Server refreshed child';
+
+type Deferred<T> = {
+  promise: Promise<T>;
+  resolve: (value: T | PromiseLike<T>) => void;
+  reject: (reason?: unknown) => void;
+};
+
+type OutlineCacheState = {
+  workspaceId?: string;
+  ownerToken?: string;
+  ownerUserId?: string;
+  targetSpaceId?: string;
+  targetSpaceName?: string;
+  refreshStarted?: boolean;
+  refreshRelease?: Deferred<void>;
+};
+
+type ApiResponse<T> = {
+  code?: number;
+  message?: string;
+  data?: T;
+};
+
+type UserWorkspaceInfoPayload = {
+  visiting_workspace: {
+    workspace_id: string;
+  };
+};
+
+type CreateViewPayload = {
+  view_id: string;
+};
+
+type CachedViewPayload = {
+  view_id: string;
+  name: string;
+  icon: null;
+  layout: number;
+  extra: Record<string, unknown> | null;
+  children: CachedViewPayload[];
+  has_children?: boolean;
+  is_published: boolean;
+  is_private: boolean;
+  parent_view_id?: string;
+};
+
+const stateByPage = new WeakMap<Page, OutlineCacheState>();
+
+Before(async ({ page }) => {
+  stateByPage.delete(page);
+  setupPageErrorHandling(page);
+  await page.setViewportSize({ width: 1440, height: 900 });
+});
+
+Given('I am signed in for sidebar outline cache testing', async ({ page, request }) => {
+  await signInAndWaitForApp(page, request, generateRandomEmail());
+  await expect(page).toHaveURL(/\/app/, { timeout: 30000 });
+  await waitForSidebarReady(page);
+  const ownerToken = await getAuthToken(page);
+
+  stateByPage.set(page, {
+    workspaceId: await getCurrentWorkspaceId(request, ownerToken),
+    ownerToken,
+    ownerUserId: await getAuthUserId(page),
+  });
+});
+
+Given('a temporary sidebar space has disk cached children', async ({ page, request }) => {
+  const state = getState(page);
+  const targetSpaceName = `BDD cached space ${Date.now()}`;
+  const createdSpace = await postApi<CreateViewPayload>(
+    request,
+    requireOwnerToken(state),
+    `/api/workspace/${requireWorkspaceId(state)}/space`,
+    {
+      name: targetSpaceName,
+      space_icon: '',
+      space_icon_color: '#00BCF0',
+      space_permission: 0,
+    }
+  );
+  const targetSpaceId = createdSpace.view_id;
+
+  state.targetSpaceId = targetSpaceId;
+  state.targetSpaceName = targetSpaceName;
+
+  await seedDiskCachedSubtree(page, requireOwnerUserId(state), requireWorkspaceId(state), targetSpaceId, targetSpaceName);
+  await clearSidebarExpansionState(page);
+  await page.reload({ waitUntil: 'domcontentloaded' });
+  await waitForSidebarSpace(page, targetSpaceId);
+  await expect(page.getByTestId(`space-${targetSpaceId}`)).toHaveAttribute('data-expanded', 'false', { timeout: 15000 });
+});
+
+Given('the temporary sidebar space subtree refresh is delayed', async ({ page }) => {
+  const state = getState(page);
+  const release = createDeferred<void>();
+
+  state.refreshRelease = release;
+  state.refreshStarted = false;
+
+  await page.route('**/api/workspace/*/view/*', async (route) => {
+    if (!isTargetSubtreeRequest(route, requireWorkspaceId(state), requireTargetSpaceId(state))) {
+      await route.continue();
+      return;
+    }
+
+    state.refreshStarted = true;
+    await release.promise;
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        code: 0,
+        message: 'success',
+        data: createSpacePayload(requireTargetSpaceId(state), requireTargetSpaceName(state), [
+          createChildPayload(REFRESHED_CHILD_ID, REFRESHED_CHILD_NAME, requireTargetSpaceId(state)),
+        ]),
+      }),
+    });
+  });
+});
+
+When('I expand the cached sidebar space', async ({ page }) => {
+  const targetSpaceId = requireTargetSpaceId(getState(page));
+
+  await page.getByTestId(`space-${targetSpaceId}`).click({ force: true });
+});
+
+Then('the sidebar shows the disk cached child before the server refresh completes', async ({ page }) => {
+  await expect
+    .poll(() => Boolean(getState(page).refreshStarted), {
+      timeout: 15000,
+      message: 'expected the server subtree refresh request to start',
+    })
+    .toBe(true);
+
+  await expect(page.getByTestId(`page-${CACHED_CHILD_ID}`)).toBeVisible({ timeout: 15000 });
+  await expect(page.getByTestId(`page-${REFRESHED_CHILD_ID}`)).toHaveCount(0);
+});
+
+When('the delayed sidebar refresh completes', async ({ page }) => {
+  const release = getState(page).refreshRelease;
+
+  if (!release) {
+    throw new Error('Sidebar refresh release was not initialized');
+  }
+
+  release.resolve();
+});
+
+Then('the sidebar shows the refreshed child from the server', async ({ page }) => {
+  await expect(page.getByTestId(`page-${REFRESHED_CHILD_ID}`)).toBeVisible({ timeout: 15000 });
+  await expect(page.getByTestId(`page-${CACHED_CHILD_ID}`)).toHaveCount(0);
+});
+
+async function waitForSidebarReady(page: Page) {
+  await expect(page.locator('[data-testid="space-item"]').first()).toBeVisible({ timeout: 60000 });
+  await expect(page.locator('[data-testid="page-item"]').first()).toBeVisible({ timeout: 60000 });
+}
+
+async function waitForSidebarSpace(page: Page, targetSpaceId: string) {
+  await expect(page.locator('[data-testid="space-item"]').first()).toBeVisible({ timeout: 60000 });
+  await expect(page.getByTestId(`space-${targetSpaceId}`)).toBeVisible({ timeout: 60000 });
+}
+
+async function clearSidebarExpansionState(page: Page) {
+  await page.evaluate(() => {
+    window.localStorage.setItem('outline_expanded', JSON.stringify({}));
+  });
+}
+
+async function getAuthToken(page: Page): Promise<string> {
+  const token = await page.evaluate(() => {
+    const tokenData = JSON.parse(localStorage.getItem('token') || '{}') as { access_token?: string };
+    return tokenData.access_token || localStorage.getItem('af_auth_token');
+  });
+
+  if (!token) {
+    throw new Error('No auth token found in browser localStorage');
+  }
+
+  return token;
+}
+
+async function getAuthUserId(page: Page): Promise<string> {
+  const userId = await page.evaluate(() => {
+    const tokenData = JSON.parse(localStorage.getItem('token') || '{}') as { user?: { id?: string } };
+
+    return tokenData.user?.id;
+  });
+
+  if (!userId) {
+    throw new Error('No auth user id found in browser localStorage');
+  }
+
+  return userId;
+}
+
+async function getCurrentWorkspaceId(request: APIRequestContext, token: string): Promise<string> {
+  const response = await request.get(`${TestConfig.apiUrl}/api/user/workspace`, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+    failOnStatusCode: false,
+  });
+  const payload = unwrapApiResponse<UserWorkspaceInfoPayload>(response.status(), await response.text());
+  const workspaceId = payload.visiting_workspace?.workspace_id;
+
+  if (!workspaceId) {
+    throw new Error(`No visiting workspace id in /api/user/workspace response: ${JSON.stringify(payload)}`);
+  }
+
+  return workspaceId;
+}
+
+async function postApi<T>(request: APIRequestContext, token: string, path: string, data: unknown): Promise<T> {
+  const response = await request.post(`${TestConfig.apiUrl}${path}`, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+    data,
+    failOnStatusCode: false,
+  });
+
+  return unwrapApiResponse<T>(response.status(), await response.text());
+}
+
+async function seedDiskCachedSubtree(
+  page: Page,
+  userId: string,
+  workspaceId: string,
+  targetSpaceId: string,
+  targetSpaceName: string
+) {
+  const cachedSpace = createSpacePayload(targetSpaceId, targetSpaceName, [
+    createChildPayload(CACHED_CHILD_ID, CACHED_CHILD_NAME, targetSpaceId),
+  ]);
+
+  await page.evaluate(
+    ({ userId: activeUserId, workspaceId: activeWorkspaceId, viewId, data }) =>
+      new Promise<void>((resolve, reject) => {
+        const openRequest = indexedDB.open('af_database_cache');
+
+        openRequest.onerror = () => reject(openRequest.error);
+        openRequest.onsuccess = () => {
+          const db = openRequest.result;
+
+          if (!db.objectStoreNames.contains('app_view_cache')) {
+            db.close();
+            reject(new Error('IndexedDB store app_view_cache does not exist'));
+            return;
+          }
+
+          const transaction = db.transaction('app_view_cache', 'readwrite');
+          const store = transaction.objectStore('app_view_cache');
+
+          store.put({
+            user_id: activeUserId,
+            workspace_id: activeWorkspaceId,
+            view_id: viewId,
+            data,
+            updated_at: Date.now(),
+          });
+          transaction.oncomplete = () => {
+            db.close();
+            resolve();
+          };
+          transaction.onerror = () => {
+            const error = transaction.error;
+            db.close();
+            reject(error);
+          };
+        };
+      }),
+    {
+      userId,
+      workspaceId,
+      viewId: targetSpaceId,
+      data: cachedSpace,
+    }
+  );
+}
+
+function isTargetSubtreeRequest(route: Route, workspaceId: string, targetSpaceId: string): boolean {
+  const request = route.request();
+
+  if (request.method() !== 'GET') return false;
+
+  const url = new URL(request.url());
+  const match = url.pathname.match(/\/api\/workspace\/([^/]+)\/view\/([^/]+)$/);
+
+  if (!match) return false;
+
+  return match[1] === workspaceId && match[2] === targetSpaceId && url.searchParams.get('depth') === '1';
+}
+
+function createSpacePayload(viewId: string, name: string, children: CachedViewPayload[]): CachedViewPayload {
+  return {
+    view_id: viewId,
+    name,
+    icon: null,
+    layout: 0,
+    extra: { is_space: true },
+    children,
+    has_children: true,
+    is_published: false,
+    is_private: false,
+  };
+}
+
+function createChildPayload(viewId: string, name: string, parentViewId: string): CachedViewPayload {
+  return {
+    view_id: viewId,
+    name,
+    icon: null,
+    layout: 0,
+    extra: null,
+    children: [],
+    has_children: false,
+    is_published: false,
+    is_private: false,
+    parent_view_id: parentViewId,
+  };
+}
+
+function getState(page: Page): OutlineCacheState {
+  const state = stateByPage.get(page);
+
+  if (!state) {
+    throw new Error('Outline cache test state was not initialized for this page');
+  }
+
+  return state;
+}
+
+function requireWorkspaceId(state: OutlineCacheState): string {
+  if (!state.workspaceId) {
+    throw new Error('Workspace id was not initialized');
+  }
+
+  return state.workspaceId;
+}
+
+function requireOwnerToken(state: OutlineCacheState): string {
+  if (!state.ownerToken) {
+    throw new Error('Owner auth token was not initialized');
+  }
+
+  return state.ownerToken;
+}
+
+function requireOwnerUserId(state: OutlineCacheState): string {
+  if (!state.ownerUserId) {
+    throw new Error('Owner user id was not initialized');
+  }
+
+  return state.ownerUserId;
+}
+
+function requireTargetSpaceId(state: OutlineCacheState): string {
+  if (!state.targetSpaceId) {
+    throw new Error('Target sidebar space id was not initialized');
+  }
+
+  return state.targetSpaceId;
+}
+
+function requireTargetSpaceName(state: OutlineCacheState): string {
+  if (!state.targetSpaceName) {
+    throw new Error('Target sidebar space name was not initialized');
+  }
+
+  return state.targetSpaceName;
+}
+
+function createDeferred<T>(): Deferred<T> {
+  let resolve!: Deferred<T>['resolve'];
+  let reject!: Deferred<T>['reject'];
+  const promise = new Promise<T>((promiseResolve, promiseReject) => {
+    resolve = promiseResolve;
+    reject = promiseReject;
+  });
+
+  return { promise, resolve, reject };
+}
+
+function unwrapApiResponse<T>(status: number, rawBody: string): T {
+  let body: ApiResponse<T> | undefined;
+
+  try {
+    body = rawBody ? (JSON.parse(rawBody) as ApiResponse<T>) : undefined;
+  } catch {
+    throw new Error(`API returned non-JSON response with status ${status}: ${rawBody}`);
+  }
+
+  if (status < 200 || status >= 300 || body?.code !== 0) {
+    throw new Error(`API request failed with status ${status}: ${rawBody}`);
+  }
+
+  return body.data as T;
+}

--- a/src/application/db/index.ts
+++ b/src/application/db/index.ts
@@ -3,6 +3,7 @@ import { IndexeddbPersistence } from 'y-indexeddb';
 import * as Y from 'yjs';
 
 import { databasePrefix } from '@/application/constants';
+import { appViewCacheSchema, type AppViewCacheTable } from '@/application/db/tables/app_view_cache';
 import {
   collabStorageSchema,
   type CollabSnapshotRecord,
@@ -27,15 +28,36 @@ type DexieTables = ViewMetasTable &
   WorkspaceMemberProfileTable &
   VersionsTable &
   SyncOutboxTable &
-  CollabStorageTable;
+  CollabStorageTable &
+  AppViewCacheTable;
 
 export type Dexie<T = DexieTables> = BaseDexie & T;
 
 export const db = new BaseDexie(`${databasePrefix}_cache`) as Dexie;
 const _schema = Object.assign(
   {},
-  { ...viewMetasSchema, ...userSchema, ...rowSchema, ...versionSchema, ...syncOutboxSchema, ...collabStorageSchema }
+  {
+    ...viewMetasSchema,
+    ...userSchema,
+    ...rowSchema,
+    ...versionSchema,
+    ...syncOutboxSchema,
+    ...collabStorageSchema,
+    ...appViewCacheSchema,
+  }
 );
+
+const legacyAppViewCacheSchema = {
+  app_view_cache: '[workspace_id+view_id], workspace_id, view_id, updated_at',
+};
+
+const legacyUserIndexedAppViewCacheSchema = {
+  app_view_cache: '[workspace_id+view_id], user_id, [user_id+workspace_id+view_id], workspace_id, view_id, updated_at',
+};
+
+const dropAppViewCacheSchema = {
+  app_view_cache: null,
+};
 
 // Version 1: Initial schema with view_metas, users, and rows
 db.version(1).stores({
@@ -147,13 +169,71 @@ db.version(7).stores({
   ...collabStorageSchema,
 });
 
+// Version 8: durable app view payload cache used by the sidebar to render
+// expanded children immediately while refreshing from the server.
+db.version(8).stores({
+  ...viewMetasSchema,
+  ...userSchema,
+  ...rowSchema,
+  ...workspaceMemberProfileSchema,
+  ...versionSchema,
+  ...syncOutboxSchema,
+  ...collabStorageSchema,
+  ...legacyAppViewCacheSchema,
+});
+
+// Version 9: add a user-scoped lookup index to app_view_cache. Existing v8 rows
+// cannot be safely attributed, so discard them during migration.
+db.version(9)
+  .stores({
+    ...viewMetasSchema,
+    ...userSchema,
+    ...rowSchema,
+    ...workspaceMemberProfileSchema,
+    ...versionSchema,
+    ...syncOutboxSchema,
+    ...collabStorageSchema,
+    ...legacyUserIndexedAppViewCacheSchema,
+  })
+  .upgrade(async (transaction) => {
+    try {
+      await transaction.table('app_view_cache').clear();
+    } catch (error) {
+      console.error('Failed to clear app_view_cache on v9 upgrade:', error);
+      throw error;
+    }
+  });
+
+// Version 10: drop the legacy app_view_cache store before changing its primary
+// key. Dexie cannot migrate an IndexedDB object store key path in place.
+db.version(10).stores({
+  ...viewMetasSchema,
+  ...userSchema,
+  ...rowSchema,
+  ...workspaceMemberProfileSchema,
+  ...versionSchema,
+  ...syncOutboxSchema,
+  ...collabStorageSchema,
+  ...dropAppViewCacheSchema,
+});
+
+// Version 11: recreate app_view_cache with user_id in the primary key so two
+// users can persist separate cache rows for the same workspace/view.
+db.version(11).stores({
+  ...viewMetasSchema,
+  ...userSchema,
+  ...rowSchema,
+  ...workspaceMemberProfileSchema,
+  ...versionSchema,
+  ...syncOutboxSchema,
+  ...collabStorageSchema,
+  ...appViewCacheSchema,
+});
+
 const openedSet = new Set<string>();
 const ensuredStores = new Map<string, Promise<void>>();
 
-const yjsStoreDefinitions = [
-  { name: 'updates', options: { autoIncrement: true } },
-  { name: 'custom' },
-];
+const yjsStoreDefinitions = [{ name: 'updates', options: { autoIncrement: true } }, { name: 'custom' }];
 
 type IndexedDBFactoryWithDatabases = IDBFactory & {
   databases?: () => Promise<Array<{ name?: string | null }>>;
@@ -355,7 +435,12 @@ const SHARED_COLLAB_COMPACT_MAX_RETRIES = 3;
 const DELETE_INDEXEDDB_BLOCKED_TIMEOUT_MS = 2000;
 
 type CollabPersistenceProvider = IndexeddbPersistence | SharedIndexeddbPersistence;
-type SharedCollabOpenOptions = { awaitSync?: boolean; expectedVersion?: string; forceReset?: boolean; skipCache?: boolean };
+type SharedCollabOpenOptions = {
+  awaitSync?: boolean;
+  expectedVersion?: string;
+  forceReset?: boolean;
+  skipCache?: boolean;
+};
 
 class SharedCollabCompactionRetry extends Error {
   constructor() {
@@ -422,7 +507,10 @@ function createCachedProviderEntry(
       if (settled) return;
 
       settled = true;
-      (provider as { off?: (event: string, listener: (...args: unknown[]) => void) => void }).off?.('synced', handleSync);
+      (provider as { off?: (event: string, listener: (...args: unknown[]) => void) => void }).off?.(
+        'synced',
+        handleSync
+      );
       resolveWhenSynced();
     },
   };
@@ -567,9 +655,11 @@ class SharedIndexeddbPersistence {
   };
 
   private queueCompact() {
-    this._pendingWrite = this._pendingWrite.then(() => this.compact()).catch((error) => {
-      Log.warn('[DB] failed to compact shared collab updates', { name: this.name, error });
-    });
+    this._pendingWrite = this._pendingWrite
+      .then(() => this.compact())
+      .catch((error) => {
+        Log.warn('[DB] failed to compact shared collab updates', { name: this.name, error });
+      });
   }
 
   private async compact() {
@@ -760,10 +850,7 @@ async function disposeRowProvider(name: string, options: { destroyDoc?: boolean 
   return disposed;
 }
 
-async function deleteIndexedDBDatabase(
-  name: string,
-  options: { blockedTimeoutMs?: number } = {}
-) {
+async function deleteIndexedDBDatabase(name: string, options: { blockedTimeoutMs?: number } = {}) {
   if (typeof indexedDB === 'undefined') return true;
 
   return new Promise<boolean>((resolve) => {
@@ -1026,7 +1113,7 @@ async function _openRowCollabDBWithProviderInternal(
     guid: name,
   }) as YDoc;
   let provider = new SharedIndexeddbPersistence(name, doc);
-  let version = await provider.get(name + '/version') as string | undefined;
+  let version = (await provider.get(name + '/version')) as string | undefined;
 
   if (options?.forceReset || (options?.expectedVersion && version !== options.expectedVersion)) {
     await provider.destroy();

--- a/src/application/db/tables/app_view_cache.ts
+++ b/src/application/db/tables/app_view_cache.ts
@@ -1,0 +1,19 @@
+import { Table } from 'dexie';
+
+import { View } from '@/application/types';
+
+export interface AppViewCacheRecord {
+  user_id: string;
+  workspace_id: string;
+  view_id: string;
+  data: View;
+  updated_at: number;
+}
+
+export type AppViewCacheTable = {
+  app_view_cache: Table<AppViewCacheRecord, [string, string, string]>;
+};
+
+export const appViewCacheSchema = {
+  app_view_cache: '[user_id+workspace_id+view_id], user_id, workspace_id, view_id, updated_at',
+};

--- a/src/application/services/domains/view.ts
+++ b/src/application/services/domains/view.ts
@@ -10,6 +10,9 @@ export {
 } from '../js-services/http/view-api';
 export {
   getAppViewCached as get,
+  getCachedAppView as getCached,
+  getCachedAppViewFromDisk as getCachedFromDisk,
   invalidateViewCache as invalidateCache,
+  refreshAppViewCache as refresh,
   getAppDatabaseViewRelationsFromCollab as getDatabaseRelations,
 } from '../js-services/cached-api';

--- a/src/application/services/js-services/__tests__/cached-api.app-view-cache.test.ts
+++ b/src/application/services/js-services/__tests__/cached-api.app-view-cache.test.ts
@@ -1,0 +1,233 @@
+import { db } from '@/application/db';
+import { getView } from '@/application/services/js-services/http';
+import { getTokenParsed } from '@/application/session/token';
+import { View, ViewLayout } from '@/application/types';
+
+import {
+  getAppViewCached,
+  getCachedAppView,
+  getCachedAppViewFromDisk,
+  invalidateViewCache,
+} from '../cached-api';
+
+jest.mock('@/application/db', () => ({
+  db: {
+    app_view_cache: {
+      delete: jest.fn(),
+      get: jest.fn(),
+      put: jest.fn(),
+    },
+  },
+  openCollabDB: jest.fn(),
+}));
+
+jest.mock('@/application/services/js-services/cache', () => ({
+  createRow: jest.fn(),
+  deleteRow: jest.fn(),
+  deleteView: jest.fn(),
+  getPageDoc: jest.fn(),
+  getPublishView: jest.fn(),
+  getPublishViewMeta: jest.fn(),
+  getUser: jest.fn(),
+  hasCollabCache: jest.fn(),
+  hasViewMetaCache: jest.fn(),
+}));
+
+jest.mock('@/application/services/js-services/device-id', () => ({
+  getOrCreateDeviceId: jest.fn(() => 'device-id'),
+}));
+
+jest.mock('@/application/services/js-services/fetch', () => ({
+  fetchPageCollab: jest.fn(),
+  fetchPublishView: jest.fn(),
+  fetchPublishViewMeta: jest.fn(),
+  fetchViewInfo: jest.fn(),
+}));
+
+jest.mock('@/application/services/js-services/http', () => ({
+  cancelImportTask: jest.fn(),
+  changePassword: jest.fn(),
+  createImportTask: jest.fn(),
+  duplicatePublishView: jest.fn(),
+  forgotPassword: jest.fn(),
+  getCollab: jest.fn(),
+  getCurrentUser: jest.fn(),
+  getUserWorkspaceInfo: jest.fn(),
+  getView: jest.fn(),
+  publishView: jest.fn(),
+  signInApple: jest.fn(),
+  signInDiscord: jest.fn(),
+  signInGithub: jest.fn(),
+  signInGoogle: jest.fn(),
+  signInOTP: jest.fn(),
+  signInSaml: jest.fn(),
+  signInWithMagicLink: jest.fn(),
+  signInWithPassword: jest.fn(),
+  signInWithUrl: jest.fn(),
+  signUpWithPassword: jest.fn(),
+  unpublishView: jest.fn(),
+  updatePublishConfig: jest.fn(),
+  updatePublishNamespace: jest.fn(),
+  uploadFileMultipart: jest.fn(),
+  uploadImportFile: jest.fn(),
+  uploadImportFileMultipart: jest.fn(),
+}));
+
+jest.mock('@/application/session', () => ({
+  emit: jest.fn(),
+  EventType: {
+    SESSION_INVALID: 'SESSION_INVALID',
+    SESSION_VALID: 'SESSION_VALID',
+  },
+}));
+
+jest.mock('@/application/session/sign_in', () => ({
+  afterAuth: jest.fn(),
+  AUTH_CALLBACK_URL: 'http://localhost/auth/callback',
+  saveRedirectTo: jest.fn(),
+}));
+
+jest.mock('@/application/session/token', () => ({
+  getTokenParsed: jest.fn(),
+}));
+
+jest.mock('@/application/ydoc/apply', () => ({
+  applyYDoc: jest.fn(),
+}));
+
+jest.mock('@/utils/upload-tracker', () => ({
+  registerUpload: jest.fn(() => 'upload-id'),
+  unregisterUpload: jest.fn(),
+}));
+
+const appViewCacheTable = db.app_view_cache as unknown as {
+  delete: jest.Mock;
+  get: jest.Mock;
+  put: jest.Mock;
+};
+const getTokenParsedMock = getTokenParsed as jest.Mock;
+const getViewMock = getView as jest.Mock;
+
+function setCurrentUser(userId: string | undefined) {
+  getTokenParsedMock.mockReturnValue(
+    userId
+      ? {
+          access_token: 'access-token',
+          expires_at: Date.now() + 60000,
+          refresh_token: 'refresh-token',
+          user: {
+            email: `${userId}@example.com`,
+            id: userId,
+          },
+        }
+      : null
+  );
+}
+
+function createView(viewId: string, name: string): View {
+  return {
+    view_id: viewId,
+    name,
+    icon: null,
+    layout: ViewLayout.Document,
+    extra: null,
+    children: [],
+    is_published: false,
+    is_private: false,
+  };
+}
+
+describe('cached app view cache user scoping', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    appViewCacheTable.delete.mockResolvedValue(undefined);
+    appViewCacheTable.get.mockResolvedValue(undefined);
+    appViewCacheTable.put.mockResolvedValue(undefined);
+  });
+
+  it('reads durable view cache using the authenticated user key', async () => {
+    const view = createView('view-from-disk', 'disk cache');
+
+    setCurrentUser('user-a');
+    appViewCacheTable.get.mockResolvedValue({
+      user_id: 'user-a',
+      workspace_id: 'workspace-a',
+      view_id: view.view_id,
+      data: view,
+      updated_at: 1,
+    });
+
+    await expect(getCachedAppViewFromDisk('workspace-a', view.view_id)).resolves.toBe(view);
+
+    expect(appViewCacheTable.get).toHaveBeenCalledWith(['user-a', 'workspace-a', view.view_id]);
+  });
+
+  it('does not promote durable fallback data into the fresh in-memory cache', async () => {
+    const workspaceId = 'workspace-disk-only';
+    const viewId = 'view-disk-only';
+    const diskView = createView(viewId, 'disk fallback');
+    const serverView = createView(viewId, 'server view');
+
+    setCurrentUser('user-a');
+    appViewCacheTable.get.mockResolvedValue({
+      user_id: 'user-a',
+      workspace_id: workspaceId,
+      view_id: viewId,
+      data: diskView,
+      updated_at: 1,
+    });
+    getViewMock.mockResolvedValue(serverView);
+
+    await expect(getCachedAppViewFromDisk(workspaceId, viewId)).resolves.toBe(diskView);
+    expect(getCachedAppView(workspaceId, viewId)).toBeUndefined();
+
+    await expect(getAppViewCached(workspaceId, viewId)).resolves.toBe(serverView);
+    expect(getViewMock).toHaveBeenCalledWith(workspaceId, viewId);
+  });
+
+  it('keeps memory and durable view caches isolated across account switches', async () => {
+    const workspaceId = 'workspace-switch';
+    const viewId = 'view-switch';
+    const userAView = createView(viewId, 'user A view');
+    const userBView = createView(viewId, 'user B view');
+
+    getViewMock.mockResolvedValueOnce(userAView).mockResolvedValueOnce(userBView);
+
+    setCurrentUser('user-a');
+    await expect(getAppViewCached(workspaceId, viewId)).resolves.toBe(userAView);
+    expect(getCachedAppView(workspaceId, viewId)).toBe(userAView);
+
+    setCurrentUser('user-b');
+    expect(getCachedAppView(workspaceId, viewId)).toBeUndefined();
+    await expect(getAppViewCached(workspaceId, viewId)).resolves.toBe(userBView);
+    expect(getCachedAppView(workspaceId, viewId)).toBe(userBView);
+
+    expect(getViewMock).toHaveBeenCalledTimes(2);
+    expect(appViewCacheTable.put).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        user_id: 'user-a',
+        workspace_id: workspaceId,
+        view_id: viewId,
+        data: userAView,
+      })
+    );
+    expect(appViewCacheTable.put).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        user_id: 'user-b',
+        workspace_id: workspaceId,
+        view_id: viewId,
+        data: userBView,
+      })
+    );
+  });
+
+  it('invalidates only the current user durable view cache entry', () => {
+    setCurrentUser('user-a');
+
+    invalidateViewCache('workspace-a', 'view-a');
+
+    expect(appViewCacheTable.delete).toHaveBeenCalledWith(['user-a', 'workspace-a', 'view-a']);
+  });
+});

--- a/src/application/services/js-services/cached-api.ts
+++ b/src/application/services/js-services/cached-api.ts
@@ -6,7 +6,7 @@
 import * as random from 'lib0/random';
 import * as Y from 'yjs';
 
-import { openCollabDB } from '@/application/db';
+import { db, openCollabDB } from '@/application/db';
 import { Log } from '@/utils/log';
 import {
   createRow,
@@ -67,6 +67,7 @@ import {
   UpdatePublishConfigPayload,
   UploadPublishNamespacePayload,
   UserWorkspaceInfo,
+  View,
   YjsEditorKey,
 } from '@/application/types';
 import { applyYDoc } from '@/application/ydoc/apply';
@@ -94,10 +95,10 @@ const publishViewInfo = new Map<
   }
 >();
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const _getAppViewInFlight = new Map<string, Promise<any>>();
-const _getAppViewCache = new Map<string, { data: unknown; expiresAt: number }>();
+const _getAppViewInFlight = new Map<string, Promise<View>>();
+const _getAppViewCache = new Map<string, { data: View; expiresAt: number }>();
 const VIEW_CACHE_TTL_MS = 5000;
+const ANONYMOUS_VIEW_CACHE_SCOPE = 'anonymous';
 
 // ============================================================================
 // Simple getters
@@ -120,35 +121,51 @@ export function getDeviceId() {
  * Multiple components (AppPage, AppBusinessLayer, useViewMeta) independently call
  * getAppView for the same view during renders/re-renders.
  */
-export async function getAppViewCached(workspaceId: string, viewId: string) {
-  const key = `${workspaceId}:${viewId}`;
+function getCurrentAppViewCacheUserId() {
+  return getTokenParsed()?.user?.id;
+}
 
-  // 1. Return cached result if still fresh
-  const cached = _getAppViewCache.get(key);
+function getAppViewCacheKey(userId: string | undefined, workspaceId: string, viewId: string) {
+  return `${userId ?? ANONYMOUS_VIEW_CACHE_SCOPE}:${workspaceId}:${viewId}`;
+}
 
-  if (cached) {
-    if (Date.now() < cached.expiresAt) {
-      return cached.data;
-    }
+function writeAppViewCaches(workspaceId: string, viewId: string, data: View, userId = getCurrentAppViewCacheUserId()) {
+  _getAppViewCache.set(getAppViewCacheKey(userId, workspaceId, viewId), {
+    data,
+    expiresAt: Date.now() + VIEW_CACHE_TTL_MS,
+  });
 
-    // Eagerly evict expired entry
-    _getAppViewCache.delete(key);
-  }
+  if (!userId) return;
 
-  // 2. Share in-flight request if one exists
+  void db.app_view_cache
+    .put({
+      user_id: userId,
+      workspace_id: workspaceId,
+      view_id: viewId,
+      data,
+      updated_at: Date.now(),
+    })
+    .catch((error) => {
+      Log.warn('[ViewCache] failed to persist app view cache', {
+        userId,
+        workspaceId,
+        viewId,
+        error,
+      });
+    });
+}
+
+function requestAppView(workspaceId: string, viewId: string, userId = getCurrentAppViewCacheUserId()) {
+  const key = getAppViewCacheKey(userId, workspaceId, viewId);
   const existing = _getAppViewInFlight.get(key);
 
   if (existing) {
     return existing;
   }
 
-  // 3. Make the actual request
   const request = getView(workspaceId, viewId)
     .then((result) => {
-      _getAppViewCache.set(key, {
-        data: result,
-        expiresAt: Date.now() + VIEW_CACHE_TTL_MS,
-      });
+      writeAppViewCaches(workspaceId, viewId, result, userId);
       return result;
     })
     .finally(() => {
@@ -159,14 +176,63 @@ export async function getAppViewCached(workspaceId: string, viewId: string) {
   return request;
 }
 
+export async function getAppViewCached(workspaceId: string, viewId: string) {
+  const userId = getCurrentAppViewCacheUserId();
+  const key = getAppViewCacheKey(userId, workspaceId, viewId);
+
+  // 1. Return cached result if still fresh
+  const cached = _getAppViewCache.get(key);
+
+  if (cached && Date.now() < cached.expiresAt) {
+    return cached.data;
+  }
+
+  // 2. Share in-flight request if one exists
+  return requestAppView(workspaceId, viewId, userId);
+}
+
+export function getCachedAppView(workspaceId: string, viewId: string): View | undefined {
+  return _getAppViewCache.get(getAppViewCacheKey(getCurrentAppViewCacheUserId(), workspaceId, viewId))?.data;
+}
+
+export async function getCachedAppViewFromDisk(workspaceId: string, viewId: string): Promise<View | undefined> {
+  const userId = getCurrentAppViewCacheUserId();
+
+  if (!userId) return undefined;
+
+  const record = await db.app_view_cache.get([userId, workspaceId, viewId]);
+
+  return record?.data;
+}
+
+export async function refreshAppViewCache(workspaceId: string, viewId: string) {
+  return requestAppView(workspaceId, viewId);
+}
+
 export function invalidateViewCache(workspaceId: string, viewId: string) {
-  const key = `${workspaceId}:${viewId}`;
+  const userId = getCurrentAppViewCacheUserId();
+  const key = getAppViewCacheKey(userId, workspaceId, viewId);
 
   _getAppViewCache.delete(key);
   _getAppViewInFlight.delete(key);
+
+  if (!userId) return;
+
+  void db.app_view_cache.delete([userId, workspaceId, viewId]).catch((error) => {
+    Log.warn('[ViewCache] failed to delete app view cache', {
+      userId,
+      workspaceId,
+      viewId,
+      error,
+    });
+  });
 }
 
-export async function getPageDocCached(workspaceId: string, viewId: string, errorCallback?: (error: { code: number }) => void) {
+export async function getPageDocCached(
+  workspaceId: string,
+  viewId: string,
+  errorCallback?: (error: { code: number }) => void
+) {
   const token = getTokenParsed();
   const userId = token?.user.id;
 
@@ -348,7 +414,9 @@ export async function getUserWorkspaceInfoTransformed(): Promise<UserWorkspaceIn
   };
 }
 
-export async function duplicatePublishViewTransformed(params: DuplicatePublishView): Promise<DuplicatePublishViewResponse> {
+export async function duplicatePublishViewTransformed(
+  params: DuplicatePublishView
+): Promise<DuplicatePublishViewResponse> {
   const response = await duplicatePublishViewAPI(params.workspaceId, {
     dest_view_id: params.spaceViewId,
     published_view_id: params.viewId,
@@ -377,7 +445,12 @@ export async function getAppDatabaseViewRelationsFromCollab(workspaceId: string,
   return result;
 }
 
-export async function uploadFileWithTracking(workspaceId: string, viewId: string, file: File, onProgress?: (progress: number) => void) {
+export async function uploadFileWithTracking(
+  workspaceId: string,
+  viewId: string,
+  file: File,
+  onProgress?: (progress: number) => void
+) {
   const uploadId = registerUpload();
 
   try {
@@ -517,7 +590,12 @@ export async function signInMagicLinkWithRedirect({ email, redirectTo }: { email
   return signInWithMagicLink(email, AUTH_CALLBACK_URL);
 }
 
-export async function signInOTPWithRedirect(params: { email: string; code: string; redirectTo: string; type?: 'magiclink' | 'recovery' | 'signup' }) {
+export async function signInOTPWithRedirect(params: {
+  email: string;
+  code: string;
+  redirectTo: string;
+  type?: 'magiclink' | 'recovery' | 'signup';
+}) {
   saveRedirectTo(params.redirectTo);
   return finishAuthFlow('signInOTP', () => signInOTP(params), {
     emitSessionValid: params.type !== 'recovery',

--- a/src/components/app/hooks/__tests__/useWorkspaceData.sidebarRevalidation.test.tsx
+++ b/src/components/app/hooks/__tests__/useWorkspaceData.sidebarRevalidation.test.tsx
@@ -4,7 +4,7 @@ import { act, renderHook, waitFor } from '@testing-library/react';
 import { type ReactNode } from 'react';
 import { MemoryRouter } from 'react-router-dom';
 
-import { APP_EVENTS } from '@/application/constants';
+import { APP_EVENTS, ERROR_CODE } from '@/application/constants';
 import { AccessService, ViewService } from '@/application/services/domains';
 import { Role, View, ViewLayout } from '@/application/types';
 import { AuthInternalContext, AuthInternalContextType } from '@/components/app/contexts/AuthInternalContext';
@@ -35,12 +35,15 @@ jest.mock('@/application/services/domains', () => ({
   },
   ViewService: {
     get: jest.fn(),
+    getCached: jest.fn(),
+    getCachedFromDisk: jest.fn(),
     getDatabaseRelations: jest.fn(),
     getMultiple: jest.fn(),
     getNavigation: jest.fn(),
     getOutline: jest.fn(),
     getTrash: jest.fn(),
     invalidateCache: jest.fn(),
+    refresh: jest.fn(),
   },
   WorkspaceService: {
     getMentionableUsers: jest.fn(),
@@ -135,9 +138,14 @@ describe('useWorkspaceData sidebar outline revalidation', () => {
     jest.clearAllMocks();
 
     (AccessService.getShareWithMe as jest.Mock).mockResolvedValue(null);
+    (ViewService.getCached as jest.Mock).mockReturnValue(undefined);
+    (ViewService.getCachedFromDisk as jest.Mock).mockResolvedValue(undefined);
     (ViewService.getDatabaseRelations as jest.Mock).mockResolvedValue({});
     (ViewService.getMultiple as jest.Mock).mockResolvedValue([]);
     (ViewService.getNavigation as jest.Mock).mockResolvedValue(createView('navigation-root'));
+    (ViewService.refresh as jest.Mock).mockImplementation((activeWorkspaceId: string, viewId: string) =>
+      ViewService.get(activeWorkspaceId, viewId)
+    );
     (ViewService.getTrash as jest.Mock).mockResolvedValue([]);
   });
 
@@ -314,6 +322,269 @@ describe('useWorkspaceData sidebar outline revalidation', () => {
       Array.from({ length: MAX_SIDEBAR_OUTLINE_REVALIDATION_EXPANDED_IDS }, (_, index) => `view-${index}`),
       1
     );
+  });
+
+  it('shows cached children immediately while refreshing a manually expanded view', async () => {
+    const eventEmitter = new EventEmitter();
+    const root = createView('space-id', {
+      has_children: true,
+    });
+    const cachedRoot = createView('space-id', {
+      children: [createView('cached-child-id')],
+      has_children: true,
+    });
+    const refreshedRoot = createView('space-id', {
+      children: [createView('refreshed-child-id')],
+      has_children: true,
+    });
+    const refresh = createDeferred<View>();
+
+    (ViewService.getOutline as jest.Mock).mockResolvedValueOnce({ outline: [root], folderRid: '1-1' });
+    (ViewService.getCached as jest.Mock).mockReturnValue(cachedRoot);
+    (ViewService.refresh as jest.Mock).mockReturnValue(refresh.promise);
+
+    const { result } = renderHook(() => useWorkspaceData(), {
+      wrapper: createWrapper(eventEmitter),
+    });
+
+    await waitFor(() => {
+      expect(result.current.outline?.map((view) => view.view_id)).toEqual(['space-id']);
+    });
+
+    let loadPromise!: Promise<View[]>;
+
+    await act(async () => {
+      loadPromise = result.current.loadViewChildren?.('space-id') ?? Promise.resolve([]);
+      await Promise.resolve();
+    });
+
+    expect(result.current.outline?.[0]?.children.map((view) => view.view_id)).toEqual(['cached-child-id']);
+    expect(ViewService.refresh).toHaveBeenCalledWith(workspaceId, 'space-id');
+    expect(ViewService.get).not.toHaveBeenCalled();
+
+    await act(async () => {
+      refresh.resolve(refreshedRoot);
+      await loadPromise;
+    });
+
+    expect(result.current.outline?.[0]?.children.map((view) => view.view_id)).toEqual(['refreshed-child-id']);
+  });
+
+  it('starts refresh immediately and shows disk cached children while the server request is pending', async () => {
+    const eventEmitter = new EventEmitter();
+    const root = createView('space-id', {
+      has_children: true,
+    });
+    const diskCachedRoot = createView('space-id', {
+      children: [createView('disk-child-id')],
+      has_children: true,
+    });
+    const refreshedRoot = createView('space-id', {
+      children: [createView('refreshed-child-id')],
+      has_children: true,
+    });
+    const diskCache = createDeferred<View | undefined>();
+    const refresh = createDeferred<View>();
+
+    (ViewService.getOutline as jest.Mock).mockResolvedValueOnce({ outline: [root], folderRid: '1-1' });
+    (ViewService.getCachedFromDisk as jest.Mock).mockReturnValue(diskCache.promise);
+    (ViewService.refresh as jest.Mock).mockReturnValue(refresh.promise);
+
+    const { result } = renderHook(() => useWorkspaceData(), {
+      wrapper: createWrapper(eventEmitter),
+    });
+
+    await waitFor(() => {
+      expect(result.current.outline?.map((view) => view.view_id)).toEqual(['space-id']);
+    });
+
+    let loadPromise!: Promise<View[]>;
+
+    await act(async () => {
+      loadPromise = result.current.loadViewChildren?.('space-id') ?? Promise.resolve([]);
+      await Promise.resolve();
+    });
+
+    expect(ViewService.refresh).toHaveBeenCalledWith(workspaceId, 'space-id');
+    expect(result.current.outline?.[0]?.children).toEqual([]);
+
+    await act(async () => {
+      diskCache.resolve(diskCachedRoot);
+      await Promise.resolve();
+    });
+
+    expect(result.current.outline?.[0]?.children.map((view) => view.view_id)).toEqual(['disk-child-id']);
+
+    await act(async () => {
+      refresh.resolve(refreshedRoot);
+      await loadPromise;
+    });
+
+    expect(result.current.outline?.[0]?.children.map((view) => view.view_id)).toEqual(['refreshed-child-id']);
+  });
+
+  it('marks manually collapsed children stale without evicting the cached view payload', async () => {
+    const eventEmitter = new EventEmitter();
+    const root = createView('space-id', {
+      has_children: true,
+    });
+    const loadedRoot = createView('space-id', {
+      children: [createView('child-id')],
+      has_children: true,
+    });
+
+    (ViewService.getOutline as jest.Mock).mockResolvedValueOnce({ outline: [root], folderRid: '1-1' });
+    (ViewService.get as jest.Mock).mockResolvedValueOnce(loadedRoot);
+
+    const { result } = renderHook(() => useWorkspaceData(), {
+      wrapper: createWrapper(eventEmitter),
+    });
+
+    await waitFor(() => {
+      expect(result.current.outline?.map((view) => view.view_id)).toEqual(['space-id']);
+    });
+
+    await act(async () => {
+      await result.current.loadViewChildren?.('space-id');
+    });
+
+    await waitFor(() => {
+      expect(result.current.loadedViewIds?.has('space-id')).toBe(true);
+    });
+
+    (ViewService.invalidateCache as jest.Mock).mockClear();
+
+    act(() => {
+      result.current.markViewChildrenStale?.('space-id');
+    });
+
+    expect(result.current.loadedViewIds?.has('space-id')).toBe(false);
+    expect(ViewService.invalidateCache).not.toHaveBeenCalled();
+  });
+
+  it('does not let stale cached children replace current outline children while refreshing', async () => {
+    const eventEmitter = new EventEmitter();
+    const childA = createView('child-a');
+    const childB = createView('child-b');
+    const childC = createView('child-c');
+    const root = createView('space-id', {
+      children: [childA, childB],
+      has_children: true,
+    });
+    const staleCachedRoot = createView('space-id', {
+      children: [childA],
+      has_children: true,
+    });
+    const refreshedRoot = createView('space-id', {
+      children: [childA, childB, childC],
+      has_children: true,
+    });
+    const refresh = createDeferred<View>();
+
+    (ViewService.getOutline as jest.Mock).mockResolvedValueOnce({ outline: [root], folderRid: '1-1' });
+    (ViewService.getCached as jest.Mock).mockReturnValue(staleCachedRoot);
+    (ViewService.refresh as jest.Mock).mockReturnValue(refresh.promise);
+
+    const { result } = renderHook(() => useWorkspaceData(), {
+      wrapper: createWrapper(eventEmitter),
+    });
+
+    await waitFor(() => {
+      expect(result.current.outline?.[0]?.children.map((view) => view.view_id)).toEqual(['child-a', 'child-b']);
+    });
+
+    let loadPromise!: Promise<View[]>;
+
+    await act(async () => {
+      loadPromise = result.current.loadViewChildren?.('space-id') ?? Promise.resolve([]);
+      await Promise.resolve();
+    });
+
+    expect(result.current.outline?.[0]?.children.map((view) => view.view_id)).toEqual(['child-a', 'child-b']);
+
+    await act(async () => {
+      refresh.resolve(refreshedRoot);
+      await loadPromise;
+    });
+
+    expect(result.current.outline?.[0]?.children.map((view) => view.view_id)).toEqual([
+      'child-a',
+      'child-b',
+      'child-c',
+    ]);
+  });
+
+  it('keeps transient fallback children visible without marking the subtree loaded', async () => {
+    const eventEmitter = new EventEmitter();
+    const root = createView('space-id', {
+      has_children: true,
+    });
+    const cachedRoot = createView('space-id', {
+      children: [createView('cached-child-id')],
+      has_children: true,
+    });
+
+    (ViewService.getOutline as jest.Mock).mockResolvedValueOnce({ outline: [root], folderRid: '1-1' });
+    (ViewService.getCached as jest.Mock).mockReturnValue(cachedRoot);
+    (ViewService.refresh as jest.Mock).mockRejectedValueOnce({ code: -1, message: 'network unavailable' });
+
+    const { result } = renderHook(() => useWorkspaceData(), {
+      wrapper: createWrapper(eventEmitter),
+    });
+
+    await waitFor(() => {
+      expect(result.current.outline?.map((view) => view.view_id)).toEqual(['space-id']);
+    });
+
+    let children: View[] = [];
+
+    await act(async () => {
+      children = (await result.current.loadViewChildren?.('space-id')) ?? [];
+    });
+
+    expect(children.map((view) => view.view_id)).toEqual(['cached-child-id']);
+    expect(result.current.outline?.[0]?.children.map((view) => view.view_id)).toEqual(['cached-child-id']);
+    expect(result.current.loadedViewIds?.has('space-id')).toBe(false);
+    expect(ViewService.invalidateCache).not.toHaveBeenCalled();
+  });
+
+  it('clears cached fallback children when refresh returns an authoritative error', async () => {
+    const eventEmitter = new EventEmitter();
+    const root = createView('space-id', {
+      has_children: true,
+    });
+    const cachedRoot = createView('space-id', {
+      children: [createView('cached-child-id')],
+      has_children: true,
+    });
+
+    (ViewService.getOutline as jest.Mock).mockResolvedValueOnce({ outline: [root], folderRid: '1-1' });
+    (ViewService.getCached as jest.Mock).mockReturnValue(cachedRoot);
+    (ViewService.refresh as jest.Mock).mockRejectedValueOnce({
+      code: ERROR_CODE.NOT_HAS_PERMISSION,
+      message: 'no permission',
+    });
+
+    const { result } = renderHook(() => useWorkspaceData(), {
+      wrapper: createWrapper(eventEmitter),
+    });
+
+    await waitFor(() => {
+      expect(result.current.outline?.map((view) => view.view_id)).toEqual(['space-id']);
+    });
+
+    let children: View[] = [createView('placeholder')];
+
+    await act(async () => {
+      children = (await result.current.loadViewChildren?.('space-id')) ?? [];
+    });
+
+    expect(children).toEqual([]);
+    expect(result.current.outline?.[0]?.children).toEqual([]);
+    expect(result.current.outline?.[0]?.has_children).toBe(false);
+    expect(result.current.loadedViewIds?.has('space-id')).toBe(false);
+    expect(ViewService.invalidateCache).toHaveBeenCalledWith(workspaceId, 'space-id');
+    expect(ViewService.invalidateCache).toHaveBeenCalledWith(workspaceId, 'cached-child-id');
   });
 
   it('does not let lazy child folder rid hide unapplied root outline changes', async () => {

--- a/src/components/app/hooks/useWorkspaceData.ts
+++ b/src/components/app/hooks/useWorkspaceData.ts
@@ -245,6 +245,56 @@ type FolderRid = {
   seqNo: number;
 };
 
+const AUTHORITATIVE_VIEW_REFRESH_ERROR_CODES = new Set<number>([
+  ERROR_CODE.RECORD_NOT_FOUND,
+  ERROR_CODE.RECORD_DELETED,
+  ERROR_CODE.NOT_LOGGED_IN,
+  ERROR_CODE.NOT_HAS_PERMISSION,
+  ERROR_CODE.USER_UNAUTHORIZED,
+  401,
+  403,
+  404,
+  410,
+]);
+
+function getRefreshErrorCode(error: unknown): number | undefined {
+  if (typeof error !== 'object' || error === null) return undefined;
+
+  const dataCode = (error as { response?: { data?: { code?: unknown } } }).response?.data?.code;
+
+  if (typeof dataCode === 'number') return dataCode;
+
+  const code = (error as { code?: unknown }).code;
+
+  if (typeof code === 'number') return code;
+
+  const status = (error as { response?: { status?: unknown } }).response?.status;
+
+  return typeof status === 'number' ? status : undefined;
+}
+
+function isAuthoritativeViewRefreshError(error: unknown): boolean {
+  const code = getRefreshErrorCode(error);
+
+  return code !== undefined && AUTHORITATIVE_VIEW_REFRESH_ERROR_CODES.has(code);
+}
+
+function canUseFallbackForViewRefreshError(error: unknown): boolean {
+  const code = getRefreshErrorCode(error);
+
+  if (code === undefined) return false;
+
+  return (
+    code === -1 ||
+    code === ERROR_CODE.REQUEST_TIMEOUT ||
+    code === ERROR_CODE.SERVICE_TEMPORARY_UNAVAILABLE ||
+    code === ERROR_CODE.TOO_MANY_REQUESTS ||
+    code === 408 ||
+    code === 429 ||
+    code >= 500
+  );
+}
+
 function parseFolderRid(value?: string | null): FolderRid | null {
   if (!value) return null;
   const [timestampRaw, seqRaw] = value.split('-');
@@ -573,6 +623,120 @@ export function useWorkspaceData() {
     ]
   );
 
+  const mergeViewChildrenIntoOutline = useCallback(
+    (
+      workspaceId: string,
+      workspaceRevision: number,
+      viewData: View,
+      options: { markLoaded: boolean; updateFolderRid: boolean }
+    ): View[] => {
+      const viewId = viewData.view_id;
+      const children = viewData.children ?? [];
+
+      if (isStaleWorkspaceRequest(workspaceId, workspaceRevision)) {
+        return children;
+      }
+
+      if (options.updateFolderRid) {
+        updateLastFolderRid(parseFolderRid(viewData.folder_rid));
+      }
+
+      const parentExists = Boolean(findView(stableOutlineRef.current, viewId));
+      const nextOutline = mergeChildrenIntoOutline(stableOutlineRef.current, viewId, children, viewData.has_children);
+
+      if (nextOutline !== stableOutlineRef.current) {
+        stableOutlineRef.current = nextOutline;
+        setOutline(nextOutline);
+        if (eventEmitter) {
+          eventEmitter.emit(APP_EVENTS.OUTLINE_LOADED, nextOutline || []);
+        }
+      }
+
+      // Mark as loaded only after an authoritative refresh confirms the
+      // subtree, even if cached fallback already rendered identical children.
+      if (options.markLoaded && parentExists && !loadedViewIdsRef.current.has(viewId)) {
+        loadedViewIdsRef.current.add(viewId);
+        setLoadedViewIdsRevision((r) => r + 1);
+      }
+
+      return children;
+    },
+    [eventEmitter, isStaleWorkspaceRequest, stableOutlineRef, updateLastFolderRid]
+  );
+
+  const mergeLoadedViewChildren = useCallback(
+    (workspaceId: string, workspaceRevision: number, viewData: View): View[] => {
+      return mergeViewChildrenIntoOutline(workspaceId, workspaceRevision, viewData, {
+        markLoaded: true,
+        updateFolderRid: true,
+      });
+    },
+    [mergeViewChildrenIntoOutline]
+  );
+
+  const mergeCachedViewChildren = useCallback(
+    (workspaceId: string, workspaceRevision: number, viewData: View): View[] => {
+      const currentView = findView(stableOutlineRef.current, viewData.view_id);
+
+      if (currentView?.children && currentView.children.length > 0) {
+        return currentView.children;
+      }
+
+      return mergeViewChildrenIntoOutline(workspaceId, workspaceRevision, viewData, {
+        markLoaded: false,
+        updateFolderRid: false,
+      });
+    },
+    [mergeViewChildrenIntoOutline, stableOutlineRef]
+  );
+
+  const clearViewChildrenAfterAuthoritativeRefreshError = useCallback(
+    (workspaceId: string, workspaceRevision: number, viewId: string) => {
+      if (isStaleWorkspaceRequest(workspaceId, workspaceRevision)) return;
+
+      const subtreeRoot = findView(stableOutlineRef.current, viewId);
+      const staleViewIds = new Set<string>([viewId]);
+
+      if (subtreeRoot) {
+        const stack: View[] = [subtreeRoot];
+
+        while (stack.length > 0) {
+          const current = stack.pop();
+
+          if (!current) continue;
+          staleViewIds.add(current.view_id);
+          current.children?.forEach((child) => stack.push(child));
+        }
+      }
+
+      let removedLoaded = false;
+
+      staleViewIds.forEach((staleViewId) => {
+        ViewService.invalidateCache(workspaceId, staleViewId);
+        loadingViewIdsRef.current.delete(staleViewId);
+
+        if (loadedViewIdsRef.current.delete(staleViewId)) {
+          removedLoaded = true;
+        }
+      });
+
+      if (removedLoaded) {
+        setLoadedViewIdsRevision((r) => r + 1);
+      }
+
+      const nextOutline = mergeChildrenIntoOutline(stableOutlineRef.current, viewId, [], false);
+
+      if (nextOutline !== stableOutlineRef.current) {
+        stableOutlineRef.current = nextOutline;
+        setOutline(nextOutline);
+        if (eventEmitter) {
+          eventEmitter.emit(APP_EVENTS.OUTLINE_LOADED, nextOutline || []);
+        }
+      }
+    },
+    [eventEmitter, isStaleWorkspaceRequest, stableOutlineRef]
+  );
+
   // Load children for a single view (lazy expand)
   const loadViewChildren = useCallback(
     async (viewId: string): Promise<View[]> => {
@@ -580,65 +744,88 @@ export function useWorkspaceData() {
 
       const workspaceId = currentWorkspaceId;
       const workspaceRevision = workspaceRevisionRef.current;
+      const cachedViewData = ViewService.getCached(workspaceId, viewId);
+      const cachedChildren = cachedViewData
+        ? mergeCachedViewChildren(workspaceId, workspaceRevision, cachedViewData)
+        : undefined;
+      let fallbackChildren = cachedChildren;
+      const loadDiskCachedChildren = async (): Promise<View[] | undefined> => {
+        if (cachedViewData) return cachedChildren;
 
-      // Dedup concurrent fetches
+        try {
+          const diskCachedViewData = await ViewService.getCachedFromDisk(workspaceId, viewId);
+
+          return diskCachedViewData
+            ? mergeCachedViewChildren(workspaceId, workspaceRevision, diskCachedViewData)
+            : undefined;
+        } catch (error) {
+          Log.warn('[Outline] [loadViewChildren] failed to read cached subtree from disk', {
+            workspaceId,
+            viewId,
+            error,
+          });
+          return undefined;
+        }
+      };
+
+      // Dedup concurrent fetches, but still allow the cached merge above to make
+      // the expanded row visible immediately while the existing refresh completes.
       if (loadingViewIdsRef.current.has(viewId)) {
         Log.debug('[Outline] [loadViewChildren] skip in-flight request', {
           workspaceId,
           viewId,
+          usedCachedChildren: Boolean(cachedViewData),
         });
-        return [];
+        return (await loadDiskCachedChildren()) ?? [];
       }
 
       loadingViewIdsRef.current.add(viewId);
+      const refreshResult = ViewService.refresh(workspaceId, viewId).then(
+        (viewData) => ({ status: 'fulfilled' as const, viewData }),
+        (error) => ({ status: 'rejected' as const, error })
+      );
 
       try {
         Log.debug('[Outline] [loadViewChildren] requesting single subtree', {
           workspaceId,
           viewId,
           depth: 1,
+          usedCachedChildren: Boolean(cachedViewData),
         });
 
-        const viewData = await ViewService.get(workspaceId, viewId);
-        const children = viewData?.children ?? [];
+        fallbackChildren = (await loadDiskCachedChildren()) ?? fallbackChildren;
+        const refreshed = await refreshResult;
 
-        if (isStaleWorkspaceRequest(workspaceId, workspaceRevision)) {
-          return children;
+        if (refreshed.status === 'rejected') {
+          throw refreshed.error;
         }
 
-        updateLastFolderRid(parseFolderRid(viewData?.folder_rid));
-
-        // Merge into outline
-        const nextOutline = mergeChildrenIntoOutline(stableOutlineRef.current, viewId, children, viewData?.has_children);
-
-        if (nextOutline !== stableOutlineRef.current) {
-          stableOutlineRef.current = nextOutline;
-          setOutline(nextOutline);
-          if (eventEmitter) {
-            eventEmitter.emit(APP_EVENTS.OUTLINE_LOADED, nextOutline || []);
-          }
-
-          // Mark as loaded only when the parent exists in the current outline
-          // and children were actually merged.
-          loadedViewIdsRef.current.add(viewId);
-          setLoadedViewIdsRevision((r) => r + 1);
-        }
-
-        return children;
+        return mergeLoadedViewChildren(workspaceId, workspaceRevision, refreshed.viewData);
       } catch (e) {
         if (isStaleWorkspaceRequest(workspaceId, workspaceRevision)) {
-          return [];
+          return fallbackChildren ?? [];
         }
 
         Log.error('[Outline] [loadViewChildren] Failed to load children for', viewId, e);
-        return [];
+        if (isAuthoritativeViewRefreshError(e)) {
+          clearViewChildrenAfterAuthoritativeRefreshError(workspaceId, workspaceRevision, viewId);
+          return [];
+        }
+
+        return canUseFallbackForViewRefreshError(e) ? fallbackChildren ?? [] : [];
       } finally {
         if (!isStaleWorkspaceRequest(workspaceId, workspaceRevision)) {
           loadingViewIdsRef.current.delete(viewId);
         }
       }
     },
-    [currentWorkspaceId, stableOutlineRef, eventEmitter, isStaleWorkspaceRequest, updateLastFolderRid]
+    [
+      clearViewChildrenAfterAuthoritativeRefreshError,
+      currentWorkspaceId,
+      isStaleWorkspaceRequest,
+      mergeCachedViewChildren,
+      mergeLoadedViewChildren,
+    ]
   );
 
   const loadViewChildrenBatch = useCallback(
@@ -759,17 +946,10 @@ export function useWorkspaceData() {
 
       if (!changed) return;
 
-      // Also invalidate the HTTP cache for the root view so the next
-      // loadViewChildren call makes a fresh API request instead of
-      // returning stale cached data.
-      if (currentWorkspaceId) {
-        ViewService.invalidateCache(currentWorkspaceId, viewId);
-      }
-
       Log.debug('[Outline] [cache] Marked view subtree stale', { viewId, clearedIds: subtreeIds.length });
       setLoadedViewIdsRevision((r) => r + 1);
     },
-    [stableOutlineRef, currentWorkspaceId]
+    [stableOutlineRef]
   );
 
   const ensureViewVisibleInOutline = useCallback(


### PR DESCRIPTION
## Summary

This PR scopes the durable sidebar app-view cache to the authenticated user so one account cannot read stale outline subtree data written by another account in the same browser.

## Root Cause

The disk-backed `app_view_cache` lookup was keyed only by workspace and view. When users switched accounts in the same browser, `loadViewChildren` could render a previous user's persisted children before an authorized server response replaced them, or keep them visible if refresh failed. The first fix also used a user-scoped lookup index while leaving the durable primary key unscoped, which could still overwrite another user's row.

## Changes

- Add `user_id` to app view cache records and make `[user_id+workspace_id+view_id]` the durable primary key.
- Drop legacy app-view cache stores before recreating the final user-keyed store, because IndexedDB key paths cannot be changed in place.
- Scope the in-memory and in-flight app-view caches by current user as well as workspace/view.
- Keep disk fallback reads out of the fresh in-memory cache so normal `ViewService.get` calls join/fetch the server result instead of returning a stale disk snapshot.
- Render cached sidebar fallback children without marking the subtree loaded; only a successful server refresh marks it loaded.
- Keep cached fallback only for transient refresh failures, and clear/invalidate cached subtree data for authoritative errors such as no permission, not found, or deleted.
- Avoid merging cached children over a current outline node that already has children.
- Update the sidebar disk-cache BDD seed to write user-scoped rows.
- Add unit regression coverage for cross-user app-view cache isolation, disk fallback promotion, stale child replacement, transient fallback retryability, and permission-denied clearing.

## Validation

- `pnpm type-check`
- `pnpm exec jest src/application/services/js-services/__tests__/cached-api.app-view-cache.test.ts --runInBand --no-coverage`
- `pnpm exec jest src/components/app/hooks/__tests__/useWorkspaceData.sidebarRevalidation.test.tsx --runInBand --no-coverage`
- `pnpm exec bddgen test -c playwright.bdd.config.ts`
- `pnpm exec eslint --quiet src/application/db/index.ts src/application/db/tables/app_view_cache.ts src/application/services/js-services/cached-api.ts src/application/services/js-services/__tests__/cached-api.app-view-cache.test.ts src/components/app/hooks/useWorkspaceData.ts src/components/app/hooks/__tests__/useWorkspaceData.sidebarRevalidation.test.tsx`