### PR TITLE
fix: repair failing CI tests (gotrue prompt param, embedded trash detection)

### DIFF
--- a/src/application/services/js-services/http/__tests__/gotrue.test.ts
+++ b/src/application/services/js-services/http/__tests__/gotrue.test.ts
@@ -227,7 +227,7 @@ describe('GoTrue provider redirects', () => {
     signInGoogle('http://localhost/auth/callback');
 
     expect(assign).toHaveBeenCalledWith(
-      'http://localhost/gotrue/authorize?provider=google&redirect_to=http%3A%2F%2Flocalhost%2Fauth%2Fcallback'
+      'http://localhost/gotrue/authorize?provider=google&redirect_to=http%3A%2F%2Flocalhost%2Fauth%2Fcallback&prompt=consent'
     );
   });
 

--- a/src/components/editor/components/blocks/database/DatabaseBlock.tsx
+++ b/src/components/editor/components/blocks/database/DatabaseBlock.tsx
@@ -158,7 +158,16 @@ function DatabaseBlockBody({ node, children, editor, forwardedRef, readOnly, ...
           idsToCheck.add(parentId);
         }
 
-        const isInTrash = trashItems?.some((item) => idsToCheck.has(item.view_id));
+        // The view API omits trashed ancestors, so on a fresh mount the child view of
+        // a trashed container reports no parent and idsToCheck can't name the trashed
+        // container. The trash entries carry the container's DatabaseViewExtra, so also
+        // match by the block's database_id: if this database's container is in the
+        // trash, the block can't render regardless of which id was used to reach it.
+        const isInTrash = trashItems?.some(
+          (item) =>
+            idsToCheck.has(item.view_id) ||
+            (!!databaseId && item.extra?.is_database_container === true && item.extra?.database_id === databaseId)
+        );
 
         if (cancelled) return;
 


### PR DESCRIPTION
## Problem

Main-branch CI has been red since Jun 24 (every `Playwright E2E Tests` run fails). Two independent failures, both also blocking unrelated PRs such as #420:

### 1. `test` job — `gotrue.test.ts › navigates Google OAuth in the current tab`

Commit 98125bf9 ("chore: use prompt (#416)") added `&prompt=consent` to the Google OAuth authorize URL, but the unit test still expected the URL without it.

**Fix:** update the expected URL. (Google-only — the other-providers test is unchanged, matching the source.)

### 2. `embedded` job — `database-sidebar-deletion.spec.ts › Scenario 5: should show placeholder when navigating back to page after deletion`

The embedded database block detects deletion by checking whether its view id **or its parent (the database container) id** appears in the trash list. The view API no longer reports a trashed ancestor: `GET /view/{id}` for the child of a trashed container now returns `parent_view_id: null` (captured from a live repro):

```
GET /view/a8f662cb…  → { "view_id": "a8f662cb…", "parent_view_id": null, "extra": { "database_id": "61679abc…", "embedded": true } }
GET /trash           → [ { "view_id": "dfa66273…", "name": "New Database", "extra": { "database_id": "61679abc…", "is_database_container": true, … } } ]
```

On a fresh mount (navigating back after deletion) the block therefore can't name its trashed container, no trash entry matches, and the live grid renders instead of the placeholder. The in-session path (Scenarios 1/6) still worked because a mounted block remembers its last-known parent.

**Fix:** also match trash entries by the block's `database_id` against entries whose `extra` marks them as database containers (`is_database_container`). If this database's container is in the trash, the block can't render regardless of which id was used to reach it.

## Verification

- `jest gotrue.test.ts` → 11/11 passed
- Full `database-sidebar-deletion.spec.ts` e2e suite locally against a current AppFlowy-Cloud-Premium backend → **6/6 passed** (Scenario 5 reproduced the failure before the fix)
- `eslint` clean on the changed component

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Resolve CI failures by aligning GoTrue Google OAuth tests with the updated authorize URL and ensuring embedded database blocks correctly detect trashed containers.

Bug Fixes:
- Update the GoTrue Google OAuth redirect test to expect the prompt=consent parameter in the authorize URL.
- Fix embedded database blocks to treat their database as trashed when the corresponding container view is in the trash, even if the parent view ID is omitted.