### PR TITLE
test: add BDD coverage for database view tab order after reopening

### DIFF
--- a/playwright/bdd/features/database/view-tab-order.feature
+++ b/playwright/bdd/features/database/view-tab-order.feature
@@ -1,0 +1,14 @@
+Feature: Database view tab order
+  New views created from the database tab bar must be appended to the end of
+  the tab order, both immediately after creation and after navigating away and
+  reopening the database.
+
+  Scenario: Creating database views from the tab bar keeps them at the end after reopening
+    Given a grid database is open for view tab order testing
+    When I add a "Board" view from the database tab bar
+    And I add a "Calendar" view from the database tab bar
+    And I rename the database view tab "Board" to "Second View"
+    And I rename the database view tab "Calendar" to "Third View"
+    Then the database view tabs appear in order "Grid, Second View, Third View"
+    When I navigate to another page and reopen the database
+    Then the database view tabs appear in order "Grid, Second View, Third View"

--- a/playwright/bdd/steps/database-view-tab-order.steps.ts
+++ b/playwright/bdd/steps/database-view-tab-order.steps.ts
@@ -1,0 +1,102 @@
+import { expect, Page } from '@playwright/test';
+import { createBdd } from 'playwright-bdd';
+
+import { signInAndCreateDatabaseView, waitForGridReady } from '../../support/database-ui-helpers';
+import { createDocumentPageAndNavigate, expandSpaceByName } from '../../support/page-utils';
+import { DatabaseViewSelectors, ModalSelectors, PageSelectors } from '../../support/selectors';
+import { generateRandomEmail } from '../../support/test-config';
+
+const { Given, When, Then } = createBdd();
+
+const SPACE_NAME = 'General';
+const DATABASE_NAME = 'New Database';
+
+async function tabLabels(page: Page): Promise<string[]> {
+  const labels = await DatabaseViewSelectors.viewTab(page).allInnerTexts();
+
+  return labels.map((label) => label.trim());
+}
+
+Given('a grid database is open for view tab order testing', async ({ page, request }) => {
+  await signInAndCreateDatabaseView(page, request, generateRandomEmail(), 'Grid', {
+    verify: async (p) => {
+      await expect(p.locator('[class*="appflowy-database"]')).toBeVisible({ timeout: 15000 });
+      await expect(DatabaseViewSelectors.viewTab(p).first()).toBeVisible({ timeout: 10000 });
+    },
+  });
+  await waitForGridReady(page);
+});
+
+When('I add a {string} view from the database tab bar', async ({ page }, viewType: string) => {
+  // Let the tab bar settle before interacting; a click during the re-render
+  // caused by a previous view creation can be swallowed.
+  await page.waitForTimeout(1000);
+
+  const previousCount = await DatabaseViewSelectors.viewTab(page).count();
+  const addButton = DatabaseViewSelectors.addViewButton(page);
+
+  await addButton.scrollIntoViewIfNeeded();
+  await expect(addButton).toBeVisible({ timeout: 5000 });
+  await addButton.click();
+  await page.waitForTimeout(500);
+
+  const menu = page.locator('[data-slot="dropdown-menu-content"]');
+
+  await expect(menu).toBeVisible({ timeout: 5000 });
+  const menuItem = menu.locator('[role="menuitem"]').filter({ hasText: viewType }).first();
+
+  await expect(menuItem).toBeVisible({ timeout: 5000 });
+  await menuItem.click({ force: true });
+  await page.waitForTimeout(1000);
+
+  await expect(DatabaseViewSelectors.viewTab(page)).toHaveCount(previousCount + 1, { timeout: 15000 });
+  await expect(DatabaseViewSelectors.viewTab(page).filter({ hasText: viewType })).toBeVisible({ timeout: 15000 });
+});
+
+When(
+  'I rename the database view tab {string} to {string}',
+  async ({ page }, currentLabel: string, nextLabel: string) => {
+    const tabSpan = page.locator('[data-testid^="view-tab-"] span').filter({ hasText: currentLabel });
+
+    await expect(tabSpan).toBeVisible({ timeout: 10000 });
+    await tabSpan.click({ button: 'right', force: true });
+    await page.waitForTimeout(500);
+
+    await expect(DatabaseViewSelectors.tabActionRename(page)).toBeVisible();
+    await DatabaseViewSelectors.tabActionRename(page).click({ force: true });
+    await expect(ModalSelectors.renameInput(page)).toBeVisible();
+    await ModalSelectors.renameInput(page).clear();
+    await ModalSelectors.renameInput(page).fill(nextLabel);
+
+    const saveButton = ModalSelectors.renameSaveButton(page);
+
+    await expect(saveButton).toBeEnabled({ timeout: 10000 });
+    await saveButton.click();
+    await expect(ModalSelectors.renameInput(page)).toBeHidden({ timeout: 10000 });
+    await expect(page.locator('[data-testid^="view-tab-"]').filter({ hasText: nextLabel })).toBeVisible({
+      timeout: 10000,
+    });
+  }
+);
+
+Then('the database view tabs appear in order {string}', async ({ page }, orderedLabels: string) => {
+  const expected = orderedLabels.split(',').map((label) => label.trim());
+
+  await expect
+    .poll(async () => tabLabels(page), {
+      timeout: 15000,
+      message: `Expected database view tabs in order: ${expected.join(', ')}`,
+    })
+    .toEqual(expected);
+});
+
+When('I navigate to another page and reopen the database', async ({ page }) => {
+  await createDocumentPageAndNavigate(page);
+  await page.waitForTimeout(2000);
+
+  await expandSpaceByName(page, SPACE_NAME);
+  await PageSelectors.nameContaining(page, DATABASE_NAME).first().click({ force: true });
+  await page.waitForTimeout(3000);
+
+  await expect(DatabaseViewSelectors.viewTab(page).first()).toBeVisible({ timeout: 15000 });
+});

