### PR TITLE
feat: scope AI chat context and show answer sources

### DIFF
--- a/playwright/e2e/page/move-page-restrictions.spec.ts
+++ b/playwright/e2e/page/move-page-restrictions.spec.ts
@@ -14,6 +14,7 @@ import { test, expect } from '@playwright/test';
 import {
   AddPageSelectors,
   EditorSelectors,
+  itemDirectChildPageItems,
   ModalSelectors,
   PageSelectors,
   SlashCommandSelectors,
@@ -197,7 +198,6 @@ test.describe('Move Page Restrictions', () => {
     // 1) Create a document page first
     testLog.step(1, 'Create document page');
     const docViewId = await createDocumentPageAndNavigate(page);
-    await page.waitForTimeout(1000);
 
     // 2) Insert NEW grid via slash menu (creates container)
     testLog.step(2, 'Insert new grid via slash menu');
@@ -205,41 +205,49 @@ test.describe('Move Page Restrictions', () => {
     await expect(editor).toBeVisible({ timeout: 15000 });
     await editor.click({ force: true });
     await page.keyboard.type('/');
-    await page.waitForTimeout(500);
 
     await expect(SlashCommandSelectors.slashPanel(page)).toBeVisible();
     await SlashCommandSelectors.slashMenuItem(page, getSlashMenuItemName('grid'))
       .first()
       .click({ force: true });
-    await page.waitForTimeout(3000);
+
+    // Creating an embedded database opens its ViewModal. Close it explicitly
+    // before interacting with the sidebar; a forced sidebar click while the
+    // modal is still mounted only dismisses the modal and does not expand the
+    // document row.
+    const newDatabaseDialog = page.locator('[role="dialog"]').filter({
+      has: page.getByText('New Database', { exact: true }),
+    });
+
+    await expect(newDatabaseDialog).toBeVisible({ timeout: 15000 });
+    await page.keyboard.press('Escape');
+    await expect(newDatabaseDialog).toBeHidden({ timeout: 10000 });
 
     // 3) Expand the document to see the database container in sidebar
     // After inserting a grid, the sidebar may take time to create the container child.
-    // Retry expansion until children appear (the expand toggle won't exist until children load).
+    // With a deep initial outline fetch, that child can already exist in the DOM
+    // inside a collapsed MUI container, so retry until it is actually visible.
     testLog.step(3, 'Expand document and find database container');
     await expandSpaceByName(page, spaceName);
 
     const docItem = page
       .locator(`[data-testid="page-item"]:has(> [data-testid="page-${docViewId}"])`)
       .first();
-    const childPageItems = docItem.locator('[data-testid="page-item"]');
+    const childPageItems = docItem.locator(itemDirectChildPageItems());
 
-    for (let attempt = 0; attempt < 20; attempt++) {
+    await expect(async () => {
       await ensurePageExpandedByViewId(page, docViewId);
-      if ((await childPageItems.count()) > 0) break;
-      await page.waitForTimeout(1500);
-    }
-
-    await expect(childPageItems.first()).toBeVisible({ timeout: 10000 });
+      await expect(childPageItems.first()).toBeVisible({ timeout: 1000 });
+    }).toPass({ timeout: 30000, intervals: [500, 1000] });
 
     // 4) Find the database container and open More Actions
     testLog.step(4, 'Open More Actions for database container');
     const dbContainerItem = childPageItems.first();
-    await dbContainerItem.hover({ force: true });
-    await page.waitForTimeout(500);
+    const moreActionsButton = dbContainerItem.getByTestId('page-more-actions').first();
 
-    await dbContainerItem.getByTestId('page-more-actions').first().click({ force: true });
-    await page.waitForTimeout(500);
+    await dbContainerItem.hover();
+    await expect(moreActionsButton).toBeVisible();
+    await moreActionsButton.click();
 
     // 5) Verify Move to is NOT disabled for database containers
     testLog.step(5, 'Verify Move to is enabled for database container');

--- a/playwright/e2e/space/create-space.spec.ts
+++ b/playwright/e2e/space/create-space.spec.ts
@@ -45,31 +45,30 @@ test.describe('Space Creation Tests', () => {
       await expect(PageSelectors.names(page).first()).toBeVisible({ timeout: 30000 });
       await page.waitForTimeout(2000);
 
-      // Step 2: Find the first space and open its more actions menu
-      const firstSpace = SpaceSelectors.items(page).first();
-      await expect(firstSpace).toBeVisible({ timeout: 10000 });
+      // Step 2: Open the global new page flow
+      await expect(PageSelectors.newPageButton(page)).toBeVisible({ timeout: 20000 });
+      await PageSelectors.newPageButton(page).click();
+      await expect(ModalSelectors.newPageModal(page)).toBeVisible({ timeout: 5000 });
 
-      // Click the more actions button for spaces (always visible in test environment)
-      await expect(SpaceSelectors.moreActionsButton(page).first()).toBeVisible({ timeout: 5000 });
-      await SpaceSelectors.moreActionsButton(page).first().click();
-      await page.waitForTimeout(1000);
-
-      // Step 3: Click on "Create New Space" option
-      await expect(SpaceSelectors.createNewSpaceButton(page)).toBeVisible({ timeout: 5000 });
-      await SpaceSelectors.createNewSpaceButton(page).click();
-      await page.waitForTimeout(1000);
+      // Step 3: Create a space from the new page modal
+      await expect(ModalSelectors.createNewSpaceButton(page)).toBeVisible({ timeout: 5000 });
+      await ModalSelectors.createNewSpaceButton(page).click();
 
       // Step 4: Fill in the space details
-      await expect(SpaceSelectors.createSpaceModal(page)).toBeVisible({ timeout: 5000 });
-      const nameInputContainer = SpaceSelectors.spaceNameInput(page);
+      const createSpaceModal = SpaceSelectors.createSpaceModal(page);
+
+      await expect(createSpaceModal).toBeVisible({ timeout: 5000 });
+      const nameInputContainer = createSpaceModal.getByTestId('space-name-input');
       await expect(nameInputContainer).toBeVisible();
       const nameInput = nameInputContainer.locator('input');
       await nameInput.clear();
       await nameInput.fill(spaceName);
 
       // Step 5: Save the new space
-      await expect(ModalSelectors.okButton(page)).toBeVisible();
-      await ModalSelectors.okButton(page).click();
+      const saveButton = createSpaceModal.getByTestId('modal-ok-button');
+
+      await expect(saveButton).toBeVisible();
+      await saveButton.click();
       await page.waitForTimeout(3000);
 
       // Step 6: Verify the new space appears in the sidebar

--- a/playwright/support/duplicate-test-helpers.ts
+++ b/playwright/support/duplicate-test-helpers.ts
@@ -370,15 +370,18 @@ export async function insertInlineGridViaSlash(page: Page, docViewId: string, li
       await openSlashMenuInEditor(page, editor, line);
       await SlashCommandSelectors.slashMenuItem(page, getSlashMenuItemName('grid')).first().click({ force: true });
 
-      const dialog = page.locator('[role="dialog"]');
+      await expect(databaseBlocks(editor).first()).toBeVisible({ timeout: 10000 });
+
+      // The database ViewModal can mount shortly after the embedded grid. Wait
+      // for that delayed render before closing it so sidebar interactions are
+      // not blocked by the modal backdrop.
+      const dialog = page.locator('[role="dialog"]').last();
+      await dialog.waitFor({ state: 'visible', timeout: 2000 }).catch(() => undefined);
       if (await dialog.isVisible().catch(() => false)) {
         await page.keyboard.press('Escape');
-        await expect(dialog)
-          .not.toBeVisible({ timeout: 5000 })
-          .catch(() => undefined);
+        await expect(dialog).toBeHidden({ timeout: 5000 });
       }
 
-      await expect(databaseBlocks(editor).first()).toBeVisible({ timeout: 10000 });
       await page.waitForTimeout(1500);
       return;
     } catch (e) {

--- a/playwright/support/duplicate-test-helpers.ts
+++ b/playwright/support/duplicate-test-helpers.ts
@@ -379,6 +379,9 @@ export async function insertInlineGridViaSlash(page: Page, docViewId: string, li
       await dialog.waitFor({ state: 'visible', timeout: 2000 }).catch(() => undefined);
       if (await dialog.isVisible().catch(() => false)) {
         await page.keyboard.press('Escape');
+        if (await dialog.isVisible().catch(() => false)) {
+          await page.mouse.click(10, 10);
+        }
         await expect(dialog).toBeHidden({ timeout: 5000 });
       }
 

--- a/playwright/support/page-utils.ts
+++ b/playwright/support/page-utils.ts
@@ -145,16 +145,18 @@ export async function ensurePageExpandedByViewId(page: Page, viewId: string): Pr
   const pageEl = page.locator(`[data-testid="page-item"]:has(> [data-testid="page-${viewId}"])`).first();
   await expect(pageEl).toBeVisible({ timeout: 10000 });
 
-  const collapseToggle = pageEl.locator('[data-testid="outline-toggle-collapse"]');
-  const isExpanded = (await collapseToggle.count()) > 0;
+  // Scope toggles to this page's row. Descendant rows stay mounted inside the
+  // MUI Collapse even while hidden and can have their own expand toggles.
+  const pageRow = pageEl.locator(`:scope > [data-testid="page-${viewId}"]`);
+  const collapseToggle = pageRow.locator('[data-testid="outline-toggle-collapse"]');
 
-  if (!isExpanded) {
-    const expandToggle = pageEl.locator('[data-testid="outline-toggle-expand"]');
-    if ((await expandToggle.count()) > 0) {
-      await expandToggle.first().click({ force: true });
-      await page.waitForTimeout(500);
-    }
-  }
+  if (await collapseToggle.isVisible().catch(() => false)) return;
+
+  const expandToggle = pageRow.locator('[data-testid="outline-toggle-expand"]');
+
+  await expect(expandToggle).toBeVisible({ timeout: 10000 });
+  await expandToggle.click();
+  await expect(collapseToggle).toBeVisible({ timeout: 5000 });
 }
 
 /**

--- a/playwright/support/page-utils.ts
+++ b/playwright/support/page-utils.ts
@@ -154,7 +154,10 @@ export async function ensurePageExpandedByViewId(page: Page, viewId: string): Pr
 
   const expandToggle = pageRow.locator('[data-testid="outline-toggle-expand"]');
 
-  await expect(expandToggle).toBeVisible({ timeout: 10000 });
+  // A newly created document has no toggle until it receives children.
+  // Preserve the helper's no-op behavior for those childless pages.
+  if (!(await expandToggle.isVisible().catch(() => false))) return;
+
   await expandToggle.click();
   await expect(collapseToggle).toBeVisible({ timeout: 5000 });
 }

--- a/playwright/support/relation-test-helpers.ts
+++ b/playwright/support/relation-test-helpers.ts
@@ -219,8 +219,19 @@ export async function openGridDatabaseByName(page: Page, pageName: string): Prom
 export async function openGridDatabaseByPageId(page: Page, pageId: string): Promise<DatabaseFixtureInfo> {
   const pageItem = PageSelectors.itemByViewId(page, pageId);
 
-  await expect(pageItem).toBeVisible({ timeout: 20000 });
-  await pageItem.click({ force: true });
+  await expect(pageItem).toBeAttached({ timeout: 20000 });
+
+  // Database routes use the nested grid view ID. With deeper outline prefetching,
+  // that grid row can be present inside a collapsed database container. Click the
+  // nearest visible page row; database containers route to their first child grid.
+  const navigationItem = pageItem
+    .locator('xpath=ancestor-or-self::div[@data-testid="page-item"]')
+    .filter({ visible: true })
+    .last();
+  const navigationRow = navigationItem.locator(':scope > [data-testid^="page-"]');
+
+  await expect(navigationRow).toBeVisible({ timeout: 20000 });
+  await navigationRow.click();
   await waitForActiveDatabasePage(page, pageId);
   await expect(DatabaseGridSelectors.grid(page)).toBeVisible({ timeout: 30000 });
   await waitForDatabaseTestContext(page);

--- a/playwright/support/selectors.ts
+++ b/playwright/support/selectors.ts
@@ -109,7 +109,6 @@ export const SpaceSelectors = {
   itemByName: (page: Page, spaceName: string) =>
     page.locator(`[data-testid="space-item"]:has([data-testid="space-name"]:text-is("${spaceName}"))`).first(),
   moreActionsButton: (page: Page) => page.getByTestId('inline-more-actions'),
-  createNewSpaceButton: (page: Page) => page.getByTestId('create-new-space-button'),
   createSpaceModal: (page: Page) => page.getByTestId('create-space-modal'),
   spaceNameInput: (page: Page) => page.getByTestId('space-name-input'),
 };
@@ -142,6 +141,7 @@ export const ModalSelectors = {
   confirmDeleteButton: (page: Page) => page.getByTestId('confirm-delete-button'),
   deletePageModal: (page: Page) => page.getByTestId('delete-page-confirm-modal'),
   newPageModal: (page: Page) => page.getByTestId('new-page-modal'),
+  createNewSpaceButton: (page: Page) => page.getByTestId('new-page-create-space-button'),
   spaceItemInModal: (page: Page) => page.getByTestId('space-item'),
   okButton: (page: Page) => page.getByTestId('modal-ok-button'),
   renameInput: (page: Page) => page.getByTestId('rename-modal-input'),

--- a/src/application/services/js-services/http/view-api.ts
+++ b/src/application/services/js-services/http/view-api.ts
@@ -7,7 +7,7 @@ const MAX_WORKSPACE_VIEW_SUBTREES_GET_URL_BYTES = 4096;
 const WORKSPACE_VIEW_SUBTREES_BATCH_CHUNK_SIZE = 50;
 
 export async function getAppOutline(workspaceId: string): Promise<AppOutlineResponse> {
-  const url = `/api/workspace/${workspaceId}/view/${workspaceId}?depth=2`;
+  const url = `/api/workspace/${workspaceId}/view/${workspaceId}?depth=6`;
 
   return executeAPIRequest<View>(() => getAxios()?.get<APIResponse<View>>(url)).then((data) => ({
     outline: Array.isArray(data.children) ? data.children : [],

--- a/src/application/types.ts
+++ b/src/application/types.ts
@@ -1201,6 +1201,8 @@ export interface View {
   extra: ViewExtra | null;
   children: View[];
   has_children?: boolean;
+  /** Authoritative space marker returned by newer folder-view APIs. */
+  is_space?: boolean;
   is_published: boolean;
   is_private: boolean;
   /** Whether this view is currently in the user's favorites. Synced via the folder. */

--- a/src/components/ai-chat/AIChat.tsx
+++ b/src/components/ai-chat/AIChat.tsx
@@ -3,14 +3,13 @@ import React, { useEffect, useMemo } from 'react';
 
 import { getUserIconUrl } from '@/application/user-metadata';
 import { useAIChatContext } from '@/components/ai-chat/AIChatProvider';
-import { useAppOperations, useCurrentWorkspaceId } from '@/components/app/app.hooks';
+import { useAppOperations, useCurrentWorkspaceId, useToView } from '@/components/app/app.hooks';
 import { useCurrentUserWorkspaceAvatar } from '@/components/app/useWorkspaceMemberProfile';
 import { Chat, ChatRequest } from '@/components/chat';
 import { useCurrentUser } from '@/components/main/app.hooks';
 import { getAxiosInstance } from '@/application/services/js-services/http';
 import { getPlatform } from '@/utils/platform';
 import { downloadPage } from '@/utils/url';
-
 
 export function AIChat({ chatId, onRendered }: { chatId: string; onRendered?: () => void }) {
   const workspaceId = useCurrentWorkspaceId();
@@ -30,6 +29,7 @@ export function AIChat({ chatId, onRendered }: { chatId: string; onRendered?: ()
   const [openMobilePrompt, setOpenMobilePrompt] = React.useState(isMobile);
 
   const { updatePage, loadDatabasePrompts, testDatabasePromptConfig } = useAppOperations();
+  const toView = useToView();
 
   const {
     selectionMode,
@@ -40,6 +40,18 @@ export function AIChat({ chatId, onRendered }: { chatId: string; onRendered?: ()
     onCloseView,
     drawerOpen,
   } = useAIChatContext();
+
+  const handleOpenSource = React.useCallback(
+    (viewId: string, rowId?: string) => {
+      if (rowId) {
+        void toView(viewId, rowId);
+        return;
+      }
+
+      onOpenView(viewId);
+    },
+    [onOpenView, toView]
+  );
 
   const requestInstance = useMemo(() => {
     if (!workspaceId) return;
@@ -93,7 +105,7 @@ export function AIChat({ chatId, onRendered }: { chatId: string; onRendered?: ()
 
   return (
     <div
-      data-testid="ai-chat-container"
+      data-testid='ai-chat-container'
       style={{
         height: 'calc(100vh - 48px)',
       }}
@@ -110,7 +122,7 @@ export function AIChat({ chatId, onRendered }: { chatId: string; onRendered?: ()
           onCloseSelectionMode={handleCloseSelectionMode}
           openingViewId={(drawerOpen && openViewId) || undefined}
           onCloseView={onCloseView}
-          onOpenView={onOpenView}
+          onOpenView={handleOpenSource}
           loadDatabasePrompts={loadDatabasePrompts}
           testDatabasePromptConfig={testDatabasePromptConfig}
         />

--- a/src/components/ai-chat/__tests__/chat-settings.test.ts
+++ b/src/components/ai-chat/__tests__/chat-settings.test.ts
@@ -17,7 +17,7 @@ function view(overrides: Partial<View>): View {
 }
 
 describe('AI chat initial settings', () => {
-  it('uses only document descendants for chats created under a workspace root', () => {
+  it('uses only an explicitly requested source for chats created under a workspace root', () => {
     const child = view({ view_id: 'doc-1' });
     const parent = view({
       view_id: 'space-id',
@@ -39,6 +39,25 @@ describe('AI chat initial settings', () => {
     });
   });
 
+  it('does not add a space or any of its children by default', () => {
+    const parent = view({
+      view_id: 'space-id',
+      extra: { is_space: true },
+      children: [
+        view({
+          view_id: 'doc-1',
+          children: [view({ view_id: 'nested-doc' })],
+        }),
+        view({ view_id: 'doc-2' }),
+      ],
+    });
+
+    expect(buildInitialAIChatSettings({ parent })).toEqual({
+      full_workspace: false,
+      rag_ids: [],
+    });
+  });
+
   it('filters explicit source context to the parent page subtree', () => {
     const parent = view({
       view_id: 'page-id',
@@ -56,18 +75,29 @@ describe('AI chat initial settings', () => {
     });
   });
 
-  it('uses the parent page subtree when no explicit sources are supplied', () => {
+  it('uses only the parent page document children when no explicit sources are supplied', () => {
     expect(
       buildInitialAIChatSettings({
         parent: view({
           view_id: 'page-id',
-          children: [view({ view_id: 'child-id' })],
+          children: [
+            view({
+              view_id: 'child-id',
+              children: [view({ view_id: 'nested-child-id' })],
+            }),
+            view({ view_id: 'second-child-id' }),
+            view({
+              view_id: 'database-id',
+              layout: ViewLayout.Grid,
+              children: [view({ view_id: 'database-child-id' })],
+            }),
+          ],
         }),
         query: 'summarize this',
       })
     ).toEqual({
       full_workspace: false,
-      rag_ids: ['page-id', 'child-id'],
+      rag_ids: ['child-id', 'second-child-id'],
       metadata: { initial_prompt: 'summarize this' },
     });
   });

--- a/src/components/ai-chat/__tests__/chat-settings.test.ts
+++ b/src/components/ai-chat/__tests__/chat-settings.test.ts
@@ -1,5 +1,6 @@
 import { View, ViewLayout } from '@/application/types';
 import { buildInitialAIChatSettings, isWorkspaceRootView } from '@/components/ai-chat/chat-settings';
+import { RAG_SOURCE_OWNERS_METADATA_KEY } from '@/components/ai-chat/rag-scope';
 
 function view(overrides: Partial<View>): View {
   return {
@@ -16,10 +17,12 @@ function view(overrides: Partial<View>): View {
 }
 
 describe('AI chat initial settings', () => {
-  it('uses full workspace context for chats created under a workspace root', () => {
+  it('uses only document descendants for chats created under a workspace root', () => {
+    const child = view({ view_id: 'doc-1' });
     const parent = view({
       view_id: 'space-id',
       extra: { is_space: true },
+      children: [child, view({ view_id: 'doc-2' })],
     });
 
     expect(isWorkspaceRootView(parent)).toBe(true);
@@ -27,20 +30,25 @@ describe('AI chat initial settings', () => {
       buildInitialAIChatSettings({
         parent,
         query: 'appflowy',
-        sourceIds: ['doc-1', 'doc-2'],
+        sourceIds: ['doc-1', 'outside-scope'],
       })
     ).toEqual({
-      full_workspace: true,
-      rag_ids: [],
+      full_workspace: false,
+      rag_ids: ['doc-1'],
       metadata: { initial_prompt: 'appflowy' },
     });
   });
 
-  it('keeps explicit source context for chats created under a page', () => {
+  it('filters explicit source context to the parent page subtree', () => {
+    const parent = view({
+      view_id: 'page-id',
+      children: [view({ view_id: 'doc-1' }), view({ view_id: 'doc-2' })],
+    });
+
     expect(
       buildInitialAIChatSettings({
-        parent: view({ view_id: 'page-id' }),
-        sourceIds: ['doc-1', 'doc-1', '', 'doc-2'],
+        parent,
+        sourceIds: ['doc-1', 'doc-1', '', 'outside-scope', 'doc-2'],
       })
     ).toEqual({
       full_workspace: false,
@@ -48,14 +56,58 @@ describe('AI chat initial settings', () => {
     });
   });
 
-  it('preserves the initial prompt without adding source context for non-root chats', () => {
+  it('uses the parent page subtree when no explicit sources are supplied', () => {
     expect(
       buildInitialAIChatSettings({
-        parent: view({ view_id: 'page-id' }),
+        parent: view({
+          view_id: 'page-id',
+          children: [view({ view_id: 'child-id' })],
+        }),
         query: 'summarize this',
       })
     ).toEqual({
+      full_workspace: false,
+      rag_ids: ['page-id', 'child-id'],
       metadata: { initial_prompt: 'summarize this' },
+    });
+  });
+
+  it('keeps an opaque RAG source when its database owner is inside the complete scope', () => {
+    const parent = view({
+      view_id: 'page-id',
+      children: [
+        view({
+          view_id: 'database-view-id',
+          layout: ViewLayout.Grid,
+          extra: { is_space: false, database_id: 'database-id' },
+        }),
+      ],
+    });
+
+    expect(
+      buildInitialAIChatSettings({
+        parent,
+        query: 'explain this row',
+        sources: [
+          {
+            ragId: 'row-id',
+            ownerDatabaseId: 'database-id',
+          },
+          {
+            ragId: 'outside-row-id',
+            ownerDatabaseId: 'outside-database-id',
+          },
+        ],
+      })
+    ).toEqual({
+      full_workspace: false,
+      rag_ids: ['row-id'],
+      metadata: {
+        initial_prompt: 'explain this row',
+        [RAG_SOURCE_OWNERS_METADATA_KEY]: {
+          'row-id': { database_id: 'database-id' },
+        },
+      },
     });
   });
 });

--- a/src/components/ai-chat/__tests__/rag-scope.test.ts
+++ b/src/components/ai-chat/__tests__/rag-scope.test.ts
@@ -1,0 +1,145 @@
+import { ViewLayout } from '@/components/chat/types/request';
+import {
+  areSameRagIds,
+  collectScopedRagIds,
+  RAG_SOURCE_OWNERS_METADATA_KEY,
+  RagScopeView,
+  resolveScopedRagIds,
+  resolveScopedRagState,
+} from '@/components/ai-chat/rag-scope';
+
+function view(overrides: Partial<RagScopeView>): RagScopeView {
+  return {
+    view_id: 'view-id',
+    layout: ViewLayout.Document,
+    extra: { is_space: false },
+    children: [],
+    ...overrides,
+  };
+}
+
+describe('AI chat RAG scope', () => {
+  const scope = [
+    view({
+      view_id: 'space-id',
+      extra: { is_space: true },
+      children: [
+        view({
+          view_id: 'parent-id',
+          children: [view({ view_id: 'child-id' })],
+        }),
+        view({ view_id: 'chat-id', layout: ViewLayout.AIChat }),
+      ],
+    }),
+  ];
+
+  it('collects document IDs while excluding container and chat IDs', () => {
+    expect(collectScopedRagIds(scope)).toEqual(['parent-id', 'child-id']);
+  });
+
+  it('honors the authoritative top-level space marker', () => {
+    const topLevelSpace = view({
+      view_id: 'space-id',
+      is_space: true,
+      extra: null,
+      children: [view({ view_id: 'document-id' })],
+    });
+
+    expect(collectScopedRagIds([topLevelSpace])).toEqual(['document-id']);
+  });
+
+  it('gives the authoritative top-level marker precedence over stale extra data', () => {
+    const document = view({
+      view_id: 'document-id',
+      is_space: false,
+      extra: { is_space: true },
+    });
+
+    expect(collectScopedRagIds([document])).toEqual(['document-id']);
+  });
+
+  it('expands full-workspace settings to the scoped document IDs', () => {
+    expect(resolveScopedRagIds(scope, { full_workspace: true, rag_ids: [] })).toEqual(['parent-id', 'child-id']);
+  });
+
+  it('removes saved IDs outside the scope and duplicates', () => {
+    expect(
+      resolveScopedRagIds(scope, {
+        full_workspace: false,
+        rag_ids: ['outside-id', 'child-id', 'child-id'],
+      })
+    ).toEqual(['child-id']);
+  });
+
+  it('compares RAG IDs without depending on order', () => {
+    expect(areSameRagIds(['parent-id', 'child-id'], ['child-id', 'parent-id'])).toBe(true);
+    expect(areSameRagIds(['parent-id'], ['parent-id', 'parent-id'])).toBe(false);
+    expect(areSameRagIds(['parent-id', 'parent-id'], ['parent-id', 'child-id'])).toBe(false);
+  });
+
+  it('preserves a database row source when its owner belongs to the parent scope', () => {
+    const databaseScope = [
+      view({
+        view_id: 'parent-id',
+        children: [
+          view({
+            view_id: 'database-view-id',
+            layout: ViewLayout.Grid,
+            extra: { is_space: false, database_id: 'database-id' },
+          }),
+        ],
+      }),
+    ];
+    const settings = {
+      full_workspace: false,
+      rag_ids: ['parent-id', 'row-id'],
+      metadata: {
+        [RAG_SOURCE_OWNERS_METADATA_KEY]: {
+          'row-id': { database_id: 'database-id' },
+        },
+      },
+    };
+
+    expect(resolveScopedRagState(databaseScope, settings)).toEqual({
+      selectedRagIds: ['parent-id'],
+      preservedRagIds: ['row-id'],
+      ragIds: ['parent-id', 'row-id'],
+      sourceOwners: {
+        'row-id': { database_id: 'database-id' },
+      },
+    });
+  });
+
+  it('removes mapped sources whose owner is outside the parent scope', () => {
+    expect(
+      resolveScopedRagState(scope, {
+        full_workspace: false,
+        rag_ids: ['child-id', 'row-id'],
+        metadata: {
+          [RAG_SOURCE_OWNERS_METADATA_KEY]: {
+            'row-id': { view_id: 'outside-database-view-id' },
+          },
+        },
+      })
+    ).toEqual({
+      selectedRagIds: ['child-id'],
+      preservedRagIds: [],
+      ragIds: ['child-id'],
+      sourceOwners: {},
+    });
+  });
+
+  it('preserves opaque legacy sources but removes IDs confirmed as outside views', () => {
+    const settings = {
+      full_workspace: false,
+      rag_ids: ['child-id', 'legacy-row-id', 'outside-view-id'],
+    };
+
+    expect(resolveScopedRagState(scope, settings, new Set(['outside-view-id']))).toEqual({
+      selectedRagIds: ['child-id'],
+      preservedRagIds: ['legacy-row-id'],
+      ragIds: ['child-id', 'legacy-row-id'],
+      sourceOwners: {},
+    });
+  });
+});

--- a/src/components/ai-chat/chat-settings.ts
+++ b/src/components/ai-chat/chat-settings.ts
@@ -1,33 +1,57 @@
 import { View } from '@/application/types';
+import {
+  AIChatRagSource,
+  collectScopedOwnerIds,
+  collectScopedRagIds,
+  createRagSourceOwners,
+  isRagSourceOwnerInScope,
+  isSpaceView,
+  RagScopeView,
+  RAG_SOURCE_OWNERS_METADATA_KEY,
+} from '@/components/ai-chat/rag-scope';
 import type { ChatSettings } from '@/components/chat/types';
 
 export function isWorkspaceRootView(view: View | undefined): boolean {
-  return Boolean(view?.extra?.is_space);
+  return view ? isSpaceView(view) : false;
 }
 
 export function buildInitialAIChatSettings({
   parent,
   query,
   sourceIds,
+  sources,
 }: {
-  parent?: View;
+  parent?: RagScopeView;
   query?: string;
   sourceIds?: string[];
+  sources?: AIChatRagSource[];
 }): Partial<Pick<ChatSettings, 'rag_ids' | 'metadata' | 'full_workspace'>> {
-  const metadata = query ? { initial_prompt: query } : undefined;
+  const scopedIds = parent ? collectScopedRagIds([parent]) : [];
+  const requestedSources: AIChatRagSource[] | null = sources?.length
+    ? sources
+    : sourceIds?.length
+    ? sourceIds.filter(Boolean).map((ragId) => ({ ragId, ownerViewId: ragId }))
+    : null;
+  const scopedOwnerIds = parent ? collectScopedOwnerIds([parent]) : new Set<string>();
+  const validSources = requestedSources
+    ? requestedSources.filter((source) => {
+        const owners = createRagSourceOwners([source]);
+        const owner = owners[source.ragId];
 
-  if (isWorkspaceRootView(parent)) {
-    return {
-      full_workspace: true,
-      rag_ids: [],
-      ...(metadata ? { metadata } : {}),
-    };
-  }
-
-  const uniqueSourceIds = Array.from(new Set(sourceIds || [])).filter(Boolean);
+        return owner ? isRagSourceOwnerInScope(owner, scopedOwnerIds) : scopedOwnerIds.has(source.ragId);
+      })
+    : [];
+  const ragIds = requestedSources
+    ? Array.from(new Set(validSources.map((source) => source.ragId).filter(Boolean)))
+    : scopedIds;
+  const sourceOwners = createRagSourceOwners(validSources.filter((source) => source.ragId !== source.ownerViewId));
+  const metadata = {
+    ...(query ? { initial_prompt: query } : {}),
+    ...(Object.keys(sourceOwners).length > 0 ? { [RAG_SOURCE_OWNERS_METADATA_KEY]: sourceOwners } : {}),
+  };
 
   return {
-    ...(uniqueSourceIds.length > 0 ? { full_workspace: false, rag_ids: uniqueSourceIds } : {}),
-    ...(metadata ? { metadata } : {}),
+    ...(parent ? { full_workspace: false, rag_ids: ragIds } : {}),
+    ...(Object.keys(metadata).length > 0 ? { metadata } : {}),
   };
 }

--- a/src/components/ai-chat/chat-settings.ts
+++ b/src/components/ai-chat/chat-settings.ts
@@ -1,8 +1,7 @@
-import { View } from '@/application/types';
+import { View, ViewLayout } from '@/application/types';
 import {
   AIChatRagSource,
   collectScopedOwnerIds,
-  collectScopedRagIds,
   createRagSourceOwners,
   isRagSourceOwnerInScope,
   isSpaceView,
@@ -26,7 +25,12 @@ export function buildInitialAIChatSettings({
   sourceIds?: string[];
   sources?: AIChatRagSource[];
 }): Partial<Pick<ChatSettings, 'rag_ids' | 'metadata' | 'full_workspace'>> {
-  const scopedIds = parent ? collectScopedRagIds([parent]) : [];
+  const defaultRagIds =
+    parent && !isSpaceView(parent)
+      ? parent.children
+          .filter((child) => child.layout === ViewLayout.Document && !isSpaceView(child))
+          .map((child) => child.view_id)
+      : [];
   const requestedSources: AIChatRagSource[] | null = sources?.length
     ? sources
     : sourceIds?.length
@@ -43,7 +47,7 @@ export function buildInitialAIChatSettings({
     : [];
   const ragIds = requestedSources
     ? Array.from(new Set(validSources.map((source) => source.ragId).filter(Boolean)))
-    : scopedIds;
+    : defaultRagIds;
   const sourceOwners = createRagSourceOwners(validSources.filter((source) => source.ragId !== source.ownerViewId));
   const metadata = {
     ...(query ? { initial_prompt: query } : {}),

--- a/src/components/ai-chat/rag-scope.ts
+++ b/src/components/ai-chat/rag-scope.ts
@@ -1,0 +1,220 @@
+import { ViewLayout } from '@/components/chat/types/request';
+
+export const RAG_SOURCE_OWNERS_METADATA_KEY = 'rag_source_owners';
+
+export interface AIChatRagSource {
+  ragId: string;
+  ownerViewId?: string;
+  ownerDatabaseId?: string;
+}
+
+export interface RagSourceOwner {
+  view_id?: string;
+  database_id?: string;
+}
+
+export type RagSourceOwners = Record<string, RagSourceOwner>;
+
+export interface RagScopeView {
+  view_id: string;
+  layout: number;
+  extra?: {
+    is_space?: boolean;
+    database_id?: string;
+  } | null;
+  children: RagScopeView[];
+  has_children?: boolean;
+  is_space?: boolean;
+}
+
+export interface ScopedRagState {
+  selectedRagIds: string[];
+  preservedRagIds: string[];
+  ragIds: string[];
+  sourceOwners: RagSourceOwners;
+}
+
+export function isSpaceView(view: Pick<RagScopeView, 'is_space' | 'extra'>): boolean {
+  return view.is_space ?? Boolean(view.extra?.is_space);
+}
+
+function visitViews(views: RagScopeView[], visit: (view: RagScopeView) => void) {
+  const stack = [...views].reverse();
+
+  while (stack.length > 0) {
+    const view = stack.pop();
+
+    if (!view) continue;
+    visit(view);
+
+    for (let index = view.children.length - 1; index >= 0; index -= 1) {
+      stack.push(view.children[index]);
+    }
+  }
+}
+
+/**
+ * Return the document IDs that can be selected as RAG sources within a chat's
+ * parent subtree. Spaces are containers rather than sources, and a
+ * non-document node ends the selectable document branch.
+ */
+export function collectScopedRagIds(views: RagScopeView[]): string[] {
+  const ids: string[] = [];
+  const stack = [...views].reverse();
+
+  while (stack.length > 0) {
+    const view = stack.pop();
+
+    if (!view || view.layout !== ViewLayout.Document) continue;
+
+    if (!isSpaceView(view)) {
+      ids.push(view.view_id);
+    }
+
+    for (let index = view.children.length - 1; index >= 0; index -= 1) {
+      stack.push(view.children[index]);
+    }
+  }
+
+  return ids;
+}
+
+/** Return every view/database identity that belongs to the raw parent scope. */
+export function collectScopedOwnerIds(views: RagScopeView[]): Set<string> {
+  const ids = new Set<string>();
+
+  visitViews(views, (view) => {
+    ids.add(view.view_id);
+    if (view.extra?.database_id) ids.add(view.extra.database_id);
+  });
+
+  return ids;
+}
+
+export function getRagSourceOwners(metadata: Record<string, unknown> | undefined): RagSourceOwners {
+  const value = metadata?.[RAG_SOURCE_OWNERS_METADATA_KEY];
+
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return {};
+
+  return Object.entries(value).reduce<RagSourceOwners>((owners, [ragId, rawOwner]) => {
+    if (!rawOwner || typeof rawOwner !== 'object' || Array.isArray(rawOwner)) return owners;
+
+    const owner = rawOwner as Record<string, unknown>;
+    const viewId = typeof owner.view_id === 'string' && owner.view_id ? owner.view_id : undefined;
+    const databaseId = typeof owner.database_id === 'string' && owner.database_id ? owner.database_id : undefined;
+
+    if (viewId || databaseId) {
+      owners[ragId] = {
+        ...(viewId ? { view_id: viewId } : {}),
+        ...(databaseId ? { database_id: databaseId } : {}),
+      };
+    }
+
+    return owners;
+  }, {});
+}
+
+export function isRagSourceOwnerInScope(owner: RagSourceOwner, scopedOwnerIds: Set<string>): boolean {
+  return Boolean(
+    (owner.view_id && scopedOwnerIds.has(owner.view_id)) || (owner.database_id && scopedOwnerIds.has(owner.database_id))
+  );
+}
+
+export function createRagSourceOwners(sources: AIChatRagSource[]): RagSourceOwners {
+  return sources.reduce<RagSourceOwners>((owners, source) => {
+    if (!source.ragId || (!source.ownerViewId && !source.ownerDatabaseId)) return owners;
+
+    owners[source.ragId] = {
+      ...(source.ownerViewId ? { view_id: source.ownerViewId } : {}),
+      ...(source.ownerDatabaseId ? { database_id: source.ownerDatabaseId } : {}),
+    };
+    return owners;
+  }, {});
+}
+
+export function resolveScopedRagState(
+  views: RagScopeView[],
+  settings: { full_workspace?: boolean; rag_ids?: string[]; metadata?: Record<string, unknown> } | null,
+  knownOutsideViewIds: ReadonlySet<string> = new Set()
+): ScopedRagState {
+  if (!settings) {
+    return { selectedRagIds: [], preservedRagIds: [], ragIds: [], sourceOwners: {} };
+  }
+
+  const selectableIds = collectScopedRagIds(views);
+
+  if (settings.full_workspace) {
+    return {
+      selectedRagIds: selectableIds,
+      preservedRagIds: [],
+      ragIds: selectableIds,
+      sourceOwners: {},
+    };
+  }
+
+  const savedIds = Array.from(new Set((settings.rag_ids || []).filter(Boolean)));
+  const savedIdSet = new Set(savedIds);
+  const selectableIdSet = new Set(selectableIds);
+  const scopedOwnerIds = collectScopedOwnerIds(views);
+  const owners = getRagSourceOwners(settings.metadata);
+  const selectedRagIds = selectableIds.filter((id) => savedIdSet.has(id));
+  const preservedRagIds: string[] = [];
+
+  for (const id of savedIds) {
+    if (selectableIdSet.has(id)) continue;
+
+    const owner = owners[id];
+
+    if (owner) {
+      if (isRagSourceOwnerInScope(owner, scopedOwnerIds)) preservedRagIds.push(id);
+      continue;
+    }
+
+    // A known view inside the raw tree is non-selectable (for example, a
+    // database view). Known out-of-scope view IDs are supplied by navigation
+    // lookups. Unknown IDs are opaque legacy sources and must not be erased.
+    if (!scopedOwnerIds.has(id) && !knownOutsideViewIds.has(id)) {
+      preservedRagIds.push(id);
+    }
+  }
+
+  const ragIds = [...selectedRagIds, ...preservedRagIds];
+  const ragIdSet = new Set(ragIds);
+  const sourceOwners = Object.entries(owners).reduce<RagSourceOwners>((next, [ragId, owner]) => {
+    if (ragIdSet.has(ragId)) next[ragId] = owner;
+    return next;
+  }, {});
+
+  return { selectedRagIds, preservedRagIds, ragIds, sourceOwners };
+}
+
+export function resolveScopedRagIds(
+  views: RagScopeView[],
+  settings: { full_workspace?: boolean; rag_ids?: string[]; metadata?: Record<string, unknown> } | null
+): string[] {
+  return resolveScopedRagState(views, settings).selectedRagIds;
+}
+
+export function areSameRagIds(left: string[], right: string[]): boolean {
+  if (left.length !== right.length) return false;
+
+  const leftIds = new Set(left);
+  const rightIds = new Set(right);
+
+  if (leftIds.size !== left.length || rightIds.size !== right.length) return false;
+
+  return left.every((id) => rightIds.has(id));
+}
+
+export function areSameRagSourceOwners(left: RagSourceOwners, right: RagSourceOwners): boolean {
+  const leftEntries = Object.entries(left);
+  const rightEntries = Object.entries(right);
+
+  if (leftEntries.length !== rightEntries.length) return false;
+
+  return leftEntries.every(([ragId, owner]) => {
+    const other = right[ragId];
+
+    return other?.view_id === owner.view_id && other?.database_id === owner.database_id;
+  });
+}

--- a/src/components/app/DatabaseView.tsx
+++ b/src/components/app/DatabaseView.tsx
@@ -57,7 +57,7 @@ function DatabaseView(props: DatabaseViewProps) {
   // server fetches for any ancestor missing from the shallow outline, so it
   // resolves the database container even when the outline tree doesn't yet
   // include the route view's parent (e.g. immediately after refresh while
-  // the outline still loads at depth=2).
+  // the outline still uses a bounded depth).
   const breadcrumbContainerView = useMemo((): View | undefined => {
     if (containerView) return undefined;
     if (viewMeta.extra?.embedded) return undefined;

--- a/src/components/app/header/MoreActionsContent.tsx
+++ b/src/components/app/header/MoreActionsContent.tsx
@@ -89,7 +89,7 @@ function MoreActionsContent({
         source: 0,
       });
       void refreshOutline?.();
-      // The shallow outline (depth=2) doesn't include children beyond space level.
+      // The bounded outline (depth=6) may not include deeply nested children.
       // Reload the parent view's children so the new duplicate appears in the sidebar.
       if (parentViewId) {
         ViewService.invalidateCache(workspaceId, parentViewId);

--- a/src/components/app/search/BestMatch.tsx
+++ b/src/components/app/search/BestMatch.tsx
@@ -1,17 +1,19 @@
 import { debounce } from 'lodash-es';
-import React, { useCallback, useEffect, useMemo, useRef } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import { View } from '@/application/types';
-import { getDatabaseIdFromExtra } from '@/application/view-utils';
 import { SearchService, ViewService } from '@/application/services/domains';
 import type {
   SearchDocumentPageResponse,
   SearchDocumentResponseItem,
   SearchSummary,
 } from '@/application/services/domains/search';
+import { View } from '@/application/types';
+import { getDatabaseIdFromExtra } from '@/application/view-utils';
 import { notify } from '@/components/_shared/notify';
 import { findView } from '@/components/_shared/outline/utils';
+import { isSpaceView } from '@/components/ai-chat/rag-scope';
+import type { AIChatRagSource } from '@/components/ai-chat/rag-scope';
 import { useAIEnabled, useAppOutline, useCurrentWorkspaceId } from '@/components/app/app.hooks';
 import { SearchAIOverview, SearchOverviewSource } from '@/components/app/search/SearchAIOverview';
 import ViewList, { SearchViewListItem } from '@/components/app/search/ViewList';
@@ -103,18 +105,18 @@ function BestMatch({
   onClose: () => void;
   searchValue: string;
   askingAI: boolean;
-  onAskAI: (query: string, sourceIds?: string[]) => void;
+  onAskAI: (query: string, sources?: AIChatRagSource[]) => void;
 }) {
-  const [items, setItems] = React.useState<SearchViewListItem[] | undefined>(undefined);
-  const [searchResults, setSearchResults] = React.useState<SearchDocumentResponseItem[]>([]);
-  const [summary, setSummary] = React.useState<SearchSummary | null>(null);
-  const [hasMore, setHasMore] = React.useState(false);
-  const [nextOffset, setNextOffset] = React.useState<number | null>(null);
+  const [items, setItems] = useState<SearchViewListItem[] | undefined>(undefined);
+  const [searchResults, setSearchResults] = useState<SearchDocumentResponseItem[]>([]);
+  const [summary, setSummary] = useState<SearchSummary | null>(null);
+  const [hasMore, setHasMore] = useState(false);
+  const [nextOffset, setNextOffset] = useState<number | null>(null);
   const { t } = useTranslation();
   const outline = useAppOutline();
-  const [loading, setLoading] = React.useState<boolean>(false);
-  const [summaryLoading, setSummaryLoading] = React.useState(false);
-  const [loadingMore, setLoadingMore] = React.useState(false);
+  const [loading, setLoading] = useState<boolean>(false);
+  const [summaryLoading, setSummaryLoading] = useState(false);
+  const [loadingMore, setLoadingMore] = useState(false);
   const aiEnabled = useAIEnabled();
   const currentWorkspaceId = useCurrentWorkspaceId();
   const searchSeqRef = useRef(0);
@@ -135,7 +137,7 @@ function BestMatch({
         const view = resolvedViews[index];
         const rowId = item.database_row_id || undefined;
 
-        if (!view || view.extra?.is_space) continue;
+        if (!view || isSpaceView(view)) continue;
 
         const viewName = view.name.trim() || t('menuAppHeader.defaultNewPageName');
         const contentPreview = previewLines(item.content || item.preview);
@@ -309,6 +311,8 @@ function BestMatch({
         targetViewId,
         targetRowId,
         ragId: sourceId,
+        ownerViewId: view?.view_id || result?.database_view_id || undefined,
+        ownerDatabaseId: result?.database_id || undefined,
         view,
         name: view?.name?.trim() || t('menuAppHeader.defaultNewPageName'),
       });
@@ -336,7 +340,7 @@ function BestMatch({
             sources={overviewSources}
             summary={summary}
             onClose={onClose}
-            onAskAI={(sourceIds) => onAskAI(searchValue, sourceIds)}
+            onAskAI={(sources) => onAskAI(searchValue, sources)}
           />
         ) : undefined
       }

--- a/src/components/app/search/Search.tsx
+++ b/src/components/app/search/Search.tsx
@@ -1,13 +1,14 @@
 import { Dialog, InputBase } from '@mui/material';
-import React, { useCallback, useEffect } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { View, ViewLayout } from '@/application/types';
 import { ReactComponent as CloseIcon } from '@/assets/icons/close.svg';
 import { ReactComponent as SearchIcon } from '@/assets/icons/search.svg';
 import { notify } from '@/components/_shared/notify';
-import { findAncestors } from '@/components/_shared/outline/utils';
 import { buildInitialAIChatSettings } from '@/components/ai-chat/chat-settings';
+import { isSpaceView } from '@/components/ai-chat/rag-scope';
+import type { AIChatRagSource } from '@/components/ai-chat/rag-scope';
 import {
   useAIEnabled,
   useAppOperations,
@@ -19,17 +20,15 @@ import {
 } from '@/components/app/app.hooks';
 import BestMatch from '@/components/app/search/BestMatch';
 import RecentViews from '@/components/app/search/RecentViews';
+import { findAncestors } from '@/components/chat/lib/views';
 import { dropdownMenuItemVariants } from '@/components/ui/dropdown-menu';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { createHotkey, createHotKeyLabel, HOT_KEY_NAME } from '@/utils/hotkeys';
 
-function getAIChatParent(outline: View[] | undefined, currentViewId: string | undefined) {
+function getFallbackAIChatParent(outline: View[] | undefined) {
   if (!outline?.length) return;
 
-  const currentPath = currentViewId ? findAncestors(outline, currentViewId) : undefined;
-  const currentSpace = currentPath?.find((view) => view.extra?.is_space);
-
-  return currentSpace || outline.find((view) => view.extra?.is_space) || outline[0];
+  return outline.find(isSpaceView) || outline[0];
 }
 
 function getErrorMessage(error: unknown) {
@@ -39,10 +38,10 @@ function getErrorMessage(error: unknown) {
 }
 
 export function Search() {
-  const [open, setOpen] = React.useState<boolean>(false);
+  const [open, setOpen] = useState<boolean>(false);
   const { t } = useTranslation();
-  const [searchValue, setSearchValue] = React.useState<string>('');
-  const [askingAI, setAskingAI] = React.useState<boolean>(false);
+  const [searchValue, setSearchValue] = useState<string>('');
+  const [askingAI, setAskingAI] = useState<boolean>(false);
   const outline = useAppOutline();
   const currentViewId = useAppViewId();
   const currentWorkspaceId = useCurrentWorkspaceId();
@@ -55,44 +54,58 @@ export function Search() {
   }, []);
 
   const handleAskAI = useCallback(
-    async (query: string, sourceIds?: string[]) => {
+    async (query: string, sources?: AIChatRagSource[]) => {
       if (!aiEnabled || !addPage || !currentWorkspaceId) return;
-
-      const parent = getAIChatParent(outline, currentViewId);
-
-      if (!parent) {
-        notify.error(t('search.createAIChatFailed', { defaultValue: 'Unable to create an AI chat here' }));
-        return;
-      }
 
       setAskingAI(true);
       try {
-        const created = await addPage(parent.view_id, {
+        const [{ ChatRequest }, { getAxiosInstance }] = await Promise.all([
+          import('@/components/chat/request'),
+          import('@/application/services/js-services/http'),
+        ]);
+        const axiosInstance = getAxiosInstance();
+
+        if (!axiosInstance) {
+          throw new Error('Missing axios instance');
+        }
+
+        const scopeRequest = new ChatRequest(currentWorkspaceId, currentViewId, axiosInstance);
+        let parentViewId: string | undefined;
+
+        if (currentViewId) {
+          const navigation = await scopeRequest.getViewNavigation(currentViewId);
+          const currentPath = findAncestors([navigation], currentViewId);
+
+          // Shared/private navigation can intentionally omit inaccessible space
+          // ancestors. In that case the visible navigation root is the only
+          // authoritative scope we can attach the new chat beneath.
+          parentViewId = currentPath?.find(isSpaceView)?.view_id || currentPath?.[0]?.view_id;
+        } else {
+          parentViewId = getFallbackAIChatParent(outline)?.view_id;
+        }
+
+        if (!parentViewId) {
+          notify.error(t('search.createAIChatFailed', { defaultValue: 'Unable to create an AI chat here' }));
+          return;
+        }
+
+        const scopedParent = await scopeRequest.fetchCompleteView(parentViewId, true);
+        const created = await addPage(scopedParent.view_id, {
           layout: ViewLayout.AIChat,
           name: query || t('chat.newChat', { defaultValue: 'New chat' }),
-          prev_view_id: parent.children?.[parent.children.length - 1]?.view_id,
+          prev_view_id: scopedParent.children?.[scopedParent.children.length - 1]?.view_id,
         });
-        const initialSettings = buildInitialAIChatSettings({ parent, query, sourceIds });
         let settingsError: unknown;
 
-        if (Object.keys(initialSettings).length > 0) {
-          try {
-            const [{ ChatRequest }, { getAxiosInstance }] = await Promise.all([
-              import('@/components/chat/request'),
-              import('@/application/services/js-services/http'),
-            ]);
-            const axiosInstance = getAxiosInstance();
+        try {
+          const request = new ChatRequest(currentWorkspaceId, created.view_id, axiosInstance);
+          const initialSettings = buildInitialAIChatSettings({ parent: scopedParent, query, sources });
 
-            if (!axiosInstance) {
-              throw new Error('Missing axios instance');
-            }
-
-            const request = new ChatRequest(currentWorkspaceId, created.view_id, axiosInstance);
-
+          if (Object.keys(initialSettings).length > 0) {
             await request.updateChatSettings(initialSettings);
-          } catch (error) {
-            settingsError = error;
           }
+        } catch (error) {
+          settingsError = error;
         }
 
         if (settingsError) {
@@ -133,7 +146,7 @@ export function Search() {
   }, [onKeyDown]);
 
   const { recentViews, loadRecentViews } = useAppRecent();
-  const [loadingRecentViews, setLoadingRecentViews] = React.useState<boolean>(false);
+  const [loadingRecentViews, setLoadingRecentViews] = useState<boolean>(false);
 
   useEffect(() => {
     if (!open) return;

--- a/src/components/app/search/SearchAIOverview.tsx
+++ b/src/components/app/search/SearchAIOverview.tsx
@@ -1,5 +1,5 @@
 import Popover from '@mui/material/Popover';
-import React, { useMemo, useState } from 'react';
+import { Fragment, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { View } from '@/application/types';
@@ -8,6 +8,7 @@ import { ReactComponent as ChatAIPageIcon } from '@/assets/icons/chat_ai_page.sv
 import { ReactComponent as HomeAIChatIcon } from '@/assets/icons/m_home_ai_chat_icon.svg';
 import { ReactComponent as ToolbarLinkIcon } from '@/assets/icons/m_toolbar_link.svg';
 import PageIcon from '@/components/_shared/view-icon/PageIcon';
+import type { AIChatRagSource } from '@/components/ai-chat/rag-scope';
 import { useToView } from '@/components/app/app.hooks';
 import { cn } from '@/lib/utils';
 
@@ -17,6 +18,8 @@ export interface SearchOverviewSource {
   targetViewId: string;
   targetRowId?: string | null;
   ragId: string;
+  ownerViewId?: string;
+  ownerDatabaseId?: string;
   view?: View;
 }
 
@@ -29,7 +32,7 @@ interface SearchAIOverviewProps {
     content: string;
     highlights?: string;
   } | null;
-  onAskAI: (sourceIds?: string[]) => void;
+  onAskAI: (sources?: AIChatRagSource[]) => void;
   onClose: () => void;
 }
 
@@ -83,7 +86,7 @@ function HighlightedSummary({
               {part}
             </mark>
           ) : (
-            <React.Fragment key={`${part}-${index}`}>{part}</React.Fragment>
+            <Fragment key={`${part}-${index}`}>{part}</Fragment>
           )
         )}
         {showReference && (
@@ -250,7 +253,15 @@ export function SearchAIOverview({
           'mt-3 inline-flex h-8 w-36 items-center justify-center gap-1.5 rounded-[16px] border border-border-primary px-3 py-1.5 text-sm font-medium leading-[22px] text-text-primary',
           'hover:bg-fill-content-hover disabled:cursor-default disabled:opacity-60'
         )}
-        onClick={() => onAskAI(sources.map((source) => source.ragId))}
+        onClick={() =>
+          onAskAI(
+            sources.map((source) => ({
+              ragId: source.ragId,
+              ownerViewId: source.ownerViewId,
+              ownerDatabaseId: source.ownerDatabaseId,
+            }))
+          )
+        }
       >
         <ChatAIPageIcon className='h-5 w-5 shrink-0 text-icon-primary' />
         {t('commandPalette.aiAskFollowUp', { defaultValue: 'Ask follow-up' })}

--- a/src/components/app/search/__tests__/BestMatch.test.tsx
+++ b/src/components/app/search/__tests__/BestMatch.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it, beforeEach, jest } from '@jest/globals';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 
 import { ViewLayout } from '@/application/types';
 import type { View } from '@/application/types';
@@ -13,6 +13,11 @@ const mockSearchWorkspaceDocumentPage = jest.fn();
 const mockGenerateSearchSummary = jest.fn();
 const mockGetView = jest.fn();
 let mockAppOutline: View[] = [];
+let mockOverviewSources: Array<{
+  ragId: string;
+  ownerViewId?: string;
+  ownerDatabaseId?: string;
+}> = [];
 const mockT = (key: string, options?: { defaultValue?: string }) => options?.defaultValue ?? key;
 
 jest.mock('react-i18next', () => ({
@@ -38,7 +43,10 @@ jest.mock('@/application/services/domains', () => ({
 }));
 
 jest.mock('@/components/app/search/SearchAIOverview', () => ({
-  SearchAIOverview: () => <div data-testid='ai-overview' />,
+  SearchAIOverview: ({ sources }: { sources: typeof mockOverviewSources }) => {
+    mockOverviewSources = sources;
+    return <div data-testid='ai-overview' />;
+  },
 }));
 
 jest.mock('@/components/app/search/ViewList', () => ({
@@ -75,6 +83,7 @@ describe('BestMatch', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockAppOutline = [];
+    mockOverviewSources = [];
     mockUseAIEnabled.mockReturnValue(true);
     mockSearchWorkspaceDocumentPage.mockResolvedValue({
       has_more: false,
@@ -121,5 +130,46 @@ describe('BestMatch', () => {
 
     expect(await screen.findByText('Annie OKRs')).toBeTruthy();
     expect(mockGetView).toHaveBeenCalledWith('workspace-id', 'deep-view-id');
+  });
+
+  it('derives database row ownership for the AI follow-up source', async () => {
+    const databaseView = createView({
+      view_id: 'database-view-id',
+      name: 'Projects',
+      layout: ViewLayout.Grid,
+      extra: { database_id: 'database-id' },
+    });
+
+    mockAppOutline = [databaseView];
+    mockSearchWorkspaceDocumentPage.mockResolvedValue({
+      has_more: false,
+      items: [
+        {
+          object_id: 'row-id',
+          workspace_id: 'workspace-id',
+          score: 1,
+          content: 'Launch project',
+          database_row_id: 'row-id',
+          database_view_id: 'database-view-id',
+          database_id: 'database-id',
+        },
+      ],
+      next_offset: null,
+    });
+    mockGenerateSearchSummary.mockResolvedValue({
+      summaries: [{ content: 'Launch summary', sources: ['row-id'] }],
+    });
+
+    renderBestMatch('launch');
+
+    await waitFor(() =>
+      expect(mockOverviewSources).toEqual([
+        expect.objectContaining({
+          ragId: 'row-id',
+          ownerViewId: 'database-view-id',
+          ownerDatabaseId: 'database-id',
+        }),
+      ])
+    );
   });
 });

--- a/src/components/app/search/__tests__/Search.test.tsx
+++ b/src/components/app/search/__tests__/Search.test.tsx
@@ -1,0 +1,198 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+import { RAG_SOURCE_OWNERS_METADATA_KEY } from '@/components/ai-chat/rag-scope';
+import { Search } from '@/components/app/search/Search';
+
+import type { ChangeEvent, ReactNode } from 'react';
+
+const mockAddPage = jest.fn();
+const mockToView = jest.fn();
+const mockGetViewNavigation = jest.fn();
+const mockFetchCompleteView = jest.fn();
+const mockUpdateChatSettings = jest.fn();
+const mockChatRequest = jest.fn();
+
+jest.mock('@mui/material', () => ({
+  Dialog: ({ children, open }: { children: ReactNode; open: boolean }) => (open ? <div>{children}</div> : null),
+  InputBase: ({ onChange, value }: { onChange: (event: ChangeEvent<HTMLInputElement>) => void; value: string }) => (
+    <input aria-label='search-input' onChange={onChange} value={value} />
+  ),
+}));
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string, options?: { defaultValue?: string }) => options?.defaultValue || key }),
+}));
+
+jest.mock('@/components/app/app.hooks', () => ({
+  useAIEnabled: () => true,
+  useAppOperations: () => ({ addPage: mockAddPage }),
+  useAppOutline: () => [],
+  useAppRecent: () => ({ recentViews: [], loadRecentViews: jest.fn() }),
+  useAppViewId: () => 'current-page-id',
+  useCurrentWorkspaceId: () => 'workspace-id',
+  useToView: () => mockToView,
+}));
+
+jest.mock('@/components/app/search/BestMatch', () => ({
+  __esModule: true,
+  default: ({ onAskAI, searchValue }: { onAskAI: (query: string, sources: unknown[]) => void; searchValue: string }) => (
+    <button
+      onClick={() =>
+        onAskAI(searchValue, [
+          {
+            ragId: 'row-id',
+            ownerViewId: 'database-view-id',
+            ownerDatabaseId: 'database-id',
+          },
+        ])
+      }
+    >
+      Ask AI
+    </button>
+  ),
+}));
+
+jest.mock('@/components/app/search/RecentViews', () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+jest.mock('@/components/chat/request', () => ({
+  ChatRequest: function MockChatRequest(...args: unknown[]) {
+    return mockChatRequest(...args);
+  },
+}));
+
+jest.mock('@/components/chat/lib/views', () => ({
+  findAncestors: (views: Array<{ view_id: string; children: unknown[] }>, targetId: string) => {
+    const visit = (
+      items: Array<{ view_id: string; children: unknown[] }>,
+      path: Array<{ view_id: string; children: unknown[] }> = []
+    ): Array<{ view_id: string; children: unknown[] }> | null => {
+      for (const item of items) {
+        const nextPath = [...path, item];
+
+        if (item.view_id === targetId) return nextPath;
+        const found = visit(item.children as Array<{ view_id: string; children: unknown[] }>, nextPath);
+
+        if (found) return found;
+      }
+
+      return null;
+    };
+
+    return visit(views);
+  },
+}));
+
+jest.mock('@/application/services/js-services/http', () => ({
+  getAxiosInstance: () => ({}),
+}));
+
+jest.mock('@/components/_shared/notify', () => ({
+  notify: { error: jest.fn() },
+}));
+
+jest.mock('@/components/ui/dropdown-menu', () => ({
+  dropdownMenuItemVariants: () => '',
+}));
+
+jest.mock('@/components/ui/tooltip', () => ({
+  Tooltip: ({ children }: { children: ReactNode }) => <>{children}</>,
+  TooltipTrigger: ({ children }: { children: ReactNode }) => <>{children}</>,
+  TooltipContent: () => null,
+}));
+
+jest.mock('@/utils/hotkeys', () => ({
+  HOT_KEY_NAME: { SEARCH: 'search' },
+  createHotkey: () => () => false,
+  createHotKeyLabel: () => '',
+}));
+
+describe('Search AI chat creation', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    const currentPage = {
+      view_id: 'current-page-id',
+      name: 'Current page',
+      icon: null,
+      layout: 0,
+      extra: null,
+      children: [],
+      is_private: false,
+    };
+    const databaseView = {
+      view_id: 'database-view-id',
+      name: 'Projects',
+      icon: null,
+      layout: 1,
+      extra: { database_id: 'database-id' },
+      children: [],
+      is_private: false,
+    };
+    const space = {
+      view_id: 'space-id',
+      name: 'Space',
+      icon: null,
+      layout: 0,
+      is_space: true,
+      extra: { is_space: false },
+      children: [currentPage, databaseView],
+      is_private: false,
+    };
+
+    mockGetViewNavigation.mockResolvedValue({
+      view_id: 'workspace-id',
+      name: 'Workspace',
+      icon: null,
+      layout: 0,
+      extra: null,
+      children: [{ ...space, children: [currentPage] }],
+      is_private: false,
+    });
+    mockFetchCompleteView.mockResolvedValue(space);
+    mockAddPage.mockResolvedValue({ view_id: 'chat-id' });
+    mockUpdateChatSettings.mockResolvedValue(undefined);
+    mockToView.mockResolvedValue(undefined);
+    mockChatRequest.mockImplementation((_workspaceId: string, chatId: string) =>
+      chatId === 'current-page-id'
+        ? {
+            getViewNavigation: mockGetViewNavigation,
+            fetchCompleteView: mockFetchCompleteView,
+          }
+        : { updateChatSettings: mockUpdateChatSettings }
+    );
+  });
+
+  it('uses authoritative navigation and persists row ownership before navigating', async () => {
+    render(<Search />);
+
+    fireEvent.click(screen.getByText('button.search'));
+    fireEvent.change(screen.getByLabelText('search-input'), { target: { value: 'launch' } });
+    fireEvent.click(screen.getByText('Ask AI'));
+
+    await waitFor(() => expect(mockToView).toHaveBeenCalledWith('chat-id'));
+
+    expect(mockGetViewNavigation).toHaveBeenCalledWith('current-page-id');
+    expect(mockFetchCompleteView).toHaveBeenCalledWith('space-id', true);
+    expect(mockAddPage).toHaveBeenCalledWith('space-id', {
+      layout: 4,
+      name: 'launch',
+      prev_view_id: 'database-view-id',
+    });
+    expect(mockUpdateChatSettings).toHaveBeenCalledWith({
+      full_workspace: false,
+      rag_ids: ['row-id'],
+      metadata: {
+        initial_prompt: 'launch',
+        [RAG_SOURCE_OWNERS_METADATA_KEY]: {
+          'row-id': {
+            view_id: 'database-view-id',
+            database_id: 'database-id',
+          },
+        },
+      },
+    });
+    expect(mockUpdateChatSettings.mock.invocationCallOrder[0]).toBeLessThan(mockToView.mock.invocationCallOrder[0]);
+  });
+});

--- a/src/components/app/search/__tests__/SearchAIOverview.test.tsx
+++ b/src/components/app/search/__tests__/SearchAIOverview.test.tsx
@@ -1,0 +1,53 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import { SearchAIOverview } from '@/components/app/search/SearchAIOverview';
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (_key: string, options?: { defaultValue?: string }) => options?.defaultValue || _key }),
+}));
+
+jest.mock('@/components/app/app.hooks', () => ({
+  useToView: () => jest.fn(),
+}));
+
+jest.mock('@/components/_shared/view-icon/PageIcon', () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+describe('SearchAIOverview', () => {
+  it('passes the raw row RAG ID together with its database owner', () => {
+    const onAskAI = jest.fn();
+
+    render(
+      <SearchAIOverview
+        askingAI={false}
+        loading={false}
+        query='revenue'
+        summary={{ content: 'Revenue increased.' }}
+        sources={[
+          {
+            id: 'row-id',
+            name: 'Revenue database',
+            targetViewId: 'database-view-id',
+            ragId: 'row-id',
+            ownerViewId: 'database-view-id',
+            ownerDatabaseId: 'database-id',
+          },
+        ]}
+        onAskAI={onAskAI}
+        onClose={jest.fn()}
+      />
+    );
+
+    fireEvent.click(screen.getByText('Ask follow-up'));
+
+    expect(onAskAI).toHaveBeenCalledWith([
+      {
+        ragId: 'row-id',
+        ownerViewId: 'database-view-id',
+        ownerDatabaseId: 'database-id',
+      },
+    ]);
+  });
+});

--- a/src/components/app/view-actions/AddPageActions.tsx
+++ b/src/components/app/view-actions/AddPageActions.tsx
@@ -38,30 +38,30 @@ function AddPageActions({ view, onImportClick }: { view: View; onImportClick?: (
         const response = await addPage(view.view_id, { layout, name, prev_view_id: lastChildViewId });
 
         if (layout === ViewLayout.AIChat && currentWorkspaceId) {
-          const initialSettings = buildInitialAIChatSettings({ parent: view });
+          try {
+            const [{ ChatRequest }, { getAxiosInstance }] = await Promise.all([
+              import('@/components/chat/request'),
+              import('@/application/services/js-services/http'),
+            ]);
+            const axiosInstance = getAxiosInstance();
 
-          if (Object.keys(initialSettings).length > 0) {
-            try {
-              const [{ ChatRequest }, { getAxiosInstance }] = await Promise.all([
-                import('@/components/chat/request'),
-                import('@/application/services/js-services/http'),
-              ]);
-              const axiosInstance = getAxiosInstance();
-
-              if (!axiosInstance) {
-                throw new Error('Missing axios instance');
-              }
-
-              const request = new ChatRequest(currentWorkspaceId, response.view_id, axiosInstance);
-
-              await request.updateChatSettings(initialSettings);
-            } catch {
-              toast.error(
-                t('search.updateAIChatSettingsFailed', {
-                  defaultValue: 'AI chat was created, but the context could not be attached',
-                })
-              );
+            if (!axiosInstance) {
+              throw new Error('Missing axios instance');
             }
+
+            const request = new ChatRequest(currentWorkspaceId, response.view_id, axiosInstance);
+            const scopedParent = await request.fetchCompleteView(view.view_id);
+            const initialSettings = buildInitialAIChatSettings({ parent: scopedParent });
+
+            if (Object.keys(initialSettings).length > 0) {
+              await request.updateChatSettings(initialSettings);
+            }
+          } catch {
+            toast.error(
+              t('search.updateAIChatSettingsFailed', {
+                defaultValue: 'AI chat was created, but the context could not be attached',
+              })
+            );
           }
         }
 

--- a/src/components/app/view-actions/AddPageActions.tsx
+++ b/src/components/app/view-actions/AddPageActions.tsx
@@ -6,6 +6,7 @@ import { View, ViewLayout } from '@/application/types';
 import { ReactComponent as UploadIcon } from '@/assets/icons/upload.svg';
 import { ViewIcon } from '@/components/_shared/view-icon';
 import { buildInitialAIChatSettings } from '@/components/ai-chat/chat-settings';
+import { isSpaceView } from '@/components/ai-chat/rag-scope';
 import {
   useAIEnabled,
   useAppOperations,
@@ -50,7 +51,7 @@ function AddPageActions({ view, onImportClick }: { view: View; onImportClick?: (
             }
 
             const request = new ChatRequest(currentWorkspaceId, response.view_id, axiosInstance);
-            const scopedParent = await request.fetchCompleteView(view.view_id);
+            const scopedParent = isSpaceView(view) ? view : await request.getView(view.view_id);
             const initialSettings = buildInitialAIChatSettings({ parent: scopedParent });
 
             if (Object.keys(initialSettings).length > 0) {

--- a/src/components/app/view-actions/NewPage.tsx
+++ b/src/components/app/view-actions/NewPage.tsx
@@ -105,6 +105,7 @@ function NewPage() {
               {t('publish.addTo')}
               {` ${t('web.or')} `}
               <Button
+                data-testid='new-page-create-space-button'
                 onClick={() => {
                   setCreateSpaceOpen(true);
                 }}

--- a/src/components/app/view-actions/__tests__/AddPageActions.test.tsx
+++ b/src/components/app/view-actions/__tests__/AddPageActions.test.tsx
@@ -6,7 +6,7 @@ import AddPageActions from '@/components/app/view-actions/AddPageActions';
 import type { ReactNode } from 'react';
 
 const mockAddPage = jest.fn();
-const mockFetchCompleteView = jest.fn();
+const mockGetView = jest.fn();
 const mockUpdateChatSettings = jest.fn();
 const mockToView = jest.fn();
 const mockOpenPageModal = jest.fn();
@@ -38,7 +38,7 @@ jest.mock('@/components/chat/request', () => ({
   ChatRequest: function MockChatRequest(...args: unknown[]) {
     mockChatRequest(...args);
     return {
-      fetchCompleteView: mockFetchCompleteView,
+      getView: mockGetView,
       updateChatSettings: mockUpdateChatSettings,
     };
   },
@@ -111,8 +111,6 @@ describe('AddPageActions AI chat context', () => {
       children: [view({ view_id: 'space-child-1' }), view({ view_id: 'space-child-2' })],
     });
 
-    mockFetchCompleteView.mockResolvedValue(space);
-
     render(<AddPageActions view={space} />);
     fireEvent.click(screen.getByTestId('add-ai-chat-button'));
 
@@ -128,7 +126,7 @@ describe('AddPageActions AI chat context', () => {
       name: 'menuAppHeader.defaultNewPageName',
       prev_view_id: 'space-child-2',
     });
-    expect(mockFetchCompleteView).toHaveBeenCalledWith('space-id');
+    expect(mockGetView).not.toHaveBeenCalled();
     expect(mockToView).toHaveBeenCalledWith('chat-id');
   });
 
@@ -148,7 +146,7 @@ describe('AddPageActions AI chat context', () => {
       children: [directDocument, directDatabase, secondDirectDocument],
     });
 
-    mockFetchCompleteView.mockResolvedValue(page);
+    mockGetView.mockResolvedValue(page);
 
     render(<AddPageActions view={page} />);
     fireEvent.click(screen.getByTestId('add-ai-chat-button'));
@@ -170,7 +168,7 @@ describe('AddPageActions AI chat context', () => {
       name: 'menuAppHeader.defaultNewPageName',
       prev_view_id: 'second-direct-document-id',
     });
-    expect(mockFetchCompleteView).toHaveBeenCalledWith('page-id');
+    expect(mockGetView).toHaveBeenCalledWith('page-id');
     expect(mockToView).toHaveBeenCalledWith('chat-id');
   });
 });

--- a/src/components/app/view-actions/__tests__/AddPageActions.test.tsx
+++ b/src/components/app/view-actions/__tests__/AddPageActions.test.tsx
@@ -1,0 +1,176 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+import { View, ViewLayout } from '@/application/types';
+import AddPageActions from '@/components/app/view-actions/AddPageActions';
+
+import type { ReactNode } from 'react';
+
+const mockAddPage = jest.fn();
+const mockFetchCompleteView = jest.fn();
+const mockUpdateChatSettings = jest.fn();
+const mockToView = jest.fn();
+const mockOpenPageModal = jest.fn();
+const mockChatRequest = jest.fn();
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: { defaultValue?: string }) => options?.defaultValue || key,
+  }),
+}));
+
+jest.mock('sonner', () => ({
+  toast: {
+    dismiss: jest.fn(),
+    error: jest.fn(),
+    loading: jest.fn(() => 'loading-toast-id'),
+  },
+}));
+
+jest.mock('@/components/app/app.hooks', () => ({
+  useAIEnabled: () => true,
+  useAppOperations: () => ({ addPage: mockAddPage }),
+  useCurrentWorkspaceId: () => 'workspace-id',
+  useOpenPageModal: () => mockOpenPageModal,
+  useToView: () => mockToView,
+}));
+
+jest.mock('@/components/chat/request', () => ({
+  ChatRequest: function MockChatRequest(...args: unknown[]) {
+    mockChatRequest(...args);
+    return {
+      fetchCompleteView: mockFetchCompleteView,
+      updateChatSettings: mockUpdateChatSettings,
+    };
+  },
+}));
+
+jest.mock('@/application/services/js-services/http', () => ({
+  getAxiosInstance: () => ({}),
+}));
+
+jest.mock('@/components/_shared/view-icon', () => ({
+  ViewIcon: () => null,
+}));
+
+jest.mock('@/components/ui/dropdown-menu', () => ({
+  DropdownMenuGroup: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DropdownMenuItem: ({
+    children,
+    disabled,
+    onClick,
+    ...props
+  }: {
+    children: ReactNode;
+    disabled?: boolean;
+    onClick?: () => void;
+    [key: string]: unknown;
+  }) => (
+    <button
+      data-testid={props['data-testid'] as string | undefined}
+      disabled={disabled}
+      onClick={onClick}
+      type='button'
+    >
+      {children}
+    </button>
+  ),
+}));
+
+jest.mock('@/components/ui/tooltip', () => ({
+  Tooltip: ({ children }: { children: ReactNode }) => <>{children}</>,
+  TooltipContent: ({ children }: { children: ReactNode }) => <>{children}</>,
+  TooltipTrigger: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+
+function view(overrides: Partial<View> = {}): View {
+  return {
+    view_id: 'view-id',
+    name: 'View',
+    icon: null,
+    layout: ViewLayout.Document,
+    extra: { is_space: false },
+    children: [],
+    is_published: false,
+    is_private: false,
+    ...overrides,
+  };
+}
+
+describe('AddPageActions AI chat context', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockAddPage.mockResolvedValue({ view_id: 'chat-id' });
+    mockUpdateChatSettings.mockResolvedValue(undefined);
+    mockToView.mockResolvedValue(undefined);
+  });
+
+  it('starts with no RAG IDs when the parent is a space', async () => {
+    const space = view({
+      view_id: 'space-id',
+      extra: { is_space: true },
+      children: [view({ view_id: 'space-child-1' }), view({ view_id: 'space-child-2' })],
+    });
+
+    mockFetchCompleteView.mockResolvedValue(space);
+
+    render(<AddPageActions view={space} />);
+    fireEvent.click(screen.getByTestId('add-ai-chat-button'));
+
+    await waitFor(() =>
+      expect(mockUpdateChatSettings).toHaveBeenCalledWith({
+        full_workspace: false,
+        rag_ids: [],
+      })
+    );
+
+    expect(mockAddPage).toHaveBeenCalledWith('space-id', {
+      layout: ViewLayout.AIChat,
+      name: 'menuAppHeader.defaultNewPageName',
+      prev_view_id: 'space-child-2',
+    });
+    expect(mockFetchCompleteView).toHaveBeenCalledWith('space-id');
+    expect(mockToView).toHaveBeenCalledWith('chat-id');
+  });
+
+  it('uses only direct document child IDs when the parent is a page', async () => {
+    const nestedDocument = view({ view_id: 'nested-document-id' });
+    const directDocument = view({
+      view_id: 'direct-document-id',
+      children: [nestedDocument],
+    });
+    const directDatabase = view({
+      view_id: 'direct-database-id',
+      layout: ViewLayout.Grid,
+    });
+    const secondDirectDocument = view({ view_id: 'second-direct-document-id' });
+    const page = view({
+      view_id: 'page-id',
+      children: [directDocument, directDatabase, secondDirectDocument],
+    });
+
+    mockFetchCompleteView.mockResolvedValue(page);
+
+    render(<AddPageActions view={page} />);
+    fireEvent.click(screen.getByTestId('add-ai-chat-button'));
+
+    await waitFor(() =>
+      expect(mockUpdateChatSettings).toHaveBeenCalledWith({
+        full_workspace: false,
+        rag_ids: ['direct-document-id', 'second-direct-document-id'],
+      })
+    );
+
+    const settings = mockUpdateChatSettings.mock.calls[0][0] as { rag_ids: string[] };
+
+    expect(settings.rag_ids).not.toContain('page-id');
+    expect(settings.rag_ids).not.toContain('nested-document-id');
+    expect(settings.rag_ids).not.toContain('direct-database-id');
+    expect(mockAddPage).toHaveBeenCalledWith('page-id', {
+      layout: ViewLayout.AIChat,
+      name: 'menuAppHeader.defaultNewPageName',
+      prev_view_id: 'second-direct-document-id',
+    });
+    expect(mockFetchCompleteView).toHaveBeenCalledWith('page-id');
+    expect(mockToView).toHaveBeenCalledWith('chat-id');
+  });
+});

--- a/src/components/chat/__tests__/ChatRequest.test.ts
+++ b/src/components/chat/__tests__/ChatRequest.test.ts
@@ -352,6 +352,37 @@ describe('ChatRequest', () => {
       expect(result).toEqual(mockSettings);
     });
 
+    it('decodes the chat ID sentinel as an empty RAG scope', async () => {
+      mockAxiosInstance.get.mockResolvedValue({
+        data: {
+          code: 0,
+          data: {
+            name: 'Empty scope',
+            rag_ids: [chatId],
+            metadata: {},
+            full_workspace: false,
+            web_search_enabled: false,
+          },
+        },
+      });
+
+      await expect(chatRequest.getChatSettings()).resolves.toMatchObject({ rag_ids: [] });
+    });
+
+    it.each([['doc-id'], [chatId, 'doc-id']])('does not decode real RAG IDs: %p', async (...ragIds: string[]) => {
+      const settings = {
+        name: 'Selected sources',
+        rag_ids: ragIds,
+        metadata: {},
+        full_workspace: false,
+        web_search_enabled: false,
+      };
+
+      mockAxiosInstance.get.mockResolvedValue({ data: { code: 0, data: settings } });
+
+      await expect(chatRequest.getChatSettings()).resolves.toEqual(settings);
+    });
+
     it('should reject when workspaceId missing', async () => {
       const request = new ChatRequest(undefined, chatId, mockAxiosInstance);
       await expect(request.getChatSettings()).rejects.toBe('workspaceId or chatId is not defined');
@@ -385,6 +416,36 @@ describe('ChatRequest', () => {
       });
 
       expect(mockAxiosInstance.post).toHaveBeenCalledWith(expect.any(String), { rag_ids: ['new-doc-1', 'new-doc-2'] });
+    });
+
+    it('encodes an empty scoped RAG list with the chat ID sentinel', async () => {
+      mockAxiosInstance.post.mockResolvedValue({ data: { code: 0 } });
+
+      await chatRequest.updateChatSettings({ full_workspace: false, rag_ids: [] });
+
+      expect(mockAxiosInstance.post).toHaveBeenCalledWith(expect.any(String), {
+        full_workspace: false,
+        rag_ids: [chatId],
+      });
+    });
+
+    it('encodes an empty RAG list when full_workspace is omitted', async () => {
+      mockAxiosInstance.post.mockResolvedValue({ data: { code: 0 } });
+
+      await chatRequest.updateChatSettings({ rag_ids: [] });
+
+      expect(mockAxiosInstance.post).toHaveBeenCalledWith(expect.any(String), { rag_ids: [chatId] });
+    });
+
+    it('keeps an empty RAG list for explicit full-workspace context', async () => {
+      mockAxiosInstance.post.mockResolvedValue({ data: { code: 0 } });
+
+      await chatRequest.updateChatSettings({ full_workspace: true, rag_ids: [] });
+
+      expect(mockAxiosInstance.post).toHaveBeenCalledWith(expect.any(String), {
+        full_workspace: true,
+        rag_ids: [],
+      });
     });
   });
 

--- a/src/components/chat/__tests__/ChatRequest.test.ts
+++ b/src/components/chat/__tests__/ChatRequest.test.ts
@@ -25,6 +25,7 @@ jest.mock('@/components/chat/lib/utils', () => ({
 }));
 
 jest.mock('@/components/chat/lib/views', () => ({
+  ...jest.requireActual('@/components/chat/lib/views'),
   findView: jest.fn(),
 }));
 
@@ -145,10 +146,9 @@ describe('ChatRequest', () => {
 
       const result = await chatRequest.getChatMessages();
 
-      expect(mockAxiosInstance.get).toHaveBeenCalledWith(
-        `/api/chat/${workspaceId}/${chatId}/message`,
-        { params: undefined }
-      );
+      expect(mockAxiosInstance.get).toHaveBeenCalledWith(`/api/chat/${workspaceId}/${chatId}/message`, {
+        params: undefined,
+      });
       expect(result).toEqual(mockMessages);
     });
 
@@ -159,26 +159,19 @@ describe('ChatRequest', () => {
 
       await chatRequest.getChatMessages({ limit: 10, offset: 20 });
 
-      expect(mockAxiosInstance.get).toHaveBeenCalledWith(
-        expect.any(String),
-        { params: { limit: 10, offset: 20 } }
-      );
+      expect(mockAxiosInstance.get).toHaveBeenCalledWith(expect.any(String), { params: { limit: 10, offset: 20 } });
     });
 
     it('should reject when workspaceId is not defined', async () => {
       const requestWithoutWorkspace = new ChatRequest(undefined, chatId, mockAxiosInstance);
 
-      await expect(requestWithoutWorkspace.getChatMessages()).rejects.toBe(
-        'workspaceId or chatId is not defined'
-      );
+      await expect(requestWithoutWorkspace.getChatMessages()).rejects.toBe('workspaceId or chatId is not defined');
     });
 
     it('should reject when chatId is not defined', async () => {
       const requestWithoutChat = new ChatRequest(workspaceId, undefined, mockAxiosInstance);
 
-      await expect(requestWithoutChat.getChatMessages()).rejects.toBe(
-        'workspaceId or chatId is not defined'
-      );
+      await expect(requestWithoutChat.getChatMessages()).rejects.toBe('workspaceId or chatId is not defined');
     });
 
     it('should reject when API returns error', async () => {
@@ -211,10 +204,10 @@ describe('ChatRequest', () => {
         message_type: 1,
       });
 
-      expect(mockAxiosInstance.post).toHaveBeenCalledWith(
-        `/api/chat/${workspaceId}/${chatId}/message/question`,
-        { content: 'Test question', message_type: 1 }
-      );
+      expect(mockAxiosInstance.post).toHaveBeenCalledWith(`/api/chat/${workspaceId}/${chatId}/message/question`, {
+        content: 'Test question',
+        message_type: 1,
+      });
       expect(result).toEqual(mockResponse);
     });
 
@@ -223,17 +216,16 @@ describe('ChatRequest', () => {
         data: { code: 400, message: 'Bad request' },
       });
 
-      await expect(
-        chatRequest.submitQuestion({ content: '', message_type: 1 })
-      ).rejects.toEqual({ code: 400, message: 'Bad request' });
+      await expect(chatRequest.submitQuestion({ content: '', message_type: 1 })).rejects.toEqual({
+        code: 400,
+        message: 'Bad request',
+      });
     });
 
     it('should handle network errors', async () => {
       mockAxiosInstance.post.mockRejectedValue(new Error('Network error'));
 
-      await expect(
-        chatRequest.submitQuestion({ content: 'test', message_type: 1 })
-      ).rejects.toThrow('Network error');
+      await expect(chatRequest.submitQuestion({ content: 'test', message_type: 1 })).rejects.toThrow('Network error');
     });
   });
 
@@ -255,21 +247,16 @@ describe('ChatRequest', () => {
         meta_data: [],
       });
 
-      expect(mockAxiosInstance.post).toHaveBeenCalledWith(
-        `/api/chat/${workspaceId}/${chatId}/message/answer`,
-        {
-          question_message_id: 123,
-          content: 'AI response',
-          meta_data: [],
-        }
-      );
+      expect(mockAxiosInstance.post).toHaveBeenCalledWith(`/api/chat/${workspaceId}/${chatId}/message/answer`, {
+        question_message_id: 123,
+        content: 'AI response',
+        meta_data: [],
+      });
       expect(result).toEqual(mockSavedAnswer);
     });
 
     it('should handle metadata in answer', async () => {
-      const metadata = [
-        { id: '1', source: 'doc1', name: 'Document 1' },
-      ];
+      const metadata = [{ id: '1', source: 'doc1', name: 'Document 1' }];
 
       mockAxiosInstance.post.mockResolvedValue({
         data: { code: 0, data: { message_id: 1 } },
@@ -333,9 +320,7 @@ describe('ChatRequest', () => {
 
       const result = await chatRequest.getSuggestions(123);
 
-      expect(mockAxiosInstance.get).toHaveBeenCalledWith(
-        `/api/chat/${workspaceId}/${chatId}/123/related_question`
-      );
+      expect(mockAxiosInstance.get).toHaveBeenCalledWith(`/api/chat/${workspaceId}/${chatId}/123/related_question`);
       expect(result).toEqual(mockSuggestions);
     });
 
@@ -363,17 +348,13 @@ describe('ChatRequest', () => {
 
       const result = await chatRequest.getChatSettings();
 
-      expect(mockAxiosInstance.get).toHaveBeenCalledWith(
-        `/api/chat/${workspaceId}/${chatId}/settings`
-      );
+      expect(mockAxiosInstance.get).toHaveBeenCalledWith(`/api/chat/${workspaceId}/${chatId}/settings`);
       expect(result).toEqual(mockSettings);
     });
 
     it('should reject when workspaceId missing', async () => {
       const request = new ChatRequest(undefined, chatId, mockAxiosInstance);
-      await expect(request.getChatSettings()).rejects.toBe(
-        'workspaceId or chatId is not defined'
-      );
+      await expect(request.getChatSettings()).rejects.toBe('workspaceId or chatId is not defined');
     });
   });
 
@@ -388,10 +369,10 @@ describe('ChatRequest', () => {
         metadata: { ai_model: 'claude-3' },
       });
 
-      expect(mockAxiosInstance.post).toHaveBeenCalledWith(
-        `/api/chat/${workspaceId}/${chatId}/settings`,
-        { name: 'New Name', metadata: { ai_model: 'claude-3' } }
-      );
+      expect(mockAxiosInstance.post).toHaveBeenCalledWith(`/api/chat/${workspaceId}/${chatId}/settings`, {
+        name: 'New Name',
+        metadata: { ai_model: 'claude-3' },
+      });
     });
 
     it('should update rag_ids', async () => {
@@ -403,10 +384,7 @@ describe('ChatRequest', () => {
         rag_ids: ['new-doc-1', 'new-doc-2'],
       });
 
-      expect(mockAxiosInstance.post).toHaveBeenCalledWith(
-        expect.any(String),
-        { rag_ids: ['new-doc-1', 'new-doc-2'] }
-      );
+      expect(mockAxiosInstance.post).toHaveBeenCalledWith(expect.any(String), { rag_ids: ['new-doc-1', 'new-doc-2'] });
     });
   });
 
@@ -425,9 +403,7 @@ describe('ChatRequest', () => {
 
       const result = await chatRequest.getModelList();
 
-      expect(mockAxiosInstance.get).toHaveBeenCalledWith(
-        `/api/ai/${workspaceId}/model/list`
-      );
+      expect(mockAxiosInstance.get).toHaveBeenCalledWith(`/api/ai/${workspaceId}/model/list`);
       expect(result).toEqual(mockModels);
     });
 
@@ -452,9 +428,7 @@ describe('ChatRequest', () => {
 
         const result = await chatRequest.fetchViews();
 
-        expect(mockAxiosInstance.get).toHaveBeenCalledWith(
-          `/api/workspace/${workspaceId}/view/${workspaceId}?depth=10`
-        );
+        expect(mockAxiosInstance.get).toHaveBeenCalledWith(`/api/workspace/${workspaceId}/view/${workspaceId}?depth=10`);
         expect(result).toEqual(mockFolder);
       });
 
@@ -489,10 +463,176 @@ describe('ChatRequest', () => {
 
         const result = await chatRequest.getView('view-1');
 
-        expect(mockAxiosInstance.get).toHaveBeenCalledWith(
-          `/api/workspace/${workspaceId}/view/view-1?depth=1`
-        );
+        expect(mockAxiosInstance.get).toHaveBeenCalledWith(`/api/workspace/${workspaceId}/view/view-1?depth=1`);
         expect(result).toEqual(mockView);
+      });
+    });
+
+    describe('fetchCompleteView', () => {
+      it('continues a subtree past the server depth boundary', async () => {
+        const root = {
+          view_id: 'parent-id',
+          name: 'Parent',
+          children: [
+            {
+              view_id: 'boundary-id',
+              name: 'Boundary',
+              has_children: true,
+              children: [],
+            },
+          ],
+        };
+        const continuation = {
+          view_id: 'boundary-id',
+          name: 'Boundary',
+          has_children: true,
+          children: [{ view_id: 'deep-id', name: 'Deep', has_children: false, children: [] }],
+        };
+
+        mockAxiosInstance.get
+          .mockResolvedValueOnce({ data: { code: 0, data: root } })
+          .mockResolvedValueOnce({ data: { code: 0, data: { views: [continuation] } } });
+
+        await expect(chatRequest.fetchCompleteView('parent-id')).resolves.toEqual({
+          ...root,
+          children: [continuation],
+        });
+        expect(mockAxiosInstance.get).toHaveBeenNthCalledWith(
+          1,
+          `/api/workspace/${workspaceId}/view/parent-id?depth=50`
+        );
+        expect(mockAxiosInstance.get).toHaveBeenNthCalledWith(
+          2,
+          `/api/workspace/${workspaceId}/views?depth=50&view_ids=boundary-id`
+        );
+      });
+
+      it('accepts a permission-filtered continuation as a visible terminal node', async () => {
+        const root = {
+          view_id: 'parent-id',
+          name: 'Parent',
+          children: [
+            {
+              view_id: 'private-boundary-id',
+              name: 'Shared boundary',
+              has_children: true,
+              children: [],
+            },
+          ],
+        };
+        const filteredContinuation = {
+          view_id: 'private-boundary-id',
+          name: 'Shared boundary',
+          has_children: true,
+          children: [],
+        };
+
+        mockAxiosInstance.get
+          .mockResolvedValueOnce({ data: { code: 0, data: root } })
+          .mockResolvedValueOnce({ data: { code: 0, data: { views: [filteredContinuation] } } });
+
+        await expect(chatRequest.fetchCompleteView('parent-id')).resolves.toEqual({
+          ...root,
+          children: [{ ...filteredContinuation, has_children: false }],
+        });
+        expect(mockAxiosInstance.get).toHaveBeenCalledTimes(2);
+      });
+
+      it('continues an old-server depth boundary when has_children is omitted', async () => {
+        const boundary = { view_id: 'legacy-boundary-id', name: 'Legacy boundary', children: [] };
+        let root = boundary;
+
+        for (let depth = 49; depth >= 0; depth -= 1) {
+          root = { view_id: `legacy-${depth}`, name: `Legacy ${depth}`, children: [root] };
+        }
+
+        mockAxiosInstance.get
+          .mockResolvedValueOnce({ data: { code: 0, data: root } })
+          .mockRejectedValueOnce({ response: { status: 404 } })
+          .mockResolvedValueOnce({ data: { code: 0, data: boundary } });
+
+        const result = await chatRequest.fetchCompleteView('legacy-0');
+        let terminal = result;
+
+        for (let depth = 0; depth < 50; depth += 1) {
+          terminal = terminal.children[0];
+        }
+
+        expect(terminal).toEqual({ ...boundary, has_children: false });
+        expect(mockAxiosInstance.get).toHaveBeenNthCalledWith(
+          2,
+          `/api/workspace/${workspaceId}/views?depth=50&view_ids=legacy-boundary-id`
+        );
+        expect(mockAxiosInstance.get).toHaveBeenNthCalledWith(
+          3,
+          `/api/workspace/${workspaceId}/view/legacy-boundary-id?depth=50`
+        );
+      });
+
+      it('fails closed when the server omits a requested continuation', async () => {
+        const root = {
+          view_id: 'parent-id',
+          name: 'Parent',
+          children: [{ view_id: 'boundary-id', name: 'Boundary', has_children: true, children: [] }],
+        };
+
+        mockAxiosInstance.get
+          .mockResolvedValueOnce({ data: { code: 0, data: root } })
+          .mockResolvedValueOnce({ data: { code: 0, data: { views: [] } } });
+
+        await expect(chatRequest.fetchCompleteView('parent-id')).rejects.toThrow(
+          'Unable to load the complete view subtree'
+        );
+      });
+
+      it('deduplicates only in-flight requests and refetches completed scopes', async () => {
+        const root = {
+          view_id: 'parent-id',
+          name: 'Parent',
+          has_children: false,
+          children: [],
+        };
+
+        mockAxiosInstance.get.mockResolvedValue({ data: { code: 0, data: root } });
+
+        await chatRequest.fetchCompleteView('parent-id');
+        await chatRequest.fetchCompleteView('parent-id');
+
+        expect(mockAxiosInstance.get).toHaveBeenCalledTimes(2);
+      });
+
+      it('loads the current chat parent from its navigation path', async () => {
+        const navigation = {
+          view_id: workspaceId,
+          name: 'Workspace',
+          children: [
+            {
+              view_id: 'parent-id',
+              name: 'Parent',
+              children: [{ view_id: chatId, name: 'Chat', children: [] }],
+            },
+          ],
+        };
+        const parent = {
+          view_id: 'parent-id',
+          name: 'Parent',
+          has_children: false,
+          children: [],
+        };
+
+        mockAxiosInstance.get
+          .mockResolvedValueOnce({ data: { code: 0, data: navigation } })
+          .mockResolvedValueOnce({ data: { code: 0, data: parent } });
+
+        await expect(chatRequest.fetchCurrentChatParentScope()).resolves.toEqual(parent);
+        expect(mockAxiosInstance.get).toHaveBeenNthCalledWith(
+          1,
+          `/api/workspace/${workspaceId}/view/${chatId}/navigation?depth=0`
+        );
+        expect(mockAxiosInstance.get).toHaveBeenNthCalledWith(
+          2,
+          `/api/workspace/${workspaceId}/view/parent-id?depth=50`
+        );
       });
     });
 
@@ -511,10 +651,11 @@ describe('ChatRequest', () => {
 
         await chatRequest.updateViewName(view as any, 'New Name');
 
-        expect(mockAxiosInstance.patch).toHaveBeenCalledWith(
-          `/api/workspace/${workspaceId}/page-view/view-1`,
-          { name: 'New Name', icon: '📄', extra: {} }
-        );
+        expect(mockAxiosInstance.patch).toHaveBeenCalledWith(`/api/workspace/${workspaceId}/page-view/view-1`, {
+          name: 'New Name',
+          icon: '📄',
+          extra: {},
+        });
       });
     });
 
@@ -543,11 +684,7 @@ describe('ChatRequest', () => {
 
         const editorData = [{ type: 'paragraph', data: {}, children: [] }];
 
-        const result = await chatRequest.createViewWithContent(
-          'parent-view',
-          'New Document',
-          editorData
-        );
+        const result = await chatRequest.createViewWithContent('parent-view', 'New Document', editorData);
 
         expect(mockAxiosInstance.post).toHaveBeenCalledWith(
           `/api/workspace/${workspaceId}/page-view`,

--- a/src/components/chat/chat/main.tsx
+++ b/src/components/chat/chat/main.tsx
@@ -1,13 +1,16 @@
 // Code: Chat main component
 import { AnimatePresence, motion } from 'framer-motion';
-import { useCallback, useMemo } from 'react';
+import { useCallback, useMemo, useRef } from 'react';
 
 import { ChatInput } from '@/components/chat/components/chat-input';
 import { ChatMessages } from '@/components/chat/components/chat-messages';
 import { ModelSelectorContext } from '@/components/chat/contexts/model-selector-context';
 import { EditorProvider } from '@/components/chat/provider/editor-provider';
 import { MessageAnimationProvider } from '@/components/chat/provider/message-animation-provider';
-import { MessagesHandlerProvider, useMessagesHandlerContext } from '@/components/chat/provider/messages-handler-provider';
+import {
+  MessagesHandlerProvider,
+  useMessagesHandlerContext,
+} from '@/components/chat/provider/messages-handler-provider';
 import { ChatMessagesProvider } from '@/components/chat/provider/messages-provider';
 import { PromptModalProvider } from '@/components/chat/provider/prompt-modal-provider';
 import { ResponseFormatProvider } from '@/components/chat/provider/response-format-provider';
@@ -21,25 +24,24 @@ import { ChatContext, useChatContext } from './context';
 
 // Component to bridge ModelSelector with MessagesHandler
 function ChatContentWithModelSync({ currentUser, selectionMode }: { currentUser?: User; selectionMode?: boolean }) {
-  const { selectedModelName, setSelectedModelName } = useMessagesHandlerContext();
+  const { chatSettings, selectedModelName, setSelectedModelName, updateChatSettings } = useMessagesHandlerContext();
   const { requestInstance, chatId } = useChatContext();
+  const savedModelRef = useRef<string>();
+
+  savedModelRef.current = chatSettings?.metadata?.ai_model as string | undefined;
   const modelRequestInstance = useMemo(
     () => ({
       getModelList: () => requestInstance.getModelList(),
-      getCurrentModel: async () => {
-        const settings = await requestInstance.getChatSettings();
-
-        return settings.metadata?.ai_model as string | undefined || '';
-      },
+      getCurrentModel: async () => savedModelRef.current || '',
       setCurrentModel: async (modelName: string) => {
-        await requestInstance.updateChatSettings({
+        await updateChatSettings({
           metadata: {
-            ai_model: modelName
-          }
+            ai_model: modelName,
+          },
         });
       },
     }),
-    [requestInstance]
+    [requestInstance, updateChatSettings]
   );
   const modelSelectorValue = useMemo(
     () => ({
@@ -53,17 +55,10 @@ function ChatContentWithModelSync({ currentUser, selectionMode }: { currentUser?
 
   return (
     <ModelSelectorContext.Provider value={modelSelectorValue}>
-      <div className={'w-full relative h-full flex flex-col'}>
+      <div className={'relative flex h-full w-full flex-col'}>
         <ChatMessages currentUser={currentUser} />
-        <motion.div
-          layout
-          className={cn(
-            'w-full relative flex pb-6 justify-center max-sm:hidden',
-          )}
-        >
-          <AnimatePresence mode='wait'>
-            {!selectionMode && <ChatInput />}
-          </AnimatePresence>
+        <motion.div layout className={cn('relative flex w-full justify-center pb-6 max-sm:hidden')}>
+          <AnimatePresence mode='wait'>{!selectionMode && <ChatInput />}</AnimatePresence>
         </motion.div>
       </div>
     </ModelSelectorContext.Provider>
@@ -126,14 +121,11 @@ function Main(props: ChatProps) {
 
   return (
     <ChatContext.Provider value={chatContextValue}>
-      <ChatMessagesProvider>
+      <ChatMessagesProvider key={`${workspaceId}:${chatId}`}>
         <MessageAnimationProvider>
           <SuggestionsProvider>
             <EditorProvider>
-              <ViewLoaderProvider
-                getView={getView}
-                fetchViews={fetchViews}
-              >
+              <ViewLoaderProvider getView={getView} fetchViews={fetchViews}>
                 <SelectionModeProvider>
                   <ResponseFormatProvider>
                     <PromptModalProvider

--- a/src/components/chat/components/chat-input/index.tsx
+++ b/src/components/chat/components/chat-input/index.tsx
@@ -21,7 +21,6 @@ import { AiPrompt } from '@/components/chat/types/prompt';
 import { Button } from '@/components/ui/button';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 
-
 import { ModelSelector } from './model-selector';
 import { PromptModal } from './prompt-modal';
 import { RelatedViews } from './related-views';
@@ -36,7 +35,15 @@ export function ChatInput() {
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
 
-  const { submitQuestion, cancelAnswerStream, answerApplying, questionSending, chatSettings, updateChatSettings } = useMessagesHandlerContext();
+  const {
+    submitQuestion,
+    cancelAnswerStream,
+    answerApplying,
+    questionSending,
+    chatSettings,
+    updateChatSettings,
+    ragScopeState,
+  } = useMessagesHandlerContext();
   const { responseFormat, responseMode, setResponseFormat, setResponseMode } = useResponseFormatContext();
   const { openModal, currentPromptId, updateCurrentPromptId, reloadDatabasePrompts } = usePromptModal();
   const { chatId } = useChatContext();
@@ -47,7 +54,7 @@ export function ChatInput() {
     void updateChatSettings({ web_search_enabled: !webSearchEnabled });
   }, [webSearchEnabled, updateChatSettings]);
 
-  const disabled = questionSending;
+  const disabled = questionSending || ragScopeState.status !== 'ready';
 
   useEffect(() => {
     return () => {
@@ -101,7 +108,7 @@ export function ChatInput() {
       return;
     }
 
-    if (questionSending || answerApplying) {
+    if (disabled || answerApplying) {
       toast.error(`${t('chat.errors.wait')}`);
       return;
     }
@@ -201,29 +208,27 @@ export function ChatInput() {
         <div className={'flex items-center justify-between gap-4'}>
           <div className={'flex items-center gap-1'}>
             <Tooltip>
-            <TooltipTrigger asChild>
-              <Button
-                onMouseDown={(e) => {
-                  e.preventDefault();
-                }}
-                variant={'ghost'}
-                size={'icon'}
-                data-testid='chat-input-format-toggle'
-                onClick={() => {
-                  setResponseMode(
-                    responseMode === ChatInputMode.FormatResponse ? ChatInputMode.Auto : ChatInputMode.FormatResponse
-                  );
-                }}
+              <TooltipTrigger asChild>
+                <Button
+                  onMouseDown={(e) => {
+                    e.preventDefault();
+                  }}
+                  variant={'ghost'}
+                  size={'icon'}
+                  data-testid='chat-input-format-toggle'
+                  onClick={() => {
+                    setResponseMode(
+                      responseMode === ChatInputMode.FormatResponse ? ChatInputMode.Auto : ChatInputMode.FormatResponse
+                    );
+                  }}
                 >
-                  <FormatIcon className='text-icon-secondary h-5 w-5' />
+                  <FormatIcon className='h-5 w-5 text-icon-secondary' />
                 </Button>
               </TooltipTrigger>
-              <TooltipContent>
-                {formatTooltip}
-              </TooltipContent>
+              <TooltipContent>{formatTooltip}</TooltipContent>
             </Tooltip>
 
-            <ModelSelector className={'h-7'} disabled={questionSending || answerApplying} />
+            <ModelSelector className={'h-7'} disabled={disabled || answerApplying} />
 
             <Tooltip>
               <TooltipTrigger asChild>
@@ -233,6 +238,7 @@ export function ChatInput() {
                   }}
                   variant={'ghost'}
                   size={'icon'}
+                  disabled={disabled || answerApplying}
                   aria-pressed={webSearchEnabled}
                   data-testid='chat-input-web-search-toggle'
                   onClick={handleToggleWebSearch}
@@ -246,25 +252,23 @@ export function ChatInput() {
             </Tooltip>
 
             <Tooltip>
-            <TooltipTrigger asChild>
-              <Button
-                onMouseDown={(e) => {
-                  e.preventDefault();
-                }}
-                variant={'ghost'}
-                className={'h-7 text-xs text-text-secondary'}
-                data-testid='chat-input-browse-prompts'
-                onClick={() => {
-                  reloadDatabasePrompts();
-                  openModal();
-                }}
-              >
+              <TooltipTrigger asChild>
+                <Button
+                  onMouseDown={(e) => {
+                    e.preventDefault();
+                  }}
+                  variant={'ghost'}
+                  className={'h-7 text-xs text-text-secondary'}
+                  data-testid='chat-input-browse-prompts'
+                  onClick={() => {
+                    reloadDatabasePrompts();
+                    openModal();
+                  }}
+                >
                   {t('chat.customPrompt.browsePrompts')}
                 </Button>
               </TooltipTrigger>
-              <TooltipContent>
-                {t('chat.customPrompt.browsePrompts')}
-              </TooltipContent>
+              <TooltipContent>{t('chat.customPrompt.browsePrompts')}</TooltipContent>
             </Tooltip>
 
             <PromptModal
@@ -281,7 +285,12 @@ export function ChatInput() {
           <div className={'flex items-center gap-2'}>
             <RelatedViews />
             {answerApplying ? (
-              <Button onClick={cancelAnswerStream} size={'icon'} variant={'link'} className={'text-fill-theme-thick p-0'}>
+              <Button
+                onClick={cancelAnswerStream}
+                size={'icon'}
+                variant={'link'}
+                className={'p-0 text-fill-theme-thick'}
+              >
                 <StopIcon className='h-7 w-7' />
               </Button>
             ) : (
@@ -289,15 +298,11 @@ export function ChatInput() {
                 onClick={handleSubmit}
                 size={'icon'}
                 variant={'link'}
-                className={'text-fill-theme-thick p-0'}
+                className={'p-0 text-fill-theme-thick'}
                 disabled={!message.trim() || disabled}
                 data-testid='chat-input-send'
               >
-                {questionSending ? (
-                  <LoadingDots />
-                ) : (
-                  <SendIcon className='h-7 w-7' />
-                )}
+                {questionSending ? <LoadingDots /> : <SendIcon className='h-7 w-7' />}
               </Button>
             )}
           </div>

--- a/src/components/chat/components/chat-input/related-views/__tests__/index.test.tsx
+++ b/src/components/chat/components/chat-input/related-views/__tests__/index.test.tsx
@@ -1,0 +1,165 @@
+import { act, fireEvent, render, screen } from '@testing-library/react';
+
+import { RelatedViews } from '@/components/chat/components/chat-input/related-views';
+import { ViewLayout } from '@/components/chat/types';
+
+import type { ReactNode } from 'react';
+
+const updateChatSettings = jest.fn().mockResolvedValue(undefined);
+const refreshRagScope = jest.fn();
+const registerChatSettingsFlush = jest.fn((_flush: () => Promise<void>) => jest.fn());
+const mockMessagesContext = {
+  chatSettings: {
+    name: 'Chat',
+    rag_ids: ['row-id'],
+    metadata: {},
+    full_workspace: false,
+    web_search_enabled: false,
+  },
+  updateChatSettings,
+  registerChatSettingsFlush,
+  questionSending: false,
+  ragScopeState: {
+    status: 'ready',
+    parentView: {
+      view_id: 'parent-id',
+      name: 'Parent',
+      icon: null,
+      layout: ViewLayout.Document,
+      extra: { is_space: false },
+      children: [],
+      is_private: false,
+    },
+    scopedSettings: null,
+  },
+  refreshRagScope,
+};
+
+jest.mock('lodash-es/debounce', () => ({
+  __esModule: true,
+  default: (callback: (...args: unknown[]) => unknown) => {
+    let pendingArgs: unknown[] | undefined;
+    const debounced = (...args: unknown[]) => {
+      pendingArgs = args;
+    };
+
+    debounced.cancel = () => {
+      pendingArgs = undefined;
+    };
+
+    debounced.flush = () => {
+      if (!pendingArgs) return;
+
+      const args = pendingArgs;
+
+      pendingArgs = undefined;
+      return callback(...args);
+    };
+
+    return debounced;
+  },
+}));
+
+jest.mock('framer-motion', () => ({
+  motion: {
+    div: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  },
+}));
+
+jest.mock('@/components/ui/popover', () => ({
+  Popover: ({ children, onOpenChange }: { children: ReactNode; onOpenChange: (open: boolean) => void }) => (
+    <div>
+      <button data-testid='open-popover' onClick={() => onOpenChange(true)} />
+      <button data-testid='close-popover' onClick={() => onOpenChange(false)} />
+      {children}
+    </div>
+  ),
+  PopoverTrigger: ({ children }: { children: ReactNode }) => <>{children}</>,
+  PopoverContent: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+
+jest.mock('@/components/chat/components/ui/search-input', () => ({
+  SearchInput: () => null,
+}));
+
+jest.mock('@/components/chat/components/chat-input/related-views/spaces', () => ({
+  Spaces: ({ spaces, onToggle }: { spaces: Array<{ name: string }>; onToggle: (view: unknown) => void }) => (
+    <button onClick={() => onToggle(spaces[0])}>Toggle source</button>
+  ),
+}));
+
+jest.mock('@/components/chat/provider/messages-handler-provider', () => ({
+  useMessagesHandlerContext: () => mockMessagesContext,
+}));
+
+describe('RelatedViews persistence', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+    mockMessagesContext.questionSending = false;
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('flushes a pending selection on unmount and retains opaque RAG sources', () => {
+    const { unmount } = render(<RelatedViews />);
+
+    fireEvent.click(screen.getByText('Toggle source'));
+    expect(updateChatSettings).not.toHaveBeenCalled();
+
+    unmount();
+
+    expect(updateChatSettings).toHaveBeenCalledWith({
+      rag_ids: ['parent-id', 'row-id'],
+      full_workspace: false,
+    });
+  });
+
+  it('registers a flush that persists the latest selection before submit', async () => {
+    render(<RelatedViews />);
+    fireEvent.click(screen.getByText('Toggle source'));
+
+    const flush = registerChatSettingsFlush.mock.calls[0][0];
+
+    await act(async () => {
+      await flush();
+    });
+
+    expect(updateChatSettings).toHaveBeenCalledWith({
+      rag_ids: ['parent-id', 'row-id'],
+      full_workspace: false,
+    });
+  });
+
+  it('does not schedule a source update after question submission begins', () => {
+    mockMessagesContext.questionSending = true;
+    const { unmount } = render(<RelatedViews />);
+
+    fireEvent.click(screen.getByText('Toggle source'));
+    unmount();
+
+    expect(updateChatSettings).not.toHaveBeenCalled();
+  });
+
+  it('does not refresh from an obsolete open after the popover closes', async () => {
+    let resolveWrite: () => void = () => undefined;
+    const write = new Promise<void>((resolve) => {
+      resolveWrite = resolve;
+    });
+
+    updateChatSettings.mockImplementationOnce(() => write);
+    render(<RelatedViews />);
+    fireEvent.click(screen.getByText('Toggle source'));
+    fireEvent.click(screen.getByTestId('open-popover'));
+    fireEvent.click(screen.getByTestId('close-popover'));
+
+    await act(async () => {
+      resolveWrite();
+      await write;
+    });
+
+    expect(refreshRagScope).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/chat/components/chat-input/related-views/__tests__/index.test.tsx
+++ b/src/components/chat/components/chat-input/related-views/__tests__/index.test.tsx
@@ -106,7 +106,9 @@ describe('RelatedViews persistence', () => {
   it('flushes a pending selection on unmount and retains opaque RAG sources', () => {
     const { unmount } = render(<RelatedViews />);
 
+    expect(screen.getByTestId('chat-input-related-views').textContent).toContain('1');
     fireEvent.click(screen.getByText('Toggle source'));
+    expect(screen.getByTestId('chat-input-related-views').textContent).toContain('2');
     expect(updateChatSettings).not.toHaveBeenCalled();
 
     unmount();

--- a/src/components/chat/components/chat-input/related-views/__tests__/spaces.test.tsx
+++ b/src/components/chat/components/chat-input/related-views/__tests__/spaces.test.tsx
@@ -1,0 +1,83 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import { Spaces } from '@/components/chat/components/chat-input/related-views/spaces';
+import { CheckStatus } from '@/components/chat/types/checkbox';
+import type { View } from '@/components/chat/types/request';
+import { ViewLayout } from '@/components/chat/types/request';
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+jest.mock('@/components/chat/components/view/view-children', () => ({
+  ViewChildren: () => null,
+}));
+
+jest.mock('@/components/chat/components/view/space-item', () => ({
+  __esModule: true,
+  default: ({ view }: { view: View }) => <div data-testid='space-item'>{view.name}</div>,
+}));
+
+jest.mock('@/components/chat/components/view/view-item', () => ({
+  ViewItem: ({ view, onToggle }: { view: View; onToggle: (view: View) => void }) => (
+    <button onClick={() => onToggle(view)}>{view.name}</button>
+  ),
+}));
+
+function view(overrides: Partial<View>): View {
+  return {
+    view_id: 'view-id',
+    name: 'View',
+    icon: null,
+    layout: ViewLayout.Document,
+    extra: { is_space: false },
+    children: [],
+    is_private: false,
+    ...overrides,
+  };
+}
+
+describe('RelatedViews Spaces', () => {
+  it('renders a document root as a selectable row even when it has no children', () => {
+    const parent = view({ view_id: 'parent-id', name: 'Parent page' });
+    const onToggle = jest.fn();
+
+    render(
+      <Spaces
+        spaces={[parent]}
+        viewsLoading={false}
+        getCheckStatus={() => CheckStatus.Unchecked}
+        getInitialExpand={() => false}
+        onToggle={onToggle}
+      />
+    );
+
+    fireEvent.click(screen.getByText('Parent page'));
+
+    expect(onToggle).toHaveBeenCalledWith(parent);
+  });
+
+  it('renders a top-level is_space view as a non-selectable space container', () => {
+    const space = view({
+      view_id: 'shared-space-id',
+      name: 'Shared space',
+      is_space: true,
+      extra: null,
+    });
+    const onToggle = jest.fn();
+
+    render(
+      <Spaces
+        spaces={[space]}
+        viewsLoading={false}
+        getCheckStatus={() => CheckStatus.Unchecked}
+        getInitialExpand={() => false}
+        onToggle={onToggle}
+      />
+    );
+
+    expect(screen.getByTestId('space-item').textContent).toBe('Shared space');
+    fireEvent.click(screen.getByText('Shared space'));
+    expect(onToggle).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/chat/components/chat-input/related-views/index.tsx
+++ b/src/components/chat/components/chat-input/related-views/index.tsx
@@ -55,9 +55,9 @@ export function RelatedViews() {
     return searchViews(scopedRoots, searchValue);
   }, [scopedRoots, searchValue]);
 
-  const { getSelected, getCheckStatus, toggleNode, getInitialExpand } = useCheckboxTree(viewIds, scopedRoots);
+  const { selected, getCheckStatus, toggleNode, getInitialExpand } = useCheckboxTree(viewIds, scopedRoots);
 
-  const length = getSelected().length;
+  const sourceCount = selected.size + preservedRagIds.length;
 
   const handleToggle = useMemo(() => {
     const scopedIds = new Set(selectableViewIds);
@@ -123,7 +123,7 @@ export function RelatedViews() {
           data-testid='chat-input-related-views'
         >
           <DocIcon className='h-5 w-5 text-icon-secondary' />
-          {length}
+          {sourceCount}
           {viewsLoading ? <LoadingDots size={12} /> : <ChevronDown className='h-5 w-3' />}
         </Button>
       </PopoverTrigger>

--- a/src/components/chat/components/chat-input/related-views/index.tsx
+++ b/src/components/chat/components/chat-input/related-views/index.tsx
@@ -1,94 +1,122 @@
 import { motion } from 'framer-motion';
 import debounce from 'lodash-es/debounce';
-import { useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { ReactComponent as DocIcon } from '@/assets/icons/page.svg';
 import { ReactComponent as ChevronDown } from '@/assets/icons/triangle_down.svg';
-import { useViewLoader } from '@/components/chat';
+import { collectScopedRagIds, resolveScopedRagIds } from '@/components/ai-chat/rag-scope';
 import LoadingDots from '@/components/chat/components/ui/loading-dots';
 import { SearchInput } from '@/components/chat/components/ui/search-input';
 import { useCheckboxTree } from '@/components/chat/hooks/use-checkbox-tree';
 import { MESSAGE_VARIANTS } from '@/components/chat/lib/animations';
-import { searchViews } from '@/components/chat/lib/views';
+import { filterDocumentViews, searchViews } from '@/components/chat/lib/views';
 import { useMessagesHandlerContext } from '@/components/chat/provider/messages-handler-provider';
-import { View, ViewLayout } from '@/components/chat/types';
+import { View } from '@/components/chat/types';
 import { Button } from '@/components/ui/button';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import { Separator } from '@/components/ui/separator';
 
 import { Spaces } from './spaces';
 
-function collectSelectableViewIds(views: View[]): string[] {
-  const ids: string[] = [];
-  const stack = [...views];
-
-  while (stack.length > 0) {
-    const view = stack.pop();
-
-    if (!view || view.layout === ViewLayout.AIChat) continue;
-
-    ids.push(view.view_id);
-    stack.push(...view.children);
-  }
-
-  return ids;
-}
-
 export function RelatedViews() {
   const [searchValue, setSearchValue] = useState('');
   const [open, setOpen] = useState(false);
+  const openGenerationRef = useRef(0);
 
-  const { chatSettings, updateChatSettings } = useMessagesHandlerContext();
+  const {
+    chatSettings,
+    updateChatSettings,
+    registerChatSettingsFlush,
+    questionSending,
+    ragScopeState,
+    refreshRagScope,
+  } = useMessagesHandlerContext();
+  const parentView = ragScopeState.parentView;
+  const viewsLoading = ragScopeState.status === 'loading';
 
-  const { fetchViews, viewsLoading } = useViewLoader();
+  const scopedRoots = useMemo(() => {
+    return parentView ? filterDocumentViews([parentView]) : [];
+  }, [parentView]);
 
-  const [folder, setFolder] = useState<View | null>(null);
+  const selectableViewIds = useMemo(() => collectScopedRagIds(scopedRoots), [scopedRoots]);
+  const ragIds = chatSettings?.rag_ids;
+  const fullWorkspace = chatSettings?.full_workspace;
+  const viewIds = useMemo(
+    () => resolveScopedRagIds(scopedRoots, { full_workspace: fullWorkspace, rag_ids: ragIds }),
+    [fullWorkspace, ragIds, scopedRoots]
+  );
+  const preservedRagIds = useMemo(() => {
+    const selectableIds = new Set(selectableViewIds);
 
-  useEffect(() => {
-    void (async () => {
-      const data = await fetchViews();
-
-      if (!data) return;
-      setFolder(data);
-    })();
-  }, [fetchViews]);
-
-  const viewIds = useMemo(() => {
-    if (chatSettings?.full_workspace && folder) {
-      return collectSelectableViewIds(folder.children || []);
-    }
-
-    return chatSettings?.rag_ids || [];
-  }, [chatSettings, folder]);
+    return Array.from(new Set(ragIds || [])).filter((id) => !selectableIds.has(id));
+  }, [ragIds, selectableViewIds]);
 
   const filteredSpaces = useMemo(() => {
-    const spaces = folder?.children.filter((view) => view.extra?.is_space);
+    return searchViews(scopedRoots, searchValue);
+  }, [scopedRoots, searchValue]);
 
-    return searchViews(spaces || [], searchValue);
-  }, [folder, searchValue]);
-
-  const views = useMemo(() => {
-    return folder?.children || [];
-  }, [folder]);
-
-  const { getSelected, getCheckStatus, toggleNode, getInitialExpand } = useCheckboxTree(viewIds, views);
+  const { getSelected, getCheckStatus, toggleNode, getInitialExpand } = useCheckboxTree(viewIds, scopedRoots);
 
   const length = getSelected().length;
 
   const handleToggle = useMemo(() => {
+    const scopedIds = new Set(selectableViewIds);
+
     return debounce(async (ids: string[]) => {
       await updateChatSettings({
-        rag_ids: ids,
+        rag_ids: [...ids.filter((id) => scopedIds.has(id)), ...preservedRagIds],
         full_workspace: false,
       });
     }, 500);
-  }, [updateChatSettings]);
+  }, [preservedRagIds, selectableViewIds, updateChatSettings]);
+
+  const flushPendingToggle = useCallback(async () => {
+    await handleToggle.flush();
+  }, [handleToggle]);
+
+  useEffect(() => {
+    return () => {
+      openGenerationRef.current += 1;
+    };
+  }, []);
+
+  useEffect(() => {
+    const unregister = registerChatSettingsFlush(flushPendingToggle);
+
+    return () => {
+      unregister();
+      void flushPendingToggle();
+      handleToggle.cancel();
+    };
+  }, [flushPendingToggle, handleToggle, registerChatSettingsFlush]);
+
+  const handleOpenChange = useCallback(
+    (nextOpen: boolean) => {
+      const generation = openGenerationRef.current + 1;
+
+      openGenerationRef.current = generation;
+      setOpen(nextOpen);
+
+      if (!nextOpen) {
+        void flushPendingToggle();
+        return;
+      }
+
+      if (ragScopeState.status !== 'loading') {
+        void (async () => {
+          await flushPendingToggle();
+          if (openGenerationRef.current === generation) refreshRagScope();
+        })();
+      }
+    },
+    [flushPendingToggle, ragScopeState.status, refreshRagScope]
+  );
 
   return (
-    <Popover open={open} onOpenChange={setOpen} modal>
+    <Popover open={open} onOpenChange={handleOpenChange} modal>
       <PopoverTrigger asChild={true}>
         <Button
-          disabled={viewsLoading}
+          disabled={viewsLoading || questionSending}
           size='sm'
           className='gap-0.5 px-1.5 text-sm text-text-secondary'
           variant={'ghost'}
@@ -116,6 +144,8 @@ export function RelatedViews() {
               viewsLoading={viewsLoading}
               getCheckStatus={getCheckStatus}
               onToggle={(view: View) => {
+                if (questionSending) return;
+
                 const ids = toggleNode(view);
 
                 void handleToggle(Array.from(ids));

--- a/src/components/chat/components/chat-input/related-views/spaces.tsx
+++ b/src/components/chat/components/chat-input/related-views/spaces.tsx
@@ -1,8 +1,10 @@
 import { useTranslation } from 'react-i18next';
 
+import { isSpaceView } from '@/components/ai-chat/rag-scope';
 import LoadingDots from '@/components/chat/components/ui/loading-dots';
 import SpaceItem from '@/components/chat/components/view/space-item';
-import ViewChildren from '@/components/chat/components/view/view-children';
+import { ViewChildren } from '@/components/chat/components/view/view-children';
+import { ViewItem } from '@/components/chat/components/view/view-item';
 import { View } from '@/components/chat/types';
 import { CheckStatus } from '@/components/chat/types/checkbox';
 
@@ -14,46 +16,53 @@ interface SpacesProps {
   getInitialExpand: (viewId: string) => boolean;
 }
 
-export function Spaces({
-  getCheckStatus,
-  onToggle,
-  spaces,
-  viewsLoading,
-  getInitialExpand,
-}: SpacesProps) {
+export function Spaces({ getCheckStatus, onToggle, spaces, viewsLoading, getInitialExpand }: SpacesProps) {
   const { t } = useTranslation();
 
-  if(viewsLoading) {
-    return <div className={'flex w-full h-full items-center py-10 justify-center'}>
-      <LoadingDots />
-    </div>;
+  if (viewsLoading) {
+    return (
+      <div className={'flex h-full w-full items-center justify-center py-10'}>
+        <LoadingDots />
+      </div>
+    );
   }
 
-  if(!spaces || spaces.length === 0) {
-    return <div className={'flex w-full opacity-60 h-full py-10 items-center justify-center'}>
-      {t('chat.search.noSpacesFound')}
-    </div>;
+  if (!spaces || spaces.length === 0) {
+    return (
+      <div className={'flex h-full w-full items-center justify-center py-10 opacity-60'}>
+        {t('chat.search.noSpacesFound')}
+      </div>
+    );
   }
 
   return (
-    <div className={'flex flex-col gap-1 h-full w-full'}>
+    <div className={'flex h-full w-full flex-col gap-1'}>
       {spaces.map((view: View) => {
-        return (
-          <SpaceItem
+        const children = (
+          <ViewChildren
+            item={view}
+            getInitialExpand={getInitialExpand}
+            onToggle={onToggle}
+            getCheckStatus={getCheckStatus}
+          />
+        );
+
+        return isSpaceView(view) ? (
+          <SpaceItem key={view.view_id} view={view} getInitialExpand={getInitialExpand}>
+            {children}
+          </SpaceItem>
+        ) : (
+          <ViewItem
             key={view.view_id}
             view={view}
             getInitialExpand={getInitialExpand}
+            onToggle={onToggle}
+            getCheckStatus={getCheckStatus}
           >
-            <ViewChildren
-              item={view}
-              getInitialExpand={getInitialExpand}
-              onToggle={onToggle}
-              getCheckStatus={getCheckStatus}
-            />
-          </SpaceItem>
+            {children}
+          </ViewItem>
         );
       })}
     </div>
   );
 }
-

--- a/src/components/chat/components/chat-messages/__tests__/empty-messages.test.tsx
+++ b/src/components/chat/components/chat-messages/__tests__/empty-messages.test.tsx
@@ -1,0 +1,46 @@
+import { render, waitFor } from '@testing-library/react';
+
+import { EmptyMessages } from '@/components/chat/components/chat-messages/empty-messages';
+
+const mockSubmitQuestion = jest.fn().mockResolvedValue(undefined);
+const mockUpdateChatSettings = jest.fn().mockResolvedValue(undefined);
+let mockScopeStatus: 'loading' | 'ready' = 'loading';
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+jest.mock('@/components/chat/provider/messages-handler-provider', () => ({
+  useMessagesHandlerContext: () => ({
+    chatSettings: {
+      metadata: { initial_prompt: 'Ask after validation' },
+    },
+    submitQuestion: mockSubmitQuestion,
+    updateChatSettings: mockUpdateChatSettings,
+    ragScopeState: { status: mockScopeStatus },
+  }),
+}));
+
+describe('EmptyMessages initial prompt', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockScopeStatus = 'loading';
+  });
+
+  it('waits for the authoritative RAG scope before submitting', async () => {
+    const { rerender } = render(<EmptyMessages />);
+
+    expect(mockSubmitQuestion).not.toHaveBeenCalled();
+
+    mockScopeStatus = 'ready';
+    rerender(<EmptyMessages />);
+
+    await waitFor(() => expect(mockSubmitQuestion).toHaveBeenCalledWith('Ask after validation'));
+    expect(mockUpdateChatSettings).toHaveBeenCalledWith({
+      metadata: {
+        initial_prompt: 'Ask after validation',
+        initial_prompt_consumed: true,
+      },
+    });
+  });
+});

--- a/src/components/chat/components/chat-messages/__tests__/message-sources.test.tsx
+++ b/src/components/chat/components/chat-messages/__tests__/message-sources.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 
 import MessageSources, {
+  getAppFlowySourceTarget,
   getMessageSourceLabel,
   getSafeWebSourceUrl,
 } from '@/components/chat/components/chat-messages/message-sources';
@@ -100,5 +101,28 @@ describe('message sources', () => {
     await waitFor(() => expect(screen.queryByRole('button', { name: 'Loaded roadmap' })).not.toBeNull());
     fireEvent.click(screen.getByRole('button', { name: 'Loaded roadmap' }));
     expect(mockOpenView).toHaveBeenCalledWith('page-id');
+  });
+
+  it('opens cited database rows through their owning database view', async () => {
+    const source = {
+      id: 'row-document-id',
+      name: 'Roadmap row',
+      source: 'appflowy',
+      title: 'Roadmap row',
+      database_id: 'database-id',
+      database_view_id: 'database-view-id',
+      database_row_id: 'database-row-id',
+    };
+
+    expect(getAppFlowySourceTarget(source)).toEqual({
+      viewId: 'database-view-id',
+      rowId: 'database-row-id',
+    });
+
+    render(<MessageSources sources={[source]} />);
+
+    expect(mockGetView).not.toHaveBeenCalled();
+    fireEvent.click(screen.getByRole('button', { name: 'Roadmap row' }));
+    expect(mockOpenView).toHaveBeenCalledWith('database-view-id', 'database-row-id');
   });
 });

--- a/src/components/chat/components/chat-messages/__tests__/message-sources.test.tsx
+++ b/src/components/chat/components/chat-messages/__tests__/message-sources.test.tsx
@@ -1,0 +1,104 @@
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+
+import MessageSources, {
+  getMessageSourceLabel,
+  getSafeWebSourceUrl,
+} from '@/components/chat/components/chat-messages/message-sources';
+
+const mockGetView = jest.fn();
+const mockOpenView = jest.fn();
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: { sourceCount?: number }) =>
+      key === 'chat.sources.label' ? `${options?.sourceCount ?? 0} sources` : key,
+  }),
+}));
+
+jest.mock('@/components/chat/provider/view-loader-provider', () => ({
+  useViewLoader: () => ({ getView: mockGetView }),
+}));
+
+jest.mock('@/components/chat/chat/context', () => ({
+  useChatContext: () => ({ onOpenView: mockOpenView }),
+}));
+
+describe('message sources', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('prefers the web result title and keeps the URL as its target', () => {
+    const source = {
+      id: 'https://example.com/article',
+      name: 'https://example.com/article',
+      source: 'web',
+      title: 'Example article',
+      citation_id: 'W1',
+    };
+
+    expect(getMessageSourceLabel(source)).toBe('Example article');
+    expect(getSafeWebSourceUrl(source)).toBe('https://example.com/article');
+  });
+
+  it('rejects unsafe web source protocols', () => {
+    expect(
+      getSafeWebSourceUrl({
+        id: 'javascript:alert(1)',
+        name: 'unsafe',
+        source: 'web',
+      })
+    ).toBeNull();
+  });
+
+  it('keeps legacy source names when no title is available', () => {
+    expect(
+      getMessageSourceLabel({
+        id: 'page-id',
+        name: 'Roadmap',
+        source: 'appflowy',
+      })
+    ).toBe('Roadmap');
+  });
+
+  it('renders a web source as a safe external link without loading a workspace view', () => {
+    render(
+      <MessageSources
+        sources={[
+          {
+            id: 'https://example.com/article',
+            name: 'https://example.com/article',
+            source: 'web',
+            title: 'Example article',
+          },
+        ]}
+      />
+    );
+
+    const link = screen.getByRole('link', { name: 'Example article' });
+
+    expect(link.getAttribute('href')).toBe('https://example.com/article');
+    expect(link.getAttribute('target')).toBe('_blank');
+    expect(link.getAttribute('rel')).toBe('noopener noreferrer');
+    expect(mockGetView).not.toHaveBeenCalled();
+  });
+
+  it('opens AppFlowy sources by object ID', async () => {
+    mockGetView.mockResolvedValue({ name: 'Loaded roadmap' });
+    render(
+      <MessageSources
+        sources={[
+          {
+            id: 'page-id',
+            name: 'Roadmap',
+            source: 'appflowy',
+          },
+        ]}
+      />
+    );
+
+    await waitFor(() => expect(screen.queryByRole('button', { name: 'Loaded roadmap' })).not.toBeNull());
+    fireEvent.click(screen.getByRole('button', { name: 'Loaded roadmap' }));
+    expect(mockOpenView).toHaveBeenCalledWith('page-id');
+  });
+});

--- a/src/components/chat/components/chat-messages/empty-messages.tsx
+++ b/src/components/chat/components/chat-messages/empty-messages.tsx
@@ -7,12 +7,9 @@ import { User } from '@/components/chat/types';
 import { Button } from '@/components/ui/button';
 import { Label } from '@/components/ui/label';
 
-
-export function EmptyMessages({ currentUser }: {
-  currentUser?: User;
-}) {
+export function EmptyMessages({ currentUser }: { currentUser?: User }) {
   const { t } = useTranslation();
-  const { chatSettings, submitQuestion, updateChatSettings } = useMessagesHandlerContext();
+  const { chatSettings, submitQuestion, updateChatSettings, ragScopeState } = useMessagesHandlerContext();
   const initialPromptSubmittedRef = useRef(false);
 
   useEffect(() => {
@@ -20,7 +17,7 @@ export function EmptyMessages({ currentUser }: {
     const initialPrompt = typeof metadata?.initial_prompt === 'string' ? metadata.initial_prompt.trim() : '';
     const consumed = metadata?.initial_prompt_consumed === true;
 
-    if (!initialPrompt || consumed || initialPromptSubmittedRef.current) {
+    if (ragScopeState.status !== 'ready' || !initialPrompt || consumed || initialPromptSubmittedRef.current) {
       return;
     }
 
@@ -39,56 +36,59 @@ export function EmptyMessages({ currentUser }: {
         console.error(e);
       }
     })();
-  }, [chatSettings, submitQuestion, updateChatSettings]);
+  }, [chatSettings, ragScopeState.status, submitQuestion, updateChatSettings]);
 
-  const handleClick = useCallback(async(content: string) => {
-    try {
-      await submitQuestion(content);
-    } catch(e) {
-      console.error(e);
-    }
-  }, [submitQuestion]);
+  const handleClick = useCallback(
+    async (content: string) => {
+      try {
+        await submitQuestion(content);
+      } catch (e) {
+        console.error(e);
+      }
+    },
+    [submitQuestion]
+  );
 
   return (
-    <div className={'w-full h-full justify-center items-center flex flex-col gap-8'}>
-      <div className={'flex flex-col gap-6 w-full justify-center items-center'}>
+    <div className={'flex h-full w-full flex-col items-center justify-center gap-8'}>
+      <div className={'flex w-full flex-col items-center justify-center gap-6'}>
         <Logo className={'h-10 w-10 text-text-secondary'} />
-        <Label className={'text-foreground/70'}>{t('chat.placeholder', {
-          name: currentUser?.name || t('chat.dear'),
-        })}</Label>
+        <Label className={'text-foreground/70'}>
+          {t('chat.placeholder', {
+            name: currentUser?.name || t('chat.dear'),
+          })}
+        </Label>
       </div>
-      <div className={'flex flex-col text-foreground/60 gap-4 w-full justify-center items-center'}>
+      <div className={'flex w-full flex-col items-center justify-center gap-4 text-foreground/60'}>
         <Button
           onClick={() => handleClick(t('chat.questions.one'))}
           variant={'outline'}
-          className={'rounded-full py-2 px-4 shadow-sm'}
+          className={'rounded-full px-4 py-2 shadow-sm'}
         >
           {t('chat.questions.one')}
         </Button>
         <Button
           onClick={() => handleClick(t('chat.questions.two'))}
           variant={'outline'}
-          className={'rounded-full py-2 px-4 shadow-sm'}
+          className={'rounded-full px-4 py-2 shadow-sm'}
         >
           {t('chat.questions.two')}
         </Button>
         <Button
           onClick={() => handleClick(t('chat.questions.three'))}
           variant={'outline'}
-          className={'rounded-full py-2 px-4 shadow-sm'}
+          className={'rounded-full px-4 py-2 shadow-sm'}
         >
           {t('chat.questions.three')}
         </Button>
         <Button
           onClick={() => handleClick(t('chat.questions.four'))}
           variant={'outline'}
-          className={'rounded-full py-2 px-4 shadow-sm'}
+          className={'rounded-full px-4 py-2 shadow-sm'}
         >
           {t('chat.questions.four')}
         </Button>
       </div>
-
-
     </div>
   );
 }

--- a/src/components/chat/components/chat-messages/message-sources.tsx
+++ b/src/components/chat/components/chat-messages/message-sources.tsx
@@ -1,47 +1,76 @@
-import { ChevronDown } from 'lucide-react';
-import { useEffect, useState } from 'react';
+import { ChevronDown, ExternalLink } from 'lucide-react';
+import { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { ReactComponent as DocumentIcon } from '@/assets/icons/page.svg';
 import { useChatContext } from '@/components/chat/chat/context';
 import { useViewLoader } from '@/components/chat/provider/view-loader-provider';
-import { ChatMessageMetadata, View } from '@/components/chat/types';
+import { ChatMessageMetadata } from '@/components/chat/types';
 import { Button } from '@/components/ui/button';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+
+export function getMessageSourceLabel(source: ChatMessageMetadata): string {
+  return source.title?.trim() || source.name.trim() || source.id;
+}
+
+export function getSafeWebSourceUrl(source: ChatMessageMetadata): string | null {
+  if (source.source !== 'web') return null;
+
+  try {
+    const url = new URL(source.id);
+
+    return url.protocol === 'http:' || url.protocol === 'https:' ? url.toString() : null;
+  } catch {
+    return null;
+  }
+}
+
+function isAppFlowySource(source: ChatMessageMetadata): boolean {
+  // Empty and unknown source values are legacy AppFlowy document metadata.
+  return source.source !== 'web' && source.source !== 'local_file';
+}
 
 function MessageSources({ sources }: { sources: ChatMessageMetadata[] }) {
   const { getView } = useViewLoader();
   const { onOpenView } = useChatContext();
   const { t } = useTranslation();
   const [expanded, setExpanded] = useState(true);
+  const [viewNames, setViewNames] = useState<Record<string, string>>({});
 
-  const [views, setViews] = useState<View[]>([]);
+  const appflowySourceIds = useMemo(
+    () => Array.from(new Set(sources.filter(isAppFlowySource).map((source) => source.id))),
+    [sources]
+  );
 
   useEffect(() => {
-    void (async () => {
-      const views = [];
+    let cancelled = false;
 
-      for (const source of sources) {
-        const view = await getView(source.id, false);
+    if (appflowySourceIds.length === 0) {
+      setViewNames((current) => (Object.keys(current).length === 0 ? current : {}));
+      return;
+    }
 
-        if (!view) {
-          continue;
-        }
+    void Promise.all(
+      appflowySourceIds.map(async (sourceId) => {
+        const view = await getView(sourceId, false);
 
-        views.push({
-          ...view,
-          name: view.name || t('chat.view.placeholder'),
-        });
+        return [sourceId, view?.name || ''] as const;
+      })
+    ).then((entries) => {
+      if (!cancelled) {
+        setViewNames(Object.fromEntries(entries));
       }
+    });
 
-      setViews(views);
-    })();
-  }, [getView, sources, t]);
+    return () => {
+      cancelled = true;
+    };
+  }, [appflowySourceIds, getView]);
 
   return (
     <div className={'flex flex-col pb-2 max-sm:hidden'}>
       <Button
-        onClick={() => setExpanded(!expanded)}
+        onClick={() => setExpanded((current) => !current)}
         variant={'link'}
         className={'w-full justify-start text-foreground !no-underline opacity-60 hover:text-primary'}
       >
@@ -53,25 +82,45 @@ function MessageSources({ sources }: { sources: ChatMessageMetadata[] }) {
 
         <ChevronDown className={`ml-1 h-4 w-4 ${expanded ? 'rotate-180 transform' : ''}`} />
       </Button>
-      {expanded && (
+      {expanded ? (
         <div className={'flex flex-wrap items-start gap-2'}>
-          {views.map((source, index) => (
-            <Tooltip key={index}>
-              <TooltipTrigger asChild>
-                <Button
-                  onClick={() => onOpenView?.(source.view_id)}
-                  variant={'ghost'}
-                  className={'max-w-[160px] overflow-hidden'}
-                >
-                  <DocumentIcon />
-                  <span className={'truncate text-foreground'}>{source.name}</span>
-                </Button>
-              </TooltipTrigger>
-              <TooltipContent>{source.name}</TooltipContent>
-            </Tooltip>
-          ))}
+          {sources.map((source) => {
+            const webUrl = getSafeWebSourceUrl(source);
+            const label = viewNames[source.id] || getMessageSourceLabel(source) || t('chat.view.placeholder');
+            const key = `${source.source}:${source.id}`;
+            const content = (
+              <>
+                {source.source === 'web' ? <ExternalLink className={'h-4 w-4'} /> : <DocumentIcon />}
+                <span className={'truncate text-foreground'}>{label}</span>
+              </>
+            );
+
+            return (
+              <Tooltip key={key}>
+                <TooltipTrigger asChild>
+                  {webUrl ? (
+                    <Button asChild variant={'ghost'} className={'max-w-[160px] overflow-hidden'}>
+                      <a href={webUrl} target={'_blank'} rel={'noopener noreferrer'}>
+                        {content}
+                      </a>
+                    </Button>
+                  ) : (
+                    <Button
+                      onClick={isAppFlowySource(source) ? () => onOpenView?.(source.id) : undefined}
+                      disabled={!isAppFlowySource(source)}
+                      variant={'ghost'}
+                      className={'max-w-[160px] overflow-hidden'}
+                    >
+                      {content}
+                    </Button>
+                  )}
+                </TooltipTrigger>
+                <TooltipContent>{label}</TooltipContent>
+              </Tooltip>
+            );
+          })}
         </div>
-      )}
+      ) : null}
     </div>
   );
 }

--- a/src/components/chat/components/chat-messages/message-sources.tsx
+++ b/src/components/chat/components/chat-messages/message-sources.tsx
@@ -30,6 +30,13 @@ function isAppFlowySource(source: ChatMessageMetadata): boolean {
   return source.source !== 'web' && source.source !== 'local_file';
 }
 
+export function getAppFlowySourceTarget(source: ChatMessageMetadata): { viewId: string; rowId?: string } {
+  return {
+    viewId: source.database_view_id || source.id,
+    rowId: source.database_row_id || undefined,
+  };
+}
+
 function MessageSources({ sources }: { sources: ChatMessageMetadata[] }) {
   const { getView } = useViewLoader();
   const { onOpenView } = useChatContext();
@@ -38,7 +45,14 @@ function MessageSources({ sources }: { sources: ChatMessageMetadata[] }) {
   const [viewNames, setViewNames] = useState<Record<string, string>>({});
 
   const appflowySourceIds = useMemo(
-    () => Array.from(new Set(sources.filter(isAppFlowySource).map((source) => source.id))),
+    () =>
+      Array.from(
+        new Set(
+          sources
+            .filter((source) => isAppFlowySource(source) && !source.title?.trim())
+            .map((source) => getAppFlowySourceTarget(source).viewId)
+        )
+      ),
     [sources]
   );
 
@@ -86,8 +100,13 @@ function MessageSources({ sources }: { sources: ChatMessageMetadata[] }) {
         <div className={'flex flex-wrap items-start gap-2'}>
           {sources.map((source) => {
             const webUrl = getSafeWebSourceUrl(source);
-            const label = viewNames[source.id] || getMessageSourceLabel(source) || t('chat.view.placeholder');
-            const key = `${source.source}:${source.id}`;
+            const appflowyTarget = isAppFlowySource(source) ? getAppFlowySourceTarget(source) : undefined;
+            const sourceLabel = getMessageSourceLabel(source);
+            const label =
+              (source.title?.trim() ? sourceLabel : appflowyTarget && viewNames[appflowyTarget.viewId]) ||
+              sourceLabel ||
+              t('chat.view.placeholder');
+            const key = `${source.source}:${source.id}:${source.database_row_id || ''}`;
             const content = (
               <>
                 {source.source === 'web' ? <ExternalLink className={'h-4 w-4'} /> : <DocumentIcon />}
@@ -106,7 +125,17 @@ function MessageSources({ sources }: { sources: ChatMessageMetadata[] }) {
                     </Button>
                   ) : (
                     <Button
-                      onClick={isAppFlowySource(source) ? () => onOpenView?.(source.id) : undefined}
+                      onClick={
+                        appflowyTarget
+                          ? () => {
+                              if (appflowyTarget.rowId) {
+                                onOpenView?.(appflowyTarget.viewId, appflowyTarget.rowId);
+                              } else {
+                                onOpenView?.(appflowyTarget.viewId);
+                              }
+                            }
+                          : undefined
+                      }
                       disabled={!isAppFlowySource(source)}
                       variant={'ghost'}
                       className={'max-w-[160px] overflow-hidden'}

--- a/src/components/chat/hooks/__tests__/use-chat-settings-loader.test.tsx
+++ b/src/components/chat/hooks/__tests__/use-chat-settings-loader.test.tsx
@@ -1,0 +1,257 @@
+import { act, renderHook } from '@testing-library/react';
+import { StrictMode } from 'react';
+
+import { useChatSettingsLoader } from '@/components/chat/hooks/use-chat-settings-loader';
+import type { ChatSettings } from '@/components/chat/types';
+
+interface Deferred<T> {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+}
+
+function deferred<T>(): Deferred<T> {
+  let resolvePromise: (value: T) => void = () => undefined;
+  const promise = new Promise<T>((resolve) => {
+    resolvePromise = resolve;
+  });
+
+  return { promise, resolve: resolvePromise };
+}
+
+function settings(name: string): ChatSettings {
+  return {
+    name,
+    rag_ids: [],
+    metadata: {},
+    full_workspace: false,
+    web_search_enabled: false,
+  };
+}
+
+const toastError = jest.fn();
+let chatContext: { chatId: string; requestInstance: ReturnType<typeof request> };
+
+function request(getChatSettings = jest.fn()) {
+  return {
+    getChatSettings,
+    updateChatSettings: jest.fn().mockResolvedValue(undefined),
+  };
+}
+
+jest.mock('sonner', () => ({
+  toast: { error: (...args: unknown[]) => toastError(...args) },
+}));
+
+jest.mock('@/components/chat/chat/context', () => ({
+  useChatContext: () => chatContext,
+}));
+
+describe('useChatSettingsLoader', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('ignores a stale settings response after switching chats', async () => {
+    const chatA = deferred<ChatSettings>();
+    const chatB = deferred<ChatSettings>();
+    const requestA = request(jest.fn(() => chatA.promise));
+    const requestB = request(jest.fn(() => chatB.promise));
+
+    chatContext = { chatId: 'chat-a', requestInstance: requestA };
+    const { result, rerender } = renderHook(() => useChatSettingsLoader());
+    let fetchA: Promise<ChatSettings | undefined>;
+
+    act(() => {
+      fetchA = result.current.fetchChatSettings();
+    });
+
+    chatContext = { chatId: 'chat-b', requestInstance: requestB };
+    rerender();
+
+    expect(result.current.chatSettings).toBeNull();
+
+    let fetchB: Promise<ChatSettings | undefined>;
+
+    act(() => {
+      fetchB = result.current.fetchChatSettings();
+      chatB.resolve(settings('Chat B'));
+    });
+    await act(async () => {
+      await fetchB;
+    });
+
+    act(() => chatA.resolve(settings('Chat A')));
+    await act(async () => {
+      await fetchA;
+    });
+
+    expect(result.current.chatSettings?.name).toBe('Chat B');
+  });
+
+  it('accepts settings responses after the Strict Mode effect replay', async () => {
+    const requestInstance = request(jest.fn().mockResolvedValue(settings('Strict Chat')));
+
+    chatContext = { chatId: 'strict-chat', requestInstance };
+    const { result } = renderHook(() => useChatSettingsLoader(), { wrapper: StrictMode });
+
+    await act(async () => {
+      await result.current.fetchChatSettings();
+    });
+
+    expect(result.current.chatSettings?.name).toBe('Strict Chat');
+  });
+
+  it('keeps stale update callbacks bound to their originating request', async () => {
+    const requestA = request(jest.fn().mockResolvedValue(settings('Chat A')));
+    const requestB = request(jest.fn().mockResolvedValue(settings('Chat B')));
+
+    chatContext = { chatId: 'chat-a', requestInstance: requestA };
+    const { result, rerender } = renderHook(() => useChatSettingsLoader());
+
+    await act(async () => {
+      await result.current.fetchChatSettings();
+    });
+    const updateChatA = result.current.updateChatSettings;
+
+    chatContext = { chatId: 'chat-b', requestInstance: requestB };
+    rerender();
+    await act(async () => {
+      await result.current.fetchChatSettings();
+      await updateChatA({ rag_ids: ['a-doc'] });
+    });
+
+    expect(requestA.updateChatSettings).toHaveBeenCalledWith({ rag_ids: ['a-doc'] });
+    expect(requestB.updateChatSettings).not.toHaveBeenCalled();
+    expect(result.current.chatSettings?.name).toBe('Chat B');
+  });
+
+  it('serializes settings writes and exposes when the queue is settled', async () => {
+    const firstWrite = deferred<void>();
+    const requestInstance = request(jest.fn().mockResolvedValue(settings('Queued Chat')));
+
+    requestInstance.updateChatSettings
+      .mockImplementationOnce(() => firstWrite.promise)
+      .mockResolvedValueOnce(undefined);
+    chatContext = { chatId: 'queued-chat', requestInstance };
+    const { result } = renderHook(() => useChatSettingsLoader());
+
+    await act(async () => {
+      await result.current.fetchChatSettings();
+    });
+
+    let first!: Promise<void>;
+    let second!: Promise<void>;
+
+    act(() => {
+      first = result.current.persistChatSettings({ rag_ids: ['first'] });
+      second = result.current.persistChatSettings({ rag_ids: ['second'] });
+    });
+    await act(async () => Promise.resolve());
+
+    expect(requestInstance.updateChatSettings).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      firstWrite.resolve(undefined);
+      await Promise.all([first, second]);
+    });
+
+    expect(requestInstance.updateChatSettings.mock.calls).toEqual([
+      [{ rag_ids: ['first'] }],
+      [{ rag_ids: ['second'] }],
+    ]);
+    await expect(result.current.waitForPendingChatSettings()).resolves.toBe(true);
+  });
+
+  it('retains a failed source write after a later unrelated write succeeds', async () => {
+    const requestInstance = request(jest.fn().mockResolvedValue(settings('Failed Queue Chat')));
+
+    requestInstance.updateChatSettings
+      .mockRejectedValueOnce(new Error('source update failed'))
+      .mockResolvedValueOnce(undefined);
+    chatContext = { chatId: 'failed-queue-chat', requestInstance };
+    const { result } = renderHook(() => useChatSettingsLoader());
+
+    await act(async () => {
+      await result.current.fetchChatSettings();
+    });
+
+    let writes!: PromiseSettledResult<void>[];
+
+    await act(async () => {
+      writes = await Promise.allSettled([
+        result.current.persistChatSettings({ rag_ids: ['new-source'] }),
+        result.current.persistChatSettings({ web_search_enabled: true }),
+      ]);
+    });
+
+    expect(writes.map((write) => write.status)).toEqual(['rejected', 'fulfilled']);
+    await expect(result.current.waitForPendingChatSettings()).resolves.toBe(false);
+    await expect(result.current.waitForPendingChatSettings()).resolves.toBe(true);
+  });
+
+  it('queues a settings refresh behind an in-flight write', async () => {
+    const write = deferred<void>();
+    const getChatSettings = jest
+      .fn()
+      .mockResolvedValueOnce(settings('Before Write'))
+      .mockResolvedValueOnce(settings('After Write'));
+    const requestInstance = request(getChatSettings);
+
+    requestInstance.updateChatSettings.mockImplementationOnce(() => write.promise);
+    chatContext = { chatId: 'read-queue-chat', requestInstance };
+    const { result } = renderHook(() => useChatSettingsLoader());
+
+    await act(async () => {
+      await result.current.fetchChatSettings();
+    });
+
+    let update!: Promise<void>;
+    let refresh!: Promise<ChatSettings | undefined>;
+
+    act(() => {
+      update = result.current.persistChatSettings({ rag_ids: ['new-source'] });
+      refresh = result.current.fetchChatSettings();
+    });
+    await act(async () => Promise.resolve());
+
+    expect(getChatSettings).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      write.resolve(undefined);
+      await Promise.all([update, refresh]);
+    });
+
+    expect(getChatSettings).toHaveBeenCalledTimes(2);
+    expect(result.current.chatSettings?.name).toBe('After Write');
+  });
+
+  it('keeps submission blocked when a critical write and rollback read both fail', async () => {
+    const getChatSettings = jest
+      .fn()
+      .mockResolvedValueOnce(settings('Before Unknown Write'))
+      .mockRejectedValueOnce(new Error('rollback unavailable'))
+      .mockResolvedValueOnce(settings('Authoritative Again'));
+    const requestInstance = request(getChatSettings);
+
+    requestInstance.updateChatSettings.mockRejectedValueOnce(new Error('source response lost'));
+    chatContext = { chatId: 'unknown-write-chat', requestInstance };
+    const { result } = renderHook(() => useChatSettingsLoader());
+
+    await act(async () => {
+      await result.current.fetchChatSettings();
+      await expect(result.current.persistChatSettings({ rag_ids: ['uncertain-source'] })).rejects.toThrow(
+        'source response lost'
+      );
+    });
+
+    await expect(result.current.waitForPendingChatSettings()).resolves.toBe(false);
+    await expect(result.current.waitForPendingChatSettings()).resolves.toBe(false);
+
+    await act(async () => {
+      await result.current.fetchChatSettings();
+    });
+
+    await expect(result.current.waitForPendingChatSettings()).resolves.toBe(true);
+    expect(result.current.chatSettings?.name).toBe('Authoritative Again');
+  });
+});

--- a/src/components/chat/hooks/__tests__/use-rag-scope-loader.test.tsx
+++ b/src/components/chat/hooks/__tests__/use-rag-scope-loader.test.tsx
@@ -1,0 +1,296 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { StrictMode } from 'react';
+
+import { useRagScopeLoader } from '@/components/chat/hooks/use-rag-scope-loader';
+import type { ChatRequest } from '@/components/chat/request/chat-request';
+import { ChatSettings, View, ViewLayout } from '@/components/chat/types';
+
+function view(overrides: Partial<View> = {}): View {
+  return {
+    view_id: 'parent-id',
+    name: 'Parent',
+    icon: null,
+    layout: ViewLayout.Document,
+    extra: { is_space: false },
+    children: [],
+    is_private: false,
+    ...overrides,
+  };
+}
+
+function settings(overrides: Partial<ChatSettings> = {}): ChatSettings {
+  return {
+    name: 'Chat',
+    rag_ids: [],
+    metadata: {},
+    full_workspace: false,
+    web_search_enabled: false,
+    ...overrides,
+  };
+}
+
+function deferred() {
+  let resolvePromise: () => void = () => undefined;
+  let rejectPromise: (error: unknown) => void = () => undefined;
+  const promise = new Promise<void>((resolve, reject) => {
+    resolvePromise = resolve;
+    rejectPromise = reject;
+  });
+
+  return { promise, resolve: resolvePromise, reject: rejectPromise };
+}
+
+function deferredValue<T>() {
+  let resolvePromise: (value: T) => void = () => undefined;
+  const promise = new Promise<T>((resolve) => {
+    resolvePromise = resolve;
+  });
+
+  return { promise, resolve: resolvePromise };
+}
+
+describe('useRagScopeLoader', () => {
+  it('uses the second setup barrier and persists migration once in React Strict Mode', async () => {
+    const parent = view({ children: [view({ view_id: 'child-id' })] });
+    const requestInstance = {
+      fetchCurrentChatParentScope: jest.fn().mockResolvedValue(parent),
+      getViewNavigation: jest.fn(),
+    } as unknown as ChatRequest;
+    const fetchChatSettings = jest.fn().mockResolvedValue(settings({ full_workspace: true }));
+    const persistChatSettings = jest.fn().mockResolvedValue(undefined);
+    const { result } = renderHook(
+      () =>
+        useRagScopeLoader({
+          chatId: 'chat-id',
+          requestInstance,
+          fetchChatSettings,
+          persistChatSettings,
+        }),
+      { wrapper: StrictMode }
+    );
+
+    await waitFor(() => expect(result.current.state.status).toBe('ready'));
+
+    await expect(result.current.waitUntilReady()).resolves.toBe(true);
+    expect(persistChatSettings).toHaveBeenCalledTimes(1);
+    expect(persistChatSettings).toHaveBeenCalledWith({
+      full_workspace: false,
+      rag_ids: ['parent-id', 'child-id'],
+    });
+  });
+
+  it('keeps readiness blocked until full-workspace migration is persisted', async () => {
+    const migration = deferred();
+    const parent = view({ children: [view({ view_id: 'child-id' })] });
+    const requestInstance = {
+      fetchCurrentChatParentScope: jest.fn().mockResolvedValue(parent),
+      getViewNavigation: jest.fn(),
+    } as unknown as ChatRequest;
+    const fetchChatSettings = jest.fn().mockResolvedValue(
+      settings({
+        full_workspace: true,
+        rag_ids: [],
+      })
+    );
+    const persistChatSettings = jest.fn(() => migration.promise);
+    const { result } = renderHook(() =>
+      useRagScopeLoader({
+        chatId: 'chat-id',
+        requestInstance,
+        fetchChatSettings,
+        persistChatSettings,
+      })
+    );
+    let ready: boolean | undefined;
+
+    act(() => {
+      void result.current.waitUntilReady().then((value) => {
+        ready = value;
+      });
+    });
+
+    await waitFor(() => expect(persistChatSettings).toHaveBeenCalledTimes(1));
+    expect(ready).toBeUndefined();
+    expect(result.current.state.status).toBe('loading');
+
+    act(() => migration.resolve());
+    await waitFor(() => expect(result.current.state.status).toBe('ready'));
+
+    expect(ready).toBe(true);
+    expect(persistChatSettings).toHaveBeenCalledWith({
+      full_workspace: false,
+      rag_ids: ['parent-id', 'child-id'],
+    });
+  });
+
+  it('invalidates the ready barrier synchronously when refreshing', async () => {
+    const parent = view();
+    const refreshedScope = deferredValue<View>();
+    const requestInstance = {
+      fetchCurrentChatParentScope: jest
+        .fn()
+        .mockResolvedValueOnce(parent)
+        .mockImplementationOnce(() => refreshedScope.promise),
+      getViewNavigation: jest.fn(),
+    } as unknown as ChatRequest;
+    const fetchChatSettings = jest.fn().mockResolvedValue(settings({ rag_ids: ['parent-id'] }));
+    const persistChatSettings = jest.fn();
+    const { result } = renderHook(() =>
+      useRagScopeLoader({
+        chatId: 'chat-id',
+        requestInstance,
+        fetchChatSettings,
+        persistChatSettings,
+      })
+    );
+
+    await waitFor(() => expect(result.current.state.status).toBe('ready'));
+
+    let refreshedReady: boolean | undefined;
+
+    act(() => {
+      result.current.refresh();
+      void result.current.waitUntilReady().then((ready) => {
+        refreshedReady = ready;
+      });
+    });
+    await act(async () => Promise.resolve());
+
+    expect(refreshedReady).toBeUndefined();
+
+    act(() => refreshedScope.resolve(parent));
+    await waitFor(() => expect(result.current.state.status).toBe('ready'));
+    expect(refreshedReady).toBe(true);
+  });
+
+  it('fails closed when the authoritative parent scope cannot be loaded', async () => {
+    const requestInstance = {
+      fetchCurrentChatParentScope: jest.fn().mockRejectedValue(new Error('scope unavailable')),
+      getViewNavigation: jest.fn(),
+    } as unknown as ChatRequest;
+    const fetchChatSettings = jest.fn().mockResolvedValue(settings());
+    const persistChatSettings = jest.fn();
+    const { result } = renderHook(() =>
+      useRagScopeLoader({
+        chatId: 'chat-id',
+        requestInstance,
+        fetchChatSettings,
+        persistChatSettings,
+      })
+    );
+
+    await waitFor(() => expect(result.current.state.status).toBe('error'));
+    await expect(result.current.waitUntilReady()).resolves.toBe(false);
+  });
+
+  it('fails closed when the scoped settings migration cannot be persisted', async () => {
+    const parent = view({ children: [view({ view_id: 'child-id' })] });
+    const requestInstance = {
+      fetchCurrentChatParentScope: jest.fn().mockResolvedValue(parent),
+      getViewNavigation: jest.fn(),
+    } as unknown as ChatRequest;
+    const fetchChatSettings = jest.fn().mockResolvedValue(
+      settings({
+        full_workspace: true,
+        rag_ids: [],
+      })
+    );
+    const persistenceError = new Error('settings unavailable');
+    const persistChatSettings = jest.fn().mockRejectedValue(persistenceError);
+    const { result } = renderHook(() =>
+      useRagScopeLoader({
+        chatId: 'chat-id',
+        requestInstance,
+        fetchChatSettings,
+        persistChatSettings,
+      })
+    );
+
+    await waitFor(() => expect(result.current.state.status).toBe('error'));
+
+    expect(persistChatSettings).toHaveBeenCalledWith({
+      full_workspace: false,
+      rag_ids: ['parent-id', 'child-id'],
+    });
+    expect(result.current.state.error).toBe(persistenceError);
+    await expect(result.current.waitUntilReady()).resolves.toBe(false);
+  });
+
+  it('removes a saved view whose navigation path is outside the parent scope', async () => {
+    const parent = view();
+    const outside = view({ view_id: 'outside-id' });
+    const requestInstance = {
+      fetchCurrentChatParentScope: jest.fn().mockResolvedValue(parent),
+      getViewNavigation: jest.fn().mockResolvedValue(
+        view({
+          view_id: 'workspace-id',
+          children: [view({ view_id: 'other-space-id', extra: { is_space: true }, children: [outside] })],
+        })
+      ),
+    } as unknown as ChatRequest;
+    const fetchChatSettings = jest.fn().mockResolvedValue(settings({ rag_ids: ['outside-id'] }));
+    const persistChatSettings = jest.fn().mockResolvedValue(undefined);
+    const { result } = renderHook(() =>
+      useRagScopeLoader({
+        chatId: 'chat-id',
+        requestInstance,
+        fetchChatSettings,
+        persistChatSettings,
+      })
+    );
+
+    await waitFor(() => expect(result.current.state.status).toBe('ready'));
+
+    expect(requestInstance.getViewNavigation).toHaveBeenCalledWith('outside-id');
+    expect(persistChatSettings).toHaveBeenCalledWith({
+      full_workspace: false,
+      rag_ids: [],
+    });
+  });
+
+  it('preserves a legacy opaque source when no view navigation exists', async () => {
+    const requestInstance = {
+      fetchCurrentChatParentScope: jest.fn().mockResolvedValue(view()),
+      getViewNavigation: jest.fn().mockRejectedValue({ code: 404 }),
+    } as unknown as ChatRequest;
+    const fetchChatSettings = jest.fn().mockResolvedValue(settings({ rag_ids: ['row-id'] }));
+    const persistChatSettings = jest.fn();
+    const { result } = renderHook(() =>
+      useRagScopeLoader({
+        chatId: 'chat-id',
+        requestInstance,
+        fetchChatSettings,
+        persistChatSettings,
+      })
+    );
+
+    await waitFor(() => expect(result.current.state.status).toBe('ready'));
+
+    expect(result.current.state.scopedSettings?.ragIds).toEqual(['row-id']);
+    expect(persistChatSettings).not.toHaveBeenCalled();
+  });
+
+  it('fails closed when saved-source navigation fails unexpectedly', async () => {
+    const navigationError = new Error('navigation unavailable');
+    const requestInstance = {
+      fetchCurrentChatParentScope: jest.fn().mockResolvedValue(view()),
+      getViewNavigation: jest.fn().mockRejectedValue(navigationError),
+    } as unknown as ChatRequest;
+    const fetchChatSettings = jest.fn().mockResolvedValue(settings({ rag_ids: ['unknown-id'] }));
+    const persistChatSettings = jest.fn();
+    const { result } = renderHook(() =>
+      useRagScopeLoader({
+        chatId: 'chat-id',
+        requestInstance,
+        fetchChatSettings,
+        persistChatSettings,
+      })
+    );
+
+    await waitFor(() => expect(result.current.state.status).toBe('error'));
+
+    expect(result.current.state.error).toBe(navigationError);
+    expect(persistChatSettings).not.toHaveBeenCalled();
+    await expect(result.current.waitUntilReady()).resolves.toBe(false);
+  });
+});

--- a/src/components/chat/hooks/use-chat-settings-loader.ts
+++ b/src/components/chat/hooks/use-chat-settings-loader.ts
@@ -1,67 +1,205 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { toast } from 'sonner';
 
+import { RAG_SOURCE_OWNERS_METADATA_KEY } from '@/components/ai-chat/rag-scope';
 import { useChatContext } from '@/components/chat/chat/context';
 import { ChatSettings } from '@/components/chat/types';
 
-export function useChatSettingsLoader() {
-  const [loading, setLoading] = useState(true);
-  const [chatSettings, setChatSettings] = useState<ChatSettings | null>(null);
-  const {
-    requestInstance,
-    chatId,
-  } = useChatContext();
-  const mountedRef = useRef(true);
+const SUBMISSION_CRITICAL_SETTINGS_KEYS = new Set([
+  'rag_ids',
+  'full_workspace',
+  `metadata.${RAG_SOURCE_OWNERS_METADATA_KEY}`,
+]);
 
+export function useChatSettingsLoader() {
+  const { requestInstance, chatId } = useChatContext();
+  const [state, setState] = useState<{
+    chatId: string;
+    requestInstance: typeof requestInstance;
+    loading: boolean;
+    chatSettings: ChatSettings | null;
+  }>(() => ({ chatId, requestInstance, loading: true, chatSettings: null }));
+  const mountedRef = useRef(true);
+  const currentOwnerRef = useRef({ chatId, requestInstance });
+  const writeQueue = useMemo(
+    () => ({
+      chatId,
+      requestInstance,
+      tail: Promise.resolve(),
+      failedKeys: new Set<string>(),
+      unverifiedKeys: new Set<string>(),
+    }),
+    [chatId, requestInstance]
+  );
+
+  currentOwnerRef.current = { chatId, requestInstance };
   useEffect(() => {
     mountedRef.current = true;
+
     return () => {
       mountedRef.current = false;
-      setLoading(true);
-      setChatSettings(null);
     };
-  }, [chatId]);
+  }, []);
 
-  const fetchChatSettings = useCallback(async() => {
+  const ownsCurrentChat = state.chatId === chatId && state.requestInstance === requestInstance;
+  const loading = ownsCurrentChat ? state.loading : true;
+  const chatSettings = ownsCurrentChat ? state.chatSettings : null;
+
+  const fetchChatSettingsFromServer = useCallback(async () => {
+    const owner = { chatId, requestInstance };
+
     try {
       const data = await requestInstance.getChatSettings();
 
-      if (!mountedRef.current) return;
-      setLoading(false);
-      setChatSettings(data);
-      return data;
-      // eslint-disable-next-line
-    } catch(e: any) {
-      if (mountedRef.current) setLoading(false);
-    }
-  }, [requestInstance]);
-
-  const updateChatSettings = useCallback(async(payload: Partial<ChatSettings>) => {
-    // Optimistic update
-    setChatSettings(current => {
-      if (!current) return current;
-      const updated = { ...current, ...payload };
-
-      if (payload.metadata && current.metadata) {
-        updated.metadata = { ...current.metadata, ...payload.metadata };
+      if (
+        !mountedRef.current ||
+        currentOwnerRef.current.chatId !== owner.chatId ||
+        currentOwnerRef.current.requestInstance !== owner.requestInstance
+      ) {
+        return;
       }
 
-      return updated;
+      setState({ ...owner, loading: false, chatSettings: data });
+      return data;
+      // eslint-disable-next-line
+    } catch (e: any) {
+      if (
+        mountedRef.current &&
+        currentOwnerRef.current.chatId === owner.chatId &&
+        currentOwnerRef.current.requestInstance === owner.requestInstance
+      ) {
+        setState({ ...owner, loading: false, chatSettings: null });
+      }
+    }
+  }, [chatId, requestInstance]);
+
+  const fetchChatSettings = useCallback(() => {
+    // Reads participate in the queue so a refresh cannot overwrite a newer
+    // optimistic value with a response captured before its POST completed.
+    const read = writeQueue.tail.then(async () => {
+      const data = await fetchChatSettingsFromServer();
+
+      if (data) {
+        // A successful authoritative read makes any earlier ambiguous write
+        // safe to reason about again. Scope validation still runs before send.
+        writeQueue.failedKeys.clear();
+        writeQueue.unverifiedKeys.clear();
+      }
+
+      return data;
     });
 
-    try {
-      await requestInstance.updateChatSettings(payload);
-      // eslint-disable-next-line
-    } catch(e: any) {
-      // Rollback by re-fetching server state
-      void fetchChatSettings();
-      toast.error(e.message);
-    }
-  }, [requestInstance, fetchChatSettings]);
+    writeQueue.tail = read.then(() => undefined);
+    return read;
+  }, [fetchChatSettingsFromServer, writeQueue]);
+
+  const persistChatSettings = useCallback(
+    (payload: Partial<ChatSettings>) => {
+      const owner = { chatId, requestInstance };
+      const payloadKeys = [
+        ...Object.keys(payload).filter((key) => key !== 'metadata'),
+        ...Object.keys(payload.metadata || {}).map((key) => `metadata.${key}`),
+      ];
+      const criticalPayloadKeys = payloadKeys.filter((key) => SUBMISSION_CRITICAL_SETTINGS_KEYS.has(key));
+      const operation = writeQueue.tail.then(async () => {
+        // Apply updates in the same order as their server writes. This prevents
+        // model, web-search, and RAG metadata patches from racing each other.
+        setState((current) => {
+          if (
+            current.chatId !== owner.chatId ||
+            current.requestInstance !== owner.requestInstance ||
+            !current.chatSettings
+          ) {
+            return current;
+          }
+
+          const updated = { ...current.chatSettings, ...payload };
+
+          if (payload.metadata && current.chatSettings.metadata) {
+            updated.metadata = { ...current.chatSettings.metadata, ...payload.metadata };
+          }
+
+          return { ...current, chatSettings: updated };
+        });
+
+        try {
+          await requestInstance.updateChatSettings(payload);
+          payloadKeys.forEach((key) => {
+            writeQueue.failedKeys.delete(key);
+            writeQueue.unverifiedKeys.delete(key);
+          });
+          // eslint-disable-next-line
+        } catch (e: any) {
+          criticalPayloadKeys.forEach((key) => writeQueue.failedKeys.add(key));
+          // Roll back by re-fetching server state before the next queued write.
+          // This read is already inside the queued operation. Calling the public
+          // queued reader here would wait on itself and deadlock.
+          const rollbackSettings = await fetchChatSettingsFromServer();
+
+          if (!rollbackSettings) {
+            criticalPayloadKeys.forEach((key) => writeQueue.unverifiedKeys.add(key));
+          }
+
+          if (
+            mountedRef.current &&
+            currentOwnerRef.current.chatId === owner.chatId &&
+            currentOwnerRef.current.requestInstance === owner.requestInstance
+          ) {
+            toast.error(e.message);
+          }
+
+          throw e;
+        }
+      });
+
+      // The queue tail represents settlement and always resolves; callers still
+      // receive the rejecting operation so they can handle their own write.
+      writeQueue.tail = operation.catch(() => undefined);
+      return operation;
+    },
+    [chatId, requestInstance, fetchChatSettingsFromServer, writeQueue]
+  );
+
+  const waitForPendingChatSettings = useCallback(async () => {
+    const waitForTail = async (pending: Promise<void>): Promise<boolean> => {
+      await pending;
+
+      if (writeQueue.tail === pending) {
+        const ready = writeQueue.failedKeys.size === 0;
+
+        // One send attempt reports the lost source change. After rollback the
+        // server state is authoritative again, so a deliberate retry can use it.
+        if (!ready) {
+          writeQueue.failedKeys.forEach((key) => {
+            if (!writeQueue.unverifiedKeys.has(key)) writeQueue.failedKeys.delete(key);
+          });
+        }
+
+        return ready;
+      }
+
+      return waitForTail(writeQueue.tail);
+    };
+
+    return waitForTail(writeQueue.tail);
+  }, [writeQueue]);
+
+  const updateChatSettings = useCallback(
+    async (payload: Partial<ChatSettings>) => {
+      try {
+        await persistChatSettings(payload);
+      } catch {
+        // Errors are already rolled back and surfaced by persistChatSettings.
+      }
+    },
+    [persistChatSettings]
+  );
 
   return {
     loading,
     fetchChatSettings,
+    persistChatSettings,
+    waitForPendingChatSettings,
     updateChatSettings,
     chatSettings,
   };

--- a/src/components/chat/hooks/use-rag-scope-loader.ts
+++ b/src/components/chat/hooks/use-rag-scope-loader.ts
@@ -1,0 +1,219 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+import { ERROR_CODE } from '@/application/constants';
+import {
+  areSameRagIds,
+  areSameRagSourceOwners,
+  collectScopedRagIds,
+  getRagSourceOwners,
+  isSpaceView,
+  RAG_SOURCE_OWNERS_METADATA_KEY,
+  resolveScopedRagState,
+  ScopedRagState,
+} from '@/components/ai-chat/rag-scope';
+import { findAncestors } from '@/components/chat/lib/views';
+import { ChatRequest } from '@/components/chat/request/chat-request';
+import { ChatSettings, View, ViewLayout } from '@/components/chat/types';
+
+export type RagScopeStatus = 'loading' | 'ready' | 'error';
+
+export interface RagScopeLoadState {
+  status: RagScopeStatus;
+  parentView: View | null;
+  scopedSettings: ScopedRagState | null;
+  error?: unknown;
+}
+
+interface ReadinessBarrier {
+  promise: Promise<boolean>;
+  resolve: (ready: boolean) => void;
+  isSettled: () => boolean;
+}
+
+function createReadinessBarrier(): ReadinessBarrier {
+  let settled = false;
+  let resolvePromise: (ready: boolean) => void = () => undefined;
+  const promise = new Promise<boolean>((resolve) => {
+    resolvePromise = resolve;
+  });
+
+  return {
+    promise,
+    isSettled: () => settled,
+    resolve: (ready) => {
+      if (settled) return;
+      settled = true;
+      resolvePromise(ready);
+    },
+  };
+}
+
+function isMissingViewError(error: unknown): boolean {
+  if (!error || typeof error !== 'object') return false;
+
+  const value = error as {
+    code?: unknown;
+    response?: { status?: unknown };
+  };
+
+  return value.code === ERROR_CODE.RECORD_NOT_FOUND || value.code === 404 || value.response?.status === 404;
+}
+
+async function findKnownOutsideViewIds(
+  requestInstance: ChatRequest,
+  parentView: View,
+  settings: ChatSettings
+): Promise<Set<string>> {
+  if (settings.full_workspace) return new Set();
+
+  const preliminary = resolveScopedRagState([parentView], settings);
+  const sourceOwners = getRagSourceOwners(settings.metadata);
+  const opaqueIds = preliminary.preservedRagIds.filter((id) => !sourceOwners[id]);
+
+  if (opaqueIds.length === 0) return new Set();
+
+  const selectableIds = new Set(collectScopedRagIds([parentView]));
+  const knownOutsideIds = new Set<string>();
+
+  await Promise.all(
+    opaqueIds.map(async (id) => {
+      try {
+        const navigation = await requestInstance.getViewNavigation(id);
+        const path = findAncestors([navigation], id);
+
+        if (!path) throw new Error('Unable to resolve a saved RAG source');
+
+        const parentIndex = path.findIndex((view) => view.view_id === parentView.view_id);
+        const target = path[path.length - 1];
+        const isSelectablePath =
+          parentIndex >= 0 &&
+          !isSpaceView(target) &&
+          path.slice(parentIndex).every((view) => view.layout === ViewLayout.Document);
+
+        if (isSelectablePath) {
+          // A complete parent subtree must contain every selectable descendant.
+          // If navigation finds one that is missing, fail closed instead of
+          // treating the incomplete response as authoritative.
+          if (!selectableIds.has(id)) {
+            throw new Error('The AI chat scope is incomplete');
+          }
+
+          return;
+        }
+
+        knownOutsideIds.add(id);
+      } catch (error) {
+        // A record-not-found response means this is an opaque source such as a
+        // database row or file. Preserve legacy opaque sources; other failures
+        // make scope validation unavailable and must remain fail-closed.
+        if (!isMissingViewError(error)) throw error;
+      }
+    })
+  );
+
+  return knownOutsideIds;
+}
+
+function buildScopedSettingsUpdate(settings: ChatSettings, scoped: ScopedRagState): Partial<ChatSettings> | null {
+  const currentOwners = getRagSourceOwners(settings.metadata);
+  const ragIdsChanged = !areSameRagIds(settings.rag_ids || [], scoped.ragIds);
+  const ownersChanged = !areSameRagSourceOwners(currentOwners, scoped.sourceOwners);
+
+  if (!settings.full_workspace && !ragIdsChanged && !ownersChanged) return null;
+
+  return {
+    full_workspace: false,
+    rag_ids: scoped.ragIds,
+    ...(ownersChanged
+      ? {
+          metadata: {
+            [RAG_SOURCE_OWNERS_METADATA_KEY]: scoped.sourceOwners,
+          },
+        }
+      : {}),
+  };
+}
+
+export function useRagScopeLoader({
+  chatId,
+  requestInstance,
+  fetchChatSettings,
+  persistChatSettings,
+}: {
+  chatId: string;
+  requestInstance: ChatRequest;
+  fetchChatSettings: () => Promise<ChatSettings | undefined>;
+  persistChatSettings: (payload: Partial<ChatSettings>) => Promise<void>;
+}) {
+  const [attempt, setAttempt] = useState(0);
+  const [state, setState] = useState<RagScopeLoadState>({
+    status: 'loading',
+    parentView: null,
+    scopedSettings: null,
+  });
+  const [initialBarrier] = useState(createReadinessBarrier);
+  const attemptRef = useRef(0);
+  const barrierRef = useRef({ attempt: 0, barrier: initialBarrier });
+
+  useEffect(() => {
+    let active = true;
+    let barrierEntry = barrierRef.current;
+
+    // A refresh installs its barrier synchronously so submissions cannot see
+    // the previous ready result before this passive effect runs. Strict Mode's
+    // second setup replaces the barrier rejected by its cleanup replay.
+    if (barrierEntry.attempt !== attempt || barrierEntry.barrier.isSettled()) {
+      barrierEntry = { attempt, barrier: createReadinessBarrier() };
+      barrierRef.current = barrierEntry;
+    }
+
+    const { barrier } = barrierEntry;
+
+    setState({ status: 'loading', parentView: null, scopedSettings: null });
+
+    void (async () => {
+      try {
+        const [settings, parentView] = await Promise.all([
+          fetchChatSettings(),
+          requestInstance.fetchCurrentChatParentScope(attempt > 0),
+        ]);
+
+        if (!settings) throw new Error('Unable to load AI chat settings');
+
+        const knownOutsideViewIds = await findKnownOutsideViewIds(requestInstance, parentView, settings);
+        const scopedSettings = resolveScopedRagState([parentView], settings, knownOutsideViewIds);
+        const update = buildScopedSettingsUpdate(settings, scopedSettings);
+
+        if (!active) return;
+        if (update) await persistChatSettings(update);
+        if (!active) return;
+
+        setState({ status: 'ready', parentView, scopedSettings });
+        barrier.resolve(true);
+      } catch (error) {
+        if (!active) return;
+
+        setState({ status: 'error', parentView: null, scopedSettings: null, error });
+        barrier.resolve(false);
+      }
+    })();
+
+    return () => {
+      active = false;
+      barrier.resolve(false);
+    };
+  }, [attempt, chatId, fetchChatSettings, persistChatSettings, requestInstance]);
+
+  const waitUntilReady = useCallback(() => barrierRef.current.barrier.promise, []);
+  const refresh = useCallback(() => {
+    const nextAttempt = attemptRef.current + 1;
+
+    attemptRef.current = nextAttempt;
+    barrierRef.current.barrier.resolve(false);
+    barrierRef.current = { attempt: nextAttempt, barrier: createReadinessBarrier() };
+    setState({ status: 'loading', parentView: null, scopedSettings: null });
+    setAttempt(nextAttempt);
+  }, []);
+
+  return { state, waitUntilReady, refresh };
+}

--- a/src/components/chat/provider/__tests__/messages-handler-provider.rag-scope.test.tsx
+++ b/src/components/chat/provider/__tests__/messages-handler-provider.rag-scope.test.tsx
@@ -1,0 +1,244 @@
+import { act, render } from '@testing-library/react';
+
+import {
+  MessagesHandlerProvider,
+  useMessagesHandlerContext,
+} from '@/components/chat/provider/messages-handler-provider';
+import { AuthorType, MessageType } from '@/components/chat/types';
+
+interface Deferred<T> {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+}
+
+function deferred<T>(): Deferred<T> {
+  let resolvePromise: (value: T) => void = () => undefined;
+  const promise = new Promise<T>((resolve) => {
+    resolvePromise = resolve;
+  });
+
+  return { promise, resolve: resolvePromise };
+}
+
+const toastError = jest.fn();
+const waitUntilReady = jest.fn<Promise<boolean>, []>();
+const waitForPendingChatSettings = jest.fn<Promise<boolean>, []>();
+const insertMessage = jest.fn();
+const requestInstance = {
+  submitQuestion: jest.fn().mockResolvedValue({
+    message_id: 10,
+    reply_message_id: 11,
+    content: 'Question',
+    author: { author_type: AuthorType.Human, author_uuid: 'user-id' },
+  }),
+  getCurrentView: jest.fn().mockResolvedValue(undefined),
+};
+
+jest.mock('sonner', () => ({
+  toast: { error: (...args: unknown[]) => toastError(...args) },
+}));
+
+jest.mock('@/components/chat/chat/context', () => ({
+  useChatContext: () => ({
+    chatId: 'chat-id',
+    requestInstance,
+    currentUser: { uuid: 'user-id' },
+  }),
+}));
+
+jest.mock('@/components/chat/hooks/use-chat-settings-loader', () => ({
+  useChatSettingsLoader: () => ({
+    chatSettings: null,
+    fetchChatSettings: jest.fn(),
+    persistChatSettings: jest.fn(),
+    waitForPendingChatSettings,
+    updateChatSettings: jest.fn(),
+  }),
+}));
+
+jest.mock('@/components/chat/hooks/use-rag-scope-loader', () => ({
+  useRagScopeLoader: () => ({
+    state: { status: 'loading', parentView: null, scopedSettings: null },
+    waitUntilReady,
+    refresh: jest.fn(),
+  }),
+}));
+
+jest.mock('@/components/chat/provider/message-animation-provider', () => ({
+  useMessageAnimation: () => ({ registerAnimation: jest.fn() }),
+}));
+
+jest.mock('@/components/chat/provider/messages-provider', () => ({
+  useChatMessagesContext: () => ({
+    messageIds: [1],
+    addMessages: jest.fn(),
+    insertMessage,
+    removeMessages: jest.fn(() => []),
+    saveMessageContent: jest.fn(),
+    getMessage: jest.fn(),
+  }),
+}));
+
+jest.mock('@/components/chat/provider/prompt-modal-provider', () => ({
+  usePromptModal: () => ({ currentPromptId: null }),
+}));
+
+jest.mock('@/components/chat/provider/response-format-provider', () => ({
+  useResponseFormatContext: () => ({ setResponseFormatWithId: jest.fn() }),
+}));
+
+jest.mock('@/components/chat/provider/suggestions-provider', () => ({
+  useSuggestionsContext: () => ({
+    registerFetchSuggestions: jest.fn(),
+    startFetchSuggestions: jest.fn(),
+  }),
+}));
+
+let messagesContext: ReturnType<typeof useMessagesHandlerContext>;
+
+function ContextProbe() {
+  messagesContext = useMessagesHandlerContext();
+  return null;
+}
+
+describe('MessagesHandlerProvider RAG scope readiness', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+    waitForPendingChatSettings.mockResolvedValue(true);
+  });
+
+  afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+  });
+
+  it('does not submit a question until scope validation succeeds', async () => {
+    const readiness = deferred<boolean>();
+
+    waitUntilReady.mockReturnValue(readiness.promise);
+    render(
+      <MessagesHandlerProvider>
+        <ContextProbe />
+      </MessagesHandlerProvider>
+    );
+
+    let submission!: Promise<void>;
+
+    act(() => {
+      submission = messagesContext.submitQuestion('Scoped question');
+    });
+
+    expect(requestInstance.submitQuestion).not.toHaveBeenCalled();
+    expect(insertMessage).not.toHaveBeenCalled();
+
+    await act(async () => {
+      readiness.resolve(true);
+      await submission;
+    });
+
+    expect(requestInstance.submitQuestion).toHaveBeenCalledWith({
+      content: 'Scoped question',
+      message_type: MessageType.User,
+      prompt_id: undefined,
+      model_name: undefined,
+    });
+  });
+
+  it('fails closed when scope validation fails', async () => {
+    waitUntilReady.mockResolvedValue(false);
+    render(
+      <MessagesHandlerProvider>
+        <ContextProbe />
+      </MessagesHandlerProvider>
+    );
+
+    await act(async () => {
+      await expect(messagesContext.submitQuestion('Unsafe question')).rejects.toThrow(
+        'Unable to validate the AI chat context'
+      );
+    });
+
+    expect(requestInstance.submitQuestion).not.toHaveBeenCalled();
+    expect(insertMessage).not.toHaveBeenCalled();
+    expect(toastError).toHaveBeenCalledWith('Unable to validate the AI chat context');
+  });
+
+  it('flushes a pending source update before sending the question', async () => {
+    const sourceWrite = deferred<void>();
+
+    waitUntilReady.mockResolvedValue(true);
+    render(
+      <MessagesHandlerProvider>
+        <ContextProbe />
+      </MessagesHandlerProvider>
+    );
+    messagesContext.registerChatSettingsFlush(() => sourceWrite.promise);
+
+    let submission!: Promise<void>;
+
+    act(() => {
+      submission = messagesContext.submitQuestion('Latest sources');
+    });
+
+    await act(async () => Promise.resolve());
+    expect(requestInstance.submitQuestion).not.toHaveBeenCalled();
+
+    await act(async () => {
+      sourceWrite.resolve(undefined);
+      await submission;
+    });
+
+    expect(requestInstance.submitQuestion).toHaveBeenCalledTimes(1);
+  });
+
+  it('fails closed when a pending settings write failed', async () => {
+    waitUntilReady.mockResolvedValue(true);
+    waitForPendingChatSettings.mockResolvedValue(false);
+    render(
+      <MessagesHandlerProvider>
+        <ContextProbe />
+      </MessagesHandlerProvider>
+    );
+
+    await act(async () => {
+      await expect(messagesContext.submitQuestion('Unsaved sources')).rejects.toThrow(
+        'Unable to save the AI chat context'
+      );
+    });
+
+    expect(requestInstance.submitQuestion).not.toHaveBeenCalled();
+    expect(insertMessage).not.toHaveBeenCalled();
+  });
+
+  it('rejects a concurrent question before it can share the readiness wait', async () => {
+    const readiness = deferred<boolean>();
+
+    waitUntilReady.mockReturnValue(readiness.promise);
+    render(
+      <MessagesHandlerProvider>
+        <ContextProbe />
+      </MessagesHandlerProvider>
+    );
+
+    let firstSubmission!: Promise<void>;
+
+    act(() => {
+      firstSubmission = messagesContext.submitQuestion('First question');
+    });
+
+    await act(async () => {
+      await expect(messagesContext.submitQuestion('Duplicate question')).rejects.toThrow(
+        'A question is already being sent'
+      );
+    });
+    expect(waitUntilReady).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      readiness.resolve(true);
+      await firstSubmission;
+    });
+
+    expect(requestInstance.submitQuestion).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/chat/provider/messages-handler-provider.tsx
+++ b/src/components/chat/provider/messages-handler-provider.tsx
@@ -3,6 +3,7 @@ import { toast } from 'sonner';
 
 import { useChatContext } from '@/components/chat/chat/context';
 import { useChatSettingsLoader } from '@/components/chat/hooks/use-chat-settings-loader';
+import { RagScopeLoadState, useRagScopeLoader } from '@/components/chat/hooks/use-rag-scope-loader';
 import { ERROR_CODE_NO_LIMIT } from '@/components/chat/lib/const';
 import {
   AuthorType,
@@ -22,7 +23,6 @@ import { usePromptModal } from './prompt-modal-provider';
 import { useResponseFormatContext } from './response-format-provider';
 import { useSuggestionsContext } from './suggestions-provider';
 
-
 interface MessagesHandlerContextTypes {
   fetchMessages: (payload?: GetChatMessagesPayload) => Promise<RepeatedChatMessage>;
   submitQuestion: (message: string) => Promise<void>;
@@ -40,6 +40,9 @@ interface MessagesHandlerContextTypes {
   setSelectedModelName?: (modelName: string, explicit?: boolean) => void;
   chatSettings: ChatSettings | null;
   updateChatSettings: (payload: Partial<ChatSettings>) => Promise<void>;
+  registerChatSettingsFlush: (flush: () => Promise<void>) => () => void;
+  ragScopeState: RagScopeLoadState;
+  refreshRagScope: () => void;
 }
 
 export const MessagesHandlerContext = createContext<MessagesHandlerContextTypes | undefined>(undefined);
@@ -47,17 +50,24 @@ export const MessagesHandlerContext = createContext<MessagesHandlerContextTypes 
 function useMessagesHandler() {
   const { chatId, requestInstance, currentUser } = useChatContext();
 
-  const { chatSettings, fetchChatSettings, updateChatSettings } = useChatSettingsLoader();
+  const { chatSettings, fetchChatSettings, persistChatSettings, waitForPendingChatSettings, updateChatSettings } =
+    useChatSettingsLoader();
+  const {
+    state: ragScopeState,
+    waitUntilReady: waitUntilRagScopeReady,
+    refresh: refreshRagScope,
+  } = useRagScopeLoader({
+    chatId,
+    requestInstance,
+    fetchChatSettings,
+    persistChatSettings,
+  });
 
   // Get the current model from chat settings
   const [selectedModelName, setSelectedModelName] = useState<string>();
   // Track whether the user has explicitly selected a model in this session.
   // Prevents async initialization (fetchChatSettings) from overwriting the user's choice.
   const userExplicitlySelectedModel = useRef(false);
-
-  useEffect(() => {
-    void fetchChatSettings();
-  }, [fetchChatSettings]);
 
   // Reset the explicit selection flag when chatId changes (new chat opened)
   useEffect(() => {
@@ -94,12 +104,29 @@ function useMessagesHandler() {
   const { registerAnimation } = useMessageAnimation();
   const { registerFetchSuggestions, startFetchSuggestions } = useSuggestionsContext();
   const [questionSending, setQuestionSending] = useState(false);
+  const questionSendingRef = useRef(false);
   const [answerApplying, setAnswerApplying] = useState(false);
   const cancelStreamRef = useRef<() => void>();
+  const chatSettingsFlushersRef = useRef(new Set<() => Promise<void>>());
+
+  const registerChatSettingsFlush = useCallback((flush: () => Promise<void>) => {
+    chatSettingsFlushersRef.current.add(flush);
+
+    return () => {
+      chatSettingsFlushersRef.current.delete(flush);
+    };
+  }, []);
+
+  const flushChatSettings = useCallback(async () => {
+    for (const flush of Array.from(chatSettingsFlushersRef.current)) {
+      await flush();
+    }
+  }, []);
 
   useEffect(() => {
     return () => {
       setQuestionSending(false);
+      questionSendingRef.current = false;
       setAnswerApplying(false);
       cancelStreamRef.current = undefined;
     };
@@ -160,8 +187,25 @@ function useMessagesHandler() {
 
   const submitQuestion = useCallback(
     async (message: string) => {
+      if (questionSendingRef.current) {
+        const error = new Error('A question is already being sent');
+
+        toast.error(error.message);
+        return Promise.reject(error);
+      }
+
+      questionSendingRef.current = true;
       try {
         setQuestionSending(true);
+
+        if (!(await waitUntilRagScopeReady())) {
+          throw new Error('Unable to validate the AI chat context');
+        }
+
+        await flushChatSettings();
+        if (!(await waitForPendingChatSettings())) {
+          throw new Error('Unable to save the AI chat context');
+        }
 
         // Capture whether this is the first message BEFORE we insert anything,
         // so the rename-from-first-prompt logic works correctly.
@@ -233,6 +277,7 @@ function useMessagesHandler() {
 
         return Promise.reject(e);
       } finally {
+        questionSendingRef.current = false;
         setQuestionSending(false);
       }
     },
@@ -245,6 +290,9 @@ function useMessagesHandler() {
       removeMessages,
       registerFetchSuggestions,
       createAssistantMessage,
+      flushChatSettings,
+      waitForPendingChatSettings,
+      waitUntilRagScopeReady,
     ]
   );
 
@@ -274,7 +322,12 @@ function useMessagesHandler() {
   );
 
   const fetchAnswerStream = useCallback(
-    async (questionId: number, format?: ResponseFormat, onMessage?: (text: string, done?: boolean) => void, onProgress?: (step: string) => void) => {
+    async (
+      questionId: number,
+      format?: ResponseFormat,
+      onMessage?: (text: string, done?: boolean) => void,
+      onProgress?: (step: string) => void
+    ) => {
       const question = getMessage(questionId);
       let answerId = question?.reply_message_id;
 
@@ -346,14 +399,7 @@ function useMessagesHandler() {
         return Promise.reject(e);
       }
     },
-    [
-      getMessage,
-      setResponseFormatWithId,
-      saveAnswer,
-      startFetchSuggestions,
-      removeAssistantMessage,
-      requestInstance,
-    ]
+    [getMessage, setResponseFormatWithId, saveAnswer, startFetchSuggestions, removeAssistantMessage, requestInstance]
   );
 
   const cancelAnswerStream = useCallback(() => {
@@ -362,47 +408,51 @@ function useMessagesHandler() {
     }
   }, []);
 
-  // Update local state and persist to chat settings.
-  // Called from both initialization (ModelSelector loadCurrentModel) and explicit user selection.
-  // The `explicit` parameter distinguishes the two to prevent async init from overwriting user choices.
+  // Keep the shared model state in sync. Explicit persistence is handled by
+  // ModelSelector's request adapter so one selection produces exactly one
+  // settings write; initialization only updates local state.
   const updateSelectedModel = useCallback((modelName: string, explicit = true) => {
     if (explicit) {
       userExplicitlySelectedModel.current = true;
     }
 
     setSelectedModelName(modelName);
-    void updateChatSettings({
-      metadata: {
-        ai_model: modelName,
-      },
-    });
-  }, [updateChatSettings]);
+  }, []);
 
-  return useMemo(() => ({
-    fetchMessages,
-    submitQuestion,
-    regenerateAnswer,
-    fetchAnswerStream,
-    cancelAnswerStream,
-    questionSending,
-    answerApplying,
-    selectedModelName,
-    setSelectedModelName: updateSelectedModel,
-    chatSettings,
-    updateChatSettings,
-  }), [
-    fetchMessages,
-    submitQuestion,
-    regenerateAnswer,
-    fetchAnswerStream,
-    cancelAnswerStream,
-    questionSending,
-    answerApplying,
-    selectedModelName,
-    updateSelectedModel,
-    chatSettings,
-    updateChatSettings,
-  ]);
+  return useMemo(
+    () => ({
+      fetchMessages,
+      submitQuestion,
+      regenerateAnswer,
+      fetchAnswerStream,
+      cancelAnswerStream,
+      questionSending,
+      answerApplying,
+      selectedModelName,
+      setSelectedModelName: updateSelectedModel,
+      chatSettings,
+      updateChatSettings,
+      registerChatSettingsFlush,
+      ragScopeState,
+      refreshRagScope,
+    }),
+    [
+      fetchMessages,
+      submitQuestion,
+      regenerateAnswer,
+      fetchAnswerStream,
+      cancelAnswerStream,
+      questionSending,
+      answerApplying,
+      selectedModelName,
+      updateSelectedModel,
+      chatSettings,
+      updateChatSettings,
+      registerChatSettingsFlush,
+      ragScopeState,
+      refreshRagScope,
+    ]
+  );
 }
 
 export function MessagesHandlerProvider({ children }: { children: ReactNode }) {

--- a/src/components/chat/request/chat-request.ts
+++ b/src/components/chat/request/chat-request.ts
@@ -41,6 +41,21 @@ function isChatMessageMetadata(value: unknown): value is ChatMessageMetadata {
   return typeof source.id === 'string' && typeof source.name === 'string' && typeof source.source === 'string';
 }
 
+function encodeEmptyRagScope(params: UpdateChatSettingsParams, chatId: string): UpdateChatSettingsParams {
+  if (params.full_workspace === true || params.rag_ids?.length !== 0) return params;
+
+  // The AI search service treats an empty object filter as workspace-wide.
+  // A chat view is not a document source, so its ID safely represents an
+  // intentionally empty scope without exposing any workspace documents.
+  return { ...params, rag_ids: [chatId] };
+}
+
+function decodeEmptyRagScope(settings: ChatSettings, chatId: string): ChatSettings {
+  if (settings.rag_ids.length !== 1 || settings.rag_ids[0] !== chatId) return settings;
+
+  return { ...settings, rag_ids: [] };
+}
+
 function collectTruncatedViewIds(root: View): string[] {
   const ids: string[] = [];
   const stack = [{ view: root, depth: 0 }];
@@ -730,7 +745,7 @@ export class ChatRequest {
     }>(url);
 
     if (response?.data.code === 0 && response.data.data) {
-      return response.data.data;
+      return decodeEmptyRagScope(response.data.data, this.chatId);
     }
 
     return Promise.reject(response?.data?.message || 'Failed to fetch chat settings');
@@ -745,7 +760,7 @@ export class ChatRequest {
     const response = await this.axiosInstance.post<{
       code: number;
       message?: string;
-    }>(url, params);
+    }>(url, encodeEmptyRagScope(params, this.chatId));
 
     if (response?.data.code === 0) {
       return;

--- a/src/components/chat/request/chat-request.ts
+++ b/src/components/chat/request/chat-request.ts
@@ -8,22 +8,113 @@ import {
   requestInterceptor,
 } from '@/components/chat/lib/requets';
 import { convertToPageData } from '@/components/chat/lib/utils';
-import { findView } from '@/components/chat/lib/views';
+import { findAncestors, findView } from '@/components/chat/lib/views';
 import {
+  ChatMessageMetadata,
   ChatMessage,
   ChatSettings,
   GetChatMessagesPayload,
   RepeatedChatMessage,
   ResponseFormat,
   SendQuestionPayload,
+  StreamType,
   Suggestions,
-  User, View, ViewLayout,
-  ChatMessageMetadata, StreamType,
+  User,
+  View,
+  ViewLayout,
 } from '@/components/chat/types';
 import { ModelList } from '@/components/chat/types/ai-model';
+
 import { extractNextJsonObject } from './stream-json-parser';
 
 export type UpdateChatSettingsParams = Partial<ChatSettings>;
+
+const COMPLETE_VIEW_DEPTH = 50;
+const COMPLETE_VIEW_BATCH_SIZE = 50;
+
+const completeViewRequests = new WeakMap<AxiosInstance, Map<string, Promise<View>>>();
+
+function isChatMessageMetadata(value: unknown): value is ChatMessageMetadata {
+  if (!value || typeof value !== 'object') return false;
+  const source = value as Partial<ChatMessageMetadata>;
+
+  return typeof source.id === 'string' && typeof source.name === 'string' && typeof source.source === 'string';
+}
+
+function collectTruncatedViewIds(root: View): string[] {
+  const ids: string[] = [];
+  const stack = [{ view: root, depth: 0 }];
+
+  while (stack.length > 0) {
+    const current = stack.pop();
+
+    if (!current) continue;
+    const { view, depth } = current;
+
+    if (
+      view.children.length === 0 &&
+      (view.has_children === true || (view.has_children === undefined && depth >= COMPLETE_VIEW_DEPTH))
+    ) {
+      ids.push(view.view_id);
+      continue;
+    }
+
+    view.children.forEach((child) => stack.push({ view: child, depth: depth + 1 }));
+  }
+
+  return ids;
+}
+
+function replaceViewSubtrees(root: View, replacements: ReadonlyMap<string, View>): View {
+  const replacement = replacements.get(root.view_id);
+
+  if (replacement) return replacement;
+  if (root.children.length === 0) return root;
+
+  let changed = false;
+  const children = root.children.map((child) => {
+    const next = replaceViewSubtrees(child, replacements);
+
+    if (next !== child) changed = true;
+    return next;
+  });
+
+  return changed ? { ...root, children } : root;
+}
+
+function normalizeContinuationRoot(view: View): View {
+  // `has_children` is based on the raw folder snapshot. Shared/private children
+  // can be filtered from the response, so a continuation that still has no
+  // visible children is a complete terminal node for the current user. This
+  // marker also terminates old-server responses that omit `has_children`.
+  if (view.children.length === 0) {
+    return { ...view, has_children: false };
+  }
+
+  return view;
+}
+
+function chunkIds(ids: string[]): string[][] {
+  const chunks: string[][] = [];
+
+  for (let index = 0; index < ids.length; index += COMPLETE_VIEW_BATCH_SIZE) {
+    chunks.push(ids.slice(index, index + COMPLETE_VIEW_BATCH_SIZE));
+  }
+
+  return chunks;
+}
+
+function isUnsupportedViewBatchError(error: unknown): boolean {
+  if (!error || typeof error !== 'object') return false;
+
+  const value = error as {
+    code?: unknown;
+    response?: { status?: unknown; data?: { code?: unknown } };
+  };
+  const status = value.response?.status ?? value.response?.data?.code ?? value.code;
+
+  return status === 404 || status === 405;
+}
 
 /**
  * ChatRequest class for handling chat-related API requests
@@ -87,7 +178,7 @@ export class ChatRequest {
     this.workspaceId = workspaceId;
     this.chatId = chatId;
 
-    if(axiosInstance) {
+    if (axiosInstance) {
       this.axiosInstance = axiosInstance;
     } else {
       this.axiosInstance.interceptors.request.use(requestInterceptor);
@@ -112,7 +203,7 @@ export class ChatRequest {
 
     const data = response?.data;
 
-    if(data?.code === 0 && data.data) {
+    if (data?.code === 0 && data.data) {
       const { uuid, email, name, metadata } = data.data;
 
       return {
@@ -127,7 +218,7 @@ export class ChatRequest {
   }
 
   async getChatMessages(payload?: GetChatMessagesPayload): Promise<RepeatedChatMessage> {
-    if(!this.workspaceId || !this.chatId) {
+    if (!this.workspaceId || !this.chatId) {
       return Promise.reject('workspaceId or chatId is not defined');
     }
 
@@ -143,7 +234,7 @@ export class ChatRequest {
 
     const data = response?.data;
 
-    if(data?.code === 0 && data.data) {
+    if (data?.code === 0 && data.data) {
       return data.data;
     }
 
@@ -162,15 +253,17 @@ export class ChatRequest {
       message: string;
     }>(url);
 
-    if(res?.data.code === 0) {
+    if (res?.data.code === 0) {
       const { data } = res.data;
 
-      return data ? {
-        uuid,
-        email: data.email,
-        name: data.name,
-        avatar: data.avatar_url,
-      } as User : Promise.reject('Member not found');
+      return data
+        ? ({
+            uuid,
+            email: data.email,
+            name: data.name,
+            avatar: data.avatar_url,
+          } as User)
+        : Promise.reject('Member not found');
     }
 
     return Promise.reject(res?.data);
@@ -185,7 +278,7 @@ export class ChatRequest {
       message: string;
     }>(url);
 
-    if(res?.data.code === 0) {
+    if (res?.data.code === 0) {
       return res.data.data;
     }
 
@@ -206,7 +299,7 @@ export class ChatRequest {
       message: string;
     }>(url, payload);
 
-    if(res?.data.code === 0) {
+    if (res?.data.code === 0) {
       return;
     }
 
@@ -222,18 +315,22 @@ export class ChatRequest {
       message: string;
     }>(url, payload);
 
-    if(res?.data.code === 0) {
+    if (res?.data.code === 0) {
       return res.data.data;
     }
 
     return Promise.reject(res?.data);
   }
 
-  async fetchAnswerStream(payload: {
-    question_id: number;
-    format: ResponseFormat;
-    model_name?: string;
-  }, onMessage: (text: string, metadata: ChatMessageMetadata[], done?: boolean) => void, onProgress?: (step: string) => void) {
+  async fetchAnswerStream(
+    payload: {
+      question_id: number;
+      format: ResponseFormat;
+      model_name?: string;
+    },
+    onMessage: (text: string, metadata: ChatMessageMetadata[], done?: boolean) => void,
+    onProgress?: (step: string) => void
+  ) {
     const baseUrl = this.axiosInstance.defaults.baseURL;
     const url = `${baseUrl}/api/chat/${this.workspaceId}/${this.chatId}/answer/stream`;
 
@@ -251,7 +348,7 @@ export class ChatRequest {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
-        'Authorization': `Bearer ${token}`,
+        Authorization: `Bearer ${token}`,
         'ai-model': payload.model_name || 'Auto',
         'x-platform': 'web-app',
       },
@@ -261,17 +358,17 @@ export class ChatRequest {
       }),
     });
 
-    if(!response.ok) {
+    if (!response.ok) {
       throw new Error(`HTTP error! status: ${response.status}`);
     }
 
-    const streamPromise = (async() => {
+    const streamPromise = (async () => {
       const contentType = response.headers.get('Content-Type');
 
-      if(contentType?.includes('application/json')) {
+      if (contentType?.includes('application/json')) {
         const json = await response.json();
 
-        if(json.code !== 0) {
+        if (json.code !== 0) {
           return Promise.reject(json);
         }
 
@@ -280,7 +377,7 @@ export class ChatRequest {
 
       reader = response.body?.getReader();
 
-      if(!reader) {
+      if (!reader) {
         throw new Error('Failed to get reader');
       }
 
@@ -293,10 +390,10 @@ export class ChatRequest {
         for await (const chunk of readableStreamToAsyncIterator(reader)) {
           buffer += decoder.decode(chunk, { stream: true });
 
-          while(buffer.length > 0) {
+          while (buffer.length > 0) {
             const extracted = extractNextJsonObject(buffer);
 
-            if(!extracted) break;
+            if (!extracted) break;
 
             try {
               const data = JSON.parse(extracted.jsonStr);
@@ -304,7 +401,7 @@ export class ChatRequest {
               Object.entries(data).forEach(([key, value]) => {
                 if (key === StreamType.META_DATA) {
                   if (Array.isArray(value)) {
-                    metadata.push(...value);
+                    metadata.push(...value.filter(isChatMessageMetadata));
                   }
 
                   return;
@@ -322,7 +419,7 @@ export class ChatRequest {
               });
 
               onMessage(text, [], false);
-            } catch(e) {
+            } catch (e) {
               console.error('Failed to parse JSON:', e);
             }
 
@@ -331,14 +428,13 @@ export class ChatRequest {
         }
 
         onMessage(text, metadata, true);
-
-      } catch(error) {
+      } catch (error) {
         console.error('Stream reading error:', error);
       } finally {
         reader.releaseLock();
         try {
           await response.body?.cancel();
-        } catch(error) {
+        } catch (error) {
           console.error('Error canceling stream:', error);
         }
       }
@@ -347,21 +443,17 @@ export class ChatRequest {
     return { cancel, streamPromise };
   }
 
-  async saveAnswer(payload: {
-    question_message_id: number;
-    content: string;
-    meta_data?: ChatMessageMetadata[],
-  }) {
+  async saveAnswer(payload: { question_message_id: number; content: string; meta_data?: ChatMessageMetadata[] }) {
     const url = `/api/chat/${this.workspaceId}/${this.chatId}/message/answer`;
 
     const res = await this.axiosInstance.post<{
       code: number;
       data: ChatMessage;
       message: string;
-      meta_data: ChatMessageMetadata[],
+      meta_data: ChatMessageMetadata[];
     }>(url, payload);
 
-    if(res?.data.code === 0) {
+    if (res?.data.code === 0) {
       return res.data.data;
     }
 
@@ -377,17 +469,152 @@ export class ChatRequest {
       message: string;
     }>(url);
 
-    if(res?.data.code === 0) {
+    if (res?.data.code === 0) {
       return res.data.data;
     }
 
     return Promise.reject(res?.data);
   }
 
+  private async fetchViewAtDepth(viewId: string, depth: number): Promise<View> {
+    if (!this.workspaceId) return Promise.reject('workspaceId is not defined');
+
+    const url = `/api/workspace/${this.workspaceId}/view/${viewId}?depth=${depth}`;
+    const res = await this.axiosInstance.get<{
+      code: number;
+      data: View;
+      message: string;
+    }>(url);
+
+    if (res?.data.code === 0) return res.data.data;
+
+    return Promise.reject(res?.data);
+  }
+
+  private async fetchViewBatch(viewIds: string[], depth: number): Promise<View[]> {
+    if (!this.workspaceId) return Promise.reject('workspaceId is not defined');
+    if (viewIds.length === 0) return [];
+
+    const url = `/api/workspace/${this.workspaceId}/views`;
+    const chunks = chunkIds(viewIds);
+
+    try {
+      const results = await Promise.all(
+        chunks.map(async (ids) => {
+          const params = new URLSearchParams();
+
+          params.set('depth', String(depth));
+          params.set('view_ids', ids.join(','));
+
+          const res = await this.axiosInstance.get<{
+            code: number;
+            data: { views: View[] };
+            message: string;
+          }>(`${url}?${params.toString()}`);
+
+          if (res?.data.code === 0) return res.data.data.views || [];
+
+          return Promise.reject(res?.data);
+        })
+      );
+
+      return results.flat();
+    } catch (error) {
+      if (!isUnsupportedViewBatchError(error)) throw error;
+
+      // Servers that omit `has_children` also predate the batch route. Preserve
+      // completeness by falling back to the single-view endpoint they expose.
+      return Promise.all(viewIds.map((id) => this.fetchViewAtDepth(id, depth)));
+    }
+  }
+
+  private async loadCompleteView(viewId: string): Promise<View> {
+    let root = await this.fetchViewAtDepth(viewId, COMPLETE_VIEW_DEPTH);
+    const continuedViewIds = new Set<string>();
+    let truncatedViewIds = collectTruncatedViewIds(root);
+
+    while (truncatedViewIds.length > 0) {
+      if (truncatedViewIds.some((id) => continuedViewIds.has(id))) {
+        throw new Error('Unable to load the complete view subtree');
+      }
+
+      truncatedViewIds.forEach((id) => continuedViewIds.add(id));
+      const continuations = (await this.fetchViewBatch(truncatedViewIds, COMPLETE_VIEW_DEPTH)).map(
+        normalizeContinuationRoot
+      );
+      const replacements = new Map(continuations.map((view) => [view.view_id, view]));
+
+      if (truncatedViewIds.some((id) => !replacements.has(id))) {
+        throw new Error('Unable to load the complete view subtree');
+      }
+
+      root = replaceViewSubtrees(root, replacements);
+      truncatedViewIds = collectTruncatedViewIds(root);
+    }
+
+    return root;
+  }
+
+  async fetchCompleteView(viewId: string, forceRefresh = false): Promise<View> {
+    if (!this.workspaceId) return Promise.reject('workspaceId is not defined');
+
+    let requests = completeViewRequests.get(this.axiosInstance);
+
+    if (!requests) {
+      requests = new Map();
+      completeViewRequests.set(this.axiosInstance, requests);
+    }
+
+    const cacheKey = `${this.workspaceId}:${viewId}`;
+    const pending = requests.get(cacheKey);
+
+    if (!forceRefresh && pending) return pending;
+
+    const promise = this.loadCompleteView(viewId);
+
+    requests.set(cacheKey, promise);
+
+    try {
+      return await promise;
+    } finally {
+      if (requests.get(cacheKey) === promise) {
+        requests.delete(cacheKey);
+      }
+    }
+  }
+
+  async getViewNavigation(viewId: string): Promise<View> {
+    if (!this.workspaceId) return Promise.reject('workspaceId is not defined');
+
+    const url = `/api/workspace/${this.workspaceId}/view/${viewId}/navigation?depth=0`;
+    const res = await this.axiosInstance.get<{
+      code: number;
+      data: View;
+      message: string;
+    }>(url);
+
+    if (res?.data.code === 0) return res.data.data;
+
+    return Promise.reject(res?.data);
+  }
+
+  async fetchCurrentChatParentScope(forceRefresh = false): Promise<View> {
+    if (!this.chatId) return Promise.reject('chatId is not defined');
+
+    const navigation = await this.getViewNavigation(this.chatId);
+    const path = findAncestors([navigation], this.chatId);
+
+    if (!path || path.length < 2) {
+      throw new Error('Unable to locate the AI chat parent');
+    }
+
+    return this.fetchCompleteView(path[path.length - 2].view_id, forceRefresh);
+  }
+
   async getView(viewId: string, forceRefresh = true) {
     const oldView = findView(this.folder?.children || [], viewId);
 
-    if(!forceRefresh && oldView) {
+    if (!forceRefresh && oldView) {
       return oldView;
     }
 
@@ -399,7 +626,7 @@ export class ChatRequest {
       message: string;
     }>(url);
 
-    if(res?.data.code === 0) {
+    if (res?.data.code === 0) {
       return res.data.data;
     }
 
@@ -407,7 +634,7 @@ export class ChatRequest {
   }
 
   async fetchViews(forceRefresh = false) {
-    if(this.folder && !forceRefresh) {
+    if (this.folder && !forceRefresh) {
       return this.folder;
     }
 
@@ -419,7 +646,7 @@ export class ChatRequest {
       message: string;
     }>(url);
 
-    if(res?.data.code === 0) {
+    if (res?.data.code === 0) {
       this.folder = res.data.data;
       return res.data.data;
     }
@@ -438,7 +665,7 @@ export class ChatRequest {
       blocks: pageData,
     });
 
-    if(res?.data.code === 0) {
+    if (res?.data.code === 0) {
       return;
     }
 
@@ -464,7 +691,7 @@ export class ChatRequest {
       name,
     });
 
-    if(res?.data.code === 0) {
+    if (res?.data.code === 0) {
       return res.data.data;
     }
 

--- a/src/components/chat/types/index.ts
+++ b/src/components/chat/types/index.ts
@@ -18,7 +18,7 @@ export interface ChatProps {
   requestInstance: ChatRequest;
   currentUser?: User;
   openingViewId?: string;
-  onOpenView?: (viewId: string) => void;
+  onOpenView?: (viewId: string, rowId?: string) => void;
   onCloseView?: () => void;
   selectionMode?: boolean;
   onOpenSelectionMode?: () => void;

--- a/src/components/chat/types/request.ts
+++ b/src/components/chat/types/request.ts
@@ -87,6 +87,10 @@ export interface ChatMessageMetadata {
   title?: string;
   // Stable request-scoped identifier used for inline citations such as [W1].
   citation_id?: string;
+  // Optional database routing metadata for opening cited row search results.
+  database_id?: string;
+  database_view_id?: string;
+  database_row_id?: string;
 }
 
 export interface SendQuestionPayload {

--- a/src/components/chat/types/request.ts
+++ b/src/components/chat/types/request.ts
@@ -83,6 +83,10 @@ export interface ChatMessageMetadata {
   // The name for the metadata. For example, @xxx, @xx.txt
   name: string;
   source: string;
+  // Human-readable label for web results. Older servers may omit it.
+  title?: string;
+  // Stable request-scoped identifier used for inline citations such as [W1].
+  citation_id?: string;
 }
 
 export interface SendQuestionPayload {
@@ -162,6 +166,9 @@ export interface View {
   layout: ViewLayout;
   extra: ViewExtra | null;
   children: View[];
+  has_children?: boolean;
+  is_space?: boolean;
+  parent_view_id?: string;
   is_private: boolean;
 }
 


### PR DESCRIPTION
## Summary

- add deterministic per-chat RAG scope loading, preserve opaque and database-backed sources, and fail closed until scope validation completes
- encode a logical empty RAG scope as a non-document chat-ID sentinel at the API boundary so AI content search cannot broaden to the workspace
- create AI chats from search with scoped sources and serialize chat-setting updates to prevent model, web-search, and RAG patches from overwriting each other
- default chats created under spaces to an empty logical RAG scope, while chats created under pages use only immediate document child IDs and exclude the parent
- fetch only direct children when creating a chat under a page, and avoid a scope fetch entirely for spaces
- parse and persist streamed source metadata, render AppFlowy pages and validated external links, and open cited database rows directly
- include preserved opaque and database-row sources in the active-context badge
- improve related-view, search, and chat-creation states with focused regression coverage

## Testing

- `pnpm type-check`
- ESLint on changed TypeScript files
- `git diff --check`
- 29 focused Jest suites: 308 tests passed