### PR TITLE
fix: send row document source when creating row pages

### DIFF
--- a/src/application/database-yjs/context.ts
+++ b/src/application/database-yjs/context.ts
@@ -16,6 +16,7 @@ import {
   LoadView,
   LoadViewMeta,
   RowId,
+  RowDocumentSourcePayload,
   Subscription,
   TestDatabasePromptConfig,
   TimeFormat,
@@ -84,7 +85,7 @@ export interface DatabaseContextState {
    * Only available in app mode - not provided in publish mode.
    * Returns the doc_state (Y.js update) to initialize the local document.
    */
-  createRowDocument?: (documentId: string) => Promise<Uint8Array | null>;
+  createRowDocument?: (documentId: string, source?: RowDocumentSourcePayload) => Promise<Uint8Array | null>;
   /** Fire-and-forget: ask the server to duplicate the row document with inline DB deep copy. */
   duplicateRowDocument?: (databaseId: string, sourceRowId: string, newRowId: string, clientDocStateB64?: string) => Promise<void>;
   navigateToView?: (viewId: string, blockId?: string) => Promise<void>;

--- a/src/application/db/tables/sync_outbox.ts
+++ b/src/application/db/tables/sync_outbox.ts
@@ -9,13 +9,12 @@ export interface SyncOutboxRecord {
   version?: string | null;
   payload: Uint8Array;
   createdAt: number;
-  // Yjs state vectors (lib0 v1) captured at the time this local update was
-  // produced, so the server can detect missing updates. `before` is the doc
-  // state before the edit, `after` the state after it. Optional: older rows
-  // written before this field existed drain without them (legacy server path).
-  // Not indexed, so no schema version bump is needed.
+  // Yjs state vector (lib0 v1) of the doc state before this local edit, so the
+  // server can detect missing updates. Optional: older rows written before this
+  // field existed drain without it (legacy server path). Not indexed, so no
+  // schema version bump is needed. We intentionally don't store an after vector —
+  // the server derives the post-update state itself and never trusts a client one.
   beforeStateVector?: Uint8Array;
-  afterStateVector?: Uint8Array;
 }
 
 export type SyncOutboxTable = {

--- a/src/application/db/tables/sync_outbox.ts
+++ b/src/application/db/tables/sync_outbox.ts
@@ -9,6 +9,13 @@ export interface SyncOutboxRecord {
   version?: string | null;
   payload: Uint8Array;
   createdAt: number;
+  // Yjs state vectors (lib0 v1) captured at the time this local update was
+  // produced, so the server can detect missing updates. `before` is the doc
+  // state before the edit, `after` the state after it. Optional: older rows
+  // written before this field existed drain without them (legacy server path).
+  // Not indexed, so no schema version bump is needed.
+  beforeStateVector?: Uint8Array;
+  afterStateVector?: Uint8Array;
 }
 
 export type SyncOutboxTable = {

--- a/src/application/services/js-services/http/page-api.ts
+++ b/src/application/services/js-services/http/page-api.ts
@@ -48,7 +48,7 @@ export async function favoritePageView(
   workspaceId: string,
   viewId: string,
   isFavorite: boolean,
-  isPinned: boolean = false
+  isPinned: boolean = true
 ): Promise<void> {
   const url = `/api/workspace/${workspaceId}/page-view/${viewId}/favorite`;
 

--- a/src/application/services/js-services/http/view-api.ts
+++ b/src/application/services/js-services/http/view-api.ts
@@ -1,5 +1,5 @@
 import { AppOutlineResponse } from '@/application/services/services.type';
-import { View } from '@/application/types';
+import { CreateOrphanedViewPayload, View } from '@/application/types';
 
 import { APIResponse, executeAPIRequest, getAxios } from './core';
 
@@ -149,7 +149,7 @@ export async function getAppTrash(workspaceId: string) {
   );
 }
 
-export async function createOrphanedView(workspaceId: string, payload: { document_id: string }): Promise<Uint8Array> {
+export async function createOrphanedView(workspaceId: string, payload: CreateOrphanedViewPayload): Promise<Uint8Array> {
   const url = `/api/workspace/${workspaceId}/orphaned-view`;
 
   // Server returns doc_state as Vec<u8> which is JSON encoded as number[]

--- a/src/application/services/js-services/sync-protocol.ts
+++ b/src/application/services/js-services/sync-protocol.ts
@@ -86,7 +86,8 @@ const handleSyncRequest = (ctx: SyncContext, message: collab.ISyncRequest): void
   });
   // send the update containing new data back to the server. This is a
   // manifest-style diff, so the causal `before` vector is the server's own
-  // advertised state (what it told us it has) and `after` is our full state.
+  // advertised state (what it told us it has). No after vector — the server
+  // derives its own post-update state and never trusts a client-provided one.
   emit({
     collabMessage: {
       objectId: doc.guid,
@@ -96,7 +97,6 @@ const handleSyncRequest = (ctx: SyncContext, message: collab.ISyncRequest): void
         payload: update,
         version: doc.version,
         beforeStateVector: stateVector,
-        afterStateVector: Y.encodeStateVector(doc),
       },
     },
   });
@@ -202,13 +202,12 @@ export const initSync = (ctx: SyncContext) => {
       return; // Ignore remote updates
     }
 
-    // Causal metadata for server-side missing-update detection. Yjs computes
-    // both state maps on the transaction (beforeState at start, afterState
-    // before the 'update' event fires), so we encode those directly rather than
-    // re-deriving from the doc (which would re-walk the store). Both use lib0 v1
-    // encoding to match the server.
+    // Causal metadata for server-side missing-update detection: the state vector
+    // before this edit. Yjs already computed `transaction.beforeState`, so we just
+    // encode it (lib0 v1, to match the server). We deliberately do NOT send an
+    // after vector — the server never trusts a client-provided one (it derives the
+    // post-update state from the update bytes itself), so it would be wasted work.
     const beforeStateVector = Y.encodeStateVector(transaction.beforeState);
-    const afterStateVector = Y.encodeStateVector(transaction.afterState);
 
     enqueueOutboxUpdate({
       objectId: doc.guid,
@@ -216,7 +215,6 @@ export const initSync = (ctx: SyncContext) => {
       version: doc.version ?? null,
       payload: update,
       beforeStateVector,
-      afterStateVector,
     });
     ctx.onLocalUpdate?.(doc.guid);
   };

--- a/src/application/services/js-services/sync-protocol.ts
+++ b/src/application/services/js-services/sync-protocol.ts
@@ -84,7 +84,9 @@ const handleSyncRequest = (ctx: SyncContext, message: collab.ISyncRequest): void
     version: doc.version,
     bytes: update.byteLength,
   });
-  // send the update containing new data back to the server
+  // send the update containing new data back to the server. This is a
+  // manifest-style diff, so the causal `before` vector is the server's own
+  // advertised state (what it told us it has) and `after` is our full state.
   emit({
     collabMessage: {
       objectId: doc.guid,
@@ -92,7 +94,9 @@ const handleSyncRequest = (ctx: SyncContext, message: collab.ISyncRequest): void
       update: {
         flags: UpdateFlags.Lib0v1,
         payload: update,
-        version: doc.version
+        version: doc.version,
+        beforeStateVector: stateVector,
+        afterStateVector: Y.encodeStateVector(doc),
       },
     },
   });
@@ -193,16 +197,26 @@ export const initSync = (ctx: SyncContext) => {
 
   ctx.discardPendingUpdates = () => deleteOutboxByObjectId(doc.guid);
 
-  const onUpdate = (update: Uint8Array, origin: string) => {
+  const onUpdate = (update: Uint8Array, origin: string, _doc: Y.Doc, transaction: Y.Transaction) => {
     if (origin === 'remote') {
       return; // Ignore remote updates
     }
+
+    // Causal metadata for server-side missing-update detection. Yjs computes
+    // both state maps on the transaction (beforeState at start, afterState
+    // before the 'update' event fires), so we encode those directly rather than
+    // re-deriving from the doc (which would re-walk the store). Both use lib0 v1
+    // encoding to match the server.
+    const beforeStateVector = Y.encodeStateVector(transaction.beforeState);
+    const afterStateVector = Y.encodeStateVector(transaction.afterState);
 
     enqueueOutboxUpdate({
       objectId: doc.guid,
       collabType,
       version: doc.version ?? null,
       payload: update,
+      beforeStateVector,
+      afterStateVector,
     });
     ctx.onLocalUpdate?.(doc.guid);
   };

--- a/src/application/sync-outbox/__tests__/sync-outbox.test.ts
+++ b/src/application/sync-outbox/__tests__/sync-outbox.test.ts
@@ -11,6 +11,8 @@ interface MockSyncOutboxRecord {
   version?: string | null;
   payload: Uint8Array;
   createdAt: number;
+  beforeStateVector?: Uint8Array;
+  afterStateVector?: Uint8Array;
 }
 
 let mockRecords: MockSyncOutboxRecord[] = [];
@@ -196,6 +198,86 @@ describe('sync outbox live send', () => {
     await flushPromises();
 
     expect(send).toHaveBeenCalledTimes(2);
+    expect(mockRecords).toHaveLength(0);
+  });
+
+  it('attaches the before/after state vectors to an immediately sent update', async () => {
+    const send = jest.fn();
+
+    configureDrain({
+      userId,
+      workspaceId,
+      send,
+      isReady: () => true,
+    });
+
+    const beforeStateVector = new Uint8Array([1, 2, 3]);
+    const afterStateVector = new Uint8Array([4, 5, 6]);
+
+    enqueueOutboxUpdate({
+      objectId,
+      collabType: Types.Document,
+      version: null,
+      payload: makeUpdate('draft'),
+      beforeStateVector,
+      afterStateVector,
+    });
+
+    expect(send).toHaveBeenCalledTimes(1);
+    const update = send.mock.calls[0][0].collabMessage.update;
+
+    expect(update.beforeStateVector).toBe(beforeStateVector);
+    expect(update.afterStateVector).toBe(afterStateVector);
+  });
+
+  it('spans the merged drain vectors from the first record before to the last record after', async () => {
+    let ready = false;
+    const send = jest.fn();
+
+    configureDrain({
+      userId,
+      workspaceId,
+      send,
+      isReady: () => ready,
+    });
+
+    const firstBefore = new Uint8Array([10]);
+    const firstAfter = new Uint8Array([11]);
+    const lastBefore = new Uint8Array([20]);
+    const lastAfter = new Uint8Array([21]);
+
+    enqueueOutboxUpdate({
+      objectId,
+      collabType: Types.Document,
+      version: null,
+      payload: makeUpdate('old'),
+      beforeStateVector: firstBefore,
+      afterStateVector: firstAfter,
+    });
+    enqueueOutboxUpdate({
+      objectId,
+      collabType: Types.Document,
+      version: null,
+      payload: makeUpdate('new'),
+      beforeStateVector: lastBefore,
+      afterStateVector: lastAfter,
+    });
+    await flushPromises();
+
+    expect(send).not.toHaveBeenCalled();
+    expect(mockRecords).toHaveLength(2);
+
+    ready = true;
+    startDrainAll();
+    await flushPromises();
+
+    expect(send).toHaveBeenCalledTimes(1);
+    const update = send.mock.calls[0][0].collabMessage.update;
+
+    // Merged payload covers first->last, so before = first record's before,
+    // after = last record's after.
+    expect(update.beforeStateVector).toBe(firstBefore);
+    expect(update.afterStateVector).toBe(lastAfter);
     expect(mockRecords).toHaveLength(0);
   });
 

--- a/src/application/sync-outbox/__tests__/sync-outbox.test.ts
+++ b/src/application/sync-outbox/__tests__/sync-outbox.test.ts
@@ -12,7 +12,6 @@ interface MockSyncOutboxRecord {
   payload: Uint8Array;
   createdAt: number;
   beforeStateVector?: Uint8Array;
-  afterStateVector?: Uint8Array;
 }
 
 let mockRecords: MockSyncOutboxRecord[] = [];
@@ -201,7 +200,7 @@ describe('sync outbox live send', () => {
     expect(mockRecords).toHaveLength(0);
   });
 
-  it('attaches the before/after state vectors to an immediately sent update', async () => {
+  it('attaches the before state vector to an immediately sent update (and no after)', async () => {
     const send = jest.fn();
 
     configureDrain({
@@ -212,7 +211,6 @@ describe('sync outbox live send', () => {
     });
 
     const beforeStateVector = new Uint8Array([1, 2, 3]);
-    const afterStateVector = new Uint8Array([4, 5, 6]);
 
     enqueueOutboxUpdate({
       objectId,
@@ -220,17 +218,16 @@ describe('sync outbox live send', () => {
       version: null,
       payload: makeUpdate('draft'),
       beforeStateVector,
-      afterStateVector,
     });
 
     expect(send).toHaveBeenCalledTimes(1);
     const update = send.mock.calls[0][0].collabMessage.update;
 
     expect(update.beforeStateVector).toBe(beforeStateVector);
-    expect(update.afterStateVector).toBe(afterStateVector);
+    expect(update.afterStateVector).toBeUndefined();
   });
 
-  it('spans the merged drain vectors from the first record before to the last record after', async () => {
+  it('takes the merged drain before vector from the first record (and sends no after)', async () => {
     let ready = false;
     const send = jest.fn();
 
@@ -242,9 +239,7 @@ describe('sync outbox live send', () => {
     });
 
     const firstBefore = new Uint8Array([10]);
-    const firstAfter = new Uint8Array([11]);
     const lastBefore = new Uint8Array([20]);
-    const lastAfter = new Uint8Array([21]);
 
     enqueueOutboxUpdate({
       objectId,
@@ -252,7 +247,6 @@ describe('sync outbox live send', () => {
       version: null,
       payload: makeUpdate('old'),
       beforeStateVector: firstBefore,
-      afterStateVector: firstAfter,
     });
     enqueueOutboxUpdate({
       objectId,
@@ -260,7 +254,6 @@ describe('sync outbox live send', () => {
       version: null,
       payload: makeUpdate('new'),
       beforeStateVector: lastBefore,
-      afterStateVector: lastAfter,
     });
     await flushPromises();
 
@@ -274,10 +267,9 @@ describe('sync outbox live send', () => {
     expect(send).toHaveBeenCalledTimes(1);
     const update = send.mock.calls[0][0].collabMessage.update;
 
-    // Merged payload covers first->last, so before = first record's before,
-    // after = last record's after.
+    // Merged payload covers first->last, so before = the first record's before.
     expect(update.beforeStateVector).toBe(firstBefore);
-    expect(update.afterStateVector).toBe(lastAfter);
+    expect(update.afterStateVector).toBeUndefined();
     expect(mockRecords).toHaveLength(0);
   });
 

--- a/src/application/sync-outbox/index.ts
+++ b/src/application/sync-outbox/index.ts
@@ -225,6 +225,8 @@ export function enqueueOutboxUpdate(record: Omit<SyncOutboxRecord, 'id' | 'creat
             flags: FLAGS_LIB0V1,
             payload: record.payload,
             version: record.version ?? undefined,
+            beforeStateVector: record.beforeStateVector,
+            afterStateVector: record.afterStateVector,
           } as collab.IUpdate,
         },
       };
@@ -490,7 +492,9 @@ async function distinctObjectIdsForSession(userId: string, workspaceId: string):
   return Array.from(ids);
 }
 
-function buildUpdateMessage(record: Pick<SyncOutboxRecord, 'objectId' | 'collabType' | 'payload' | 'version'>): messages.IMessage {
+function buildUpdateMessage(
+  record: Pick<SyncOutboxRecord, 'objectId' | 'collabType' | 'payload' | 'version' | 'beforeStateVector' | 'afterStateVector'>,
+): messages.IMessage {
   return {
     collabMessage: {
       objectId: record.objectId,
@@ -499,6 +503,8 @@ function buildUpdateMessage(record: Pick<SyncOutboxRecord, 'objectId' | 'collabT
         flags: FLAGS_LIB0V1,
         payload: record.payload,
         version: record.version ?? undefined,
+        beforeStateVector: record.beforeStateVector,
+        afterStateVector: record.afterStateVector,
       } as collab.IUpdate,
     },
   };
@@ -580,11 +586,20 @@ async function drainObjectWhileReady(objectId: string): Promise<void> {
 
     if (records.length === 0) return;
 
+    // Records are sorted by id (insertion order), so first/last bound the batch.
+    const firstRecord = records[0];
+    const lastRecord = records[records.length - 1];
+
     const merged = records.length === 1
-      ? records[0].payload
+      ? firstRecord.payload
       : Y.mergeUpdates(records.map((r) => r.payload));
-    const collabType = records[records.length - 1].collabType as Types;
-    const version = records[records.length - 1].version;
+    const collabType = lastRecord.collabType as Types;
+    const version = lastRecord.version;
+    // The merged payload spans from the first queued edit to the last, so its
+    // causal `before` is the first record's before-vector and its `after` is the
+    // last record's after-vector.
+    const beforeStateVector = firstRecord.beforeStateVector;
+    const afterStateVector = lastRecord.afterStateVector;
 
     const message: messages.IMessage = {
       collabMessage: {
@@ -594,6 +609,8 @@ async function drainObjectWhileReady(objectId: string): Promise<void> {
           flags: FLAGS_LIB0V1,
           payload: merged,
           version: version ?? undefined,
+          beforeStateVector,
+          afterStateVector,
         } as collab.IUpdate,
       },
     };

--- a/src/application/sync-outbox/index.ts
+++ b/src/application/sync-outbox/index.ts
@@ -226,7 +226,6 @@ export function enqueueOutboxUpdate(record: Omit<SyncOutboxRecord, 'id' | 'creat
             payload: record.payload,
             version: record.version ?? undefined,
             beforeStateVector: record.beforeStateVector,
-            afterStateVector: record.afterStateVector,
           } as collab.IUpdate,
         },
       };
@@ -493,7 +492,7 @@ async function distinctObjectIdsForSession(userId: string, workspaceId: string):
 }
 
 function buildUpdateMessage(
-  record: Pick<SyncOutboxRecord, 'objectId' | 'collabType' | 'payload' | 'version' | 'beforeStateVector' | 'afterStateVector'>,
+  record: Pick<SyncOutboxRecord, 'objectId' | 'collabType' | 'payload' | 'version' | 'beforeStateVector'>,
 ): messages.IMessage {
   return {
     collabMessage: {
@@ -504,7 +503,6 @@ function buildUpdateMessage(
         payload: record.payload,
         version: record.version ?? undefined,
         beforeStateVector: record.beforeStateVector,
-        afterStateVector: record.afterStateVector,
       } as collab.IUpdate,
     },
   };
@@ -596,10 +594,8 @@ async function drainObjectWhileReady(objectId: string): Promise<void> {
     const collabType = lastRecord.collabType as Types;
     const version = lastRecord.version;
     // The merged payload spans from the first queued edit to the last, so its
-    // causal `before` is the first record's before-vector and its `after` is the
-    // last record's after-vector.
+    // causal `before` is the first record's before-vector.
     const beforeStateVector = firstRecord.beforeStateVector;
-    const afterStateVector = lastRecord.afterStateVector;
 
     const message: messages.IMessage = {
       collabMessage: {
@@ -610,7 +606,6 @@ async function drainObjectWhileReady(objectId: string): Promise<void> {
           payload: merged,
           version: version ?? undefined,
           beforeStateVector,
-          afterStateVector,
         } as collab.IUpdate,
       },
     };

--- a/src/application/types.ts
+++ b/src/application/types.ts
@@ -1203,6 +1203,10 @@ export interface View {
   has_children?: boolean;
   is_published: boolean;
   is_private: boolean;
+  /** Whether this view is currently in the user's favorites. Synced via the folder. */
+  is_favorite?: boolean;
+  /** Favorite-section pin state returned by the favorites endpoint. */
+  is_pinned?: boolean;
   /** Whether the page is locked (read-only) for everyone until unlocked. Synced via the folder. */
   is_locked?: boolean;
   last_edited_time?: string;

--- a/src/application/types.ts
+++ b/src/application/types.ts
@@ -1348,6 +1348,17 @@ export interface UpdatePagePayload {
   is_locked?: boolean;
 }
 
+export interface RowDocumentSourcePayload {
+  database_id: string;
+  database_view_id: string;
+  row_id: string;
+}
+
+export interface CreateOrphanedViewPayload {
+  document_id: string;
+  row_document_source?: RowDocumentSourcePayload;
+}
+
 export type ViewMetaCover = ViewCover;
 
 export interface ViewMetaProps {
@@ -1396,7 +1407,7 @@ export interface ViewComponentProps {
    * Create a row document on the server (orphaned view).
    * Only available in app mode - not provided in publish mode.
    */
-  createRowDocument?: (documentId: string) => Promise<Uint8Array | null>;
+  createRowDocument?: (documentId: string, source?: RowDocumentSourcePayload) => Promise<Uint8Array | null>;
   duplicateRowDocument?: (
     databaseId: string,
     sourceRowId: string,

--- a/src/components/app/contexts/AppOperationsContext.ts
+++ b/src/components/app/contexts/AppOperationsContext.ts
@@ -5,6 +5,7 @@ import { SyncContext } from '@/application/services/js-services/sync-protocol';
 import {
   CreateDatabaseViewPayload,
   CreateDatabaseViewResponse,
+  CreateOrphanedViewPayload,
   DuplicatePageOperationOptions,
   CreatePagePayload,
   CreatePageResponse,
@@ -15,6 +16,7 @@ import {
   LoadDatabasePrompts,
   LoadView,
   LoadViewMeta,
+  RowDocumentSourcePayload,
   Subscription,
   TestDatabasePromptConfig,
   TextCount,
@@ -113,7 +115,7 @@ export interface AppOperationsContextType {
 
   // ── Database operations ────────────────────────────────────────────
   /** Create an orphaned view (e.g. for inline database within a document). */
-  createOrphanedView?: (payload: { document_id: string }) => Promise<Uint8Array>;
+  createOrphanedView?: (payload: CreateOrphanedViewPayload) => Promise<Uint8Array>;
   /** Load AI prompt templates for a database. */
   loadDatabasePrompts?: LoadDatabasePrompts;
   /** Test an AI prompt config against a database. */
@@ -123,7 +125,7 @@ export interface AppOperationsContextType {
   /** Load an existing row document. */
   loadRowDocument?: (documentId: string) => Promise<YDoc | null>;
   /** Create a new row document (returns encoded initial state). */
-  createRowDocument?: (documentId: string) => Promise<Uint8Array | null>;
+  createRowDocument?: (documentId: string, source?: RowDocumentSourcePayload) => Promise<Uint8Array | null>;
   /** Fire-and-forget: ask the server to duplicate the row document with inline DB deep copy. */
   duplicateRowDocument?: (databaseId: string, sourceRowId: string, newRowId: string, clientDocStateB64?: string) => Promise<void>;
   /** Resolve a database ID to its primary view ID. */

--- a/src/components/app/favorite/Favorite.tsx
+++ b/src/components/app/favorite/Favorite.tsx
@@ -1,11 +1,11 @@
 import { Collapse } from '@mui/material';
 import { PopoverProps } from '@mui/material/Popover';
 import dayjs from 'dayjs';
-import { groupBy, sortBy } from 'lodash-es';
+import { groupBy, orderBy, sortBy } from 'lodash-es';
 import React, { useEffect, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import { UIVariant, ViewLayout } from '@/application/types';
+import { UIVariant, View, ViewLayout } from '@/application/types';
 import { ReactComponent as FavoritedIcon } from '@/assets/icons/filled_star.svg';
 import { ReactComponent as MoreIcon } from '@/assets/icons/more.svg';
 import OutlineItem from '@/components/_shared/outline/OutlineItem';
@@ -29,6 +29,20 @@ enum FavoriteGroup {
   yesterday = 'yesterday',
   thisWeek = 'thisWeek',
   Others = 'Others',
+}
+
+function favoriteTimestampMs(view: View): number {
+  if (!view.favorited_at) {
+    return 0;
+  }
+
+  const timestamp = Date.parse(view.favorited_at);
+
+  return Number.isNaN(timestamp) ? 0 : timestamp;
+}
+
+function isPinnedFavorite(view: View): boolean {
+  return view.is_pinned ?? view.extra?.is_pinned ?? true;
 }
 
 export function Favorite() {
@@ -64,18 +78,26 @@ export function Favorite() {
     return favoriteViews.filter((view) => view.layout !== ViewLayout.AIChat);
   }, [aiEnabled, favoriteViews]);
 
-  const { pinViews, unpinViews } = useMemo(() => {
+  const sortedFavoriteViews = useMemo(() => {
     if (visibleFavoriteViews.length === 0) {
+      return [];
+    }
+
+    return orderBy(visibleFavoriteViews, [(view) => favoriteTimestampMs(view), (view) => view.view_id], ['desc', 'asc']);
+  }, [visibleFavoriteViews]);
+
+  const { pinViews, unpinViews } = useMemo(() => {
+    if (sortedFavoriteViews.length === 0) {
       return { pinViews: [], unpinViews: [] };
     }
 
-    return groupBy(visibleFavoriteViews, (view) => (view.extra?.is_pinned ? 'pinViews' : 'unpinViews'));
-  }, [visibleFavoriteViews]);
+    return groupBy(sortedFavoriteViews, (view) => (isPinnedFavorite(view) ? 'pinViews' : 'unpinViews'));
+  }, [sortedFavoriteViews]);
 
   const groupByViewsWithDay = useMemo(() => {
-    if (visibleFavoriteViews.length === 0) return {};
+    if (sortedFavoriteViews.length === 0) return {};
 
-    return groupBy(visibleFavoriteViews, (view) => {
+    return groupBy(sortedFavoriteViews, (view) => {
       if (!view.favorited_at) {
         return FavoriteGroup.Others;
       }
@@ -95,17 +117,17 @@ export function Favorite() {
       if (thisWeek) return FavoriteGroup.thisWeek;
       return FavoriteGroup.Others;
     });
-  }, [visibleFavoriteViews]);
+  }, [sortedFavoriteViews]);
 
   const groupByViews = useMemo(() => {
     return sortBy(Object.entries(groupByViewsWithDay), ([key]) => {
       return key === FavoriteGroup.today
         ? 0
         : key === FavoriteGroup.yesterday
-          ? 1
-          : key === FavoriteGroup.thisWeek
-            ? 2
-            : 3;
+        ? 1
+        : key === FavoriteGroup.thisWeek
+        ? 2
+        : 3;
     }).map(([key, value]) => {
       const timeLabel: Record<string, string> = {
         [FavoriteGroup.today]: t('calendar.navigation.today'),

--- a/src/components/app/header/FavoriteButton.tsx
+++ b/src/components/app/header/FavoriteButton.tsx
@@ -9,10 +9,6 @@ import { ReactComponent as StarIcon } from '@/assets/icons/star.svg';
 import { useAppFavorites, useCurrentWorkspaceId } from '@/components/app/app.hooks';
 import { Button } from '@/components/ui/button';
 
-// Matches the desktop behavior: a newly favorited view is auto-pinned only
-// while there are fewer than this many pinned favorites.
-const MAX_AUTO_PINNED_FAVORITES = 3;
-
 export function FavoriteButton({ viewId }: { viewId: string }) {
   const { t } = useTranslation();
   const workspaceId = useCurrentWorkspaceId();
@@ -36,7 +32,6 @@ export function FavoriteButton({ viewId }: { viewId: string }) {
   // rather than memoized (see rerender-simple-expression-in-memo).
   const serverFavorite = !!favoriteViews?.some((view) => view.view_id === viewId);
   const isFavorite = optimisticFavorite ?? serverFavorite;
-  const pinnedCount = favoriteViews?.filter((view) => view.extra?.is_pinned).length ?? 0;
 
   const handleToggle = useCallback(async () => {
     // Don't toggle against unknown state: undefined favorites would read as
@@ -47,7 +42,7 @@ export function FavoriteButton({ viewId }: { viewId: string }) {
     setSubmitting(true);
     setOptimisticFavorite(next);
     try {
-      await PageService.favorite(workspaceId, viewId, next, next && pinnedCount < MAX_AUTO_PINNED_FAVORITES);
+      await PageService.favorite(workspaceId, viewId, next, next);
       // Refresh only the favorites list — favoriting doesn't change the outline
       // tree, so a full outline reload would be wasted work.
       await loadFavoriteViews?.();
@@ -60,7 +55,7 @@ export function FavoriteButton({ viewId }: { viewId: string }) {
       setOptimisticFavorite(null);
       setSubmitting(false);
     }
-  }, [workspaceId, favoritesLoaded, isFavorite, viewId, pinnedCount, loadFavoriteViews, t]);
+  }, [workspaceId, favoritesLoaded, isFavorite, viewId, loadFavoriteViews, t]);
 
   return (
     <Tooltip title={isFavorite ? t('disclosureAction.unfavorite') : t('disclosureAction.favorite')}>

--- a/src/components/app/hooks/useDatabaseOperations.ts
+++ b/src/components/app/hooks/useDatabaseOperations.ts
@@ -11,6 +11,7 @@ import {
   DatabasePromptRow,
   GenerateAISummaryRowPayload,
   GenerateAITranslateRowPayload,
+  RowDocumentSourcePayload,
   Types,
   YDatabase,
   YDoc,
@@ -332,15 +333,18 @@ export function useDatabaseOperations(
 
   // Create a row document on the server (orphaned view)
   const createRowDocument = useCallback(
-    async (documentId: string): Promise<Uint8Array | null> => {
+    async (documentId: string, source?: RowDocumentSourcePayload): Promise<Uint8Array | null> => {
       if (!currentWorkspaceId) {
         Log.warn('[createRowDocument] service or workspaceId not available');
         return null;
       }
 
       try {
-        Log.debug('[createRowDocument] creating', { documentId });
-        const docState = await ViewService.createOrphaned(currentWorkspaceId, { document_id: documentId });
+        Log.debug('[createRowDocument] creating', { documentId, source });
+        const docState = await ViewService.createOrphaned(currentWorkspaceId, {
+          document_id: documentId,
+          row_document_source: source,
+        });
 
         return docState;
       } catch (e) {

--- a/src/components/app/hooks/usePageOperations.ts
+++ b/src/components/app/hooks/usePageOperations.ts
@@ -11,6 +11,7 @@ import {
 } from '@/application/services/js-services/http/publish-api';
 import {
   CreateDatabaseViewPayload,
+  CreateOrphanedViewPayload,
   DuplicatePageOperationOptions,
   CreatePagePayload,
   CreateSpacePayload,
@@ -458,7 +459,7 @@ export function usePageOperations({
 
   // Create orphaned view
   const createOrphanedViewOp = useCallback(
-    async (payload: { document_id: string }) => {
+    async (payload: CreateOrphanedViewPayload) => {
       if (!currentWorkspaceId) {
         throw new Error('No workspace or service found');
       }

--- a/src/components/app/hooks/useWorkspaceData.ts
+++ b/src/components/app/hooks/useWorkspaceData.ts
@@ -352,6 +352,14 @@ function isOnlyNonVisualOutlineChange(patch: JsonPatchOperation[]): boolean {
   });
 }
 
+function folderOutlinePatchMayAffectFavorites(patch: JsonPatchOperation[]): boolean {
+  return patch.some((op) => {
+    const path = op.path ?? '';
+
+    return path === '/outline' || path.endsWith('/is_favorite') || path.endsWith('/extra');
+  });
+}
+
 // Hook for managing workspace data (outline, favorites, recent, trash)
 export function useWorkspaceData() {
   const { currentWorkspaceId, userWorkspaceInfo } = useAuthInternal();
@@ -370,6 +378,7 @@ export function useWorkspaceData() {
   const [favoriteViews, setFavoriteViews] = useState<View[]>();
   const [recentViews, setRecentViews] = useState<View[]>();
   const [trashList, setTrashList] = useState<View[]>();
+  const favoriteViewsLoadedRef = useRef(false);
   const [workspaceDatabases, setWorkspaceDatabases] = useState<DatabaseRelations | undefined>(undefined);
   const workspaceDatabasesRef = useRef<DatabaseRelations | undefined>(undefined);
   const [requestAccessError, setRequestAccessError] = useState<RequestAccessError | null>(null);
@@ -415,6 +424,33 @@ export function useWorkspaceData() {
 
     return mergedOutline;
   }, []);
+
+  const refreshFavoriteViewsForWorkspace = useCallback(async (workspaceId: string) => {
+    try {
+      const res = await ViewService.getFavorites(workspaceId);
+
+      if (!res) {
+        throw new Error('Favorite views not found');
+      }
+
+      favoriteViewsLoadedRef.current = true;
+      setFavoriteViews(res);
+      return res;
+    } catch (e) {
+      console.error('Favorite views not found');
+    }
+  }, []);
+
+  const refreshLoadedFavoriteViewsInBackground = useCallback(
+    (workspaceId: string) => {
+      if (!favoriteViewsLoadedRef.current) {
+        return;
+      }
+
+      void refreshFavoriteViewsForWorkspace(workspaceId);
+    },
+    [refreshFavoriteViewsForWorkspace]
+  );
 
   // Load application outline
   const updateLastFolderRid = useCallback((next: FolderRid | null) => {
@@ -1190,6 +1226,7 @@ export function useWorkspaceData() {
       if (!payload?.outlineDiffJson) {
         Log.debug('[Outline] [FolderOutlineChanged] No diff JSON, reloading outline');
         refreshTrashListInBackground();
+        refreshLoadedFavoriteViewsInBackground(currentWorkspaceId);
         void loadOutline(currentWorkspaceId, false);
         return;
       }
@@ -1229,6 +1266,9 @@ export function useWorkspaceData() {
       }
 
       refreshTrashListInBackground();
+      if (folderOutlinePatchMayAffectFavorites(patch)) {
+        refreshLoadedFavoriteViewsInBackground(currentWorkspaceId);
+      }
 
       Log.debug('[Outline] [FolderOutlineChanged] parsed patch', patch);
 
@@ -1320,6 +1360,7 @@ export function useWorkspaceData() {
     currentWorkspaceId,
     eventEmitter,
     loadOutline,
+    refreshLoadedFavoriteViewsInBackground,
     refreshTrashListInBackground,
     replaceOutlinePreservingChildren,
     stableOutlineRef,
@@ -1352,8 +1393,12 @@ export function useWorkspaceData() {
           if (!payload.viewJson) break;
           try {
             const updatedView = JSON.parse(payload.viewJson) as View;
+            const previousView = findView(nextOutline, updatedView.view_id);
 
             nextOutline = updateViewInOutline(nextOutline, updatedView);
+            if (previousView?.is_favorite !== updatedView.is_favorite) {
+              refreshLoadedFavoriteViewsInBackground(currentWorkspaceId);
+            }
           } catch (error) {
             Log.warn('[Outline] [FolderViewChanged] Failed to parse view_json for fields changed', error);
             void loadOutline(currentWorkspaceId, false);
@@ -1459,6 +1504,7 @@ export function useWorkspaceData() {
     currentWorkspaceId,
     eventEmitter,
     loadOutline,
+    refreshLoadedFavoriteViewsInBackground,
     refreshTrashListInBackground,
     stableOutlineRef,
     updateLastFolderRid,
@@ -1467,19 +1513,8 @@ export function useWorkspaceData() {
   // Load favorite views
   const loadFavoriteViews = useCallback(async () => {
     if (!currentWorkspaceId) return;
-    try {
-      const res = await ViewService.getFavorites(currentWorkspaceId);
-
-      if (!res) {
-        throw new Error('Favorite views not found');
-      }
-
-      setFavoriteViews(res);
-      return res;
-    } catch (e) {
-      console.error('Favorite views not found');
-    }
-  }, [currentWorkspaceId]);
+    return refreshFavoriteViewsForWorkspace(currentWorkspaceId);
+  }, [currentWorkspaceId, refreshFavoriteViewsForWorkspace]);
 
   // Load recent views
   const loadRecentViews = useCallback(async () => {
@@ -1652,6 +1687,7 @@ export function useWorkspaceData() {
     // `undefined` (the unloaded state) also lets lazy consumers — e.g. the
     // header FavoriteButton — detect the stale state and refetch for the new
     // workspace instead of rendering the previous workspace's favorites.
+    favoriteViewsLoadedRef.current = false;
     setFavoriteViews(undefined);
     setRecentViews(undefined);
     // Clear database relations cache when switching workspaces to prevent

--- a/src/components/database/Database.tsx
+++ b/src/components/database/Database.tsx
@@ -27,6 +27,7 @@ import {
   LoadView,
   LoadViewMeta,
   RowId,
+  RowDocumentSourcePayload,
   UIVariant,
   UpdatePagePayload,
   View,
@@ -74,7 +75,7 @@ export interface Database2Props {
    * Create a row document on the server (orphaned view).
    * Only available in app mode - not provided in publish mode.
    */
-  createRowDocument?: (documentId: string) => Promise<Uint8Array | null>;
+  createRowDocument?: (documentId: string, source?: RowDocumentSourcePayload) => Promise<Uint8Array | null>;
   duplicateRowDocument?: (
     databaseId: string,
     sourceRowId: string,

--- a/src/components/database/components/database-row/DatabaseRowSubDocument.tsx
+++ b/src/components/database/components/database-row/DatabaseRowSubDocument.tsx
@@ -25,6 +25,7 @@ import {
   YDatabaseRow,
   YDoc,
   YDocWithMeta,
+  RowDocumentSourcePayload,
   YjsDatabaseKey,
   YjsEditorKey,
 } from '@/application/types';
@@ -124,6 +125,20 @@ export const DatabaseRowSubDocument = memo(({ rowId }: { rowId: string }) => {
   const createRowDocument = context?.createRowDocument;
   const checkIfRowDocumentExists = context?.checkIfRowDocumentExists;
   const bindViewSync = context?.bindViewSync;
+  const rowDocumentSource = useMemo<RowDocumentSourcePayload | undefined>(() => {
+    const databaseId = (database?.get(YjsDatabaseKey.id) as string | undefined) || context?.databaseDoc?.guid;
+    const databaseViewId = context?.activeViewId || context?.databasePageId;
+
+    if (!databaseId || !databaseViewId) {
+      return undefined;
+    }
+
+    return {
+      database_id: databaseId,
+      database_view_id: databaseViewId,
+      row_id: rowId,
+    };
+  }, [context?.activeViewId, context?.databaseDoc, context?.databasePageId, database, rowId]);
   const updateRowMeta = useUpdateRowMetaDispatch(rowId);
   const editorRef = useRef<YjsEditor | null>(null);
   const lastIsEmptyRef = useRef<boolean | null>(null);
@@ -412,7 +427,7 @@ export const DatabaseRowSubDocument = memo(({ rowId }: { rowId: string }) => {
 
         try {
           Log.debug('[DatabaseRowSubDocument] calling createRowDocument', { documentId, requireServerReady });
-          docState = await createRowDocument(documentId);
+          docState = await createRowDocument(documentId, rowDocumentSource);
           Log.debug('[DatabaseRowSubDocument] createRowDocument success', {
             documentId,
             docStateSize: docState?.length ?? 0,
@@ -452,7 +467,15 @@ export const DatabaseRowSubDocument = memo(({ rowId }: { rowId: string }) => {
         setLoading(false);
       }
     },
-    [createRowDocument, handleOpenDocument, hasLocalDocContent, loadRowDocument, openDocumentWithState, rowId]
+    [
+      createRowDocument,
+      handleOpenDocument,
+      hasLocalDocContent,
+      loadRowDocument,
+      openDocumentWithState,
+      rowDocumentSource,
+      rowId,
+    ]
   );
 
   const scheduleEnsureRowDocumentExists = useCallback(() => {
@@ -477,7 +500,7 @@ export const DatabaseRowSubDocument = memo(({ rowId }: { rowId: string }) => {
             rowId,
             documentId,
           });
-          await createRowDocument(documentId);
+          await createRowDocument(documentId, rowDocumentSource);
         }
 
         if (pendingNonEmptyRef.current) {
@@ -507,6 +530,7 @@ export const DatabaseRowSubDocument = memo(({ rowId }: { rowId: string }) => {
     createRowDocument,
     documentId,
     isDocumentEmpty,
+    rowDocumentSource,
     updateRowMeta,
     rowId,
   ]);
@@ -682,7 +706,7 @@ export const DatabaseRowSubDocument = memo(({ rowId }: { rowId: string }) => {
                   rowId,
                   documentId,
                 });
-                await createRowDocument(documentId);
+                await createRowDocument(documentId, rowDocumentSource);
               } catch {
                 // Ignore; we'll retry loading below.
               }
@@ -722,6 +746,7 @@ export const DatabaseRowSubDocument = memo(({ rowId }: { rowId: string }) => {
     isDocumentEmptyResolved,
     hasLocalDocContent,
     createRowDocument,
+    rowDocumentSource,
     rowId,
     doc,
   ]);
@@ -823,7 +848,7 @@ export const DatabaseRowSubDocument = memo(({ rowId }: { rowId: string }) => {
     // Only create orphaned view if document doesn't exist
     if (createRowDocument) {
       try {
-        await createRowDocument(documentId);
+        await createRowDocument(documentId, rowDocumentSource);
         rowDocEnsuredRef.current = true;
         return true;
       } catch {
@@ -833,7 +858,7 @@ export const DatabaseRowSubDocument = memo(({ rowId }: { rowId: string }) => {
     }
 
     return false;
-  }, [checkIfRowDocumentExists, createRowDocument, documentId]);
+  }, [checkIfRowDocumentExists, createRowDocument, documentId, rowDocumentSource]);
 
   useEffect(() => {
     if (!doc) return;

--- a/src/components/editor/EditorContext.tsx
+++ b/src/components/editor/EditorContext.tsx
@@ -24,6 +24,7 @@ import {
   Subscription,
   MentionablePerson,
   DatabaseRelations,
+  RowDocumentSourcePayload,
   YDoc,
 } from '@/application/types';
 import { SyncContext } from '@/application/services/js-services/sync-protocol';
@@ -77,7 +78,7 @@ export interface EditorContextState {
   loadView?: LoadView;
   loadRowDocument?: (documentId: string) => Promise<YDoc | null>;
   checkIfRowDocumentExists?: (documentId: string) => Promise<boolean>;
-  createRowDocument?: (documentId: string) => Promise<Uint8Array | null>;
+  createRowDocument?: (documentId: string, source?: RowDocumentSourcePayload) => Promise<Uint8Array | null>;
   createRow?: CreateRow;
   bindViewSync?: (doc: YDoc) => SyncContext | null;
   readSummary?: boolean;

--- a/src/proto/collab.proto
+++ b/src/proto/collab.proto
@@ -65,6 +65,18 @@ message Update {
 
   // Collab version this update is related to.
   string version = 4;
+
+  // Yjs Doc state vector (lib0 v1 encoding) as known to the sender BEFORE it
+  // generated this update. The server uses it to detect missing updates: if the
+  // server's state does not cover this vector, an earlier update was lost.
+  // Empty/absent falls back to the legacy path (server derives a lower bound
+  // from the update bytes).
+  bytes before_state_vector = 5;
+
+  // Yjs Doc state vector (lib0 v1 encoding) as known to the sender AFTER it
+  // generated this update. Advisory only — the server never trusts a
+  // client-provided after vector; it derives its own from the update bytes.
+  bytes after_state_vector = 6;
 }
 
 /**

--- a/src/proto/messages.d.ts
+++ b/src/proto/messages.d.ts
@@ -454,6 +454,12 @@ export namespace collab {
 
         /** Update version */
         version?: (string|null);
+
+        /** Update beforeStateVector */
+        beforeStateVector?: (Uint8Array|null);
+
+        /** Update afterStateVector */
+        afterStateVector?: (Uint8Array|null);
     }
 
     /**
@@ -480,6 +486,12 @@ export namespace collab {
 
         /** Update version. */
         public version: string;
+
+        /** Update beforeStateVector. */
+        public beforeStateVector: Uint8Array;
+
+        /** Update afterStateVector. */
+        public afterStateVector: Uint8Array;
 
         /**
          * Creates a new Update instance using the specified properties.

--- a/src/proto/messages.js
+++ b/src/proto/messages.js
@@ -1057,6 +1057,8 @@ export const collab = $root.collab = (() => {
          * @property {number|null} [flags] Update flags
          * @property {Uint8Array|null} [payload] Update payload
          * @property {string|null} [version] Update version
+         * @property {Uint8Array|null} [beforeStateVector] Update beforeStateVector
+         * @property {Uint8Array|null} [afterStateVector] Update afterStateVector
          */
 
         /**
@@ -1109,6 +1111,22 @@ export const collab = $root.collab = (() => {
         Update.prototype.version = "";
 
         /**
+         * Update beforeStateVector.
+         * @member {Uint8Array} beforeStateVector
+         * @memberof collab.Update
+         * @instance
+         */
+        Update.prototype.beforeStateVector = $util.newBuffer([]);
+
+        /**
+         * Update afterStateVector.
+         * @member {Uint8Array} afterStateVector
+         * @memberof collab.Update
+         * @instance
+         */
+        Update.prototype.afterStateVector = $util.newBuffer([]);
+
+        /**
          * Creates a new Update instance using the specified properties.
          * @function create
          * @memberof collab.Update
@@ -1140,6 +1158,10 @@ export const collab = $root.collab = (() => {
                 writer.uint32(/* id 3, wireType 2 =*/26).bytes(message.payload);
             if (message.version != null && Object.hasOwnProperty.call(message, "version"))
                 writer.uint32(/* id 4, wireType 2 =*/34).string(message.version);
+            if (message.beforeStateVector != null && Object.hasOwnProperty.call(message, "beforeStateVector"))
+                writer.uint32(/* id 5, wireType 2 =*/42).bytes(message.beforeStateVector);
+            if (message.afterStateVector != null && Object.hasOwnProperty.call(message, "afterStateVector"))
+                writer.uint32(/* id 6, wireType 2 =*/50).bytes(message.afterStateVector);
             return writer;
         };
 
@@ -1192,6 +1214,14 @@ export const collab = $root.collab = (() => {
                         message.version = reader.string();
                         break;
                     }
+                case 5: {
+                        message.beforeStateVector = reader.bytes();
+                        break;
+                    }
+                case 6: {
+                        message.afterStateVector = reader.bytes();
+                        break;
+                    }
                 default:
                     reader.skipType(tag & 7);
                     break;
@@ -1241,6 +1271,12 @@ export const collab = $root.collab = (() => {
             if (message.version != null && message.hasOwnProperty("version"))
                 if (!$util.isString(message.version))
                     return "version: string expected";
+            if (message.beforeStateVector != null && message.hasOwnProperty("beforeStateVector"))
+                if (!(message.beforeStateVector && typeof message.beforeStateVector.length === "number" || $util.isString(message.beforeStateVector)))
+                    return "beforeStateVector: buffer expected";
+            if (message.afterStateVector != null && message.hasOwnProperty("afterStateVector"))
+                if (!(message.afterStateVector && typeof message.afterStateVector.length === "number" || $util.isString(message.afterStateVector)))
+                    return "afterStateVector: buffer expected";
             return null;
         };
 
@@ -1270,6 +1306,16 @@ export const collab = $root.collab = (() => {
                     message.payload = object.payload;
             if (object.version != null)
                 message.version = String(object.version);
+            if (object.beforeStateVector != null)
+                if (typeof object.beforeStateVector === "string")
+                    $util.base64.decode(object.beforeStateVector, message.beforeStateVector = $util.newBuffer($util.base64.length(object.beforeStateVector)), 0);
+                else if (object.beforeStateVector.length >= 0)
+                    message.beforeStateVector = object.beforeStateVector;
+            if (object.afterStateVector != null)
+                if (typeof object.afterStateVector === "string")
+                    $util.base64.decode(object.afterStateVector, message.afterStateVector = $util.newBuffer($util.base64.length(object.afterStateVector)), 0);
+                else if (object.afterStateVector.length >= 0)
+                    message.afterStateVector = object.afterStateVector;
             return message;
         };
 
@@ -1297,6 +1343,20 @@ export const collab = $root.collab = (() => {
                         object.payload = $util.newBuffer(object.payload);
                 }
                 object.version = "";
+                if (options.bytes === String)
+                    object.beforeStateVector = "";
+                else {
+                    object.beforeStateVector = [];
+                    if (options.bytes !== Array)
+                        object.beforeStateVector = $util.newBuffer(object.beforeStateVector);
+                }
+                if (options.bytes === String)
+                    object.afterStateVector = "";
+                else {
+                    object.afterStateVector = [];
+                    if (options.bytes !== Array)
+                        object.afterStateVector = $util.newBuffer(object.afterStateVector);
+                }
             }
             if (message.messageId != null && message.hasOwnProperty("messageId"))
                 object.messageId = $root.collab.Rid.toObject(message.messageId, options);
@@ -1306,6 +1366,10 @@ export const collab = $root.collab = (() => {
                 object.payload = options.bytes === String ? $util.base64.encode(message.payload, 0, message.payload.length) : options.bytes === Array ? Array.prototype.slice.call(message.payload) : message.payload;
             if (message.version != null && message.hasOwnProperty("version"))
                 object.version = message.version;
+            if (message.beforeStateVector != null && message.hasOwnProperty("beforeStateVector"))
+                object.beforeStateVector = options.bytes === String ? $util.base64.encode(message.beforeStateVector, 0, message.beforeStateVector.length) : options.bytes === Array ? Array.prototype.slice.call(message.beforeStateVector) : message.beforeStateVector;
+            if (message.afterStateVector != null && message.hasOwnProperty("afterStateVector"))
+                object.afterStateVector = options.bytes === String ? $util.base64.encode(message.afterStateVector, 0, message.afterStateVector.length) : options.bytes === Array ? Array.prototype.slice.call(message.afterStateVector) : message.afterStateVector;
             return object;
         };
 


### PR DESCRIPTION
## Summary
- add a typed row document source payload for orphaned-view creation
- pass `database_id`, `database_view_id`, and `row_id` from row page creation calls
- keep existing orphaned-view callers compatible by making the source optional

## Notes
This is paired with the server PR that validates and persists the source into folder view extra. This web change is backward-compatible with older servers because the added field is optional from the client side and can be ignored by older server DTOs.

## Verification
- `pnpm run type-check`

## Summary by Sourcery

Propagate row document source metadata when creating row documents so orphaned views can be associated with their originating database row.

New Features:
- Include a typed row document source payload (database, view, and row identifiers) when creating row documents and orphaned views.

Enhancements:
- Extend createRowDocument and createOrphanedView APIs and related context/props to accept an optional row document source in a backward-compatible way.