--- a/src/application/types.ts
+++ b/src/application/types.ts
@@ -1484,7 +1484,10 @@ export interface DuplicatePageOperationOptions extends DuplicatePageOptions {
 
 export interface CreateDatabaseViewPayload {
   parent_view_id: string;
-  /** Insert the new database view after this sibling. When omitted the backend prepends. */
+  /**
+   * Insert the new database view after this sibling. When omitted, the
+   * backend appends the view to the end of the parent's children.
+   */
   prev_view_id?: string;
   database_id: string;
   layout: ViewLayout;


### PR DESCRIPTION
## What

Adds a Playwright BDD scenario (`playwright/bdd/features/database/view-tab-order.feature`) covering the database view tab-order bug:

1. Create a grid database (cloud account)
2. Add a Board and a Calendar view from the tab bar
3. Rename them to "Second View" / "Third View"
4. Assert tab order is `Grid, Second View, Third View`
5. Navigate to another page, reopen the database
6. Assert the order survived

Also updates the stale `CreateDatabaseViewPayload.prev_view_id` comment: omitting the field now means the backend **appends** to the end of the parent's children (it used to prepend).

## Context

The web client was already sending `prev_view_id` (the container's last child) on view creation, but the server had no such field in its DTO and silently dropped it, prepending every new view. That server-side fix is AppFlowy-IO/AppFlowy-Cloud-Premium#786 — no functional web change was needed.

## Verification

- Against an **unfixed** local server, this test reproduced the bug: tabs rendered fully reversed (`Third View, Second View, Grid`).
- Against the fixed server (cloud-premium#786), the test passes:
  `bddgen && playwright test -c playwright.bdd.config.ts --grep "view tab order"` → 1 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add BDD coverage ensuring database view tabs created from the tab bar remain appended at the end of the tab order across navigation and reopenings.

Enhancements:
- Clarify CreateDatabaseViewPayload.prev_view_id documentation to reflect that omitting the field appends the new view to the end of the parent’s children.

Tests:
- Introduce a Playwright BDD scenario and step definitions covering database view tab ordering before and after reopening the database view.