### PR TITLE
Gate share and view actions by effective permissions

### DIFF
--- a/playwright/bdd/features/page/eva-more-actions-permissions.feature
+++ b/playwright/bdd/features/page/eva-more-actions-permissions.feature
@@ -1,0 +1,37 @@
+@eva-more-actions-permissions
+Feature: Eva page action permissions
+  The Eva permission fixture already exists in the local AppFlowy Cloud database.
+  These scenarios verify page action menus for Full access, Can edit, and Can view pages.
+
+  Background:
+    Given the seeded Eva page action permission fixture exists
+
+  Scenario: Eva sees permission-specific sidebar more actions
+    Given I sign in as seeded Eva
+    When I open Eva's sidebar more menu for "Grante full access for eva"
+    Then Eva's sidebar more menu shows only "Rename, Change icon, Lock page, Duplicate, Move to, Delete, Open in a new tab"
+    When I close Eva's sidebar more menu
+    And I open Eva's sidebar more menu for "Edit only permission for eva"
+    Then Eva's sidebar more menu shows only "Duplicate, Open in a new tab"
+    When I close Eva's sidebar more menu
+    And I open Eva's sidebar more menu for "Read only permission for eva"
+    Then Eva's sidebar more menu shows only "Open in a new tab"
+
+  Scenario: Eva sees permission-specific page more actions
+    Given I sign in as seeded Eva
+    When I open Eva's page "Grante full access for eva"
+    And I open Eva's page more menu
+    Then Eva's page more menu shows only "Lock page, Duplicate, Move to, Find and replace, Delete, Version history"
+    When I close Eva's page more menu
+    And I open Eva's page "Edit only permission for eva"
+    And I open Eva's page more menu
+    Then Eva's page more menu shows only "Duplicate, Find and replace, Version history"
+    When I close Eva's page more menu
+    And I open Eva's page "Read only permission for eva"
+    And I open Eva's page more menu
+    Then Eva's page more menu shows only "Find and replace"
+
+  Scenario: Eva does not see workspace creation from a selected-space more menu
+    Given I sign in as seeded Eva
+    When I open Eva's space more menu for "Annie space"
+    Then Eva's space more menu shows only "Duplicate Space"

--- a/playwright/bdd/steps/eva-more-actions-permissions.steps.ts
+++ b/playwright/bdd/steps/eva-more-actions-permissions.steps.ts
@@ -1,0 +1,219 @@
+import { expect, Locator, Page } from '@playwright/test';
+import { createBdd } from 'playwright-bdd';
+
+import { signInWithPasswordViaUi } from '../../support/auth-flow-helpers';
+import { expandSpaceByName } from '../../support/page-utils';
+import {
+  DropdownSelectors,
+  HeaderSelectors,
+  PageSelectors,
+  SidebarSelectors,
+  SpaceSelectors,
+  ViewActionSelectors,
+} from '../../support/selectors';
+import { setupPageErrorHandling } from '../../support/test-config';
+
+const { Given, When, Then, Before } = createBdd();
+
+const EVA_EMAIL = 'eva@appflowy.io';
+const EVA_PASSWORD = 'AppFlowy!@123';
+const EVA_PERMISSION_SPACE_NAME = 'Annie space';
+const MENU_ACTIONS = {
+  Rename: (page: Page) => ViewActionSelectors.renameButton(page),
+  'Change icon': (page: Page) => ViewActionSelectors.changeIconButton(page),
+  'Lock page': (page: Page) => page.getByTestId('more-page-lock'),
+  Duplicate: (page: Page) => ViewActionSelectors.duplicateButton(page),
+  'Move to': (page: Page) => ViewActionSelectors.moveToButton(page),
+  'Find and replace': (page: Page) => page.getByTestId('more-page-find-and-replace'),
+  Delete: (page: Page) => ViewActionSelectors.deleteButton(page),
+  'Version history': (page: Page) => page.getByTestId('more-page-version-history'),
+  'Open in a new tab': (page: Page) => ViewActionSelectors.openNewTabButton(page),
+} satisfies Record<string, (page: Page) => Locator>;
+const SPACE_MENU_ACTIONS = {
+  'Manage Space': (page: Page) => page.getByTestId('space-action-manage'),
+  'Duplicate Space': (page: Page) => page.getByTestId('space-action-duplicate'),
+  'Create a new space': (page: Page) => page.getByTestId('create-new-space-button'),
+  Delete: (page: Page) => page.getByTestId('space-action-delete'),
+} satisfies Record<string, (page: Page) => Locator>;
+
+type MenuActionLabel = keyof typeof MENU_ACTIONS;
+type SpaceMenuActionLabel = keyof typeof SPACE_MENU_ACTIONS;
+
+Before(async ({ page }) => {
+  setupPageErrorHandling(page);
+  await page.setViewportSize({ width: 1440, height: 900 });
+});
+
+Given('the seeded Eva page action permission fixture exists', async () => {
+  // This BDD suite intentionally reuses the local Eva/Annie permission fixture.
+});
+
+Given('I sign in as seeded Eva', async ({ page }) => {
+  await signInWithPasswordViaUi(page, EVA_EMAIL, EVA_PASSWORD, 2000);
+  await expect(page).toHaveURL(/\/app/, { timeout: 30000 });
+  await expect(SidebarSelectors.pageHeader(page)).toBeVisible({ timeout: 30000 });
+  await expandSpaceByName(page, EVA_PERMISSION_SPACE_NAME);
+});
+
+When("I open Eva's sidebar more menu for {string}", async ({ page }, pageName: string) => {
+  await openSidebarMoreMenuForPage(page, pageName);
+});
+
+When("I open Eva's space more menu for {string}", async ({ page }, spaceName: string) => {
+  await openSpaceMoreMenu(page, spaceName);
+});
+
+When("I open Eva's page {string}", async ({ page }, pageName: string) => {
+  await openPageFromSidebar(page, pageName);
+});
+
+When("I open Eva's page more menu", async ({ page }) => {
+  await openPageMoreMenu(page);
+});
+
+When("I close Eva's sidebar more menu", async ({ page }) => {
+  await page.keyboard.press('Escape');
+  await expect(ViewActionSelectors.popover(page)).toHaveCount(0);
+});
+
+When("I close Eva's page more menu", async ({ page }) => {
+  await page.keyboard.press('Escape');
+  await expect(DropdownSelectors.content(page)).toHaveCount(0);
+});
+
+Then("Eva's sidebar more menu shows only {string}", async ({ page }, expectedActions: string) => {
+  await expect(ViewActionSelectors.popover(page)).toBeVisible({ timeout: 15000 });
+  await assertMoreMenuShowsOnly(page, ViewActionSelectors.popover(page), expectedActions);
+});
+
+Then("Eva's page more menu shows only {string}", async ({ page }, expectedActions: string) => {
+  const menu = DropdownSelectors.content(page).last();
+
+  await expect(menu).toBeVisible({ timeout: 15000 });
+  await assertMoreMenuShowsOnly(page, menu, expectedActions);
+});
+
+Then("Eva's space more menu shows only {string}", async ({ page }, expectedActions: string) => {
+  const expectedLabels = parseExpectedSpaceLabels(expectedActions);
+  const popover = ViewActionSelectors.popover(page);
+
+  await expect(popover).toBeVisible({ timeout: 15000 });
+  await expect(page.getByTestId('space-action-permission-loading')).toHaveCount(0, { timeout: 15000 });
+  await expect(popover.locator('[role="menuitem"]:visible')).toHaveCount(expectedLabels.size);
+
+  for (const [label, locatorForPage] of Object.entries(SPACE_MENU_ACTIONS) as [
+    SpaceMenuActionLabel,
+    (page: Page) => Locator,
+  ][]) {
+    const locator = locatorForPage(page);
+
+    if (expectedLabels.has(label)) {
+      await expect(locator).toBeVisible({ timeout: 15000 });
+    } else {
+      await expect(locator).toHaveCount(0);
+    }
+  }
+});
+
+async function assertMoreMenuShowsOnly(page: Page, popover: Locator, expectedActions: string): Promise<void> {
+  const expectedLabels = parseExpectedLabels(expectedActions);
+
+  await expect(page.getByTestId('more-actions-permission-loading')).toHaveCount(0, { timeout: 15000 });
+  await expect(popover.locator('[role="menuitem"]:visible')).toHaveCount(expectedLabels.size);
+
+  for (const [label, locatorForPage] of Object.entries(MENU_ACTIONS) as [
+    MenuActionLabel,
+    (page: Page) => Locator,
+  ][]) {
+    const locator = locatorForPage(page);
+
+    if (expectedLabels.has(label)) {
+      await expect(locator).toBeVisible({ timeout: 15000 });
+    } else {
+      await expect(locator).toHaveCount(0);
+    }
+  }
+}
+
+async function openSidebarMoreMenuForPage(page: Page, pageName: string): Promise<void> {
+  const pageItem = PageSelectors.itemByName(page, pageName);
+
+  await expect(pageItem).toBeVisible({ timeout: 30000 });
+  await pageItem.scrollIntoViewIfNeeded();
+  await pageItem.hover({ force: true });
+
+  const moreActionsButton = pageItem.getByTestId('page-more-actions').first();
+
+  await expect(moreActionsButton).toBeVisible({ timeout: 10000 });
+  await moreActionsButton.click({ force: true });
+  await expect(ViewActionSelectors.popover(page)).toBeVisible({ timeout: 15000 });
+}
+
+async function openSpaceMoreMenu(page: Page, spaceName: string): Promise<void> {
+  const spaceItem = SpaceSelectors.itemByName(page, spaceName);
+
+  await expect(spaceItem).toBeVisible({ timeout: 30000 });
+  await spaceItem.scrollIntoViewIfNeeded();
+  await spaceItem.hover({ force: true });
+
+  const moreActionsButton = spaceItem.getByTestId('inline-more-actions').first();
+
+  await expect(moreActionsButton).toBeVisible({ timeout: 10000 });
+  await moreActionsButton.click({ force: true });
+  await expect(ViewActionSelectors.popover(page)).toBeVisible({ timeout: 15000 });
+}
+
+async function openPageFromSidebar(page: Page, pageName: string): Promise<void> {
+  const pageItem = PageSelectors.itemByName(page, pageName);
+
+  await expect(pageItem).toBeVisible({ timeout: 30000 });
+  await pageItem.scrollIntoViewIfNeeded();
+  await pageItem.getByTestId('page-name').click({ force: true });
+  await expect(page.locator('main').getByText(pageName, { exact: true }).first()).toBeVisible({ timeout: 30000 });
+}
+
+async function openPageMoreMenu(page: Page): Promise<void> {
+  const moreActionsButton = HeaderSelectors.moreActionsButton(page);
+
+  await expect(moreActionsButton).toBeVisible({ timeout: 15000 });
+  await moreActionsButton.click({ force: true });
+  await expect(DropdownSelectors.content(page).last()).toBeVisible({ timeout: 15000 });
+}
+
+function parseExpectedLabels(expectedActions: string): Set<MenuActionLabel> {
+  const labels = expectedActions
+    .split(',')
+    .map((label) => label.trim())
+    .filter(Boolean);
+
+  for (const label of labels) {
+    if (!isMenuActionLabel(label)) {
+      throw new Error(`Unknown Eva more-action menu label: ${label}`);
+    }
+  }
+
+  return new Set(labels);
+}
+
+function parseExpectedSpaceLabels(expectedActions: string): Set<SpaceMenuActionLabel> {
+  const labels = expectedActions
+    .split(',')
+    .map((label) => label.trim())
+    .filter(Boolean);
+
+  for (const label of labels) {
+    if (!isSpaceMenuActionLabel(label)) {
+      throw new Error(`Unknown Eva space more-action menu label: ${label}`);
+    }
+  }
+
+  return new Set(labels);
+}
+
+function isMenuActionLabel(label: string): label is MenuActionLabel {
+  return label in MENU_ACTIONS;
+}
+
+function isSpaceMenuActionLabel(label: string): label is SpaceMenuActionLabel {
+  return label in SPACE_MENU_ACTIONS;
+}

--- a/src/application/services/domains/page.ts
+++ b/src/application/services/domains/page.ts
@@ -10,6 +10,7 @@ export {
   movePageTo as moveTo,
   deleteTrash,
   createSpace,
+  createSpaceWithInitialPage,
   updateSpace,
   createDatabaseView,
 } from '../js-services/http/page-api';

