### PR TITLE
fix(editor): apply monospace font to inline code (#394)

### DIFF
--- a/src/components/editor/components/leaf/Leaf.tsx
+++ b/src/components/editor/components/leaf/Leaf.tsx
@@ -62,7 +62,7 @@ export function Leaf({ attributes, children, leaf, text }: RenderLeafProps) {
 
   if (leaf.code && !(leaf.formula || leaf.mention || leaf.reference)) {
     newChildren = (
-      <span className={cn('bg-border-primary font-medium', style['color'] ? undefined : 'text-[#EB5757]')}>
+      <span className={cn('bg-border-primary font-medium font-mono', style['color'] ? undefined : 'text-[#EB5757]')}>
         {newChildren}
       </span>
     );


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Update inline code leaf rendering to include a monospace font for code text in the editor.