### PR TITLE
Fix row-page inline grid duplication

### DIFF
--- a/playwright/bdd/features/database/row-document.feature
+++ b/playwright/bdd/features/database/row-document.feature
@@ -8,3 +8,11 @@ Feature: Database row document
     Then the card primary cell shows a row document icon
     When I switch the database to a new Grid view
     Then the grid primary cell shows a row document icon
+
+  Scenario: Duplicating an inline grid block in a row page creates an independent database
+    Given a grid database is open for row-page inline grid duplication
+    When I open the first row as a full row page
+    And I create an inline grid in the row page
+    And I duplicate the inline grid block in the row page
+    And I edit the duplicated inline grid
+    Then the original row-page inline grid remains unchanged

--- a/playwright/bdd/features/database/row-document.feature
+++ b/playwright/bdd/features/database/row-document.feature
@@ -14,5 +14,9 @@ Feature: Database row document
     When I open the first row as a full row page
     And I create an inline grid in the row page
     And I duplicate the inline grid block in the row page
-    And I edit the duplicated inline grid
+    Then the duplicated inline grid shows a loading placeholder
+    Then the duplicated inline grid has a fresh database view id
+    When I edit the duplicated inline grid
     Then the original row-page inline grid remains unchanged
+    When I edit the original inline grid
+    Then the duplicated row-page inline grid remains unchanged

--- a/playwright/bdd/steps/database-row-document.steps.ts
+++ b/playwright/bdd/steps/database-row-document.steps.ts
@@ -1,4 +1,4 @@
-import { expect, Locator, Page } from '@playwright/test';
+import { expect, Locator, Page, Route } from '@playwright/test';
 import { createBdd } from 'playwright-bdd';
 import { v4 as uuidv4 } from 'uuid';
 
@@ -30,6 +30,7 @@ interface DatabaseBlockState {
   parentId: string | null;
   viewIds: string[];
   databaseId: string | null;
+  isDuplicatePlaceholder: boolean;
 }
 
 interface RowInlineGridState {
@@ -37,6 +38,7 @@ interface RowInlineGridState {
   originalBlock?: DatabaseBlockState;
   duplicatedBlock?: DatabaseBlockState;
   originalCellText?: string;
+  originalEditedCellText?: string;
   duplicateCellText?: string;
 }
 
@@ -117,6 +119,7 @@ Given('a grid database is open for row-page inline grid duplication', async ({ p
   setupPageErrorHandling(page);
   rowInlineGridStateByPage.set(page, {
     originalCellText: `row-page-original-${uuidv4().slice(0, 6)}`,
+    originalEditedCellText: `row-page-original-edited-${uuidv4().slice(0, 6)}`,
     duplicateCellText: `row-page-duplicate-${uuidv4().slice(0, 6)}`,
   });
 
@@ -163,12 +166,40 @@ When('I create an inline grid in the row page', async ({ page }) => {
 });
 
 When('I duplicate the inline grid block in the row page', async ({ page }) => {
+  const state = getRowInlineGridState(page);
+  const rowPageViewId = getRowPageViewId(page);
+  const editor = editorForView(page, rowPageViewId);
+  const originalDatabaseId = state.originalBlock?.databaseId;
+
+  if (!originalDatabaseId) {
+    throw new Error('Expected original inline grid database id before duplication');
+  }
+
+  await Promise.all([
+    delayNextDatabaseBlobDiffRequest(page, 1500, [originalDatabaseId]),
+    delayNextPageDuplicateRequest(page, 3000),
+  ]);
+
+  await duplicateDatabaseBlockAt(page, editor, 0, { waitAfterMs: 0 });
+  await expect(databaseBlocks(editor)).toHaveCount(2, { timeout: 30000 });
+});
+
+Then('the duplicated inline grid shows a loading placeholder', async ({ page }) => {
   const rowPageViewId = getRowPageViewId(page);
   const editor = editorForView(page, rowPageViewId);
 
-  await duplicateDatabaseBlockAt(page, editor, 0);
-  await expect(databaseBlocks(editor)).toHaveCount(2, { timeout: 30000 });
-  getRowInlineGridState(page).duplicatedBlock = await waitForInlineGridDuplicateRewrite(page, rowPageViewId);
+  await expect(databaseBlocks(editor).nth(1).getByTestId('database-duplicate-placeholder')).toBeVisible({
+    timeout: 5000,
+  });
+  await expectDuplicatedInlineGridLoadingPlaceholder(page, rowPageViewId);
+});
+
+Then('the duplicated inline grid has a fresh database view id', async ({ page }) => {
+  const state = getRowInlineGridState(page);
+  const rowPageViewId = getRowPageViewId(page);
+
+  state.duplicatedBlock = await waitForDuplicatedInlineGridFreshIds(page, rowPageViewId);
+  expectDuplicatedBlockHasFreshIds(state);
 });
 
 When('I edit the duplicated inline grid', async ({ page }) => {
@@ -183,27 +214,62 @@ Then('the original row-page inline grid remains unchanged', async ({ page }) => 
   const state = getRowInlineGridState(page);
   const rowPageViewId = getRowPageViewId(page);
   const editor = editorForView(page, rowPageViewId);
+  const originalCellText = state.originalCellText ?? 'row-page-original';
+  const duplicateCellText = state.duplicateCellText ?? 'row-page-duplicate';
 
-  expect(state.duplicatedBlock?.viewIds[0]).toBeTruthy();
-  expect(state.duplicatedBlock?.databaseId).toBeTruthy();
-  expect(state.duplicatedBlock?.viewIds[0]).not.toBe(state.originalBlock?.viewIds[0]);
-  expect(state.duplicatedBlock?.databaseId).not.toBe(state.originalBlock?.databaseId);
+  expectDuplicatedBlockHasFreshIds(state);
 
   await expect
     .poll(async () => firstGridCellText(databaseBlocks(editor).first()), {
       timeout: 15000,
       message: 'Expected editing the duplicated inline grid not to modify the original inline grid',
     })
-    .toContain(state.originalCellText ?? 'row-page-original');
-  expect(await firstGridCellText(databaseBlocks(editor).first())).not.toContain(
-    state.duplicateCellText ?? 'row-page-duplicate'
-  );
+    .toContain(originalCellText);
+  expect(await firstGridCellText(databaseBlocks(editor).first())).not.toContain(duplicateCellText);
+
+  await expect
+    .poll(async () => firstGridCellText(databaseBlocks(editor).nth(1)), {
+      timeout: 15000,
+      message: 'Expected editing the duplicated inline grid to update the duplicated inline grid',
+    })
+    .toContain(duplicateCellText);
+});
+
+When('I edit the original inline grid', async ({ page }) => {
+  const rowPageViewId = getRowPageViewId(page);
+  const editor = editorForView(page, rowPageViewId);
+  const originalEditedCellText = getRowInlineGridState(page).originalEditedCellText ?? 'row-page-original-edited';
+
+  await editFirstGridCell(page, databaseBlocks(editor).first(), originalEditedCellText);
+});
+
+Then('the duplicated row-page inline grid remains unchanged', async ({ page }) => {
+  const state = getRowInlineGridState(page);
+  const rowPageViewId = getRowPageViewId(page);
+  const editor = editorForView(page, rowPageViewId);
+  const duplicateCellText = state.duplicateCellText ?? 'row-page-duplicate';
+  const originalEditedCellText = state.originalEditedCellText ?? 'row-page-original-edited';
+
+  expectDuplicatedBlockHasFreshIds(state);
+
+  await expect
+    .poll(async () => firstGridCellText(databaseBlocks(editor).first()), {
+      timeout: 15000,
+      message: 'Expected editing the original inline grid to update the original inline grid',
+    })
+    .toContain(originalEditedCellText);
+
+  await expect
+    .poll(async () => firstGridCellText(databaseBlocks(editor).nth(1)), {
+      timeout: 15000,
+      message: 'Expected editing the original inline grid not to modify the duplicated inline grid',
+    })
+    .toContain(duplicateCellText);
+  expect(await firstGridCellText(databaseBlocks(editor).nth(1))).not.toContain(originalEditedCellText);
 });
 
 async function addNewCard(page: Page, cardName: string) {
-  const todoColumn = BoardSelectors.boardContainer(page)
-    .locator('[data-column-id]')
-    .filter({ hasText: 'To Do' });
+  const todoColumn = BoardSelectors.boardContainer(page).locator('[data-column-id]').filter({ hasText: 'To Do' });
 
   await todoColumn.getByText('New').click({ force: true });
   await page.waitForTimeout(500);
@@ -275,6 +341,7 @@ async function getDatabaseBlockStates(page: Page, rowPageViewId: string): Promis
               view_id?: string;
               view_ids?: string[];
               database_id?: string;
+              is_database_duplicate_placeholder?: boolean;
             };
           }>;
         }
@@ -288,17 +355,14 @@ async function getDatabaseBlockStates(page: Page, rowPageViewId: string): Promis
       .map((node) => ({
         blockId: node.blockId,
         parentId: node.data?.parent_id ?? null,
-        viewIds: Array.isArray(node.data?.view_ids)
-          ? node.data.view_ids
-          : node.data?.view_id
-            ? [node.data.view_id]
-            : [],
+        viewIds: Array.isArray(node.data?.view_ids) ? node.data.view_ids : node.data?.view_id ? [node.data.view_id] : [],
         databaseId: node.data?.database_id ?? null,
+        isDuplicatePlaceholder: node.data?.is_database_duplicate_placeholder === true,
       }));
   }, rowPageViewId);
 }
 
