### PR TITLE
fix: avoid forcing Google OAuth consent

### DIFF
--- a/src/application/services/js-services/http/__tests__/gotrue.test.ts
+++ b/src/application/services/js-services/http/__tests__/gotrue.test.ts
@@ -1,4 +1,7 @@
 const mockGrantClient = {
+  defaults: {
+    baseURL: '',
+  },
   interceptors: {
     request: {
       use: jest.fn(),
@@ -7,7 +10,10 @@ const mockGrantClient = {
   post: jest.fn(),
 };
 
-const mockAxiosCreate = jest.fn(() => mockGrantClient);
+const mockAxiosCreate = jest.fn((config?: { baseURL?: string }) => {
+  mockGrantClient.defaults.baseURL = config?.baseURL || '';
+  return mockGrantClient;
+});
 
 jest.mock('axios', () => ({
   __esModule: true,
@@ -36,7 +42,14 @@ jest.mock('@/utils/log', () => ({
 }));
 
 const { signInWithUrl } = require('../auth-api') as typeof import('../auth-api');
-const { initGrantService, signInOTP, signInWithPassword } = require('../gotrue') as typeof import('../gotrue');
+const {
+  initGrantService,
+  signInDiscord,
+  signInGithub,
+  signInGoogle,
+  signInOTP,
+  signInWithPassword,
+} = require('../gotrue') as typeof import('../gotrue');
 const { verifyToken } = require('../cloud-auth') as { verifyToken: jest.Mock };
 const { saveGoTrueAuth } = require('@/application/session/token') as { saveGoTrueAuth: jest.Mock };
 
@@ -182,6 +195,55 @@ describe('GoTrue login token completion', () => {
       }
     }
   );
+});
+
+describe('GoTrue provider redirects', () => {
+  const assign = jest.fn();
+  const originalLocation = window.location;
+
+  beforeAll(() => {
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: {
+        ...originalLocation,
+        assign,
+      },
+    });
+  });
+
+  afterAll(() => {
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: originalLocation,
+    });
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    initGrantService('http://localhost/gotrue');
+  });
+
+  it('navigates Google OAuth in the current tab', () => {
+    signInGoogle('http://localhost/auth/callback');
+
+    expect(assign).toHaveBeenCalledWith(
+      'http://localhost/gotrue/authorize?provider=google&redirect_to=http%3A%2F%2Flocalhost%2Fauth%2Fcallback'
+    );
+  });
+
+  it('navigates other OAuth providers in the current tab', () => {
+    signInGithub('http://localhost/auth/callback');
+    signInDiscord('http://localhost/auth/callback');
+
+    expect(assign).toHaveBeenNthCalledWith(
+      1,
+      'http://localhost/gotrue/authorize?provider=github&redirect_to=http%3A%2F%2Flocalhost%2Fauth%2Fcallback'
+    );
+    expect(assign).toHaveBeenNthCalledWith(
+      2,
+      'http://localhost/gotrue/authorize?provider=discord&redirect_to=http%3A%2F%2Flocalhost%2Fauth%2Fcallback'
+    );
+  });
 });
 
 function createToken(prefix: string) {

--- a/src/application/services/js-services/http/gotrue.ts
+++ b/src/application/services/js-services/http/gotrue.ts
@@ -460,16 +460,18 @@ export async function settings() {
   return res?.data;
 }
 
+function redirectToAuthProvider(url: string) {
+  window.location.assign(url);
+}
+
 export function signInGoogle(authUrl: string) {
   const provider = 'google';
   const redirectTo = encodeURIComponent(authUrl);
-  const accessType = 'offline';
-  const prompt = 'consent';
   const baseURL = axiosInstance?.defaults.baseURL;
-  const url = `${baseURL}/authorize?provider=${provider}&redirect_to=${redirectTo}&access_type=${accessType}&prompt=${prompt}`;
+  const url = `${baseURL}/authorize?provider=${provider}&redirect_to=${redirectTo}`;
 
   Log.info('[Auth] signInGoogle: redirecting to Google OAuth');
-  window.open(url, '_current');
+  redirectToAuthProvider(url);
 }
 
 export function signInApple(authUrl: string) {
@@ -479,7 +481,7 @@ export function signInApple(authUrl: string) {
   const url = `${baseURL}/authorize?provider=${provider}&redirect_to=${redirectTo}`;
 
   Log.info('[Auth] signInApple: redirecting to Apple OAuth');
-  window.open(url, '_current');
+  redirectToAuthProvider(url);
 }
 
 export function signInGithub(authUrl: string) {
@@ -489,7 +491,7 @@ export function signInGithub(authUrl: string) {
   const url = `${baseURL}/authorize?provider=${provider}&redirect_to=${redirectTo}`;
 
   Log.info('[Auth] signInGithub: redirecting to GitHub OAuth');
-  window.open(url, '_current');
+  redirectToAuthProvider(url);
 }
 
 export function signInDiscord(authUrl: string) {
@@ -499,7 +501,7 @@ export function signInDiscord(authUrl: string) {
   const url = `${baseURL}/authorize?provider=${provider}&redirect_to=${redirectTo}`;
 
   Log.info('[Auth] signInDiscord: redirecting to Discord OAuth');
-  window.open(url, '_current');
+  redirectToAuthProvider(url);
 }
 
 interface AxiosErrorLike {


### PR DESCRIPTION
## Summary
- Remove `access_type=offline` and `prompt=consent` from Google OAuth redirects so returning users are not forced through Google consent every login.
- Use `window.location.assign` for OAuth provider redirects instead of `window.open(..., `_current`)`.
- Add GoTrue redirect tests covering Google and other OAuth providers.

## Context
The reported Chromium/macOS freeze happens on Google's consent screen. The frontend was always adding `prompt=consent`, which forces that screen. This change lets Google skip consent when the user has already approved the OAuth client/scopes. Google may still show consent when it is genuinely required by the client, scopes, revoked grant, or Workspace policy.

## Test plan
- `pnpm jest src/application/services/js-services/http/__tests__/gotrue.test.ts --runInBand --no-coverage`
- `pnpm run type-check`
- `git diff --check`

## Summary by Sourcery

Simplify GoTrue OAuth redirects and align tests with the new behavior.

Enhancements:
- Use a shared helper to navigate OAuth provider redirects via window.location.assign in the current tab instead of window.open.

Tests:
- Extend GoTrue HTTP service tests to cover Google and other OAuth provider redirect URLs and base URL configuration in the mocked Axios client.