--- a/src/application/services/js-services/http/access-api.ts
+++ b/src/application/services/js-services/http/access-api.ts
@@ -109,24 +109,72 @@ export async function sendRequestAccess(workspaceId: string, viewId: string) {
 async function getLegacyShareDetail(
   workspaceId: string,
   viewId: string,
-  ancestorViewIds: string[],
-  signal?: AbortSignal
+  ancestorViewIds: string[]
 ): Promise<ShareAccessDetails> {
   const url = `/api/sharing/workspace/${workspaceId}/view/${viewId}/access-details`;
 
-  return withRetry(
-    () =>
-      executeAPIRequest<ShareAccessDetails>(() =>
-        getAxios()?.post<APIResponse<ShareAccessDetails>>(
-          url,
-          {
-            ancestor_view_ids: ancestorViewIds,
-          },
-          { signal }
-        )
-      ),
-    { signal }
+  return withRetry(() =>
+    executeAPIRequest<ShareAccessDetails>(() =>
+      getAxios()?.post<APIResponse<ShareAccessDetails>>(url, {
+        ancestor_view_ids: ancestorViewIds,
+      })
+    )
   );
+}
+
+// A server that answers 404/405 for the v2 endpoint won't start supporting it
+// mid-session, so remember the outcome instead of re-failing on every call.
+let shareDetailV2Unsupported = false;
+
+const SHARE_DETAIL_CACHE_TTL_MS = 10_000;
+const shareDetailCache = new Map<string, { promise: Promise<ShareAccessDetails>; cachedAt: number }>();
+
+function invalidateShareDetailCache(workspaceId: string) {
+  // Sharing changes on one view can alter effective permissions of its
+  // descendants, so drop every cached view in the workspace.
+  for (const key of shareDetailCache.keys()) {
+    if (key.startsWith(`${workspaceId}:`)) {
+      shareDetailCache.delete(key);
+    }
+  }
+}
+
+function getErrorCode(error: unknown): number | undefined {
+  if (typeof error === 'object' && error !== null && 'code' in error) {
+    const code = (error as { code: unknown }).code;
+
+    if (typeof code === 'number') return code;
+  }
+
+  return undefined;
+}
+
+async function fetchShareDetail(
+  workspaceId: string,
+  viewId: string,
+  ancestorViewIds: string[]
+): Promise<ShareAccessDetails> {
+  if (!shareDetailV2Unsupported) {
+    const params = new URLSearchParams({
+      type: 'page',
+      page_id: viewId,
+    });
+    const url = `/api/sharing/workspace/${workspaceId}/access-details/v2?${params.toString()}`;
+
+    try {
+      return await withRetry(() =>
+        executeAPIRequest<ShareAccessDetails>(() => getAxios()?.get<APIResponse<ShareAccessDetails>>(url))
+      );
+    } catch (error) {
+      const code = getErrorCode(error);
+
+      if (code === 404 || code === 405) {
+        shareDetailV2Unsupported = true;
+      }
+    }
+  }
+
+  return getLegacyShareDetail(workspaceId, viewId, ancestorViewIds);
 }
 
 export async function getShareDetail(
@@ -135,56 +183,64 @@ export async function getShareDetail(
   ancestorViewIds: string[],
   signal?: AbortSignal
 ) {
-  const params = new URLSearchParams({
-    type: 'page',
-    page_id: viewId,
-  });
-  const url = `/api/sharing/workspace/${workspaceId}/access-details/v2?${params.toString()}`;
-
-  try {
-    return await withRetry(
-      () =>
-        executeAPIRequest<ShareAccessDetails>(() =>
-          getAxios()?.get<APIResponse<ShareAccessDetails>>(url, { signal })
-        ),
-      { signal }
-    );
-  } catch (error) {
-    if (signal?.aborted) throw error;
-
-    return getLegacyShareDetail(workspaceId, viewId, ancestorViewIds, signal);
+  if (signal?.aborted) {
+    return Promise.reject({ code: -1, message: 'Request aborted' });
   }
+
+  const key = `${workspaceId}:${viewId}`;
+  const cached = shareDetailCache.get(key);
+
+  if (cached && Date.now() - cached.cachedAt < SHARE_DETAIL_CACHE_TTL_MS) {
+    return cached.promise;
+  }
+
+  // The in-flight promise is shared between callers (share panel, view action
+  // menus), so it is not tied to any single caller's abort signal — aborted
+  // callers simply ignore the settled result.
+  const promise = fetchShareDetail(workspaceId, viewId, ancestorViewIds);
+
+  shareDetailCache.set(key, { promise, cachedAt: Date.now() });
+  promise.catch(() => {
+    if (shareDetailCache.get(key)?.promise === promise) {
+      shareDetailCache.delete(key);
+    }
+  });
+
+  return promise;
 }
 
 export async function sharePageTo(workspaceId: string, viewId: string, emails: string[], accessLevel?: AccessLevel) {
   const url = `/api/sharing/workspace/${workspaceId}/view`;
 
-  return executeAPIVoidRequest(() =>
+  await executeAPIVoidRequest(() =>
     getAxios()?.put<APIResponse>(url, {
       view_id: viewId,
       emails,
       access_level: accessLevel || AccessLevel.ReadOnly,
     })
   );
+  invalidateShareDetailCache(workspaceId);
 }
 
 export async function revokeAccess(workspaceId: string, viewId: string, emails: string[]) {
   const url = `/api/sharing/workspace/${workspaceId}/view/${viewId}/revoke-access`;
 
-  return executeAPIVoidRequest(() =>
+  await executeAPIVoidRequest(() =>
     getAxios()?.post<APIResponse>(url, { emails })
   );
+  invalidateShareDetailCache(workspaceId);
 }
 
 export async function turnIntoMember(workspaceId: string, email: string) {
   const url = `/api/workspace/${workspaceId}/member`;
 
-  return executeAPIVoidRequest(() =>
+  await executeAPIVoidRequest(() =>
     getAxios()?.put<APIResponse>(url, {
       email,
       role: Role.Member,
     })
   );
+  invalidateShareDetailCache(workspaceId);
 }
 
 export async function getShareWithMe(workspaceId: string): Promise<View> {

--- a/src/application/services/js-services/http/access-api.ts
+++ b/src/application/services/js-services/http/access-api.ts
@@ -3,9 +3,9 @@ import {
   AFWebUser,
   GetRequestAccessInfoResponse,
   Invitation,
-  IPeopleWithAccessType,
   RequestAccessInfoStatus,
   Role,
+  ShareAccessDetails,
   View,
   Workspace,
 } from '@/application/types';
@@ -106,23 +106,54 @@ export async function sendRequestAccess(workspaceId: string, viewId: string) {
   );
 }
 
-export async function getShareDetail(workspaceId: string, viewId: string, ancestorViewIds: string[], signal?: AbortSignal) {
+async function getLegacyShareDetail(
+  workspaceId: string,
+  viewId: string,
+  ancestorViewIds: string[],
+  signal?: AbortSignal
+): Promise<ShareAccessDetails> {
   const url = `/api/sharing/workspace/${workspaceId}/view/${viewId}/access-details`;
 
-  return withRetry(() =>
-    executeAPIRequest<{
-      view_id: string;
-      shared_with: IPeopleWithAccessType[];
-    }>(() =>
-      getAxios()?.post<APIResponse<{
-        view_id: string;
-        shared_with: IPeopleWithAccessType[];
-      }>>(url, {
-        ancestor_view_ids: ancestorViewIds,
-      })
-    ),
+  return withRetry(
+    () =>
+      executeAPIRequest<ShareAccessDetails>(() =>
+        getAxios()?.post<APIResponse<ShareAccessDetails>>(
+          url,
+          {
+            ancestor_view_ids: ancestorViewIds,
+          },
+          { signal }
+        )
+      ),
     { signal }
   );
+}
+
+export async function getShareDetail(
+  workspaceId: string,
+  viewId: string,
+  ancestorViewIds: string[],
+  signal?: AbortSignal
+) {
+  const params = new URLSearchParams({
+    type: 'page',
+    page_id: viewId,
+  });
+  const url = `/api/sharing/workspace/${workspaceId}/access-details/v2?${params.toString()}`;
+
+  try {
+    return await withRetry(
+      () =>
+        executeAPIRequest<ShareAccessDetails>(() =>
+          getAxios()?.get<APIResponse<ShareAccessDetails>>(url, { signal })
+        ),
+      { signal }
+    );
+  } catch (error) {
+    if (signal?.aborted) throw error;
+
+    return getLegacyShareDetail(workspaceId, viewId, ancestorViewIds, signal);
+  }
 }
 
 export async function sharePageTo(workspaceId: string, viewId: string, emails: string[], accessLevel?: AccessLevel) {

--- a/src/application/services/js-services/http/page-api.ts
+++ b/src/application/services/js-services/http/page-api.ts
@@ -7,6 +7,8 @@ import {
   CreatePagePayload,
   CreatePageResponse,
   CreateSpacePayload,
+  CreateSpaceWithInitialPagePayload,
+  CreateSpaceWithInitialPageResponse,
   UpdatePagePayload,
   UpdateSpacePayload,
   ViewIconType,
@@ -132,6 +134,14 @@ export async function createSpace(workspaceId: string, payload: CreateSpacePaylo
   return executeAPIRequest<{ view_id: string }>(() =>
     getAxios()?.post<APIResponse<{ view_id: string }>>(url, payload)
   ).then((data) => data.view_id);
+}
+
+export async function createSpaceWithInitialPage(workspaceId: string, payload: CreateSpaceWithInitialPagePayload) {
+  const url = `/api/workspace/${workspaceId}/v2/space`;
+
+  return executeAPIRequest<CreateSpaceWithInitialPageResponse>(() =>
+    getAxios()?.post<APIResponse<CreateSpaceWithInitialPageResponse>>(url, payload)
+  );
 }
 
 export async function updateSpace(workspaceId: string, payload: UpdateSpacePayload) {

--- a/src/application/types.ts
+++ b/src/application/types.ts
@@ -1563,6 +1563,23 @@ export interface CreateSpacePayload {
   space_permission?: SpacePermission; // 0 for public space, 1 for private space
 }
 
+export interface CreateSpaceInitialPagePayload extends Omit<CreatePagePayload, 'prev_view_id'> {
+  page_data?: unknown;
+  view_id?: string;
+  prev_view_id?: string | null;
+}
+
+export interface CreateSpaceWithInitialPagePayload extends CreateSpacePayload {
+  initial_page: CreateSpaceInitialPagePayload;
+}
+
+export interface CreateSpaceWithInitialPageResponse {
+  space: {
+    view_id: string;
+  };
+  page: CreatePageResponse;
+}
+
 export interface UpdateSpacePayload extends CreateSpacePayload {
   view_id: string;
 }

--- a/src/application/types.ts
+++ b/src/application/types.ts
@@ -1691,6 +1691,27 @@ export interface IPeopleWithAccessType {
   pending_invitation: boolean;
 }
 
+export interface ObjectPermission {
+  object_id?: string;
+  object_type?: string;
+  access_level?: AccessLevel;
+  visible?: boolean;
+  object_creator?: boolean;
+  ancestor_creator?: boolean;
+  parent_private_view_id?: string | null;
+  governing_view_id?: string | null;
+}
+
+export interface ShareAccessDetails {
+  view_id?: string;
+  target?: {
+    type: string;
+    page_id?: string;
+  };
+  current_user_permission?: ObjectPermission | null;
+  shared_with: IPeopleWithAccessType[];
+}
+
 export enum AccessLevel {
   ReadOnly = 10,
   ReadAndComment = 20,

--- a/src/components/app/contexts/AppOperationsContext.ts
+++ b/src/components/app/contexts/AppOperationsContext.ts
@@ -11,6 +11,8 @@ import {
   CreatePageResponse,
   CreateRow,
   CreateSpacePayload,
+  CreateSpaceWithInitialPagePayload,
+  CreateSpaceWithInitialPageResponse,
   GenerateAISummaryRowPayload,
   GenerateAITranslateRowPayload,
   LoadDatabasePrompts,
@@ -88,6 +90,10 @@ export interface AppOperationsContextType {
   // ── Space operations ───────────────────────────────────────────────
   /** Create a new workspace space (top-level folder). */
   createSpace?: (payload: CreateSpacePayload) => Promise<string>;
+  /** Create a new workspace space and first page atomically. */
+  createSpaceWithInitialPage?: (
+    payload: CreateSpaceWithInitialPagePayload
+  ) => Promise<CreateSpaceWithInitialPageResponse>;
   /** Update space properties. */
   updateSpace?: (payload: UpdateSpacePayload) => Promise<void>;
   /** Create a new database view (Grid/Board/Calendar tab) within an existing database. */
@@ -127,7 +133,12 @@ export interface AppOperationsContextType {
   /** Create a new row document (returns encoded initial state). */
   createRowDocument?: (documentId: string, source?: RowDocumentSourcePayload) => Promise<Uint8Array | null>;
   /** Fire-and-forget: ask the server to duplicate the row document with inline DB deep copy. */
-  duplicateRowDocument?: (databaseId: string, sourceRowId: string, newRowId: string, clientDocStateB64?: string) => Promise<void>;
+  duplicateRowDocument?: (
+    databaseId: string,
+    sourceRowId: string,
+    newRowId: string,
+    clientDocStateB64?: string
+  ) => Promise<void>;
   /** Resolve a database ID to its primary view ID. */
   getViewIdFromDatabaseId?: (databaseId: string) => Promise<string | null>;
 

--- a/src/components/app/header/MoreActions.tsx
+++ b/src/components/app/header/MoreActions.tsx
@@ -52,10 +52,14 @@ function PermissionedMoreActionsContent({
   view: ReturnType<typeof useAppView>;
   viewId: string;
 }) {
-  const { canManageViewActions, canUsePageHistory, isLoadingViewActionPermissions } = useViewActionPermissions(
-    view,
-    true
-  );
+  const {
+    canCreateViewActions,
+    canManageViewActions,
+    canUsePageHistory,
+    hasLoadedViewActionPermissions,
+    isLoadingViewActionPermissions,
+  } = useViewActionPermissions(view, true);
+  const isResolvingViewActionPermissions = isLoadingViewActionPermissions || !hasLoadedViewActionPermissions;
 
   return (
     <>
@@ -65,9 +69,10 @@ function PermissionedMoreActionsContent({
         itemClicked={handleClose}
         onDeleted={onDeleted}
         viewId={viewId}
+        canDuplicateActions={canCreateViewActions}
         canManageActions={canManageViewActions}
         canUsePageHistory={canUsePageHistory}
-        isLoadingActions={isLoadingViewActionPermissions}
+        isLoadingActions={isResolvingViewActionPermissions}
         onOpenHistory={showHistory ? onOpenHistory : undefined}
         onFindAndReplace={isDocument ? onFindAndReplace : undefined}
       />

--- a/src/components/app/header/MoreActions.tsx
+++ b/src/components/app/header/MoreActions.tsx
@@ -2,15 +2,20 @@ import { lazy, Suspense, useCallback, useEffect, useMemo, useState, type Compone
 import { useTranslation } from 'react-i18next';
 
 import { APP_EVENTS } from '@/application/constants';
-import { Role, ViewLayout } from '@/application/types';
+import { ViewLayout } from '@/application/types';
 import { ReactComponent as AddToPageIcon } from '@/assets/icons/add_to_page.svg';
 import { ReactComponent as MoreIcon } from '@/assets/icons/more.svg';
-import { ReactComponent as SearchIcon } from '@/assets/icons/search.svg';
-import { findViewInShareWithMe } from '@/components/_shared/outline/utils';
 import { useAIChatContext } from '@/components/ai-chat/AIChatProvider';
 import { AIService } from '@/application/services/domains';
-import { useAIEnabled, useAppOutline, useAppView, useCurrentWorkspaceId, useEventEmitter, usePageHistoryEnabled, useUserWorkspaceInfo } from '@/components/app/app.hooks';
+import {
+  useAIEnabled,
+  useAppView,
+  useCurrentWorkspaceId,
+  useEventEmitter,
+  usePageHistoryEnabled,
+} from '@/components/app/app.hooks';
 import DocumentInfo from '@/components/app/header/DocumentInfo';
+import { useViewActionPermissions } from '@/components/app/view-actions/useViewActionPermissions';
 import { Button } from '@/components/ui/button';
 import {
   DropdownMenu,
@@ -43,9 +48,9 @@ function MoreActions({
   const [hasMessages, setHasMessages] = useState(false);
   const [open, setOpen] = useState(false);
   const [historyOpen, setHistoryOpen] = useState(false);
-  const outline = useAppOutline();
 
   const view = useAppView(viewId);
+  const { canManageViewActions, isLoadingViewActionPermissions } = useViewActionPermissions(view, open);
   const { t } = useTranslation();
 
   const handleClose = useCallback(() => {
@@ -70,10 +75,6 @@ function MoreActions({
   useEffect(() => {
     void handleFetchChatMessages();
   }, [handleFetchChatMessages]);
-
-  const userWorkspaceInfo = useUserWorkspaceInfo();
-
-  const role = userWorkspaceInfo?.selectedWorkspace.role;
 
   const ChatOptions = useMemo(() => {
     return aiEnabled && view?.layout === ViewLayout.AIChat ? (
@@ -125,10 +126,6 @@ function MoreActions({
     }
   }, [showHistory, historyOpen]);
 
-  const shareWithMeView = useMemo(() => {
-    return findViewInShareWithMe(outline || [], viewId);
-  }, [outline, viewId]);
-
   if (aiEnabled && view?.layout === ViewLayout.AIChat && selectionMode) {
     return null;
   }
@@ -144,39 +141,18 @@ function MoreActions({
         <DropdownMenuContent {...menuContentProps}>
           <DropdownMenuGroup>{ChatOptions}</DropdownMenuGroup>
 
-          {role === Role.Guest || shareWithMeView ? (
-            // Guests and shared-with-me viewers don't get the editing actions
-            // in MoreActionsContent, but Find still works in read-only mode
-            // (the panel disables Replace itself), so surface it here.
-            isDocument && (
-              <>
-                <DropdownMenuItem
-                  data-testid={'more-page-find-and-replace'}
-                  onSelect={(event) => {
-                    event.preventDefault();
-                    handleFindAndReplace();
-                  }}
-                >
-                  <SearchIcon />
-                  {t('shareAction.findAndReplace')}
-                </DropdownMenuItem>
-                <DropdownMenuSeparator />
-              </>
-            )
-          ) : (
-            <>
-              <MoreActionsContent
-                itemClicked={() => {
-                  handleClose();
-                }}
-                onDeleted={onDeleted}
-                viewId={viewId}
-                onOpenHistory={showHistory ? handleOpenHistory : undefined}
-                onFindAndReplace={isDocument ? handleFindAndReplace : undefined}
-              />
-              <DropdownMenuSeparator />
-            </>
-          )}
+          <MoreActionsContent
+            itemClicked={() => {
+              handleClose();
+            }}
+            onDeleted={onDeleted}
+            viewId={viewId}
+            canManageActions={canManageViewActions}
+            isLoadingActions={isLoadingViewActionPermissions}
+            onOpenHistory={showHistory ? handleOpenHistory : undefined}
+            onFindAndReplace={isDocument ? handleFindAndReplace : undefined}
+          />
+          <DropdownMenuSeparator />
 
           <DocumentInfo viewId={viewId} />
         </DropdownMenuContent>

--- a/src/components/app/header/MoreActions.tsx
+++ b/src/components/app/header/MoreActions.tsx
@@ -1,4 +1,4 @@
-import { lazy, Suspense, useCallback, useEffect, useMemo, useState, type ComponentProps } from 'react';
+import { lazy, Suspense, useCallback, useEffect, useMemo, useState, type ComponentProps, type ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { APP_EVENTS } from '@/application/constants';
@@ -31,6 +31,53 @@ import MoreActionsContent from './MoreActionsContent';
 
 const DocumentHistoryModal = lazy(() => import('@/components/document/history/DocumentHistoryModal'));
 
+function PermissionedMoreActionsContent({
+  chatOptions,
+  handleClose,
+  isDocument,
+  onDeleted,
+  onFindAndReplace,
+  onOpenHistory,
+  showHistory,
+  view,
+  viewId,
+}: {
+  chatOptions: ReactNode;
+  handleClose: () => void;
+  isDocument: boolean;
+  onDeleted?: () => void;
+  onFindAndReplace: () => void;
+  onOpenHistory: () => void;
+  showHistory: boolean;
+  view: ReturnType<typeof useAppView>;
+  viewId: string;
+}) {
+  const { canManageViewActions, canUsePageHistory, isLoadingViewActionPermissions } = useViewActionPermissions(
+    view,
+    true
+  );
+
+  return (
+    <>
+      <DropdownMenuGroup>{chatOptions}</DropdownMenuGroup>
+
+      <MoreActionsContent
+        itemClicked={handleClose}
+        onDeleted={onDeleted}
+        viewId={viewId}
+        canManageActions={canManageViewActions}
+        canUsePageHistory={canUsePageHistory}
+        isLoadingActions={isLoadingViewActionPermissions}
+        onOpenHistory={showHistory ? onOpenHistory : undefined}
+        onFindAndReplace={isDocument ? onFindAndReplace : undefined}
+      />
+      <DropdownMenuSeparator />
+
+      <DocumentInfo viewId={viewId} />
+    </>
+  );
+}
+
 function MoreActions({
   viewId,
   onDeleted,
@@ -50,7 +97,6 @@ function MoreActions({
   const [historyOpen, setHistoryOpen] = useState(false);
 
   const view = useAppView(viewId);
-  const { canManageViewActions, isLoadingViewActionPermissions } = useViewActionPermissions(view, open);
   const { t } = useTranslation();
 
   const handleClose = useCallback(() => {
@@ -139,22 +185,19 @@ function MoreActions({
           </Button>
         </DropdownMenuTrigger>
         <DropdownMenuContent {...menuContentProps}>
-          <DropdownMenuGroup>{ChatOptions}</DropdownMenuGroup>
-
-          <MoreActionsContent
-            itemClicked={() => {
-              handleClose();
-            }}
-            onDeleted={onDeleted}
-            viewId={viewId}
-            canManageActions={canManageViewActions}
-            isLoadingActions={isLoadingViewActionPermissions}
-            onOpenHistory={showHistory ? handleOpenHistory : undefined}
-            onFindAndReplace={isDocument ? handleFindAndReplace : undefined}
-          />
-          <DropdownMenuSeparator />
-
-          <DocumentInfo viewId={viewId} />
+          {open && (
+            <PermissionedMoreActionsContent
+              chatOptions={ChatOptions}
+              handleClose={handleClose}
+              isDocument={isDocument}
+              onDeleted={onDeleted}
+              onFindAndReplace={handleFindAndReplace}
+              onOpenHistory={handleOpenHistory}
+              showHistory={showHistory}
+              view={view}
+              viewId={viewId}
+            />
+          )}
         </DropdownMenuContent>
       </DropdownMenu>
       {showHistory && historyOpen && (

--- a/src/components/app/header/MoreActionsContent.tsx
+++ b/src/components/app/header/MoreActionsContent.tsx
@@ -34,6 +34,7 @@ function MoreActionsContent({
   onOpenHistory,
   onFindAndReplace,
   canManageActions = true,
+  canUsePageHistory = true,
   isLoadingActions = false,
 }: {
   itemClicked?: () => void;
@@ -42,6 +43,7 @@ function MoreActionsContent({
   onOpenHistory?: () => void;
   onFindAndReplace?: () => void;
   canManageActions?: boolean;
+  canUsePageHistory?: boolean;
   isLoadingActions?: boolean;
 }) {
   const { t } = useTranslation();
@@ -217,7 +219,7 @@ function MoreActionsContent({
         </DropdownMenuItem>
       )}
 
-      {canManageActions && isDocument && onOpenHistory && (
+      {canUsePageHistory && isDocument && onOpenHistory && (
         <DropdownMenuItem
           data-testid='more-page-version-history'
           onSelect={(event) => {

--- a/src/components/app/header/MoreActionsContent.tsx
+++ b/src/components/app/header/MoreActionsContent.tsx
@@ -23,6 +23,7 @@ import {
 import { useSyncInternal } from '@/components/app/contexts/SyncInternalContext';
 import MovePagePopover from '@/components/app/view-actions/MovePagePopover';
 import { DropdownMenuGroup, DropdownMenuItem, DropdownMenuSeparator } from '@/components/ui/dropdown-menu';
+import { Progress } from '@/components/ui/progress';
 import { Switch } from '@/components/ui/switch';
 
 const DUPLICATE_PRE_SYNC_TIMEOUT_MS = 8000;
@@ -32,12 +33,16 @@ function MoreActionsContent({
   viewId,
   onOpenHistory,
   onFindAndReplace,
+  canManageActions = true,
+  isLoadingActions = false,
 }: {
   itemClicked?: () => void;
   onDeleted?: () => void;
   viewId: string;
   onOpenHistory?: () => void;
   onFindAndReplace?: () => void;
+  canManageActions?: boolean;
+  isLoadingActions?: boolean;
 }) {
   const { t } = useTranslation();
   const { openDeleteModal, showBlockingLoader, hideBlockingLoader } = useAppOverlayContext();
@@ -133,7 +138,7 @@ function MoreActionsContent({
   return (
     <DropdownMenuGroup>
       <div ref={containerRef} />
-      {isDocument && (
+      {canManageActions && isDocument && (
         <>
           <DropdownMenuItem
             data-testid={'more-page-lock'}
@@ -157,7 +162,13 @@ function MoreActionsContent({
         <DuplicateIcon />
         {t('button.duplicate')}
       </DropdownMenuItem>
-      {container && (
+      {isLoadingActions && (
+        <DropdownMenuItem data-testid='more-actions-permission-loading' disabled>
+          <Progress variant='primary' />
+          {t('loading')}
+        </DropdownMenuItem>
+      )}
+      {canManageActions && container && (
         <MovePagePopover
           viewId={viewId}
           onMoved={itemClicked}
@@ -193,18 +204,20 @@ function MoreActionsContent({
         </DropdownMenuItem>
       )}
 
-      <DropdownMenuItem
-        data-testid='view-action-delete'
-        variant={'destructive'}
-        onSelect={() => {
-          openDeleteModal(viewId);
-        }}
-      >
-        <DeleteIcon />
-        {t('button.delete')}
-      </DropdownMenuItem>
+      {canManageActions && (
+        <DropdownMenuItem
+          data-testid='view-action-delete'
+          variant={'destructive'}
+          onSelect={() => {
+            openDeleteModal(viewId);
+          }}
+        >
+          <DeleteIcon />
+          {t('button.delete')}
+        </DropdownMenuItem>
+      )}
 
-      {isDocument && onOpenHistory && (
+      {canManageActions && isDocument && onOpenHistory && (
         <DropdownMenuItem
           data-testid='more-page-version-history'
           onSelect={(event) => {

--- a/src/components/app/header/MoreActionsContent.tsx
+++ b/src/components/app/header/MoreActionsContent.tsx
@@ -33,6 +33,7 @@ function MoreActionsContent({
   viewId,
   onOpenHistory,
   onFindAndReplace,
+  canDuplicateActions = true,
   canManageActions = true,
   canUsePageHistory = true,
   isLoadingActions = false,
@@ -42,6 +43,7 @@ function MoreActionsContent({
   viewId: string;
   onOpenHistory?: () => void;
   onFindAndReplace?: () => void;
+  canDuplicateActions?: boolean;
   canManageActions?: boolean;
   canUsePageHistory?: boolean;
   isLoadingActions?: boolean;
@@ -156,14 +158,16 @@ function MoreActionsContent({
           <DropdownMenuSeparator />
         </>
       )}
-      <DropdownMenuItem
-        data-testid={'more-page-duplicate'}
-        className={`${layout === ViewLayout.AIChat ? 'hidden' : ''}`}
-        onSelect={handleDuplicateClick}
-      >
-        <DuplicateIcon />
-        {t('button.duplicate')}
-      </DropdownMenuItem>
+      {canDuplicateActions && (
+        <DropdownMenuItem
+          data-testid={'more-page-duplicate'}
+          className={`${layout === ViewLayout.AIChat ? 'hidden' : ''}`}
+          onSelect={handleDuplicateClick}
+        >
+          <DuplicateIcon />
+          {t('button.duplicate')}
+        </DropdownMenuItem>
+      )}
       {isLoadingActions && (
         <DropdownMenuItem data-testid='more-actions-permission-loading' disabled>
           <Progress variant='primary' />

--- a/src/components/app/hooks/usePageOperations.ts
+++ b/src/components/app/hooks/usePageOperations.ts
@@ -5,16 +5,14 @@ import { BillingService, FileService, PageService, PublishService, ViewService }
 import { deleteView as clearViewCache } from '@/application/services/js-services/cache';
 import { clearPublishViewInfoCache } from '@/application/services/js-services/cached-api';
 import { gatherDatabasePublishData } from '@/application/services/js-services/publish-database-data';
-import {
-  publishCollabs,
-  PublishCollabMetadata,
-} from '@/application/services/js-services/http/publish-api';
+import { publishCollabs, PublishCollabMetadata } from '@/application/services/js-services/http/publish-api';
 import {
   CreateDatabaseViewPayload,
   CreateOrphanedViewPayload,
   DuplicatePageOperationOptions,
   CreatePagePayload,
   CreateSpacePayload,
+  CreateSpaceWithInitialPagePayload,
   Role,
   UpdatePagePayload,
   UpdateSpacePayload,
@@ -293,6 +291,24 @@ export function usePageOperations({
     [currentWorkspaceId, loadOutline]
   );
 
+  const createSpaceWithInitialPage = useCallback(
+    async (payload: CreateSpaceWithInitialPagePayload) => {
+      if (!currentWorkspaceId) {
+        throw new Error('No workspace or service found');
+      }
+
+      try {
+        const res = await PageService.createSpaceWithInitialPage(currentWorkspaceId, payload);
+
+        void loadOutline?.(currentWorkspaceId, false);
+        return res;
+      } catch (e) {
+        return Promise.reject(e);
+      }
+    },
+    [currentWorkspaceId, loadOutline]
+  );
+
   // Update space
   const updateSpace = useCallback(
     async (payload: UpdateSpacePayload) => {
@@ -370,9 +386,7 @@ export function usePageOperations({
       if (!currentWorkspaceId) return;
       const viewId = view.view_id;
       const isDatabaseLayout =
-        view.layout === ViewLayout.Grid ||
-        view.layout === ViewLayout.Board ||
-        view.layout === ViewLayout.Calendar;
+        view.layout === ViewLayout.Grid || view.layout === ViewLayout.Board || view.layout === ViewLayout.Calendar;
 
       if (isDatabaseLayout) {
         // Database views: gather data client-side and send via binary publish endpoint
@@ -383,7 +397,12 @@ export function usePageOperations({
         // reconnecting).
         void flushAllSync?.();
 
-        const slug = view.name.replace(/[^a-zA-Z0-9-]/g, '-').replace(/-+/g, '-').replace(/^-|-$/g, '').slice(0, 40) || 'untitled';
+        const slug =
+          view.name
+            .replace(/[^a-zA-Z0-9-]/g, '-')
+            .replace(/-+/g, '-')
+            .replace(/^-|-$/g, '')
+            .slice(0, 40) || 'untitled';
 
         const name = publishName || `${slug}-${viewId.slice(0, 8)}`;
 
@@ -397,7 +416,7 @@ export function usePageOperations({
           const parentView = findParentView(outlineRef.current, viewId);
 
           if (parentView?.extra?.is_database_container && parentView.children?.length > 0) {
-            resolvedVisibleViewIds = parentView.children.map(c => c.view_id);
+            resolvedVisibleViewIds = parentView.children.map((c) => c.view_id);
           }
         }
 
@@ -486,6 +505,7 @@ export function usePageOperations({
     deleteTrash,
     restorePage,
     createSpace,
+    createSpaceWithInitialPage,
     updateSpace,
     createDatabaseView,
     uploadFile,

--- a/src/components/app/layers/AppBusinessLayer.tsx
+++ b/src/components/app/layers/AppBusinessLayer.tsx
@@ -11,7 +11,10 @@ import { AppOperationsContext, AppOperationsContextType } from '@/components/app
 import { AppOutlineContext, AppOutlineContextType } from '@/components/app/contexts/AppOutlineContext';
 import { AppSyncContext, AppSyncContextType } from '@/components/app/contexts/AppSyncContext';
 import { useSyncInternal } from '@/components/app/contexts/SyncInternalContext';
-import { DATABASE_TAB_VIEW_ID_QUERY_PARAM, resolveSidebarSelectedViewId } from '@/components/app/hooks/resolveSidebarSelectedViewId';
+import {
+  DATABASE_TAB_VIEW_ID_QUERY_PARAM,
+  resolveSidebarSelectedViewId,
+} from '@/components/app/hooks/resolveSidebarSelectedViewId';
 
 import { AppContextConsumer } from '../components/AppContextConsumer';
 import { useAuthInternal } from '../contexts/AuthInternalContext';
@@ -148,9 +151,23 @@ export const AppBusinessLayer: FC<AppBusinessLayerProps> = ({ children }) => {
 
   // Initialize page operations
   const {
-    addPage, deletePage: rawDeletePage, duplicatePage, updatePage, updatePageIcon, updatePageName,
-    movePage, deleteTrash, restorePage, createSpace, updateSpace,
-    createDatabaseView, uploadFile, getSubscriptions, publish, unpublish,
+    addPage,
+    deletePage: rawDeletePage,
+    duplicatePage,
+    updatePage,
+    updatePageIcon,
+    updatePageName,
+    movePage,
+    deleteTrash,
+    restorePage,
+    createSpace,
+    createSpaceWithInitialPage,
+    updateSpace,
+    createDatabaseView,
+    uploadFile,
+    getSubscriptions,
+    publish,
+    unpublish,
     createOrphanedView,
   } = usePageOperations({
     outlineRef: stableOutlineRef,
@@ -224,9 +241,7 @@ export const AppBusinessLayer: FC<AppBusinessLayerProps> = ({ children }) => {
 
     const cacheKey = `${currentWorkspaceId}:${viewId}`;
     const cached = routeViewExistsCacheRef.current.get(cacheKey);
-    const cacheExpired = cached
-      ? Date.now() - cached.checkedAt >= ROUTE_VIEW_EXISTS_REVALIDATE_MS
-      : true;
+    const cacheExpired = cached ? Date.now() - cached.checkedAt >= ROUTE_VIEW_EXISTS_REVALIDATE_MS : true;
 
     // Cache policy: both true and false are periodically revalidated.
     // A false entry may be stale if the view was created or synced after
@@ -463,9 +478,14 @@ export const AppBusinessLayer: FC<AppBusinessLayerProps> = ({ children }) => {
 
   // Initialize database operations
   const {
-    generateAISummaryForRow, generateAITranslateForRow,
-    loadDatabasePrompts, testDatabasePromptConfig,
-    checkIfRowDocumentExists, loadRowDocument, createRowDocument, duplicateRowDocument,
+    generateAISummaryForRow,
+    generateAITranslateForRow,
+    loadDatabasePrompts,
+    testDatabasePromptConfig,
+    checkIfRowDocumentExists,
+    loadRowDocument,
+    createRowDocument,
+    duplicateRowDocument,
   } = useDatabaseOperations(enhancedLoadView, createRow, syncContext.syncAllToServer);
 
   // ── Focused context values ──────────────────────────────────────────────────
@@ -484,7 +504,17 @@ export const AppBusinessLayer: FC<AppBusinessLayerProps> = ({ children }) => {
       openPageModalViewId: openModalViewId,
       openPageModal,
     }),
-    [viewId, breadcrumbs, appendBreadcrumb, rendered, onRendered, viewNotFound, viewHasBeenDeleted, openModalViewId, openPageModal]
+    [
+      viewId,
+      breadcrumbs,
+      appendBreadcrumb,
+      rendered,
+      onRendered,
+      viewNotFound,
+      viewHasBeenDeleted,
+      openModalViewId,
+      openPageModal,
+    ]
   );
 
   // Outline state — MEDIUM change frequency (outline, favorites, recent, trash)
@@ -510,10 +540,24 @@ export const AppBusinessLayer: FC<AppBusinessLayerProps> = ({ children }) => {
       loadMentionableUsers,
     }),
     [
-      outline, favoriteViews, recentViews, trashList, loadedViewIds,
-      loadViewChildren, loadViewChildrenBatch, markViewChildrenStale, ensureViewVisibleInOutline, revalidateSidebarOutline,
-      loadFavoriteViews, loadRecentViews, loadTrash, loadViews,
-      refreshOutline, loadDatabaseRelations, getMentionUser, loadMentionableUsers,
+      outline,
+      favoriteViews,
+      recentViews,
+      trashList,
+      loadedViewIds,
+      loadViewChildren,
+      loadViewChildrenBatch,
+      markViewChildrenStale,
+      ensureViewVisibleInOutline,
+      revalidateSidebarOutline,
+      loadFavoriteViews,
+      loadRecentViews,
+      loadTrash,
+      loadViews,
+      refreshOutline,
+      loadDatabaseRelations,
+      getMentionUser,
+      loadMentionableUsers,
     ]
   );
 
@@ -535,6 +579,7 @@ export const AppBusinessLayer: FC<AppBusinessLayerProps> = ({ children }) => {
       deleteTrash,
       restorePage,
       createSpace,
+      createSpaceWithInitialPage,
       updateSpace,
       createDatabaseView,
       uploadFile,
@@ -560,16 +605,44 @@ export const AppBusinessLayer: FC<AppBusinessLayerProps> = ({ children }) => {
       onChangeWorkspace: authContext.onChangeWorkspace,
     }),
     [
-      enhancedToView, loadViewMeta, enhancedLoadView, createRow, bindViewSync,
-      addPage, enhancedDeletePage, duplicatePage, updatePage, updatePageIcon, updatePageName,
-      movePage, deleteTrash, restorePage, createSpace, updateSpace,
-      createDatabaseView, uploadFile, getSubscriptions, publish, unpublish, createOrphanedView,
-      generateAISummaryForRow, generateAITranslateForRow,
-      loadDatabasePrompts, testDatabasePromptConfig,
+      enhancedToView,
+      loadViewMeta,
+      enhancedLoadView,
+      createRow,
+      bindViewSync,
+      addPage,
+      enhancedDeletePage,
+      duplicatePage,
+      updatePage,
+      updatePageIcon,
+      updatePageName,
+      movePage,
+      deleteTrash,
+      restorePage,
+      createSpace,
+      createSpaceWithInitialPage,
+      updateSpace,
+      createDatabaseView,
+      uploadFile,
+      getSubscriptions,
+      publish,
+      unpublish,
+      createOrphanedView,
+      generateAISummaryForRow,
+      generateAITranslateForRow,
+      loadDatabasePrompts,
+      testDatabasePromptConfig,
       openPageModal,
-      checkIfRowDocumentExists, loadRowDocument, createRowDocument, duplicateRowDocument,
-      getViewIdFromDatabaseId, getWordCount, setWordCount,
-      getCollabHistory, previewCollabVersion, revertCollabVersion,
+      checkIfRowDocumentExists,
+      loadRowDocument,
+      createRowDocument,
+      duplicateRowDocument,
+      getViewIdFromDatabaseId,
+      getWordCount,
+      setWordCount,
+      getCollabHistory,
+      previewCollabVersion,
+      revertCollabVersion,
       authContext.onChangeWorkspace,
     ]
   );

--- a/src/components/app/share/AccessLevelDropdown.tsx
+++ b/src/components/app/share/AccessLevelDropdown.tsx
@@ -92,7 +92,7 @@ export function AccessLevelDropdown({
     );
   }, [loading, isYou, handleRemoveAccess, t]);
 
-  if (person.access_level === AccessLevel.FullAccess && !canModify) {
+  if (!canModify) {
     return (
       <div className='mr-2 flex min-w-fit items-center justify-center whitespace-nowrap px-3 py-1.5 text-sm text-text-secondary'>
         {getAccessLevelText(person.access_level)}

--- a/src/components/app/share/AccessLevelDropdown.tsx
+++ b/src/components/app/share/AccessLevelDropdown.tsx
@@ -23,6 +23,7 @@ interface AccessLevelDropdownProps {
   person: IPeopleWithAccessType;
   canModify: boolean;
   currentUserHasFullAccess: boolean;
+  currentUserCanGrantFullAccess?: boolean;
   isYou: boolean;
   onAccessLevelChange: (email: string, accessLevel: AccessLevel) => Promise<void>;
   onRemoveAccess: (email: string) => Promise<void>;
@@ -32,6 +33,7 @@ export function AccessLevelDropdown({
   person,
   canModify,
   currentUserHasFullAccess,
+  currentUserCanGrantFullAccess = false,
   isYou,
   onAccessLevelChange,
   onRemoveAccess,
@@ -162,32 +164,34 @@ export function AccessLevelDropdown({
                 {!loading && person.access_level === AccessLevel.ReadAndWrite && <DropdownMenuItemTick />}
                 {loading === 'edit' && <Progress variant='primary' />}
               </DropdownMenuItem>
-              <DropdownMenuItem
-                disabled={loading === 'full'}
-                onSelect={async (e) => {
-                  e.preventDefault();
-                  setLoading('full');
-                  try {
-                    await onAccessLevelChange(person.email, AccessLevel.FullAccess);
-                    setOpen(false);
-                    notify.success(t('shareAction.changeAccessSuccess', { email: person.email }));
-                  } catch (error) {
-                    notify.error(t('shareAction.changeAccessError'));
-                  } finally {
-                    setLoading(null);
-                  }
-                }}
-              >
-                <div className='flex items-center gap-2'>
-                  <CrownIcon />
-                  <div className='flex flex-col'>
-                    <div className='text-sm text-text-primary'>{t('shareAction.fullAccess')}</div>
-                    <div className='text-xs text-text-tertiary'>{t('shareAction.fullAccessDescription')}</div>
+              {currentUserCanGrantFullAccess && (
+                <DropdownMenuItem
+                  disabled={loading === 'full'}
+                  onSelect={async (e) => {
+                    e.preventDefault();
+                    setLoading('full');
+                    try {
+                      await onAccessLevelChange(person.email, AccessLevel.FullAccess);
+                      setOpen(false);
+                      notify.success(t('shareAction.changeAccessSuccess', { email: person.email }));
+                    } catch (error) {
+                      notify.error(t('shareAction.changeAccessError'));
+                    } finally {
+                      setLoading(null);
+                    }
+                  }}
+                >
+                  <div className='flex items-center gap-2'>
+                    <CrownIcon />
+                    <div className='flex flex-col'>
+                      <div className='text-sm text-text-primary'>{t('shareAction.fullAccess')}</div>
+                      <div className='text-xs text-text-tertiary'>{t('shareAction.fullAccessDescription')}</div>
+                    </div>
                   </div>
-                </div>
-                {!loading && person.access_level === AccessLevel.FullAccess && <DropdownMenuItemTick />}
-                {loading === 'full' && <Progress variant='primary' />}
-              </DropdownMenuItem>
+                  {!loading && person.access_level === AccessLevel.FullAccess && <DropdownMenuItemTick />}
+                  {loading === 'full' && <Progress variant='primary' />}
+                </DropdownMenuItem>
+              )}
               <DropdownMenuSeparator />
               {renderRemoveAccess()}
             </>

--- a/src/components/app/share/InviteGuest.tsx
+++ b/src/components/app/share/InviteGuest.tsx
@@ -50,6 +50,7 @@ interface InviteGuestProps {
   onInviteSuccess: () => Promise<void>;
   viewId: string;
   hasFullAccess: boolean;
+  canGrantFullAccess: boolean;
 }
 
 export function InviteGuest({
@@ -61,6 +62,7 @@ export function InviteGuest({
   onInviteSuccess,
   viewId,
   hasFullAccess,
+  canGrantFullAccess,
 }: InviteGuestProps) {
   const { t } = useTranslation();
   const [searchValue, setSearchValue] = useState<string>('');
@@ -81,6 +83,12 @@ export function InviteGuest({
   const [upgradeLoading, setUpgradeLoading] = useState(false);
   const userWorkspaceInfo = useUserWorkspaceInfo();
   const isOwner = userWorkspaceInfo?.selectedWorkspace?.role === Role.Owner;
+
+  useEffect(() => {
+    if (!canGrantFullAccess && selectedAccessLevel === AccessLevel.FullAccess) {
+      setSelectedAccessLevel(AccessLevel.ReadOnly);
+    }
+  }, [canGrantFullAccess, selectedAccessLevel]);
 
   // Email suggestions based on search input
   const emailSuggestions = useMemo(() => {
@@ -380,24 +388,34 @@ export function InviteGuest({
             </div>
             {selectedAccessLevel === AccessLevel.ReadAndWrite && <DropdownMenuItemTick />}
           </div>
-          <div
-            onMouseDown={(e) => e.preventDefault()}
-            className={cn(dropdownMenuItemVariants({ variant: 'default' }))}
-            onClick={() => handleAccessLevelSelect(AccessLevel.FullAccess)}
-          >
-            <div className='flex items-center gap-2'>
-              <CrownIcon className='h-4 w-4' />
-              <div className='flex flex-col'>
-                <div className='text-sm text-text-primary'>{t('shareAction.fullAccess')}</div>
-                <div className='text-xs text-text-tertiary'>{t('shareAction.fullAccessDescription')}</div>
+          {canGrantFullAccess && (
+            <div
+              onMouseDown={(e) => e.preventDefault()}
+              className={cn(dropdownMenuItemVariants({ variant: 'default' }))}
+              onClick={() => handleAccessLevelSelect(AccessLevel.FullAccess)}
+            >
+              <div className='flex items-center gap-2'>
+                <CrownIcon className='h-4 w-4' />
+                <div className='flex flex-col'>
+                  <div className='text-sm text-text-primary'>{t('shareAction.fullAccess')}</div>
+                  <div className='text-xs text-text-tertiary'>{t('shareAction.fullAccessDescription')}</div>
+                </div>
               </div>
+              {selectedAccessLevel === AccessLevel.FullAccess && <DropdownMenuItemTick />}
             </div>
-            {selectedAccessLevel === AccessLevel.FullAccess && <DropdownMenuItemTick />}
-          </div>
+          )}
         </PopoverContent>
       </Popover>
     );
-  }, [emailTags.length, accessLevelPopoverOpen, getAccessLevelText, selectedAccessLevel, t, handleAccessLevelSelect]);
+  }, [
+    emailTags.length,
+    accessLevelPopoverOpen,
+    getAccessLevelText,
+    selectedAccessLevel,
+    t,
+    canGrantFullAccess,
+    handleAccessLevelSelect,
+  ]);
 
   const handleUpgrade = useCallback(async () => {
     if (!currentWorkspaceId) return;

--- a/src/components/app/share/InviteGuest.tsx
+++ b/src/components/app/share/InviteGuest.tsx
@@ -84,11 +84,10 @@ export function InviteGuest({
   const userWorkspaceInfo = useUserWorkspaceInfo();
   const isOwner = userWorkspaceInfo?.selectedWorkspace?.role === Role.Owner;
 
-  useEffect(() => {
-    if (!canGrantFullAccess && selectedAccessLevel === AccessLevel.FullAccess) {
-      setSelectedAccessLevel(AccessLevel.ReadOnly);
-    }
-  }, [canGrantFullAccess, selectedAccessLevel]);
+  // Clamp during render: a selection made before permissions resolved must
+  // never let a user submit a level they cannot grant.
+  const effectiveAccessLevel =
+    !canGrantFullAccess && selectedAccessLevel === AccessLevel.FullAccess ? AccessLevel.ReadOnly : selectedAccessLevel;
 
   // Email suggestions based on search input
   const emailSuggestions = useMemo(() => {
@@ -348,7 +347,7 @@ export function InviteGuest({
             size='sm'
             className='relative top-[-0.5px] h-6 px-2'
           >
-            {getAccessLevelText(selectedAccessLevel)}
+            {getAccessLevelText(effectiveAccessLevel)}
             <ArrowDownIcon className='h-3 w-3 text-icon-secondary' />
           </Button>
         </PopoverTrigger>
@@ -372,7 +371,7 @@ export function InviteGuest({
                 <div className='text-xs text-text-tertiary'>{t('shareAction.canViewDescription')}</div>
               </div>
             </div>
-            {selectedAccessLevel === AccessLevel.ReadOnly && <DropdownMenuItemTick />}
+            {effectiveAccessLevel === AccessLevel.ReadOnly && <DropdownMenuItemTick />}
           </div>
           <div
             onMouseDown={(e) => e.preventDefault()}
@@ -386,7 +385,7 @@ export function InviteGuest({
                 <div className='text-xs text-text-tertiary'>{t('shareAction.canEditDescription')}</div>
               </div>
             </div>
-            {selectedAccessLevel === AccessLevel.ReadAndWrite && <DropdownMenuItemTick />}
+            {effectiveAccessLevel === AccessLevel.ReadAndWrite && <DropdownMenuItemTick />}
           </div>
           {canGrantFullAccess && (
             <div
@@ -401,7 +400,7 @@ export function InviteGuest({
                   <div className='text-xs text-text-tertiary'>{t('shareAction.fullAccessDescription')}</div>
                 </div>
               </div>
-              {selectedAccessLevel === AccessLevel.FullAccess && <DropdownMenuItemTick />}
+              {effectiveAccessLevel === AccessLevel.FullAccess && <DropdownMenuItemTick />}
             </div>
           )}
         </PopoverContent>
@@ -411,7 +410,7 @@ export function InviteGuest({
     emailTags.length,
     accessLevelPopoverOpen,
     getAccessLevelText,
-    selectedAccessLevel,
+    effectiveAccessLevel,
     t,
     canGrantFullAccess,
     handleAccessLevelSelect,
@@ -459,7 +458,7 @@ export function InviteGuest({
         currentWorkspaceId,
         viewId,
         emailTags.map((tag) => tag.email),
-        selectedAccessLevel
+        effectiveAccessLevel
       );
       notify.success(t('shareAction.inviteSuccess'));
       // eslint-disable-next-line
@@ -488,7 +487,7 @@ export function InviteGuest({
 
     // Notify parent component to refresh the people list
     await onInviteSuccess();
-  }, [currentWorkspaceId, emailTags, onInviteSuccess, viewId, t, selectedAccessLevel]);
+  }, [currentWorkspaceId, emailTags, onInviteSuccess, viewId, t, effectiveAccessLevel]);
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent) => {

--- a/src/components/app/share/PeopleWithAccess.tsx
+++ b/src/components/app/share/PeopleWithAccess.tsx
@@ -18,9 +18,17 @@ interface PeopleWithAccessProps {
   isLoading: boolean;
   onPeopleChange: () => Promise<void>;
   hasFullAccess: boolean;
+  canGrantFullAccess: boolean;
 }
 
-export function PeopleWithAccess({ viewId, people, onPeopleChange, isLoading, hasFullAccess }: PeopleWithAccessProps) {
+export function PeopleWithAccess({
+  viewId,
+  people,
+  onPeopleChange,
+  isLoading,
+  hasFullAccess,
+  canGrantFullAccess,
+}: PeopleWithAccessProps) {
   const { t } = useTranslation();
   const currentUser = useCurrentUser();
 
@@ -93,7 +101,8 @@ export function PeopleWithAccess({ viewId, people, onPeopleChange, isLoading, ha
   );
 
   // Check if current user is owner
-  const currentUserIsOwner = people.find((p) => p.email === currentUser?.email)?.role === Role.Owner;
+  const currentUserIsOwner =
+    canGrantFullAccess || people.find((p) => p.email === currentUser?.email)?.role === Role.Owner;
 
   return (
     <div className='w-full px-2 pt-4'>
@@ -112,6 +121,7 @@ export function PeopleWithAccess({ viewId, people, onPeopleChange, isLoading, ha
               isYou={isYou}
               currentUserHasFullAccess={hasFullAccess}
               currentUserIsOwner={currentUserIsOwner}
+              currentUserCanGrantFullAccess={currentUserIsOwner}
               onAccessLevelChange={handleAccessLevelChange}
               onRemoveAccess={handleRemoveAccess}
               onTurnIntoMember={handleTurnIntoMember}

--- a/src/components/app/share/PeopleWithAccess.tsx
+++ b/src/components/app/share/PeopleWithAccess.tsx
@@ -100,9 +100,8 @@ export function PeopleWithAccess({
     [onPeopleChange, currentWorkspaceId]
   );
 
-  // Check if current user is owner
-  const currentUserIsOwner =
-    canGrantFullAccess || people.find((p) => p.email === currentUser?.email)?.role === Role.Owner;
+  const currentUserRole = people.find((p) => p.email === currentUser?.email)?.role;
+  const currentUserIsOwner = currentUserRole === Role.Owner;
 
   return (
     <div className='w-full px-2 pt-4'>
@@ -121,7 +120,7 @@ export function PeopleWithAccess({
               isYou={isYou}
               currentUserHasFullAccess={hasFullAccess}
               currentUserIsOwner={currentUserIsOwner}
-              currentUserCanGrantFullAccess={currentUserIsOwner}
+              currentUserCanGrantFullAccess={canGrantFullAccess}
               onAccessLevelChange={handleAccessLevelChange}
               onRemoveAccess={handleRemoveAccess}
               onTurnIntoMember={handleTurnIntoMember}

--- a/src/components/app/share/PersonItem.tsx
+++ b/src/components/app/share/PersonItem.tsx
@@ -34,7 +34,7 @@ export function PersonItem({
   onTurnIntoMember,
 }: PersonItemProps) {
   const { t } = useTranslation();
-  const canModifyThisPerson = currentUserHasFullAccess || isYou;
+  const canModifyThisPerson = currentUserHasFullAccess && !isYou && person.role !== Role.Owner;
 
   const [turnIntoMemberLoading, setTurnIntoMemberLoading] = useState<boolean>(false);
   // Show "Turn into Member" button if:

--- a/src/components/app/share/PersonItem.tsx
+++ b/src/components/app/share/PersonItem.tsx
@@ -17,6 +17,7 @@ interface PersonItemProps {
   isYou: boolean;
   currentUserHasFullAccess: boolean;
   currentUserIsOwner: boolean;
+  currentUserCanGrantFullAccess: boolean;
   onAccessLevelChange: (email: string, accessLevel: AccessLevel) => Promise<void>;
   onRemoveAccess: (email: string) => Promise<void>;
   onTurnIntoMember?: (email: string) => Promise<void>;
@@ -27,6 +28,7 @@ export function PersonItem({
   isYou,
   currentUserHasFullAccess,
   currentUserIsOwner,
+  currentUserCanGrantFullAccess,
   onAccessLevelChange,
   onRemoveAccess,
   onTurnIntoMember,
@@ -116,6 +118,7 @@ export function PersonItem({
         person={person}
         canModify={canModifyThisPerson}
         currentUserHasFullAccess={currentUserHasFullAccess}
+        currentUserCanGrantFullAccess={currentUserCanGrantFullAccess}
         isYou={isYou}
         onAccessLevelChange={onAccessLevelChange}
         onRemoveAccess={onRemoveAccess}

--- a/src/components/app/share/SharePanel.tsx
+++ b/src/components/app/share/SharePanel.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 
-import { IPeopleWithAccessType, MentionablePerson, Role, SubscriptionPlan } from '@/application/types';
+import { AccessLevel, IPeopleWithAccessType, MentionablePerson, Role, SubscriptionPlan } from '@/application/types';
 import { notify } from '@/components/_shared/notify';
 import { useLoadMentionableUsers, useGetSubscriptions, useUserWorkspaceInfo } from '@/components/app/app.hooks';
 import { CopyLink } from '@/components/app/share/CopyLink';
@@ -17,6 +17,7 @@ function SharePanel({
   isLoadingPeople,
   onPeopleChange,
   hasFullAccess,
+  currentUserAccessLevel,
   sectionType,
 }: {
   viewId: string;
@@ -24,6 +25,7 @@ function SharePanel({
   isLoadingPeople: boolean;
   onPeopleChange: () => Promise<void>;
   hasFullAccess: boolean;
+  currentUserAccessLevel?: AccessLevel;
   sectionType: ShareSectionType;
 }) {
   const userWorkspaceInfo = useUserWorkspaceInfo();
@@ -35,10 +37,11 @@ function SharePanel({
   const [mentionableError, setMentionableError] = useState<string | null>(null);
   const isOwner = role === Role.Owner;
   const isMember = role === Role.Member;
+  const showInviteControls = currentUserAccessLevel !== undefined && currentUserAccessLevel !== AccessLevel.ReadOnly;
 
   // Load mentionable users
   const loadMentionableData = useCallback(async () => {
-    if (!loadMentionableUsers) return;
+    if (!showInviteControls || !loadMentionableUsers) return;
 
     setIsLoadingMentionable(true);
     setMentionableError(null);
@@ -55,12 +58,14 @@ function SharePanel({
     } finally {
       setIsLoadingMentionable(false);
     }
-  }, [loadMentionableUsers]);
+  }, [loadMentionableUsers, showInviteControls]);
 
   // Load mentionable data on component mount
   useEffect(() => {
+    if (!showInviteControls) return;
+
     void loadMentionableData();
-  }, [loadMentionableData]);
+  }, [loadMentionableData, showInviteControls]);
 
   // Refresh people list after invite or other changes
   const refreshPeople = useCallback(async () => {
@@ -96,7 +101,7 @@ function SharePanel({
   }, [getSubscriptions]);
 
   useEffect(() => {
-    if (!isHosted) {
+    if (!showInviteControls || !isHosted) {
       setActiveSubscriptionPlan(null);
       return;
     }
@@ -104,30 +109,34 @@ function SharePanel({
     if (isOwner || isMember) {
       void loadSubscription();
     }
-  }, [isHosted, isMember, isOwner, loadSubscription]);
+  }, [isHosted, isMember, isOwner, loadSubscription, showInviteControls]);
 
   return (
     <div className='flex flex-col items-start gap-1 self-stretch py-4'>
       <div className='flex flex-col items-start self-stretch px-2'>
-        <InviteGuest
-          viewId={viewId}
-          sharedPeople={people}
-          isLoadingPeople={isLoadingPeople}
-          mentionable={mentionable}
-          isLoadingMentionable={isLoadingMentionable}
-          mentionableError={mentionableError}
-          onInviteSuccess={refreshPeople}
-          hasFullAccess={hasFullAccess}
-          canGrantFullAccess={isOwner}
-        />
-        {isHosted && <UpgradeBanner activeSubscriptionPlan={activeSubscriptionPlan} />}
+        {showInviteControls && (
+          <>
+            <InviteGuest
+              viewId={viewId}
+              sharedPeople={people}
+              isLoadingPeople={isLoadingPeople}
+              mentionable={mentionable}
+              isLoadingMentionable={isLoadingMentionable}
+              mentionableError={mentionableError}
+              onInviteSuccess={refreshPeople}
+              hasFullAccess={hasFullAccess}
+              canGrantFullAccess={hasFullAccess}
+            />
+            {isHosted && <UpgradeBanner activeSubscriptionPlan={activeSubscriptionPlan} />}
+          </>
+        )}
         <PeopleWithAccess
           viewId={viewId}
           people={people}
           isLoading={isLoadingPeople}
           onPeopleChange={refreshPeople}
           hasFullAccess={hasFullAccess}
-          canGrantFullAccess={isOwner}
+          canGrantFullAccess={hasFullAccess}
         />
         <GeneralAccess sectionType={sectionType} />
         <CopyLink />

--- a/src/components/app/share/SharePanel.tsx
+++ b/src/components/app/share/SharePanel.tsx
@@ -118,6 +118,7 @@ function SharePanel({
           mentionableError={mentionableError}
           onInviteSuccess={refreshPeople}
           hasFullAccess={hasFullAccess}
+          canGrantFullAccess={isOwner}
         />
         {isHosted && <UpgradeBanner activeSubscriptionPlan={activeSubscriptionPlan} />}
         <PeopleWithAccess
@@ -126,6 +127,7 @@ function SharePanel({
           isLoading={isLoadingPeople}
           onPeopleChange={refreshPeople}
           hasFullAccess={hasFullAccess}
+          canGrantFullAccess={isOwner}
         />
         <GeneralAccess sectionType={sectionType} />
         <CopyLink />

--- a/src/components/app/share/ShareTabs.tsx
+++ b/src/components/app/share/ShareTabs.tsx
@@ -111,6 +111,7 @@ function ShareTabs({
                 isLoadingPeople={isLoadingPeople}
                 onPeopleChange={loadPeople}
                 hasFullAccess={hasFullAccess}
+                currentUserAccessLevel={currentUserAccessLevel}
                 sectionType={sectionType}
               />
             ) : option.value === TabKey.PUBLISH ? (

--- a/src/components/app/share/__tests__/AccessLevelDropdown.test.tsx
+++ b/src/components/app/share/__tests__/AccessLevelDropdown.test.tsx
@@ -78,6 +78,7 @@ function renderAccessLevelDropdown(overrides: Partial<ComponentProps<typeof Acce
   const props: ComponentProps<typeof AccessLevelDropdown> = {
     canModify: true,
     currentUserHasFullAccess: true,
+    currentUserCanGrantFullAccess: false,
     isYou: false,
     onAccessLevelChange: async () => undefined,
     onRemoveAccess: async () => undefined,
@@ -89,7 +90,7 @@ function renderAccessLevelDropdown(overrides: Partial<ComponentProps<typeof Acce
 }
 
 describe('AccessLevelDropdown', () => {
-  it('keeps full-access collaborators editable for users who can modify access', () => {
+  it('lets non-owner full-access users downgrade or remove access without granting full access', () => {
     renderAccessLevelDropdown();
 
     const trigger = screen.getByRole('button', { name: 'Full access' });
@@ -97,8 +98,20 @@ describe('AccessLevelDropdown', () => {
     expect(trigger.disabled).toBe(false);
     expect(screen.getByText('Can view')).toBeTruthy();
     expect(screen.getByText('Can edit')).toBeTruthy();
-    expect(screen.getAllByText('Full access')).toHaveLength(2);
+    expect(screen.getAllByText('Full access')).toHaveLength(1);
+    expect(screen.queryByText('Can edit and share with others')).toBeNull();
     expect(screen.getByText('Remove access')).toBeTruthy();
+  });
+
+  it('shows full-access grants for workspace owners', () => {
+    renderAccessLevelDropdown({
+      currentUserCanGrantFullAccess: true,
+      person: createPerson({ access_level: AccessLevel.ReadAndWrite }),
+    });
+
+    expect(screen.getByRole('button', { name: 'Can edit' }).disabled).toBe(false);
+    expect(screen.getByText('Full access')).toBeTruthy();
+    expect(screen.getByText('Can edit and share with others')).toBeTruthy();
   });
 
   it('keeps non-modifiable full-access rows as static labels', () => {

--- a/src/components/app/share/__tests__/AccessLevelDropdown.test.tsx
+++ b/src/components/app/share/__tests__/AccessLevelDropdown.test.tsx
@@ -90,16 +90,18 @@ function renderAccessLevelDropdown(overrides: Partial<ComponentProps<typeof Acce
 }
 
 describe('AccessLevelDropdown', () => {
-  it('lets non-owner full-access users downgrade or remove access without granting full access', () => {
-    renderAccessLevelDropdown();
+  it('lets full-access users change, remove, or grant full access when allowed', () => {
+    renderAccessLevelDropdown({
+      currentUserCanGrantFullAccess: true,
+    });
 
     const trigger = screen.getByRole('button', { name: 'Full access' });
 
     expect(trigger.disabled).toBe(false);
     expect(screen.getByText('Can view')).toBeTruthy();
     expect(screen.getByText('Can edit')).toBeTruthy();
-    expect(screen.getAllByText('Full access')).toHaveLength(1);
-    expect(screen.queryByText('Can edit and share with others')).toBeNull();
+    expect(screen.getAllByText('Full access')).toHaveLength(2);
+    expect(screen.getByText('Can edit and share with others')).toBeTruthy();
     expect(screen.getByText('Remove access')).toBeTruthy();
   });
 
@@ -122,6 +124,18 @@ describe('AccessLevelDropdown', () => {
 
     expect(screen.queryByRole('button', { name: 'Full access' })).toBeNull();
     expect(screen.getByText('Full access')).toBeTruthy();
+    expect(screen.queryByText('Remove access')).toBeNull();
+  });
+
+  it('keeps non-modifiable read-only rows as static labels', () => {
+    renderAccessLevelDropdown({
+      canModify: false,
+      currentUserHasFullAccess: false,
+      person: createPerson({ access_level: AccessLevel.ReadOnly }),
+    });
+
+    expect(screen.queryByRole('button', { name: 'Can view' })).toBeNull();
+    expect(screen.getByText('Can view')).toBeTruthy();
     expect(screen.queryByText('Remove access')).toBeNull();
   });
 });

--- a/src/components/app/share/__tests__/PersonItem.test.tsx
+++ b/src/components/app/share/__tests__/PersonItem.test.tsx
@@ -1,0 +1,136 @@
+import { describe, expect, it, jest } from '@jest/globals';
+import { render, screen } from '@testing-library/react';
+
+import { AccessLevel, IPeopleWithAccessType, Role } from '@/application/types';
+
+import { PersonItem } from '../PersonItem';
+
+import type { ComponentProps, ReactNode } from 'react';
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+jest.mock('@/components/_shared/notify', () => ({
+  notify: {
+    error: jest.fn(),
+    success: jest.fn(),
+  },
+}));
+
+jest.mock('@/components/ui/tooltip', () => ({
+  Tooltip: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  TooltipContent: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  TooltipTrigger: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+
+jest.mock('../AccessLevelDropdown', () => ({
+  AccessLevelDropdown: ({
+    person,
+    canModify,
+    currentUserCanGrantFullAccess,
+  }: {
+    person: IPeopleWithAccessType;
+    canModify: boolean;
+    currentUserCanGrantFullAccess: boolean;
+  }) => (
+    <div
+      data-testid={`access-level-${person.email}`}
+      data-can-grant-full-access={String(currentUserCanGrantFullAccess)}
+      data-can-modify={String(canModify)}
+    >
+      {person.access_level}
+    </div>
+  ),
+}));
+
+const createPerson = (overrides: Partial<IPeopleWithAccessType> = {}): IPeopleWithAccessType => ({
+  access_level: AccessLevel.FullAccess,
+  avatar_url: '',
+  email: 'owner@appflowy.local',
+  name: 'Owner',
+  pending_invitation: false,
+  role: Role.Owner,
+  ...overrides,
+});
+
+function renderPersonItem(overrides: Partial<ComponentProps<typeof PersonItem>> = {}) {
+  const props: ComponentProps<typeof PersonItem> = {
+    currentUserCanGrantFullAccess: true,
+    currentUserHasFullAccess: true,
+    currentUserIsOwner: false,
+    isYou: false,
+    onAccessLevelChange: async () => undefined,
+    onRemoveAccess: async () => undefined,
+    person: createPerson(),
+    ...overrides,
+  };
+
+  return render(<PersonItem {...props} />);
+}
+
+describe('PersonItem', () => {
+  it('keeps workspace owner rows non-modifiable for page full-access members', () => {
+    renderPersonItem();
+
+    const ownerAccess = screen.getByTestId('access-level-owner@appflowy.local');
+
+    expect(ownerAccess.dataset.canGrantFullAccess).toBe('true');
+    expect(ownerAccess.dataset.canModify).toBe('false');
+  });
+
+  it('lets page full-access members modify non-owner member rows', () => {
+    renderPersonItem({
+      person: createPerson({
+        access_level: AccessLevel.ReadAndWrite,
+        email: 'member@appflowy.local',
+        name: 'Member',
+        role: Role.Member,
+      }),
+    });
+
+    const memberAccess = screen.getByTestId('access-level-member@appflowy.local');
+
+    expect(memberAccess.dataset.canGrantFullAccess).toBe('true');
+    expect(memberAccess.dataset.canModify).toBe('true');
+  });
+
+  it('does not let read-write users modify their own page permissions', () => {
+    renderPersonItem({
+      currentUserCanGrantFullAccess: false,
+      currentUserHasFullAccess: false,
+      isYou: true,
+      person: createPerson({
+        access_level: AccessLevel.ReadAndWrite,
+        email: 'member@appflowy.local',
+        name: 'Member',
+        role: Role.Member,
+      }),
+    });
+
+    const memberAccess = screen.getByTestId('access-level-member@appflowy.local');
+
+    expect(memberAccess.dataset.canGrantFullAccess).toBe('false');
+    expect(memberAccess.dataset.canModify).toBe('false');
+  });
+
+  it('does not let read-only users modify page permissions', () => {
+    renderPersonItem({
+      currentUserCanGrantFullAccess: false,
+      currentUserHasFullAccess: false,
+      person: createPerson({
+        access_level: AccessLevel.ReadOnly,
+        email: 'member@appflowy.local',
+        name: 'Member',
+        role: Role.Member,
+      }),
+    });
+
+    const memberAccess = screen.getByTestId('access-level-member@appflowy.local');
+
+    expect(memberAccess.dataset.canGrantFullAccess).toBe('false');
+    expect(memberAccess.dataset.canModify).toBe('false');
+  });
+});

--- a/src/components/app/share/__tests__/SharePanel.test.tsx
+++ b/src/components/app/share/__tests__/SharePanel.test.tsx
@@ -1,0 +1,96 @@
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { render, screen, waitFor } from '@testing-library/react';
+
+import { AccessLevel } from '@/application/types';
+
+import SharePanel from '../SharePanel';
+import { ShareSectionType } from '../shareSectionType';
+
+const mockGetSubscriptions = jest.fn(async () => []);
+const mockLoadMentionableUsers = jest.fn(async () => []);
+let mockIsHosted = false;
+
+jest.mock('@/components/app/app.hooks', () => ({
+  useGetSubscriptions: () => mockGetSubscriptions,
+  useLoadMentionableUsers: () => mockLoadMentionableUsers,
+  useUserWorkspaceInfo: () => ({
+    selectedWorkspace: {
+      role: 'Member',
+    },
+  }),
+}));
+
+jest.mock('@/components/_shared/notify', () => ({
+  notify: {
+    error: jest.fn(),
+  },
+}));
+
+jest.mock('@/utils/subscription', () => ({
+  getProAccessPlanFromSubscriptions: () => null,
+  isAppFlowyHosted: () => mockIsHosted,
+}));
+
+jest.mock('../InviteGuest', () => ({
+  InviteGuest: () => <div data-testid='invite-guest' />,
+}));
+
+jest.mock('../PeopleWithAccess', () => ({
+  PeopleWithAccess: () => <div data-testid='people-with-access' />,
+}));
+
+jest.mock('../GeneralAccess', () => ({
+  GeneralAccess: () => <div data-testid='general-access' />,
+}));
+
+jest.mock('../CopyLink', () => ({
+  CopyLink: () => <div data-testid='copy-link' />,
+}));
+
+function renderSharePanel(currentUserAccessLevel: AccessLevel | undefined) {
+  return render(
+    <SharePanel
+      viewId='view-1'
+      people={[]}
+      isLoadingPeople={false}
+      onPeopleChange={async () => undefined}
+      hasFullAccess={currentUserAccessLevel === AccessLevel.FullAccess}
+      currentUserAccessLevel={currentUserAccessLevel}
+      sectionType={ShareSectionType.Private}
+    />
+  );
+}
+
+describe('SharePanel', () => {
+  beforeEach(() => {
+    mockGetSubscriptions.mockClear();
+    mockLoadMentionableUsers.mockClear();
+    mockIsHosted = false;
+  });
+
+  it('hides invite controls for read-only users while keeping the access list visible', () => {
+    renderSharePanel(AccessLevel.ReadOnly);
+
+    expect(screen.queryByTestId('invite-guest')).toBeNull();
+    expect(screen.getByTestId('people-with-access')).toBeTruthy();
+    expect(screen.getByTestId('general-access')).toBeTruthy();
+    expect(screen.getByTestId('copy-link')).toBeTruthy();
+    expect(mockLoadMentionableUsers).not.toHaveBeenCalled();
+  });
+
+  it('keeps invite controls visible for edit users', async () => {
+    renderSharePanel(AccessLevel.ReadAndWrite);
+
+    expect(screen.getByTestId('invite-guest')).toBeTruthy();
+    await waitFor(() => expect(mockLoadMentionableUsers).toHaveBeenCalledTimes(1));
+  });
+
+  it('does not load subscription data when invite controls are hidden', () => {
+    mockIsHosted = true;
+
+    renderSharePanel(AccessLevel.ReadOnly);
+
+    expect(screen.queryByTestId('invite-guest')).toBeNull();
+    expect(mockGetSubscriptions).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/app/share/shareAccessLevel.ts
+++ b/src/components/app/share/shareAccessLevel.ts
@@ -1,0 +1,19 @@
+import { AccessLevel, IPeopleWithAccessType, ObjectPermission } from '@/application/types';
+
+export function resolveCurrentUserAccessLevel({
+  currentUserEmail,
+  currentUserPermission,
+  outlineAccessLevel,
+  sharedPeople,
+}: {
+  currentUserEmail?: string | null;
+  currentUserPermission?: ObjectPermission | null;
+  outlineAccessLevel?: AccessLevel;
+  sharedPeople: IPeopleWithAccessType[];
+}) {
+  return (
+    currentUserPermission?.access_level ??
+    sharedPeople.find((person) => person.email === currentUserEmail)?.access_level ??
+    outlineAccessLevel
+  );
+}

--- a/src/components/app/share/useShareAccessDetails.test.ts
+++ b/src/components/app/share/useShareAccessDetails.test.ts
@@ -1,4 +1,5 @@
 import { AccessLevel, IPeopleWithAccessType, Role, View, ViewLayout } from '@/application/types';
+import { resolveCurrentUserAccessLevel } from '@/components/app/share/shareAccessLevel';
 import { resolveShareSectionType, ShareSectionType } from '@/components/app/share/shareSectionType';
 
 const createView = (overrides: Partial<View> = {}): View => ({
@@ -84,5 +85,36 @@ describe('resolveShareSectionType', () => {
         sharedPeople: [createPerson('owner@appflowy.io')],
       })
     ).toBe(ShareSectionType.Shared);
+  });
+});
+
+describe('resolveCurrentUserAccessLevel', () => {
+  it('prefers the v2 current user permission over shared rows and outline access', () => {
+    expect(
+      resolveCurrentUserAccessLevel({
+        currentUserEmail: 'member@appflowy.io',
+        currentUserPermission: { access_level: AccessLevel.ReadOnly },
+        outlineAccessLevel: AccessLevel.ReadAndWrite,
+        sharedPeople: [createPerson('member@appflowy.io', { access_level: AccessLevel.FullAccess })],
+      })
+    ).toBe(AccessLevel.ReadOnly);
+  });
+
+  it('falls back to shared rows and then outline access for legacy responses', () => {
+    expect(
+      resolveCurrentUserAccessLevel({
+        currentUserEmail: 'member@appflowy.io',
+        outlineAccessLevel: AccessLevel.ReadOnly,
+        sharedPeople: [createPerson('member@appflowy.io', { access_level: AccessLevel.ReadAndWrite })],
+      })
+    ).toBe(AccessLevel.ReadAndWrite);
+
+    expect(
+      resolveCurrentUserAccessLevel({
+        currentUserEmail: 'missing@appflowy.io',
+        outlineAccessLevel: AccessLevel.ReadOnly,
+        sharedPeople: [createPerson('member@appflowy.io', { access_level: AccessLevel.ReadAndWrite })],
+      })
+    ).toBe(AccessLevel.ReadOnly);
   });
 });

--- a/src/components/app/share/useShareAccessDetails.ts
+++ b/src/components/app/share/useShareAccessDetails.ts
@@ -1,9 +1,10 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
-import { AccessLevel, IPeopleWithAccessType } from '@/application/types';
+import { AccessLevel, IPeopleWithAccessType, ObjectPermission } from '@/application/types';
 import { findAncestors, findView } from '@/components/_shared/outline/utils';
 import { useAppOutline, useCurrentWorkspaceId, useUserWorkspaceInfo } from '@/components/app/app.hooks';
 import { AccessService } from '@/application/services/domains';
+import { resolveCurrentUserAccessLevel } from '@/components/app/share/shareAccessLevel';
 import { resolveShareSectionType, ShareSectionType } from '@/components/app/share/shareSectionType';
 import { useCurrentUser } from '@/components/main/app.hooks';
 
@@ -17,6 +18,7 @@ export function useShareAccessDetails(viewId: string, opened: boolean) {
   const [isLoadingPeople, setIsLoadingPeople] = useState(false);
   const [hasLoadedPeople, setHasLoadedPeople] = useState(false);
   const [loadedPeopleViewId, setLoadedPeopleViewId] = useState<string | null>(null);
+  const [currentUserPermission, setCurrentUserPermission] = useState<ObjectPermission | null>(null);
   const loadPeopleRequestSeq = useRef(0);
 
   const loadPeople = useCallback(
@@ -35,12 +37,14 @@ export function useShareAccessDetails(viewId: string, opened: boolean) {
 
         if (signal?.aborted || requestSeq !== loadPeopleRequestSeq.current) return;
         setPeople(detail.shared_with);
+        setCurrentUserPermission(detail.current_user_permission ?? null);
         setHasLoadedPeople(true);
         setLoadedPeopleViewId(viewId);
       } catch (error) {
         if (signal?.aborted || requestSeq !== loadPeopleRequestSeq.current) return;
         console.error(error);
         setPeople([]);
+        setCurrentUserPermission(null);
         setHasLoadedPeople(false);
         setLoadedPeopleViewId(null);
       } finally {
@@ -66,11 +70,15 @@ export function useShareAccessDetails(viewId: string, opened: boolean) {
     () => (loadedPeopleViewId === viewId ? people : []),
     [loadedPeopleViewId, people, viewId]
   );
+  const currentUserPermissionForCurrentView = loadedPeopleViewId === viewId ? currentUserPermission : null;
   const currentUserAccessLevel = useMemo(() => {
-    return (
-      peopleForCurrentView.find((person) => person.email === currentUserEmail)?.access_level ?? outlineView?.access_level
-    );
-  }, [currentUserEmail, outlineView?.access_level, peopleForCurrentView]);
+    return resolveCurrentUserAccessLevel({
+      currentUserEmail,
+      currentUserPermission: currentUserPermissionForCurrentView,
+      outlineAccessLevel: outlineView?.access_level,
+      sharedPeople: peopleForCurrentView,
+    });
+  }, [currentUserEmail, currentUserPermissionForCurrentView, outlineView?.access_level, peopleForCurrentView]);
   const sectionType = useMemo(() => {
     if (!hasLoadedPeople || loadedPeopleViewId !== viewId) {
       return ShareSectionType.Unknown;

--- a/src/components/app/view-actions/CreateSpaceModal.tsx
+++ b/src/components/app/view-actions/CreateSpaceModal.tsx
@@ -2,7 +2,7 @@ import { OutlinedInput } from '@mui/material';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 
-import { SpacePermission } from '@/application/types';
+import { CreatePagePayload, SpacePermission } from '@/application/types';
 import { NormalModal } from '@/components/_shared/modal';
 import { notify } from '@/components/_shared/notify';
 import { useAppOperations } from '@/components/app/app.hooks';
@@ -13,10 +13,12 @@ function CreateSpaceModal({
   open,
   onClose,
   onCreated,
+  initialPage,
 }: {
   open: boolean;
   onClose: () => void;
-  onCreated?: (spaceId: string) => void;
+  onCreated?: (spaceId: string, initialPageId?: string) => void;
+  initialPage?: CreatePagePayload;
 }) {
   const [spaceName, setSpaceName] = React.useState<string>('');
   const [spaceIcon, setSpaceIcon] = React.useState<string>('');
@@ -24,17 +26,32 @@ function CreateSpaceModal({
   const [spacePermission, setSpacePermission] = React.useState<SpacePermission>(SpacePermission.Public);
   const [loading, setLoading] = React.useState<boolean>(false);
   const { t } = useTranslation();
-  const { createSpace } = useAppOperations();
+  const { createSpace, createSpaceWithInitialPage } = useAppOperations();
   const handleOk = async () => {
-    if (!createSpace) return;
+    if (!createSpace && !(initialPage && createSpaceWithInitialPage)) return;
     setLoading(true);
     try {
-      const spaceId = await createSpace({
+      const spacePayload = {
         name: spaceName,
         space_icon: spaceIcon,
         space_icon_color: spaceIconColor,
         space_permission: spacePermission,
-      });
+      };
+
+      if (initialPage) {
+        if (!createSpaceWithInitialPage) return;
+        const result = await createSpaceWithInitialPage({
+          ...spacePayload,
+          initial_page: initialPage,
+        });
+
+        onClose();
+        onCreated && onCreated(result.space.view_id, result.page.view_id);
+        return;
+      }
+
+      if (!createSpace) return;
+      const spaceId = await createSpace(spacePayload);
 
       onClose();
 
@@ -88,7 +105,7 @@ function CreateSpaceModal({
         <div className={'flex flex-col gap-2'}>
           <div className={'text-text-secondary'}>{t('space.spaceName')}</div>
           <OutlinedInput
-            data-testid="space-name-input"
+            data-testid='space-name-input'
             value={spaceName}
             fullWidth={true}
             onChange={(e) => setSpaceName(e.target.value)}

--- a/src/components/app/view-actions/MorePageActions.tsx
+++ b/src/components/app/view-actions/MorePageActions.tsx
@@ -16,11 +16,13 @@ import { DropdownMenuGroup, DropdownMenuItem, DropdownMenuSeparator } from '@/co
 function MorePageActions({
   view,
   onClose,
+  canDuplicateActions,
   canManageActions,
   isLoadingActions,
 }: {
   view: View;
   onClose?: () => void;
+  canDuplicateActions: boolean;
   canManageActions: boolean;
   isLoadingActions: boolean;
 }) {
@@ -112,6 +114,7 @@ function MorePageActions({
       <MoreActionsContent
         itemClicked={onClose}
         viewId={view.view_id}
+        canDuplicateActions={canDuplicateActions}
         canManageActions={canManageActions}
         isLoadingActions={isLoadingActions}
       />

--- a/src/components/app/view-actions/MorePageActions.tsx
+++ b/src/components/app/view-actions/MorePageActions.tsx
@@ -11,57 +11,62 @@ import { CustomIconPopover } from '@/components/_shared/cutsom-icon';
 import { useAppOverlayContext } from '@/components/app/app-overlay/AppOverlayContext';
 import { useAppOperations, useCurrentWorkspaceId } from '@/components/app/app.hooks';
 import MoreActionsContent from '@/components/app/header/MoreActionsContent';
-import {
-  DropdownMenuGroup,
-  DropdownMenuItem,
-  DropdownMenuSeparator,
-} from '@/components/ui/dropdown-menu';
+import { DropdownMenuGroup, DropdownMenuItem, DropdownMenuSeparator } from '@/components/ui/dropdown-menu';
 
-
-
-function MorePageActions({ view, onClose }: {
+function MorePageActions({
+  view,
+  onClose,
+  canManageActions,
+  isLoadingActions,
+}: {
   view: View;
   onClose?: () => void;
+  canManageActions: boolean;
+  isLoadingActions: boolean;
 }) {
   const currentWorkspaceId = useCurrentWorkspaceId();
 
-  const {
-    openRenameModal,
-  } = useAppOverlayContext();
+  const { openRenameModal } = useAppOverlayContext();
 
-  const {
-    updatePage,
-    uploadFile,
-  } = useAppOperations();
+  const { updatePage, uploadFile } = useAppOperations();
   const { t } = useTranslation();
 
   const viewId = view.view_id;
 
-  const onUploadFile = useCallback(async (file: File) => {
-    if (!uploadFile) return Promise.reject();
-    return uploadFile(viewId, file);
-  }, [uploadFile, viewId]);
+  const onUploadFile = useCallback(
+    async (file: File) => {
+      if (!uploadFile) return Promise.reject();
+      return uploadFile(viewId, file);
+    },
+    [uploadFile, viewId]
+  );
 
-  const handleChangeIcon = useCallback(async (icon: { ty: ViewIconType, value: string, color?: string }) => {
-    try {
-      await updatePage?.(view.view_id, {
-        icon: icon.ty === ViewIconType.Icon ? {
-          ty: ViewIconType.Icon,
-          value: JSON.stringify({
-            color: icon.color,
-            groupName: icon.value.split('/')[0],
-            iconName: icon.value.split('/')[1],
-          }),
-        } : icon,
-        name: view.name,
-        extra: view.extra || {},
-      });
-      onClose?.();
-      // eslint-disable-next-line
-    } catch (e: any) {
-      toast.error(e.message);
-    }
-  }, [onClose, updatePage, view.extra, view.name, view.view_id]);
+  const handleChangeIcon = useCallback(
+    async (icon: { ty: ViewIconType; value: string; color?: string }) => {
+      try {
+        await updatePage?.(view.view_id, {
+          icon:
+            icon.ty === ViewIconType.Icon
+              ? {
+                  ty: ViewIconType.Icon,
+                  value: JSON.stringify({
+                    color: icon.color,
+                    groupName: icon.value.split('/')[0],
+                    iconName: icon.value.split('/')[1],
+                  }),
+                }
+              : icon,
+          name: view.name,
+          extra: view.extra || {},
+        });
+        onClose?.();
+        // eslint-disable-next-line
+      } catch (e: any) {
+        toast.error(e.message);
+      }
+    },
+    [onClose, updatePage, view.extra, view.name, view.view_id]
+  );
 
   const handleRemoveIcon = useCallback(() => {
     void handleChangeIcon({ ty: 0, value: '' });
@@ -69,40 +74,46 @@ function MorePageActions({ view, onClose }: {
 
   return (
     <>
-      <DropdownMenuGroup>
-        <DropdownMenuItem
-          data-testid={'more-page-rename'}
-          onSelect={() => {
-            onClose?.();
-            openRenameModal(viewId);
-          }}
-        >
-          <EditIcon />{t('button.rename')}
-        </DropdownMenuItem>
-        <CustomIconPopover
-          modal
-          onSelectIcon={handleChangeIcon}
-          removeIcon={handleRemoveIcon}
-          onUploadFile={onUploadFile}
-          popoverContentProps={{
-            side: 'right',
-            align: 'start',
-          }}
-        >
+      {canManageActions && (
+        <DropdownMenuGroup>
           <DropdownMenuItem
-            data-testid={'more-page-change-icon'}
-            onSelect={(e) => {
-              e.preventDefault();
+            data-testid={'more-page-rename'}
+            onSelect={() => {
+              onClose?.();
+              openRenameModal(viewId);
             }}
           >
-            <EmojiIcon />{t('disclosureAction.changeIcon')}
+            <EditIcon />
+            {t('button.rename')}
           </DropdownMenuItem>
-        </CustomIconPopover>
-      </DropdownMenuGroup>
+          <CustomIconPopover
+            modal
+            onSelectIcon={handleChangeIcon}
+            removeIcon={handleRemoveIcon}
+            onUploadFile={onUploadFile}
+            popoverContentProps={{
+              side: 'right',
+              align: 'start',
+            }}
+          >
+            <DropdownMenuItem
+              data-testid={'more-page-change-icon'}
+              onSelect={(e) => {
+                e.preventDefault();
+              }}
+            >
+              <EmojiIcon />
+              {t('disclosureAction.changeIcon')}
+            </DropdownMenuItem>
+          </CustomIconPopover>
+        </DropdownMenuGroup>
+      )}
 
       <MoreActionsContent
         itemClicked={onClose}
         viewId={view.view_id}
+        canManageActions={canManageActions}
+        isLoadingActions={isLoadingActions}
       />
       <DropdownMenuSeparator />
       <DropdownMenuGroup>
@@ -119,7 +130,6 @@ function MorePageActions({ view, onClose }: {
           {t('disclosureAction.openNewTab')}
         </DropdownMenuItem>
       </DropdownMenuGroup>
-
     </>
   );
 }

--- a/src/components/app/view-actions/MoreSpaceActions.tsx
+++ b/src/components/app/view-actions/MoreSpaceActions.tsx
@@ -2,33 +2,37 @@ import { useCallback, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { toast } from 'sonner';
 
-import { View } from '@/application/types';
+import { Role, View } from '@/application/types';
 import { ReactComponent as DeleteIcon } from '@/assets/icons/delete.svg';
 import { ReactComponent as DuplicateIcon } from '@/assets/icons/duplicate.svg';
-import { ReactComponent as AddIcon } from '@/assets/icons/plus.svg';
 import { ReactComponent as SettingsIcon } from '@/assets/icons/settings.svg';
 import { PageService } from '@/application/services/domains';
 import { useAppOverlayContext } from '@/components/app/app-overlay/AppOverlayContext';
-import { useRefreshOutline, useCurrentWorkspaceId } from '@/components/app/app.hooks';
+import { useRefreshOutline, useCurrentWorkspaceId, useUserWorkspaceInfo } from '@/components/app/app.hooks';
 import { DropdownMenuGroup, DropdownMenuItem, DropdownMenuSeparator } from '@/components/ui/dropdown-menu';
 import { Progress } from '@/components/ui/progress';
 
 function MoreSpaceActions({
   view,
   onClose,
+  canDuplicateActions,
   canManageActions,
   isLoadingActions,
 }: {
   view: View;
   onClose: () => void;
+  canDuplicateActions: boolean;
   canManageActions: boolean;
   isLoadingActions: boolean;
 }) {
   const { t } = useTranslation();
-  const { openCreateSpaceModal, openDeleteSpaceModal, openManageSpaceModal } = useAppOverlayContext();
+  const { openDeleteSpaceModal, openManageSpaceModal } = useAppOverlayContext();
   const workspaceId = useCurrentWorkspaceId();
+  const userWorkspaceInfo = useUserWorkspaceInfo();
   const [duplicateLoading, setDuplicateLoading] = useState(false);
   const refreshOutline = useRefreshOutline();
+  const workspaceRole = userWorkspaceInfo?.selectedWorkspace?.role;
+  const canCreateSpace = workspaceRole === Role.Owner || workspaceRole === Role.Member;
 
   const handleDuplicateClick = useCallback(async () => {
     if (!workspaceId) return;
@@ -59,14 +63,16 @@ function MoreSpaceActions({
           {t('space.manage')}
         </DropdownMenuItem>
       )}
-      <DropdownMenuItem
-        data-testid={'space-action-duplicate'}
-        onSelect={handleDuplicateClick}
-        disabled={duplicateLoading}
-      >
-        {duplicateLoading ? <Progress variant={'primary'} /> : <DuplicateIcon />}
-        {t('space.duplicate')}
-      </DropdownMenuItem>
+      {canDuplicateActions && canCreateSpace && (
+        <DropdownMenuItem
+          data-testid={'space-action-duplicate'}
+          onSelect={handleDuplicateClick}
+          disabled={duplicateLoading}
+        >
+          {duplicateLoading ? <Progress variant={'primary'} /> : <DuplicateIcon />}
+          {t('space.duplicate')}
+        </DropdownMenuItem>
+      )}
       {isLoadingActions && (
         <DropdownMenuItem data-testid='space-action-permission-loading' disabled>
           <Progress variant='primary' />
@@ -75,17 +81,6 @@ function MoreSpaceActions({
       )}
       {canManageActions && (
         <>
-          <DropdownMenuSeparator className={'w-full'} />
-          <DropdownMenuItem
-            data-testid='create-new-space-button'
-            onSelect={() => {
-              onClose();
-              openCreateSpaceModal();
-            }}
-          >
-            <AddIcon />
-            {t('space.createNewSpace')}
-          </DropdownMenuItem>
           <DropdownMenuSeparator className={'w-full'} />
           <DropdownMenuItem
             data-testid={'space-action-delete'}

--- a/src/components/app/view-actions/MoreSpaceActions.tsx
+++ b/src/components/app/view-actions/MoreSpaceActions.tsx
@@ -16,16 +16,16 @@ import { Progress } from '@/components/ui/progress';
 function MoreSpaceActions({
   view,
   onClose,
+  canManageActions,
+  isLoadingActions,
 }: {
   view: View;
   onClose: () => void;
+  canManageActions: boolean;
+  isLoadingActions: boolean;
 }) {
   const { t } = useTranslation();
-  const {
-    openCreateSpaceModal,
-    openDeleteSpaceModal,
-    openManageSpaceModal,
-  } = useAppOverlayContext();
+  const { openCreateSpaceModal, openDeleteSpaceModal, openManageSpaceModal } = useAppOverlayContext();
   const workspaceId = useCurrentWorkspaceId();
   const [duplicateLoading, setDuplicateLoading] = useState(false);
   const refreshOutline = useRefreshOutline();
@@ -53,13 +53,12 @@ function MoreSpaceActions({
 
   return (
     <DropdownMenuGroup>
-      <DropdownMenuItem
-        data-testid={'space-action-manage'}
-        onSelect={handleManageClick}
-      >
-        <SettingsIcon />
-        {t('space.manage')}
-      </DropdownMenuItem>
+      {canManageActions && (
+        <DropdownMenuItem data-testid={'space-action-manage'} onSelect={handleManageClick}>
+          <SettingsIcon />
+          {t('space.manage')}
+        </DropdownMenuItem>
+      )}
       <DropdownMenuItem
         data-testid={'space-action-duplicate'}
         onSelect={handleDuplicateClick}
@@ -68,28 +67,38 @@ function MoreSpaceActions({
         {duplicateLoading ? <Progress variant={'primary'} /> : <DuplicateIcon />}
         {t('space.duplicate')}
       </DropdownMenuItem>
-      <DropdownMenuSeparator className={'w-full'} />
-      <DropdownMenuItem
-        data-testid="create-new-space-button"
-        onSelect={() => {
-          onClose();
-          openCreateSpaceModal();
-        }}
-      >
-        <AddIcon />
-        {t('space.createNewSpace')}
-      </DropdownMenuItem>
-      <DropdownMenuSeparator className={'w-full'} />
-      <DropdownMenuItem
-        data-testid={'space-action-delete'}
-        onSelect={() => {
-          onClose();
-          openDeleteSpaceModal(view.view_id);
-        }}
-      >
-        <DeleteIcon />
-        {t('button.delete')}
-      </DropdownMenuItem>
+      {isLoadingActions && (
+        <DropdownMenuItem data-testid='space-action-permission-loading' disabled>
+          <Progress variant='primary' />
+          {t('loading')}
+        </DropdownMenuItem>
+      )}
+      {canManageActions && (
+        <>
+          <DropdownMenuSeparator className={'w-full'} />
+          <DropdownMenuItem
+            data-testid='create-new-space-button'
+            onSelect={() => {
+              onClose();
+              openCreateSpaceModal();
+            }}
+          >
+            <AddIcon />
+            {t('space.createNewSpace')}
+          </DropdownMenuItem>
+          <DropdownMenuSeparator className={'w-full'} />
+          <DropdownMenuItem
+            data-testid={'space-action-delete'}
+            onSelect={() => {
+              onClose();
+              openDeleteSpaceModal(view.view_id);
+            }}
+          >
+            <DeleteIcon />
+            {t('button.delete')}
+          </DropdownMenuItem>
+        </>
+      )}
     </DropdownMenuGroup>
   );
 }

--- a/src/components/app/view-actions/NewPage.tsx
+++ b/src/components/app/view-actions/NewPage.tsx
@@ -13,6 +13,8 @@ import { dropdownMenuItemVariants } from '@/components/ui/dropdown-menu';
 import { cn } from '@/lib/utils';
 import { Log } from '@/utils/log';
 
+const CREATE_SPACE_INITIAL_PAGE = { layout: ViewLayout.Document };
+
 function NewPage() {
   const { t } = useTranslation();
   const [open, setOpen] = React.useState<boolean>(false);
@@ -118,13 +120,14 @@ function NewPage() {
       <CreateSpaceModal
         open={createSpaceOpen}
         onClose={() => setCreateSpaceOpen(false)}
-        initialPage={{ layout: ViewLayout.Document }}
+        initialPage={CREATE_SPACE_INITIAL_PAGE}
         onCreated={(spaceId: string, initialPageId?: string) => {
           if (initialPageId) {
             openPageModal?.(initialPageId);
             onClose();
             return;
           }
+
           void handleAddPage(spaceId);
         }}
       />

--- a/src/components/app/view-actions/NewPage.tsx
+++ b/src/components/app/view-actions/NewPage.tsx
@@ -70,12 +70,16 @@ function NewPage() {
 
   return (
     <>
-      <div data-testid="new-page-button" onClick={() => setOpen(true)} className={cn(dropdownMenuItemVariants(), 'w-full')}>
+      <div
+        data-testid='new-page-button'
+        onClick={() => setOpen(true)}
+        className={cn(dropdownMenuItemVariants(), 'w-full')}
+      >
         <Add />
         {t('newPageText')}
       </div>
       <NormalModal
-        data-testid="new-page-modal"
+        data-testid='new-page-modal'
         okText={t('button.add')}
         title={t('publish.duplicateTitle')}
         open={open}
@@ -114,7 +118,13 @@ function NewPage() {
       <CreateSpaceModal
         open={createSpaceOpen}
         onClose={() => setCreateSpaceOpen(false)}
-        onCreated={(spaceId: string) => {
+        initialPage={{ layout: ViewLayout.Document }}
+        onCreated={(spaceId: string, initialPageId?: string) => {
+          if (initialPageId) {
+            openPageModal?.(initialPageId);
+            onClose();
+            return;
+          }
           void handleAddPage(spaceId);
         }}
       />

--- a/src/components/app/view-actions/ViewActionsPopover.tsx
+++ b/src/components/app/view-actions/ViewActionsPopover.tsx
@@ -5,7 +5,24 @@ import AddPageActions from '@/components/app/view-actions/AddPageActions';
 import MorePageActions from '@/components/app/view-actions/MorePageActions';
 import MoreSpaceActions from '@/components/app/view-actions/MoreSpaceActions';
 import { useViewActionPermissions } from '@/components/app/view-actions/useViewActionPermissions';
-import { DropdownMenu, DropdownMenuContent, DropdownMenuTrigger } from '@/components/ui/dropdown-menu';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import { Progress } from '@/components/ui/progress';
+
+function PermissionLoadingItem({ testId }: { testId: string }) {
+  return (
+    <DropdownMenuGroup>
+      <DropdownMenuItem data-testid={testId} disabled>
+        <Progress variant='primary' />
+      </DropdownMenuItem>
+    </DropdownMenuGroup>
+  );
+}
 
 function ViewActionsPopover({
   popoverType,
@@ -26,10 +43,9 @@ function ViewActionsPopover({
   // dropdown closes.
   onImportClick?: (view: View) => void;
 } & React.ComponentProps<typeof DropdownMenu>) {
-  const { canManageViewActions, isLoadingViewActionPermissions } = useViewActionPermissions(
-    view,
-    Boolean(open && popoverType?.type === 'more')
-  );
+  const { canCreateViewActions, canManageViewActions, hasLoadedViewActionPermissions, isLoadingViewActionPermissions } =
+    useViewActionPermissions(view, Boolean(open && popoverType));
+  const isResolvingViewActionPermissions = isLoadingViewActionPermissions || !hasLoadedViewActionPermissions;
 
   const onClose = useCallback(() => {
     onOpenChange?.(false);
@@ -39,6 +55,12 @@ function ViewActionsPopover({
     if (!popoverType || !view) return null;
 
     if (popoverType.type === 'add') {
+      if (isResolvingViewActionPermissions) {
+        return <PermissionLoadingItem testId='add-page-permission-loading' />;
+      }
+
+      if (!canCreateViewActions) return null;
+
       return <AddPageActions view={view} onImportClick={onImportClick} />;
     }
 
@@ -47,8 +69,9 @@ function ViewActionsPopover({
         <MoreSpaceActions
           onClose={onClose}
           view={view}
+          canDuplicateActions={canCreateViewActions}
           canManageActions={canManageViewActions}
-          isLoadingActions={isLoadingViewActionPermissions}
+          isLoadingActions={isResolvingViewActionPermissions}
         />
       );
     } else {
@@ -56,12 +79,21 @@ function ViewActionsPopover({
         <MorePageActions
           view={view}
           onClose={onClose}
+          canDuplicateActions={canCreateViewActions}
           canManageActions={canManageViewActions}
-          isLoadingActions={isLoadingViewActionPermissions}
+          isLoadingActions={isResolvingViewActionPermissions}
         />
       );
     }
-  }, [canManageViewActions, isLoadingViewActionPermissions, onClose, popoverType, view, onImportClick]);
+  }, [
+    canCreateViewActions,
+    canManageViewActions,
+    isResolvingViewActionPermissions,
+    onClose,
+    popoverType,
+    view,
+    onImportClick,
+  ]);
 
   return (
     <DropdownMenu open={open} onOpenChange={onOpenChange}>

--- a/src/components/app/view-actions/ViewActionsPopover.tsx
+++ b/src/components/app/view-actions/ViewActionsPopover.tsx
@@ -4,9 +4,10 @@ import { View } from '@/application/types';
 import AddPageActions from '@/components/app/view-actions/AddPageActions';
 import MorePageActions from '@/components/app/view-actions/MorePageActions';
 import MoreSpaceActions from '@/components/app/view-actions/MoreSpaceActions';
+import { useViewActionPermissions } from '@/components/app/view-actions/useViewActionPermissions';
 import { DropdownMenu, DropdownMenuContent, DropdownMenuTrigger } from '@/components/ui/dropdown-menu';
 
-function ViewActionsPopover ({
+function ViewActionsPopover({
   popoverType,
   view,
   children,
@@ -18,13 +19,17 @@ function ViewActionsPopover ({
   popoverType?: {
     category: 'space' | 'page';
     type: 'more' | 'add';
-  },
+  };
   children: React.ReactNode;
   // Forwarded to AddPageActions. The dialog itself must live in a persistent
   // ancestor (e.g. Outline) since this popover is unmounted as soon as the
   // dropdown closes.
   onImportClick?: (view: View) => void;
 } & React.ComponentProps<typeof DropdownMenu>) {
+  const { canManageViewActions, isLoadingViewActionPermissions } = useViewActionPermissions(
+    view,
+    Boolean(open && popoverType?.type === 'more')
+  );
 
   const onClose = useCallback(() => {
     onOpenChange?.(false);
@@ -34,43 +39,42 @@ function ViewActionsPopover ({
     if (!popoverType || !view) return null;
 
     if (popoverType.type === 'add') {
-      return <AddPageActions
-        view={view}
-        onImportClick={onImportClick}
-      />;
+      return <AddPageActions view={view} onImportClick={onImportClick} />;
     }
 
     if (popoverType.category === 'space') {
-      return <MoreSpaceActions
-        onClose={onClose}
-        view={view}
-      />;
+      return (
+        <MoreSpaceActions
+          onClose={onClose}
+          view={view}
+          canManageActions={canManageViewActions}
+          isLoadingActions={isLoadingViewActionPermissions}
+        />
+      );
     } else {
-      return <MorePageActions
-        view={view}
-        onClose={onClose}
-      />;
+      return (
+        <MorePageActions
+          view={view}
+          onClose={onClose}
+          canManageActions={canManageViewActions}
+          isLoadingActions={isLoadingViewActionPermissions}
+        />
+      );
     }
-  }, [onClose, popoverType, view, onImportClick]);
+  }, [canManageViewActions, isLoadingViewActionPermissions, onClose, popoverType, view, onImportClick]);
 
   return (
-    <DropdownMenu
-      open={open}
-      onOpenChange={onOpenChange}
-    >
-      <DropdownMenuTrigger asChild>
-        {children}
-      </DropdownMenuTrigger>
+    <DropdownMenu open={open} onOpenChange={onOpenChange}>
+      <DropdownMenuTrigger asChild>{children}</DropdownMenuTrigger>
       <DropdownMenuContent
-        data-testid="view-actions-popover"
+        data-testid='view-actions-popover'
         align={'start'}
-        onCloseAutoFocus={e => {
+        onCloseAutoFocus={(e) => {
           e.preventDefault();
         }}
       >
         {popoverContent}
       </DropdownMenuContent>
-
     </DropdownMenu>
   );
 }

--- a/src/components/app/view-actions/__tests__/actionPermissionGates.test.tsx
+++ b/src/components/app/view-actions/__tests__/actionPermissionGates.test.tsx
@@ -1,0 +1,270 @@
+import { describe, expect, it, jest, beforeEach } from '@jest/globals';
+import { render, screen } from '@testing-library/react';
+
+import { Role } from '@/application/types';
+import MoreActionsContent from '@/components/app/header/MoreActionsContent';
+import MoreSpaceActions from '@/components/app/view-actions/MoreSpaceActions';
+import ViewActionsPopover from '@/components/app/view-actions/ViewActionsPopover';
+
+import type { ReactNode } from 'react';
+
+const mockUseViewActionPermissions = jest.fn();
+let mockWorkspaceRole = Role.Member;
+const mockDocumentView = {
+  children: [],
+  extra: null,
+  icon: null,
+  is_published: false,
+  layout: 0,
+  name: 'Document',
+  parent_view_id: 'space-1',
+  view_id: 'view-1',
+};
+const mockSpaceView = {
+  ...mockDocumentView,
+  extra: {
+    is_space: true,
+  },
+  parent_view_id: undefined,
+  view_id: 'space-1',
+};
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+jest.mock('sonner', () => ({
+  toast: {
+    error: jest.fn(),
+    loading: jest.fn(() => 'toast-id'),
+    dismiss: jest.fn(),
+    success: jest.fn(),
+  },
+}));
+
+jest.mock('@/components/ui/dropdown-menu', () => ({
+  DropdownMenu: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DropdownMenuContent: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DropdownMenuGroup: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DropdownMenuItem: ({
+    children,
+    disabled,
+    onSelect,
+    ...props
+  }: {
+    children: ReactNode;
+    disabled?: boolean;
+    onSelect?: (event: { preventDefault: () => void }) => void;
+    [key: string]: unknown;
+  }) => (
+    <button
+      data-testid={props['data-testid'] as string | undefined}
+      disabled={disabled}
+      type='button'
+      onClick={() => onSelect?.({ preventDefault: () => undefined })}
+    >
+      {children}
+    </button>
+  ),
+  DropdownMenuSeparator: () => <hr />,
+  DropdownMenuTrigger: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+
+jest.mock('@/components/ui/progress', () => ({
+  Progress: () => <span data-testid='progress' />,
+}));
+
+jest.mock('@/components/ui/switch', () => ({
+  Switch: () => <span data-testid='switch' />,
+}));
+
+jest.mock('@/components/app/app-overlay/AppOverlayContext', () => ({
+  useAppOverlayContext: () => ({
+    hideBlockingLoader: jest.fn(),
+    openCreateSpaceModal: jest.fn(),
+    openDeleteModal: jest.fn(),
+    openDeleteSpaceModal: jest.fn(),
+    openManageSpaceModal: jest.fn(),
+    showBlockingLoader: jest.fn(),
+  }),
+}));
+
+jest.mock('@/components/app/app.hooks', () => ({
+  useAppOutline: () => [],
+  useAppView: () => mockDocumentView,
+  useCurrentWorkspaceId: () => 'workspace-1',
+  useLoadViewChildren: () => jest.fn(),
+  useRefreshOutline: () => jest.fn(),
+  useUserWorkspaceInfo: () => ({
+    selectedWorkspace: {
+      role: mockWorkspaceRole,
+    },
+  }),
+}));
+
+jest.mock('@/components/app/contexts/SyncInternalContext', () => ({
+  useSyncInternal: () => ({
+    syncAllToServer: jest.fn(async () => undefined),
+  }),
+}));
+
+jest.mock('@/components/app/view-actions/MovePagePopover', () => ({
+  __esModule: true,
+  default: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+
+jest.mock('@/components/app/view-actions/AddPageActions', () => ({
+  __esModule: true,
+  default: () => <div data-testid='add-page-actions' />,
+}));
+
+jest.mock('@/components/app/view-actions/MorePageActions', () => ({
+  __esModule: true,
+  default: () => <div data-testid='more-page-actions' />,
+}));
+
+jest.mock('@/components/app/view-actions/useViewActionPermissions', () => ({
+  useViewActionPermissions: (...args: unknown[]) => mockUseViewActionPermissions(...args),
+}));
+
+describe('view action permission gates', () => {
+  beforeEach(() => {
+    mockUseViewActionPermissions.mockReset();
+    mockWorkspaceRole = Role.Member;
+  });
+
+  it('keeps page duplicate available for edit access while hiding full-management actions', () => {
+    render(
+      <MoreActionsContent
+        viewId='view-1'
+        canDuplicateActions
+        canManageActions={false}
+        canUsePageHistory={false}
+        onFindAndReplace={jest.fn()}
+      />
+    );
+
+    expect(screen.getByTestId('more-page-duplicate')).toBeTruthy();
+    expect(screen.queryByTestId('more-page-move-to')).toBeNull();
+    expect(screen.queryByTestId('view-action-delete')).toBeNull();
+    expect(screen.getByTestId('more-page-find-and-replace')).toBeTruthy();
+  });
+
+  it('hides page duplicate when edit/create permission is denied', () => {
+    render(
+      <MoreActionsContent
+        viewId='view-1'
+        canDuplicateActions={false}
+        canManageActions={false}
+        canUsePageHistory={false}
+        onFindAndReplace={jest.fn()}
+      />
+    );
+
+    expect(screen.queryByTestId('more-page-duplicate')).toBeNull();
+  });
+
+  it('keeps space duplicate for members while hiding selected-space management and workspace create', () => {
+    render(
+      <MoreSpaceActions
+        view={mockSpaceView}
+        onClose={jest.fn()}
+        canDuplicateActions
+        canManageActions={false}
+        isLoadingActions={false}
+      />
+    );
+
+    expect(screen.queryByTestId('space-action-manage')).toBeNull();
+    expect(screen.getByTestId('space-action-duplicate')).toBeTruthy();
+    expect(screen.queryByTestId('create-new-space-button')).toBeNull();
+    expect(screen.queryByTestId('space-action-delete')).toBeNull();
+  });
+
+  it('hides space duplicate and workspace create for guests without selected-space management permission', () => {
+    mockWorkspaceRole = Role.Guest;
+
+    render(
+      <MoreSpaceActions
+        view={mockSpaceView}
+        onClose={jest.fn()}
+        canDuplicateActions
+        canManageActions={false}
+        isLoadingActions={false}
+      />
+    );
+
+    expect(screen.queryByTestId('create-new-space-button')).toBeNull();
+    expect(screen.queryByTestId('space-action-duplicate')).toBeNull();
+  });
+
+  it('does not mount add actions until effective permissions allow mutations', () => {
+    mockUseViewActionPermissions.mockReturnValue({
+      canCreateViewActions: false,
+      canManageViewActions: false,
+      hasLoadedViewActionPermissions: true,
+      isLoadingViewActionPermissions: false,
+    });
+
+    render(
+      <ViewActionsPopover
+        view={mockDocumentView}
+        popoverType={{ category: 'page', type: 'add' }}
+        open
+        onOpenChange={jest.fn()}
+      >
+        <button type='button'>trigger</button>
+      </ViewActionsPopover>
+    );
+
+    expect(mockUseViewActionPermissions).toHaveBeenCalledWith(mockDocumentView, true);
+    expect(screen.queryByTestId('add-page-actions')).toBeNull();
+  });
+
+  it('shows a loading item while add action permissions are unresolved', () => {
+    mockUseViewActionPermissions.mockReturnValue({
+      canCreateViewActions: false,
+      canManageViewActions: false,
+      hasLoadedViewActionPermissions: false,
+      isLoadingViewActionPermissions: false,
+    });
+
+    render(
+      <ViewActionsPopover
+        view={mockDocumentView}
+        popoverType={{ category: 'page', type: 'add' }}
+        open
+        onOpenChange={jest.fn()}
+      >
+        <button type='button'>trigger</button>
+      </ViewActionsPopover>
+    );
+
+    expect(screen.getByTestId('add-page-permission-loading')).toBeTruthy();
+    expect(screen.queryByTestId('add-page-actions')).toBeNull();
+  });
+
+  it('mounts add actions for edit access even when manage actions are denied', () => {
+    mockUseViewActionPermissions.mockReturnValue({
+      canCreateViewActions: true,
+      canManageViewActions: false,
+      hasLoadedViewActionPermissions: true,
+      isLoadingViewActionPermissions: false,
+    });
+
+    render(
+      <ViewActionsPopover
+        view={mockDocumentView}
+        popoverType={{ category: 'page', type: 'add' }}
+        open
+        onOpenChange={jest.fn()}
+      >
+        <button type='button'>trigger</button>
+      </ViewActionsPopover>
+    );
+
+    expect(screen.getByTestId('add-page-actions')).toBeTruthy();
+  });
+});

--- a/src/components/app/view-actions/useViewActionPermissions.test.ts
+++ b/src/components/app/view-actions/useViewActionPermissions.test.ts
@@ -1,5 +1,6 @@
 import { AccessLevel, Role } from '@/application/types';
 import {
+  canUseChildViewCreationActions,
   canUsePageHistoryAction,
   canUseViewMutationActions,
   resolveCurrentUserActionAccessLevel,
@@ -22,7 +23,7 @@ describe('canUseViewMutationActions', () => {
     ).toBe(false);
   });
 
-  it('allows the object creator even without full access', () => {
+  it('denies the object creator when the resolved access level is read-only', () => {
     expect(
       canUseViewMutationActions({
         currentUserPermission: {
@@ -30,10 +31,10 @@ describe('canUseViewMutationActions', () => {
           object_creator: true,
         },
       })
-    ).toBe(true);
+    ).toBe(false);
   });
 
-  it('allows the ancestor creator for inherited private-space permissions', () => {
+  it('denies the ancestor creator when the resolved access level is read-only', () => {
     expect(
       canUseViewMutationActions({
         currentUserPermission: {
@@ -41,7 +42,7 @@ describe('canUseViewMutationActions', () => {
           ancestor_creator: true,
         },
       })
-    ).toBe(true);
+    ).toBe(false);
   });
 
   it('allows full access from the resolved current user permission', () => {
@@ -116,6 +117,38 @@ describe('canUsePageHistoryAction', () => {
 
   it('denies page history before permission has loaded', () => {
     expect(canUsePageHistoryAction({})).toBe(false);
+  });
+});
+
+describe('canUseChildViewCreationActions', () => {
+  it('allows read-write and stronger page access to create child views', () => {
+    expect(
+      canUseChildViewCreationActions({
+        currentUserPermission: {
+          access_level: AccessLevel.ReadAndWrite,
+        },
+      })
+    ).toBe(true);
+
+    expect(
+      canUseChildViewCreationActions({
+        currentUserPermission: {
+          access_level: AccessLevel.FullAccess,
+        },
+      })
+    ).toBe(true);
+  });
+
+  it('denies read-only page access and unloaded permissions', () => {
+    expect(
+      canUseChildViewCreationActions({
+        currentUserPermission: {
+          access_level: AccessLevel.ReadOnly,
+        },
+      })
+    ).toBe(false);
+
+    expect(canUseChildViewCreationActions({})).toBe(false);
   });
 });
 

--- a/src/components/app/view-actions/useViewActionPermissions.test.ts
+++ b/src/components/app/view-actions/useViewActionPermissions.test.ts
@@ -1,5 +1,6 @@
 import { AccessLevel, Role } from '@/application/types';
 import {
+  canUsePageHistoryAction,
   canUseViewMutationActions,
   resolveCurrentUserActionAccessLevel,
 } from '@/components/app/view-actions/viewActionPermission';
@@ -79,6 +80,42 @@ describe('canUseViewMutationActions', () => {
         },
       })
     ).toBe(false);
+  });
+});
+
+describe('canUsePageHistoryAction', () => {
+  it('allows read-write and stronger page access to use page history', () => {
+    expect(
+      canUsePageHistoryAction({
+        currentUserPermission: {
+          access_level: AccessLevel.ReadAndWrite,
+        },
+      })
+    ).toBe(true);
+
+    expect(
+      canUsePageHistoryAction({
+        currentUserPermission: {
+          access_level: AccessLevel.FullAccess,
+        },
+      })
+    ).toBe(true);
+  });
+
+  it('denies read-only page access even when the user is a creator', () => {
+    expect(
+      canUsePageHistoryAction({
+        currentUserPermission: {
+          access_level: AccessLevel.ReadOnly,
+          object_creator: true,
+          ancestor_creator: true,
+        },
+      })
+    ).toBe(false);
+  });
+
+  it('denies page history before permission has loaded', () => {
+    expect(canUsePageHistoryAction({})).toBe(false);
   });
 });
 

--- a/src/components/app/view-actions/useViewActionPermissions.test.ts
+++ b/src/components/app/view-actions/useViewActionPermissions.test.ts
@@ -1,9 +1,8 @@
-import { AccessLevel, Role } from '@/application/types';
+import { AccessLevel } from '@/application/types';
 import {
   canUseChildViewCreationActions,
   canUsePageHistoryAction,
   canUseViewMutationActions,
-  resolveCurrentUserActionAccessLevel,
 } from '@/components/app/view-actions/viewActionPermission';
 
 describe('canUseViewMutationActions', () => {
@@ -149,36 +148,5 @@ describe('canUseChildViewCreationActions', () => {
     ).toBe(false);
 
     expect(canUseChildViewCreationActions({})).toBe(false);
-  });
-});
-
-describe('resolveCurrentUserActionAccessLevel', () => {
-  it('falls back from v2 current user permission to legacy shared rows and outline access', () => {
-    expect(
-      resolveCurrentUserActionAccessLevel({
-        currentUserEmail: 'eva@appflowy.io',
-        currentUserPermission: null,
-        outlineAccessLevel: AccessLevel.ReadOnly,
-        sharedPeople: [
-          {
-            email: 'eva@appflowy.io',
-            name: 'Eva',
-            access_level: AccessLevel.FullAccess,
-            role: Role.Guest,
-            avatar_url: '',
-            pending_invitation: false,
-          },
-        ],
-      })
-    ).toBe(AccessLevel.FullAccess);
-
-    expect(
-      resolveCurrentUserActionAccessLevel({
-        currentUserEmail: 'missing@appflowy.io',
-        currentUserPermission: null,
-        outlineAccessLevel: AccessLevel.ReadOnly,
-        sharedPeople: [],
-      })
-    ).toBe(AccessLevel.ReadOnly);
   });
 });

--- a/src/components/app/view-actions/useViewActionPermissions.test.ts
+++ b/src/components/app/view-actions/useViewActionPermissions.test.ts
@@ -1,0 +1,114 @@
+import { AccessLevel, Role } from '@/application/types';
+import {
+  canUseViewMutationActions,
+  resolveCurrentUserActionAccessLevel,
+} from '@/components/app/view-actions/viewActionPermission';
+
+describe('canUseViewMutationActions', () => {
+  it('denies management before server permission has loaded', () => {
+    expect(canUseViewMutationActions({})).toBe(false);
+  });
+
+  it('does not allow non-creators with read/write access to manage pages', () => {
+    expect(
+      canUseViewMutationActions({
+        currentUserPermission: {
+          access_level: AccessLevel.ReadAndWrite,
+          object_creator: false,
+          ancestor_creator: false,
+        },
+      })
+    ).toBe(false);
+  });
+
+  it('allows the object creator even without full access', () => {
+    expect(
+      canUseViewMutationActions({
+        currentUserPermission: {
+          access_level: AccessLevel.ReadOnly,
+          object_creator: true,
+        },
+      })
+    ).toBe(true);
+  });
+
+  it('allows the ancestor creator for inherited private-space permissions', () => {
+    expect(
+      canUseViewMutationActions({
+        currentUserPermission: {
+          access_level: AccessLevel.ReadOnly,
+          ancestor_creator: true,
+        },
+      })
+    ).toBe(true);
+  });
+
+  it('allows full access from the resolved current user permission', () => {
+    expect(
+      canUseViewMutationActions({
+        currentUserPermission: {
+          access_level: AccessLevel.FullAccess,
+        },
+      })
+    ).toBe(true);
+  });
+
+  it('does not let stale outline access override the resolved current user permission', () => {
+    expect(
+      canUseViewMutationActions({
+        currentUserPermission: {
+          access_level: AccessLevel.ReadAndWrite,
+        },
+      })
+    ).toBe(false);
+  });
+
+  it('denies read-only and read-write guests that are not creators', () => {
+    expect(
+      canUseViewMutationActions({
+        currentUserPermission: {
+          access_level: AccessLevel.ReadOnly,
+        },
+      })
+    ).toBe(false);
+
+    expect(
+      canUseViewMutationActions({
+        currentUserPermission: {
+          access_level: AccessLevel.ReadAndWrite,
+        },
+      })
+    ).toBe(false);
+  });
+});
+
+describe('resolveCurrentUserActionAccessLevel', () => {
+  it('falls back from v2 current user permission to legacy shared rows and outline access', () => {
+    expect(
+      resolveCurrentUserActionAccessLevel({
+        currentUserEmail: 'eva@appflowy.io',
+        currentUserPermission: null,
+        outlineAccessLevel: AccessLevel.ReadOnly,
+        sharedPeople: [
+          {
+            email: 'eva@appflowy.io',
+            name: 'Eva',
+            access_level: AccessLevel.FullAccess,
+            role: Role.Guest,
+            avatar_url: '',
+            pending_invitation: false,
+          },
+        ],
+      })
+    ).toBe(AccessLevel.FullAccess);
+
+    expect(
+      resolveCurrentUserActionAccessLevel({
+        currentUserEmail: 'missing@appflowy.io',
+        currentUserPermission: null,
+        outlineAccessLevel: AccessLevel.ReadOnly,
+        sharedPeople: [],
+      })
+    ).toBe(AccessLevel.ReadOnly);
+  });
+});

--- a/src/components/app/view-actions/useViewActionPermissions.ts
+++ b/src/components/app/view-actions/useViewActionPermissions.ts
@@ -4,11 +4,11 @@ import { AccessService } from '@/application/services/domains';
 import { ObjectPermission, View } from '@/application/types';
 import { findAncestors, findSharedAccessLevel } from '@/components/_shared/outline/utils';
 import { useAppOutline, useCurrentWorkspaceId } from '@/components/app/app.hooks';
+import { resolveCurrentUserAccessLevel } from '@/components/app/share/shareAccessLevel';
 import {
   canUseChildViewCreationActions,
   canUsePageHistoryAction,
   canUseViewMutationActions,
-  resolveCurrentUserActionAccessLevel,
 } from '@/components/app/view-actions/viewActionPermission';
 import { useCurrentUserOptional } from '@/components/main/app.hooks';
 
@@ -57,7 +57,7 @@ export function useViewActionPermissions(view: View | null | undefined, opened: 
     void AccessService.getShareDetail(workspaceId, viewId, ancestorViewIds, controller.signal)
       .then((detail) => {
         if (controller.signal.aborted || seq !== requestSeq.current) return;
-        const accessLevel = resolveCurrentUserActionAccessLevel({
+        const accessLevel = resolveCurrentUserAccessLevel({
           currentUserEmail: currentUser?.email,
           currentUserPermission: detail.current_user_permission ?? null,
           outlineAccessLevel: outlineAccessLevelRef.current,

--- a/src/components/app/view-actions/useViewActionPermissions.ts
+++ b/src/components/app/view-actions/useViewActionPermissions.ts
@@ -1,0 +1,100 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+
+import { AccessService } from '@/application/services/domains';
+import { ObjectPermission, View } from '@/application/types';
+import { findAncestors, findSharedAccessLevel } from '@/components/_shared/outline/utils';
+import { useAppOutline, useCurrentWorkspaceId } from '@/components/app/app.hooks';
+import {
+  canUseViewMutationActions,
+  resolveCurrentUserActionAccessLevel,
+} from '@/components/app/view-actions/viewActionPermission';
+import { useCurrentUserOptional } from '@/components/main/app.hooks';
+
+export function useViewActionPermissions(view: View | null | undefined, opened: boolean) {
+  const workspaceId = useCurrentWorkspaceId();
+  const currentUser = useCurrentUserOptional();
+  const outline = useAppOutline();
+  const viewId = view?.view_id;
+  const requestSeq = useRef(0);
+  const outlineRef = useRef(outline);
+  const outlineAccessLevelRef = useRef<ReturnType<typeof findSharedAccessLevel> | undefined>(undefined);
+  const [loadedViewId, setLoadedViewId] = useState<string | null>(null);
+  const [currentUserPermission, setCurrentUserPermission] = useState<ObjectPermission | null>(null);
+  const [isLoadingViewActionPermissions, setIsLoadingViewActionPermissions] = useState(false);
+  const outlineAccessLevel = useMemo(() => {
+    if (!viewId) return undefined;
+
+    return findSharedAccessLevel(outline || [], viewId) ?? view?.access_level;
+  }, [outline, view?.access_level, viewId]);
+
+  useEffect(() => {
+    outlineRef.current = outline;
+    outlineAccessLevelRef.current = outlineAccessLevel;
+  }, [outline, outlineAccessLevel]);
+
+  useEffect(() => {
+    setLoadedViewId(null);
+    setCurrentUserPermission(null);
+    setIsLoadingViewActionPermissions(false);
+  }, [viewId]);
+
+  useEffect(() => {
+    if (!opened || !workspaceId || !viewId) {
+      setIsLoadingViewActionPermissions(false);
+      return;
+    }
+
+    const controller = new AbortController();
+    const seq = ++requestSeq.current;
+    const ancestorViewIds = findAncestors(outlineRef.current || [], viewId)?.map((item) => item.view_id) || [];
+
+    setLoadedViewId(null);
+    setCurrentUserPermission(null);
+    setIsLoadingViewActionPermissions(true);
+
+    void AccessService.getShareDetail(workspaceId, viewId, ancestorViewIds, controller.signal)
+      .then((detail) => {
+        if (controller.signal.aborted || seq !== requestSeq.current) return;
+        const accessLevel = resolveCurrentUserActionAccessLevel({
+          currentUserEmail: currentUser?.email,
+          currentUserPermission: detail.current_user_permission ?? null,
+          outlineAccessLevel: outlineAccessLevelRef.current,
+          sharedPeople: detail.shared_with ?? [],
+        });
+        const permission =
+          detail.current_user_permission || accessLevel !== undefined
+            ? {
+                ...(detail.current_user_permission ?? {}),
+                access_level: accessLevel,
+              }
+            : null;
+
+        setCurrentUserPermission(permission);
+        setLoadedViewId(viewId);
+        setIsLoadingViewActionPermissions(false);
+      })
+      .catch((error) => {
+        if (controller.signal.aborted || seq !== requestSeq.current) return;
+        console.error(error);
+        setCurrentUserPermission(null);
+        setLoadedViewId(null);
+        setIsLoadingViewActionPermissions(false);
+      });
+
+    return () => {
+      controller.abort();
+    };
+  }, [currentUser?.email, opened, viewId, workspaceId]);
+
+  const hasLoadedViewActionPermissions = loadedViewId === viewId;
+  const canManageViewActions = hasLoadedViewActionPermissions
+    ? canUseViewMutationActions({
+        currentUserPermission,
+      })
+    : false;
+
+  return {
+    canManageViewActions,
+    isLoadingViewActionPermissions,
+  };
+}

--- a/src/components/app/view-actions/useViewActionPermissions.ts
+++ b/src/components/app/view-actions/useViewActionPermissions.ts
@@ -5,6 +5,7 @@ import { ObjectPermission, View } from '@/application/types';
 import { findAncestors, findSharedAccessLevel } from '@/components/_shared/outline/utils';
 import { useAppOutline, useCurrentWorkspaceId } from '@/components/app/app.hooks';
 import {
+  canUseChildViewCreationActions,
   canUsePageHistoryAction,
   canUseViewMutationActions,
   resolveCurrentUserActionAccessLevel,
@@ -78,7 +79,7 @@ export function useViewActionPermissions(view: View | null | undefined, opened: 
         if (controller.signal.aborted || seq !== requestSeq.current) return;
         console.error(error);
         setCurrentUserPermission(null);
-        setLoadedViewId(null);
+        setLoadedViewId(viewId);
         setIsLoadingViewActionPermissions(false);
       });
 
@@ -87,7 +88,8 @@ export function useViewActionPermissions(view: View | null | undefined, opened: 
     };
   }, [currentUser?.email, opened, viewId, workspaceId]);
 
-  const hasLoadedViewActionPermissions = loadedViewId === viewId;
+  const canLoadViewActionPermissions = Boolean(opened && workspaceId && viewId);
+  const hasLoadedViewActionPermissions = !canLoadViewActionPermissions || loadedViewId === viewId;
   const canManageViewActions = hasLoadedViewActionPermissions
     ? canUseViewMutationActions({
         currentUserPermission,
@@ -98,10 +100,17 @@ export function useViewActionPermissions(view: View | null | undefined, opened: 
         currentUserPermission,
       })
     : false;
+  const canCreateViewActions = hasLoadedViewActionPermissions
+    ? canUseChildViewCreationActions({
+        currentUserPermission,
+      })
+    : false;
 
   return {
+    canCreateViewActions,
     canManageViewActions,
     canUsePageHistory,
+    hasLoadedViewActionPermissions,
     isLoadingViewActionPermissions,
   };
 }

--- a/src/components/app/view-actions/useViewActionPermissions.ts
+++ b/src/components/app/view-actions/useViewActionPermissions.ts
@@ -5,6 +5,7 @@ import { ObjectPermission, View } from '@/application/types';
 import { findAncestors, findSharedAccessLevel } from '@/components/_shared/outline/utils';
 import { useAppOutline, useCurrentWorkspaceId } from '@/components/app/app.hooks';
 import {
+  canUsePageHistoryAction,
   canUseViewMutationActions,
   resolveCurrentUserActionAccessLevel,
 } from '@/components/app/view-actions/viewActionPermission';
@@ -92,9 +93,15 @@ export function useViewActionPermissions(view: View | null | undefined, opened: 
         currentUserPermission,
       })
     : false;
+  const canUsePageHistory = hasLoadedViewActionPermissions
+    ? canUsePageHistoryAction({
+        currentUserPermission,
+      })
+    : false;
 
   return {
     canManageViewActions,
+    canUsePageHistory,
     isLoadingViewActionPermissions,
   };
 }

--- a/src/components/app/view-actions/viewActionPermission.ts
+++ b/src/components/app/view-actions/viewActionPermission.ts
@@ -1,0 +1,35 @@
+import { AccessLevel, IPeopleWithAccessType, ObjectPermission } from '@/application/types';
+
+export function canUseViewMutationActions({
+  currentUserPermission,
+}: {
+  currentUserPermission?: ObjectPermission | null;
+}) {
+  if (currentUserPermission?.object_creator || currentUserPermission?.ancestor_creator) {
+    return true;
+  }
+
+  if (currentUserPermission?.access_level !== undefined) {
+    return currentUserPermission.access_level >= AccessLevel.FullAccess;
+  }
+
+  return false;
+}
+
+export function resolveCurrentUserActionAccessLevel({
+  currentUserEmail,
+  currentUserPermission,
+  outlineAccessLevel,
+  sharedPeople,
+}: {
+  currentUserEmail?: string | null;
+  currentUserPermission?: ObjectPermission | null;
+  outlineAccessLevel?: AccessLevel;
+  sharedPeople: IPeopleWithAccessType[];
+}) {
+  return (
+    currentUserPermission?.access_level ??
+    sharedPeople.find((person) => person.email === currentUserEmail)?.access_level ??
+    outlineAccessLevel
+  );
+}

--- a/src/components/app/view-actions/viewActionPermission.ts
+++ b/src/components/app/view-actions/viewActionPermission.ts
@@ -5,10 +5,6 @@ export function canUseViewMutationActions({
 }: {
   currentUserPermission?: ObjectPermission | null;
 }) {
-  if (currentUserPermission?.object_creator || currentUserPermission?.ancestor_creator) {
-    return true;
-  }
-
   if (currentUserPermission?.access_level !== undefined) {
     return currentUserPermission.access_level >= AccessLevel.FullAccess;
   }
@@ -17,6 +13,18 @@ export function canUseViewMutationActions({
 }
 
 export function canUsePageHistoryAction({ currentUserPermission }: { currentUserPermission?: ObjectPermission | null }) {
+  if (currentUserPermission?.access_level !== undefined) {
+    return currentUserPermission.access_level >= AccessLevel.ReadAndWrite;
+  }
+
+  return false;
+}
+
+export function canUseChildViewCreationActions({
+  currentUserPermission,
+}: {
+  currentUserPermission?: ObjectPermission | null;
+}) {
   if (currentUserPermission?.access_level !== undefined) {
     return currentUserPermission.access_level >= AccessLevel.ReadAndWrite;
   }

--- a/src/components/app/view-actions/viewActionPermission.ts
+++ b/src/components/app/view-actions/viewActionPermission.ts
@@ -1,4 +1,4 @@
-import { AccessLevel, IPeopleWithAccessType, ObjectPermission } from '@/application/types';
+import { AccessLevel, ObjectPermission } from '@/application/types';
 
 export function canUseViewMutationActions({
   currentUserPermission,
@@ -30,22 +30,4 @@ export function canUseChildViewCreationActions({
   }
 
   return false;
-}
-
-export function resolveCurrentUserActionAccessLevel({
-  currentUserEmail,
-  currentUserPermission,
-  outlineAccessLevel,
-  sharedPeople,
-}: {
-  currentUserEmail?: string | null;
-  currentUserPermission?: ObjectPermission | null;
-  outlineAccessLevel?: AccessLevel;
-  sharedPeople: IPeopleWithAccessType[];
-}) {
-  return (
-    currentUserPermission?.access_level ??
-    sharedPeople.find((person) => person.email === currentUserEmail)?.access_level ??
-    outlineAccessLevel
-  );
 }

--- a/src/components/app/view-actions/viewActionPermission.ts
+++ b/src/components/app/view-actions/viewActionPermission.ts
@@ -16,6 +16,14 @@ export function canUseViewMutationActions({
   return false;
 }
 
+export function canUsePageHistoryAction({ currentUserPermission }: { currentUserPermission?: ObjectPermission | null }) {
+  if (currentUserPermission?.access_level !== undefined) {
+    return currentUserPermission.access_level >= AccessLevel.ReadAndWrite;
+  }
+
+  return false;
+}
+
 export function resolveCurrentUserActionAccessLevel({
   currentUserEmail,
   currentUserPermission,

--- a/src/components/view-meta/TitleEditable.tsx
+++ b/src/components/view-meta/TitleEditable.tsx
@@ -9,7 +9,7 @@ import { Log } from '@/utils/log';
  * Title Update Flow & Echo Prevention Mechanism:
  * 
  * 1. USER INPUT → LOCAL UPDATE
- *    - User types → debounced update (300ms) → send to server
+ *    - User types → debounced update (3s) → send to server
  *    - User blurs/enters → immediate update → send to server
  *    - Cache sent values with timestamps for echo detection
  * 
@@ -136,7 +136,7 @@ function TitleEditable({
   }, [onUpdateName, scheduleCleanup]);
 
   const debouncedUpdate = useMemo(() => {
-    return debounce((value: string) => sendUpdate(value, false), 300);
+    return debounce((value: string) => sendUpdate(value, false), 3000);
   }, [sendUpdate]);
 
   const sendUpdateImmediately = useCallback((value: string) => {
@@ -335,6 +335,11 @@ function TitleEditable({
   // Cleanup timers
   useEffect(() => {
     return () => {
+      // Flush (not cancel) so a pending edit survives unmounting without a
+      // blur (e.g. navigating to another page); the 3s debounce window is
+      // long enough for users to leave mid-wait.
+      debouncedUpdate.flush();
+
       if (inputTimerRef.current) {
         clearTimeout(inputTimerRef.current);
       }
@@ -346,8 +351,6 @@ function TitleEditable({
       if (cleanupTimerRef.current) {
         clearTimeout(cleanupTimerRef.current);
       }
-
-      debouncedUpdate.cancel();
     };
   }, [debouncedUpdate]);
 


### PR DESCRIPTION
## Summary

- Add `access-details/v2` loading with legacy fallback and current-user permission typing.
- Resolve share-panel access from `current_user_permission` before legacy shared rows or outline access.
- Gate FullAccess grant controls separately from lower-level share-management actions.
- Gate page and space mutation menu actions from effective object permissions, with loading states while permissions resolve.

## Why

The previous UI inferred share and view-action authority from workspace role, shared rows, or outline access alone. That could hide valid actions for target creators/full-access users or expose controls before effective object permissions were known.

## Impact

Users keep read-only actions such as duplicate/open/find where allowed, while mutation actions like move, delete, lock, manage space, and FullAccess grants are shown only after effective permissions allow them.

## Validation

- `pnpm exec jest src/components/app/view-actions/useViewActionPermissions.test.ts src/components/app/share/__tests__/AccessLevelDropdown.test.tsx src/components/app/share/useShareAccessDetails.test.ts --no-coverage --runInBand`
- `pnpm run type-check`

## Summary by Sourcery

Gate share and view mutation controls based on effective per-page permissions rather than workspace role or legacy outline access.

New Features:
- Load share access details via the v2 access-details endpoint with a legacy fallback and expose current-user permission data.
- Derive per-view action permissions for pages and spaces and expose management capability and loading state to UI components.

Enhancements:
- Restrict page/space management actions in More actions menus to users with appropriate object permissions, while keeping duplicate and basic view actions available.
- Separate the ability to grant FullAccess from general share management so non-owner full-access users can downgrade/remove access without granting FullAccess.
- Use a shared helper to resolve the current user’s access level from v2 permissions, shared rows, and outline access.

Tests:
- Add unit tests for view action permission resolution and management gating based on current-user permissions.
- Extend share access detail and access level dropdown tests to cover v2 permission precedence and FullAccess grant visibility.