-async function waitForInlineGridDuplicateRewrite(page: Page, rowPageViewId: string): Promise<DatabaseBlockState> {
+async function waitForDuplicatedInlineGridFreshIds(page: Page, rowPageViewId: string): Promise<DatabaseBlockState> {
   await expect
     .poll(
       async () => {
@@ -308,23 +372,104 @@ async function waitForInlineGridDuplicateRewrite(page: Page, rowPageViewId: stri
 
         return Boolean(
           original?.viewIds[0] &&
-            duplicated?.viewIds[0] &&
             original?.databaseId &&
+            duplicated?.viewIds[0] &&
             duplicated?.databaseId &&
-            original.parentId === rowPageViewId &&
             duplicated.parentId === rowPageViewId &&
-            original.viewIds[0] !== duplicated.viewIds[0] &&
-            original.databaseId !== duplicated.databaseId
+            !duplicated.isDuplicatePlaceholder &&
+            duplicated.viewIds[0] !== original.viewIds[0] &&
+            duplicated.databaseId !== original.databaseId
         );
       },
       {
         timeout: 30000,
-        message: 'Expected duplicated row-page inline grid block to be rewritten to fresh view/database ids',
+        message: 'Expected duplicated row-page inline grid placeholder to be replaced with fresh view/database ids',
       }
     )
     .toBe(true);
 
-  return (await getDatabaseBlockStates(page, rowPageViewId))[1];
+  return expectDuplicatedInlineGridHasFreshIds(page, rowPageViewId);
+}
+
+function expectDuplicatedBlockHasFreshIds(state: RowInlineGridState): void {
+  expect(state.duplicatedBlock?.viewIds[0]).toBeTruthy();
+  expect(state.duplicatedBlock?.databaseId).toBeTruthy();
+  expect(state.duplicatedBlock?.viewIds[0]).not.toBe(state.originalBlock?.viewIds[0]);
+  expect(state.duplicatedBlock?.databaseId).not.toBe(state.originalBlock?.databaseId);
+}
+
+async function expectDuplicatedInlineGridHasFreshIds(page: Page, rowPageViewId: string): Promise<DatabaseBlockState> {
+  const blocks = await getDatabaseBlockStates(page, rowPageViewId);
+  const original = blocks[0];
+  const duplicated = blocks[1];
+
+  expect(original?.viewIds[0]).toBeTruthy();
+  expect(original?.databaseId).toBeTruthy();
+  expect(duplicated?.parentId).toBe(rowPageViewId);
+  expect(duplicated?.isDuplicatePlaceholder).toBe(false);
+  expect(duplicated?.viewIds[0]).toBeTruthy();
+  expect(duplicated?.databaseId).toBeTruthy();
+  expect(duplicated?.viewIds[0]).not.toBe(original?.viewIds[0]);
+  expect(duplicated?.databaseId).not.toBe(original?.databaseId);
+
+  return duplicated as DatabaseBlockState;
+}
+
+async function expectDuplicatedInlineGridLoadingPlaceholder(page: Page, rowPageViewId: string): Promise<void> {
+  const blocks = await getDatabaseBlockStates(page, rowPageViewId);
+  const original = blocks[0];
+  const duplicated = blocks[1];
+
+  expect(original?.viewIds[0]).toBeTruthy();
+  expect(original?.databaseId).toBeTruthy();
+  expect(duplicated?.parentId).toBe(rowPageViewId);
+  expect(duplicated?.isDuplicatePlaceholder).toBe(true);
+  expect(duplicated?.viewIds).toEqual([]);
+  expect(duplicated?.databaseId).toBeNull();
+}
+
+async function delayNextPageDuplicateRequest(page: Page, delayMs: number): Promise<void> {
+  await page.route(
+    /\/api\/workspace\/[^/]+\/page-view\/[^/]+\/duplicate(?:\?|$)/,
+    async (route) => {
+      await page.waitForTimeout(delayMs);
+      await route.continue();
+    },
+    { times: 1 }
+  );
+}
+
+async function delayNextDatabaseBlobDiffRequest(
+  page: Page,
+  delayMs: number,
+  excludedDatabaseIds: string[] = []
+): Promise<void> {
+  const excludedDatabaseIdSet = new Set(excludedDatabaseIds);
+  const routePattern = /\/api\/workspace\/[^/]+\/database\/[^/]+\/blob\/diff(?:\?|$)/;
+  let handledDuplicatedRequest = false;
+  const getDatabaseIdFromBlobDiffUrl = (url: string): string | undefined => {
+    return url.match(/\/api\/workspace\/[^/]+\/database\/([^/]+)\/blob\/diff(?:\?|$)/)?.[1];
+  };
+  const handler = async (route: Route) => {
+    const databaseId = getDatabaseIdFromBlobDiffUrl(route.request().url());
+
+    if (databaseId && excludedDatabaseIdSet.has(databaseId)) {
+      await route.continue();
+      return;
+    }
+
+    if (handledDuplicatedRequest) {
+      await route.continue();
+      return;
+    }
+
+    handledDuplicatedRequest = true;
+    await page.waitForTimeout(delayMs);
+    await route.continue();
+    void page.unroute(routePattern, handler).catch(() => undefined);
+  };
+
+  await page.route(routePattern, handler);
 }
 
 async function hoverDatabaseBlock(page: Page, gridBlock: Locator): Promise<void> {
@@ -358,7 +503,12 @@ async function hoverDatabaseBlock(page: Page, gridBlock: Locator): Promise<void>
     .toBe(true);
 }
 
-async function duplicateDatabaseBlockAt(page: Page, editor: Locator, blockIndex: number): Promise<void> {
+async function duplicateDatabaseBlockAt(
+  page: Page,
+  editor: Locator,
+  blockIndex: number,
+  options: { waitAfterMs?: number } = {}
+): Promise<void> {
   const gridBlock = databaseBlocks(editor).nth(blockIndex);
 
   await expect(gridBlock).toBeVisible({ timeout: 15000 });
@@ -366,5 +516,8 @@ async function duplicateDatabaseBlockAt(page: Page, editor: Locator, blockIndex:
   await BlockSelectors.dragHandle(page).click({ force: true });
   await expect(BlockSelectors.controlsMenu(page)).toBeVisible({ timeout: 5000 });
   await BlockSelectors.controlsMenuAction(page, 'duplicate').click({ force: true });
-  await page.waitForTimeout(3000);
+
+  if (options.waitAfterMs !== 0) {
+    await page.waitForTimeout(options.waitAfterMs ?? 3000);
+  }
 }

--- a/playwright/bdd/steps/database-row-document.steps.ts
+++ b/playwright/bdd/steps/database-row-document.steps.ts
@@ -1,15 +1,44 @@
-import { expect, Page } from '@playwright/test';
+import { expect, Locator, Page } from '@playwright/test';
 import { createBdd } from 'playwright-bdd';
 import { v4 as uuidv4 } from 'uuid';
 
 import { signInAndCreateDatabaseView, waitForGridReady } from '../../support/database-ui-helpers';
-import { closeRowDetailWithEscape } from '../../support/row-detail-helpers';
-import { BoardSelectors, DatabaseGridSelectors, DatabaseViewSelectors, RowDetailSelectors } from '../../support/selectors';
-import { generateRandomEmail } from '../../support/test-config';
+import {
+  databaseBlocks,
+  editFirstGridCell,
+  editorForView,
+  firstGridCellText,
+  insertInlineGridViaSlash,
+} from '../../support/duplicate-test-helpers';
+import { closeRowDetailWithEscape, openRowDetail } from '../../support/row-detail-helpers';
+import {
+  BlockSelectors,
+  BoardSelectors,
+  DatabaseGridSelectors,
+  DatabaseViewSelectors,
+  RowDetailSelectors,
+} from '../../support/selectors';
+import { generateRandomEmail, setupPageErrorHandling } from '../../support/test-config';
 
 const { Given, When, Then } = createBdd();
 
 const cardNamesByPage = new WeakMap<Page, string>();
+const rowInlineGridStateByPage = new WeakMap<Page, RowInlineGridState>();
+
+interface DatabaseBlockState {
+  blockId?: string;
+  parentId: string | null;
+  viewIds: string[];
+  databaseId: string | null;
+}
+
+interface RowInlineGridState {
+  rowPageViewId?: string;
+  originalBlock?: DatabaseBlockState;
+  duplicatedBlock?: DatabaseBlockState;
+  originalCellText?: string;
+  duplicateCellText?: string;
+}
 
 Given('a board database with a card is open', async ({ page, request }) => {
   const currentCardName = `ImageLink-${uuidv4().slice(0, 6)}`;
@@ -84,6 +113,93 @@ Then('the grid primary cell shows a row document icon', async ({ page }) => {
   await expect(row.locator('.custom-icon')).toBeVisible({ timeout: 15000 });
 });
 
+Given('a grid database is open for row-page inline grid duplication', async ({ page, request }) => {
+  setupPageErrorHandling(page);
+  rowInlineGridStateByPage.set(page, {
+    originalCellText: `row-page-original-${uuidv4().slice(0, 6)}`,
+    duplicateCellText: `row-page-duplicate-${uuidv4().slice(0, 6)}`,
+  });
+
+  await signInAndCreateDatabaseView(page, request, generateRandomEmail(), 'Grid', {
+    createWaitMs: 6000,
+    verify: waitForGridReady,
+  });
+});
+
+When('I open the first row as a full row page', async ({ page }) => {
+  await openRowDetail(page, 0);
+  await page.locator('.MuiDialogTitle-root').locator('button').first().click({ force: true });
+  await page.waitForTimeout(2000);
+
+  const editor = page.locator('[id^="editor-"]').first();
+
+  await expect(editor).toBeVisible({ timeout: 15000 });
+  const editorId = await editor.getAttribute('id');
+  const rowPageViewId = editorId?.replace('editor-', '');
+
+  if (!rowPageViewId) {
+    throw new Error(`Expected mounted row document editor id, got ${String(editorId)}`);
+  }
+
+  getRowInlineGridState(page).rowPageViewId = rowPageViewId;
+});
+
+When('I create an inline grid in the row page', async ({ page }) => {
+  const state = getRowInlineGridState(page);
+  const rowPageViewId = getRowPageViewId(page);
+  const editor = editorForView(page, rowPageViewId);
+
+  await insertInlineGridViaSlash(page, rowPageViewId);
+  await expect(databaseBlocks(editor)).toHaveCount(1, { timeout: 30000 });
+
+  const originalGrid = databaseBlocks(editor).first();
+  const originalCellText = state.originalCellText ?? 'row-page-original';
+
+  await editFirstGridCell(page, originalGrid, originalCellText);
+  state.originalBlock = (await getDatabaseBlockStates(page, rowPageViewId))[0];
+
+  expect(state.originalBlock?.viewIds[0]).toBeTruthy();
+  expect(state.originalBlock?.databaseId).toBeTruthy();
+});
+
+When('I duplicate the inline grid block in the row page', async ({ page }) => {
+  const rowPageViewId = getRowPageViewId(page);
+  const editor = editorForView(page, rowPageViewId);
+
+  await duplicateDatabaseBlockAt(page, editor, 0);
+  await expect(databaseBlocks(editor)).toHaveCount(2, { timeout: 30000 });
+  getRowInlineGridState(page).duplicatedBlock = await waitForInlineGridDuplicateRewrite(page, rowPageViewId);
+});
+
+When('I edit the duplicated inline grid', async ({ page }) => {
+  const rowPageViewId = getRowPageViewId(page);
+  const editor = editorForView(page, rowPageViewId);
+  const duplicateCellText = getRowInlineGridState(page).duplicateCellText ?? 'row-page-duplicate';
+
+  await editFirstGridCell(page, databaseBlocks(editor).nth(1), duplicateCellText);
+});
+
+Then('the original row-page inline grid remains unchanged', async ({ page }) => {
+  const state = getRowInlineGridState(page);
+  const rowPageViewId = getRowPageViewId(page);
+  const editor = editorForView(page, rowPageViewId);
+
+  expect(state.duplicatedBlock?.viewIds[0]).toBeTruthy();
+  expect(state.duplicatedBlock?.databaseId).toBeTruthy();
+  expect(state.duplicatedBlock?.viewIds[0]).not.toBe(state.originalBlock?.viewIds[0]);
+  expect(state.duplicatedBlock?.databaseId).not.toBe(state.originalBlock?.databaseId);
+
+  await expect
+    .poll(async () => firstGridCellText(databaseBlocks(editor).first()), {
+      timeout: 15000,
+      message: 'Expected editing the duplicated inline grid not to modify the original inline grid',
+    })
+    .toContain(state.originalCellText ?? 'row-page-original');
+  expect(await firstGridCellText(databaseBlocks(editor).first())).not.toContain(
+    state.duplicateCellText ?? 'row-page-duplicate'
+  );
+});
+
 async function addNewCard(page: Page, cardName: string) {
   const todoColumn = BoardSelectors.boardContainer(page)
     .locator('[data-column-id]')
@@ -123,4 +239,132 @@ function getCurrentCardName(page: Page) {
   }
 
   return cardName;
+}
+
+function getRowInlineGridState(page: Page): RowInlineGridState {
+  const state = rowInlineGridStateByPage.get(page);
+
+  if (!state) {
+    throw new Error('No row inline grid duplication state is available for this scenario');
+  }
+
+  return state;
+}
+
+function getRowPageViewId(page: Page): string {
+  const rowPageViewId = getRowInlineGridState(page).rowPageViewId;
+
+  if (!rowPageViewId) {
+    throw new Error('No row page view id is available for this scenario');
+  }
+
+  return rowPageViewId;
+}
+
+async function getDatabaseBlockStates(page: Page, rowPageViewId: string): Promise<DatabaseBlockState[]> {
+  return page.evaluate((currentRowPageViewId) => {
+    const testWindow = window as Window & {
+      __TEST_EDITORS__?: Record<
+        string,
+        {
+          children?: Array<{
+            type?: string;
+            blockId?: string;
+            data?: {
+              parent_id?: string;
+              view_id?: string;
+              view_ids?: string[];
+              database_id?: string;
+            };
+          }>;
+        }
+      >;
+    };
+    const editor = testWindow.__TEST_EDITORS__?.[currentRowPageViewId];
+    const children = editor?.children ?? [];
+
+    return children
+      .filter((node) => node?.type === 'grid')
+      .map((node) => ({
+        blockId: node.blockId,
+        parentId: node.data?.parent_id ?? null,
+        viewIds: Array.isArray(node.data?.view_ids)
+          ? node.data.view_ids
+          : node.data?.view_id
+            ? [node.data.view_id]
+            : [],
+        databaseId: node.data?.database_id ?? null,
+      }));
+  }, rowPageViewId);
+}
+
+async function waitForInlineGridDuplicateRewrite(page: Page, rowPageViewId: string): Promise<DatabaseBlockState> {
+  await expect
+    .poll(
+      async () => {
+        const blocks = await getDatabaseBlockStates(page, rowPageViewId);
+        const original = blocks[0];
+        const duplicated = blocks[1];
+
+        return Boolean(
+          original?.viewIds[0] &&
+            duplicated?.viewIds[0] &&
+            original?.databaseId &&
+            duplicated?.databaseId &&
+            original.parentId === rowPageViewId &&
+            duplicated.parentId === rowPageViewId &&
+            original.viewIds[0] !== duplicated.viewIds[0] &&
+            original.databaseId !== duplicated.databaseId
+        );
+      },
+      {
+        timeout: 30000,
+        message: 'Expected duplicated row-page inline grid block to be rewritten to fresh view/database ids',
+      }
+    )
+    .toBe(true);
+
+  return (await getDatabaseBlockStates(page, rowPageViewId))[1];
+}
+
+async function hoverDatabaseBlock(page: Page, gridBlock: Locator): Promise<void> {
+  await gridBlock.scrollIntoViewIfNeeded();
+  await expect
+    .poll(
+      async () => {
+        const box = await gridBlock.boundingBox();
+
+        if (!box) {
+          return false;
+        }
+
+        await page.mouse.move(
+          box.x + Math.min(Math.max(box.width / 2, 16), box.width - 1),
+          box.y + Math.min(Math.max(box.height / 2, 16), box.height - 1)
+        );
+        await page.waitForTimeout(250);
+
+        return (
+          (await BlockSelectors.hoverControls(page)
+            .isVisible()
+            .catch(() => false)) &&
+          (await BlockSelectors.dragHandle(page)
+            .isVisible()
+            .catch(() => false))
+        );
+      },
+      { timeout: 10000, message: 'Expected database block hover controls to become visible' }
+    )
+    .toBe(true);
+}
+
+async function duplicateDatabaseBlockAt(page: Page, editor: Locator, blockIndex: number): Promise<void> {
+  const gridBlock = databaseBlocks(editor).nth(blockIndex);
+
+  await expect(gridBlock).toBeVisible({ timeout: 15000 });
+  await hoverDatabaseBlock(page, gridBlock);
+  await BlockSelectors.dragHandle(page).click({ force: true });
+  await expect(BlockSelectors.controlsMenu(page)).toBeVisible({ timeout: 5000 });
+  await BlockSelectors.controlsMenuAction(page, 'duplicate').click({ force: true });
+  await page.waitForTimeout(3000);
 }

--- a/src/application/database-blob/index.ts
+++ b/src/application/database-blob/index.ts
@@ -29,6 +29,8 @@ type PrefetchOptions = {
    * sorted views need row data for the full view, not only recent changes.
    */
   forceFullSync?: boolean;
+  /** Allow the next caller to reuse this entry after it settles. */
+  reuseSettled?: boolean;
   /** Called immediately after seeds are cached (before IndexedDB persist). */
   onSeedsReady?: () => void;
 };
@@ -37,6 +39,7 @@ type SharedPrefetchEntry = {
   priorityRowIds: Set<string>;
   onSeedsReadyCallbacks: Set<() => void>;
   seedsReady: boolean;
+  reuseSettled?: boolean;
   settled?: boolean;
   clearWhenSettled?: boolean;
   promise?: Promise<database_blob.DatabaseBlobDiffResponse>;
@@ -89,6 +92,10 @@ function retryDelayMs(retryAfterSecs?: number | null): number {
 }
 
 function applyPrefetchOptions(entry: SharedPrefetchEntry, options?: PrefetchOptions) {
+  if (options?.reuseSettled) {
+    entry.reuseSettled = true;
+  }
+
   options?.priorityRowIds?.forEach((rowId) => entry.priorityRowIds.add(rowId));
 
   if (!options?.onSeedsReady) return;
@@ -906,9 +913,15 @@ export async function prefetchDatabaseBlobDiff(
 
   if (existingEntry?.promise) {
     const canReuseSettledFullSeed = Boolean(options?.forceFullSync && existingEntry.settled && existingEntry.seedsReady);
+    const canReuseSettledSeed = Boolean(existingEntry.reuseSettled && existingEntry.settled && existingEntry.seedsReady);
 
-    if (!existingEntry.settled || canReuseSettledFullSeed) {
+    if (!existingEntry.settled || canReuseSettledFullSeed || canReuseSettledSeed) {
       applyPrefetchOptions(existingEntry, options);
+
+      if (canReuseSettledSeed && !options?.reuseSettled) {
+        existingEntry.reuseSettled = false;
+      }
+
       return existingEntry.promise;
     }
   }

--- a/src/application/database-yjs/context.ts
+++ b/src/application/database-yjs/context.ts
@@ -6,6 +6,7 @@ import { createContext, useContext, useEffect, useState } from 'react';
 import {
   CreateDatabaseViewPayload,
   CreateDatabaseViewResponse,
+  DuplicatePageOperationOptions,
   CreateRow,
   DatabaseRelations,
   DateFormat,
@@ -94,6 +95,7 @@ export interface DatabaseContextState {
   addPage?: (parentId: string, payload: import('@/application/types').CreatePagePayload) => Promise<import('@/application/types').CreatePageResponse>;
   openPageModal?: (viewId: string) => void;
   deletePage?: (viewId: string) => Promise<void>;
+  duplicatePage?: (viewId: string, options?: DuplicatePageOperationOptions) => Promise<void>;
   generateAISummaryForRow?: (payload: GenerateAISummaryRowPayload) => Promise<string>;
   generateAITranslateForRow?: (payload: GenerateAITranslateRowPayload) => Promise<string>;
   loadDatabaseRelations?: (options?: { refresh?: boolean }) => Promise<DatabaseRelations | undefined>;

--- a/src/application/slate-yjs/command/index.ts
+++ b/src/application/slate-yjs/command/index.ts
@@ -924,9 +924,14 @@ export const CustomEditor = {
     ReactEditor.focus(editor);
   },
 
-  duplicateBlock(editor: YjsEditor, blockId: string, prevId?: string) {
+  duplicateBlock(editor: YjsEditor, blockId: string, prevId?: string, options?: { data?: BlockData }) {
     const sharedRoot = getSharedRoot(editor);
     const block = getBlock(blockId, sharedRoot);
+
+    if (!block) {
+      Log.warn('Block not found');
+      return;
+    }
 
     const parent = getParent(blockId, sharedRoot);
     const prevIndex = getBlockIndex(prevId || blockId, sharedRoot);
@@ -942,7 +947,7 @@ export const CustomEditor = {
       sharedRoot,
       [
         () => {
-          newBlockId = deepCopyBlock(sharedRoot, block);
+          newBlockId = deepCopyBlock(sharedRoot, block, options?.data);
 
           if (!newBlockId) {
             Log.warn('Copied block not found');

--- a/src/application/slate-yjs/utils/yjs.ts
+++ b/src/application/slate-yjs/utils/yjs.ts
@@ -766,11 +766,11 @@ export function moveNode(sharedRoot: YSharedRoot, sourceBlock: YBlock, targetPar
   return copiedBlockId;
 }
 
-export function deepCopyBlock(sharedRoot: YSharedRoot, sourceBlock: YBlock): string | null {
+export function deepCopyBlock(sharedRoot: YSharedRoot, sourceBlock: YBlock, dataOverride?: BlockData): string | null {
   try {
     const newBlock = createBlock(sharedRoot, {
       ty: sourceBlock.get(YjsEditorKey.block_type),
-      data: dataStringTOJson(sourceBlock.get(YjsEditorKey.block_data)),
+      data: dataOverride ?? dataStringTOJson(sourceBlock.get(YjsEditorKey.block_data)),
     });
 
     copyBlockText(sharedRoot, sourceBlock, newBlock);

--- a/src/application/types.ts
+++ b/src/application/types.ts
@@ -290,6 +290,7 @@ export interface DatabaseNodeData extends BlockData {
   view_ids?: ViewId[];
   parent_id?: ViewId;
   database_id?: string;
+  is_database_duplicate_placeholder?: boolean;
 }
 
 export interface SubpageNodeData extends BlockData {

--- a/src/components/database/Database.tsx
+++ b/src/components/database/Database.tsx
@@ -17,6 +17,7 @@ import {
   AppendBreadcrumb,
   CreateDatabaseViewPayload,
   CreateDatabaseViewResponse,
+  DuplicatePageOperationOptions,
   CreatePagePayload,
   CreatePageResponse,
   CreateRow,
@@ -133,6 +134,7 @@ export interface Database2Props {
   addPage?: (parentId: string, payload: CreatePagePayload) => Promise<CreatePageResponse>;
   openPageModal?: (viewId: string) => void;
   updatePage?: (viewId: string, payload: UpdatePagePayload) => Promise<void>;
+  duplicatePage?: (viewId: string, options?: DuplicatePageOperationOptions) => Promise<void>;
   /**
    * Delete a page/view (move to trash).
    * This is used by database tab delete to sync with the sidebar.
@@ -821,6 +823,7 @@ function Database(props: Database2Props) {
       createDatabaseView: props.createDatabaseView,
       updatePage: props.updatePage,
       deletePage: props.deletePage,
+      duplicatePage: props.duplicatePage,
       eventEmitter: props.eventEmitter,
       getViewIdFromDatabaseId: props.getViewIdFromDatabaseId,
       loadDatabaseRelations,
@@ -861,6 +864,7 @@ function Database(props: Database2Props) {
       props.createDatabaseView,
       props.updatePage,
       props.deletePage,
+      props.duplicatePage,
       props.eventEmitter,
       props.getViewIdFromDatabaseId,
       loadDatabaseRelations,

--- a/src/components/editor/CollaborativeEditor.tsx
+++ b/src/components/editor/CollaborativeEditor.tsx
@@ -1,6 +1,6 @@
 import { debounce } from 'lodash-es';
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { createEditor, Descendant, Editor, Element as SlateElement, Node } from 'slate';
+import { createEditor, Descendant, Editor, Element as SlateElement, Node, Operation } from 'slate';
 import { ReactEditor, Slate, withReact } from 'slate-react';
 import * as Y from 'yjs';
 
@@ -52,6 +52,27 @@ type DatabaseBlockInfo = {
   parentId: string;
   viewIds: string[];
 };
+
+function isDatabaseBlockNode(node: Node): boolean {
+  return SlateElement.isElement(node) && DATABASE_BLOCK_TYPES.has((node as unknown as { type: BlockType }).type);
+}
+
+function isDatabaseBlockLifecycleOperation(editor: YjsEditor, op: Operation): boolean {
+  if (op.type === 'insert_node' || op.type === 'remove_node') {
+    return isDatabaseBlockNode(op.node);
+  }
+
+  if (op.type !== 'set_node') return false;
+  if (!('data' in op.properties) && !('data' in op.newProperties)) return false;
+
+  try {
+    const node = Node.get(editor, op.path);
+
+    return isDatabaseBlockNode(node);
+  } catch {
+    return false;
+  }
+}
 
 function CollaborativeEditor({
   doc,
@@ -142,17 +163,9 @@ function CollaborativeEditor({
       if (editor.interceptLocalChange) return;
 
       // Avoid scanning the whole document on every keystroke. Only react to operations that can
-      // affect database block presence (insert/remove).
+      // affect database block presence or database view references.
       const hasDatabaseBlockOps = editor.operations.some((op) => {
-        if (op.type !== 'insert_node' && op.type !== 'remove_node') return false;
-        if (!('node' in op)) return false;
-
-        const node = (op as { node: Node }).node;
-
-        return (
-          SlateElement.isElement(node) &&
-          DATABASE_BLOCK_TYPES.has((node as unknown as { type: BlockType }).type)
-        );
+        return isDatabaseBlockLifecycleOperation(editor, op);
       });
 
       if (!hasDatabaseBlockOps) return;

--- a/src/components/editor/components/blocks/database/DatabaseBlock.tsx
+++ b/src/components/editor/components/blocks/database/DatabaseBlock.tsx
@@ -1,4 +1,6 @@
-import { forwardRef, memo, useCallback, useEffect, useRef, useState } from 'react';
+import CircularProgress from '@mui/material/CircularProgress';
+import { forwardRef, memo, useCallback, useEffect, useRef, useState, type ForwardedRef } from 'react';
+import { useTranslation } from 'react-i18next';
 import { Element, Transforms } from 'slate';
 import { ReactEditor, useReadOnly, useSlateStatic } from 'slate-react';
 
@@ -16,383 +18,428 @@ import { useDocumentLoader } from './hooks/useDocumentLoader';
 import { useResizePositioning } from './hooks/useResizePositioning';
 import { useViewMeta } from './hooks/useViewMeta';
 import { useViewSelection } from './hooks/useViewSelection';
-import { addViewId, getViewIds, removeViewId } from './utils/databaseBlockUtils';
+import { addViewId, getViewIds, isDatabaseDuplicatePlaceholder, removeViewId } from './utils/databaseBlockUtils';
+
+function DatabaseDuplicatePlaceholder() {
+  const { t } = useTranslation();
+
+  return (
+    <div
+      data-testid='database-duplicate-placeholder'
+      className='flex min-h-12 w-full items-center gap-3 rounded border border-line-divider bg-background-primary px-3 text-sm font-medium text-text-secondary'
+    >
+      <CircularProgress size={16} />
+      <span>{t('document.inlineDatabase.duplicating', 'Duplicating database...')}</span>
+    </div>
+  );
+}
+
+type DatabaseBlockBodyProps = EditorElementProps<DatabaseNode> & {
+  editor: ReactEditor;
+  forwardedRef: ForwardedRef<HTMLDivElement>;
+  readOnly: boolean;
+};
+
+function DatabaseBlockBody({ node, children, editor, forwardedRef, readOnly, ...attributes }: DatabaseBlockBodyProps) {
+  const viewIds = getViewIds(node.data);
+  const viewId = viewIds.length > 0 ? viewIds[0] : '';
+  const allowedViewIds = Array.isArray(node.data?.view_ids) ? node.data.view_ids : undefined;
+  const databaseId = typeof node.data?.database_id === 'string' ? node.data.database_id : undefined;
+  const context = useEditorContext();
+  const workspaceId = context.workspaceId;
+
+  const navigateToView = context?.navigateToView;
+  const loadView = context?.loadView;
+  const createRow = context?.createRow;
+  const bindViewSync = context?.bindViewSync;
+
+  const [hasDatabase, setHasDatabase] = useState(false);
+  const [deletionStatus, setDeletionStatus] = useState<'none' | 'inTrash' | 'deleted' | null>(null);
+  const effectiveDeletionStatus =
+    context.variant === UIVariant.Publish && deletionStatus === null ? 'none' : deletionStatus;
+  const containerRef = useRef<HTMLDivElement | null>(null);
+
+  // Compose focused hooks instead of one monolithic hook
+  // 1. Document loading
+  const { doc, notFound, setNotFound } = useDocumentLoader({
+    viewId,
+    databaseId,
+    loadView,
+    bindViewSync,
+    eventEmitter: context.eventEmitter,
+  });
+
+  // 2. Visible view IDs from block data
+  const { visibleViewIds, onViewAdded: onVisibleViewAdded } = useEmbeddedVisibleViewIds({
+    allowedViewIds,
+  });
+
+  // 3. View selection management
+  const { selectedViewId, onChangeView, onViewAddedSelection } = useViewSelection({
+    viewId,
+    visibleViewIds,
+  });
+
+  // 4. View metadata loading
+  const { databaseName, loadViewMeta } = useViewMeta({
+    viewId,
+    loadViewMeta: context?.loadViewMeta,
+    ignoreMetaErrors: true, // Embedded databases don't require meta
+    onNotFound: () => setNotFound(true),
+  });
+
+  // 5. Detect when the database page is deleted from (or restored to) the sidebar.
+  //    When OUTLINE_LOADED fires (after any folder change), fetch the fresh trash list
+  //    and check if our view is in it. This is reliable because:
+  //    - The server API (ViewService.get) returns trashed views as if they still exist
+  //    - The app's trashList state may not be updated yet due to async race conditions
+  //    - Fetching trash directly from the API gives an authoritative answer
+  const notFoundRef = useRef(notFound);
+
+  notFoundRef.current = notFound;
+
+  // Remember the database container (parent) id while the view is still reachable.
+  // Once the container is moved to trash, ViewService.get(viewId) returns 404 and
+  // viewMeta becomes null, so the response can no longer tell us the parent id. We
+  // still need it to recognize the deletion as "in trash" rather than "permanently
+  // deleted": the trash list only contains the container id, never the embedded
+  // child view id. Keyed by viewId so a stale parent is ignored if the block swaps views.
+  const lastKnownParentRef = useRef<{ viewId: string; parentId: string } | null>(null);
+
+  useEffect(() => {
+    const eventEmitter = context.eventEmitter;
+
+    if (!eventEmitter || !viewId || !hasDatabase || !workspaceId) return;
+
+    let cancelled = false;
+
+    const checkView = async () => {
+      try {
+        // Invalidate the view cache to get an authoritative answer from the server.
+        // Without this, the 5-second cache could return stale data for a permanently
+        // deleted view, causing it to be misclassified as "restored".
+        ViewService.invalidateCache(workspaceId, viewId);
+
+        // Fetch view metadata and trash list in parallel (async-parallel rule).
+        // Only treat 404-like failures (record not found) as permanent deletion.
+        const [viewResult, trashResult] = await Promise.allSettled([
+          ViewService.get(workspaceId, viewId),
+          ViewService.getTrash(workspaceId),
+        ]);
+
+        const viewMeta = viewResult.status === 'fulfilled' ? viewResult.value : null;
+        const viewGone = viewResult.status === 'rejected';
+        const trashItems = trashResult.status === 'fulfilled' ? trashResult.value : null;
+
+        // If both requests failed, optimistically allow rendering rather than
+        // blocking the user with an infinite spinner.
+        if (viewResult.status === 'rejected' && trashResult.status === 'rejected') {
+          if (cancelled) return;
+          setDeletionStatus('none');
+          return;
+        }
+
+        // Cache the parent id whenever the view is reachable, so we can still resolve
+        // the container after it is trashed (at which point viewMeta is null).
+        if (viewMeta?.parent_view_id) {
+          lastKnownParentRef.current = { viewId, parentId: viewMeta.parent_view_id };
+        }
+
+        // Build the set of IDs to check: the view itself and its parent (database
+        // container). When a database container is trashed, only the container ID
+        // appears in trash — not its child view IDs — so fall back to the last known
+        // parent id when the trashed view no longer reports its metadata.
+        const cachedParentId =
+          lastKnownParentRef.current?.viewId === viewId ? lastKnownParentRef.current.parentId : null;
+        const parentId = viewMeta?.parent_view_id ?? cachedParentId;
+        const idsToCheck = new Set<string>([viewId]);
+
+        if (parentId) {
+          idsToCheck.add(parentId);
+        }
+
+        const isInTrash = trashItems?.some((item) => idsToCheck.has(item.view_id));
+
+        if (cancelled) return;
+
+        if (isInTrash) {
+          // Database container is in the trash
+          setDeletionStatus('inTrash');
+
+          if (!notFoundRef.current) {
+            setNotFound(true);
+          }
+        } else if (viewGone && !viewMeta) {
+          // Not in trash AND API can't find the view — permanently deleted
+          setDeletionStatus('deleted');
+
+          if (!notFoundRef.current) {
+            setNotFound(true);
+          }
+        } else if (viewMeta) {
+          // View exists and is not in trash — confirmed alive (or restored)
+          setDeletionStatus('none');
+
+          if (notFoundRef.current) {
+            setNotFound(false);
+          }
+        }
+      } catch {
+        // Network error — do nothing, keep current state
+      }
+    };
+
+    // Check immediately on mount (covers navigating back to a page after deletion)
+    void checkView();
+
+    eventEmitter.on(APP_EVENTS.OUTLINE_LOADED, checkView);
+    return () => {
+      cancelled = true;
+      eventEmitter.off(APP_EVENTS.OUTLINE_LOADED, checkView);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- node.data excluded to avoid re-subscribing on every block edit
+  }, [context.eventEmitter, viewId, workspaceId, hasDatabase, setNotFound]);
+
+  // Combined callback when a view is added
+  const onViewAdded = useCallback(
+    (newViewId: string) => {
+      onVisibleViewAdded(newViewId);
+      onViewAddedSelection(newViewId);
+    },
+    [onVisibleViewAdded, onViewAddedSelection]
+  );
+
+  // Track latest valid scroll position to restore if layout shift resets it
+  const latestScrollTop = useRef<number>(0);
+
+  useEffect(() => {
+    let scrollContainer: HTMLElement | null = null;
+
+    try {
+      const domNode = ReactEditor.toDOMNode(editor, editor);
+
+      scrollContainer = domNode.closest('.appflowy-scroll-container');
+    } catch {
+      // ignore
+    }
+
+    if (!scrollContainer) {
+      scrollContainer = document.querySelector('.appflowy-scroll-container');
+    }
+
+    if (!scrollContainer) return;
+
+    // Initialize with current scroll position if already scrolled
+    if (scrollContainer.scrollTop > 0) {
+      latestScrollTop.current = scrollContainer.scrollTop;
+    }
+
+    const handleScroll = () => {
+      if (scrollContainer && scrollContainer.scrollTop > 0) {
+        latestScrollTop.current = scrollContainer.scrollTop;
+      }
+    };
+
+    scrollContainer.addEventListener('scroll', handleScroll, { passive: true });
+    return () => {
+      scrollContainer?.removeEventListener('scroll', handleScroll);
+    };
+  }, [editor]);
+
+  const handleRendered = useCallback(() => {
+    const restore = () => {
+      try {
+        let scrollContainer: HTMLElement | null = null;
+
+        try {
+          const domNode = ReactEditor.toDOMNode(editor, editor);
+
+          scrollContainer = domNode.closest('.appflowy-scroll-container');
+        } catch {
+          // fallback
+        }
+
+        if (!scrollContainer) {
+          scrollContainer = document.querySelector('.appflowy-scroll-container');
+        }
+
+        // Only restore if scroll position was reset to 0 (or close to 0) and we had a previous scroll
+        if (scrollContainer && scrollContainer.scrollTop < 10 && latestScrollTop.current > 50) {
+          scrollContainer.scrollTop = latestScrollTop.current;
+        }
+      } catch {
+        // Ignore
+      }
+    };
+
+    restore();
+    // Try next tick in case of layout shifts
+    setTimeout(restore, 50);
+
+    // Clear the ref only after attempts to allow future 0-scrolls if valid
+    setTimeout(() => {
+      latestScrollTop.current = 0;
+    }, 1000);
+  }, [editor]);
+
+  const handleNavigateToRow = useCallback(
+    async (rowId: string) => {
+      if (!viewId) return;
+      await navigateToView?.(viewId, rowId);
+    },
+    [navigateToView, viewId]
+  );
+
+  /**
+   * Callback to update view_ids in the block data when views are added or removed.
+   * Similar to Flutter's onViewIdsChanged callback in database_view_widget.dart.
+   */
+  const handleViewIdsChanged = useCallback(
+    (currentViewIds: string[]) => {
+      if (readOnly) return;
+
+      const existingViewIds = getViewIds(node.data);
+
+      // Find new view IDs (additions)
+      const addedViewIds = currentViewIds.filter((id) => !existingViewIds.includes(id));
+
+      // Find removed view IDs (deletions)
+      const removedViewIds = existingViewIds.filter((id) => !currentViewIds.includes(id));
+
+      if (addedViewIds.length === 0 && removedViewIds.length === 0) return;
+
+      Log.debug('[DatabaseBlock] View IDs changed', {
+        addedViewIds,
+        removedViewIds,
+        existingViewIds,
+        currentViewIds,
+      });
+
+      // Build the new data object
+      let updatedData = { ...node.data };
+
+      for (const id of addedViewIds) {
+        updatedData = addViewId(updatedData, id);
+      }
+
+      for (const id of removedViewIds) {
+        updatedData = removeViewId(updatedData, id);
+      }
+
+      // Update the Slate node
+      try {
+        const path = ReactEditor.findPath(editor, node as unknown as Element);
+
+        Transforms.setNodes(editor, { data: updatedData }, { at: path });
+      } catch (e) {
+        console.error('[DatabaseBlock] Error updating view_ids:', e);
+      }
+    },
+    [editor, node, readOnly]
+  );
+
+  const { paddingStart, paddingEnd, width } = useResizePositioning({
+    editor,
+    node: node as unknown as Element,
+  });
+
+  useEffect(() => {
+    const sharedRoot = doc?.getMap(YjsEditorKey.data_section) as YSharedRoot;
+
+    if (!sharedRoot) return;
+
+    const setStatus = () => {
+      const hasDb = !!sharedRoot.get(YjsEditorKey.database);
+
+      setHasDatabase(hasDb);
+    };
+
+    setStatus();
+    sharedRoot.observe(setStatus);
+
+    return () => {
+      sharedRoot.unobserve(setStatus);
+    };
+  }, [doc, viewId]);
+
+  return (
+    <div {...attributes} contentEditable={readOnly ? false : undefined} className='relative w-full cursor-pointer'>
+      <div ref={forwardedRef} className='absolute left-0 top-0 h-full w-full caret-transparent'>
+        {children}
+      </div>
+      <div
+        contentEditable={false}
+        ref={containerRef}
+        className='container-bg relative my-1 flex w-full select-none flex-col'
+      >
+        <DatabaseContent
+          baseViewId={viewId}
+          selectedViewId={selectedViewId}
+          hasDatabase={hasDatabase}
+          notFound={notFound}
+          deletionStatus={effectiveDeletionStatus}
+          paddingStart={paddingStart}
+          paddingEnd={paddingEnd}
+          width={width}
+          doc={doc}
+          workspaceId={workspaceId}
+          createRow={createRow}
+          loadView={loadView}
+          navigateToView={navigateToView}
+          onOpenRowPage={handleNavigateToRow}
+          loadViewMeta={loadViewMeta}
+          databaseName={databaseName}
+          visibleViewIds={visibleViewIds}
+          onChangeView={onChangeView}
+          onViewAdded={onViewAdded}
+          onRendered={handleRendered}
+          onViewIdsChanged={handleViewIdsChanged}
+          // EditorContextState shares common fields with DatabaseContextState but not all
+          // The missing fields (databaseDoc, databasePageId, activeViewId, rowMap) are
+          // explicitly set by DatabaseContent via baseViewId, selectedViewId, and doc props
+          context={context as unknown as DatabaseContextState}
+        />
+      </div>
+    </div>
+  );
+}
 
 export const DatabaseBlock = memo(
   forwardRef<HTMLDivElement, EditorElementProps<DatabaseNode>>(({ node, children, ...attributes }, ref) => {
-    const viewIds = getViewIds(node.data);
-    const viewId = viewIds.length > 0 ? viewIds[0] : '';
-    const allowedViewIds = Array.isArray(node.data?.view_ids) ? node.data.view_ids : undefined;
-    const databaseId = typeof node.data?.database_id === 'string' ? node.data.database_id : undefined;
-    const context = useEditorContext();
-    const workspaceId = context.workspaceId;
-
-    const navigateToView = context?.navigateToView;
-    const loadView = context?.loadView;
-    const createRow = context?.createRow;
-    const bindViewSync = context?.bindViewSync;
-
-    const [hasDatabase, setHasDatabase] = useState(false);
-    const [deletionStatus, setDeletionStatus] = useState<'none' | 'inTrash' | 'deleted' | null>(null);
-    const effectiveDeletionStatus =
-      context.variant === UIVariant.Publish && deletionStatus === null ? 'none' : deletionStatus;
-    const containerRef = useRef<HTMLDivElement | null>(null);
+    const isDuplicatePlaceholder = isDatabaseDuplicatePlaceholder(node.data);
     const editor = useSlateStatic();
     const readOnly = useReadOnly() || editor.isElementReadOnly(node as unknown as Element);
 
-    // Compose focused hooks instead of one monolithic hook
-    // 1. Document loading
-    const { doc, notFound, setNotFound } = useDocumentLoader({
-      viewId,
-      databaseId,
-      loadView,
-      bindViewSync,
-      eventEmitter: context.eventEmitter,
-    });
-
-    // 2. Visible view IDs from block data
-    const { visibleViewIds, onViewAdded: onVisibleViewAdded } = useEmbeddedVisibleViewIds({
-      allowedViewIds,
-    });
-
-    // 3. View selection management
-    const { selectedViewId, onChangeView, onViewAddedSelection } = useViewSelection({
-      viewId,
-      visibleViewIds,
-    });
-
-    // 4. View metadata loading
-    const { databaseName, loadViewMeta } = useViewMeta({
-      viewId,
-      loadViewMeta: context?.loadViewMeta,
-      ignoreMetaErrors: true, // Embedded databases don't require meta
-      onNotFound: () => setNotFound(true),
-    });
-
-    // 5. Detect when the database page is deleted from (or restored to) the sidebar.
-    //    When OUTLINE_LOADED fires (after any folder change), fetch the fresh trash list
-    //    and check if our view is in it. This is reliable because:
-    //    - The server API (ViewService.get) returns trashed views as if they still exist
-    //    - The app's trashList state may not be updated yet due to async race conditions
-    //    - Fetching trash directly from the API gives an authoritative answer
-    const notFoundRef = useRef(notFound);
-
-    notFoundRef.current = notFound;
-
-    // Remember the database container (parent) id while the view is still reachable.
-    // Once the container is moved to trash, ViewService.get(viewId) returns 404 and
-    // viewMeta becomes null, so the response can no longer tell us the parent id. We
-    // still need it to recognize the deletion as "in trash" rather than "permanently
-    // deleted": the trash list only contains the container id, never the embedded
-    // child view id. Keyed by viewId so a stale parent is ignored if the block swaps views.
-    const lastKnownParentRef = useRef<{ viewId: string; parentId: string } | null>(null);
-
-    useEffect(() => {
-      const eventEmitter = context.eventEmitter;
-
-      if (!eventEmitter || !viewId || !hasDatabase || !workspaceId) return;
-
-      let cancelled = false;
-
-      const checkView = async () => {
-        try {
-          // Invalidate the view cache to get an authoritative answer from the server.
-          // Without this, the 5-second cache could return stale data for a permanently
-          // deleted view, causing it to be misclassified as "restored".
-          ViewService.invalidateCache(workspaceId, viewId);
-
-          // Fetch view metadata and trash list in parallel (async-parallel rule).
-          // Only treat 404-like failures (record not found) as permanent deletion.
-          const [viewResult, trashResult] = await Promise.allSettled([
-            ViewService.get(workspaceId, viewId),
-            ViewService.getTrash(workspaceId),
-          ]);
-
-          const viewMeta = viewResult.status === 'fulfilled' ? viewResult.value : null;
-          const viewGone = viewResult.status === 'rejected';
-          const trashItems = trashResult.status === 'fulfilled' ? trashResult.value : null;
-
-          // If both requests failed, optimistically allow rendering rather than
-          // blocking the user with an infinite spinner.
-          if (viewResult.status === 'rejected' && trashResult.status === 'rejected') {
-            if (cancelled) return;
-            setDeletionStatus('none');
-            return;
-          }
-
-          // Cache the parent id whenever the view is reachable, so we can still resolve
-          // the container after it is trashed (at which point viewMeta is null).
-          if (viewMeta?.parent_view_id) {
-            lastKnownParentRef.current = { viewId, parentId: viewMeta.parent_view_id };
-          }
-
-          // Build the set of IDs to check: the view itself and its parent (database
-          // container). When a database container is trashed, only the container ID
-          // appears in trash — not its child view IDs — so fall back to the last known
-          // parent id when the trashed view no longer reports its metadata.
-          const cachedParentId =
-            lastKnownParentRef.current?.viewId === viewId ? lastKnownParentRef.current.parentId : null;
-          const parentId = viewMeta?.parent_view_id ?? cachedParentId;
-          const idsToCheck = new Set<string>([viewId]);
-
-          if (parentId) {
-            idsToCheck.add(parentId);
-          }
-
-          const isInTrash = trashItems?.some((item) => idsToCheck.has(item.view_id));
-
-          if (cancelled) return;
-
-          if (isInTrash) {
-            // Database container is in the trash
-            setDeletionStatus('inTrash');
-
-            if (!notFoundRef.current) {
-              setNotFound(true);
-            }
-          } else if (viewGone && !viewMeta) {
-            // Not in trash AND API can't find the view — permanently deleted
-            setDeletionStatus('deleted');
-
-            if (!notFoundRef.current) {
-              setNotFound(true);
-            }
-          } else if (viewMeta) {
-            // View exists and is not in trash — confirmed alive (or restored)
-            setDeletionStatus('none');
-
-            if (notFoundRef.current) {
-              setNotFound(false);
-            }
-          }
-        } catch {
-          // Network error — do nothing, keep current state
-        }
-      };
-
-      // Check immediately on mount (covers navigating back to a page after deletion)
-      void checkView();
-
-      eventEmitter.on(APP_EVENTS.OUTLINE_LOADED, checkView);
-      return () => {
-        cancelled = true;
-        eventEmitter.off(APP_EVENTS.OUTLINE_LOADED, checkView);
-      };
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- node.data excluded to avoid re-subscribing on every block edit
-    }, [context.eventEmitter, viewId, workspaceId, hasDatabase, setNotFound]);
-
-    // Combined callback when a view is added
-    const onViewAdded = useCallback(
-      (newViewId: string) => {
-        onVisibleViewAdded(newViewId);
-        onViewAddedSelection(newViewId);
-      },
-      [onVisibleViewAdded, onViewAddedSelection]
-    );
-
-    // Track latest valid scroll position to restore if layout shift resets it
-    const latestScrollTop = useRef<number>(0);
-
-    useEffect(() => {
-      let scrollContainer: HTMLElement | null = null;
-      
-      try {
-        const domNode = ReactEditor.toDOMNode(editor, editor);
-        
-        scrollContainer = domNode.closest('.appflowy-scroll-container');
-      } catch {
-        // ignore
-      }
-
-      if (!scrollContainer) {
-        scrollContainer = document.querySelector('.appflowy-scroll-container');
-      }
-
-      if (!scrollContainer) return;
-
-      // Initialize with current scroll position if already scrolled
-      if (scrollContainer.scrollTop > 0) {
-        latestScrollTop.current = scrollContainer.scrollTop;
-      }
-
-      const handleScroll = () => {
-        if (scrollContainer && scrollContainer.scrollTop > 0) {
-          latestScrollTop.current = scrollContainer.scrollTop;
-        }
-      };
-
-      scrollContainer.addEventListener('scroll', handleScroll, { passive: true });
-      return () => {
-        scrollContainer?.removeEventListener('scroll', handleScroll);
-      };
-    }, [editor]);
-
-    const handleRendered = useCallback(() => {
-      const restore = () => {
-        try {
-          let scrollContainer: HTMLElement | null = null;
-          
-          try {
-            const domNode = ReactEditor.toDOMNode(editor, editor);
-            
-            scrollContainer = domNode.closest('.appflowy-scroll-container');
-          } catch {
-            // fallback
-          }
-
-          if (!scrollContainer) {
-            scrollContainer = document.querySelector('.appflowy-scroll-container');
-          }
-          
-          // Only restore if scroll position was reset to 0 (or close to 0) and we had a previous scroll
-          if (scrollContainer && scrollContainer.scrollTop < 10 && latestScrollTop.current > 50) {
-            scrollContainer.scrollTop = latestScrollTop.current;
-          }
-        } catch {
-          // Ignore
-        }
-      };
-
-      restore();
-      // Try next tick in case of layout shifts
-      setTimeout(restore, 50);
-      
-      // Clear the ref only after attempts to allow future 0-scrolls if valid
-      setTimeout(() => {
-        latestScrollTop.current = 0;
-      }, 1000);
-    }, [editor]);
-
-    const handleNavigateToRow = useCallback(
-      async (rowId: string) => {
-        if (!viewId) return;
-        await navigateToView?.(viewId, rowId);
-      },
-      [navigateToView, viewId]
-    );
-
-    /**
-     * Callback to update view_ids in the block data when views are added or removed.
-     * Similar to Flutter's onViewIdsChanged callback in database_view_widget.dart.
-     */
-    const handleViewIdsChanged = useCallback(
-      (currentViewIds: string[]) => {
-        if (readOnly) return;
-
-        const existingViewIds = getViewIds(node.data);
-
-        // Find new view IDs (additions)
-        const addedViewIds = currentViewIds.filter((id) => !existingViewIds.includes(id));
-
-        // Find removed view IDs (deletions)
-        const removedViewIds = existingViewIds.filter((id) => !currentViewIds.includes(id));
-
-        if (addedViewIds.length === 0 && removedViewIds.length === 0) return;
-
-        Log.debug('[DatabaseBlock] View IDs changed', {
-          addedViewIds,
-          removedViewIds,
-          existingViewIds,
-          currentViewIds,
-        });
-
-        // Build the new data object
-        let updatedData = { ...node.data };
-
-        for (const id of addedViewIds) {
-          updatedData = addViewId(updatedData, id);
-        }
-
-        for (const id of removedViewIds) {
-          updatedData = removeViewId(updatedData, id);
-        }
-
-        // Update the Slate node
-        try {
-          const path = ReactEditor.findPath(editor, node as unknown as Element);
-
-          Transforms.setNodes(
-            editor,
-            { data: updatedData },
-            { at: path }
-          );
-        } catch (e) {
-          console.error('[DatabaseBlock] Error updating view_ids:', e);
-        }
-      },
-      [editor, node, readOnly]
-    );
-
-    const { paddingStart, paddingEnd, width } = useResizePositioning({
-      editor,
-      node: node as unknown as Element,
-    });
-
-    useEffect(() => {
-      const sharedRoot = doc?.getMap(YjsEditorKey.data_section) as YSharedRoot;
-
-      if (!sharedRoot) return;
-
-      const setStatus = () => {
-        const hasDb = !!sharedRoot.get(YjsEditorKey.database);
-
-        setHasDatabase(hasDb);
-      };
-
-      setStatus();
-      sharedRoot.observe(setStatus);
-
-      return () => {
-        sharedRoot.unobserve(setStatus);
-      };
-    }, [doc, viewId]);
+    if (isDuplicatePlaceholder) {
+      return (
+        <div {...attributes} contentEditable={readOnly ? false : undefined} className='relative w-full cursor-pointer'>
+          <div ref={ref} className='absolute left-0 top-0 h-full w-full caret-transparent'>
+            {children}
+          </div>
+          <div contentEditable={false} className='container-bg relative my-1 flex w-full select-none flex-col'>
+            <DatabaseDuplicatePlaceholder />
+          </div>
+        </div>
+      );
+    }
 
     return (
-      <div {...attributes} contentEditable={readOnly ? false : undefined} className='relative w-full cursor-pointer'>
-        <div ref={ref} className='absolute left-0 top-0 h-full w-full caret-transparent'>
-          {children}
-        </div>
-        <div
-          contentEditable={false}
-          ref={containerRef}
-          className='container-bg relative my-1 flex w-full select-none flex-col'
-        >
-          <DatabaseContent
-            baseViewId={viewId}
-            selectedViewId={selectedViewId}
-            hasDatabase={hasDatabase}
-            notFound={notFound}
-            deletionStatus={effectiveDeletionStatus}
-            paddingStart={paddingStart}
-            paddingEnd={paddingEnd}
-            width={width}
-            doc={doc}
-            workspaceId={workspaceId}
-            createRow={createRow}
-            loadView={loadView}
-            navigateToView={navigateToView}
-            onOpenRowPage={handleNavigateToRow}
-            loadViewMeta={loadViewMeta}
-            databaseName={databaseName}
-            visibleViewIds={visibleViewIds}
-            onChangeView={onChangeView}
-            onViewAdded={onViewAdded}
-            onRendered={handleRendered}
-            onViewIdsChanged={handleViewIdsChanged}
-            // EditorContextState shares common fields with DatabaseContextState but not all
-            // The missing fields (databaseDoc, databasePageId, activeViewId, rowMap) are
-            // explicitly set by DatabaseContent via baseViewId, selectedViewId, and doc props
-            context={context as unknown as DatabaseContextState}
-          />
-        </div>
-      </div>
+      <DatabaseBlockBody {...attributes} node={node} editor={editor} forwardedRef={ref} readOnly={readOnly}>
+        {children}
+      </DatabaseBlockBody>
     );
   }),
   (prevProps, nextProps) => {
     const prevViewIds = getViewIds(prevProps.node.data);
     const nextViewIds = getViewIds(nextProps.node.data);
+    const prevDatabaseId = prevProps.node.data.database_id;
+    const nextDatabaseId = nextProps.node.data.database_id;
+    const prevIsDuplicatePlaceholder = isDatabaseDuplicatePlaceholder(prevProps.node.data);
+    const nextIsDuplicatePlaceholder = isDatabaseDuplicatePlaceholder(nextProps.node.data);
 
     return (
+      prevDatabaseId === nextDatabaseId &&
+      prevIsDuplicatePlaceholder === nextIsDuplicatePlaceholder &&
       prevViewIds.length === nextViewIds.length &&
       prevViewIds.every((id, index) => id === nextViewIds[index])
     );

--- a/src/components/editor/components/blocks/database/utils/databaseBlockUtils.ts
+++ b/src/components/editor/components/blocks/database/utils/databaseBlockUtils.ts
@@ -58,6 +58,18 @@ export function createDatabaseNodeData(params: {
   };
 }
 
+export function createDatabaseDuplicatePlaceholderData(parentId?: string): DatabaseNodeData {
+  return {
+    parent_id: parentId,
+    view_ids: [],
+    is_database_duplicate_placeholder: true,
+  };
+}
+
+export function isDatabaseDuplicatePlaceholder(data: DatabaseNodeData): boolean {
+  return data.is_database_duplicate_placeholder === true;
+}
+
 /**
  * Add a view ID to existing database node data (returns new data object).
  */

--- a/src/components/editor/components/toolbar/block-controls/ControlsMenu.tsx
+++ b/src/components/editor/components/toolbar/block-controls/ControlsMenu.tsx
@@ -11,9 +11,8 @@ import { getAxios, executeAPIRequest, APIResponse } from '@/application/services
 import { getView } from '@/application/services/js-services/http/view-api';
 import { YjsEditor } from '@/application/slate-yjs';
 import { CustomEditor } from '@/application/slate-yjs/command';
-import { dataStringTOJson, getBlock } from '@/application/slate-yjs/utils/yjs';
 import { findSlateEntryByBlockId } from '@/application/slate-yjs/utils/editor';
-import { BlockType, View, YjsEditorKey } from '@/application/types';
+import { BlockType, View } from '@/application/types';
 import { getDatabaseIdFromExtra } from '@/application/view-utils';
 import { ReactComponent as DeleteIcon } from '@/assets/icons/delete.svg';
 import { ReactComponent as DuplicateIcon } from '@/assets/icons/duplicate.svg';
@@ -104,23 +103,13 @@ function ControlsMenu({
   const duplicateDatabaseBlock = useCallback(
     async (sourceNode: DatabaseNode, duplicatedBlockId: string) => {
       const replaceDuplicatedBlockData = (nextData: ReturnType<typeof createDatabaseNodeData>) => {
-        const duplicatedBlock = getBlock(duplicatedBlockId, editor.sharedRoot);
+        const entry = findSlateEntryByBlockId(editor, duplicatedBlockId);
 
-        if (!duplicatedBlock) {
+        if (!entry) {
           throw new Error(t('document.plugins.subPage.errors.failedDuplicatePage'));
         }
 
-        const previousData = dataStringTOJson(
-          duplicatedBlock.get(YjsEditorKey.block_data)
-        );
-
-        duplicatedBlock.set(
-          YjsEditorKey.block_data,
-          JSON.stringify({
-            ...previousData,
-            ...nextData,
-          })
-        );
+        Transforms.setNodes(editor, { data: nextData }, { at: entry[1] });
       };
 
       const parentId = sourceNode.data.parent_id;

--- a/src/components/editor/components/toolbar/block-controls/ControlsMenu.tsx
+++ b/src/components/editor/components/toolbar/block-controls/ControlsMenu.tsx
@@ -19,7 +19,10 @@ import { ReactComponent as DuplicateIcon } from '@/assets/icons/duplicate.svg';
 import { ReactComponent as CopyLinkIcon } from '@/assets/icons/link.svg';
 import { notify } from '@/components/_shared/notify';
 import { Popover } from '@/components/_shared/popover';
-import { createDatabaseNodeData } from '@/components/editor/components/blocks/database/utils/databaseBlockUtils';
+import {
+  createDatabaseDuplicatePlaceholderData,
+  createDatabaseNodeData,
+} from '@/components/editor/components/blocks/database/utils/databaseBlockUtils';
 import CalloutTextColor from '@/components/editor/components/toolbar/block-controls/CalloutTextColor';
 import {
   OutlineCollapseControl,
@@ -41,9 +44,30 @@ import {
 function getViewNoCache(workspaceId: string, viewId: string, depth: number = 1): Promise<View> {
   const url = `/api/workspace/${workspaceId}/view/${viewId}?depth=${depth}&_t=${Date.now()}`;
 
-  return executeAPIRequest<View>(() =>
-    getAxios()?.get<APIResponse<View>>(url)
-  );
+  return executeAPIRequest<View>(() => getAxios()?.get<APIResponse<View>>(url));
+}
+
+function waitForDatabaseBlobSeeds(workspaceId: string, databaseId: string): Promise<void> {
+  const timeoutMs = 10000;
+
+  return new Promise((resolve) => {
+    let resolved = false;
+    const finish = () => {
+      if (resolved) return;
+      resolved = true;
+      window.clearTimeout(timeoutId);
+      resolve();
+    };
+
+    const timeoutId = window.setTimeout(finish, timeoutMs);
+
+    void prefetchDatabaseBlobDiff(workspaceId, databaseId, {
+      reuseSettled: true,
+      onSeedsReady: finish,
+    })
+      .then(finish)
+      .catch(finish);
+  });
 }
 
 const popoverProps: Partial<PopoverProps> = {
@@ -100,24 +124,27 @@ function ControlsMenu({
   const { t } = useTranslation();
   const duplicateCopySuffix = useMemo(() => ` (${t('menuAppHeader.pageNameSuffix')})`, [t]);
 
-  const duplicateDatabaseBlock = useCallback(
-    async (sourceNode: DatabaseNode, duplicatedBlockId: string) => {
-      const replaceDuplicatedBlockData = (nextData: ReturnType<typeof createDatabaseNodeData>) => {
-        const entry = findSlateEntryByBlockId(editor, duplicatedBlockId);
+  const setDatabaseBlockData = useCallback(
+    (blockId: string, nextData: DatabaseNode['data']) => {
+      const entry = findSlateEntryByBlockId(editor, blockId);
 
-        if (!entry) {
-          throw new Error(t('document.plugins.subPage.errors.failedDuplicatePage'));
-        }
+      if (!entry) {
+        throw new Error(t('document.plugins.subPage.errors.failedDuplicatePage'));
+      }
 
-        Transforms.setNodes(editor, { data: nextData }, { at: entry[1] });
-      };
+      Transforms.setNodes(editor, { data: nextData }, { at: entry[1] });
+    },
+    [editor, t]
+  );
 
+  const resolveDuplicatedDatabaseBlockData = useCallback(
+    async (sourceNode: DatabaseNode): Promise<DatabaseNode['data']> => {
       const parentId = sourceNode.data.parent_id;
       const sourceViewIds = sourceNode.data.view_ids?.length
         ? sourceNode.data.view_ids
         : sourceNode.data.view_id
-          ? [sourceNode.data.view_id]
-          : [];
+        ? [sourceNode.data.view_id]
+        : [];
       const databaseId = sourceNode.data.database_id;
 
       if (!parentId || sourceViewIds.length === 0 || !databaseId) {
@@ -137,9 +164,7 @@ function ControlsMenu({
       const isLinkedDuplicate = firstSourceView.parent_view_id === parentId;
 
       if (isLinkedDuplicate) {
-        const sourceViews = await Promise.all(
-          sourceViewIds.map((id) => loadViewMeta(id).catch(() => null))
-        );
+        const sourceViews = await Promise.all(sourceViewIds.map((id) => loadViewMeta(id).catch(() => null)));
 
         const duplicatedViewIds = await Promise.all(
           sourceViewIds.map(async (_, i) => {
@@ -162,21 +187,17 @@ function ControlsMenu({
           })
         );
 
-        replaceDuplicatedBlockData(
-          createDatabaseNodeData({
-            parentId,
-            viewIds: duplicatedViewIds,
-            databaseId,
-          })
-        );
-
-        return;
+        return createDatabaseNodeData({
+          parentId,
+          viewIds: duplicatedViewIds,
+          databaseId,
+        });
       }
 
       if (!workspaceId || !duplicatePage) {
-        // duplicatePage is not available in all editor contexts (e.g. row sub-documents).
+        // duplicatePage is not available in every editor context.
         // Fall back to the shallow block copy without database-specific rewiring.
-        return;
+        return sourceNode.data;
       }
 
       const sourceContainerId = firstSourceView.parent_view_id;
@@ -239,7 +260,8 @@ function ControlsMenu({
         if (
           candidatePrimaryViewId &&
           candidateDatabaseId &&
-          (candidatePrimaryViewId !== sourceViewIds[0] || candidateDatabaseId !== databaseId)
+          candidatePrimaryViewId !== sourceViewIds[0] &&
+          candidateDatabaseId !== databaseId
         ) {
           duplicatedContainerView = candidate;
           duplicatedContainer = candidateContainer;
@@ -255,6 +277,8 @@ function ControlsMenu({
         throw new Error(t('document.plugins.subPage.errors.failedDuplicatePage'));
       }
 
+      await waitForDatabaseBlobSeeds(workspaceId, newDatabaseId);
+
       // Map source view IDs to their index positions within the source container,
       // then select the same positions from the duplicated container. This preserves
       // the block's tab subset (e.g., if the block only shows tabs B and C out of
@@ -266,29 +290,20 @@ function ControlsMenu({
         .filter((i) => i >= 0 && i < duplicatedChildIds.length)
         .map((i) => duplicatedChildIds[i]);
 
-      const allDuplicatedViewIds = mappedViewIds.length > 0
-        ? mappedViewIds
-        : duplicatedChildIds.length > 0
+      const allDuplicatedViewIds =
+        mappedViewIds.length > 0
+          ? mappedViewIds
+          : duplicatedChildIds.length > 0
           ? duplicatedChildIds.slice(0, sourceViewIds.length)
           : [newPrimaryViewId];
 
-      replaceDuplicatedBlockData(
-        createDatabaseNodeData({
-          parentId,
-          viewIds: allDuplicatedViewIds,
-          databaseId: newDatabaseId,
-        })
-      );
+      return createDatabaseNodeData({
+        parentId,
+        viewIds: allDuplicatedViewIds,
+        databaseId: newDatabaseId,
+      });
     },
-    [
-      createDatabaseView,
-      duplicateCopySuffix,
-      duplicatePage,
-      editor,
-      loadViewMeta,
-      t,
-      workspaceId,
-    ]
+    [createDatabaseView, duplicateCopySuffix, duplicatePage, loadViewMeta, t, workspaceId]
   );
 
   const duplicateSelectedBlocks = useCallback(async () => {
@@ -304,10 +319,14 @@ function ControlsMenu({
       }
 
       const [selectedNode] = entry;
+      const isDatabaseBlock = isDatabaseBlockType(selectedNode.type as BlockType);
       const newBlockId = CustomEditor.duplicateBlock(
         editor,
         blockId,
-        index === 0 ? prevId : newBlockIds[index - 1]
+        index === 0 ? prevId : newBlockIds[index - 1],
+        isDatabaseBlock
+          ? { data: createDatabaseDuplicatePlaceholderData((selectedNode as DatabaseNode).data.parent_id) }
+          : undefined
       );
 
       if (!newBlockId) {
@@ -316,21 +335,20 @@ function ControlsMenu({
 
       newBlockIds.push(newBlockId);
 
-      if (!isDatabaseBlockType(selectedNode.type as BlockType)) {
-        continue;
-      }
+      if (isDatabaseBlock) {
+        hasDatabaseBlock = true;
 
-      hasDatabaseBlock = true;
+        try {
+          const nextDatabaseBlockData = await resolveDuplicatedDatabaseBlockData(selectedNode as DatabaseNode);
 
-      try {
-        await duplicateDatabaseBlock(selectedNode as DatabaseNode, newBlockId);
-      } catch (error) {
-        // Roll back ALL previously duplicated blocks, not just the current one
-        for (const id of newBlockIds) {
-          CustomEditor.deleteBlock(editor, id);
+          setDatabaseBlockData(newBlockId, nextDatabaseBlockData);
+        } catch (error) {
+          for (const id of newBlockIds) {
+            CustomEditor.deleteBlock(editor, id);
+          }
+
+          throw error;
         }
-
-        throw error;
       }
     }
 
@@ -348,7 +366,7 @@ function ControlsMenu({
     if (entry) {
       selectPathStartSafely(editor, entry[1]);
     }
-  }, [duplicateDatabaseBlock, editor, selectedBlockIds, t]);
+  }, [editor, resolveDuplicatedDatabaseBlockData, selectedBlockIds, setDatabaseBlockData, t]);
 
   const options = useMemo(() => {
     return [
@@ -423,9 +441,7 @@ function ControlsMenu({
                 onClose();
                 Promise.resolve(option.onClick()).catch((error) => {
                   notify.error(
-                    error instanceof Error
-                      ? error.message
-                      : t('document.plugins.subPage.errors.failedDuplicatePage')
+                    error instanceof Error ? error.message : t('document.plugins.subPage.errors.failedDuplicatePage')
                   );
                 });
               }}

--- a/src/pages/AppPage.tsx
+++ b/src/pages/AppPage.tsx
@@ -548,6 +548,7 @@ function AppPage() {
         updatePage={updatePage}
         addPage={addPage}
         deletePage={deletePage}
+        duplicatePage={operations.duplicatePage}
         openPageModal={openPageModal}
         loadViews={loadViews}
         onWordCountChange={setWordCount}


### PR DESCRIPTION
## Summary

Fixes row-page inline database duplication so duplicating an inline grid inside a database row page creates an independent database instead of a shadow copy that still points at the original database/view IDs.

## Root Cause

Row page editors did not receive the page-level `duplicatePage` operation through the database context. When an inline database block inside a row page was duplicated, the copied Slate block could retain the original inline grid metadata (`parent_id`, `view_ids`, and `database_id`). That made the duplicate behave like a shadow copy of the source inline grid.

## Changes

- Thread `duplicatePage` through the database context and top-level `Database` mounting path.
- Update database block duplication to rewrite the duplicated Slate node through the editor entry rather than mutating the backing Yjs block directly.
- Add a Playwright BDD scenario covering the row-page flow: create inline grid, duplicate it, edit the duplicate, and assert the original remains unchanged with distinct database/view metadata.

## Validation

- `git diff --check`
- `pnpm exec bddgen test -c playwright.bdd.config.ts`
- Attempted `pnpm exec playwright test -c playwright.bdd.config.ts playwright/.features-gen/playwright/bdd/features/database/row-document.feature.spec.js -g "Duplicating an inline grid block"`, but the latest rerun was blocked because the local backend at `localhost:8000` was not running (`ECONNREFUSED`).

## Summary by Sourcery

Fix inline database block duplication so duplicated inline grids create independent databases with proper loading and ID rewiring, including in row-page editors.

Bug Fixes:
- Ensure duplicating an inline grid block in a row page creates a new database and view instead of a shadow copy sharing original IDs.
- Prevent database duplication logic from mutating backing Yjs blocks directly by rewriting the duplicated Slate node data through the editor.

Enhancements:
- Show a temporary loading placeholder for duplicated database blocks while their new database and views are being created and seeded.
- Optimize collaborative editor change handling by only reacting to database block lifecycle operations that affect database presence or view references.
- Allow database blob prefetch to optionally reuse settled seeds for subsequent callers to reduce redundant network work.

Tests:
- Add a Playwright BDD scenario that covers creating, duplicating, and independently editing an inline grid inside a row page to ensure separate databases and views.
- Introduce test helpers for duplicating database blocks and inspecting inline database block state in row-page editors.