### PR TITLE
fix: connect banner missing WebSocket status on late mount

### DIFF
--- a/src/components/app/ConnectBanner.tsx
+++ b/src/components/app/ConnectBanner.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useSyncExternalStore } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { APP_EVENTS } from '@/application/constants';
@@ -26,31 +26,33 @@ function getStoredWebSocketReadyState(eventEmitter: AppEventEmitter) {
 
 export function ConnectBanner() {
   const eventEmitter = useEventEmitter();
-  const [readyState, setReadyState] = useState<number>(
-    () => getStoredWebSocketReadyState(eventEmitter) ?? READY_STATE.CONNECTING
-  );
   const autoReconnectAttemptedRef = useRef(0); // timestamp of last auto-reconnect attempt
   const { t } = useTranslation();
 
-  // Listen to WebSocket status changes
-  useLayoutEffect(() => {
-    if (!eventEmitter) return;
+  // Subscribe to WebSocket status via the event emitter, which caches the
+  // latest readyState (see AppSyncLayer). useSyncExternalStore reads that
+  // cached snapshot on mount, so a banner that mounts after the socket already
+  // opened reflects the current state instead of waiting for the next event.
+  const subscribe = useCallback(
+    (onChange: () => void) => {
+      eventEmitter.on(APP_EVENTS.WEBSOCKET_STATUS, onChange);
 
-    const handleWebSocketStatus = (status: number) => {
-      setReadyState(status);
-    };
+      return () => {
+        eventEmitter.off(APP_EVENTS.WEBSOCKET_STATUS, onChange);
+      };
+    },
+    [eventEmitter]
+  );
 
-    eventEmitter.on(APP_EVENTS.WEBSOCKET_STATUS, handleWebSocketStatus);
-    setReadyState(getStoredWebSocketReadyState(eventEmitter) ?? READY_STATE.CONNECTING);
+  const getSnapshot = useCallback(
+    () => getStoredWebSocketReadyState(eventEmitter) ?? READY_STATE.CONNECTING,
+    [eventEmitter]
+  );
 
-    return () => {
-      eventEmitter.off(APP_EVENTS.WEBSOCKET_STATUS, handleWebSocketStatus);
-    };
-  }, [eventEmitter]);
+  const readyState = useSyncExternalStore(subscribe, getSnapshot);
 
   // Manual reconnect
   const handleReconnect = useCallback(() => {
-    if (!eventEmitter) return;
     eventEmitter.emit(APP_EVENTS.RECONNECT_WEBSOCKET);
   }, [eventEmitter]);
 

--- a/src/components/app/ConnectBanner.tsx
+++ b/src/components/app/ConnectBanner.tsx
@@ -1,8 +1,9 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { APP_EVENTS } from '@/application/constants';
 import { ReactComponent as CloudOffIcon } from '@/assets/icons/cloud_off.svg';
+import type { AppEventEmitter } from '@/components/app/contexts/AppEventEmitterContext';
 import { Button } from '@/components/ui/button';
 import { Progress } from '@/components/ui/progress';
 import { Log } from '@/utils/log';
@@ -17,14 +18,22 @@ const READY_STATE = {
   CLOSED: 3,
 } as const;
 
+function getStoredWebSocketReadyState(eventEmitter: AppEventEmitter) {
+  const { webSocketReadyState } = eventEmitter;
+
+  return typeof webSocketReadyState === 'number' ? webSocketReadyState : undefined;
+}
+
 export function ConnectBanner() {
-  const [readyState, setReadyState] = useState<number>(READY_STATE.CONNECTING);
-  const autoReconnectAttemptedRef = useRef(0); // timestamp of last auto-reconnect attempt
   const eventEmitter = useEventEmitter();
+  const [readyState, setReadyState] = useState<number>(
+    () => getStoredWebSocketReadyState(eventEmitter) ?? READY_STATE.CONNECTING
+  );
+  const autoReconnectAttemptedRef = useRef(0); // timestamp of last auto-reconnect attempt
   const { t } = useTranslation();
 
   // Listen to WebSocket status changes
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (!eventEmitter) return;
 
     const handleWebSocketStatus = (status: number) => {
@@ -32,6 +41,7 @@ export function ConnectBanner() {
     };
 
     eventEmitter.on(APP_EVENTS.WEBSOCKET_STATUS, handleWebSocketStatus);
+    setReadyState(getStoredWebSocketReadyState(eventEmitter) ?? READY_STATE.CONNECTING);
 
     return () => {
       eventEmitter.off(APP_EVENTS.WEBSOCKET_STATUS, handleWebSocketStatus);

--- a/src/components/app/__tests__/ConnectBanner.test.tsx
+++ b/src/components/app/__tests__/ConnectBanner.test.tsx
@@ -1,0 +1,52 @@
+import EventEmitter from 'events';
+
+import { act, render, screen } from '@testing-library/react';
+
+import { APP_EVENTS } from '@/application/constants';
+import { ConnectBanner } from '@/components/app/ConnectBanner';
+import type { AppEventEmitter } from '@/components/app/contexts/AppEventEmitterContext';
+
+let mockEventEmitter: AppEventEmitter;
+
+jest.mock('@/components/app/app.hooks', () => ({
+  useEventEmitter: () => mockEventEmitter,
+}));
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+function createEventEmitter() {
+  return new EventEmitter() as AppEventEmitter;
+}
+
+function renderConnectBanner(eventEmitter: AppEventEmitter) {
+  mockEventEmitter = eventEmitter;
+
+  return render(<ConnectBanner />);
+}
+
+describe('ConnectBanner', () => {
+  it('does not show connecting when websocket is already open before subscribing', () => {
+    const eventEmitter = createEventEmitter();
+
+    eventEmitter.webSocketReadyState = 1;
+    renderConnectBanner(eventEmitter);
+
+    expect(screen.queryByTestId('connect-banner')).toBeNull();
+  });
+
+  it('hides when websocket status changes to open', () => {
+    const eventEmitter = createEventEmitter();
+
+    renderConnectBanner(eventEmitter);
+    expect(screen.queryByTestId('connect-banner-connecting')).not.toBeNull();
+
+    act(() => {
+      eventEmitter.webSocketReadyState = 1;
+      eventEmitter.emit(APP_EVENTS.WEBSOCKET_STATUS, 1);
+    });
+
+    expect(screen.queryByTestId('connect-banner')).toBeNull();
+  });
+});

--- a/src/components/app/contexts/AppEventEmitterContext.ts
+++ b/src/components/app/contexts/AppEventEmitterContext.ts
@@ -2,10 +2,14 @@ import EventEmitter from 'events';
 
 import { createContext } from 'react';
 
+export type AppEventEmitter = EventEmitter & {
+  webSocketReadyState?: number;
+};
+
 /**
  * Stable app-wide event bus context.
  *
  * Separated from `AppSyncContext` so consumers that only need the event emitter
  * do not re-render on high-frequency awareness updates.
  */
-export const AppEventEmitterContext = createContext<EventEmitter | null>(null);
+export const AppEventEmitterContext = createContext<AppEventEmitter | null>(null);

--- a/src/components/app/contexts/SyncInternalContext.ts
+++ b/src/components/app/contexts/SyncInternalContext.ts
@@ -1,9 +1,8 @@
-import EventEmitter from 'events';
-
 import { createContext, useContext } from 'react';
 import { Awareness } from 'y-protocols/awareness';
 
 import { SyncContext } from '@/application/services/js-services/sync-protocol';
+import type { AppEventEmitter } from '@/components/app/contexts/AppEventEmitterContext';
 import { RegisterSyncContext } from '@/components/ws/useSync';
 
 // Internal context for synchronization layer
@@ -15,7 +14,7 @@ import { RegisterSyncContext } from '@/components/ws/useSync';
 export interface SyncInternalContextType {
   registerSyncContext: (params: RegisterSyncContext) => SyncContext;
   revertCollabVersion: (viewId: string, version: string) => Promise<void>;
-  eventEmitter: EventEmitter;
+  eventEmitter: AppEventEmitter;
   awarenessMap: Record<string, Awareness>;
   /**
    * Flush all pending updates for all registered sync contexts.

--- a/src/components/app/layers/AppSyncLayer.tsx
+++ b/src/components/app/layers/AppSyncLayer.tsx
@@ -1,6 +1,6 @@
 import EventEmitter from 'events';
 
-import React, { useEffect, useMemo, useRef, useState } from 'react';
+import { type FC, type ReactNode, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { Awareness } from 'y-protocols/awareness';
 
 import { APP_EVENTS } from '@/application/constants';
@@ -8,6 +8,7 @@ import { db } from '@/application/db';
 import { CollabService, UserService } from '@/application/services/domains';
 import { getTokenParsed } from '@/application/session/token';
 import { clearDrainConfig, configureDrain, setCurrentSession, startDrainAll } from '@/application/sync-outbox';
+import type { AppEventEmitter } from '@/components/app/contexts/AppEventEmitterContext';
 import { useAppflowyWebSocket, useBroadcastChannel, useSync } from '@/components/ws';
 import { notification } from '@/proto/messages';
 
@@ -15,7 +16,7 @@ import { useAuthInternal } from '../contexts/AuthInternalContext';
 import { SyncInternalContext, SyncInternalContextType } from '../contexts/SyncInternalContext';
 
 interface AppSyncLayerProps {
-  children: React.ReactNode;
+  children: ReactNode;
 }
 
 const WS_READY_STATE_OPEN = 1;
@@ -23,10 +24,10 @@ const WS_READY_STATE_OPEN = 1;
 // Second layer: WebSocket connection and synchronization
 // Handles WebSocket connection, broadcast channel, sync context, and event management
 // Depends on workspace ID and service from auth layer
-export const AppSyncLayer: React.FC<AppSyncLayerProps> = ({ children }) => {
+export const AppSyncLayer: FC<AppSyncLayerProps> = ({ children }) => {
   const { currentWorkspaceId, isAuthenticated } = useAuthInternal();
   const [awarenessMap] = useState<Record<string, Awareness>>({});
-  const eventEmitterRef = useRef<EventEmitter>(new EventEmitter());
+  const eventEmitterRef = useRef<AppEventEmitter>(new EventEmitter() as AppEventEmitter);
 
   useEffect(() => {
     if (typeof window === 'undefined') return;
@@ -79,9 +80,10 @@ export const AppSyncLayer: React.FC<AppSyncLayerProps> = ({ children }) => {
   // webSocket identity change (which happens for each incoming message).
   const webSocketReadyState = webSocket.readyState;
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     const currentEventEmitter = eventEmitterRef.current;
 
+    currentEventEmitter.webSocketReadyState = webSocketReadyState;
     currentEventEmitter.emit(APP_EVENTS.WEBSOCKET_STATUS, webSocketReadyState);
   }, [webSocketReadyState]);
 

--- a/src/components/app/layers/AppSyncLayer.tsx
+++ b/src/components/app/layers/AppSyncLayer.tsx
@@ -27,7 +27,15 @@ const WS_READY_STATE_OPEN = 1;
 export const AppSyncLayer: FC<AppSyncLayerProps> = ({ children }) => {
   const { currentWorkspaceId, isAuthenticated } = useAuthInternal();
   const [awarenessMap] = useState<Record<string, Awareness>>({});
-  const eventEmitterRef = useRef<AppEventEmitter>(new EventEmitter() as AppEventEmitter);
+  // Lazy-init so a throwaway EventEmitter isn't constructed on every render
+  // (useRef keeps only the first value but still evaluates its argument each time).
+  const eventEmitterRef = useRef<AppEventEmitter | null>(null);
+
+  if (eventEmitterRef.current === null) {
+    eventEmitterRef.current = new EventEmitter() as AppEventEmitter;
+  }
+
+  const eventEmitter = eventEmitterRef.current;
 
   useEffect(() => {
     if (typeof window === 'undefined') return;
@@ -39,9 +47,9 @@ export const AppSyncLayer: FC<AppSyncLayerProps> = ({ children }) => {
 
     if (globalWindow.Cypress) {
       // Expose event emitter for Cypress so tests can simulate workspace notifications
-      globalWindow.__APPFLOWY_EVENT_EMITTER__ = eventEmitterRef.current;
+      globalWindow.__APPFLOWY_EVENT_EMITTER__ = eventEmitter;
     }
-  }, []);
+  }, [eventEmitter]);
 
   // Initialize WebSocket connection - currentWorkspaceId and service are guaranteed to exist when this component renders
   const webSocket = useAppflowyWebSocket({
@@ -57,7 +65,7 @@ export const AppSyncLayer: FC<AppSyncLayerProps> = ({ children }) => {
   const { registerSyncContext, flushAllSync, syncAllToServer, revertCollabVersion, scheduleDeferredCleanup } = useSync(
     webSocket,
     broadcastChannel,
-    eventEmitterRef.current,
+    eventEmitter,
     currentWorkspaceId!
   );
 
@@ -67,25 +75,25 @@ export const AppSyncLayer: FC<AppSyncLayerProps> = ({ children }) => {
 
   // Set up WebSocket reconnection event listener
   useEffect(() => {
-    const currentEventEmitter = eventEmitterRef.current;
+    const currentEventEmitter = eventEmitter;
 
     currentEventEmitter.on(APP_EVENTS.RECONNECT_WEBSOCKET, webSocketReconnect);
 
     return () => {
       currentEventEmitter.off(APP_EVENTS.RECONNECT_WEBSOCKET, webSocketReconnect);
     };
-  }, [webSocketReconnect]);
+  }, [eventEmitter, webSocketReconnect]);
 
   // Emit WebSocket status on actual readyState transitions only — not on every
   // webSocket identity change (which happens for each incoming message).
   const webSocketReadyState = webSocket.readyState;
 
   useLayoutEffect(() => {
-    const currentEventEmitter = eventEmitterRef.current;
+    const currentEventEmitter = eventEmitter;
 
     currentEventEmitter.webSocketReadyState = webSocketReadyState;
     currentEventEmitter.emit(APP_EVENTS.WEBSOCKET_STATUS, webSocketReadyState);
-  }, [webSocketReadyState]);
+  }, [eventEmitter, webSocketReadyState]);
 
   // Wire the persistent sync_outbox drain to this WebSocket. The drain loop
   // runs whenever a record is enqueued AND the socket is OPEN. The drain is
@@ -191,7 +199,7 @@ export const AppSyncLayer: FC<AppSyncLayerProps> = ({ children }) => {
   useEffect(() => {
     if (!isAuthenticated || !currentWorkspaceId) return;
 
-    const currentEventEmitter = eventEmitterRef.current;
+    const currentEventEmitter = eventEmitter;
 
     const handleUserProfileChange = async (profileChange: notification.IUserProfileChange) => {
       try {
@@ -373,7 +381,7 @@ export const AppSyncLayer: FC<AppSyncLayerProps> = ({ children }) => {
       currentEventEmitter.off(APP_EVENTS.USER_PROFILE_CHANGED, handleUserProfileChange);
       currentEventEmitter.off(APP_EVENTS.WORKSPACE_MEMBER_PROFILE_CHANGED, handleWorkspaceMemberProfileChange);
     };
-  }, [isAuthenticated, currentWorkspaceId]);
+  }, [eventEmitter, isAuthenticated, currentWorkspaceId]);
 
   // Context value for synchronization layer. The webSocket/broadcastChannel
   // transports are intentionally excluded: their identity changes on every
@@ -383,13 +391,13 @@ export const AppSyncLayer: FC<AppSyncLayerProps> = ({ children }) => {
     () => ({
       registerSyncContext,
       revertCollabVersion,
-      eventEmitter: eventEmitterRef.current,
+      eventEmitter,
       awarenessMap,
       flushAllSync,
       syncAllToServer,
       scheduleDeferredCleanup,
     }),
-    [registerSyncContext, revertCollabVersion, awarenessMap, flushAllSync, syncAllToServer, scheduleDeferredCleanup]
+    [eventEmitter, registerSyncContext, revertCollabVersion, awarenessMap, flushAllSync, syncAllToServer, scheduleDeferredCleanup]
   );
 
   return <SyncInternalContext.Provider value={syncContextValue}>{children}</SyncInternalContext.Provider>;

--- a/src/components/app/layers/__tests__/AppSyncLayer.test.tsx
+++ b/src/components/app/layers/__tests__/AppSyncLayer.test.tsx
@@ -82,6 +82,7 @@ const authContextValue = {
 
 let consumerRenderCount = 0;
 let websocketStatusEmits = 0;
+let latestWebSocketReadyState: number | undefined;
 
 const ContextConsumer = memo(function ContextConsumer() {
   const { eventEmitter } = useSyncInternal();
@@ -93,6 +94,7 @@ const ContextConsumer = memo(function ContextConsumer() {
       websocketStatusEmits += 1;
     };
 
+    latestWebSocketReadyState = eventEmitter.webSocketReadyState;
     eventEmitter.on(APP_EVENTS.WEBSOCKET_STATUS, handleStatus);
 
     return () => {
@@ -126,6 +128,7 @@ describe('AppSyncLayer per-message churn', () => {
     jest.clearAllMocks();
     consumerRenderCount = 0;
     websocketStatusEmits = 0;
+    latestWebSocketReadyState = undefined;
     mockUseBroadcastChannel.mockReturnValue(stableBcValue);
     mockUseSync.mockReturnValue(stableSyncValue);
     mockUseAppflowyWebSocket.mockReturnValue(createWsValue(null));
@@ -169,5 +172,11 @@ describe('AppSyncLayer per-message churn', () => {
     rerenderLayer(rerender);
 
     expect(websocketStatusEmits).toBe(emitsAfterMount + 1);
+  });
+
+  it('stores the latest readyState for consumers that subscribe after the status event', () => {
+    renderLayer();
+
+    expect(latestWebSocketReadyState).toBe(1);
   });
 });


### PR DESCRIPTION
## Summary

Fixes the `ConnectBanner` getting stuck showing **connecting** when it mounted *after* the WebSocket had already opened. The banner subscribed to the one-shot `WEBSOCKET_STATUS` event, so any transition that fired before it subscribed was lost.

- Cache the latest readyState on the app event emitter (`AppEventEmitter.webSocketReadyState`), written synchronously before the status event is emitted (`AppSyncLayer`).
- `ConnectBanner` reads WS status via `useSyncExternalStore` (subscribe + cached snapshot), so a late-mounting banner reflects the current connection state immediately instead of waiting for the next transition. This also makes the rendered snapshot correct-by-construction (no tear between init read and subscription) and removes the need for `useLayoutEffect`/`useState` plumbing.
- Drop unreachable `!eventEmitter` guards — `useEventEmitter()` throws when the context is missing.

## Testing

- `ConnectBanner.test.tsx` — covers (a) socket already open before subscribing, (b) hiding when status transitions to open.
- `AppSyncLayer.test.tsx` — verifies the latest readyState is cached for consumers that subscribe after the status event.
- All 6 tests pass; ESLint and `tsc` clean on the changed source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Ensure ConnectBanner reflects the current WebSocket connection state even when it mounts after the socket is already open.

Bug Fixes:
- Prevent ConnectBanner from remaining stuck in a connecting state when subscribing after the WebSocket has opened.

Enhancements:
- Cache the latest WebSocket readyState on the shared AppEventEmitter and expose it to consumers.
- Adopt useSyncExternalStore in ConnectBanner for consistent WebSocket status subscription and snapshot reading.
- Type AppEventEmitter to include cached WebSocket readyState and propagate this type through sync-related contexts.
- Use React FC/ReactNode typings and useLayoutEffect in AppSyncLayer to synchronously cache and emit WebSocket status updates.

Tests:
- Add unit tests for ConnectBanner covering late subscription to an already open WebSocket and hiding on open transition.
- Extend AppSyncLayer tests to verify the latest WebSocket readyState is stored for consumers subscribing after the status event.