### PR TITLE
fix: align field type conversion with desktop

### DIFF
--- a/src/application/database-yjs/__tests__/cell-field-type-migration.test.ts
+++ b/src/application/database-yjs/__tests__/cell-field-type-migration.test.ts
@@ -1,0 +1,164 @@
+import * as Y from 'yjs';
+
+import { installLegacyCellFieldTypeNormalizer } from '@/application/database-yjs/cell.field-type';
+import { FieldType } from '@/application/database-yjs/database.type';
+import {
+  DATABASE_SCHEMA_VERSION,
+  migrateDatabaseFieldTypes,
+} from '@/application/database-yjs/migrations/rollup_fieldtype';
+import {
+  YDatabase,
+  YDatabaseCell,
+  YDatabaseField,
+  YDatabaseFields,
+  YDatabaseMetas,
+  YDatabaseRow,
+  YDatabaseView,
+  YDatabaseViews,
+  YDoc,
+  YjsDatabaseKey,
+  YjsEditorKey,
+} from '@/application/types';
+
+import { createRowDoc } from './test-helpers';
+
+function createMigrationFixture(schemaVersion = 2) {
+  const databaseId = 'database-id';
+  const fieldId = 'field-id';
+  const rowId = 'row-id';
+  const doc = new Y.Doc({ guid: databaseId }) as YDoc;
+  const root = doc.getMap(YjsEditorKey.data_section);
+  const database = new Y.Map() as YDatabase;
+  const fields = new Y.Map<YDatabaseField>() as YDatabaseFields;
+  const field = new Y.Map() as YDatabaseField;
+  const views = new Y.Map<YDatabaseView>() as YDatabaseViews;
+  const view = new Y.Map() as YDatabaseView;
+  const rowOrders = new Y.Array<{ id: string; height: number }>();
+  const metas = new Y.Map() as YDatabaseMetas;
+
+  field.set(YjsDatabaseKey.id, fieldId);
+  field.set(YjsDatabaseKey.type, FieldType.RichText);
+  fields.set(fieldId, field);
+  rowOrders.push([{ id: rowId, height: 36 }]);
+  view.set(YjsDatabaseKey.row_orders, rowOrders);
+  views.set('view-id', view);
+  metas.set(YjsDatabaseKey.schema_version, schemaVersion);
+  database.set(YjsDatabaseKey.id, databaseId);
+  database.set(YjsDatabaseKey.fields, fields);
+  database.set(YjsDatabaseKey.views, views);
+  database.set(YjsDatabaseKey.metas, metas);
+  root.set(YjsEditorKey.database, database);
+
+  return { databaseId, fieldId, rowId, doc, metas };
+}
+
+function getCell(rowDoc: YDoc, fieldId: string) {
+  const row = rowDoc.getMap(YjsEditorKey.data_section).get(YjsEditorKey.database_row) as YDatabaseRow;
+
+  return row.get(YjsDatabaseKey.cells).get(fieldId) as YDatabaseCell;
+}
+
+describe('legacy Web cell field-type migration', () => {
+  it('rewrites source_field_type into Desktop-compatible field_type without touching data', async () => {
+    const { databaseId, fieldId, rowId, doc, metas } = createMigrationFixture();
+
+    const rawData = 'opt-a,opt-b';
+    const rowDoc = createRowDoc(rowId, databaseId, {
+      [fieldId]: {
+        data: rawData,
+        fieldType: FieldType.RichText,
+        sourceType: FieldType.MultiSelect,
+      },
+    });
+    const loadRow = jest.fn(async () => rowDoc);
+
+    await expect(migrateDatabaseFieldTypes(doc, { loadRow })).resolves.toBe(true);
+
+    const cell = getCell(rowDoc, fieldId);
+
+    expect(cell.get(YjsDatabaseKey.data)).toBe(rawData);
+    expect(cell.get(YjsDatabaseKey.field_type)).toBe(FieldType.MultiSelect);
+    expect(cell.get(YjsDatabaseKey.source_field_type)).toBeUndefined();
+    expect(metas.get(YjsDatabaseKey.schema_version)).toBe(DATABASE_SCHEMA_VERSION);
+    expect(loadRow).toHaveBeenCalledTimes(1);
+
+    await expect(migrateDatabaseFieldTypes(doc, { loadRow })).resolves.toBe(false);
+    expect(loadRow).toHaveBeenCalledTimes(1);
+  });
+
+  it('canonicalizes string field_type values that Desktop cannot read as i64', async () => {
+    const { databaseId, fieldId, rowId, doc } = createMigrationFixture();
+    const rowDoc = createRowDoc(rowId, databaseId, {
+      [fieldId]: { data: 'Yes', fieldType: FieldType.Checkbox },
+    });
+    const cell = getCell(rowDoc, fieldId);
+
+    cell.set(YjsDatabaseKey.field_type, String(FieldType.Checkbox));
+
+    await migrateDatabaseFieldTypes(doc, { loadRow: async () => rowDoc });
+
+    expect(cell.get(YjsDatabaseKey.data)).toBe('Yes');
+    expect(cell.get(YjsDatabaseKey.field_type)).toBe(FieldType.Checkbox);
+  });
+
+  it('defers the schema version until row documents are available', async () => {
+    const { databaseId, fieldId, rowId, doc, metas } = createMigrationFixture();
+    const rowDoc = createRowDoc(rowId, databaseId, {
+      [fieldId]: {
+        data: 'option-id',
+        fieldType: FieldType.RichText,
+        sourceType: FieldType.SingleSelect,
+      },
+    });
+
+    await expect(migrateDatabaseFieldTypes(doc)).resolves.toBe(true);
+    expect(metas.get(YjsDatabaseKey.schema_version)).toBe(2);
+
+    await expect(migrateDatabaseFieldTypes(doc, { loadRow: async () => new Y.Doc() as YDoc })).resolves.toBe(true);
+    expect(metas.get(YjsDatabaseKey.schema_version)).toBe(2);
+
+    await expect(migrateDatabaseFieldTypes(doc, { loadRow: async () => rowDoc })).resolves.toBe(true);
+    expect(getCell(rowDoc, fieldId).get(YjsDatabaseKey.field_type)).toBe(FieldType.SingleSelect);
+    expect(metas.get(YjsDatabaseKey.schema_version)).toBe(DATABASE_SCHEMA_VERSION);
+  });
+
+  it('normalizes newly downloaded rows even after the shared schema version advanced', async () => {
+    const { databaseId, fieldId, rowId, doc, metas } = createMigrationFixture(DATABASE_SCHEMA_VERSION);
+    const rowDoc = createRowDoc(rowId, databaseId, {
+      [fieldId]: {
+        data: 'option-id',
+        fieldType: FieldType.RichText,
+        sourceType: FieldType.SingleSelect,
+      },
+    });
+
+    await expect(
+      migrateDatabaseFieldTypes(doc, {
+        loadRow: async () => rowDoc,
+        rowIds: [rowId],
+      })
+    ).resolves.toBe(true);
+
+    expect(getCell(rowDoc, fieldId).get(YjsDatabaseKey.field_type)).toBe(FieldType.SingleSelect);
+    expect(getCell(rowDoc, fieldId).get(YjsDatabaseKey.source_field_type)).toBeUndefined();
+    expect(metas.get(YjsDatabaseKey.schema_version)).toBe(DATABASE_SCHEMA_VERSION);
+  });
+
+  it('normalizes legacy metadata synced by an older Web client after the row is loaded', () => {
+    const { databaseId, fieldId, rowId } = createMigrationFixture(DATABASE_SCHEMA_VERSION);
+    const rowDoc = createRowDoc(rowId, databaseId, {
+      [fieldId]: { data: 'option-id', fieldType: FieldType.RichText },
+    });
+    const cell = getCell(rowDoc, fieldId);
+
+    installLegacyCellFieldTypeNormalizer(rowDoc);
+    rowDoc.transact(() => {
+      cell.set(YjsDatabaseKey.field_type, String(FieldType.RichText));
+      cell.set(YjsDatabaseKey.source_field_type, String(FieldType.SingleSelect));
+    });
+
+    expect(cell.get(YjsDatabaseKey.data)).toBe('option-id');
+    expect(cell.get(YjsDatabaseKey.field_type)).toBe(FieldType.SingleSelect);
+    expect(cell.get(YjsDatabaseKey.source_field_type)).toBeUndefined();
+  });
+});

--- a/src/application/database-yjs/__tests__/cell-field-type-migration.test.ts
+++ b/src/application/database-yjs/__tests__/cell-field-type-migration.test.ts
@@ -144,6 +144,34 @@ describe('legacy Web cell field-type migration', () => {
     expect(metas.get(YjsDatabaseKey.schema_version)).toBe(DATABASE_SCHEMA_VERSION);
   });
 
+  it('loads row documents concurrently with a bounded migration pool', async () => {
+    const { databaseId, fieldId, rowId, doc, metas } = createMigrationFixture();
+    const rowDoc = createRowDoc(rowId, databaseId, {
+      [fieldId]: {
+        data: 'option-id',
+        fieldType: FieldType.RichText,
+        sourceType: FieldType.SingleSelect,
+      },
+    });
+    const rowIds = Array.from({ length: 24 }, (_, index) => `row-${index}`);
+    let activeLoads = 0;
+    let maxActiveLoads = 0;
+    const loadRow = jest.fn(async () => {
+      activeLoads += 1;
+      maxActiveLoads = Math.max(maxActiveLoads, activeLoads);
+      await new Promise<void>((resolve) => setTimeout(resolve, 1));
+      activeLoads -= 1;
+      return rowDoc;
+    });
+
+    await expect(migrateDatabaseFieldTypes(doc, { loadRow, rowIds })).resolves.toBe(true);
+
+    expect(loadRow).toHaveBeenCalledTimes(rowIds.length);
+    expect(maxActiveLoads).toBeGreaterThan(1);
+    expect(maxActiveLoads).toBeLessThanOrEqual(8);
+    expect(metas.get(YjsDatabaseKey.schema_version)).toBe(DATABASE_SCHEMA_VERSION);
+  });
+
   it('normalizes legacy metadata synced by an older Web client after the row is loaded', () => {
     const { databaseId, fieldId, rowId } = createMigrationFixture(DATABASE_SCHEMA_VERSION);
     const rowDoc = createRowDoc(rowId, databaseId, {

--- a/src/application/database-yjs/__tests__/cell.parse.lazy.test.ts
+++ b/src/application/database-yjs/__tests__/cell.parse.lazy.test.ts
@@ -4,9 +4,11 @@ jest.mock('@/utils/runtime-config', () => ({
   getConfigValue: (_key: string, defaultValue: string) => defaultValue,
 }));
 
-import { getCellDataText } from '@/application/database-yjs/cell.parse';
+import { getCellDataText, parseYDatabaseCellToCell } from '@/application/database-yjs/cell.parse';
 import { FieldType } from '@/application/database-yjs/database.type';
-import { SelectOption } from '@/application/database-yjs/fields';
+import { SelectOption, SelectOptionColor } from '@/application/database-yjs/fields';
+import { EnhancedBigStats } from '@/application/database-yjs/fields/number/EnhancedBigStats';
+import { NumberFormat } from '@/application/database-yjs/fields/number/number.type';
 import { YDatabaseCell, YDatabaseField, YjsDatabaseKey } from '@/application/types';
 
 function createField(type: FieldType, typeOptionContent?: unknown): YDatabaseField {
@@ -27,10 +29,7 @@ function createCell(data: unknown, currentType: FieldType, sourceType?: FieldTyp
   const doc = new Y.Doc();
   const cell = doc.getMap('cell') as YDatabaseCell;
   cell.set(YjsDatabaseKey.data, data);
-  cell.set(YjsDatabaseKey.field_type, String(currentType));
-  if (sourceType !== undefined) {
-    cell.set(YjsDatabaseKey.source_field_type, String(sourceType));
-  }
+  cell.set(YjsDatabaseKey.field_type, String(sourceType ?? currentType));
   return cell;
 }
 
@@ -60,11 +59,11 @@ describe('lazy cell parsing parity with desktop', () => {
   });
 
   it('maps checklist selections to select option names when viewing as select', () => {
-    const option: SelectOption = { id: 'opt1', name: 'Alpha', color: 0 };
+    const option: SelectOption = { id: 'opt1', name: 'Alpha', color: SelectOptionColor.OptionColor1 };
     const field = createField(FieldType.SingleSelect, { options: [option], disable_color: false });
 
     const checklistJson = JSON.stringify({
-      options: [{ id: 'opt1', name: 'Alpha', color: 0 }],
+      options: [{ id: 'opt1', name: 'Alpha', color: SelectOptionColor.OptionColor1 }],
       selected_option_ids: ['opt1'],
     });
     const cell = createCell(checklistJson, FieldType.SingleSelect, FieldType.Checklist);
@@ -106,14 +105,85 @@ describe('Number field type conversions', () => {
   it('returns empty for non-numeric RichText to Number', () => {
     const field = createField(FieldType.Number);
     const cell = createCell('not a number', FieldType.Number, FieldType.RichText);
-    // Non-numeric text should either return empty or the original value
-    const result = getCellDataText(cell, field);
-    expect(result === '' || result === 'not a number').toBe(true);
+    expect(getCellDataText(cell, field)).toBe('');
+  });
+
+  it.each(['1e100', '0.1e29', '79228162514264337593543950336', '1e-29'])(
+    'rejects values outside Desktop rust_decimal range: %s',
+    (input) => {
+      const field = createField(FieldType.Number);
+      const cell = createCell(input, FieldType.Number, FieldType.RichText);
+
+      expect(getCellDataText(cell, field)).toBe('');
+    }
+  );
+
+  it.each([
+    ['79228162514264337593543950335', '79228162514264337593543950335'],
+    ['7.92281625142643375935439503356', '7.922816251426433759354395034'],
+  ])('matches Desktop rust_decimal precision for %s', (input, expected) => {
+    const field = createField(FieldType.Number);
+    const cell = createCell(input, FieldType.Number, FieldType.RichText);
+
+    expect(getCellDataText(cell, field)).toBe(expected);
   });
 
   it('handles empty string from RichText to Number', () => {
     const field = createField(FieldType.Number);
     const cell = createCell('', FieldType.Number, FieldType.RichText);
+    expect(getCellDataText(cell, field)).toBe('');
+  });
+
+  it.each([
+    ['0.5', '50%'],
+    ['50', '5,000%'],
+  ])('uses Desktop Percent scaling for %s', (input, expected) => {
+    const field = createField(FieldType.Number);
+    const typeOption = new Y.Map();
+
+    typeOption.set(YjsDatabaseKey.format, NumberFormat.Percent);
+    field.get(YjsDatabaseKey.type_option)?.set(String(FieldType.Number), typeOption);
+
+    const cell = createCell(input, FieldType.Number, FieldType.RichText);
+    const parsed = parseYDatabaseCellToCell(cell, field);
+
+    expect(EnhancedBigStats.parse(String(parsed.data), NumberFormat.Percent)).toBe(expected);
+  });
+
+  it.each([
+    ['0.5', '50%'],
+    ['50', '5,000%'],
+  ])('stringifies a stored Percent number as Desktop text for %s', (input, expected) => {
+    const field = createField(FieldType.RichText);
+    const typeOptions = new Y.Map();
+    const numberOption = new Y.Map();
+
+    numberOption.set(YjsDatabaseKey.format, NumberFormat.Percent);
+    typeOptions.set(String(FieldType.Number), numberOption);
+    field.set(YjsDatabaseKey.type_option, typeOptions);
+
+    const cell = createCell(input, FieldType.RichText, FieldType.Number);
+
+    expect(getCellDataText(cell, field)).toBe(expected);
+  });
+
+  it.each([
+    ['3h', '10800000'],
+    ['45m', '2700000'],
+    ['2h 15m', '8100000'],
+    ['9:30', '34200000'],
+    ['09:30:45', '34245000'],
+  ])('matches Desktop RichText -> Time parsing for %s', (input, expected) => {
+    const field = createField(FieldType.Time);
+    const cell = createCell(input, FieldType.Time, FieldType.RichText);
+
+    expect(getCellDataText(cell, field)).toBe(expected);
+  });
+
+  it.each(['1.5', '1e3', '0x10', 'Infinity'])('rejects non-i64 Desktop time input %s', (input) => {
+    const field = createField(FieldType.Time);
+    const cell = createCell(input, FieldType.Time, FieldType.RichText);
+
     expect(getCellDataText(cell, field)).toBe('');
   });
 
@@ -141,10 +211,11 @@ describe('Number field type conversions', () => {
   });
 
   // Number -> Checkbox
-  it('non-zero number becomes checked checkbox', () => {
+  it('unsupported Number -> Checkbox renders the default unchecked value without mutating data', () => {
     const field = createField(FieldType.Checkbox);
     const cell = createCell('1', FieldType.Checkbox, FieldType.Number);
-    expect(getCellDataText(cell, field)).toBe('Yes');
+    expect(getCellDataText(cell, field)).toBe('No');
+    expect(cell.get(YjsDatabaseKey.data)).toBe('1');
   });
 
   it('zero becomes unchecked checkbox', () => {
@@ -154,17 +225,18 @@ describe('Number field type conversions', () => {
   });
 
   // Time -> Number (potentially lossy)
-  it('time milliseconds to Number is preserved', () => {
+  it('unsupported Time -> Number renders empty while preserving the raw value', () => {
     const field = createField(FieldType.Number);
     const cell = createCell('36000000', FieldType.Number, FieldType.Time);
-    expect(getCellDataText(cell, field)).toBe('36000000');
+    expect(getCellDataText(cell, field)).toBe('');
+    expect(cell.get(YjsDatabaseKey.data)).toBe('36000000');
   });
 
   // Number -> Time
-  it('numeric milliseconds displayed as Time value', () => {
+  it('unsupported Number -> Time renders empty', () => {
     const field = createField(FieldType.Time);
     const cell = createCell('36000000', FieldType.Time, FieldType.Number);
-    expect(getCellDataText(cell, field)).toBe('36000000');
+    expect(getCellDataText(cell, field)).toBe('');
   });
 
   // URL -> Number
@@ -177,10 +249,10 @@ describe('Number field type conversions', () => {
   });
 
   // Number -> URL
-  it('number displayed as URL', () => {
+  it('unsupported Number -> URL renders empty', () => {
     const field = createField(FieldType.URL);
     const cell = createCell('12345', FieldType.URL, FieldType.Number);
-    expect(getCellDataText(cell, field)).toBe('12345');
+    expect(getCellDataText(cell, field)).toBe('');
   });
 
   // SingleSelect -> Number
@@ -213,9 +285,8 @@ describe('Number field type conversions', () => {
   it('handles scientific notation', () => {
     const field = createField(FieldType.Number);
     const cell = createCell('1e10', FieldType.Number, FieldType.RichText);
-    // Should parse as number (10000000000)
-    const result = getCellDataText(cell, field);
-    expect(result === '1e10' || result === '10000000000').toBe(true);
+
+    expect(getCellDataText(cell, field)).toBe('10000000000');
   });
 });
 
@@ -258,19 +329,17 @@ describe('DateTime field type conversions', () => {
   });
 
   // Number -> DateTime
-  it('number as Unix timestamp to DateTime', () => {
+  it('unsupported Number -> DateTime renders empty', () => {
     const field = createField(FieldType.DateTime);
     const cell = createCell('1705276800', FieldType.DateTime, FieldType.Number);
-    // Unix timestamp should be preserved
-    const result = getCellDataText(cell, field);
-    expect(result === '1705276800' || result.length > 0).toBe(true);
+    expect(getCellDataText(cell, field)).toBe('');
   });
 
   // DateTime -> Number
-  it('DateTime timestamp to Number', () => {
+  it('unsupported DateTime -> Number renders empty', () => {
     const field = createField(FieldType.Number);
     const cell = createCell('1705276800', FieldType.Number, FieldType.DateTime);
-    expect(getCellDataText(cell, field)).toBe('1705276800');
+    expect(getCellDataText(cell, field)).toBe('');
   });
 
   // Checkbox -> DateTime (lossy)
@@ -325,10 +394,10 @@ describe('DateTime field type conversions', () => {
   });
 
   // DateTime -> URL
-  it('DateTime to URL shows timestamp', () => {
+  it('unsupported DateTime -> URL renders empty', () => {
     const field = createField(FieldType.URL);
     const cell = createCell('1705276800', FieldType.URL, FieldType.DateTime);
-    expect(getCellDataText(cell, field)).toBe('1705276800');
+    expect(getCellDataText(cell, field)).toBe('');
   });
 
   // SingleSelect -> DateTime
@@ -419,10 +488,10 @@ describe('Time field type conversions', () => {
   });
 
   // Time -> URL
-  it('time to URL shows milliseconds', () => {
+  it('unsupported Time -> URL renders empty', () => {
     const field = createField(FieldType.URL);
     const cell = createCell('36000000', FieldType.URL, FieldType.Time);
-    expect(getCellDataText(cell, field)).toBe('36000000');
+    expect(getCellDataText(cell, field)).toBe('');
   });
 
   // Time -> SingleSelect
@@ -512,7 +581,7 @@ describe('Multi-hop conversion data preservation', () => {
     expect(result.toLowerCase()).toBe('yes');
   });
 
-  it('RichText -> Time -> Number -> RichText preserves time string', () => {
+  it('RichText -> Time -> Number keeps the original raw text across an unsupported direct hop', () => {
     // RichText with time string
     const originalData = '09:30';
 
@@ -524,31 +593,30 @@ describe('Multi-hop conversion data preservation', () => {
     // Time -> Number (milliseconds as number)
     const numberField = createField(FieldType.Number);
     const toNumber = createCell(originalData, FieldType.Number, FieldType.Time);
-    // In lazy mode, original data is preserved
-    const result = getCellDataText(toNumber, numberField);
-    expect(result === '09:30' || result === '34200000').toBe(true);
+    expect(getCellDataText(toNumber, numberField)).toBe('');
+    expect(toNumber.get(YjsDatabaseKey.data)).toBe(originalData);
   });
 
-  it('Number -> Checkbox -> SingleSelect -> Number preserves data', () => {
+  it('Number -> Checkbox -> SingleSelect -> Number preserves raw data through unsupported hops', () => {
     // Use '1' which parseCheckboxValue recognizes as truthy
     const originalData = '1';
 
-    // Number -> Checkbox ('1' is truthy)
+    // Number -> Checkbox is not a supported direct Desktop conversion.
     const checkboxField = createField(FieldType.Checkbox);
     const toCheckbox = createCell(originalData, FieldType.Checkbox, FieldType.Number);
-    expect(getCellDataText(toCheckbox, checkboxField)).toBe('Yes');
+    expect(getCellDataText(toCheckbox, checkboxField)).toBe('No');
 
     // Checkbox -> SingleSelect
     const option: SelectOption = { id: 'yes-opt', name: 'Yes', color: 0 };
     const selectField = createField(FieldType.SingleSelect, { options: [option], disable_color: false });
     const toSelect = createCell(originalData, FieldType.SingleSelect, FieldType.Checkbox);
     const selectResult = getCellDataText(toSelect, selectField);
-    // May show 'Yes' from mapping or the original '1'
-    expect(selectResult === 'Yes' || selectResult === '1' || selectResult === '').toBe(true);
+    expect(selectResult).toBe('Yes');
 
     // Back to Number (original preserved)
     const numberField = createField(FieldType.Number);
     const backToNumber = createCell(originalData, FieldType.Number, FieldType.SingleSelect);
-    expect(getCellDataText(backToNumber, numberField)).toBe('1');
+    expect(getCellDataText(backToNumber, numberField)).toBe('');
+    expect(backToNumber.get(YjsDatabaseKey.data)).toBe(originalData);
   });
 });

--- a/src/application/database-yjs/__tests__/cell.transform.test.ts
+++ b/src/application/database-yjs/__tests__/cell.transform.test.ts
@@ -1,4 +1,3 @@
-import dayjs from 'dayjs';
 import * as Y from 'yjs';
 
 jest.mock('@/utils/runtime-config', () => ({
@@ -7,14 +6,14 @@ jest.mock('@/utils/runtime-config', () => ({
 
 import { parseYDatabaseCellToCell } from '@/application/database-yjs/cell.parse';
 import { FieldType } from '@/application/database-yjs/database.type';
-import { SelectOption } from '@/application/database-yjs/fields';
+import { SelectOption, SelectOptionColor } from '@/application/database-yjs/fields';
 import { YDatabaseCell, YDatabaseField, YjsDatabaseKey } from '@/application/types';
 import { ChecklistCell, SelectOptionCell, TextCell } from '@/application/database-yjs/cell.type';
 
 function createField(type: FieldType, typeOptionContent?: unknown): YDatabaseField {
   const doc = new Y.Doc();
   const field = doc.getMap('field') as YDatabaseField;
-  
+
   field.set(YjsDatabaseKey.type, String(type));
   if (typeOptionContent !== undefined) {
     const typeOptionMap = new Y.Map();
@@ -29,24 +28,24 @@ function createField(type: FieldType, typeOptionContent?: unknown): YDatabaseFie
 function createCell(data: unknown, currentType: FieldType, sourceType?: FieldType): YDatabaseCell {
   const doc = new Y.Doc();
   const cell = doc.getMap('cell') as YDatabaseCell;
-  
+
   cell.set(YjsDatabaseKey.data, data);
-  cell.set(YjsDatabaseKey.field_type, String(currentType));
-  if (sourceType !== undefined) {
-    cell.set(YjsDatabaseKey.source_field_type, String(sourceType));
-  }
+  cell.set(YjsDatabaseKey.field_type, String(sourceType ?? currentType));
   return cell;
 }
 
 describe('Lazy Cell Transformation (Object Structure)', () => {
-  
   describe('RichText <-> Checklist', () => {
     it('RichText -> Checklist: parses markdown text into checklist structure', () => {
       const field = createField(FieldType.Checklist);
       // Source is RichText, Target is Checklist
-      const cell = createCell(`[x] Done
-[ ] Todo`, FieldType.Checklist, FieldType.RichText);
-      
+      const cell = createCell(
+        `[x] Done
+[ ] Todo`,
+        FieldType.Checklist,
+        FieldType.RichText
+      );
+
       const parsed = parseYDatabaseCellToCell(cell, field) as unknown as ChecklistCell;
       const parsedData = JSON.parse(parsed.data);
 
@@ -63,15 +62,15 @@ describe('Lazy Cell Transformation (Object Structure)', () => {
       const checklistData = JSON.stringify({
         options: [
           { id: '1', name: 'Task A', color: 0 },
-          { id: '2', name: 'Task B', color: 0 }
+          { id: '2', name: 'Task B', color: 0 },
         ],
-        selected_option_ids: ['1']
+        selected_option_ids: ['1'],
       });
       // Source is Checklist, Target is RichText
       const cell = createCell(checklistData, FieldType.RichText, FieldType.Checklist);
 
       const parsed = parseYDatabaseCellToCell(cell, field) as unknown as TextCell;
-      
+
       expect(parsed.fieldType).toBe(FieldType.RichText);
       expect(parsed.data).toBe(`[x] Task A
 [ ] Task B`);
@@ -79,9 +78,13 @@ describe('Lazy Cell Transformation (Object Structure)', () => {
 
     it('RichText -> Checklist: handles plain text list', () => {
       const field = createField(FieldType.Checklist);
-      const cell = createCell(`Item 1
-Item 2`, FieldType.Checklist, FieldType.RichText);
-      
+      const cell = createCell(
+        `Item 1
+Item 2`,
+        FieldType.Checklist,
+        FieldType.RichText
+      );
+
       const parsed = parseYDatabaseCellToCell(cell, field) as unknown as ChecklistCell;
       const parsedData = JSON.parse(parsed.data);
 
@@ -98,7 +101,7 @@ Item 2`, FieldType.Checklist, FieldType.RichText);
       const options: SelectOption[] = [
         { id: 'opt1', name: 'Apple', color: 0 },
         { id: 'opt2', name: 'Banana', color: 0 },
-        { id: 'opt3', name: 'Cherry', color: 0 }
+        { id: 'opt3', name: 'Cherry', color: 0 },
       ];
       const field = createField(FieldType.MultiSelect, { options });
 
@@ -107,9 +110,9 @@ Item 2`, FieldType.Checklist, FieldType.RichText);
         options: [
           { id: 'c1', name: 'Apple', color: 0 }, // Should match opt1
           { id: 'c2', name: 'Cherry', color: 0 }, // Should match opt3
-          { id: 'c3', name: 'Durian', color: 0 }  // No match
+          { id: 'c3', name: 'Durian', color: 0 }, // No match
         ],
-        selected_option_ids: ['c1', 'c2'] // Both checked
+        selected_option_ids: ['c1', 'c2'], // Both checked
       });
 
       const cell = createCell(checklistData, FieldType.MultiSelect, FieldType.Checklist);
@@ -123,33 +126,36 @@ Item 2`, FieldType.Checklist, FieldType.RichText);
     });
 
     it('MultiSelect -> Checklist: converts options to checklist items', () => {
-        const options: SelectOption[] = [
-          { id: 'opt1', name: 'Red', color: 0 },
-          { id: 'opt2', name: 'Blue', color: 0 }
-        ];
-        // After converting MultiSelect -> Checklist, the select options remain
-        // under the source (MultiSelect) type-option key (the switch adds the
-        // new type-option without deleting the old one). The read path resolves
-        // them by the cell's source type, not the field's current type.
-        const field = createField(FieldType.Checklist);
-        const typeOptionMap = new Y.Map();
-        const option = new Y.Map();
+      const options: SelectOption[] = [
+        { id: 'opt1', name: 'Red', color: SelectOptionColor.OptionColor7 },
+        { id: 'opt2', name: 'Blue', color: SelectOptionColor.OptionColor9 },
+      ];
+      // After converting MultiSelect -> Checklist, the select options remain
+      // under the source (MultiSelect) type-option key (the switch adds the
+      // new type-option without deleting the old one). The read path resolves
+      // them by the cell's source type, not the field's current type.
+      const field = createField(FieldType.Checklist);
+      const typeOptionMap = new Y.Map();
+      const option = new Y.Map();
 
-        option.set(YjsDatabaseKey.content, JSON.stringify({ options }));
-        typeOptionMap.set(String(FieldType.MultiSelect), option);
-        field.set(YjsDatabaseKey.type_option, typeOptionMap);
+      option.set(YjsDatabaseKey.content, JSON.stringify({ options }));
+      typeOptionMap.set(String(FieldType.MultiSelect), option);
+      field.set(YjsDatabaseKey.type_option, typeOptionMap);
 
-        const cell = createCell('opt1,opt2', FieldType.Checklist, FieldType.MultiSelect);
-        
-        const parsed = parseYDatabaseCellToCell(cell, field) as unknown as ChecklistCell;
-        const parsedData = JSON.parse(parsed.data);
-  
-        expect(parsedData.options).toHaveLength(2);
-        // IDs are regenerated in the implementation
-        expect(parsedData.options[0].name).toBe('Red'); 
-        expect(parsedData.options[1].name).toBe('Blue');
-        expect(parsedData.selected_option_ids).toHaveLength(2);
-      });
+      const cell = createCell('opt1,opt1,opt2', FieldType.Checklist, FieldType.MultiSelect);
+
+      const parsed = parseYDatabaseCellToCell(cell, field) as unknown as ChecklistCell;
+      const parsedData = JSON.parse(parsed.data);
+
+      expect(parsedData.options).toHaveLength(2);
+      // IDs are regenerated in the implementation
+      expect(parsedData.options[0].name).toBe('Red');
+      expect(parsedData.options[1].name).toBe('Blue');
+      expect(parsedData.options.every((option: SelectOption) => option.color === SelectOptionColor.OptionColor1)).toBe(
+        true
+      );
+      expect(parsedData.selected_option_ids).toHaveLength(2);
+    });
   });
 
   describe('SingleSelect <-> MultiSelect (desktop parity: keep option IDs)', () => {
@@ -186,9 +192,26 @@ Item 2`, FieldType.Checklist, FieldType.RichText);
 
       const parsed = parseYDatabaseCellToCell(cell, field);
 
-      // data is a unix-seconds string that round-trips back to the same date
-      expect(typeof parsed.data).toBe('string');
-      expect(dayjs.unix(Number(parsed.data)).format('YYYY-MM-DD')).toBe('2026-05-14');
+      expect(parsed.data).toBe('1778716800');
+    });
+
+    it.each([
+      ['2026-05-14 18:40', '1778784000'],
+      ['1705276800', '1705276800'],
+      ['1705276800000', '1705276800000'],
+      ['February 9, 2024 10:45 AM (GMT+08:00)', '1707446700'],
+    ])('matches Desktop UTC parsing for %s', (input, expected) => {
+      const field = createField(FieldType.DateTime);
+      const cell = createCell(input, FieldType.DateTime, FieldType.RichText);
+
+      expect(parseYDatabaseCellToCell(cell, field).data).toBe(expected);
+    });
+
+    it.each(['999999999', '2024-02-30', '31/1/123'])('rejects non-Desktop date input %s', (input) => {
+      const field = createField(FieldType.DateTime);
+      const cell = createCell(input, FieldType.DateTime, FieldType.RichText);
+
+      expect(parseYDatabaseCellToCell(cell, field).data).toBe('');
     });
 
     it('returns empty for unparseable text', () => {
@@ -203,19 +226,19 @@ Item 2`, FieldType.Checklist, FieldType.RichText);
 
   describe('Other Transformations', () => {
     it('RichText -> Checkbox: parses "yes" variants', () => {
-        const field = createField(FieldType.Checkbox);
-        const cell = createCell('yes', FieldType.Checkbox, FieldType.RichText);
-        
-        const parsed = parseYDatabaseCellToCell(cell, field);
-        expect(parsed.data).toBe('Yes');
+      const field = createField(FieldType.Checkbox);
+      const cell = createCell('yes', FieldType.Checkbox, FieldType.RichText);
+
+      const parsed = parseYDatabaseCellToCell(cell, field);
+      expect(parsed.data).toBe('Yes');
     });
 
-    it('RichText -> Checkbox: parses "[x]" as Yes', () => {
-        const field = createField(FieldType.Checkbox);
-        const cell = createCell('[x]', FieldType.Checkbox, FieldType.RichText);
-        
-        const parsed = parseYDatabaseCellToCell(cell, field);
-        expect(parsed.data).toBe('Yes');
+    it('RichText -> Checkbox: treats non-desktop truthy aliases as unchecked', () => {
+      const field = createField(FieldType.Checkbox);
+      const cell = createCell('[x]', FieldType.Checkbox, FieldType.RichText);
+
+      const parsed = parseYDatabaseCellToCell(cell, field);
+      expect(parsed.data).toBe('No');
     });
   });
 });

--- a/src/application/database-yjs/__tests__/decode.lazy.test.ts
+++ b/src/application/database-yjs/__tests__/decode.lazy.test.ts
@@ -4,7 +4,7 @@ jest.mock('@/utils/runtime-config', () => ({
   getConfigValue: (_key: string, defaultValue: string) => defaultValue,
 }));
 
-import { decodeCellForSort } from '@/application/database-yjs/decode';
+import { decodeCellForSort, decodeCellToText } from '@/application/database-yjs/decode';
 import { FieldType } from '@/application/database-yjs/database.type';
 import { SelectOption, SelectOptionFilterCondition } from '@/application/database-yjs/fields';
 import { parseChecklistFlexible } from '@/application/database-yjs/fields/checklist/parse';
@@ -29,19 +29,45 @@ function createCell(data: unknown, currentType: FieldType, sourceType?: FieldTyp
   const doc = new Y.Doc();
   const cell = doc.getMap('cell') as YDatabaseCell;
   cell.set(YjsDatabaseKey.data, data);
-  cell.set(YjsDatabaseKey.field_type, String(currentType));
-  if (sourceType !== undefined) {
-    cell.set(YjsDatabaseKey.source_field_type, String(sourceType));
-  }
+  cell.set(YjsDatabaseKey.field_type, String(sourceType ?? currentType));
   return cell;
 }
 
 describe('lazy decode + filters parity', () => {
+  it('sorts converted select cells by their displayed option names', () => {
+    const field = createField(FieldType.RichText);
+    const typeOptionMap = new Y.Map();
+    const option = new Y.Map();
+
+    option.set(
+      YjsDatabaseKey.content,
+      JSON.stringify({
+        disable_color: false,
+        options: [{ id: 'opt1', name: 'Alpha', color: 0 }],
+      })
+    );
+    typeOptionMap.set(String(FieldType.MultiSelect), option);
+    field.set(YjsDatabaseKey.type_option, typeOptionMap);
+
+    const cell = createCell('opt1', FieldType.RichText, FieldType.MultiSelect);
+
+    expect(decodeCellToText(cell, field)).toBe('Alpha');
+    expect(decodeCellForSort(cell, field)).toBe('Alpha');
+  });
+
   it('computes checklist percentage from markdown/plain text for sorting', () => {
     const field = createField(FieldType.Checklist);
     const cell = createCell('[x] Done\n[ ] Todo', FieldType.Checklist, FieldType.RichText);
 
     expect(decodeCellForSort(cell, field)).toBeCloseTo(0.5);
+  });
+
+  it('keeps unsupported conversions blank instead of coercing them to a target default', () => {
+    const field = createField(FieldType.Checkbox);
+    const cell = createCell('42', FieldType.Checkbox, FieldType.Number);
+
+    expect(decodeCellToText(cell, field)).toBe('');
+    expect(decodeCellForSort(cell, field)).toBe('');
   });
 
   it('maps checklist data to select option ids when filtering', () => {

--- a/src/application/database-yjs/__tests__/field-type-conversion.test.tsx
+++ b/src/application/database-yjs/__tests__/field-type-conversion.test.tsx
@@ -1,9 +1,11 @@
-import { act, renderHook } from '@testing-library/react';
+import { act, renderHook, waitFor } from '@testing-library/react';
 import * as Y from 'yjs';
 
 import { DatabaseContext, DatabaseContextState, FieldType } from '@/application/database-yjs';
 import { getCellDataText, parseYDatabaseCellToCell } from '@/application/database-yjs/cell.parse';
 import { useSwitchPropertyType } from '@/application/database-yjs/dispatch';
+import { parseSelectOptionTypeOptions, SelectOptionColor } from '@/application/database-yjs/fields';
+import { useCellSelector } from '@/application/database-yjs/selector';
 import {
   YDatabase,
   YDatabaseCell,
@@ -106,9 +108,15 @@ function setup() {
   const wrapper = ({ children }: { children: React.ReactNode }) => (
     <DatabaseContext.Provider value={contextValue}>{children}</DatabaseContext.Provider>
   );
-  const { result } = renderHook(() => useSwitchPropertyType(), { wrapper });
+  const { result } = renderHook(
+    () => ({
+      cell: useCellSelector({ rowId, fieldId }),
+      switchType: useSwitchPropertyType(),
+    }),
+    { wrapper }
+  );
 
-  return { databaseDoc, rowDoc, switchType: result.current };
+  return { databaseDoc, rowDoc, result, switchType: result.current.switchType };
 }
 
 describe('Bug B (fixed) — field-type conversion preserves select values', () => {
@@ -122,7 +130,7 @@ describe('Bug B (fixed) — field-type conversion preserves select values', () =
     const { databaseDoc, rowDoc, switchType } = setup();
 
     act(() => {
-      switchType(fieldId, FieldType.RichText);
+      void switchType(fieldId, FieldType.RichText);
     });
 
     const cell = getCell(rowDoc);
@@ -130,6 +138,9 @@ describe('Bug B (fixed) — field-type conversion preserves select values', () =
 
     // Raw data is preserved...
     expect(cell.get(YjsDatabaseKey.data)).toBe(CELL_DATA);
+    expect(field.get(YjsDatabaseKey.type)).toBe(FieldType.RichText);
+    expect(cell.get(YjsDatabaseKey.field_type)).toBe(FieldType.MultiSelect);
+    expect(cell.get(YjsDatabaseKey.source_field_type)).toBeUndefined();
 
     // ...and now renders, because options are resolved by the cell's source
     // type (MultiSelect) rather than the field's current type (RichText).
@@ -141,10 +152,10 @@ describe('Bug B (fixed) — field-type conversion preserves select values', () =
     const { databaseDoc, rowDoc, switchType } = setup();
 
     act(() => {
-      switchType(fieldId, FieldType.RichText);
+      void switchType(fieldId, FieldType.RichText);
     });
     act(() => {
-      switchType(fieldId, FieldType.MultiSelect);
+      void switchType(fieldId, FieldType.MultiSelect);
     });
 
     const cell = getCell(rowDoc);
@@ -157,7 +168,184 @@ describe('Bug B (fixed) — field-type conversion preserves select values', () =
     // overwritten with the intermediate RichText hop), so the cell is native
     // MultiSelect once more.
     expect(cell.get(YjsDatabaseKey.source_field_type)).toBeUndefined();
+    expect(cell.get(YjsDatabaseKey.field_type)).toBe(FieldType.MultiSelect);
     expect(getCellDataText(cell, field)).toBe('0,60,82');
+  });
+
+  it('schema-only switching immediately refreshes the subscribed cell value', async () => {
+    const { result, switchType } = setup();
+
+    expect(result.current.cell?.fieldType).toBe(FieldType.MultiSelect);
+
+    act(() => {
+      void switchType(fieldId, FieldType.RichText);
+    });
+
+    await waitFor(() => {
+      expect(result.current.cell?.fieldType).toBe(FieldType.RichText);
+      expect(result.current.cell?.data).toBe('0,60,82');
+    });
+  });
+
+  it('normalizes a legacy Web source marker on the next switch without changing data', () => {
+    const { databaseDoc, rowDoc, switchType } = setup();
+    const cell = getCell(rowDoc);
+    const field = getField(databaseDoc);
+
+    act(() => {
+      field.set(YjsDatabaseKey.type, FieldType.RichText);
+      cell.set(YjsDatabaseKey.field_type, FieldType.RichText);
+      cell.set(YjsDatabaseKey.source_field_type, String(FieldType.MultiSelect));
+    });
+
+    act(() => {
+      void switchType(fieldId, FieldType.MultiSelect);
+    });
+
+    expect(cell.get(YjsDatabaseKey.data)).toBe(CELL_DATA);
+    expect(cell.get(YjsDatabaseKey.field_type)).toBe(FieldType.MultiSelect);
+    expect(cell.get(YjsDatabaseKey.source_field_type)).toBeUndefined();
+    expect(getCellDataText(cell, field)).toBe('0,60,82');
+  });
+
+  it('canonicalizes a string cell field_type for Desktop on switch', () => {
+    const { rowDoc, switchType } = setup();
+    const cell = getCell(rowDoc);
+
+    act(() => {
+      cell.set(YjsDatabaseKey.field_type, String(FieldType.MultiSelect));
+    });
+
+    act(() => {
+      void switchType(fieldId, FieldType.RichText);
+    });
+
+    expect(cell.get(YjsDatabaseKey.field_type)).toBe(FieldType.MultiSelect);
+    expect(cell.get(YjsDatabaseKey.data)).toBe(CELL_DATA);
+  });
+
+  it('replaces a stale target select option set from the immediately previous select type', () => {
+    const { databaseDoc, rowDoc, switchType } = setup();
+    const field = getField(databaseDoc);
+    const staleOption = new Y.Map();
+
+    act(() => {
+      staleOption.set(
+        YjsDatabaseKey.content,
+        JSON.stringify({
+          disable_color: false,
+          options: [{ id: 'stale', name: 'Stale', color: SelectOptionColor.OptionColor1 }],
+        })
+      );
+      field.get(YjsDatabaseKey.type_option).set(String(FieldType.SingleSelect), staleOption);
+    });
+
+    act(() => {
+      void switchType(fieldId, FieldType.SingleSelect);
+    });
+
+    expect(parseSelectOptionTypeOptions(field).options).toEqual(OPTIONS);
+    expect(getCellDataText(getCell(rowDoc), field)).toBe('0,60,82');
+  });
+
+  it('adds missing Desktop Yes/No options to an existing select target', () => {
+    const { databaseDoc, rowDoc, switchType } = setup();
+    const field = getField(databaseDoc);
+    const cell = getCell(rowDoc);
+    const targetOption = new Y.Map();
+
+    act(() => {
+      targetOption.set(
+        YjsDatabaseKey.content,
+        JSON.stringify({
+          disable_color: false,
+          options: [{ id: 'existing', name: 'Existing', color: SelectOptionColor.OptionColor1 }],
+        })
+      );
+      field.get(YjsDatabaseKey.type_option).set(String(FieldType.SingleSelect), targetOption);
+      field.set(YjsDatabaseKey.type, FieldType.Checkbox);
+      cell.set(YjsDatabaseKey.field_type, FieldType.Checkbox);
+      cell.set(YjsDatabaseKey.data, 'Yes');
+    });
+
+    act(() => {
+      void switchType(fieldId, FieldType.SingleSelect);
+    });
+
+    expect(parseSelectOptionTypeOptions(field).options.map(({ name, color }) => ({ name, color }))).toEqual([
+      { name: 'Existing', color: SelectOptionColor.OptionColor1 },
+      { name: 'Yes', color: SelectOptionColor.OptionColor7 },
+      { name: 'No', color: SelectOptionColor.OptionColor5 },
+    ]);
+    expect(getCellDataText(cell, field)).toBe('Yes');
+  });
+
+  it('includes off-screen rows added while RichText-to-select hydration is pending', async () => {
+    const databaseDoc = createDatabaseDoc();
+    const database = databaseDoc.getMap(YjsEditorKey.data_section).get(YjsEditorKey.database) as YDatabase;
+    const field = getField(databaseDoc);
+    const unloadedRowId = 'unloaded-row-id';
+    const concurrentlyAddedRowId = 'concurrently-added-row-id';
+    const loadedRowDoc = createRowDoc(rowId, databaseId, {
+      [fieldId]: { fieldType: FieldType.RichText, data: 'Loaded option' },
+    });
+    const unloadedRowDoc = createRowDoc(unloadedRowId, databaseId, {
+      [fieldId]: { fieldType: FieldType.RichText, data: 'Off-screen option' },
+    });
+    const concurrentlyAddedRowDoc = createRowDoc(concurrentlyAddedRowId, databaseId, {
+      [fieldId]: { fieldType: FieldType.RichText, data: 'Concurrent option' },
+    });
+    const openedUnloadedRowDoc = new Y.Doc({ guid: unloadedRowId }) as YDoc;
+    const unloadedRowUpdate = Y.encodeStateAsUpdate(unloadedRowDoc);
+    const rowOrders = new Y.Array<{ id: string; height: number }>();
+
+    rowOrders.push([
+      { id: rowId, height: 36 },
+      { id: unloadedRowId, height: 36 },
+    ]);
+    database.get(YjsDatabaseKey.views).get(viewId).set(YjsDatabaseKey.row_orders, rowOrders);
+    field.set(YjsDatabaseKey.type, FieldType.RichText);
+
+    const ensureRow = jest.fn(async (requestedRowId: string) => {
+      if (requestedRowId === concurrentlyAddedRowId) return concurrentlyAddedRowDoc;
+
+      setTimeout(() => {
+        rowOrders.push([{ id: concurrentlyAddedRowId, height: 36 }]);
+        Y.applyUpdate(openedUnloadedRowDoc, unloadedRowUpdate);
+      }, 0);
+      return openedUnloadedRowDoc;
+    });
+    const contextValue = {
+      readOnly: false,
+      databaseDoc,
+      databasePageId: viewId,
+      activeViewId: viewId,
+      rowMap: { [rowId]: loadedRowDoc },
+      ensureRow,
+      workspaceId: 'workspace-id',
+    } as unknown as DatabaseContextState;
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <DatabaseContext.Provider value={contextValue}>{children}</DatabaseContext.Provider>
+    );
+    const { result } = renderHook(() => useSwitchPropertyType(), { wrapper });
+
+    act(() => {
+      void result.current(fieldId, FieldType.SingleSelect);
+    });
+
+    await waitFor(() => {
+      expect(field.get(YjsDatabaseKey.type)).toBe(FieldType.SingleSelect);
+    });
+
+    expect(ensureRow).toHaveBeenCalledWith(unloadedRowId);
+    expect(ensureRow).toHaveBeenCalledWith(concurrentlyAddedRowId);
+    expect(parseSelectOptionTypeOptions(field).options.map(({ name }) => name)).toEqual([
+      'Loaded option',
+      'Off-screen option',
+      'Concurrent option',
+    ]);
+    expect(getCellDataText(getCell(openedUnloadedRowDoc), field)).toBe('Off-screen option');
+    expect(getCellDataText(getCell(concurrentlyAddedRowDoc), field)).toBe('Concurrent option');
   });
 });
 
@@ -176,15 +364,26 @@ describe('Created/LastEditedTime -> DateTime (desktop parity: materialize timest
     return field;
   }
 
-  function setupTimestamp(type: FieldType, meta: { createdAt?: string; lastModified?: string }) {
+  function setupTimestamp(
+    type: FieldType,
+    meta: { createdAt?: string; lastModified?: string },
+    offscreen?: { rowId: string; createdAt?: string; lastModified?: string }
+  ) {
     const doc = new Y.Doc({ guid: databaseId }) as YDoc;
     const sharedRoot = doc.getMap(YjsEditorKey.data_section);
     const database = new Y.Map() as YDatabase;
     const fields = new Y.Map<YDatabaseField>() as YDatabaseFields;
     const views = new Y.Map<YDatabaseView>() as YDatabaseViews;
+    const view = new Y.Map() as YDatabaseView;
+    const rowOrders = new Y.Array<{ id: string; height: number }>();
 
     fields.set(fieldId, createTimestampField(type));
-    views.set(viewId, new Y.Map() as YDatabaseView);
+    rowOrders.push([
+      { id: rowId, height: 36 },
+      ...(offscreen ? [{ id: offscreen.rowId, height: 36 }] : []),
+    ]);
+    view.set(YjsDatabaseKey.row_orders, rowOrders);
+    views.set(viewId, view);
     database.set(YjsDatabaseKey.id, databaseId);
     database.set(YjsDatabaseKey.fields, fields);
     database.set(YjsDatabaseKey.views, views);
@@ -193,12 +392,23 @@ describe('Created/LastEditedTime -> DateTime (desktop parity: materialize timest
     // Row carries the timestamp on its meta and has NO cell for the field
     // (created/last-edited time has no cell data of its own).
     const rowDoc = createRowDoc(rowId, databaseId, {}, meta.createdAt ?? '0', meta.lastModified ?? '0');
+    const offscreenRowDoc = offscreen
+      ? createRowDoc(
+          offscreen.rowId,
+          databaseId,
+          {},
+          offscreen.createdAt ?? '0',
+          offscreen.lastModified ?? '0'
+        )
+      : undefined;
+    const ensureRow = offscreenRowDoc ? jest.fn(async () => offscreenRowDoc) : undefined;
     const contextValue = {
       readOnly: false,
       databaseDoc: doc,
       databasePageId: viewId,
       activeViewId: viewId,
       rowMap: { [rowId]: rowDoc },
+      ensureRow,
       workspaceId: 'workspace-id',
     } as unknown as DatabaseContextState;
     const wrapper = ({ children }: { children: React.ReactNode }) => (
@@ -206,20 +416,22 @@ describe('Created/LastEditedTime -> DateTime (desktop parity: materialize timest
     );
     const { result } = renderHook(() => useSwitchPropertyType(), { wrapper });
 
-    return { databaseDoc: doc, rowDoc, switchType: result.current };
+    return { databaseDoc: doc, rowDoc, offscreenRowDoc, ensureRow, switchType: result.current };
   }
 
   it('CreatedTime -> DateTime: materializes row.created_at into the cell and renders a date', () => {
     const { databaseDoc, rowDoc, switchType } = setupTimestamp(FieldType.CreatedTime, { createdAt: TIMESTAMP });
 
     act(() => {
-      switchType(fieldId, FieldType.DateTime);
+      void switchType(fieldId, FieldType.DateTime);
     });
 
     const cell = getCell(rowDoc);
     const field = getField(databaseDoc);
 
     expect(cell.get(YjsDatabaseKey.data)).toBe(TIMESTAMP);
+    expect(cell.get(YjsDatabaseKey.field_type)).toBe(FieldType.CreatedTime);
+    expect(cell.get(YjsDatabaseKey.source_field_type)).toBeUndefined();
     expect(getCellDataText(cell, field).length).toBeGreaterThan(0);
   });
 
@@ -227,10 +439,52 @@ describe('Created/LastEditedTime -> DateTime (desktop parity: materialize timest
     const { rowDoc, switchType } = setupTimestamp(FieldType.LastEditedTime, { lastModified: TIMESTAMP });
 
     act(() => {
-      switchType(fieldId, FieldType.DateTime);
+      void switchType(fieldId, FieldType.DateTime);
     });
 
-    expect(getCell(rowDoc).get(YjsDatabaseKey.data)).toBe(TIMESTAMP);
+    const cell = getCell(rowDoc);
+
+    expect(cell.get(YjsDatabaseKey.data)).toBe(TIMESTAMP);
+    expect(cell.get(YjsDatabaseKey.field_type)).toBe(FieldType.LastEditedTime);
+    expect(cell.get(YjsDatabaseKey.source_field_type)).toBeUndefined();
+  });
+
+  it('selecting the current timestamp type is a no-op', () => {
+    const { databaseDoc, rowDoc, switchType } = setupTimestamp(FieldType.CreatedTime, { createdAt: TIMESTAMP });
+    const field = getField(databaseDoc);
+    const originalLastModified = field.get(YjsDatabaseKey.last_modified);
+
+    act(() => {
+      void switchType(fieldId, FieldType.CreatedTime);
+    });
+
+    const row = rowDoc.getMap(YjsEditorKey.data_section).get(YjsEditorKey.database_row) as YDatabaseRow;
+
+    expect(row.get(YjsDatabaseKey.cells).get(fieldId)).toBeUndefined();
+    expect(field.get(YjsDatabaseKey.last_modified)).toBe(originalLastModified);
+  });
+
+  it('loads and materializes off-screen timestamp rows before changing the schema', async () => {
+    const offscreenRowId = 'offscreen-timestamp-row';
+    const { databaseDoc, offscreenRowDoc, ensureRow, switchType } = setupTimestamp(
+      FieldType.CreatedTime,
+      { createdAt: TIMESTAMP },
+      { rowId: offscreenRowId, createdAt: TIMESTAMP }
+    );
+
+    act(() => {
+      void switchType(fieldId, FieldType.DateTime);
+    });
+
+    await waitFor(() => {
+      expect(getField(databaseDoc).get(YjsDatabaseKey.type)).toBe(FieldType.DateTime);
+    });
+
+    expect(ensureRow).toHaveBeenCalledWith(offscreenRowId);
+    const cell = getCell(offscreenRowDoc as YDoc);
+
+    expect(cell.get(YjsDatabaseKey.data)).toBe(TIMESTAMP);
+    expect(cell.get(YjsDatabaseKey.field_type)).toBe(FieldType.CreatedTime);
   });
 });
 
@@ -324,6 +578,7 @@ describe('round-trip A -> B -> A preserves cell data (desktop parity)', () => {
     ['Number <-> RichText', FieldType.Number, { format: 0 }, '42', FieldType.RichText],
     ['URL <-> RichText', FieldType.URL, undefined, 'http://example.com', FieldType.RichText],
     ['Checklist <-> RichText', FieldType.Checklist, undefined, checklistData, FieldType.RichText],
+    ['Checklist <-> MultiSelect', FieldType.Checklist, undefined, checklistData, FieldType.MultiSelect],
     ['DateTime <-> RichText', FieldType.DateTime, {}, '1747180800', FieldType.RichText],
   ];
 
@@ -335,13 +590,15 @@ describe('round-trip A -> B -> A preserves cell data (desktop parity)', () => {
     expect(before.length).toBeGreaterThan(0);
 
     act(() => {
-      result.current(fid, typeB);
+      void result.current(fid, typeB);
     });
     act(() => {
-      result.current(fid, typeA);
+      void result.current(fid, typeA);
     });
 
     expect(getCellDataText(cellOf(), fieldOf())).toBe(before);
     expect(cellOf().get(YjsDatabaseKey.data)).toBe(cellData);
+    expect(cellOf().get(YjsDatabaseKey.field_type)).toBe(typeA);
+    expect(cellOf().get(YjsDatabaseKey.source_field_type)).toBeUndefined();
   });
 });

--- a/src/application/database-yjs/__tests__/field-type-conversion.test.tsx
+++ b/src/application/database-yjs/__tests__/field-type-conversion.test.tsx
@@ -280,6 +280,66 @@ describe('Bug B (fixed) — field-type conversion preserves select values', () =
     expect(getCellDataText(cell, field)).toBe('Yes');
   });
 
+  it('merges edited RichText values into a preserved select option set', () => {
+    const { databaseDoc, rowDoc, switchType } = setup();
+    const field = getField(databaseDoc);
+    const cell = getCell(rowDoc);
+
+    act(() => {
+      void switchType(fieldId, FieldType.RichText);
+    });
+    act(() => {
+      cell.set(YjsDatabaseKey.data, 'New option');
+      cell.set(YjsDatabaseKey.field_type, FieldType.RichText);
+    });
+    act(() => {
+      void switchType(fieldId, FieldType.MultiSelect);
+    });
+
+    const options = parseSelectOptionTypeOptions(field).options;
+
+    expect(options.slice(0, OPTIONS.length)).toEqual(OPTIONS);
+    expect(options.filter(({ name }) => name === 'New option')).toHaveLength(1);
+    expect(getCellDataText(cell, field)).toBe('New option');
+  });
+
+  it('merges Checklist values without duplicating preserved select options', () => {
+    const { databaseDoc, rowDoc, switchType } = setup();
+    const field = getField(databaseDoc);
+    const cell = getCell(rowDoc);
+    const existingTask = {
+      id: 'existing-task',
+      name: 'Task',
+      color: SelectOptionColor.OptionColor1,
+    };
+    const checklistData = JSON.stringify({
+      options: [
+        { id: 'check-task', name: 'Task', color: SelectOptionColor.OptionColor2 },
+        { id: 'check-new', name: 'New task', color: SelectOptionColor.OptionColor3 },
+      ],
+      selected_option_ids: ['check-task', 'check-new'],
+    });
+
+    act(() => {
+      field
+        .get(YjsDatabaseKey.type_option)
+        .get(String(FieldType.MultiSelect))
+        .set(YjsDatabaseKey.content, JSON.stringify({ disable_color: false, options: [existingTask] }));
+      field.set(YjsDatabaseKey.type, FieldType.Checklist);
+      cell.set(YjsDatabaseKey.field_type, FieldType.Checklist);
+      cell.set(YjsDatabaseKey.data, checklistData);
+    });
+    act(() => {
+      void switchType(fieldId, FieldType.MultiSelect);
+    });
+
+    const options = parseSelectOptionTypeOptions(field).options;
+
+    expect(options.filter(({ name }) => name === 'Task')).toEqual([existingTask]);
+    expect(options.filter(({ name }) => name === 'New task')).toHaveLength(1);
+    expect(getCellDataText(cell, field)).toBe('Task,New task');
+  });
+
   it('includes off-screen rows added while RichText-to-select hydration is pending', async () => {
     const databaseDoc = createDatabaseDoc();
     const database = databaseDoc.getMap(YjsEditorKey.data_section).get(YjsEditorKey.database) as YDatabase;

--- a/src/application/database-yjs/__tests__/filter.test.ts
+++ b/src/application/database-yjs/__tests__/filter.test.ts
@@ -1230,6 +1230,39 @@ describe('desktop grid filter parity', () => {
     ]);
   });
 
+  it('re-evaluates filters with lazily converted cell data after a field type switch', () => {
+    const { makeDataFilter, makeFilters } = buildFilterHarness();
+    const field = fixture.fields.get(fixture.fieldIds.multiSelect);
+
+    expect(field).toBeDefined();
+
+    // Populate the condition cache while the cells and field are MultiSelect.
+    expect(
+      applyFilters(
+        makeFilters([
+          makeDataFilter(
+            fixture.fieldIds.multiSelect,
+            FieldType.MultiSelect,
+            SelectOptionFilterCondition.OptionContains,
+            fixture.multiSelectOptions[0].id
+          ),
+        ])
+      )
+    ).toEqual([fixture.rowIds[0], fixture.rowIds[1], fixture.rowIds[2]]);
+
+    // Desktop changes only the field schema. The cells keep MultiSelect data,
+    // which must be decoded as Checklist data for the new filter.
+    field?.set(YjsDatabaseKey.type, FieldType.Checklist);
+
+    expect(
+      applyFilters(
+        makeFilters([
+          makeDataFilter(fixture.fieldIds.multiSelect, FieldType.Checklist, ChecklistFilterCondition.IsComplete),
+        ])
+      )
+    ).toEqual([fixture.rowIds[2]]);
+  });
+
   it('filters select option conditions', () => {
     const { makeDataFilter, makeFilters } = buildFilterHarness();
 
@@ -1354,6 +1387,19 @@ describe('desktop grid filter parity', () => {
     expect(row0RelationCell && 'toJSON' in row0RelationCell ? row0RelationCell.toJSON() : row0RelationCell).toEqual([
       fixture.rowIds[1],
     ]);
+
+    // A schema-only Media -> Relation conversion can leave a Y.Array payload
+    // that is not relation data. It must still count as an empty relation.
+    const foreignRow = fixture.rowMetas[fixture.rowIds[1]]
+      .getMap(YjsEditorKey.data_section)
+      .get(YjsEditorKey.database_row) as YDatabaseRow;
+    const foreignCell = new Y.Map() as YDatabaseCell;
+    const foreignData = new Y.Array<string>();
+
+    foreignData.push(['{"id":"file-a"}']);
+    foreignCell.set(YjsDatabaseKey.field_type, FieldType.Media);
+    foreignCell.set(YjsDatabaseKey.data, foreignData);
+    foreignRow.get(YjsDatabaseKey.cells).set(fixture.fieldIds.relation, foreignCell);
 
     const { makeDataFilter, makeFilters } = buildFilterHarness();
     const emptyContent = JSON.stringify([]);

--- a/src/application/database-yjs/__tests__/group.test.ts
+++ b/src/application/database-yjs/__tests__/group.test.ts
@@ -141,6 +141,48 @@ describe('select option group tests', () => {
   });
 });
 
+describe('desktop-model lazy conversion grouping', () => {
+  const databaseId = 'db-group-lazy-conversion';
+
+  it('groups a preserved text cell through the current checkbox field type', () => {
+    const fieldId = 'converted-checkbox';
+    const field = createField(fieldId, FieldType.Checkbox);
+    const rows: Row[] = [{ id: 'row-a', height: 0 }];
+    const rowMetas: Record<RowId, YDoc> = {
+      'row-a': createRowDoc('row-a', databaseId, {
+        [fieldId]: createCell(FieldType.RichText, 'true'),
+      }),
+    };
+
+    const result = groupByCheckbox(rows, rowMetas, field);
+
+    expect(result?.get('Yes')?.map((row) => row.id)).toEqual(['row-a']);
+    expect(result?.get('No')).toEqual([]);
+  });
+
+  it('resolves a preserved text value through the current select options', () => {
+    const fieldId = 'converted-select';
+    const field = createField(fieldId, FieldType.MultiSelect, {
+      options: [
+        { id: 'opt-a', name: 'Alpha', color: 0 },
+        { id: 'opt-b', name: 'Beta', color: 0 },
+      ],
+      disable_color: false,
+    });
+    const rows: Row[] = [{ id: 'row-a', height: 0 }];
+    const rowMetas: Record<RowId, YDoc> = {
+      'row-a': createRowDoc('row-a', databaseId, {
+        [fieldId]: createCell(FieldType.RichText, 'Alpha'),
+      }),
+    };
+
+    const result = groupBySelectOption(rows, rowMetas, field);
+
+    expect(result?.get('opt-a')?.map((row) => row.id)).toEqual(['row-a']);
+    expect(result?.get(fieldId)).toEqual([]);
+  });
+});
+
 describe('group by field fallback', () => {
   it('returns undefined for unsupported field types', () => {
     const fields = new Y.Map() as YDatabaseFields;

--- a/src/application/database-yjs/__tests__/relation-desktop-parity.test.ts
+++ b/src/application/database-yjs/__tests__/relation-desktop-parity.test.ts
@@ -4,12 +4,19 @@ jest.mock('@/utils/runtime-config', () => ({
 
 import * as Y from 'yjs';
 
-import { applyRelationCellChangeset } from '@/application/database-yjs/dispatch/relation';
+import { applyRelationCellChangeset, getRelationRowIdsFromCell } from '@/application/database-yjs/dispatch/relation';
 import { FieldType } from '@/application/database-yjs/database.type';
 import { parseRelationTypeOption } from '@/application/database-yjs/fields/relation/parse';
 import { RelationLimit } from '@/application/database-yjs/fields/relation/relation.type';
 import { createRelationField } from '@/application/database-yjs/fields/relation/utils';
-import { YDatabase, YDatabaseField, YDatabaseFields, YjsDatabaseKey, YjsEditorKey } from '@/application/types';
+import {
+  YDatabase,
+  YDatabaseCell,
+  YDatabaseField,
+  YDatabaseFields,
+  YjsDatabaseKey,
+  YjsEditorKey,
+} from '@/application/types';
 
 function createAttachedRelationField(fieldId = 'relation-field') {
   const doc = new Y.Doc();
@@ -24,7 +31,49 @@ function createAttachedRelationField(fieldId = 'relation-field') {
   return fields.get(fieldId) as YDatabaseField;
 }
 
+function createAttachedCell() {
+  return new Y.Doc().getMap('cell') as YDatabaseCell;
+}
+
 describe('relation desktop parity helpers', () => {
+  it('reads only native relation payloads as row IDs', () => {
+    const convertedText = createAttachedCell();
+
+    convertedText.set(YjsDatabaseKey.field_type, FieldType.RichText);
+    convertedText.set(YjsDatabaseKey.data, 'row-a,row-b');
+    expect(getRelationRowIdsFromCell(convertedText)).toEqual([]);
+
+    const convertedMedia = createAttachedCell();
+    const mediaData = new Y.Array<string>();
+
+    mediaData.push(['{"id":"file-a"}']);
+    convertedMedia.set(YjsDatabaseKey.field_type, FieldType.Media);
+    convertedMedia.set(YjsDatabaseKey.data, mediaData);
+    expect(getRelationRowIdsFromCell(convertedMedia)).toEqual([]);
+
+    const legacyWebCell = createAttachedCell();
+
+    legacyWebCell.set(YjsDatabaseKey.field_type, FieldType.Relation);
+    legacyWebCell.set(YjsDatabaseKey.source_field_type, String(FieldType.RichText));
+    legacyWebCell.set(YjsDatabaseKey.data, 'row-a,row-b');
+    expect(getRelationRowIdsFromCell(legacyWebCell)).toEqual([]);
+
+    const nativeRelation = createAttachedCell();
+    const relationData = new Y.Array<string>();
+
+    relationData.push(['row-a', 'row-b']);
+    nativeRelation.set(YjsDatabaseKey.field_type, FieldType.Relation);
+    nativeRelation.set(YjsDatabaseKey.data, relationData);
+    expect(getRelationRowIdsFromCell(nativeRelation)).toEqual(['row-a', 'row-b']);
+
+    const legacyRelationWithoutType = createAttachedCell();
+    const legacyRelationData = new Y.Array<string>();
+
+    legacyRelationData.push(['row-c']);
+    legacyRelationWithoutType.set(YjsDatabaseKey.data, legacyRelationData);
+    expect(getRelationRowIdsFromCell(legacyRelationWithoutType)).toEqual(['row-c']);
+  });
+
   it('creates relation fields with desktop-compatible type option defaults', () => {
     const field = createAttachedRelationField();
     const option = parseRelationTypeOption(field);

--- a/src/application/database-yjs/__tests__/rollup-desktop-parity.test.ts
+++ b/src/application/database-yjs/__tests__/rollup-desktop-parity.test.ts
@@ -968,8 +968,10 @@ describe('rollup desktop parity (blog_posts + authors)', () => {
     const relatedRow2 = fixture.relatedFixture.rows[1].id as RowId;
 
     const checkboxFieldId = ensureField(fixture.relatedFixture.fields, FieldType.Checkbox, 'author-checkbox');
-    setCellValue(fixture.relatedFixture.rowMetas[relatedRow1], checkboxFieldId, FieldType.Checkbox, 'Yes');
-    setCellValue(fixture.relatedFixture.rowMetas[relatedRow2], checkboxFieldId, FieldType.Checkbox, 'No');
+    // Desktop decodes supported RichText lazily, while an unsupported Number
+    // payload stays preserved but appears unchecked under a Checkbox field.
+    setCellValue(fixture.relatedFixture.rowMetas[relatedRow1], checkboxFieldId, FieldType.RichText, 'Yes');
+    setCellValue(fixture.relatedFixture.rowMetas[relatedRow2], checkboxFieldId, FieldType.Number, '1');
 
     setRelationCellRowIds(fixture.baseRowMetas[baseRowId], fixture.relationFieldId, [relatedRow1, relatedRow2]);
 

--- a/src/application/database-yjs/__tests__/selector.field-type.test.tsx
+++ b/src/application/database-yjs/__tests__/selector.field-type.test.tsx
@@ -1,0 +1,216 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import type React from 'react';
+import * as Y from 'yjs';
+
+import {
+  DatabaseContext,
+  DatabaseContextState,
+  FieldType,
+  useCalendarEventsSelector,
+  useFieldCellsSelector,
+  useRowPrimaryContentSelector,
+} from '@/application/database-yjs';
+import {
+  YDatabase,
+  YDatabaseField,
+  YDatabaseFields,
+  YDatabaseRowOrders,
+  YDatabaseSorts,
+  YDatabaseView,
+  YDatabaseViews,
+  YDoc,
+  YjsDatabaseKey,
+  YjsEditorKey,
+} from '@/application/types';
+import { AFConfigContext } from '@/components/main/app.hooks';
+
+import { createRowDoc } from './test-helpers';
+
+jest.mock('@/utils/runtime-config', () => ({
+  getConfigValue: (_key: string, fallback: string) => fallback,
+}));
+
+const databaseId = 'database-id';
+const viewId = 'view-id';
+const rowId = 'row-id';
+const fieldId = 'field-id';
+
+function createFixture() {
+  const databaseDoc = new Y.Doc({ guid: databaseId }) as YDoc;
+  const sharedRoot = databaseDoc.getMap(YjsEditorKey.data_section);
+  const database = new Y.Map() as YDatabase;
+  const fields = new Y.Map<YDatabaseField>() as YDatabaseFields;
+  const views = new Y.Map<YDatabaseView>() as YDatabaseViews;
+  const view = new Y.Map() as YDatabaseView;
+  const rowOrders = new Y.Array<{ id: string; height: number }>() as YDatabaseRowOrders;
+  const field = new Y.Map() as YDatabaseField;
+  const typeOptions = new Y.Map();
+  const multiSelectOption = new Y.Map();
+
+  field.set(YjsDatabaseKey.id, fieldId);
+  field.set(YjsDatabaseKey.name, 'Measurements');
+  field.set(YjsDatabaseKey.type, FieldType.MultiSelect);
+  field.set(YjsDatabaseKey.is_primary, true);
+  multiSelectOption.set(
+    YjsDatabaseKey.content,
+    JSON.stringify({
+      options: [
+        { id: 'option-a', name: 'Alpha', color: 'Purple' },
+        { id: 'option-b', name: 'Beta', color: 'Pink' },
+      ],
+    })
+  );
+  typeOptions.set(String(FieldType.MultiSelect), multiSelectOption);
+  field.set(YjsDatabaseKey.type_option, typeOptions);
+
+  rowOrders.push([{ id: rowId, height: 44 }]);
+  view.set(YjsDatabaseKey.row_orders, rowOrders);
+  view.set(YjsDatabaseKey.filters, new Y.Array());
+  view.set(YjsDatabaseKey.sorts, new Y.Array() as YDatabaseSorts);
+  fields.set(fieldId, field);
+  views.set(viewId, view);
+  database.set(YjsDatabaseKey.id, databaseId);
+  database.set(YjsDatabaseKey.fields, fields);
+  database.set(YjsDatabaseKey.views, views);
+  sharedRoot.set(YjsEditorKey.database, database);
+
+  const rowDoc = createRowDoc(rowId, databaseId, {
+    [fieldId]: { fieldType: FieldType.MultiSelect, data: 'option-a,option-b' },
+  });
+  const contextValue = {
+    readOnly: false,
+    databaseDoc,
+    databasePageId: viewId,
+    activeViewId: viewId,
+    rowMap: { [rowId]: rowDoc },
+    workspaceId: 'workspace-id',
+  } as DatabaseContextState;
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <DatabaseContext.Provider value={contextValue}>{children}</DatabaseContext.Provider>
+  );
+
+  return { field, rowDoc, wrapper };
+}
+
+function createCalendarFixture() {
+  const calendarFieldId = 'calendar-field-id';
+  const primaryFieldId = 'primary-field-id';
+  const databaseDoc = new Y.Doc({ guid: databaseId }) as YDoc;
+  const sharedRoot = databaseDoc.getMap(YjsEditorKey.data_section);
+  const database = new Y.Map() as YDatabase;
+  const fields = new Y.Map<YDatabaseField>() as YDatabaseFields;
+  const views = new Y.Map<YDatabaseView>() as YDatabaseViews;
+  const view = new Y.Map() as YDatabaseView;
+  const rowOrders = new Y.Array<{ id: string; height: number }>() as YDatabaseRowOrders;
+  const layoutSettings = new Y.Map();
+  const calendarSettings = new Y.Map();
+  const calendarField = new Y.Map() as YDatabaseField;
+  const primaryField = new Y.Map() as YDatabaseField;
+  const primaryTypeOptions = new Y.Map();
+  const primaryMultiSelectOption = new Y.Map();
+
+  calendarField.set(YjsDatabaseKey.id, calendarFieldId);
+  calendarField.set(YjsDatabaseKey.name, 'Date');
+  calendarField.set(YjsDatabaseKey.type, FieldType.DateTime);
+
+  primaryField.set(YjsDatabaseKey.id, primaryFieldId);
+  primaryField.set(YjsDatabaseKey.name, 'Name');
+  primaryField.set(YjsDatabaseKey.type, FieldType.RichText);
+  primaryField.set(YjsDatabaseKey.is_primary, true);
+  primaryMultiSelectOption.set(
+    YjsDatabaseKey.content,
+    JSON.stringify({ options: [{ id: 'title-option', name: 'Experiment Alpha', color: 'Purple' }] })
+  );
+  primaryTypeOptions.set(String(FieldType.MultiSelect), primaryMultiSelectOption);
+  primaryField.set(YjsDatabaseKey.type_option, primaryTypeOptions);
+
+  calendarSettings.set(YjsDatabaseKey.field_id, calendarFieldId);
+  layoutSettings.set('2', calendarSettings);
+  rowOrders.push([{ id: rowId, height: 44 }]);
+  view.set(YjsDatabaseKey.row_orders, rowOrders);
+  view.set(YjsDatabaseKey.filters, new Y.Array());
+  view.set(YjsDatabaseKey.sorts, new Y.Array() as YDatabaseSorts);
+  view.set(YjsDatabaseKey.layout_settings, layoutSettings);
+  fields.set(calendarFieldId, calendarField);
+  fields.set(primaryFieldId, primaryField);
+  views.set(viewId, view);
+  database.set(YjsDatabaseKey.id, databaseId);
+  database.set(YjsDatabaseKey.fields, fields);
+  database.set(YjsDatabaseKey.views, views);
+  sharedRoot.set(YjsEditorKey.database, database);
+
+  const rowDoc = createRowDoc(rowId, databaseId, {
+    [calendarFieldId]: { fieldType: FieldType.RichText, data: '2025-01-02' },
+    [primaryFieldId]: { fieldType: FieldType.MultiSelect, data: 'title-option' },
+  });
+  const contextValue = {
+    readOnly: false,
+    databaseDoc,
+    databasePageId: viewId,
+    activeViewId: viewId,
+    rowMap: { [rowId]: rowDoc },
+    workspaceId: 'workspace-id',
+  } as DatabaseContextState;
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <AFConfigContext.Provider
+      value={{
+        isAuthenticated: false,
+        updateCurrentUser: async () => undefined,
+        openLoginModal: () => undefined,
+      }}
+    >
+      <DatabaseContext.Provider value={contextValue}>{children}</DatabaseContext.Provider>
+    </AFConfigContext.Provider>
+  );
+
+  return { calendarField, wrapper };
+}
+
+describe('field-schema-aware selectors', () => {
+  it('recomputes aggregate and primary content without rewriting the stored cell', async () => {
+    const { field, rowDoc, wrapper } = createFixture();
+    const { result } = renderHook(
+      () => ({
+        cells: useFieldCellsSelector(fieldId).cells,
+        primaryContent: useRowPrimaryContentSelector(rowDoc, fieldId),
+      }),
+      { wrapper }
+    );
+
+    await waitFor(() => {
+      expect(result.current.cells?.get(rowId)).toBe('option-a,option-b');
+      expect(result.current.primaryContent).toBe('Alpha,Beta');
+    });
+
+    act(() => {
+      field.set(YjsDatabaseKey.type, FieldType.RichText);
+    });
+
+    await waitFor(() => {
+      expect(result.current.cells?.get(rowId)).toBe('Alpha,Beta');
+      expect(result.current.primaryContent).toBe('Alpha,Beta');
+    });
+  });
+
+  it('recomputes lazy calendar values and clears stale events for an incompatible target type', async () => {
+    const { calendarField, wrapper } = createCalendarFixture();
+    const { result } = renderHook(() => useCalendarEventsSelector(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.events).toHaveLength(1);
+      expect(result.current.events[0]?.title).toBe('Experiment Alpha');
+      expect(result.current.events[0]?.start?.getFullYear()).toBe(2025);
+      expect(result.current.events[0]?.start?.getMonth()).toBe(0);
+      expect(result.current.events[0]?.start?.getDate()).toBe(2);
+    });
+
+    act(() => {
+      calendarField.set(YjsDatabaseKey.type, FieldType.RichText);
+    });
+
+    await waitFor(() => {
+      expect(result.current.events).toEqual([]);
+      expect(result.current.emptyEvents).toEqual([]);
+    });
+  });
+});

--- a/src/application/database-yjs/__tests__/shared-yjs-observer.test.ts
+++ b/src/application/database-yjs/__tests__/shared-yjs-observer.test.ts
@@ -1,0 +1,32 @@
+import * as Y from 'yjs';
+
+import { subscribeSharedYjsDeep } from '@/application/database-yjs/shared-yjs-observer';
+
+describe('subscribeSharedYjsDeep', () => {
+  it('uses one Yjs observer and keeps subscriber cleanup independent', () => {
+    const doc = new Y.Doc();
+    const target = doc.getMap('target');
+    const observe = jest.spyOn(target, 'observeDeep');
+    const unobserve = jest.spyOn(target, 'unobserveDeep');
+    const first = jest.fn();
+    const second = jest.fn();
+
+    const unsubscribeFirst = subscribeSharedYjsDeep(target, first);
+    const unsubscribeSecond = subscribeSharedYjsDeep(target, second);
+
+    expect(observe).toHaveBeenCalledTimes(1);
+
+    target.set('first-change', true);
+    expect(first).toHaveBeenCalledTimes(1);
+    expect(second).toHaveBeenCalledTimes(1);
+
+    unsubscribeFirst();
+    target.set('second-change', true);
+    expect(first).toHaveBeenCalledTimes(1);
+    expect(second).toHaveBeenCalledTimes(2);
+    expect(unobserve).not.toHaveBeenCalled();
+
+    unsubscribeSecond();
+    expect(unobserve).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/application/database-yjs/__tests__/useDuplicatePropertyDispatch.test.tsx
+++ b/src/application/database-yjs/__tests__/useDuplicatePropertyDispatch.test.tsx
@@ -1,0 +1,113 @@
+import { act, renderHook } from '@testing-library/react';
+import type React from 'react';
+import * as Y from 'yjs';
+
+import { DatabaseContext, DatabaseContextState, FieldType } from '@/application/database-yjs';
+import { getCellDataText } from '@/application/database-yjs/cell.parse';
+import { useDuplicatePropertyDispatch } from '@/application/database-yjs/dispatch';
+import {
+  YDatabase,
+  YDatabaseField,
+  YDatabaseFields,
+  YDatabaseRow,
+  YDatabaseView,
+  YDatabaseViews,
+  YDoc,
+  YjsDatabaseKey,
+  YjsEditorKey,
+} from '@/application/types';
+
+import { createRowDoc } from './test-helpers';
+
+jest.mock('@/utils/runtime-config', () => ({
+  getConfigValue: (_key: string, fallback: string) => fallback,
+}));
+
+describe('useDuplicatePropertyDispatch', () => {
+  it('preserves stored cell types and every retained type option', () => {
+    const databaseId = 'database-id';
+    const viewId = 'view-id';
+    const fieldId = 'field-id';
+    const rowId = 'row-id';
+    const databaseDoc = new Y.Doc({ guid: databaseId }) as YDoc;
+    const root = databaseDoc.getMap(YjsEditorKey.data_section);
+    const database = new Y.Map() as YDatabase;
+    const fields = new Y.Map<YDatabaseField>() as YDatabaseFields;
+    const field = new Y.Map() as YDatabaseField;
+    const typeOptions = new Y.Map();
+    const richTextOption = new Y.Map();
+    const multiSelectOption = new Y.Map();
+    const relationOption = new Y.Map();
+    const views = new Y.Map<YDatabaseView>() as YDatabaseViews;
+    const view = new Y.Map() as YDatabaseView;
+    const fieldOrders = new Y.Array<{ id: string }>();
+    const fieldSettings = new Y.Map<Y.Map<unknown>>();
+
+    multiSelectOption.set(
+      YjsDatabaseKey.content,
+      JSON.stringify({
+        disable_color: false,
+        options: [{ id: 'opt-a', name: 'Alpha', color: 'Purple' }],
+      })
+    );
+    typeOptions.set(String(FieldType.RichText), richTextOption);
+    typeOptions.set(String(FieldType.MultiSelect), multiSelectOption);
+    relationOption.set(YjsDatabaseKey.database_id, 'related-database');
+    relationOption.set(YjsDatabaseKey.is_two_way, true);
+    relationOption.set(YjsDatabaseKey.reciprocal_field_id, 'reciprocal-id');
+    relationOption.set(YjsDatabaseKey.reciprocal_field_name, 'Backlink');
+    typeOptions.set(String(FieldType.Relation), relationOption);
+    field.set(YjsDatabaseKey.id, fieldId);
+    field.set(YjsDatabaseKey.name, 'Converted');
+    field.set(YjsDatabaseKey.type, FieldType.RichText);
+    field.set(YjsDatabaseKey.type_option, typeOptions);
+    fields.set(fieldId, field);
+    fieldOrders.push([{ id: fieldId }]);
+    fieldSettings.set(fieldId, new Y.Map());
+    view.set(YjsDatabaseKey.field_orders, fieldOrders);
+    view.set(YjsDatabaseKey.field_settings, fieldSettings);
+    views.set(viewId, view);
+    database.set(YjsDatabaseKey.id, databaseId);
+    database.set(YjsDatabaseKey.fields, fields);
+    database.set(YjsDatabaseKey.views, views);
+    root.set(YjsEditorKey.database, database);
+
+    const rowDoc = createRowDoc(rowId, databaseId, {
+      [fieldId]: { fieldType: FieldType.MultiSelect, data: 'opt-a' },
+    });
+    const contextValue = {
+      readOnly: false,
+      databaseDoc,
+      databasePageId: viewId,
+      activeViewId: viewId,
+      rowMap: { [rowId]: rowDoc },
+      workspaceId: 'workspace-id',
+    } as DatabaseContextState;
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <DatabaseContext.Provider value={contextValue}>{children}</DatabaseContext.Provider>
+    );
+    const { result } = renderHook(() => useDuplicatePropertyDispatch(), { wrapper });
+    let duplicateFieldId = '';
+
+    act(() => {
+      duplicateFieldId = result.current(fieldId);
+    });
+
+    const duplicateField = fields.get(duplicateFieldId);
+    const row = rowDoc.getMap(YjsEditorKey.data_section).get(YjsEditorKey.database_row) as YDatabaseRow;
+    const duplicateCell = row.get(YjsDatabaseKey.cells).get(duplicateFieldId);
+
+    expect(duplicateField.get(YjsDatabaseKey.type_option).has(String(FieldType.RichText))).toBe(true);
+    expect(duplicateField.get(YjsDatabaseKey.type_option).has(String(FieldType.MultiSelect))).toBe(true);
+    const duplicateRelationOption = duplicateField.get(YjsDatabaseKey.type_option).get(String(FieldType.Relation));
+
+    expect(duplicateRelationOption.get(YjsDatabaseKey.database_id)).toBe('related-database');
+    expect(duplicateRelationOption.get(YjsDatabaseKey.is_two_way)).toBe(false);
+    expect(duplicateRelationOption.get(YjsDatabaseKey.reciprocal_field_id)).toBeUndefined();
+    expect(duplicateRelationOption.get(YjsDatabaseKey.reciprocal_field_name)).toBeUndefined();
+    expect(duplicateCell.get(YjsDatabaseKey.data)).toBe('opt-a');
+    expect(duplicateCell.get(YjsDatabaseKey.field_type)).toBe(FieldType.MultiSelect);
+    expect(duplicateCell.get(YjsDatabaseKey.source_field_type)).toBeUndefined();
+    expect(getCellDataText(duplicateCell, duplicateField)).toBe('Alpha');
+  });
+});

--- a/src/application/database-yjs/__tests__/useDuplicateRowDispatch.test.tsx
+++ b/src/application/database-yjs/__tests__/useDuplicateRowDispatch.test.tsx
@@ -7,7 +7,16 @@ import { DatabaseContext, DatabaseContextState } from '@/application/database-yj
 import { FieldType, RowMetaKey } from '@/application/database-yjs/database.type';
 import { useDuplicateRowDispatch } from '@/application/database-yjs/dispatch/row';
 import { getMetaIdMap, getRowKey } from '@/application/database-yjs/row_meta';
-import { RowId, YDatabase, YDatabaseField, YDatabaseView, YDoc, YjsDatabaseKey, YjsEditorKey } from '@/application/types';
+import {
+  RowId,
+  YDatabase,
+  YDatabaseField,
+  YDatabaseRow,
+  YDatabaseView,
+  YDoc,
+  YjsDatabaseKey,
+  YjsEditorKey,
+} from '@/application/types';
 
 import { createCell, createRowDoc } from './test-helpers';
 
@@ -64,12 +73,15 @@ function createDatabaseDoc(): YDoc {
   return doc;
 }
 
-function createReferenceRowDoc(options: {
-  documentId?: string;
-  isEmptyDocument?: boolean;
-} = {}): YDoc {
+function createReferenceRowDoc(
+  options: {
+    documentId?: string;
+    isEmptyDocument?: boolean;
+    storedFieldType?: FieldType;
+  } = {}
+): YDoc {
   const rowDoc = createRowDoc(sourceRowId, databaseId, {
-    [fieldId]: createCell(FieldType.RichText, 'Source row'),
+    [fieldId]: createCell(options.storedFieldType ?? FieldType.RichText, 'Source row'),
   });
   const meta = new Y.Map<unknown>();
   const metaKeys = getMetaIdMap(sourceRowId);
@@ -128,6 +140,63 @@ function createWrapper({
 }
 
 describe('useDuplicateRowDispatch', () => {
+  it('preserves a lazy cell raw value and stored type', async () => {
+    const databaseDoc = createDatabaseDoc();
+    const referenceRowDoc = createReferenceRowDoc({ storedFieldType: FieldType.MultiSelect });
+    const createdRows = new Map<string, YDoc>();
+    const duplicateRowDocument = jest.fn().mockResolvedValue(undefined);
+    const { result } = renderHook(() => useDuplicateRowDispatch(), {
+      wrapper: createWrapper({ databaseDoc, referenceRowDoc, createdRows, duplicateRowDocument }),
+    });
+    let duplicatedRowId = '';
+
+    await act(async () => {
+      duplicatedRowId = await result.current(sourceRowId);
+    });
+
+    const createdRowDoc = createdRows.get(getRowKey(databaseDocId, duplicatedRowId)) as YDoc;
+    const row = createdRowDoc.getMap(YjsEditorKey.data_section).get(YjsEditorKey.database_row) as YDatabaseRow;
+    const cell = row.get(YjsDatabaseKey.cells).get(fieldId);
+
+    expect(cell.get(YjsDatabaseKey.data)).toBe('Source row');
+    expect(cell.get(YjsDatabaseKey.field_type)).toBe(FieldType.MultiSelect);
+    expect(cell.get(YjsDatabaseKey.source_field_type)).toBeUndefined();
+  });
+
+  it('deep-clones Y.Array cell data so duplicate edits do not mutate the source', async () => {
+    const databaseDoc = createDatabaseDoc();
+    const referenceRowDoc = createReferenceRowDoc({ storedFieldType: FieldType.Relation });
+    const referenceRow = referenceRowDoc
+      .getMap(YjsEditorKey.data_section)
+      .get(YjsEditorKey.database_row) as YDatabaseRow;
+    const referenceCell = referenceRow.get(YjsDatabaseKey.cells).get(fieldId);
+    const sourceIds = new Y.Array<string>();
+
+    referenceCell.set(YjsDatabaseKey.data, sourceIds);
+    sourceIds.push(['row-a', 'row-b']);
+
+    const createdRows = new Map<string, YDoc>();
+    const duplicateRowDocument = jest.fn().mockResolvedValue(undefined);
+    const { result } = renderHook(() => useDuplicateRowDispatch(), {
+      wrapper: createWrapper({ databaseDoc, referenceRowDoc, createdRows, duplicateRowDocument }),
+    });
+    let duplicatedRowId = '';
+
+    await act(async () => {
+      duplicatedRowId = await result.current(sourceRowId);
+    });
+
+    const createdRowDoc = createdRows.get(getRowKey(databaseDocId, duplicatedRowId)) as YDoc;
+    const duplicatedRow = createdRowDoc.getMap(YjsEditorKey.data_section).get(YjsEditorKey.database_row) as YDatabaseRow;
+    const duplicatedCell = duplicatedRow.get(YjsDatabaseKey.cells).get(fieldId);
+    const duplicatedIds = duplicatedCell.get(YjsDatabaseKey.data) as Y.Array<string>;
+
+    expect(duplicatedIds.toArray()).toEqual(['row-a', 'row-b']);
+    duplicatedIds.push(['row-c']);
+    expect(sourceIds.toArray()).toEqual(['row-a', 'row-b']);
+    expect(duplicatedIds.toArray()).toEqual(['row-a', 'row-b', 'row-c']);
+  });
+
   it('does not create or duplicate a row page when the source row is document-empty', async () => {
     const databaseDoc = createDatabaseDoc();
     const referenceRowDoc = createReferenceRowDoc({ isEmptyDocument: true });

--- a/src/application/database-yjs/__tests__/useMoveCardDispatch.test.tsx
+++ b/src/application/database-yjs/__tests__/useMoveCardDispatch.test.tsx
@@ -1,0 +1,98 @@
+import { act, renderHook } from '@testing-library/react';
+import type React from 'react';
+import * as Y from 'yjs';
+
+import { DatabaseContext, DatabaseContextState, FieldType } from '@/application/database-yjs';
+import { useMoveCardDispatch } from '@/application/database-yjs/dispatch';
+import {
+  YDatabase,
+  YDatabaseField,
+  YDatabaseFields,
+  YDatabaseRow,
+  YDatabaseView,
+  YDatabaseViews,
+  YDoc,
+  YjsDatabaseKey,
+  YjsEditorKey,
+} from '@/application/types';
+
+import { createRowDoc } from './test-helpers';
+
+jest.mock('@/utils/runtime-config', () => ({
+  getConfigValue: (_key: string, fallback: string) => fallback,
+}));
+
+describe('useMoveCardDispatch', () => {
+  it('transforms a lazy cell before writing the new board group value', () => {
+    const databaseId = 'database-id';
+    const viewId = 'view-id';
+    const fieldId = 'field-id';
+    const rowId = 'row-id';
+    const databaseDoc = new Y.Doc({ guid: databaseId }) as YDoc;
+    const root = databaseDoc.getMap(YjsEditorKey.data_section);
+    const database = new Y.Map() as YDatabase;
+    const fields = new Y.Map<YDatabaseField>() as YDatabaseFields;
+    const field = new Y.Map() as YDatabaseField;
+    const typeOptions = new Y.Map();
+    const selectOption = new Y.Map();
+    const views = new Y.Map<YDatabaseView>() as YDatabaseViews;
+    const view = new Y.Map() as YDatabaseView;
+    const rowOrders = new Y.Array<{ id: string; height: number }>();
+
+    selectOption.set(
+      YjsDatabaseKey.content,
+      JSON.stringify({
+        disable_color: false,
+        options: [
+          { id: 'alpha-id', name: 'Alpha', color: 'Purple' },
+          { id: 'beta-id', name: 'Beta', color: 'Pink' },
+          { id: 'gamma-id', name: 'Gamma', color: 'Orange' },
+        ],
+      })
+    );
+    typeOptions.set(String(FieldType.MultiSelect), selectOption);
+    field.set(YjsDatabaseKey.id, fieldId);
+    field.set(YjsDatabaseKey.type, FieldType.MultiSelect);
+    field.set(YjsDatabaseKey.type_option, typeOptions);
+    fields.set(fieldId, field);
+    rowOrders.push([{ id: rowId, height: 36 }]);
+    view.set(YjsDatabaseKey.row_orders, rowOrders);
+    views.set(viewId, view);
+    database.set(YjsDatabaseKey.id, databaseId);
+    database.set(YjsDatabaseKey.fields, fields);
+    database.set(YjsDatabaseKey.views, views);
+    root.set(YjsEditorKey.database, database);
+
+    const rowDoc = createRowDoc(rowId, databaseId, {
+      [fieldId]: { fieldType: FieldType.RichText, data: 'Alpha,Gamma' },
+    });
+    const contextValue = {
+      readOnly: false,
+      databaseDoc,
+      databasePageId: viewId,
+      activeViewId: viewId,
+      rowMap: { [rowId]: rowDoc },
+      workspaceId: 'workspace-id',
+    } as DatabaseContextState;
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <DatabaseContext.Provider value={contextValue}>{children}</DatabaseContext.Provider>
+    );
+    const { result } = renderHook(() => useMoveCardDispatch(), { wrapper });
+
+    act(() => {
+      result.current({
+        rowId,
+        fieldId,
+        startColumnId: 'alpha-id',
+        finishColumnId: 'beta-id',
+      });
+    });
+
+    const row = rowDoc.getMap(YjsEditorKey.data_section).get(YjsEditorKey.database_row) as YDatabaseRow;
+    const cell = row.get(YjsDatabaseKey.cells).get(fieldId);
+
+    expect(cell.get(YjsDatabaseKey.data)).toBe('beta-id,gamma-id');
+    expect(cell.get(YjsDatabaseKey.field_type)).toBe(FieldType.MultiSelect);
+    expect(cell.get(YjsDatabaseKey.source_field_type)).toBeUndefined();
+  });
+});

--- a/src/application/database-yjs/__tests__/useUpdateCellDispatch.test.tsx
+++ b/src/application/database-yjs/__tests__/useUpdateCellDispatch.test.tsx
@@ -100,6 +100,34 @@ describe('useUpdateCellDispatch', () => {
     });
     expect(ensureRow).toHaveBeenCalledWith(rowId);
   });
+
+  it('makes an edited lazy cell native to the current field type', async () => {
+    const databaseDoc = createDatabaseDoc();
+    const rowDoc = createRowDoc(rowId, databaseId, {
+      [fieldId]: { fieldType: FieldType.MultiSelect, data: 'opt-a,opt-b' },
+    });
+    const contextValue: DatabaseContextState = {
+      readOnly: false,
+      databaseDoc,
+      databasePageId: viewId,
+      activeViewId: viewId,
+      rowMap: { [rowId]: rowDoc },
+      workspaceId: 'workspace-id',
+    };
+    const { result } = renderHook(() => useUpdateCellDispatch(rowId, fieldId), {
+      wrapper: createWrapper(contextValue),
+    });
+
+    result.current('Edited value');
+
+    await waitFor(() => {
+      const cell = getCell(rowDoc);
+
+      expect(cell?.get(YjsDatabaseKey.data)).toBe('Edited value');
+      expect(cell?.get(YjsDatabaseKey.field_type)).toBe(FieldType.RichText);
+      expect(cell?.get(YjsDatabaseKey.source_field_type)).toBeUndefined();
+    });
+  });
 });
 
 describe('useUpdateStartEndTimeCell', () => {
@@ -152,6 +180,36 @@ describe('useUpdateStartEndTimeCell', () => {
 
     await waitFor(() => {
       expect(ensureRow).toHaveBeenCalledWith(rowId);
+    });
+  });
+
+  it('makes an updated converted cell native DateTime data', async () => {
+    const databaseDoc = createDatabaseDoc();
+    const rowDoc = createRowDoc(rowId, databaseId, {
+      [fieldId]: { fieldType: FieldType.RichText, data: 'old text' },
+    });
+    const cell = getCell(rowDoc);
+
+    cell?.set(YjsDatabaseKey.source_field_type, String(FieldType.MultiSelect));
+
+    const contextValue: DatabaseContextState = {
+      readOnly: false,
+      databaseDoc,
+      databasePageId: viewId,
+      activeViewId: viewId,
+      rowMap: { [rowId]: rowDoc },
+      workspaceId: 'workspace-id',
+    };
+    const { result } = renderHook(() => useUpdateStartEndTimeCell(), {
+      wrapper: createWrapper(contextValue),
+    });
+
+    result.current(rowId, fieldId, '100', '200', false);
+
+    await waitFor(() => {
+      expect(cell?.get(YjsDatabaseKey.data)).toBe('100');
+      expect(cell?.get(YjsDatabaseKey.field_type)).toBe(FieldType.DateTime);
+      expect(cell?.get(YjsDatabaseKey.source_field_type)).toBeUndefined();
     });
   });
 });

--- a/src/application/database-yjs/cell.clone.ts
+++ b/src/application/database-yjs/cell.clone.ts
@@ -1,0 +1,31 @@
+import dayjs from 'dayjs';
+import * as Y from 'yjs';
+
+import { getStoredCellFieldType, setCellStoredType } from '@/application/database-yjs/cell.field-type';
+import { FieldType } from '@/application/database-yjs/database.type';
+import { YDatabaseCell, YjsDatabaseKey } from '@/application/types';
+
+/** Clone raw cell data without changing the format that cell.field_type describes. */
+export function cloneDatabaseCell(fieldType: FieldType, referenceCell?: YDatabaseCell): YDatabaseCell {
+  const cell = new Y.Map() as YDatabaseCell;
+
+  referenceCell?.forEach((value, key) => {
+    let newValue = value;
+
+    if (typeof value === 'bigint') {
+      newValue = value.toString();
+    } else if (value instanceof Y.Array) {
+      newValue = value.clone();
+    }
+
+    cell.set(key, newValue);
+  });
+
+  const storedType = referenceCell ? getStoredCellFieldType(referenceCell, fieldType) : fieldType;
+
+  setCellStoredType(cell, storedType);
+  cell.set(YjsDatabaseKey.last_modified, String(dayjs().unix()));
+  cell.set(YjsDatabaseKey.created_at, String(dayjs().unix()));
+
+  return cell;
+}

--- a/src/application/database-yjs/cell.field-type.ts
+++ b/src/application/database-yjs/cell.field-type.ts
@@ -1,0 +1,135 @@
+import * as Y from 'yjs';
+
+import { FieldType } from '@/application/database-yjs/database.type';
+import { YDatabaseCell, YDatabaseField, YDatabaseRow, YDoc, YjsDatabaseKey, YjsEditorKey } from '@/application/types';
+
+export type CellFieldTypeContext = {
+  storedType: FieldType;
+  targetType: FieldType;
+};
+
+function parseFieldType(value: unknown): FieldType | undefined {
+  const fieldType = Number(value);
+
+  if (!Number.isInteger(fieldType) || FieldType[fieldType] === undefined) {
+    return undefined;
+  }
+
+  return fieldType as FieldType;
+}
+
+/**
+ * Returns the type that describes the cell's raw data encoding.
+ *
+ * `fallbackType` mirrors Desktop's behavior for old cells that do not contain
+ * field_type: the reader treats them as native to the field being read.
+ */
+export function getStoredCellFieldType(cell: YDatabaseCell, fallbackType: FieldType = FieldType.RichText): FieldType {
+  return (
+    parseFieldType(cell.get(YjsDatabaseKey.source_field_type)) ??
+    parseFieldType(cell.get(YjsDatabaseKey.field_type)) ??
+    fallbackType
+  );
+}
+
+/**
+ * A cell's field_type describes the format of its raw data. The field's type
+ * describes how that data should currently be presented and edited.
+ *
+ * Older Web clients overwrote cell.field_type during a field switch and kept
+ * the actual storage type in source_field_type. Prefer that legacy marker when
+ * present so those cells remain readable while new writes use Desktop's model.
+ */
+export function getCellFieldTypeContext(cell: YDatabaseCell, field?: YDatabaseField): CellFieldTypeContext {
+  const cellType = parseFieldType(cell.get(YjsDatabaseKey.field_type));
+  const targetType = parseFieldType(field?.get(YjsDatabaseKey.type)) ?? cellType ?? FieldType.RichText;
+  const storedType = getStoredCellFieldType(cell, targetType);
+
+  return { storedType, targetType };
+}
+
+/** Mark newly written data as native to the current field type. */
+export function setCellStoredType(cell: YDatabaseCell, fieldType: FieldType): void {
+  cell.set(YjsDatabaseKey.field_type, fieldType);
+  cell.delete(YjsDatabaseKey.source_field_type);
+}
+
+/**
+ * Convert an older Web cell to the canonical Desktop representation without
+ * touching its raw data. Invalid legacy metadata is left intact rather than
+ * guessing at the data format.
+ */
+export function normalizeLegacyCellFieldType(cell: YDatabaseCell): boolean {
+  const sourceType = parseFieldType(cell.get(YjsDatabaseKey.source_field_type));
+
+  if (sourceType !== undefined) {
+    cell.set(YjsDatabaseKey.field_type, sourceType);
+    cell.delete(YjsDatabaseKey.source_field_type);
+    return true;
+  }
+
+  const rawFieldType = cell.get(YjsDatabaseKey.field_type);
+  const fieldType = parseFieldType(rawFieldType);
+
+  // Older Web writers stored this enum as a Yjs string. Desktop reads it as
+  // i64, so canonicalize the representation even when no legacy source marker
+  // is present.
+  if (fieldType === undefined || typeof rawFieldType !== 'string') return false;
+
+  cell.set(YjsDatabaseKey.field_type, fieldType);
+  return true;
+}
+
+/** Normalize every cell in a row without changing any cell payload. */
+export function normalizeLegacyRowCellFieldTypes(rowDoc: YDoc): boolean {
+  const root = rowDoc.getMap(YjsEditorKey.data_section);
+  const row = root.get(YjsEditorKey.database_row) as YDatabaseRow | undefined;
+  const cells = row?.get(YjsDatabaseKey.cells);
+
+  if (!cells) return false;
+
+  let changed = false;
+
+  rowDoc.transact(() => {
+    cells.forEach((cell) => {
+      changed = normalizeLegacyCellFieldType(cell as YDatabaseCell) || changed;
+    });
+  });
+
+  return changed;
+}
+
+const normalizedRowDocs = new WeakSet<YDoc>();
+
+/**
+ * Keep a loaded row canonical while older Web clients may still sync the
+ * retired source_field_type representation during the rollout.
+ */
+export function installLegacyCellFieldTypeNormalizer(rowDoc: YDoc): void {
+  if (normalizedRowDocs.has(rowDoc)) return;
+  normalizedRowDocs.add(rowDoc);
+
+  const root = rowDoc.getMap(YjsEditorKey.data_section);
+  let normalizing = false;
+  const normalize = (events?: Y.YEvent[]) => {
+    const metadataChanged = events?.some(
+      (event) =>
+        event.path.length < 3 ||
+        event.keys.has(YjsDatabaseKey.field_type) ||
+        event.keys.has(YjsDatabaseKey.source_field_type)
+    );
+
+    if (events && !metadataChanged) return;
+    if (normalizing) return;
+
+    normalizing = true;
+    try {
+      normalizeLegacyRowCellFieldTypes(rowDoc);
+    } finally {
+      normalizing = false;
+    }
+  };
+
+  root.observeDeep(normalize);
+  normalize();
+}

--- a/src/application/database-yjs/cell.parse.ts
+++ b/src/application/database-yjs/cell.parse.ts
@@ -1,44 +1,58 @@
+import dayjs from 'dayjs';
 import * as Y from 'yjs';
 
 import { FieldType } from '@/application/database-yjs/database.type';
 import {
   ChecklistCellData,
   SelectOption,
+  SelectOptionColor,
   generateOptionId,
   getDateCellStr,
+  parseChecklistData,
+  parseDesktopChecklistText,
+  parseDesktopDateToUnixSeconds,
   parseChecklistFlexible,
   parseSelectOptionTypeOptions,
-  safeParseTimestamp,
   stringifyChecklist,
 } from '@/application/database-yjs/fields';
-import { parseCheckboxValue, parseTimeStringToMs } from '@/application/database-yjs/fields/text/utils';
+import {
+  parseDesktopNumberValue,
+  parseNumberTypeOptions,
+  stringifyDesktopNumberValue,
+} from '@/application/database-yjs/fields/number/parse';
+import {
+  parseCheckboxValue,
+  parseDesktopCheckboxValue,
+  parseDesktopI64,
+  parseTimeStringToMs,
+} from '@/application/database-yjs/fields/text/utils';
 import { User, YDatabaseCell, YDatabaseField, YjsDatabaseKey } from '@/application/types';
 
+import { getCellFieldTypeContext } from './cell.field-type';
 import { Cell, DateTimeCell, FileMediaCell, FileMediaCellData } from './cell.type';
 
-export function parseYDatabaseCommonCellToCell(cell: YDatabaseCell): Cell {
+export function parseYDatabaseCommonCellToCell(cell: YDatabaseCell, fieldType?: FieldType): Cell {
   return {
     createdAt: Number(cell.get(YjsDatabaseKey.created_at)),
     lastModified: Number(cell.get(YjsDatabaseKey.last_modified)),
-    fieldType: parseInt(cell.get(YjsDatabaseKey.field_type)) as FieldType,
+    fieldType: fieldType ?? getCellFieldTypeContext(cell).targetType,
     data: cell.get(YjsDatabaseKey.data),
   };
 }
 
 export function parseYDatabaseCellToCell(cell: YDatabaseCell, field?: YDatabaseField): Cell {
-  const cellType = parseInt(cell.get(YjsDatabaseKey.field_type));
-  const sourceType = Number(
-    cell.get(YjsDatabaseKey.source_field_type) ?? cellType
-  ) as FieldType;
+  const { storedType, targetType } = getCellFieldTypeContext(cell, field);
 
-  let value = parseYDatabaseCommonCellToCell(cell);
+  let value = parseYDatabaseCommonCellToCell(cell, targetType);
 
-  if (sourceType !== cellType) {
-    value.data = transformCellData(cell, sourceType, cellType, field);
+  if (storedType !== targetType) {
+    value.data = isCellDataTransformable(storedType, targetType)
+      ? transformCellData(cell, storedType, targetType, field)
+      : '';
   }
 
-  if (cellType === FieldType.DateTime) {
-    if (sourceType !== FieldType.DateTime) {
+  if (targetType === FieldType.DateTime) {
+    if (storedType !== FieldType.DateTime) {
       value = {
         ...value,
         fieldType: FieldType.DateTime,
@@ -53,15 +67,58 @@ export function parseYDatabaseCellToCell(cell: YDatabaseCell, field?: YDatabaseF
     }
   }
 
-  if (cellType === FieldType.Media) {
-    value = parseYDatabaseFileMediaCellToCell(cell);
+  if (targetType === FieldType.Media) {
+    value =
+      storedType === FieldType.Media
+        ? parseYDatabaseFileMediaCellToCell(cell)
+        : ({ ...value, fieldType: FieldType.Media, data: [] } as FileMediaCell);
   }
 
-  if (cellType === FieldType.Relation) {
-    value = parseYDatabaseRelationCellToCell(cell);
+  if (targetType === FieldType.Relation) {
+    value =
+      storedType === FieldType.Relation
+        ? parseYDatabaseRelationCellToCell(cell)
+        : { ...value, fieldType: FieldType.Relation, data: null };
   }
 
   return value;
+}
+
+/** Direct lazy conversions supported by Desktop's type-option decoder. */
+export function isCellDataTransformable(sourceType: FieldType, targetType: FieldType): boolean {
+  if (sourceType === targetType || targetType === FieldType.RichText) return true;
+
+  if (sourceType === FieldType.RichText) {
+    return [
+      FieldType.SingleSelect,
+      FieldType.MultiSelect,
+      FieldType.URL,
+      FieldType.Number,
+      FieldType.DateTime,
+      FieldType.Time,
+      FieldType.Checklist,
+      FieldType.Checkbox,
+    ].includes(targetType);
+  }
+
+  if (sourceType === FieldType.Checkbox) {
+    return targetType === FieldType.SingleSelect || targetType === FieldType.MultiSelect;
+  }
+
+  if (sourceType === FieldType.SingleSelect || sourceType === FieldType.MultiSelect) {
+    return (
+      targetType === FieldType.SingleSelect || targetType === FieldType.MultiSelect || targetType === FieldType.Checklist
+    );
+  }
+
+  if (sourceType === FieldType.Checklist) {
+    return targetType === FieldType.SingleSelect || targetType === FieldType.MultiSelect;
+  }
+
+  return (
+    (sourceType === FieldType.CreatedTime || sourceType === FieldType.LastEditedTime) &&
+    targetType === FieldType.DateTime
+  );
 }
 
 function transformCellData(
@@ -81,33 +138,45 @@ function transformCellData(
     case FieldType.Checklist: {
       if (typeof data !== 'string') return '';
       if (sourceType === FieldType.RichText) {
-        const parsed = parseChecklistFlexible(data);
-
-        if (!parsed) return '';
+        const parsed = parseDesktopChecklistText(data);
 
         return stringifyChecklistStruct(parsed);
       }
 
-      if (
-        (sourceType === FieldType.SingleSelect || sourceType === FieldType.MultiSelect) &&
-        field
-      ) {
+      if ((sourceType === FieldType.SingleSelect || sourceType === FieldType.MultiSelect) && field) {
         // Resolve options by the source select type — the field's current type
         // is Checklist here, so its own type-option holds no select options.
         const typeOption = parseSelectOptionTypeOptions(field, sourceType);
         const options = typeOption?.options || [];
-        const selectedIds = data.split(',');
+        const selectedIds = new Set(data.split(',').filter(Boolean));
         const checklistOptions: SelectOption[] = [];
         const checklistSelectedIds: string[] = [];
 
         options.forEach((opt) => {
-          const newOpt = { ...opt, id: generateOptionId() };
+          const newOpt = {
+            id: generateOptionId(),
+            name: opt.name,
+            color: SelectOptionColor.OptionColor1,
+          };
 
           checklistOptions.push(newOpt);
-          if (selectedIds.includes(opt.id)) {
+          if (selectedIds.has(opt.id)) {
             checklistSelectedIds.push(newOpt.id);
           }
         });
+
+        if (options.length === 0) {
+          selectedIds.forEach((id) => {
+            const option: SelectOption = {
+              id: generateOptionId(),
+              name: id,
+              color: SelectOptionColor.OptionColor1,
+            };
+
+            checklistOptions.push(option);
+            checklistSelectedIds.push(option.id);
+          });
+        }
 
         return JSON.stringify({
           options: checklistOptions,
@@ -134,7 +203,7 @@ function transformCellData(
       const options = typeOption?.options || [];
 
       if (sourceType === FieldType.Checklist && typeof data === 'string') {
-        const checklist = parseChecklistFlexible(data);
+        const checklist = parseChecklistData(data);
 
         if (!checklist) return '';
         const selectedIds: string[] = [];
@@ -151,16 +220,23 @@ function transformCellData(
 
       if (sourceType === FieldType.RichText && typeof data === 'string') {
         const names = data.split(',').map((s) => s.trim());
-        const ids = names
-          .map((name) => options.find((o) => o.name === name)?.id)
-          .filter(Boolean);
+        const ids = names.map((name) => options.find((o) => o.name === name)?.id).filter(Boolean);
+
+        if (ids.length === 0) {
+          const exactMatch = options.find((option) => option.name === data);
+
+          if (exactMatch) ids.push(exactMatch.id);
+        }
 
         return ids.join(',');
       }
 
       // Checkbox → SingleSelect/MultiSelect: map "Yes"/"No" to option IDs
-      if (sourceType === FieldType.Checkbox && (typeof data === 'string' || typeof data === 'number' || typeof data === 'boolean')) {
-        const isChecked = parseCheckboxValue(data);
+      if (
+        sourceType === FieldType.Checkbox &&
+        (typeof data === 'string' || typeof data === 'number' || typeof data === 'boolean')
+      ) {
+        const isChecked = parseDesktopCheckboxValue(data);
         const targetName = isChecked ? 'Yes' : 'No';
         const matchingOption = options.find((o) => o.name === targetName);
 
@@ -172,7 +248,7 @@ function transformCellData(
 
     case FieldType.Number:
       if (typeof data === 'string' || typeof data === 'number') {
-        return String(data);
+        return parseDesktopNumberValue(data, field ? parseNumberTypeOptions(field).format : 0);
       }
 
       return '';
@@ -180,21 +256,23 @@ function transformCellData(
     case FieldType.DateTime: {
       // text -> DateTime: parse a free-text date into a unix timestamp in
       // SECONDS (desktop parity: cast_string_to_timestamp). A materialized
-      // Created/LastEditedTime timestamp (numeric seconds/ms) normalizes through
-      // safeParseTimestamp to seconds as well.
+      // Created/LastEditedTime timestamp keeps Desktop's direct i64 value.
       if (typeof data !== 'string' && typeof data !== 'number') return '';
-      const raw = String(data).trim();
+      const raw = String(data);
 
       if (!raw) return '';
-      const parsed = safeParseTimestamp(raw);
+      const parsed =
+        sourceType === FieldType.CreatedTime || sourceType === FieldType.LastEditedTime
+          ? parseDesktopI64(raw)
+          : parseDesktopDateToUnixSeconds(raw);
 
-      return parsed.isValid() ? String(parsed.unix()) : '';
+      return parsed ?? '';
     }
 
     case FieldType.Checkbox:
       if (sourceType === FieldType.RichText) {
         if (typeof data === 'string' || typeof data === 'number' || typeof data === 'boolean') {
-          return parseCheckboxValue(data) ? 'Yes' : 'No';
+          return parseDesktopCheckboxValue(data) ? 'Yes' : 'No';
         }
 
         return '';
@@ -299,31 +377,16 @@ export function parseYDatabaseRelationCellToCell(cell: YDatabaseCell): Cell {
 }
 
 export function getCellDataText(cell: YDatabaseCell, field: YDatabaseField, currentUser?: User): string {
-  const type = parseInt(field.get(YjsDatabaseKey.type));
-  const sourceType = Number(
-    cell.get(YjsDatabaseKey.source_field_type) ?? cell.get(YjsDatabaseKey.field_type)
-  ) as FieldType;
+  const { targetType: type } = getCellFieldTypeContext(cell, field);
+  const parsedCell = parseYDatabaseCellToCell(cell, field);
+  const data = parsedCell.data;
 
   switch (type) {
     case FieldType.SingleSelect:
     case FieldType.MultiSelect: {
-      const data = cell.get(YjsDatabaseKey.data);
       const options = parseSelectOptionTypeOptions(field)?.options || [];
 
       if (typeof data === 'string') {
-        // If the data came from a checklist, map checked items to option names
-        const checklist = parseChecklistFlexible(data);
-
-        if (checklist && sourceType === FieldType.Checklist) {
-          const selectedNames = checklist.selectedOptionIds
-            ?.map((id) => options.find((opt) => opt.id === id || opt.name === id)?.name)
-            .filter(Boolean);
-
-          if (selectedNames?.length) {
-            return selectedNames.join(',');
-          }
-        }
-
         return (
           data
             .split(',')
@@ -341,10 +404,8 @@ export function getCellDataText(cell: YDatabaseCell, field: YDatabaseField, curr
     }
 
     case FieldType.Checklist: {
-      const cellData = cell.get(YjsDatabaseKey.data);
-
-      if (typeof cellData === 'string') {
-        const parsed = parseChecklistFlexible(cellData);
+      if (typeof data === 'string') {
+        const parsed = parseChecklistFlexible(data);
 
         if (!parsed) return '';
         return stringifyChecklist(parsed.options || [], parsed.selectedOptionIds || []);
@@ -354,8 +415,6 @@ export function getCellDataText(cell: YDatabaseCell, field: YDatabaseField, curr
     }
 
     case FieldType.Checkbox: {
-      const data = cell.get(YjsDatabaseKey.data);
-
       if (typeof data === 'string' || typeof data === 'number' || typeof data === 'boolean') {
         const isChecked = parseCheckboxValue(data);
 
@@ -366,8 +425,6 @@ export function getCellDataText(cell: YDatabaseCell, field: YDatabaseField, curr
     }
 
     case FieldType.Time: {
-      const data = cell.get(YjsDatabaseKey.data);
-
       if (data === undefined || data === null) return '';
 
       if (typeof data === 'number') {
@@ -384,8 +441,6 @@ export function getCellDataText(cell: YDatabaseCell, field: YDatabaseField, curr
     }
 
     case FieldType.URL: {
-      const data = cell.get(YjsDatabaseKey.data);
-
       if (typeof data === 'string' || typeof data === 'number') {
         return String(data).trim();
       }
@@ -394,9 +449,7 @@ export function getCellDataText(cell: YDatabaseCell, field: YDatabaseField, curr
     }
 
     case FieldType.DateTime: {
-      const dateCell = parseYDatabaseDateTimeCellToCell(cell);
-
-      return getDateCellStr({ cell: dateCell, field, currentUser });
+      return getDateCellStr({ cell: parsedCell as DateTimeCell, field, currentUser });
     }
 
     case FieldType.CreatedTime:
@@ -405,14 +458,7 @@ export function getCellDataText(cell: YDatabaseCell, field: YDatabaseField, curr
       return '';
 
     default: {
-      const data = cell.get(YjsDatabaseKey.data);
-
       if (typeof data === 'string' || typeof data === 'number') {
-        // When displaying as RichText but source is another type, fall back to source-aware stringify
-        if (type === FieldType.RichText && sourceType !== type) {
-          return stringifyFromSource(cell, field, sourceType, currentUser);
-        }
-
         return String(data);
       }
 
@@ -431,7 +477,8 @@ function stringifyFromSource(
 
   switch (sourceType) {
     case FieldType.Number:
-      return typeof data === 'number' || typeof data === 'string' ? String(data) : '';
+      if (typeof data !== 'number' && typeof data !== 'string') return '';
+      return stringifyDesktopNumberValue(data, field ? parseNumberTypeOptions(field, FieldType.Number).format : 0);
     case FieldType.DateTime: {
       const dateCell = parseYDatabaseDateTimeCellToCell(cell);
 
@@ -459,23 +506,22 @@ function stringifyFromSource(
 
     case FieldType.Checkbox:
       if (typeof data === 'string' || typeof data === 'number' || typeof data === 'boolean') {
-        return parseCheckboxValue(data) ? 'Yes' : 'No';
+        return parseDesktopCheckboxValue(data) ? 'Yes' : 'No';
       }
 
       return '';
     case FieldType.Time:
-      if (typeof data === 'number') return String(data);
-      if (typeof data === 'string') return parseTimeStringToMs(data) ?? data;
+      if (typeof data === 'number' || typeof data === 'string') return parseDesktopI64(data) ?? '';
       return '';
     case FieldType.URL:
       if (typeof data === 'string' || typeof data === 'number') {
-        return String(data).trim();
+        return String(data);
       }
 
       return '';
     case FieldType.Checklist: {
       if (typeof data === 'string') {
-        const parsed = parseChecklistFlexible(data);
+        const parsed = parseChecklistData(data);
 
         if (!parsed) return '';
 
@@ -484,6 +530,38 @@ function stringifyFromSource(
 
       return '';
     }
+
+    case FieldType.CreatedTime:
+    case FieldType.LastEditedTime: {
+      if (typeof data !== 'string' && typeof data !== 'number') return '';
+      const parsedTimestamp = parseDesktopI64(data);
+
+      if (parsedTimestamp === null) return '';
+      return dayjs.unix(Number(parsedTimestamp)).format('MMM DD, YYYY HH:mm');
+    }
+
+    case FieldType.Media: {
+      if (!(data instanceof Y.Array)) return '';
+
+      return data
+        .toArray()
+        .map((item) => {
+          if (typeof item !== 'string') return '';
+          try {
+            const file = JSON.parse(item) as { name?: unknown };
+
+            return typeof file.name === 'string' ? file.name : '';
+          } catch {
+            return '';
+          }
+        })
+        .join(', ');
+    }
+
+    case FieldType.Relation:
+    case FieldType.Person:
+    case FieldType.Rollup:
+      return '';
 
     default:
       return typeof data === 'string' || typeof data === 'number' ? String(data) : '';

--- a/src/application/database-yjs/condition-value-cache.ts
+++ b/src/application/database-yjs/condition-value-cache.ts
@@ -1,6 +1,7 @@
-import { parseYDatabaseDateTimeCellToCell } from '@/application/database-yjs/cell.parse';
+import { parseYDatabaseCellToCell } from '@/application/database-yjs/cell.parse';
 import { DateTimeCell } from '@/application/database-yjs/cell.type';
 import { decodeCellForSort, decodeCellToText } from '@/application/database-yjs/decode';
+import { getRelationRowIdsFromCell } from '@/application/database-yjs/relation/cell';
 import {
   FieldId,
   YDatabaseCell,
@@ -129,19 +130,23 @@ export function invalidateRowConditionCache(rowDoc?: YDoc | null) {
   rowConditionCache.delete(rowDoc);
 }
 
-export function getConditionCellData(snapshot: RowConditionSnapshot, fieldId: FieldId) {
+export function getConditionCellData(snapshot: RowConditionSnapshot, fieldId: FieldId, field: YDatabaseField) {
   const cell = getSnapshotCell(snapshot, fieldId);
-  const revision = getCellRevision(cell);
+  const revision = `${getFieldCacheKey(fieldId, field)}:${getCellRevision(cell)}`;
   const cached = snapshot.cellDataByField.get(fieldId);
 
   if (cached?.revision === revision) {
     return cached.value;
   }
 
-  const data = cell?.get(YjsDatabaseKey.data);
+  const data = cell ? parseYDatabaseCellToCell(cell, field).data : undefined;
 
   snapshot.cellDataByField.set(fieldId, { revision, value: data });
   return data;
+}
+
+export function getConditionRelationRowIds(snapshot: RowConditionSnapshot, fieldId: FieldId) {
+  return getRelationRowIdsFromCell(getSnapshotCell(snapshot, fieldId));
 }
 
 export function getConditionCellText(snapshot: RowConditionSnapshot, fieldId: FieldId, field: YDatabaseField) {
@@ -172,16 +177,16 @@ export function getConditionSortValue(snapshot: RowConditionSnapshot, fieldId: F
   return value;
 }
 
-export function getConditionDateCell(snapshot: RowConditionSnapshot, fieldId: FieldId) {
+export function getConditionDateCell(snapshot: RowConditionSnapshot, fieldId: FieldId, field: YDatabaseField) {
   const cell = getSnapshotCell(snapshot, fieldId);
-  const revision = getCellRevision(cell);
+  const revision = `${getFieldCacheKey(fieldId, field)}:${getCellRevision(cell)}`;
   const cached = snapshot.dateCellByField.get(fieldId);
 
   if (cached?.revision === revision) {
     return cached.value;
   }
 
-  const value = cell ? parseYDatabaseDateTimeCellToCell(cell) : null;
+  const value = cell ? (parseYDatabaseCellToCell(cell, field) as DateTimeCell) : null;
 
   snapshot.dateCellByField.set(fieldId, { revision, value });
   return value;

--- a/src/application/database-yjs/decode.ts
+++ b/src/application/database-yjs/decode.ts
@@ -1,38 +1,28 @@
-import { parseYDatabaseDateTimeCellToCell } from '@/application/database-yjs/cell.parse';
+import { getCellFieldTypeContext } from '@/application/database-yjs/cell.field-type';
+import { isCellDataTransformable, parseYDatabaseCellToCell } from '@/application/database-yjs/cell.parse';
+import { DateTimeCell } from '@/application/database-yjs/cell.type';
 import { FieldType } from '@/application/database-yjs/database.type';
-import { parseChecklistFlexible, parseSelectOptionTypeOptions, stringifyChecklist } from '@/application/database-yjs/fields';
+import {
+  parseChecklistFlexible,
+  parseSelectOptionTypeOptions,
+  stringifyChecklist,
+} from '@/application/database-yjs/fields';
 import { getDateCellStr } from '@/application/database-yjs/fields/date/utils';
 import { parseTimeStringToMs, parseCheckboxValue } from '@/application/database-yjs/fields/text/utils';
-import { User, YDatabaseCell, YDatabaseField, YjsDatabaseKey } from '@/application/types';
+import { getRelationRowIdsFromCell } from '@/application/database-yjs/relation/cell';
+import { User, YDatabaseCell, YDatabaseField } from '@/application/types';
 
 /**
  * Decode a cell to a string representation for rendering/filtering/sorting,
  * using the cell's recorded source type when it differs from the field's current type.
  */
-export function decodeCellToText(
-  cell: YDatabaseCell,
-  field: YDatabaseField,
-  currentUser?: User
-): string {
-  const targetType = Number(field.get(YjsDatabaseKey.type)) as FieldType;
-  const sourceType = Number(cell.get(YjsDatabaseKey.source_field_type) ?? cell.get(YjsDatabaseKey.field_type)) as FieldType;
-  const data = cell.get(YjsDatabaseKey.data);
+export function decodeCellToText(cell: YDatabaseCell, field: YDatabaseField, currentUser?: User): string {
+  const { storedType, targetType } = getCellFieldTypeContext(cell, field);
 
-  // If types match and data is string/number, return raw string. Skip the
-  // fast-path for select/checklist: their cell data stores option IDs, but
-  // for rendering / filtering we need the option names.
-  const needsOptionResolution =
-    targetType === FieldType.SingleSelect ||
-    targetType === FieldType.MultiSelect ||
-    targetType === FieldType.Checklist;
+  if (storedType !== targetType && !isCellDataTransformable(storedType, targetType)) return '';
 
-  if (
-    sourceType === targetType &&
-    !needsOptionResolution &&
-    (typeof data === 'string' || typeof data === 'number')
-  ) {
-    return String(data);
-  }
+  const parsedCell = parseYDatabaseCellToCell(cell, field);
+  const data = parsedCell.data;
 
   switch (targetType) {
     case FieldType.Checkbox:
@@ -63,16 +53,6 @@ export function decodeCellToText(
     case FieldType.MultiSelect: {
       if (typeof data !== 'string') return '';
       const options = parseSelectOptionTypeOptions(field)?.options || [];
-      // If source was checklist, map selected IDs->names
-      const checklist = parseChecklistFlexible(data);
-
-      if (checklist && sourceType === FieldType.Checklist) {
-        const names = checklist.selectedOptionIds
-          ?.map((id) => options.find((opt) => opt.id === id || opt.name === id)?.name)
-          .filter(Boolean);
-
-        if (names?.length) return names.join(',');
-      }
 
       return data
         .split(',')
@@ -82,20 +62,11 @@ export function decodeCellToText(
     }
 
     case FieldType.DateTime: {
-      const dateCell = parseYDatabaseDateTimeCellToCell(cell);
-
-      return getDateCellStr({ cell: dateCell, field, currentUser });
+      return getDateCellStr({ cell: parsedCell as DateTimeCell, field, currentUser });
     }
 
-    case FieldType.Relation: {
-      if (data && typeof data === 'object' && 'toJSON' in data) {
-        const ids = (data as { toJSON: () => unknown }).toJSON();
-
-        return Array.isArray(ids) ? ids.join(',') : '';
-      }
-
-      return Array.isArray(data) ? data.join(',') : '';
-    }
+    case FieldType.Relation:
+      return getRelationRowIdsFromCell(cell).join(',');
 
     default:
       return typeof data === 'string' || typeof data === 'number' ? String(data) : '';
@@ -110,20 +81,15 @@ export function decodeCellForSort(
   field: YDatabaseField,
   currentUser?: User
 ): string | number | boolean {
-  const targetType = Number(field.get(YjsDatabaseKey.type)) as FieldType;
-  const sourceType = Number(cell.get(YjsDatabaseKey.source_field_type) ?? cell.get(YjsDatabaseKey.field_type)) as FieldType;
-  const data = cell.get(YjsDatabaseKey.data);
+  const { storedType, targetType } = getCellFieldTypeContext(cell, field);
+
+  if (storedType !== targetType && !isCellDataTransformable(storedType, targetType)) return '';
+
+  const data = parseYDatabaseCellToCell(cell, field).data;
 
   switch (targetType) {
-    case FieldType.Relation: {
-      if (data && typeof data === 'object' && 'toJSON' in data) {
-        const ids = (data as { toJSON: () => unknown }).toJSON();
-
-        return Array.isArray(ids) ? ids.join(',') : '';
-      }
-
-      return Array.isArray(data) ? data.join(',') : '';
-    }
+    case FieldType.Relation:
+      return getRelationRowIdsFromCell(cell).join(',');
 
     case FieldType.Checkbox:
       if (typeof data === 'string' || typeof data === 'number' || typeof data === 'boolean') {
@@ -156,18 +122,6 @@ export function decodeCellForSort(
     case FieldType.MultiSelect: {
       if (typeof data !== 'string') return '';
       const options = parseSelectOptionTypeOptions(field)?.options || [];
-
-      // For checklist source, use selected names
-      if (sourceType === FieldType.Checklist) {
-        const checklist = parseChecklistFlexible(data);
-
-        if (checklist) {
-          return checklist.selectedOptionIds
-            ?.map((id) => options.find((opt) => opt.id === id || opt.name === id)?.name)
-            .filter(Boolean)
-            .join(',') ?? '';
-        }
-      }
 
       return data
         .split(',')

--- a/src/application/database-yjs/dispatch.ts
+++ b/src/application/database-yjs/dispatch.ts
@@ -4,6 +4,9 @@ import { useCallback, useMemo } from 'react';
 import * as Y from 'yjs';
 
 import { calculateFieldValue } from '@/application/database-yjs/calculation';
+import { cloneDatabaseCell } from '@/application/database-yjs/cell.clone';
+import { normalizeLegacyCellFieldType, setCellStoredType } from '@/application/database-yjs/cell.field-type';
+import { parseYDatabaseCellToCell } from '@/application/database-yjs/cell.parse';
 import {
   useDatabase,
   useDatabaseContext,
@@ -29,7 +32,15 @@ import {
 } from '@/application/database-yjs/database.type';
 import { deleteReciprocalRelationField } from '@/application/database-yjs/dispatch/relation';
 import { useNewRowDispatch } from '@/application/database-yjs/dispatch/row';
-import { getFieldName, NumberFormat, parseSelectOptionTypeOptions, SelectOption, SelectOptionColor, SelectTypeOption } from '@/application/database-yjs/fields';
+import {
+  getFieldName,
+  NumberFormat,
+  parseChecklistData,
+  parseSelectOptionTypeOptions,
+  SelectOption,
+  SelectOptionColor,
+  SelectTypeOption,
+} from '@/application/database-yjs/fields';
 import { createCheckboxCell } from '@/application/database-yjs/fields/checkbox/utils';
 import { parseRelationTypeOption } from '@/application/database-yjs/fields/relation/parse';
 import { createRelationField } from '@/application/database-yjs/fields/relation/utils';
@@ -39,6 +50,7 @@ import { createDateTimeField } from '@/application/database-yjs/fields/text/util
 import { getDefaultFilterCondition } from '@/application/database-yjs/filter';
 import { DEFAULT_FIELD_WRAP } from '@/application/database-yjs/const';
 import { getOptionsFromRow } from '@/application/database-yjs/row';
+import { waitForDatabaseRowHydration } from '@/application/database-yjs/row.hydration';
 import { getMetaIdMap } from '@/application/database-yjs/row_meta';
 import { useBoardLayoutSettings, useCalendarLayoutSetting, useFieldType } from '@/application/database-yjs/selector';
 import { deleteCollabDB } from '@/application/db';
@@ -48,6 +60,7 @@ import {
   DatabaseViewLayout,
   DateFormat,
   FieldId,
+  RowId,
   TimeFormat,
   UpdatePagePayload,
   View,
@@ -74,6 +87,7 @@ import {
   YDatabaseSort,
   YDatabaseSorts,
   YDatabaseView,
+  YDoc,
   YjsDatabaseKey,
   YjsEditorKey,
   YMapFieldTypeOption,
@@ -613,6 +627,10 @@ export function useMoveCardDispatch() {
 
             const field = database.get(YjsDatabaseKey.fields)?.get(fieldId);
 
+            if (!field) {
+              throw new Error(`Field not found`);
+            }
+
             const fieldType = Number(field.get(YjsDatabaseKey.type));
 
             const rowDoc = rowMap?.[rowId];
@@ -638,7 +656,7 @@ export function useMoveCardDispatch() {
 
               cells.set(fieldId, cell);
             } else {
-              const cellData = cell.get(YjsDatabaseKey.data);
+              const cellData = parseYDatabaseCellToCell(cell, field).data;
               let newCellData = cellData;
 
               if (isSelectOptionField) {
@@ -658,6 +676,9 @@ export function useMoveCardDispatch() {
               }
 
               cell.set(YjsDatabaseKey.data, newCellData);
+              setCellStoredType(cell, fieldType);
+              cell.set(YjsDatabaseKey.last_modified, String(dayjs().unix()));
+              row.set(YjsDatabaseKey.last_modified, String(dayjs().unix()));
             }
 
             reorderRow(rowId, beforeRowId, view);
@@ -884,10 +905,7 @@ export function useUpdatePropertyNameDispatch(fieldId: string) {
 }
 
 function createField(type: FieldType, fieldId: string) {
-  const createSimpleField = (
-    fieldType: FieldType,
-    initTypeOption?: (typeOption: YMapFieldTypeOption) => void
-  ) => {
+  const createSimpleField = (fieldType: FieldType, initTypeOption?: (typeOption: YMapFieldTypeOption) => void) => {
     const field = new Y.Map() as YDatabaseField;
     const typeOptionMap = new Y.Map() as YDatabaseFieldTypeOption;
     const typeOption = new Y.Map() as YMapFieldTypeOption;
@@ -1249,7 +1267,7 @@ export function useCreateCalendarEvent() {
         }
 
         return fieldOrders.toArray().some((fieldOrder) => fieldOrder.id === calendarSetting.fieldId);
-      }
+      };
 
       let finalFieldId = calendarSetting?.fieldId;
 
@@ -1289,28 +1307,6 @@ export function useCreateCalendarEvent() {
     },
     [newRowDispatch, currentView, defaultTimeSetting, enhanceCalendarLayoutByFieldExists, calendarSetting]
   );
-}
-
-function cloneCell(fieldType: FieldType, referenceCell?: YDatabaseCell) {
-  const cell = new Y.Map() as YDatabaseCell;
-
-  referenceCell?.forEach((value, key) => {
-    let newValue = value;
-
-    if (typeof value === 'bigint') {
-      newValue = value.toString();
-    } else if (value instanceof Y.Array) {
-      newValue = value.clone();
-    }
-
-    cell.set(key, newValue);
-  });
-
-  cell.set(YjsDatabaseKey.last_modified, String(dayjs().unix()));
-  cell.set(YjsDatabaseKey.created_at, String(dayjs().unix()));
-  cell.set(YjsDatabaseKey.field_type, fieldType);
-
-  return cell;
 }
 
 // Re-export from the extracted dispatch module.
@@ -1557,18 +1553,19 @@ export function useDuplicatePropertyDispatch() {
 
             if (fieldTypeOptionMap) {
               const newFieldTypeOptionMap = new Y.Map() as YDatabaseFieldTypeOption;
-              const fieldTypeOption = fieldTypeOptionMap.get(String(fieldType));
 
-              if (fieldTypeOption) {
+              fieldTypeOptionMap.forEach((fieldTypeOption, typeOptionKey) => {
                 const newFieldTypeOption = new Y.Map() as YMapFieldTypeOption;
+                const typeOptionFieldType = Number(typeOptionKey) as FieldType;
+                const sourceFieldTypeOption = fieldTypeOption as YMapFieldTypeOption;
 
-                fieldTypeOption.forEach((value, key) => {
+                sourceFieldTypeOption.forEach((value, key) => {
                   // Reciprocal metadata is owned by the original field. Copying it
                   // would let a deletion of the duplicate orphan or remove the
                   // original's reciprocal in the related database, so the duplicate
                   // starts as a plain one-way relation.
                   if (
-                    fieldType === FieldType.Relation &&
+                    typeOptionFieldType === FieldType.Relation &&
                     (key === YjsDatabaseKey.is_two_way ||
                       key === YjsDatabaseKey.reciprocal_field_id ||
                       key === YjsDatabaseKey.reciprocal_field_name)
@@ -1584,8 +1581,13 @@ export function useDuplicatePropertyDispatch() {
                     newFieldTypeOption.set(key, value);
                   }
                 });
-                newFieldTypeOptionMap.set(String(fieldType), newFieldTypeOption);
-              }
+
+                if (typeOptionFieldType === FieldType.Relation) {
+                  newFieldTypeOption.set(YjsDatabaseKey.is_two_way, false);
+                }
+
+                newFieldTypeOptionMap.set(typeOptionKey, newFieldTypeOption);
+              });
 
               newField.set(YjsDatabaseKey.type_option, newFieldTypeOptionMap);
             }
@@ -1673,7 +1675,7 @@ export function useDuplicatePropertyDispatch() {
           const fieldType = Number(field.get(YjsDatabaseKey.type));
 
           const cell = cells.get(fieldId);
-          const newCell = cloneCell(fieldType, cell);
+          const newCell = cloneDatabaseCell(fieldType, cell);
 
           cells.set(newId, newCell);
 
@@ -1817,64 +1819,61 @@ function useEnhanceCalendarLayoutByFieldExists() {
 
   const sharedRoot = useSharedRoot();
 
-  return useCallback((fieldOrders: YDatabaseFieldOrders) => {
-    // find date field in all views
-    let dateField: YDatabaseField | undefined;
+  return useCallback(
+    (fieldOrders: YDatabaseFieldOrders) => {
+      // find date field in all views
+      let dateField: YDatabaseField | undefined;
 
-    fieldOrders.forEach((fieldOrder) => {
-      const field = fields?.get(fieldOrder.id);
+      fieldOrders.forEach((fieldOrder) => {
+        const field = fields?.get(fieldOrder.id);
 
-      if (
-        !dateField &&
-        [FieldType.DateTime].includes(
-          Number(field?.get(YjsDatabaseKey.type))
-        )
-      ) {
-        dateField = field;
+        if (!dateField && [FieldType.DateTime].includes(Number(field?.get(YjsDatabaseKey.type)))) {
+          dateField = field;
+        }
+      });
+
+      // if no date field, create a new one
+      if (!dateField) {
+        const fieldId = nanoid(6);
+
+        dateField = createField(FieldType.DateTime, fieldId);
+
+        const typeOptionMap = generateDateTimeFieldTypeOptions();
+
+        dateField.set(YjsDatabaseKey.type_option, typeOptionMap);
+        fields.set(fieldId, dateField);
+
+        executeOperationWithAllViews(
+          sharedRoot,
+          database,
+          (view) => {
+            const fieldOrders = view?.get(YjsDatabaseKey.field_orders);
+            const fieldSettings = view?.get(YjsDatabaseKey.field_settings);
+
+            if (!fieldSettings) {
+              throw new Error(`Field settings not found`);
+            }
+
+            fieldOrders.push([
+              {
+                id: fieldId,
+              },
+            ]);
+
+            const setting = new Y.Map() as YDatabaseFieldSetting;
+
+            setting.set(YjsDatabaseKey.visibility, FieldVisibility.AlwaysShown);
+            setting.set(YjsDatabaseKey.wrap, DEFAULT_FIELD_WRAP);
+            fieldSettings.set(fieldId, setting);
+          },
+          'newDateTimeField'
+        );
       }
-    });
 
-    // if no date field, create a new one
-    if (!dateField) {
-      const fieldId = nanoid(6);
-
-      dateField = createField(FieldType.DateTime, fieldId);
-
-      const typeOptionMap = generateDateTimeFieldTypeOptions();
-
-      dateField.set(YjsDatabaseKey.type_option, typeOptionMap);
-      fields.set(fieldId, dateField);
-
-      executeOperationWithAllViews(
-        sharedRoot,
-        database,
-        (view) => {
-          const fieldOrders = view?.get(YjsDatabaseKey.field_orders);
-          const fieldSettings = view?.get(YjsDatabaseKey.field_settings);
-
-          if (!fieldSettings) {
-            throw new Error(`Field settings not found`);
-          }
-
-          fieldOrders.push([
-            {
-              id: fieldId,
-            },
-          ]);
-
-          const setting = new Y.Map() as YDatabaseFieldSetting;
-
-          setting.set(YjsDatabaseKey.visibility, FieldVisibility.AlwaysShown);
-          setting.set(YjsDatabaseKey.wrap, DEFAULT_FIELD_WRAP);
-          fieldSettings.set(fieldId, setting);
-        },
-        'newDateTimeField'
-      );
-    }
-
-    return dateField;
-  }, [database, fields, sharedRoot])
-
+      return dateField;
+    },
+    [database, fields, sharedRoot]
+  );
 }
 
 /**
@@ -2063,7 +2062,6 @@ export function useUpdateDatabaseLayout(viewId: string) {
               const layoutSettings = generateCalendarLayoutSettings(fieldId, defaultTimeSetting);
 
               view.set(YjsDatabaseKey.layout_settings, layoutSettings);
-
             }
 
             view.set(YjsDatabaseKey.layout, layout);
@@ -2159,11 +2157,107 @@ function generateDateTimeFieldTypeOptions() {
   return typeOptionMap;
 }
 
+const FIELD_SWITCH_ROW_LOAD_CONCURRENCY = 8;
+const fieldSwitchRequestVersions = new WeakMap<YDatabase, Map<FieldId, number>>();
+
+function beginFieldSwitchRequest(database: YDatabase, fieldId: FieldId): number {
+  let versions = fieldSwitchRequestVersions.get(database);
+
+  if (!versions) {
+    versions = new Map();
+    fieldSwitchRequestVersions.set(database, versions);
+  }
+
+  const version = (versions.get(fieldId) ?? 0) + 1;
+
+  versions.set(fieldId, version);
+  return version;
+}
+
+function isCurrentFieldSwitchRequest(database: YDatabase, fieldId: FieldId, version: number): boolean {
+  return fieldSwitchRequestVersions.get(database)?.get(fieldId) === version;
+}
+
+function getFieldSwitchDatabaseRow(rowDoc?: YDoc): YDatabaseRow | undefined {
+  return rowDoc?.getMap(YjsEditorKey.data_section).get(YjsEditorKey.database_row) as YDatabaseRow | undefined;
+}
+
+function collectDatabaseRowIds(database: YDatabase, loadedRows: Record<RowId, YDoc>): RowId[] {
+  const rowIds = new Set<RowId>(Object.keys(loadedRows));
+  const views = database.get(YjsDatabaseKey.views);
+
+  views?.forEach((view) => {
+    const rowOrders = view.get(YjsDatabaseKey.row_orders)?.toArray() as Array<{ id?: RowId }> | undefined;
+
+    rowOrders?.forEach(({ id }) => {
+      if (id) rowIds.add(id);
+    });
+  });
+
+  return Array.from(rowIds);
+}
+
+function fieldSwitchRequiresEveryRow(sourceType: FieldType, targetType: FieldType): boolean {
+  if (sourceType === targetType) return false;
+
+  if (sourceType === FieldType.CreatedTime || sourceType === FieldType.LastEditedTime) {
+    return true;
+  }
+
+  return (
+    (targetType === FieldType.SingleSelect || targetType === FieldType.MultiSelect) &&
+    (sourceType === FieldType.RichText || sourceType === FieldType.Checklist)
+  );
+}
+
+async function loadFieldSwitchRowDocs({
+  rowMap,
+  rowIds,
+  ensureRow,
+}: {
+  rowMap: Record<RowId, YDoc>;
+  rowIds: RowId[];
+  ensureRow?: (rowId: RowId) => Promise<YDoc | undefined> | void;
+}): Promise<Record<RowId, YDoc>> {
+  const rowDocs = { ...rowMap };
+  const missingRowIds = rowIds.filter((rowId) => !getFieldSwitchDatabaseRow(rowDocs[rowId]));
+
+  if (missingRowIds.length === 0) return rowDocs;
+  if (!ensureRow) throw new Error('Cannot switch field type before every database row is available');
+
+  for (let index = 0; index < missingRowIds.length; index += FIELD_SWITCH_ROW_LOAD_CONCURRENCY) {
+    const batch = missingRowIds.slice(index, index + FIELD_SWITCH_ROW_LOAD_CONCURRENCY);
+    const loaded = await Promise.all(
+      batch.map(async (rowId) => {
+        const openedRowDoc = await ensureRow(rowId);
+
+        if (!openedRowDoc) {
+          throw new Error(`Database row ${rowId} could not be opened for the field-type switch`);
+        }
+
+        const rowDoc = await waitForDatabaseRowHydration(openedRowDoc);
+
+        if (!rowDoc) {
+          throw new Error(`Database row ${rowId} did not hydrate before the field-type switch`);
+        }
+
+        return [rowId, rowDoc] as const;
+      })
+    );
+
+    loaded.forEach(([rowId, rowDoc]) => {
+      rowDocs[rowId] = rowDoc;
+    });
+  }
+
+  return rowDocs;
+}
+
 export function useSwitchPropertyType() {
   const database = useDatabase();
   const sharedRoot = useSharedRoot();
   const rowMap = useRowMap();
-  const { databaseDoc, loadView, getViewIdFromDatabaseId, bindViewSync } = useDatabaseContext();
+  const { databaseDoc, loadView, getViewIdFromDatabaseId, bindViewSync, ensureRow } = useDatabaseContext();
 
   return useCallback(
     (fieldId: string, fieldType: FieldType) => {
@@ -2171,278 +2265,346 @@ export function useSwitchPropertyType() {
         throw new Error(`Row docs not found`);
       }
 
-      const rows = Object.keys(rowMap);
+      const field = database.get(YjsDatabaseKey.fields)?.get(fieldId);
 
-      // Capture the relation option before the switch so we can clean up the
-      // reciprocal field in the related database when leaving Relation. After
-      // the switch, the type_option for Relation may be cleared/replaced and
-      // the reciprocal pointer is no longer reachable from this field.
-      const fieldBefore = database.get(YjsDatabaseKey.fields)?.get(fieldId);
-      const oldFieldTypeBefore = fieldBefore ? Number(fieldBefore.get(YjsDatabaseKey.type)) : null;
-      const relationOptionToCleanUp =
-        fieldBefore && oldFieldTypeBefore === FieldType.Relation && fieldType !== FieldType.Relation
-          ? parseRelationTypeOption(fieldBefore)
-          : null;
+      if (!field) {
+        throw new Error(`Field not found`);
+      }
 
-      executeOperations(
-        sharedRoot,
-        [
-          () => {
-            const field = database.get(YjsDatabaseKey.fields)?.get(fieldId);
+      const sourceType = Number(field.get(YjsDatabaseKey.type)) as FieldType;
+      const requestVersion = beginFieldSwitchRequest(database, fieldId);
 
-            if (!field) {
-              throw new Error(`Field not found`);
-            }
+      if (sourceType === fieldType) return Promise.resolve();
 
-            const oldFieldType = Number(field.get(YjsDatabaseKey.type));
+      const rowIds = collectDatabaseRowIds(database, rowMap);
 
-            let typeOptionMap = field?.get(YjsDatabaseKey.type_option);
+      const performSwitch = (resolvedRowMap: Record<RowId, YDoc>) => {
+        const rows = Object.keys(resolvedRowMap);
 
-            // Check if the field type is supported for type options
-            if (
-              [
-                FieldType.Number,
-                FieldType.SingleSelect,
-                FieldType.MultiSelect,
-                FieldType.Checklist,
-                FieldType.Checkbox,
-                FieldType.URL,
-                FieldType.DateTime,
-                FieldType.CreatedTime,
-                FieldType.LastEditedTime,
-                FieldType.Media,
-                FieldType.Translate,
-                FieldType.Rollup,
-              ].includes(fieldType)
-            ) {
-              // Ensure the type option map is created
-              if (!typeOptionMap) {
-                typeOptionMap = new Y.Map() as YDatabaseFieldTypeOption;
+        // Capture the relation option before the switch so we can clean up the
+        // reciprocal field in the related database when leaving Relation. After
+        // the switch, the type_option for Relation may be cleared/replaced and
+        // the reciprocal pointer is no longer reachable from this field.
+        const fieldBefore = database.get(YjsDatabaseKey.fields)?.get(fieldId);
+        const oldFieldTypeBefore = fieldBefore ? Number(fieldBefore.get(YjsDatabaseKey.type)) : null;
+        const relationOptionToCleanUp =
+          fieldBefore && oldFieldTypeBefore === FieldType.Relation && fieldType !== FieldType.Relation
+            ? parseRelationTypeOption(fieldBefore)
+            : null;
 
-                field.set(YjsDatabaseKey.type_option, typeOptionMap);
+        executeOperations(
+          sharedRoot,
+          [
+            () => {
+              const field = database.get(YjsDatabaseKey.fields)?.get(fieldId);
+
+              if (!field) {
+                throw new Error(`Field not found`);
               }
 
-              const typeOption = typeOptionMap.get(String(fieldType));
+              const oldFieldType = Number(field.get(YjsDatabaseKey.type));
 
-              // Check if the type option is created, if not, create it with default values
-              // Otherwise, just ignore it
-              if (typeOption === undefined || Array.from(typeOption.keys()).length === 0) {
-                const newTypeOption = new Y.Map() as YMapFieldTypeOption;
+              let typeOptionMap = field?.get(YjsDatabaseKey.type_option);
 
-                // Set default values for the type option
-                if ([FieldType.CreatedTime, FieldType.LastEditedTime, FieldType.DateTime].includes(fieldType)) {
-                  // to DateTime
-                  if (oldFieldType !== FieldType.DateTime) {
-                    newTypeOption.set(YjsDatabaseKey.include_time, true);
+              // Check if the field type is supported for type options
+              if (
+                [
+                  FieldType.Number,
+                  FieldType.SingleSelect,
+                  FieldType.MultiSelect,
+                  FieldType.Checklist,
+                  FieldType.Checkbox,
+                  FieldType.URL,
+                  FieldType.DateTime,
+                  FieldType.CreatedTime,
+                  FieldType.LastEditedTime,
+                  FieldType.Media,
+                  FieldType.Translate,
+                  FieldType.Rollup,
+                ].includes(fieldType)
+              ) {
+                // Ensure the type option map is created
+                if (!typeOptionMap) {
+                  typeOptionMap = new Y.Map() as YDatabaseFieldTypeOption;
+
+                  field.set(YjsDatabaseKey.type_option, typeOptionMap);
+                }
+
+                const typeOption = typeOptionMap.get(String(fieldType));
+
+                // Check if the type option is created, if not, create it with default values
+                // Otherwise, just ignore it
+                if (typeOption === undefined || Array.from(typeOption.keys()).length === 0) {
+                  const newTypeOption = new Y.Map() as YMapFieldTypeOption;
+
+                  // Set default values for the type option
+                  if ([FieldType.CreatedTime, FieldType.LastEditedTime, FieldType.DateTime].includes(fieldType)) {
+                    // to DateTime
+                    if (oldFieldType !== FieldType.DateTime) {
+                      newTypeOption.set(YjsDatabaseKey.include_time, true);
+                    }
+                  } else if (fieldType === FieldType.Number) {
+                    // to Number
+                    newTypeOption.set(YjsDatabaseKey.format, NumberFormat.Num);
+                  } else if ([FieldType.SingleSelect, FieldType.MultiSelect].includes(fieldType)) {
+                    newTypeOption.set(YjsDatabaseKey.content, JSON.stringify({ disable_color: false, options: [] }));
+                  } else if (fieldType === FieldType.URL) {
+                    newTypeOption.set(YjsDatabaseKey.content, '');
+                  } else if (fieldType === FieldType.Translate) {
+                    newTypeOption.set(YjsDatabaseKey.language, AITranslateLanguage.English);
+                  } else if (fieldType === FieldType.Media) {
+                    const content = JSON.stringify({
+                      hide_file_names: true,
+                    });
+
+                    newTypeOption.set(YjsDatabaseKey.content, content);
+                  } else if (fieldType === FieldType.Rollup) {
+                    newTypeOption.set(YjsDatabaseKey.relation_field_id, '');
+                    newTypeOption.set(YjsDatabaseKey.target_field_id, '');
+                    newTypeOption.set(YjsDatabaseKey.calculation_type, CalculationType.Count);
+                    newTypeOption.set(YjsDatabaseKey.show_as, RollupDisplayMode.Calculated);
+                    newTypeOption.set(YjsDatabaseKey.condition_value, '');
                   }
-                } else if (fieldType === FieldType.Number) {
-                  // to Number
-                  newTypeOption.set(YjsDatabaseKey.format, NumberFormat.Num);
-                } else if ([FieldType.SingleSelect, FieldType.MultiSelect].includes(fieldType)) {
-                  // to Select
-                  const rows = Object.keys(rowMap);
-                  let content = '';
+
+                  typeOptionMap.set(String(fieldType), newTypeOption);
+                }
+
+                // Desktop transforms the target type option on every switch,
+                // including when an older target entry already exists.
+                if ([FieldType.SingleSelect, FieldType.MultiSelect].includes(fieldType)) {
+                  const targetTypeOption = typeOptionMap.get(String(fieldType));
+                  const target = parseSelectOptionTypeOptions(field, fieldType);
+                  let options = [...(target.options ?? [])];
 
                   switch (oldFieldType) {
-                    // From SingleSelect or MultiSelect to Select, keep the content
                     case FieldType.SingleSelect:
-                    case FieldType.MultiSelect: {
-                      const oldTypeOption = typeOptionMap.get(String(oldFieldType));
-
-                      if (oldTypeOption) {
-                        content = oldTypeOption.get(YjsDatabaseKey.content) || '';
-                      }
-
+                    case FieldType.MultiSelect:
+                      options = [...(parseSelectOptionTypeOptions(field, oldFieldType).options ?? [])];
                       break;
-                    }
 
-                    // From other types to Select, generate options from rows
                     case FieldType.Checkbox:
-                    case FieldType.RichText:
-                    case FieldType.Number:
-                    case FieldType.URL: {
-                      const options = new Set<string>();
-
-                      // If the old field type is Checkbox, add Yes/No options
-                      if (oldFieldType === FieldType.Checkbox) {
-                        options.add('Yes');
-                        options.add('No');
-                      } else {
-                        rows.forEach((rowId) => {
-                          const rowDoc = rowMap[rowId];
-
-                          if (!rowDoc) {
-                            return;
-                          }
-
-                          getOptionsFromRow(rowDoc, fieldId).forEach((option) => {
-                            options.add(option);
-                          });
+                      if (!options.some((option) => option.name === 'Yes')) {
+                        options.push({
+                          id: nanoid(6),
+                          name: 'Yes',
+                          color: SelectOptionColor.OptionColor7,
                         });
                       }
 
-                      content = JSON.stringify({
-                        disable_color: false,
-                        options: Array.from(options).map((name, index) => {
-                          return {
-                            id: name,
-                            name,
-                            color: Object.values(SelectOptionColor)[index % 10],
-                          };
-                        }),
+                      if (!options.some((option) => option.name === 'No')) {
+                        options.push({
+                          id: nanoid(6),
+                          name: 'No',
+                          color: SelectOptionColor.OptionColor5,
+                        });
+                      }
+
+                      break;
+
+                    case FieldType.RichText:
+                      if (options.length === 0) {
+                        const names = new Set<string>();
+
+                        Object.keys(resolvedRowMap).forEach((rowId) => {
+                          const rowDoc = resolvedRowMap[rowId];
+
+                          if (!rowDoc) return;
+                          getOptionsFromRow(rowDoc, fieldId).forEach((name) => names.add(name));
+                        });
+
+                        options = Array.from(names).map((name, index) => ({
+                          id: nanoid(6),
+                          name,
+                          color: Object.values(SelectOptionColor)[index % 10],
+                        }));
+                      }
+
+                      break;
+
+                    case FieldType.Checklist: {
+                      const generated = new Map<string, SelectOption>();
+
+                      Object.keys(resolvedRowMap).forEach((rowId) => {
+                        const row = resolvedRowMap[rowId]
+                          ?.getMap(YjsEditorKey.data_section)
+                          .get(YjsEditorKey.database_row) as YDatabaseRow | undefined;
+                        const data = row?.get(YjsDatabaseKey.cells)?.get(fieldId)?.get(YjsDatabaseKey.data);
+                        const checklist = typeof data === 'string' ? parseChecklistData(data) : null;
+
+                        checklist?.options?.forEach((option) => {
+                          if (option.name && !generated.has(option.name)) {
+                            generated.set(option.name, option);
+                          }
+                        });
                       });
 
+                      options.push(...generated.values());
                       break;
                     }
                   }
 
-                  // Set the content for the type option
-                  newTypeOption.set(YjsDatabaseKey.content, content);
-                } else if (fieldType === FieldType.URL) {
-                  newTypeOption.set(YjsDatabaseKey.content, '');
-                } else if (fieldType === FieldType.Translate) {
-                  newTypeOption.set(YjsDatabaseKey.language, AITranslateLanguage.English);
-                } else if (fieldType === FieldType.Media) {
-                  const content = JSON.stringify({
-                    hide_file_names: true,
-                  });
-
-                  newTypeOption.set(YjsDatabaseKey.content, content);
-                } else if (fieldType === FieldType.Rollup) {
-                  newTypeOption.set(YjsDatabaseKey.relation_field_id, '');
-                  newTypeOption.set(YjsDatabaseKey.target_field_id, '');
-                  newTypeOption.set(YjsDatabaseKey.calculation_type, CalculationType.Count);
-                  newTypeOption.set(YjsDatabaseKey.show_as, RollupDisplayMode.Calculated);
-                  newTypeOption.set(YjsDatabaseKey.condition_value, '');
-                }
-
-                typeOptionMap.set(String(fieldType), newTypeOption);
-              }
-            }
-
-            // When leaving Relation, drop reciprocal metadata from the preserved
-            // Relation type_option entry. The reciprocal field in the related
-            // database is being deleted in the post-switch cleanup; without
-            // clearing this, a later switch back to Relation would skip
-            // reciprocal recreation (because reciprocal_field_id is already set)
-            // and silently break two-way sync.
-            if (oldFieldType === FieldType.Relation && fieldType !== FieldType.Relation) {
-              const relationTypeOption = typeOptionMap?.get(String(FieldType.Relation));
-
-              if (relationTypeOption) {
-                relationTypeOption.delete(YjsDatabaseKey.reciprocal_field_id);
-                relationTypeOption.delete(YjsDatabaseKey.reciprocal_field_name);
-                relationTypeOption.set(YjsDatabaseKey.is_two_way, false);
-              }
-            }
-
-            field.set(YjsDatabaseKey.type, fieldType);
-
-            const lastModified = field.get(YjsDatabaseKey.last_modified);
-            const createdAt = field.get(YjsDatabaseKey.created_at);
-            const currentName = field.get(YjsDatabaseKey.name);
-            const oldDefaultName = getFieldName(oldFieldType);
-            const isNewField =
-              createdAt !== undefined &&
-              lastModified !== undefined &&
-              String(createdAt) === String(lastModified);
-
-            // Only auto-rename for untouched default fields (desktop parity).
-            if (isNewField && (!currentName || currentName === oldDefaultName)) {
-              field.set(YjsDatabaseKey.name, getFieldName(fieldType));
-            }
-
-            field.set(YjsDatabaseKey.last_modified, String(dayjs().unix()));
-
-            rows.forEach((row) => {
-              const rowDoc = rowMap?.[row];
-
-              if (!rowDoc) {
-                return;
-              }
-
-              rowDoc.transact(() => {
-                const rowSharedRoot = rowDoc.getMap(YjsEditorKey.data_section) as YSharedRoot;
-                const row = rowSharedRoot.get(YjsEditorKey.database_row);
-                const cells = row.get(YjsDatabaseKey.cells);
-                const cell = cells.get(fieldId);
-
-                // Created/LastEditedTime fields have no cell data of their own —
-                // the timestamp lives on the row meta. Materialize it into the
-                // cell so the value survives the switch (desktop parity:
-                // switch_to_field_type writes row.created_at / row.modified_at
-                // into the cell before transforming).
-                if (oldFieldType === FieldType.CreatedTime || oldFieldType === FieldType.LastEditedTime) {
-                  const timestamp =
-                    oldFieldType === FieldType.CreatedTime
-                      ? row.get(YjsDatabaseKey.created_at)
-                      : row.get(YjsDatabaseKey.last_modified);
-                  const materialized = cell ?? (new Y.Map() as YDatabaseCell);
-
-                  if (!cell) {
-                    cells.set(fieldId, materialized);
-                  }
-
-                  materialized.set(YjsDatabaseKey.source_field_type, String(oldFieldType));
-                  materialized.set(YjsDatabaseKey.field_type, fieldType);
-                  materialized.set(
-                    YjsDatabaseKey.data,
-                    timestamp !== undefined && timestamp !== null ? String(timestamp) : ''
+                  targetTypeOption?.set(
+                    YjsDatabaseKey.content,
+                    JSON.stringify({
+                      ...target,
+                      disable_color: 'disable_color' in target ? target.disable_color : false,
+                      options,
+                    })
                   );
-                  materialized.set(YjsDatabaseKey.last_modified, String(dayjs().unix()));
+                }
+              }
 
+              // When leaving Relation, drop reciprocal metadata from the preserved
+              // Relation type_option entry. The reciprocal field in the related
+              // database is being deleted in the post-switch cleanup; without
+              // clearing this, a later switch back to Relation would skip
+              // reciprocal recreation (because reciprocal_field_id is already set)
+              // and silently break two-way sync.
+              if (oldFieldType === FieldType.Relation && fieldType !== FieldType.Relation) {
+                const relationTypeOption = typeOptionMap?.get(String(FieldType.Relation));
+
+                if (relationTypeOption) {
+                  relationTypeOption.delete(YjsDatabaseKey.reciprocal_field_id);
+                  relationTypeOption.delete(YjsDatabaseKey.reciprocal_field_name);
+                  relationTypeOption.set(YjsDatabaseKey.is_two_way, false);
+                }
+              }
+
+              field.set(YjsDatabaseKey.type, fieldType);
+
+              const lastModified = field.get(YjsDatabaseKey.last_modified);
+              const createdAt = field.get(YjsDatabaseKey.created_at);
+              const currentName = field.get(YjsDatabaseKey.name);
+              const oldDefaultName = getFieldName(oldFieldType);
+              const isNewField =
+                createdAt !== undefined && lastModified !== undefined && String(createdAt) === String(lastModified);
+
+              // Only auto-rename for untouched default fields (desktop parity).
+              if (isNewField && (!currentName || currentName === oldDefaultName)) {
+                field.set(YjsDatabaseKey.name, getFieldName(fieldType));
+              }
+
+              field.set(YjsDatabaseKey.last_modified, String(dayjs().unix()));
+
+              rows.forEach((row) => {
+                const rowDoc = resolvedRowMap[row];
+
+                if (!rowDoc) {
                   return;
                 }
 
-                // Update each cell lazily: preserve existing data, record source type, update target type only.
-                if (cell) {
-                  const data = cell.get(YjsDatabaseKey.data);
-                  const oldCellType = Number(cell.get(YjsDatabaseKey.field_type));
+                rowDoc.transact(() => {
+                  const rowSharedRoot = rowDoc.getMap(YjsEditorKey.data_section) as YSharedRoot;
+                  const row = rowSharedRoot.get(YjsEditorKey.database_row);
 
-                  // Preserve the TRUE origin type across chained conversions
-                  // (mirrors desktop, where a cell's written-at type is never
-                  // overwritten by a switch). The data is still in the origin
-                  // type's format, so the origin is the existing source_field_type
-                  // if present, otherwise the cell's current type.
-                  const existingSource = cell.get(YjsDatabaseKey.source_field_type);
-                  const originType = existingSource !== undefined ? Number(existingSource) : oldCellType;
+                  if (!row) return;
 
-                  if (originType === fieldType) {
-                    // Switched back to the type the data was written at — the
-                    // cell is native again, so drop the source marker.
-                    cell.delete(YjsDatabaseKey.source_field_type);
-                  } else if (existingSource === undefined) {
-                    // First divergence from the written-at type: record the origin.
-                    cell.set(YjsDatabaseKey.source_field_type, String(oldCellType));
+                  const cells = row.get(YjsDatabaseKey.cells);
+                  const cell = cells.get(fieldId);
+
+                  // Created/LastEditedTime fields have no cell data of their own —
+                  // the timestamp lives on the row meta. Materialize it into the
+                  // cell so the value survives the switch (desktop parity:
+                  // switch_to_field_type writes row.created_at / row.modified_at
+                  // into the cell before transforming).
+                  if (oldFieldType === FieldType.CreatedTime || oldFieldType === FieldType.LastEditedTime) {
+                    const timestamp =
+                      oldFieldType === FieldType.CreatedTime
+                        ? row.get(YjsDatabaseKey.created_at)
+                        : row.get(YjsDatabaseKey.last_modified);
+                    const materialized = cell ?? (new Y.Map() as YDatabaseCell);
+
+                    if (!cell) {
+                      cells.set(fieldId, materialized);
+                    }
+
+                    // Desktop keeps the cell type aligned with the raw payload's
+                    // encoding. The field carries the new presentation type.
+                    materialized.set(YjsDatabaseKey.field_type, oldFieldType);
+                    materialized.delete(YjsDatabaseKey.source_field_type);
+                    materialized.set(
+                      YjsDatabaseKey.data,
+                      timestamp !== undefined && timestamp !== null ? String(timestamp) : ''
+                    );
+                    materialized.set(YjsDatabaseKey.last_modified, String(dayjs().unix()));
+
+                    return;
                   }
-                  // else: keep the already-recorded origin (do NOT overwrite it
-                  // with the intermediate hop — that is what hid the values).
 
-                  // Move the cell to the new type without mutating data.
-                  cell.set(YjsDatabaseKey.field_type, fieldType);
-                  cell.set(YjsDatabaseKey.data, data instanceof Y.Array ? data.clone() : data);
-                  cell.set(YjsDatabaseKey.last_modified, String(dayjs().unix()));
-                  row.set(YjsDatabaseKey.last_modified, String(dayjs().unix()));
-                }
+                  // New switches follow Desktop's model and leave ordinary cells
+                  // untouched. Older Web cells stored the true data format in
+                  // source_field_type; normalize only that legacy metadata so
+                  // Desktop can decode it through cell.field_type as well.
+                  if (cell) {
+                    normalizeLegacyCellFieldType(cell);
+                  }
+                });
               });
-            });
-          },
-        ],
-        'switchPropertyType'
-      );
+            },
+          ],
+          'switchPropertyType'
+        );
 
-      if (relationOptionToCleanUp) {
-        void deleteReciprocalRelationField({
-          sourceDatabase: database,
-          sourceDatabaseDoc: databaseDoc,
-          relationOption: relationOptionToCleanUp,
-          loadView,
-          getViewIdFromDatabaseId,
-          bindViewSync,
-        });
+        if (relationOptionToCleanUp) {
+          void deleteReciprocalRelationField({
+            sourceDatabase: database,
+            sourceDatabaseDoc: databaseDoc,
+            relationOption: relationOptionToCleanUp,
+            loadView,
+            getViewIdFromDatabaseId,
+            bindViewSync,
+          });
+        }
+      };
+
+      const requiresEveryRow = fieldSwitchRequiresEveryRow(sourceType, fieldType);
+      const everyRowIsLoaded = rowIds.every((rowId) => Boolean(getFieldSwitchDatabaseRow(rowMap[rowId])));
+
+      if (!requiresEveryRow || everyRowIsLoaded) {
+        performSwitch(rowMap);
+        return Promise.resolve();
       }
+
+      // These conversions derive schema/cell data from every row. Change the
+      // field only after off-screen row collabs hydrate, so a partial rowMap
+      // cannot make Desktop and Web persist different results.
+      const loadRowsAndSwitch = async () => {
+        let resolvedRowMap = rowMap;
+        let rowSetIsStable = false;
+
+        while (!rowSetIsStable) {
+          const latestRowIds = collectDatabaseRowIds(database, resolvedRowMap);
+
+          resolvedRowMap = await loadFieldSwitchRowDocs({
+            rowMap: resolvedRowMap,
+            rowIds: latestRowIds,
+            ensureRow,
+          });
+
+          if (!isCurrentFieldSwitchRequest(database, fieldId, requestVersion)) {
+            throw new Error('Field-type switch was superseded by a newer request');
+          }
+
+          // No await occurs between this stability check and performSwitch, so
+          // another Yjs event cannot insert an unprocessed row before commit.
+          const stableRowIds = collectDatabaseRowIds(database, resolvedRowMap);
+
+          rowSetIsStable = stableRowIds.every((rowId) => Boolean(getFieldSwitchDatabaseRow(resolvedRowMap[rowId])));
+        }
+
+        performSwitch(resolvedRowMap);
+      };
+
+      return loadRowsAndSwitch().catch((error: unknown) => {
+          Log.warn('[useSwitchPropertyType] Field type was not changed', {
+            fieldId,
+            fieldType,
+            error,
+          });
+          throw error;
+      });
     },
-    [bindViewSync, database, databaseDoc, getViewIdFromDatabaseId, loadView, sharedRoot, rowMap]
+    [bindViewSync, database, databaseDoc, ensureRow, getViewIdFromDatabaseId, loadView, sharedRoot, rowMap]
   );
 }
 

--- a/src/application/database-yjs/dispatch.ts
+++ b/src/application/database-yjs/dispatch.ts
@@ -49,7 +49,6 @@ import { createSelectOptionCell } from '@/application/database-yjs/fields/select
 import { createDateTimeField } from '@/application/database-yjs/fields/text/utils';
 import { getDefaultFilterCondition } from '@/application/database-yjs/filter';
 import { DEFAULT_FIELD_WRAP } from '@/application/database-yjs/const';
-import { getOptionsFromRow } from '@/application/database-yjs/row';
 import { waitForDatabaseRowHydration } from '@/application/database-yjs/row.hydration';
 import { getMetaIdMap } from '@/application/database-yjs/row_meta';
 import { useBoardLayoutSettings, useCalendarLayoutSetting, useFieldType } from '@/application/database-yjs/selector';
@@ -2182,6 +2181,13 @@ function getFieldSwitchDatabaseRow(rowDoc?: YDoc): YDatabaseRow | undefined {
   return rowDoc?.getMap(YjsEditorKey.data_section).get(YjsEditorKey.database_row) as YDatabaseRow | undefined;
 }
 
+function getFieldSwitchCellData(rowDoc: YDoc, fieldId: FieldId, field: YDatabaseField): unknown {
+  const row = getFieldSwitchDatabaseRow(rowDoc);
+  const cell = row?.get(YjsDatabaseKey.cells)?.get(fieldId);
+
+  return cell ? parseYDatabaseCellToCell(cell, field).data : undefined;
+}
+
 function collectDatabaseRowIds(database: YDatabase, loadedRows: Record<RowId, YDoc>): RowId[] {
   const rowIds = new Set<RowId>(Object.keys(loadedRows));
   const views = database.get(YjsDatabaseKey.views);
@@ -2402,21 +2408,28 @@ export function useSwitchPropertyType() {
                       break;
 
                     case FieldType.RichText:
-                      if (options.length === 0) {
-                        const names = new Set<string>();
+                      {
+                        const names = new Set(options.map((option) => option.name));
 
                         Object.keys(resolvedRowMap).forEach((rowId) => {
                           const rowDoc = resolvedRowMap[rowId];
 
                           if (!rowDoc) return;
-                          getOptionsFromRow(rowDoc, fieldId).forEach((name) => names.add(name));
-                        });
+                          const data = getFieldSwitchCellData(rowDoc, fieldId, field);
 
-                        options = Array.from(names).map((name, index) => ({
-                          id: nanoid(6),
-                          name,
-                          color: Object.values(SelectOptionColor)[index % 10],
-                        }));
+                          if (typeof data !== 'string') return;
+                          data.split(',').forEach((item) => {
+                            const name = item.trim();
+
+                            if (!name || names.has(name)) return;
+                            names.add(name);
+                            options.push({
+                              id: nanoid(6),
+                              name,
+                              color: Object.values(SelectOptionColor)[options.length % 10],
+                            });
+                          });
+                        });
                       }
 
                       break;
@@ -2425,10 +2438,10 @@ export function useSwitchPropertyType() {
                       const generated = new Map<string, SelectOption>();
 
                       Object.keys(resolvedRowMap).forEach((rowId) => {
-                        const row = resolvedRowMap[rowId]
-                          ?.getMap(YjsEditorKey.data_section)
-                          .get(YjsEditorKey.database_row) as YDatabaseRow | undefined;
-                        const data = row?.get(YjsDatabaseKey.cells)?.get(fieldId)?.get(YjsDatabaseKey.data);
+                        const rowDoc = resolvedRowMap[rowId];
+
+                        if (!rowDoc) return;
+                        const data = getFieldSwitchCellData(rowDoc, fieldId, field);
                         const checklist = typeof data === 'string' ? parseChecklistData(data) : null;
 
                         checklist?.options?.forEach((option) => {
@@ -2438,7 +2451,13 @@ export function useSwitchPropertyType() {
                         });
                       });
 
-                      options.push(...generated.values());
+                      const names = new Set(options.map((option) => option.name));
+
+                      generated.forEach((option, name) => {
+                        if (names.has(name)) return;
+                        names.add(name);
+                        options.push(option);
+                      });
                       break;
                     }
                   }

--- a/src/application/database-yjs/dispatch/cell.ts
+++ b/src/application/database-yjs/dispatch/cell.ts
@@ -10,6 +10,7 @@ import dayjs from 'dayjs';
 import { useCallback } from 'react';
 import * as Y from 'yjs';
 
+import { setCellStoredType } from '@/application/database-yjs/cell.field-type';
 import { useDatabaseContext } from '@/application/database-yjs/context';
 import { FieldType } from '@/application/database-yjs/database.type';
 import { useFieldSelector } from '@/application/database-yjs/selector';
@@ -152,7 +153,7 @@ function writeCellToRow({
   row: YDatabaseRow;
   cells: YDatabaseCells;
   fieldId: string;
-  fieldType: number;
+  fieldType: FieldType;
   data: CellUpdateData;
   dateOpts?: DateCellOptions;
 }) {
@@ -163,7 +164,7 @@ function writeCellToRow({
       const newCell = new Y.Map() as YDatabaseCell;
 
       newCell.set(YjsDatabaseKey.created_at, String(dayjs().unix()));
-      newCell.set(YjsDatabaseKey.field_type, fieldType);
+      setCellStoredType(newCell, fieldType);
       newCell.set(YjsDatabaseKey.data, data);
       newCell.set(YjsDatabaseKey.last_modified, String(dayjs().unix()));
 
@@ -185,12 +186,7 @@ function writeCellToRow({
         });
       }
 
-      cell.set(YjsDatabaseKey.field_type, fieldType);
-      // The data is now written in the current field type's format, so any
-      // lingering source-type marker from an earlier conversion is stale.
-      // Clearing it makes the cell native again (mirrors desktop, where a real
-      // write updates the cell's written-at type).
-      cell.delete(YjsDatabaseKey.source_field_type);
+      setCellStoredType(cell, fieldType);
       cell.set(YjsDatabaseKey.last_modified, String(dayjs().unix()));
     }
 
@@ -231,7 +227,7 @@ export function useUpdateCellDispatch(rowId: string, fieldId: string) {
           row: target.row,
           cells: target.cells,
           fieldId,
-          fieldType: Number(field.get(YjsDatabaseKey.type)),
+          fieldType: Number(field.get(YjsDatabaseKey.type)) as FieldType,
           data,
           dateOpts,
         });
@@ -269,13 +265,14 @@ export function useUpdateStartEndTimeCell() {
 
           if (!cell) {
             cell = new Y.Map() as YDatabaseCell;
-            cell.set(YjsDatabaseKey.field_type, FieldType.DateTime);
+            setCellStoredType(cell, FieldType.DateTime);
 
             cell.set(YjsDatabaseKey.created_at, String(dayjs().unix()));
             writableTarget.cells.set(fieldId, cell);
           }
 
           cell.set(YjsDatabaseKey.data, startTimestamp);
+          setCellStoredType(cell, FieldType.DateTime);
           cell.set(YjsDatabaseKey.last_modified, String(dayjs().unix()));
 
           updateDateCell(cell, {

--- a/src/application/database-yjs/dispatch/relation.ts
+++ b/src/application/database-yjs/dispatch/relation.ts
@@ -4,7 +4,7 @@ import { useCallback } from 'react';
 import { v4 as uuidv4 } from 'uuid';
 import * as Y from 'yjs';
 
-import { hasRowConditionData } from '@/application/database-yjs/condition-value-cache';
+import { getStoredCellFieldType, setCellStoredType } from '@/application/database-yjs/cell.field-type';
 import {
   useDatabase,
   useDatabaseContext,
@@ -16,7 +16,9 @@ import { normalizeRelationTypeOption, parseRelationTypeOption } from '@/applicat
 import { RelationLimit, RelationTypeOption } from '@/application/database-yjs/fields/relation/relation.type';
 import { createRelationField, setRelationTypeOptionValues } from '@/application/database-yjs/fields/relation/utils';
 import { initialDatabaseRow } from '@/application/database-yjs/row';
+import { waitForDatabaseRowHydration } from '@/application/database-yjs/row.hydration';
 import { getRowKey } from '@/application/database-yjs/row_meta';
+import { getRelationRowIdsFromCell } from '@/application/database-yjs/relation/cell';
 import { executeOperations } from '@/application/slate-yjs/utils/yjs';
 import {
   FieldId,
@@ -56,44 +58,7 @@ function uniq(ids: RowId[]) {
 // instance keeps our binding to a single owner per doc.
 const boundRelatedDocs = new WeakSet<YDoc>();
 
-export function getRelationRowIdsFromCell(cell?: YDatabaseCell): RowId[] {
-  if (!cell) return [];
-
-  // useSwitchPropertyType preserves the original cell payload when a non-relation
-  // column is converted to Relation (string text, Y.Array file blobs, etc.).
-  // Treat anything coming from a different source type as empty so foreign data
-  // never gets interpreted as relation row IDs.
-  const sourceType = cell.get(YjsDatabaseKey.source_field_type);
-
-  if (sourceType !== undefined && Number(sourceType) !== FieldType.Relation) {
-    return [];
-  }
-
-  const data = cell.get(YjsDatabaseKey.data);
-
-  if (!data) return [];
-  if (data instanceof Y.Array) {
-    return uniq(data.toArray().map(String));
-  }
-
-  if (Array.isArray(data)) {
-    return uniq(data.map(String));
-  }
-
-  if (typeof data === 'string') {
-    try {
-      const parsed = JSON.parse(data);
-
-      if (Array.isArray(parsed)) {
-        return uniq(parsed.map(String));
-      }
-    } catch {
-      return uniq(data.split(',').map((id) => id.trim()));
-    }
-  }
-
-  return [];
-}
+export { getRelationRowIdsFromCell };
 
 function getDatabaseFromDoc(doc: YDoc): YDatabase | null {
   return (doc.getMap(YjsEditorKey.data_section)?.get(YjsEditorKey.database) as YDatabase | undefined) ?? null;
@@ -123,8 +88,9 @@ function getOrCreateRelationCell(rowDoc: YDoc, fieldId: FieldId): YDatabaseCell 
   }
 
   const data = cell.get(YjsDatabaseKey.data);
+  const sourceType = getStoredCellFieldType(cell, FieldType.Relation);
 
-  if (!(data instanceof Y.Array)) {
+  if (sourceType !== FieldType.Relation || !(data instanceof Y.Array)) {
     const relationData = new Y.Array<string>();
     const existing = getRelationRowIdsFromCell(cell);
 
@@ -133,10 +99,9 @@ function getOrCreateRelationCell(rowDoc: YDoc, fieldId: FieldId): YDatabaseCell 
     }
 
     cell.set(YjsDatabaseKey.data, relationData);
-    // The cell now holds canonical relation row IDs, so the source-type marker
-    // (carried over from useSwitchPropertyType) must not keep filtering reads
-    // through getRelationRowIdsFromCell as foreign data.
-    cell.delete(YjsDatabaseKey.source_field_type);
+    setCellStoredType(cell, FieldType.Relation);
+    // The cell now holds canonical relation row IDs, so legacy source metadata
+    // must not keep filtering reads as foreign data.
   }
 
   return cell;
@@ -204,11 +169,10 @@ function setRelationCellRowIds(rowDoc: YDoc, fieldId: FieldId, rowIds: RowId[]) 
     }
 
     cell.set(YjsDatabaseKey.data, data);
-    cell.set(YjsDatabaseKey.field_type, FieldType.Relation);
+    setCellStoredType(cell, FieldType.Relation);
     // Drop any leftover source-type marker — getRelationRowIdsFromCell uses it
     // to ignore preserved-on-conversion payloads, but we just wrote canonical
     // relation data so the marker would now suppress real reads.
-    cell.delete(YjsDatabaseKey.source_field_type);
     cell.set(YjsDatabaseKey.last_modified, String(dayjs().unix()));
     row.set(YjsDatabaseKey.last_modified, String(dayjs().unix()));
   });
@@ -324,37 +288,6 @@ function collectDatabaseRowIds(database: YDatabase, loadedRowIds: RowId[] = []) 
   return Array.from(rowIds);
 }
 
-// `createRow` opens / binds a row doc but the `database_row` map arrives
-// asynchronously from sync. Without waiting, getOrCreateRelationCell sees no
-// row and silently drops the reciprocal write — leaving two-way relations
-// pointing at a row that never got a back-link. Wait briefly for the data to
-// arrive; resolve null on timeout so we don't block forever on a permanently
-// missing row.
-const ROW_HYDRATION_TIMEOUT_MS = 3000;
-
-function waitForRowHydration(rowDoc: YDoc, timeoutMs = ROW_HYDRATION_TIMEOUT_MS): Promise<YDoc | null> {
-  if (hasRowConditionData(rowDoc)) return Promise.resolve(rowDoc);
-
-  return new Promise((resolve) => {
-    let settled = false;
-    const finish = (value: YDoc | null) => {
-      if (settled) return;
-      settled = true;
-      rowDoc.off('update', listener);
-      clearTimeout(timer);
-      resolve(value);
-    };
-
-    const listener = () => {
-      if (hasRowConditionData(rowDoc)) finish(rowDoc);
-    };
-
-    const timer = setTimeout(() => finish(null), timeoutMs);
-
-    rowDoc.on('update', listener);
-  });
-}
-
 async function loadRowDoc(args: {
   databaseDoc: YDoc;
   rowId: RowId;
@@ -368,7 +301,7 @@ async function loadRowDoc(args: {
 
   const rowDoc = await args.createRow(getRowKey(args.databaseDoc.guid, args.rowId));
 
-  return waitForRowHydration(rowDoc);
+  return waitForDatabaseRowHydration(rowDoc);
 }
 
 async function loadRelatedDatabaseDoc(args: {

--- a/src/application/database-yjs/dispatch/row.ts
+++ b/src/application/database-yjs/dispatch/row.ts
@@ -16,6 +16,9 @@ import { useCallback, useEffect, useRef } from 'react';
 import { v4 as uuidv4 } from 'uuid';
 import * as Y from 'yjs';
 
+import { cloneDatabaseCell } from '@/application/database-yjs/cell.clone';
+import { setCellStoredType } from '@/application/database-yjs/cell.field-type';
+import { parseYDatabaseCellToCell } from '@/application/database-yjs/cell.parse';
 import {
   useCreateRow,
   useDatabase,
@@ -85,31 +88,6 @@ function reorderRow(rowId: string, beforeRowId: string | undefined, view: YDatab
   rows.insert(adjustedTargetIndex, [row]);
 }
 
-/**
- * Helper: Clone a cell for row duplication
- */
-function cloneCell(fieldType: FieldType, referenceCell?: YDatabaseCell) {
-  const cell = new Y.Map() as YDatabaseCell;
-
-  referenceCell?.forEach((value, key) => {
-    let newValue = value;
-
-    if (typeof value === 'bigint') {
-      newValue = value.toString();
-    } else if (value instanceof Y.Array) {
-      newValue = value.clone();
-    }
-
-    cell.set(key, newValue);
-  });
-
-  cell.set(YjsDatabaseKey.last_modified, String(dayjs().unix()));
-  cell.set(YjsDatabaseKey.created_at, String(dayjs().unix()));
-  cell.set(YjsDatabaseKey.field_type, fieldType);
-
-  return cell;
-}
-
 export function useReorderRowDispatch() {
   const view = useDatabaseView();
   const sharedRoot = useSharedRoot();
@@ -164,6 +142,10 @@ export function useMoveCardDispatch() {
 
             const field = database.get(YjsDatabaseKey.fields)?.get(fieldId);
 
+            if (!field) {
+              throw new Error(`Field not found`);
+            }
+
             const fieldType = Number(field.get(YjsDatabaseKey.type));
 
             const rowDoc = rowMap?.[rowId];
@@ -189,7 +171,7 @@ export function useMoveCardDispatch() {
 
               cells.set(fieldId, cell);
             } else {
-              const cellData = cell.get(YjsDatabaseKey.data);
+              const cellData = parseYDatabaseCellToCell(cell, field).data;
               let newCellData = cellData;
 
               if (isSelectOptionField) {
@@ -209,6 +191,9 @@ export function useMoveCardDispatch() {
               }
 
               cell.set(YjsDatabaseKey.data, newCellData);
+              setCellStoredType(cell, fieldType);
+              cell.set(YjsDatabaseKey.last_modified, String(dayjs().unix()));
+              row.set(YjsDatabaseKey.last_modified, String(dayjs().unix()));
             }
 
             reorderRow(rowId, beforeRowId, view);
@@ -630,7 +615,7 @@ export function useDuplicateRowDispatch() {
 
             const fieldType = Number(fields.get(fieldId)?.get(YjsDatabaseKey.type));
 
-            const cell = cloneCell(fieldType, referenceCell);
+            const cell = cloneDatabaseCell(fieldType, referenceCell);
 
             cells.set(fieldId, cell);
           } catch (e) {

--- a/src/application/database-yjs/fields/checkbox/utils.ts
+++ b/src/application/database-yjs/fields/checkbox/utils.ts
@@ -9,7 +9,7 @@ export function createCheckboxCell(fieldId: string, data: string) {
 
   cell.set(YjsDatabaseKey.id, fieldId);
   cell.set(YjsDatabaseKey.data, data);
-  cell.set(YjsDatabaseKey.field_type, String(FieldType.Checkbox));
+  cell.set(YjsDatabaseKey.field_type, FieldType.Checkbox);
   cell.set(YjsDatabaseKey.created_at, String(dayjs().unix()));
   cell.set(YjsDatabaseKey.last_modified, String(dayjs().unix()));
 

--- a/src/application/database-yjs/fields/checklist/parse.ts
+++ b/src/application/database-yjs/fields/checklist/parse.ts
@@ -12,17 +12,71 @@ function normalizeChecklistOptions(options: SelectOption[] = []) {
 
 export function parseChecklistData(data: string): ChecklistCellData | null {
   try {
-    const { options, selected_option_ids } = JSON.parse(data);
-    const percentage = selected_option_ids.length / options.length;
+    const parsed = JSON.parse(data) as {
+      options?: unknown;
+      selected_option_ids?: unknown;
+    };
+
+    if (!Array.isArray(parsed.options)) return null;
+    if (parsed.selected_option_ids !== undefined && !Array.isArray(parsed.selected_option_ids)) return null;
+
+    const options = parsed.options as SelectOption[];
+    const selectedOptionIds = (parsed.selected_option_ids ?? []) as string[];
+    const percentage = options.length === 0 ? 0 : selectedOptionIds.length / options.length;
 
     return {
       percentage,
       options,
-      selectedOptionIds: selected_option_ids,
+      selectedOptionIds,
     };
   } catch (e) {
     return null;
   }
+}
+
+export function parseDesktopChecklistText(text: string): ChecklistCellData {
+  const options: SelectOption[] = [];
+  const selectedOptionIds: string[] = [];
+
+  text.split('\n').forEach((rawLine) => {
+    const line = rawLine.trim();
+
+    if (!line) return;
+
+    let checked = false;
+    let name = line;
+
+    if (line.startsWith('[x]') || line.startsWith('[X]')) {
+      checked = true;
+      name = line.slice(3).trim();
+    } else if (line.startsWith('[ ]')) {
+      name = line.slice(3).trim();
+    } else if (line.startsWith('- [x]') || line.startsWith('- [X]')) {
+      checked = true;
+      name = line.slice(5).trim();
+    } else if (line.startsWith('- [ ]')) {
+      name = line.slice(5).trim();
+    } else if (line.startsWith('- ')) {
+      name = line.slice(2).trim();
+    }
+
+    if (!name) return;
+
+    const option: SelectOption = {
+      id: generateOptionId(),
+      name,
+      color: SelectOptionColor.OptionColor1,
+    };
+
+    options.push(option);
+    if (checked) selectedOptionIds.push(option.id);
+  });
+
+  return {
+    options,
+    selectedOptionIds,
+    percentage: options.length === 0 ? 0 : selectedOptionIds.length / options.length,
+  };
 }
 
 function parseChecklistTextToStruct(text: string): { options: SelectOption[]; selectedOptionIds: string[] } | null {

--- a/src/application/database-yjs/fields/date/desktop-parse.ts
+++ b/src/application/database-yjs/fields/date/desktop-parse.ts
@@ -1,0 +1,300 @@
+type DateParts = {
+  year: number;
+  month: number;
+  day: number;
+  hour: number;
+  minute: number;
+  second: number;
+  hasTime: boolean;
+};
+
+const MONTH_BY_NAME: Record<string, number> = {
+  january: 1,
+  jan: 1,
+  february: 2,
+  feb: 2,
+  march: 3,
+  mar: 3,
+  april: 4,
+  apr: 4,
+  may: 5,
+  june: 6,
+  jun: 6,
+  july: 7,
+  jul: 7,
+  august: 8,
+  aug: 8,
+  september: 9,
+  sep: 9,
+  october: 10,
+  oct: 10,
+  november: 11,
+  nov: 11,
+  december: 12,
+  dec: 12,
+};
+
+function dateParts(
+  year: string | number,
+  month: string | number,
+  day: string | number,
+  hour: string | number = 0,
+  minute: string | number = 0,
+  second: string | number = 0,
+  hasTime = false
+): DateParts {
+  return {
+    year: Number(year),
+    month: Number(month),
+    day: Number(day),
+    hour: Number(hour),
+    minute: Number(minute),
+    second: Number(second),
+    hasTime,
+  };
+}
+
+function withMeridiem(parts: DateParts, meridiem: string): DateParts | null {
+  if (parts.hour < 1 || parts.hour > 12) return null;
+
+  const isPm = meridiem.toLowerCase() === 'pm';
+
+  return {
+    ...parts,
+    hour: (parts.hour % 12) + (isPm ? 12 : 0),
+  };
+}
+
+function toUnixSeconds(parts: DateParts, offsetMinutes: number): string | null {
+  if (
+    !Number.isInteger(parts.year) ||
+    !Number.isInteger(parts.month) ||
+    !Number.isInteger(parts.day) ||
+    !Number.isInteger(parts.hour) ||
+    !Number.isInteger(parts.minute) ||
+    !Number.isInteger(parts.second) ||
+    parts.month < 1 ||
+    parts.month > 12 ||
+    parts.day < 1 ||
+    parts.day > 31 ||
+    parts.hour < 0 ||
+    parts.hour > 23 ||
+    parts.minute < 0 ||
+    parts.minute > 59 ||
+    parts.second < 0 ||
+    parts.second > 59
+  ) {
+    return null;
+  }
+
+  const date = new Date(0);
+
+  date.setUTCFullYear(parts.year, parts.month - 1, parts.day);
+  date.setUTCHours(parts.hour, parts.minute, parts.second, 0);
+
+  if (
+    date.getUTCFullYear() !== parts.year ||
+    date.getUTCMonth() !== parts.month - 1 ||
+    date.getUTCDate() !== parts.day ||
+    date.getUTCHours() !== parts.hour ||
+    date.getUTCMinutes() !== parts.minute ||
+    date.getUTCSeconds() !== parts.second
+  ) {
+    return null;
+  }
+
+  return String(Math.trunc(date.getTime() / 1000) - (parts.hasTime ? offsetMinutes * 60 : 0));
+}
+
+function parseTimezoneAnnotation(value: string): { value: string; offsetMinutes: number } | null {
+  const match = value.match(/^(.*) \(([^)]*)\)$/);
+
+  if (!match) return { value, offsetMinutes: 0 };
+
+  const annotation = match[2].trim();
+  const prefix = annotation.startsWith('GMT') ? 'GMT' : annotation.startsWith('UTC') ? 'UTC' : null;
+
+  if (!prefix) return { value, offsetMinutes: 0 };
+
+  const offset = annotation.slice(prefix.length);
+
+  if (!offset) return { value: match[1].trimEnd(), offsetMinutes: 0 };
+
+  const sign = offset[0] === '-' ? -1 : offset[0] === '+' ? 1 : 0;
+
+  if (!sign) return null;
+
+  const valueWithoutSign = offset.slice(1);
+  let hoursText = '';
+  let minutesText = '0';
+
+  if (valueWithoutSign.includes(':')) {
+    const parts = valueWithoutSign.split(':');
+
+    if (parts.length !== 2 || !parts[0] || !parts[1]) return null;
+    [hoursText, minutesText] = parts;
+  } else if (valueWithoutSign.length === 1 || valueWithoutSign.length === 2) {
+    hoursText = valueWithoutSign;
+  } else if (valueWithoutSign.length === 4) {
+    hoursText = valueWithoutSign.slice(0, 2);
+    minutesText = valueWithoutSign.slice(2);
+  } else {
+    return null;
+  }
+
+  if (!/^\d+$/.test(hoursText) || !/^\d+$/.test(minutesText)) return null;
+
+  const hours = Number(hoursText);
+  const minutes = Number(minutesText);
+
+  if (hours > 23 || minutes > 59) return null;
+
+  return {
+    value: match[1].trimEnd(),
+    offsetMinutes: sign * (hours * 60 + minutes),
+  };
+}
+
+function isAmbiguousMonthDay(first: number, second: number) {
+  return first <= 12 && second <= 12;
+}
+
+function parseNumericDateTime(value: string): DateParts | null {
+  let match = value.match(/^(\d{4})-(\d{1,2})-(\d{1,2})([ T])(\d{1,2}):(\d{2})(?::(\d{2}))?$/);
+
+  if (match) {
+    return dateParts(match[1], match[2], match[3], match[5], match[6], match[7] ?? 0, true);
+  }
+
+  match = value.match(/^(\d{4})-(\d{1,2})-(\d{1,2}) (\d{1,2}):(\d{2})(?::(\d{2}))? (AM|PM)$/i);
+  if (match) {
+    return withMeridiem(dateParts(match[1], match[2], match[3], match[4], match[5], match[6] ?? 0, true), match[7]);
+  }
+
+  match = value.match(/^(\d{1,2})\/(\d{1,2})\/(\d{4}) (\d{1,2}):(\d{2})(?: (AM|PM))?$/i);
+  if (match) {
+    const first = Number(match[1]);
+    const second = Number(match[2]);
+
+    if (isAmbiguousMonthDay(first, second)) return null;
+
+    const month = first <= 12 ? first : second;
+    const day = first <= 12 ? second : first;
+    const parts = dateParts(match[3], month, day, match[4], match[5], 0, true);
+
+    return match[6] ? withMeridiem(parts, match[6]) : parts;
+  }
+
+  match = value.match(/^(\d{1,2})-(\d{1,2})-(\d{4}) (\d{1,2}):(\d{2})$/);
+  if (match) {
+    const day = Number(match[1]);
+    const month = Number(match[2]);
+
+    if (isAmbiguousMonthDay(day, month)) return null;
+    return dateParts(match[3], month, day, match[4], match[5], 0, true);
+  }
+
+  return null;
+}
+
+function parseTextualDateTime(value: string): DateParts | null {
+  let match = value.match(/^([A-Za-z]+) (\d{1,2}), (\d{4}) (\d{1,2}):(\d{2})(?::(\d{2}))? (AM|PM)$/i);
+
+  if (match) {
+    const month = MONTH_BY_NAME[match[1].toLowerCase()];
+
+    if (!month || (match[6] && match[1].length === 3 && match[1].toLowerCase() !== 'may')) return null;
+    return withMeridiem(dateParts(match[3], month, match[2], match[4], match[5], match[6] ?? 0, true), match[7]);
+  }
+
+  match = value.match(/^([A-Za-z]+) (\d{1,2}), (\d{4}) (\d{1,2}):(\d{2})$/i);
+  if (match) {
+    const month = MONTH_BY_NAME[match[1].toLowerCase()];
+
+    return month ? dateParts(match[3], month, match[2], match[4], match[5], 0, true) : null;
+  }
+
+  return null;
+}
+
+function parseDateOnly(value: string): DateParts | null {
+  let match = value.match(/^(\d{4})([-/.])(\d{1,2})\2(\d{1,2})$/);
+
+  if (match) return dateParts(match[1], match[3], match[4]);
+
+  match = value.match(/^(\d{1,2})\/(\d{1,2})\/(\d{4})$/);
+  if (match) {
+    const first = Number(match[1]);
+    const second = Number(match[2]);
+    const monthFirst = dateParts(match[3], first, second);
+
+    if (toUnixSeconds(monthFirst, 0) !== null) return monthFirst;
+    return dateParts(match[3], second, first);
+  }
+
+  match = value.match(/^(\d{1,2})-(\d{1,2})-(\d{4})$/);
+  if (match) {
+    const first = Number(match[1]);
+    const second = Number(match[2]);
+
+    if (isAmbiguousMonthDay(first, second)) return null;
+    return first <= 12 ? dateParts(match[3], first, second) : dateParts(match[3], second, first);
+  }
+
+  match = value.match(/^([A-Za-z]+) (\d{1,2}), (\d{4})$/i);
+  if (match) {
+    const month = MONTH_BY_NAME[match[1].toLowerCase()];
+
+    return month ? dateParts(match[3], month, match[2]) : null;
+  }
+
+  match = value.match(/^(\d{1,2}) ([A-Za-z]+) (\d{4})$/i);
+  if (match) {
+    const month = MONTH_BY_NAME[match[2].toLowerCase()];
+
+    return month ? dateParts(match[3], month, match[1]) : null;
+  }
+
+  match = value.match(/^(\d{1,2})\.(\d{1,2})\.(\d{4})$/);
+  if (match) return dateParts(match[3], match[2], match[1]);
+
+  match = value.match(/^(\d{1,2})([-/.])(\d{1,2})\2(\d{1,2})$/);
+  if (!match) return null;
+
+  const first = Number(match[1]);
+  const second = Number(match[3]);
+
+  if (isAmbiguousMonthDay(first, second)) return null;
+
+  const year = Number(match[4]) >= 50 ? 1900 + Number(match[4]) : 2000 + Number(match[4]);
+
+  if (match[2] === '.') return dateParts(year, second, first);
+  return first <= 12 ? dateParts(year, first, second) : dateParts(year, second, first);
+}
+
+/** Deterministic port of Desktop's cast_string_to_timestamp parser. */
+export function parseDesktopDateToUnixSeconds(input: string): string | null {
+  const timezone = parseTimezoneAnnotation(input.trim());
+
+  if (!timezone) return null;
+
+  if (/^[+-]?\d+$/.test(timezone.value)) {
+    try {
+      const timestamp = BigInt(timezone.value);
+
+      if (timestamp > 1_000_000_000n && timestamp <= 8_210_266_876_799n) {
+        const numericTimestamp = Number(timestamp);
+        const date = new Date(numericTimestamp * 1000);
+
+        if (!Number.isNaN(date.getTime())) return timestamp.toString();
+      }
+    } catch {
+      return null;
+    }
+  }
+
+  const parts =
+    parseNumericDateTime(timezone.value) ?? parseTextualDateTime(timezone.value) ?? parseDateOnly(timezone.value);
+
+  return parts ? toUnixSeconds(parts, timezone.offsetMinutes) : null;
+}

--- a/src/application/database-yjs/fields/date/index.ts
+++ b/src/application/database-yjs/fields/date/index.ts
@@ -1,3 +1,4 @@
 export * from './date.type';
 export * from './relativeDate';
 export * from './utils';
+export * from './desktop-parse';

--- a/src/application/database-yjs/fields/number/format.ts
+++ b/src/application/database-yjs/fields/number/format.ts
@@ -156,7 +156,7 @@ export const currencyFormaterMap: Record<NumberFormat, (n: bigint | number) => s
     new Intl.NumberFormat('en-US', {
       ...commonProps,
       style: 'decimal',
-    }).format(n) + '%',
+    }).format(typeof n === 'bigint' ? n * 100n : n * 100) + '%',
   [NumberFormat.USD]: (n: bigint | number) =>
     new Intl.NumberFormat('en-US', {
       ...commonProps,

--- a/src/application/database-yjs/fields/number/parse.ts
+++ b/src/application/database-yjs/fields/number/parse.ts
@@ -1,11 +1,18 @@
+import Big from 'big.js';
+
+import { FieldType } from '@/application/database-yjs/database.type';
 import { YDatabaseField } from '@/application/types';
 
 import { getTypeOptions } from '../type_option';
 
+import { currencyFormaterMap } from './format';
 import { NumberFormat } from './number.type';
 
-export function parseNumberTypeOptions (field: YDatabaseField) {
-  const numberTypeOption = getTypeOptions(field)?.toJSON();
+const RUST_DECIMAL_MAX_COEFFICIENT = 79_228_162_514_264_337_593_543_950_335n;
+const RUST_DECIMAL_MAX_SCALE = 28;
+
+export function parseNumberTypeOptions(field: YDatabaseField, fieldType?: FieldType) {
+  const numberTypeOption = getTypeOptions(field, fieldType)?.toJSON();
 
   if (!numberTypeOption) {
     return {
@@ -13,7 +20,91 @@ export function parseNumberTypeOptions (field: YDatabaseField) {
     };
   }
 
+  const format = Number.parseInt(String(numberTypeOption.format), 10);
+
   return {
-    format: parseInt(numberTypeOption.format) as NumberFormat,
+    format: NumberFormat[format] === undefined ? NumberFormat.Num : (format as NumberFormat),
   };
+}
+
+/**
+ * Decode text with Desktop's Number type-option rules, but return the
+ * unformatted decimal expected by the Web number cell renderer.
+ */
+export function parseDesktopNumberValue(input: string | number, format: NumberFormat): string {
+  const text = String(input);
+  let candidate = '';
+
+  if (format === NumberFormat.Num) {
+    if (/[+-]?\d*\.?\d+e[+-]?\d+/.test(text)) {
+      candidate = /^[+-]?(?:\d+(?:\.\d*)?|\.\d+)e[+-]?\d+$/.test(text) ? text : '';
+    } else {
+      candidate = text.match(/^\.\d+/)?.[0] ?? text.match(/-?\d+(?:\.\d+)?/)?.[0] ?? '';
+      if (candidate.startsWith('.')) candidate = `0${candidate}`;
+    }
+  } else {
+    const matches = text.match(/-?\d+(?:\.\d+)?/g) ?? [];
+
+    candidate = matches.join('');
+    if (candidate && !text.startsWith('-')) candidate = candidate.replace(/^-/, '');
+  }
+
+  if (!candidate) return '';
+
+  try {
+    return normalizeRustDecimal(candidate);
+  } catch {
+    return '';
+  }
+}
+
+/** Match Desktop's 96-bit rust_decimal range and half-up precision reduction. */
+function normalizeRustDecimal(candidate: string): string {
+  const scientific = /^([+-]?(?:\d+(?:\.\d*)?|\.\d+))e([+-]?\d+)$/i.exec(candidate);
+
+  if (scientific) {
+    const exponent = Number(scientific[2]);
+
+    if (!Number.isSafeInteger(exponent)) return '';
+
+    const baseScale = scientific[1].split('.')[1]?.length ?? 0;
+
+    // Decimal::from_scientific adjusts the parsed base scale directly; it
+    // rejects exponents that cannot fit rather than silently underflowing.
+    if (exponent < 0 && baseScale - exponent > RUST_DECIMAL_MAX_SCALE) return '';
+    if (exponent > RUST_DECIMAL_MAX_SCALE) return '';
+  }
+
+  const value = new Big(candidate);
+  const absolute = value.abs();
+  const integerDigits = absolute.lt(1) ? 0 : absolute.round(0, Big.roundDown).toFixed().length;
+  let decimalPlaces = Math.min(RUST_DECIMAL_MAX_SCALE, Math.max(0, 29 - integerDigits));
+
+  while (decimalPlaces >= 0) {
+    const rounded = value.round(decimalPlaces, Big.roundHalfUp);
+    const normalized = rounded.toFixed();
+    const coefficient = BigInt(normalized.replace('-', '').replace('.', '') || '0');
+
+    if (coefficient <= RUST_DECIMAL_MAX_COEFFICIENT) return normalized;
+    if (decimalPlaces === 0) return '';
+    decimalPlaces -= 1;
+  }
+
+  return '';
+}
+
+export function stringifyDesktopNumberValue(input: string | number, format: NumberFormat): string {
+  const value = parseDesktopNumberValue(input, format);
+
+  if (!value || format === NumberFormat.Num) return value;
+
+  const formatter = currencyFormaterMap[format];
+
+  if (!formatter) return value;
+
+  try {
+    return formatter(value.includes('.') ? Number(value) : BigInt(value));
+  } catch {
+    return value;
+  }
 }

--- a/src/application/database-yjs/fields/text/utils.ts
+++ b/src/application/database-yjs/fields/text/utils.ts
@@ -66,13 +66,66 @@ export function parseCheckboxValue(data?: string | number | boolean): boolean {
   return false;
 }
 
+/** Match Desktop's CheckboxCellDataPB parser for lazy RichText conversion. */
+export function parseDesktopCheckboxValue(data: string | number | boolean): boolean {
+  return ['1', 'true', 'yes'].includes(String(data).toLowerCase());
+}
+
+export function parseDesktopI64(value: string | number): string | null {
+  const text = String(value);
+
+  if (!/^[+-]?\d+$/.test(text)) return null;
+
+  try {
+    const parsed = BigInt(text);
+
+    return parsed >= -9223372036854775808n && parsed <= 9223372036854775807n ? parsed.toString() : null;
+  } catch {
+    return null;
+  }
+}
+
 export function parseTimeStringToMs(text: string): string | null {
   const trimmed = text.trim();
 
   if (!trimmed) return '';
 
-  if (!Number.isNaN(Number(trimmed))) {
-    return String(trimmed);
+  const directMilliseconds = parseDesktopI64(trimmed);
+
+  if (directMilliseconds !== null) return directMilliseconds;
+
+  let durationOffset = 0;
+  let durationHours: bigint | null = null;
+  let durationMinutes: bigint | null = null;
+  const durationPart = /\s*(\d+)([hm])/y;
+
+  while (durationOffset < trimmed.length) {
+    durationPart.lastIndex = durationOffset;
+    const match = durationPart.exec(trimmed);
+
+    if (!match) break;
+
+    const value = BigInt(match[1]);
+
+    if (match[2] === 'h') {
+      if (durationHours !== null) return null;
+      durationHours = value;
+    } else {
+      if (durationMinutes !== null) return null;
+      durationMinutes = value;
+    }
+
+    durationOffset = durationPart.lastIndex;
+  }
+
+  if (durationOffset === trimmed.length && (durationHours !== null || durationMinutes !== null)) {
+    const milliseconds = ((durationHours ?? 0n) * 60n + (durationMinutes ?? 0n)) * 60_000n;
+
+    if (milliseconds >= -9223372036854775808n && milliseconds <= 9223372036854775807n) {
+      return milliseconds.toString();
+    }
+
+    return null;
   }
 
   const hhmmMatch = trimmed.match(/^(\d{1,2}):(\d{2})(?::(\d{2}))?$/);

--- a/src/application/database-yjs/filter.ts
+++ b/src/application/database-yjs/filter.ts
@@ -4,6 +4,7 @@ import { every, filter, some } from 'lodash-es';
 import { DateTimeCell } from '@/application/database-yjs/cell.type';
 import {
   getConditionCellData,
+  getConditionRelationRowIds,
   getConditionCellText,
   getConditionDateCell,
   getRowConditionSnapshot,
@@ -620,11 +621,13 @@ export function filterBy(
 
       if (!snapshot) return false;
 
-      const cellData = getConditionCellData(snapshot, fieldId);
+      const cellData = getConditionCellData(snapshot, fieldId, field);
 
       if (fieldType === FieldType.Relation) {
+        const relationCellData = getConditionRelationRowIds(snapshot, fieldId);
+
         if (relationRowIds !== null && relationRowIds !== undefined) {
-          return relationFilterCheck(cellData, relationRowIds, condition);
+          return relationFilterCheck(relationCellData, relationRowIds, condition);
         }
 
         // Empty content on the new relation conditions (IsEmpty / IsNotEmpty /
@@ -639,7 +642,7 @@ export function filterBy(
             condition === RelationFilterCondition.RelationContains ||
             condition === RelationFilterCondition.RelationDoesNotContain)
         ) {
-          return relationFilterCheck(cellData, [], condition);
+          return relationFilterCheck(relationCellData, [], condition);
         }
 
         const cellText = options?.getRelationCellText?.(rowId, fieldId) ?? '';
@@ -674,7 +677,7 @@ export function filterBy(
         case FieldType.Checklist:
           return checklistFilterCheck(cellData as string, content, condition);
         case FieldType.DateTime:
-          return dateFilterCheck(getConditionDateCell(snapshot, fieldId), filterValue as DateFilter);
+          return dateFilterCheck(getConditionDateCell(snapshot, fieldId, field), filterValue as DateFilter);
         case FieldType.CreatedTime: {
           const data = snapshot.row.get(YjsDatabaseKey.created_at);
 

--- a/src/application/database-yjs/group.ts
+++ b/src/application/database-yjs/group.ts
@@ -1,11 +1,11 @@
 import { getCell } from '@/application/database-yjs/const';
 import { FieldType } from '@/application/database-yjs/database.type';
+import { parseYDatabaseCellToCell } from '@/application/database-yjs/cell.parse';
 import {
   CheckboxFilterCondition,
   parseSelectOptionTypeOptions,
   SelectOptionFilterCondition,
 } from '@/application/database-yjs/fields';
-import { parseChecklistFlexible } from '@/application/database-yjs/fields/checklist/parse';
 import { parseCheckboxValue } from '@/application/database-yjs/fields/text/utils';
 import { checkboxFilterCheck, selectOptionFilterCheck } from '@/application/database-yjs/filter';
 import { Row } from '@/application/database-yjs/selector';
@@ -95,7 +95,7 @@ export function groupByCheckbox(
     }
 
     const cell = getCell(row.id, fieldId, rowMetas);
-    const cellData = cell?.get(YjsDatabaseKey.data);
+    const cellData = cell ? parseYDatabaseCellToCell(cell, field).data : undefined;
     const checked = parseCheckboxValue(cellData as string);
     const groupName = checked ? 'Yes' : 'No';
 
@@ -171,21 +171,11 @@ export function groupBySelectOption(
     }
 
     const cell = getCell(row.id, fieldId, rowMetas);
-    const cellData = cell?.get(YjsDatabaseKey.data);
-    const sourceType = Number(
-      cell?.get(YjsDatabaseKey.source_field_type) ?? cell?.get(YjsDatabaseKey.field_type)
-    ) as FieldType;
+    const cellData = cell ? parseYDatabaseCellToCell(cell, field).data : undefined;
 
     let selectedIds: string[] = [];
 
-    if (sourceType === FieldType.Checklist && typeof cellData === 'string') {
-      const checklist = parseChecklistFlexible(cellData);
-
-      selectedIds =
-        checklist?.selectedOptionIds
-          ?.map((idOrName) => typeOption.options.find((opt) => opt.id === idOrName || opt.name === idOrName)?.id)
-          .filter((id): id is string => Boolean(id)) ?? [];
-    } else if (typeof cellData === 'string') {
+    if (typeof cellData === 'string') {
       selectedIds =
         cellData
           .split(',')

--- a/src/application/database-yjs/hooks/useRollupFieldObservers.ts
+++ b/src/application/database-yjs/hooks/useRollupFieldObservers.ts
@@ -8,6 +8,7 @@ import { getRelationRowIdsFromCell } from '@/application/database-yjs/relation/c
 import { invalidateRelationCell } from '@/application/database-yjs/relation/cache';
 import { invalidateRollupCell } from '@/application/database-yjs/rollup/cache';
 import { getRowKey } from '@/application/database-yjs/row_meta';
+import { subscribeSharedYjsDeep } from '@/application/database-yjs/shared-yjs-observer';
 import { YDatabaseRow, YDoc, YjsDatabaseKey, YjsEditorKey } from '@/application/types';
 
 const ROLLUP_OBSERVER_POOL_SIZE = 4;
@@ -69,7 +70,7 @@ export function useRollupFieldObservers(onConditionsChange: () => void, rollupWa
     if (relationFieldIds.size === 0 && rollupFieldIds.size === 0) return;
 
     let cancelled = false;
-    const observers: Array<{ doc: YDoc; handler: () => void }> = [];
+    const observerCleanups: Array<() => void> = [];
     const rowDocCache = new Map<string, YDoc>();
     const relatedDocCache = new Map<string, YDoc | null>();
     const viewIdCache = new Map<string, string | null>();
@@ -84,6 +85,7 @@ export function useRollupFieldObservers(onConditionsChange: () => void, rollupWa
         ? viewIdCache.get(databaseId)
         : await getViewIdFromDatabaseId(databaseId);
 
+      if (cancelled) return null;
       viewIdCache.set(databaseId, viewId ?? null);
       if (!viewId) {
         relatedDocCache.set(databaseId, null);
@@ -92,6 +94,7 @@ export function useRollupFieldObservers(onConditionsChange: () => void, rollupWa
 
       const doc = await loadView(viewId);
 
+      if (cancelled) return null;
       relatedDocCache.set(databaseId, doc);
       return doc;
     };
@@ -100,6 +103,7 @@ export function useRollupFieldObservers(onConditionsChange: () => void, rollupWa
       if (rowDocCache.has(rowKey)) return rowDocCache.get(rowKey);
       const doc = await createRow(rowKey);
 
+      if (cancelled) return undefined;
       if (doc) {
         rowDocCache.set(rowKey, doc);
       }
@@ -139,6 +143,7 @@ export function useRollupFieldObservers(onConditionsChange: () => void, rollupWa
         if (!relationOption?.database_id) continue;
         const relatedDoc = await getRelatedDoc(relationOption.database_id);
 
+        if (cancelled) return;
         if (!relatedDoc) continue;
 
         const invalidateRelatedRelationValues = () => {
@@ -148,8 +153,9 @@ export function useRollupFieldObservers(onConditionsChange: () => void, rollupWa
           debouncedChange();
         };
 
-        relatedDoc.getMap(YjsEditorKey.data_section).observeDeep(invalidateRelatedRelationValues);
-        observers.push({ doc: relatedDoc, handler: invalidateRelatedRelationValues });
+        observerCleanups.push(
+          subscribeSharedYjsDeep(relatedDoc.getMap(YjsEditorKey.data_section), invalidateRelatedRelationValues)
+        );
 
         for (const [rowId, rowDoc] of Object.entries(rows)) {
           if (cancelled) return;
@@ -164,14 +170,13 @@ export function useRollupFieldObservers(onConditionsChange: () => void, rollupWa
               if (cancelled) return;
               const relatedRowDoc = await getRowDoc(getRowKey(relatedDoc.guid, relatedRowId));
 
-              if (!relatedRowDoc) return;
+              if (cancelled || !relatedRowDoc) return;
               const handler = () => {
                 invalidateRelationCell(`${rowId}:${relationFieldId}`);
                 debouncedChange();
               };
 
-              relatedRowDoc.getMap(YjsEditorKey.data_section).observeDeep(handler);
-              observers.push({ doc: relatedRowDoc, handler });
+              observerCleanups.push(subscribeSharedYjsDeep(relatedRowDoc.getMap(YjsEditorKey.data_section), handler));
             });
           });
         }
@@ -194,6 +199,7 @@ export function useRollupFieldObservers(onConditionsChange: () => void, rollupWa
 
         const relatedDoc = await getRelatedDoc(relationOption.database_id);
 
+        if (cancelled) return;
         if (!relatedDoc) continue;
         const docGuid = relatedDoc.guid;
         const invalidateRelatedRollupValues = () => {
@@ -203,8 +209,9 @@ export function useRollupFieldObservers(onConditionsChange: () => void, rollupWa
           debouncedChange();
         };
 
-        relatedDoc.getMap(YjsEditorKey.data_section).observeDeep(invalidateRelatedRollupValues);
-        observers.push({ doc: relatedDoc, handler: invalidateRelatedRollupValues });
+        observerCleanups.push(
+          subscribeSharedYjsDeep(relatedDoc.getMap(YjsEditorKey.data_section), invalidateRelatedRollupValues)
+        );
 
         for (const [rowId, rowDoc] of Object.entries(rows)) {
           if (cancelled) return;
@@ -222,14 +229,13 @@ export function useRollupFieldObservers(onConditionsChange: () => void, rollupWa
               if (cancelled) return;
               const relatedRowDoc = await getRowDoc(getRowKey(docGuid, relatedRowId));
 
-              if (!relatedRowDoc) return;
+              if (cancelled || !relatedRowDoc) return;
               const handler = () => {
                 invalidateRollupCell(`${rowId}:${rollupFieldId}`);
                 debouncedChange();
               };
 
-              relatedRowDoc.getMap(YjsEditorKey.data_section).observeDeep(handler);
-              observers.push({ doc: relatedRowDoc, handler });
+              observerCleanups.push(subscribeSharedYjsDeep(relatedRowDoc.getMap(YjsEditorKey.data_section), handler));
             });
           }
         }
@@ -243,9 +249,7 @@ export function useRollupFieldObservers(onConditionsChange: () => void, rollupWa
     return () => {
       cancelled = true;
       debouncedChange.cancel();
-      observers.forEach(({ doc, handler }) => {
-        doc.getMap(YjsEditorKey.data_section).unobserveDeep(handler);
-      });
+      observerCleanups.forEach((cleanup) => cleanup());
     };
   }, [
     rows,

--- a/src/application/database-yjs/hooks/useRollupFieldObservers.ts
+++ b/src/application/database-yjs/hooks/useRollupFieldObservers.ts
@@ -4,25 +4,13 @@ import { useEffect } from 'react';
 import { useDatabase, useDatabaseContext, useDatabaseFields, useDatabaseView, useRowMap } from '@/application/database-yjs/context';
 import { FieldType } from '@/application/database-yjs/database.type';
 import { parseRelationTypeOption, parseRollupTypeOption } from '@/application/database-yjs/fields';
+import { getRelationRowIdsFromCell } from '@/application/database-yjs/relation/cell';
+import { invalidateRelationCell } from '@/application/database-yjs/relation/cache';
 import { invalidateRollupCell } from '@/application/database-yjs/rollup/cache';
 import { getRowKey } from '@/application/database-yjs/row_meta';
-import { YDatabaseCell, YDatabaseRow, YDoc, YjsDatabaseKey, YjsEditorKey } from '@/application/types';
+import { YDatabaseRow, YDoc, YjsDatabaseKey, YjsEditorKey } from '@/application/types';
 
 const ROLLUP_OBSERVER_POOL_SIZE = 4;
-
-function getRelationRowIdsFromCell(cell?: YDatabaseCell): string[] {
-  if (!cell) return [];
-  const data = cell.get(YjsDatabaseKey.data);
-
-  if (!data) return [];
-  if (typeof data === 'object' && 'toJSON' in data) {
-    const ids = (data as { toJSON: () => unknown }).toJSON();
-
-    return Array.isArray(ids) ? (ids as string[]) : [];
-  }
-
-  return Array.isArray(data) ? (data as string[]) : [];
-}
 
 /**
  * Hook that sets up observers for rollup fields used in sorts/filters.
@@ -44,7 +32,8 @@ export function useRollupFieldObservers(onConditionsChange: () => void, rollupWa
   useEffect(() => {
     if (!rows || !fields || !database || !loadView || !createRow || !getViewIdFromDatabaseId) return;
 
-    // Find rollup fields used in sorts/filters
+    // Find relation and rollup fields used in sorts/filters.
+    const relationFieldIds = new Set<string>();
     const rollupFieldIds = new Set<string>();
 
     sorts?.forEach((sort) => {
@@ -52,6 +41,10 @@ export function useRollupFieldObservers(onConditionsChange: () => void, rollupWa
 
       if (!fieldId) return;
       const field = fields.get(fieldId);
+
+      if (field && Number(field.get(YjsDatabaseKey.type)) === FieldType.Relation) {
+        relationFieldIds.add(fieldId);
+      }
 
       if (field && Number(field.get(YjsDatabaseKey.type)) === FieldType.Rollup) {
         rollupFieldIds.add(fieldId);
@@ -64,12 +57,16 @@ export function useRollupFieldObservers(onConditionsChange: () => void, rollupWa
       if (!fieldId) return;
       const field = fields.get(fieldId);
 
+      if (field && Number(field.get(YjsDatabaseKey.type)) === FieldType.Relation) {
+        relationFieldIds.add(fieldId);
+      }
+
       if (field && Number(field.get(YjsDatabaseKey.type)) === FieldType.Rollup) {
         rollupFieldIds.add(fieldId);
       }
     });
 
-    if (rollupFieldIds.size === 0) return;
+    if (relationFieldIds.size === 0 && rollupFieldIds.size === 0) return;
 
     let cancelled = false;
     const observers: Array<{ doc: YDoc; handler: () => void }> = [];
@@ -134,6 +131,52 @@ export function useRollupFieldObservers(onConditionsChange: () => void, rollupWa
     const setup = async () => {
       const tasks: Array<() => Promise<void>> = [];
 
+      for (const relationFieldId of relationFieldIds) {
+        if (cancelled) return;
+        const relationField = fields.get(relationFieldId);
+        const relationOption = relationField ? parseRelationTypeOption(relationField) : null;
+
+        if (!relationOption?.database_id) continue;
+        const relatedDoc = await getRelatedDoc(relationOption.database_id);
+
+        if (!relatedDoc) continue;
+
+        const invalidateRelatedRelationValues = () => {
+          Object.keys(rows).forEach((rowId) => {
+            invalidateRelationCell(`${rowId}:${relationFieldId}`);
+          });
+          debouncedChange();
+        };
+
+        relatedDoc.getMap(YjsEditorKey.data_section).observeDeep(invalidateRelatedRelationValues);
+        observers.push({ doc: relatedDoc, handler: invalidateRelatedRelationValues });
+
+        for (const [rowId, rowDoc] of Object.entries(rows)) {
+          if (cancelled) return;
+          const row = rowDoc.getMap(YjsEditorKey.data_section).get(YjsEditorKey.database_row) as
+            | YDatabaseRow
+            | undefined;
+          const relationCell = row?.get(YjsDatabaseKey.cells)?.get(relationFieldId);
+          const relatedRowIds = getRelationRowIdsFromCell(relationCell);
+
+          relatedRowIds.forEach((relatedRowId) => {
+            tasks.push(async () => {
+              if (cancelled) return;
+              const relatedRowDoc = await getRowDoc(getRowKey(relatedDoc.guid, relatedRowId));
+
+              if (!relatedRowDoc) return;
+              const handler = () => {
+                invalidateRelationCell(`${rowId}:${relationFieldId}`);
+                debouncedChange();
+              };
+
+              relatedRowDoc.getMap(YjsEditorKey.data_section).observeDeep(handler);
+              observers.push({ doc: relatedRowDoc, handler });
+            });
+          });
+        }
+      }
+
       for (const rollupFieldId of rollupFieldIds) {
         if (cancelled) return;
         const rollupField = fields.get(rollupFieldId);
@@ -153,6 +196,15 @@ export function useRollupFieldObservers(onConditionsChange: () => void, rollupWa
 
         if (!relatedDoc) continue;
         const docGuid = relatedDoc.guid;
+        const invalidateRelatedRollupValues = () => {
+          Object.keys(rows).forEach((rowId) => {
+            invalidateRollupCell(`${rowId}:${rollupFieldId}`);
+          });
+          debouncedChange();
+        };
+
+        relatedDoc.getMap(YjsEditorKey.data_section).observeDeep(invalidateRelatedRollupValues);
+        observers.push({ doc: relatedDoc, handler: invalidateRelatedRollupValues });
 
         for (const [rowId, rowDoc] of Object.entries(rows)) {
           if (cancelled) return;

--- a/src/application/database-yjs/migrations/rollup_fieldtype.ts
+++ b/src/application/database-yjs/migrations/rollup_fieldtype.ts
@@ -1,5 +1,6 @@
 import * as Y from 'yjs';
 
+import { normalizeLegacyCellFieldType } from '@/application/database-yjs/cell.field-type';
 import { FieldType } from '@/application/database-yjs/database.type';
 import { getRowKey } from '@/application/database-yjs/row_meta';
 import {
@@ -16,7 +17,9 @@ import {
   YjsEditorKey,
 } from '@/application/types';
 
-export const ROLLUP_SCHEMA_VERSION = 2;
+const ROLLUP_SCHEMA_VERSION = 2;
+
+export const DATABASE_SCHEMA_VERSION = 3;
 
 type RowLoader = (rowKey: string) => Promise<YDoc>;
 
@@ -64,16 +67,12 @@ function isLegacyTimeField(fieldType: number, field: Y.Map<unknown>): boolean {
 
   const typeOptionMap = field.get(YjsDatabaseKey.type_option) as Y.Map<unknown> | undefined;
   const typeOption = typeOptionMap?.get(String(fieldType)) as Y.Map<unknown> | undefined;
-  const hasRollupKeys =
-    typeOption && Array.from(typeOption.keys()).some((key) => ROLLUP_OPTION_KEYS.has(key));
+  const hasRollupKeys = typeOption && Array.from(typeOption.keys()).some((key) => ROLLUP_OPTION_KEYS.has(key));
 
   return !hasRollupKeys;
 }
 
-function migrateFieldType(
-  field: Y.Map<unknown>,
-  fieldTypeById: Map<string, number>
-): void {
+function migrateFieldType(field: Y.Map<unknown>, fieldTypeById: Map<string, number>): void {
   const fieldId = field.get(YjsDatabaseKey.id) as string;
   const fieldType = Number(field.get(YjsDatabaseKey.type));
 
@@ -98,37 +97,48 @@ function migrateFieldType(
 
 async function migrateRowCells(
   rowDoc: YDoc,
-  fieldTypeById: Map<string, number>
-): Promise<void> {
+  fieldTypeById: Map<string, number>,
+  migrateRollupFieldType: boolean,
+  migrateLegacyCellType: boolean
+): Promise<boolean> {
   const rowRoot = rowDoc.getMap(YjsEditorKey.data_section);
   const row = rowRoot?.get(YjsEditorKey.database_row) as YDatabaseRow | undefined;
 
-  if (!row) return;
+  if (!row) return false;
 
   const cells = row.get(YjsDatabaseKey.cells) as YDatabaseCells | undefined;
 
-  if (!cells) return;
+  if (!cells) return true;
 
   rowDoc.transact(() => {
     cells.forEach((cell, fieldId) => {
       const cellMap = cell as YDatabaseCell;
-      const expectedType = fieldTypeById.get(fieldId);
 
-      if (!expectedType) return;
+      if (migrateRollupFieldType) {
+        const expectedType = fieldTypeById.get(fieldId);
 
-      const currentType = Number(cellMap.get(YjsDatabaseKey.field_type));
+        if (expectedType !== undefined) {
+          const currentType = Number(cellMap.get(YjsDatabaseKey.field_type));
 
-      if (currentType === FieldType.Rollup && expectedType === FieldType.Time) {
-        cellMap.set(YjsDatabaseKey.field_type, FieldType.Time);
+          if (currentType === FieldType.Rollup && expectedType === FieldType.Time) {
+            cellMap.set(YjsDatabaseKey.field_type, FieldType.Time);
+          }
+
+          const sourceType = Number(cellMap.get(YjsDatabaseKey.source_field_type));
+
+          if (sourceType === FieldType.Rollup && expectedType === FieldType.Time) {
+            cellMap.set(YjsDatabaseKey.source_field_type, FieldType.Time);
+          }
+        }
       }
 
-      const sourceType = Number(cellMap.get(YjsDatabaseKey.source_field_type));
-
-      if (sourceType === FieldType.Rollup && expectedType === FieldType.Time) {
-        cellMap.set(YjsDatabaseKey.source_field_type, FieldType.Time);
+      if (migrateLegacyCellType) {
+        normalizeLegacyCellFieldType(cellMap);
       }
     });
   });
+
+  return true;
 }
 
 export async function migrateDatabaseFieldTypes(
@@ -148,35 +158,50 @@ export async function migrateDatabaseFieldTypes(
   const metas = ensureMetas(database);
   const currentVersion = Number(metas.get(YjsDatabaseKey.schema_version) ?? 0);
 
-  if (currentVersion >= ROLLUP_SCHEMA_VERSION) return false;
+  const normalizeRequestedRows = Boolean(options?.rowIds?.length && options.loadRow);
+
+  if (currentVersion >= DATABASE_SCHEMA_VERSION && !normalizeRequestedRows) return false;
 
   const fields = database.get(YjsDatabaseKey.fields) as YDatabaseFields | undefined;
 
   if (!fields) return false;
 
   const fieldTypeById = new Map<string, number>();
+  const migrateRollupFieldType = currentVersion < ROLLUP_SCHEMA_VERSION;
+  const migrateLegacyCellType = currentVersion < DATABASE_SCHEMA_VERSION || normalizeRequestedRows;
 
-  doc.transact(() => {
-    fields.forEach((field) => {
-      migrateFieldType(field as Y.Map<unknown>, fieldTypeById);
+  if (migrateRollupFieldType) {
+    doc.transact(() => {
+      fields.forEach((field) => {
+        migrateFieldType(field as Y.Map<unknown>, fieldTypeById);
+      });
     });
-  });
+  }
 
   const rowIds = options?.rowIds ?? collectRowIds(database);
   const loadRow = options?.loadRow;
   const rowKeyPrefix = options?.databaseId || doc.guid;
 
+  let migratedEveryRow = rowIds.length === 0;
+
   if (loadRow && rowIds.length > 0) {
+    migratedEveryRow = true;
     for (const rowId of rowIds) {
       const rowKey = getRowKey(rowKeyPrefix, rowId);
       const rowDoc = await loadRow(rowKey);
 
-      await migrateRowCells(rowDoc, fieldTypeById);
+      const migrated = await migrateRowCells(rowDoc, fieldTypeById, migrateRollupFieldType, migrateLegacyCellType);
+
+      migratedEveryRow = migratedEveryRow && migrated;
     }
   }
 
-  if (options?.commitVersion ?? true) {
-    metas.set(YjsDatabaseKey.schema_version, ROLLUP_SCHEMA_VERSION);
+  // Do not mark a row migration complete when row docs were unavailable. A
+  // later open with a loader must still get a chance to repair them.
+  const canCommitVersion = rowIds.length === 0 || (Boolean(loadRow) && migratedEveryRow);
+
+  if (currentVersion < DATABASE_SCHEMA_VERSION && (options?.commitVersion ?? true) && canCommitVersion) {
+    metas.set(YjsDatabaseKey.schema_version, DATABASE_SCHEMA_VERSION);
   }
 
   return true;

--- a/src/application/database-yjs/migrations/rollup_fieldtype.ts
+++ b/src/application/database-yjs/migrations/rollup_fieldtype.ts
@@ -18,6 +18,7 @@ import {
 } from '@/application/types';
 
 const ROLLUP_SCHEMA_VERSION = 2;
+const ROW_MIGRATION_CONCURRENCY = 8;
 
 export const DATABASE_SCHEMA_VERSION = 3;
 
@@ -186,14 +187,23 @@ export async function migrateDatabaseFieldTypes(
 
   if (loadRow && rowIds.length > 0) {
     migratedEveryRow = true;
-    for (const rowId of rowIds) {
-      const rowKey = getRowKey(rowKeyPrefix, rowId);
-      const rowDoc = await loadRow(rowKey);
+    let nextRowIndex = 0;
+    const workerCount = Math.min(ROW_MIGRATION_CONCURRENCY, rowIds.length);
 
-      const migrated = await migrateRowCells(rowDoc, fieldTypeById, migrateRollupFieldType, migrateLegacyCellType);
+    await Promise.all(
+      Array.from({ length: workerCount }, async () => {
+        while (nextRowIndex < rowIds.length) {
+          const rowId = rowIds[nextRowIndex];
 
-      migratedEveryRow = migratedEveryRow && migrated;
-    }
+          nextRowIndex += 1;
+          const rowKey = getRowKey(rowKeyPrefix, rowId);
+          const rowDoc = await loadRow(rowKey);
+          const migrated = await migrateRowCells(rowDoc, fieldTypeById, migrateRollupFieldType, migrateLegacyCellType);
+
+          if (!migrated) migratedEveryRow = false;
+        }
+      })
+    );
   }
 
   // Do not mark a row migration complete when row docs were unavailable. A

--- a/src/application/database-yjs/relation/cache.ts
+++ b/src/application/database-yjs/relation/cache.ts
@@ -1,11 +1,11 @@
 import { FieldType } from '@/application/database-yjs/database.type';
 import { decodeCellToText } from '@/application/database-yjs/decode';
 import { parseRelationTypeOption } from '@/application/database-yjs/fields/relation/parse';
+import { getRelationRowIdsFromCell } from '@/application/database-yjs/relation/cell';
 import { getRowKey } from '@/application/database-yjs/row_meta';
 import {
   RowId,
   YDatabase,
-  YDatabaseCell,
   YDatabaseField,
   YDatabaseFields,
   YDatabaseRow,
@@ -122,20 +122,6 @@ function touchRelatedDocCache(viewId: string, promise: Promise<YDoc | null>) {
   }
 }
 
-function getRelationRowIds(cell?: YDatabaseCell): RowId[] {
-  if (!cell) return [];
-  const data = cell.get(YjsDatabaseKey.data);
-
-  if (!data) return [];
-  if (typeof data === 'object' && 'toJSON' in data) {
-    const ids = (data as { toJSON: () => unknown }).toJSON();
-
-    return Array.isArray(ids) ? (ids as RowId[]) : [];
-  }
-
-  return Array.isArray(data) ? (data as RowId[]) : [];
-}
-
 function getPrimaryFieldId(database: YDatabase): string | undefined {
   const fields = database?.get(YjsDatabaseKey.fields);
 
@@ -178,7 +164,7 @@ async function computeRelationCellValue(context: RelationComputeContext): Promis
     }
 
     const relationCell = row?.get(YjsDatabaseKey.cells)?.get(fieldId);
-    const relatedRowIds = getRelationRowIds(relationCell);
+    const relatedRowIds = getRelationRowIdsFromCell(relationCell);
 
     if (relatedRowIds.length === 0) return { value: '' };
 

--- a/src/application/database-yjs/relation/cell.ts
+++ b/src/application/database-yjs/relation/cell.ts
@@ -1,0 +1,54 @@
+import * as Y from 'yjs';
+
+import { getStoredCellFieldType } from '@/application/database-yjs/cell.field-type';
+import { FieldType } from '@/application/database-yjs/database.type';
+import { RowId, YDatabaseCell, YjsDatabaseKey } from '@/application/types';
+
+function uniq(ids: RowId[]) {
+  return Array.from(new Set(ids.filter(Boolean)));
+}
+
+/**
+ * Decode only cells whose raw payload is actually relation data.
+ *
+ * Several cell types use arrays. Checking the payload shape alone can turn a
+ * lazily converted Media/Person cell into relation row IDs and make rollups or
+ * reciprocal updates operate on unrelated data.
+ */
+export function getRelationRowIdsFromCell(cell?: YDatabaseCell): RowId[] {
+  if (!cell || getStoredCellFieldType(cell, FieldType.Relation) !== FieldType.Relation) {
+    return [];
+  }
+
+  const data = cell.get(YjsDatabaseKey.data);
+
+  if (!data) return [];
+
+  if (data instanceof Y.Array) {
+    return uniq(data.toArray().map(String));
+  }
+
+  if (typeof data === 'object' && 'toJSON' in data) {
+    const ids = (data as { toJSON: () => unknown }).toJSON();
+
+    return Array.isArray(ids) ? uniq(ids.map(String)) : [];
+  }
+
+  if (Array.isArray(data)) {
+    return uniq(data.map(String));
+  }
+
+  if (typeof data === 'string') {
+    try {
+      const parsed = JSON.parse(data);
+
+      if (Array.isArray(parsed)) {
+        return uniq(parsed.map(String));
+      }
+    } catch {
+      return uniq(data.split(',').map((id) => id.trim()));
+    }
+  }
+
+  return [];
+}

--- a/src/application/database-yjs/rollup/cache.ts
+++ b/src/application/database-yjs/rollup/cache.ts
@@ -1,3 +1,4 @@
+import { parseYDatabaseCellToCell } from '@/application/database-yjs/cell.parse';
 import { DateTimeCell } from '@/application/database-yjs/cell.type';
 import { CalculationType, FieldType, RollupDisplayMode } from '@/application/database-yjs/database.type';
 import { decodeCellToText } from '@/application/database-yjs/decode';
@@ -6,12 +7,12 @@ import { EnhancedBigStats } from '@/application/database-yjs/fields/number/Enhan
 import { parseNumberTypeOptions } from '@/application/database-yjs/fields/number/parse';
 import { parseRelationTypeOption } from '@/application/database-yjs/fields/relation/parse';
 import { parseRollupTypeOption } from '@/application/database-yjs/fields/rollup/parse';
+import { getRelationRowIdsFromCell } from '@/application/database-yjs/relation/cell';
 import { parseCheckboxValue } from '@/application/database-yjs/fields/text/utils';
 import { getRowKey } from '@/application/database-yjs/row_meta';
 import {
   RowId,
   YDatabase,
-  YDatabaseCell,
   YDatabaseField,
   YDatabaseFields,
   YDatabaseRow,
@@ -165,10 +166,7 @@ function touchRelatedDocCache(viewId: string, promise: Promise<YDoc | null>) {
   }
 }
 
-async function loadRelatedDoc(
-  viewId: string,
-  loadView?: (viewId: string) => Promise<YDoc | null>
-) {
+async function loadRelatedDoc(viewId: string, loadView?: (viewId: string) => Promise<YDoc | null>) {
   if (!loadView) return null;
   const cached = relatedDocCache.get(viewId);
 
@@ -184,20 +182,6 @@ async function loadRelatedDoc(
 
   touchRelatedDocCache(viewId, promise);
   return promise;
-}
-
-function getRelationRowIds(cell?: YDatabaseCell): RowId[] {
-  if (!cell) return [];
-  const data = cell.get(YjsDatabaseKey.data);
-
-  if (!data) return [];
-  if (typeof data === 'object' && 'toJSON' in data) {
-    const ids = (data as { toJSON: () => unknown }).toJSON();
-
-    return Array.isArray(ids) ? (ids as RowId[]) : [];
-  }
-
-  return Array.isArray(data) ? (data as RowId[]) : [];
 }
 
 function isEmptyValue(value: string) {
@@ -324,7 +308,7 @@ async function computeRollupCellValue(context: RollupComputeContext): Promise<Ro
   }
 
   const relationCell = row?.get(YjsDatabaseKey.cells)?.get(rollupOption.relation_field_id);
-  const relatedRowIds = getRelationRowIds(relationCell);
+  const relatedRowIds = getRelationRowIdsFromCell(relationCell);
 
   const showAs = (rollupOption.show_as ?? RollupDisplayMode.Calculated) as RollupDisplayMode;
   const calculationType = (rollupOption.calculation_type ?? CalculationType.Count) as CalculationType;
@@ -391,7 +375,7 @@ async function computeRollupCellValue(context: RollupComputeContext): Promise<Ro
 
     if (!relatedRow) continue;
     const cell = relatedRow.get(YjsDatabaseKey.cells)?.get(rollupOption.target_field_id);
-    const rawData = cell?.get(YjsDatabaseKey.data);
+    const parsedData = cell ? parseYDatabaseCellToCell(cell, targetField).data : undefined;
 
     let text = '';
 
@@ -412,7 +396,7 @@ async function computeRollupCellValue(context: RollupComputeContext): Promise<Ro
     } else if (cell) {
       text = decodeCellToText(cell, targetField);
       if (targetFieldType === FieldType.DateTime) {
-        const ts = normalizeTimestamp(cell.get(YjsDatabaseKey.data));
+        const ts = normalizeTimestamp(parsedData);
 
         if (ts !== null) {
           timestampValues.push(ts);
@@ -424,7 +408,7 @@ async function computeRollupCellValue(context: RollupComputeContext): Promise<Ro
     nonEmptyFlags.push(!isEmptyValue(text));
 
     if (targetFieldType === FieldType.Number) {
-      const numeric = parseNumber(rawData ?? text);
+      const numeric = parseNumber(parsedData ?? text);
 
       if (numeric !== null) {
         numericValues.push(numeric);
@@ -433,15 +417,21 @@ async function computeRollupCellValue(context: RollupComputeContext): Promise<Ro
 
     if (targetFieldType === FieldType.Checkbox) {
       const checkboxInput =
-        typeof rawData === 'string' || typeof rawData === 'number' || typeof rawData === 'boolean'
-          ? rawData
+        typeof parsedData === 'string' || typeof parsedData === 'number' || typeof parsedData === 'boolean'
+          ? parsedData
           : text;
 
       checkboxValues.push(parseCheckboxValue(checkboxInput));
     }
 
     if (targetFieldType === FieldType.SingleSelect || targetFieldType === FieldType.MultiSelect) {
-      const ids = typeof rawData === 'string' ? rawData.split(',').map((id) => id.trim()).filter(Boolean) : [];
+      const ids =
+        typeof parsedData === 'string'
+          ? parsedData
+              .split(',')
+              .map((id) => id.trim())
+              .filter(Boolean)
+          : [];
 
       selectValues.push(ids);
     }
@@ -628,10 +618,7 @@ async function computeRollupCellValue(context: RollupComputeContext): Promise<Ro
     }
 
     case CalculationType.CountValue: {
-      if (
-        ![FieldType.SingleSelect, FieldType.MultiSelect].includes(targetFieldType) ||
-        conditionValue.trim() === ''
-      ) {
+      if (![FieldType.SingleSelect, FieldType.MultiSelect].includes(targetFieldType) || conditionValue.trim() === '') {
         return { value: '' };
       }
 

--- a/src/application/database-yjs/row.hydration.ts
+++ b/src/application/database-yjs/row.hydration.ts
@@ -1,0 +1,34 @@
+import { YDoc, YjsEditorKey } from '@/application/types';
+
+const ROW_HYDRATION_TIMEOUT_MS = 3000;
+
+function hasDatabaseRow(rowDoc: YDoc): boolean {
+  return rowDoc.getMap(YjsEditorKey.data_section).has(YjsEditorKey.database_row);
+}
+
+/** Wait until an opened row collab contains its database_row payload. */
+export function waitForDatabaseRowHydration(
+  rowDoc: YDoc,
+  timeoutMs = ROW_HYDRATION_TIMEOUT_MS
+): Promise<YDoc | null> {
+  if (hasDatabaseRow(rowDoc)) return Promise.resolve(rowDoc);
+
+  return new Promise((resolve) => {
+    let settled = false;
+    const finish = (value: YDoc | null) => {
+      if (settled) return;
+      settled = true;
+      rowDoc.off('update', listener);
+      clearTimeout(timer);
+      resolve(value);
+    };
+
+    const listener = () => {
+      if (hasDatabaseRow(rowDoc)) finish(rowDoc);
+    };
+
+    const timer = setTimeout(() => finish(null), timeoutMs);
+
+    rowDoc.on('update', listener);
+  });
+}

--- a/src/application/database-yjs/selector.ts
+++ b/src/application/database-yjs/selector.ts
@@ -15,6 +15,7 @@ import {
   useRow,
   useRowMap,
 } from '@/application/database-yjs/context';
+import { decodeCellToText } from '@/application/database-yjs/decode';
 import {
   getDateCellStr,
   getFieldDateTimeFormats,
@@ -32,6 +33,7 @@ import {
   readRelationCellText,
   subscribeRelationCache,
 } from '@/application/database-yjs/relation/cache';
+import { getRelationRowIdsFromCell } from '@/application/database-yjs/relation/cell';
 import {
   invalidateRollupCell,
   readRollupCell,
@@ -48,7 +50,6 @@ import {
   SortId,
   TimeFormat,
   YDatabase,
-  YDatabaseCell,
   YDatabaseChartLayoutSetting,
   YDatabaseField,
   YDatabaseFilters,
@@ -65,7 +66,16 @@ import { useCurrentUser } from '@/components/main/app.hooks';
 import { getDateFormat, getTimeFormat, renderDate } from '@/utils/time';
 
 import { ChartLayoutSettings } from './chart.type';
-import { CalendarLayoutSetting, DateGroupCondition, FieldType, FieldVisibility, Filter, FilterType, RowMeta, SortCondition } from './database.type';
+import {
+  CalendarLayoutSetting,
+  DateGroupCondition,
+  FieldType,
+  FieldVisibility,
+  Filter,
+  FilterType,
+  RowMeta,
+  SortCondition,
+} from './database.type';
 
 export interface Column {
   fieldId: string;
@@ -107,11 +117,14 @@ const defaultVisible = [FieldVisibility.AlwaysShown, FieldVisibility.HideWhenEmp
 type ConditionReference = { id: string; fieldId: string };
 
 function areConditionReferencesEqual(left: ConditionReference[], right: ConditionReference[]) {
-  return left.length === right.length && left.every((item, index) => {
-    const rightItem = right[index];
+  return (
+    left.length === right.length &&
+    left.every((item, index) => {
+      const rightItem = right[index];
 
-    return item.id === rightItem?.id && item.fieldId === rightItem.fieldId;
-  });
+      return item.id === rightItem?.id && item.fieldId === rightItem.fieldId;
+    })
+  );
 }
 
 /**
@@ -471,7 +484,7 @@ export function useFiltersSelector() {
     const observerEvent = () => {
       const nextFilters = getFilters();
 
-      setFilters((prevFilters) => areConditionReferencesEqual(prevFilters, nextFilters) ? prevFilters : nextFilters);
+      setFilters((prevFilters) => (areConditionReferencesEqual(prevFilters, nextFilters) ? prevFilters : nextFilters));
     };
 
     observerEvent();
@@ -706,7 +719,9 @@ export function useAdvancedFilterSelector(filterId: string) {
       // Handle both Yjs Y.Array (with .get() method) and plain JavaScript array (from desktop sync)
       const isYArray = typeof (children as { get?: unknown }).get === 'function';
       const childrenArray = children as { length: number; get?: (index: number) => unknown } | unknown[];
-      const childCount = Array.isArray(childrenArray) ? childrenArray.length : (childrenArray as { length: number }).length;
+      const childCount = Array.isArray(childrenArray)
+        ? childrenArray.length
+        : (childrenArray as { length: number }).length;
 
       let foundFilter: unknown = null;
 
@@ -805,7 +820,7 @@ export function useSortsSelector() {
     const observerEvent = () => {
       const nextSorts = getSorts();
 
-      setSorts((prevSorts) => areConditionReferencesEqual(prevSorts, nextSorts) ? prevSorts : nextSorts);
+      setSorts((prevSorts) => (areConditionReferencesEqual(prevSorts, nextSorts) ? prevSorts : nextSorts));
     };
 
     setSorts(getSorts());
@@ -1009,9 +1024,7 @@ export function useGroup(groupId: string) {
         .map(normalizeGroupColumn)
         .filter((column): column is GroupColumn => Boolean(column));
 
-      setColumns(
-        persistedColumns.length > 0 ? persistedColumns : getFallbackGroupColumns(fields?.get(groupFieldId))
-      );
+      setColumns(persistedColumns.length > 0 ? persistedColumns : getFallbackGroupColumns(fields?.get(groupFieldId)));
     };
 
     observerEvent();
@@ -1689,20 +1702,6 @@ export function useRowDataSelector(rowId: string) {
   };
 }
 
-function getRelationRowIdsFromCell(cell?: YDatabaseCell): string[] {
-  if (!cell) return [];
-  const data = cell.get(YjsDatabaseKey.data);
-
-  if (!data) return [];
-  if (typeof data === 'object' && 'toJSON' in data) {
-    const ids = (data as { toJSON: () => unknown }).toJSON();
-
-    return Array.isArray(ids) ? (ids as string[]) : [];
-  }
-
-  return Array.isArray(data) ? (data as string[]) : [];
-}
-
 function useRollupCellValue({
   row,
   field,
@@ -1825,6 +1824,13 @@ function useRollupCellValue({
 
       if (!relatedDoc) return;
       const docGuid = relatedDoc.guid;
+      const handleRelatedSchemaChange = () => {
+        invalidateRollupCell(cellId);
+        void readRollupCell(rollupContext);
+      };
+
+      relatedDoc.getMap(YjsEditorKey.data_section).observeDeep(handleRelatedSchemaChange);
+      observers.push({ doc: relatedDoc, handler: handleRelatedSchemaChange });
 
       for (const relatedRowId of relatedRowIds) {
         if (cancelled) return;
@@ -1897,7 +1903,7 @@ export function useCellSelector({ rowId, fieldId }: { rowId: string; fieldId: st
     return () => {
       cell?.unobserveDeep(observerEvent);
     };
-  }, [cell, field, rowId, fieldId]);
+  }, [cell, field, fieldClock, rowId, fieldId]);
 
   useEffect(() => {
     if (!cells) return;
@@ -1920,7 +1926,7 @@ export function useCellSelector({ rowId, fieldId }: { rowId: string; fieldId: st
     return () => {
       cells.unobserve(observerEvent);
     };
-  }, [cells, fieldId, field, rowId]);
+  }, [cells, fieldId, field, fieldClock, rowId]);
 
   if (fieldType === FieldType.Rollup) {
     return rollupCell;
@@ -1941,9 +1947,10 @@ export interface CalendarEvent {
 
 export function useCalendarEventsSelector() {
   const setting = useCalendarLayoutSetting();
-  const filedId = setting?.fieldId || '';
-  const { field } = useFieldSelector(filedId);
+  const fieldId = setting?.fieldId || '';
+  const { field, clock: fieldClock } = useFieldSelector(fieldId);
   const primaryFieldId = usePrimaryFieldId();
+  const { field: primaryField, clock: primaryFieldClock } = useFieldSelector(primaryFieldId || '');
   const rowOrders = useRowOrdersSelector();
   const rows = useRowMap();
   const { ensureRow } = useDatabaseContext();
@@ -1951,10 +1958,19 @@ export function useCalendarEventsSelector() {
   const [emptyEvents, setEmptyEvents] = useState<CalendarEvent[]>([]);
 
   useEffect(() => {
-    if (!field || !rowOrders || !filedId) return;
-    const fieldType = Number(field?.get(YjsDatabaseKey.type)) as FieldType;
+    if (!field || !rowOrders || !fieldId || !primaryFieldId) {
+      setEvents([]);
+      setEmptyEvents([]);
+      return;
+    }
 
-    if (![FieldType.DateTime, FieldType.LastEditedTime, FieldType.CreatedTime].includes(fieldType) || !primaryFieldId) return;
+    const fieldType = Number(field.get(YjsDatabaseKey.type)) as FieldType;
+
+    if (![FieldType.DateTime, FieldType.LastEditedTime, FieldType.CreatedTime].includes(fieldType)) {
+      setEvents([]);
+      setEmptyEvents([]);
+      return;
+    }
 
     const observerEvent = () => {
       const newEvents: CalendarEvent[] = [];
@@ -1985,23 +2001,23 @@ export function useCalendarEventsSelector() {
           return;
         }
 
-        const cell = getCell(row.id, filedId, rows);
+        const cell = getCell(row.id, fieldId, rows);
         const primaryCell = getCell(row.id, primaryFieldId, rows);
-        const allDay = !cell?.get(YjsDatabaseKey.include_time);
-
-        const title = (primaryCell?.get(YjsDatabaseKey.data) as string) || '';
+        const title = primaryCell && primaryField ? decodeCellToText(primaryCell, primaryField) : '';
 
         const rowSharedRoot = doc.getMap(YjsEditorKey.data_section) as YSharedRoot;
-        const databbaseRow = rowSharedRoot?.get(YjsEditorKey.database_row);
+        const databaseRow = rowSharedRoot?.get(YjsEditorKey.database_row);
 
-        if (!databbaseRow) return;
+        if (!databaseRow) return;
 
-        const rowCreatedTime = databbaseRow.get(YjsDatabaseKey.created_at).toString();
-        const rowLastEditedTime = databbaseRow.get(YjsDatabaseKey.last_modified).toString();
+        const rowCreatedTime = databaseRow.get(YjsDatabaseKey.created_at).toString();
+        const rowLastEditedTime = databaseRow.get(YjsDatabaseKey.last_modified).toString();
 
-        const value = cell ? parseYDatabaseCellToCell(cell, field) as DateTimeCell : undefined;
+        const value = cell ? (parseYDatabaseCellToCell(cell, field) as DateTimeCell) : undefined;
+        const allDay = !value?.includeTime;
 
-        if ((!value?.data && fieldType !== FieldType.CreatedTime && fieldType !== FieldType.LastEditedTime) ||
+        if (
+          (!value?.data && fieldType !== FieldType.CreatedTime && fieldType !== FieldType.LastEditedTime) ||
           (fieldType === FieldType.CreatedTime && !rowCreatedTime) ||
           (fieldType === FieldType.LastEditedTime && !rowLastEditedTime)
         ) {
@@ -2020,7 +2036,6 @@ export function useCalendarEventsSelector() {
           return dayjsResult.toDate();
         };
 
-
         if ([FieldType.CreatedTime, FieldType.LastEditedTime].includes(fieldType)) {
           newEvents.push({
             id: `${row.id}`,
@@ -2034,23 +2049,22 @@ export function useCalendarEventsSelector() {
             id: `${row.id}`,
             start: getDate(value.data),
             isRange: value.isRange || false,
-            end: value.endTimestamp && value.isRange ? getDate(value.endTimestamp) : dayjs(getDate(value.data)).add(30, 'minute').toDate(),
+            end:
+              value.endTimestamp && value.isRange
+                ? getDate(value.endTimestamp)
+                : dayjs(getDate(value.data)).add(30, 'minute').toDate(),
             title,
             allDay,
             rowId: row.id,
           });
         }
-
-
       });
 
       setEvents(newEvents);
       setEmptyEvents(emptyEvents);
-    }
+    };
 
     observerEvent();
-
-    field?.observeDeep(observerEvent);
 
     const debouncedObserverEvent = debounce(observerEvent, 150);
 
@@ -2064,7 +2078,6 @@ export function useCalendarEventsSelector() {
 
     return () => {
       debouncedObserverEvent.cancel();
-      field?.unobserveDeep(observerEvent);
       rowOrders?.forEach((row) => {
         const rowDoc = rows?.[row.id];
 
@@ -2072,8 +2085,7 @@ export function useCalendarEventsSelector() {
         rowDoc.getMap(YjsEditorKey.data_section).unobserveDeep(debouncedObserverEvent);
       });
     };
-
-  }, [field, rowOrders, rows, filedId, primaryFieldId, ensureRow]);
+  }, [field, fieldClock, rowOrders, rows, fieldId, primaryFieldId, primaryField, primaryFieldClock, ensureRow]);
 
   return { events, emptyEvents };
 }
@@ -2092,7 +2104,10 @@ export function useCalendarLayoutSetting() {
     const view = database.get(YjsDatabaseKey.views)?.get(viewId);
     const observerHandler = () => {
       const layoutSetting = view?.get(YjsDatabaseKey.layout_settings)?.get('2');
-      const firstDayOfWeek = layoutSetting?.get(YjsDatabaseKey.first_day_of_week) === undefined ? startWeekOn : Number(layoutSetting?.get(YjsDatabaseKey.first_day_of_week) || 0);
+      const firstDayOfWeek =
+        layoutSetting?.get(YjsDatabaseKey.first_day_of_week) === undefined
+          ? startWeekOn
+          : Number(layoutSetting?.get(YjsDatabaseKey.first_day_of_week) || 0);
 
       setSetting({
         fieldId: layoutSetting?.get(YjsDatabaseKey.field_id),
@@ -2155,15 +2170,17 @@ export const useRowMetaSelector = (rowId: string) => {
       const promise = ensureRow(rowId);
 
       if (promise) {
-        promise.then((doc) => {
-          if (!cancelled && doc) {
-            setRowDoc(doc);
-          }
-        }).catch((error: unknown) => {
-          if (!cancelled) {
-            console.error('[useRowMetaSelector] Failed to ensure row doc:', error);
-          }
-        });
+        promise
+          .then((doc) => {
+            if (!cancelled && doc) {
+              setRowDoc(doc);
+            }
+          })
+          .catch((error: unknown) => {
+            if (!cancelled) {
+              console.error('[useRowMetaSelector] Failed to ensure row doc:', error);
+            }
+          });
       }
     }
 
@@ -2236,12 +2253,16 @@ export const useFieldCellsSelector = (fieldId: string) => {
   const rows = useRowOrdersSelector();
   const [cells, setCells] = useState<Map<string, unknown> | null>(null);
   const rowMap = useRowMap();
-  const cellObserverEventsRef = useRef<(() => void)[]>([]);
+  const { field, clock: fieldClock } = useFieldSelector(fieldId);
 
   useEffect(() => {
-    if (!rows || !rowMap) return;
+    if (!rows || !rowMap) {
+      setCells(null);
+      return;
+    }
 
-    setCells(null);
+    const nextCells = new Map<string, unknown>();
+    const unobserveCells: Array<() => void> = [];
 
     rows.forEach((row) => {
       const rowDoc = rowMap?.[row.id];
@@ -2252,47 +2273,38 @@ export const useFieldCellsSelector = (fieldId: string) => {
       if (!databaseRow) return;
 
       const cells = databaseRow.get(YjsDatabaseKey.cells);
-
-      const observerEvent = () => {
+      const getCellValue = () => {
         const cell = databaseRow.get(YjsDatabaseKey.cells)?.get(fieldId);
 
-        if (!cell) {
-          setCells((prev) => {
-            const newMap = new Map(prev);
+        return cell ? parseYDatabaseCellToCell(cell, field).data : '';
+      };
 
-            newMap.set(row.id, '');
-
-            return newMap;
-          });
-          return;
-        }
-
-        const cellData = cell.get(YjsDatabaseKey.data);
-
+      const observerEvent = () => {
         setCells((prev) => {
           const newMap = new Map(prev);
 
-          newMap.set(row.id, cellData);
+          newMap.set(row.id, getCellValue());
 
           return newMap;
         });
       };
 
-      observerEvent();
+      nextCells.set(row.id, getCellValue());
       cells?.observeDeep(observerEvent);
 
-      cellObserverEventsRef.current.push(() => {
+      unobserveCells.push(() => {
         cells?.unobserveDeep(observerEvent);
       });
     });
 
+    setCells(nextCells);
+
     return () => {
-      cellObserverEventsRef.current.forEach((unobserverEvent) => {
+      unobserveCells.forEach((unobserverEvent) => {
         unobserverEvent();
       });
-      cellObserverEventsRef.current = [];
     };
-  }, [rows, rowMap, fieldId]);
+  }, [rows, rowMap, fieldId, field, fieldClock]);
 
   return {
     cells,
@@ -2478,26 +2490,26 @@ export const useSelectFieldOptions = (fieldId: string, searchValue?: string) => 
 
 export function useRowPrimaryContentSelector(rowDoc: YDoc | null, primaryFieldId: string) {
   const [primaryContent, setPrimaryContent] = useState<string | null>(null);
-  const { field } = useFieldSelector(primaryFieldId);
+  const { field, clock: fieldClock } = useFieldSelector(primaryFieldId);
 
   const rowSharedRoot = rowDoc?.getMap(YjsEditorKey.data_section);
   const row = rowSharedRoot?.get(YjsEditorKey.database_row) as YDatabaseRow;
 
   useEffect(() => {
     const observerEvent = () => {
-      if (!row) return;
+      if (!row) {
+        setPrimaryContent(null);
+        return;
+      }
 
       const cell = row.get(YjsDatabaseKey.cells)?.get(primaryFieldId);
 
-      if (!cell) return;
-
-      const cellValue = parseYDatabaseCellToCell(cell, field);
-
-      if (cellValue) {
-        setPrimaryContent(cellValue.data as string);
-      } else {
+      if (!cell) {
         setPrimaryContent(null);
+        return;
       }
+
+      setPrimaryContent(field ? decodeCellToText(cell, field) : String(parseYDatabaseCellToCell(cell).data ?? ''));
     };
 
     observerEvent();
@@ -2507,15 +2519,12 @@ export function useRowPrimaryContentSelector(rowDoc: YDoc | null, primaryFieldId
     return () => {
       row?.unobserveDeep(observerEvent);
     };
-  }, [primaryFieldId, row, rowDoc, field]);
+  }, [primaryFieldId, row, rowDoc, field, fieldClock]);
 
   return primaryContent;
 }
 
-function chartSettingsEqual(
-  a: ChartLayoutSettings | null,
-  b: ChartLayoutSettings | null
-): boolean {
+function chartSettingsEqual(a: ChartLayoutSettings | null, b: ChartLayoutSettings | null): boolean {
   if (a === b) return true;
   if (!a || !b) return false;
   return (
@@ -2580,11 +2589,9 @@ export function useChartLayoutSetting(): ChartLayoutSettings | null {
         aggregationType: Number(chartSettingMap.get('aggregationType') || 0) as ChartLayoutSettings['aggregationType'],
         yFieldId: chartSettingMap.get('yFieldId') ? String(chartSettingMap.get('yFieldId')) : undefined,
         cumulative: Boolean(chartSettingMap.get('cumulative')),
-        dateCondition: (
-          dateConditionRaw === undefined || dateConditionRaw === null
-            ? DateGroupCondition.Month
-            : Number(dateConditionRaw)
-        ) as ChartLayoutSettings['dateCondition'],
+        dateCondition: (dateConditionRaw === undefined || dateConditionRaw === null
+          ? DateGroupCondition.Month
+          : Number(dateConditionRaw)) as ChartLayoutSettings['dateCondition'],
       };
 
       setSetting((prev) => (chartSettingsEqual(prev, next) ? prev : next));

--- a/src/application/database-yjs/selector.ts
+++ b/src/application/database-yjs/selector.ts
@@ -43,6 +43,7 @@ import {
   subscribeRollupCache,
 } from '@/application/database-yjs/rollup/cache';
 import { getMetaJSON, getRowKey } from '@/application/database-yjs/row_meta';
+import { subscribeSharedYjsDeep } from '@/application/database-yjs/shared-yjs-observer';
 import { sortBy } from '@/application/database-yjs/sort';
 import {
   DatabaseViewLayout,
@@ -1813,45 +1814,44 @@ function useRollupCellValue({
     if (relatedRowIds.length === 0) return;
 
     let cancelled = false;
-    const observers: Array<{ doc: YDoc; handler: () => void }> = [];
+    const observerCleanups: Array<() => void> = [];
 
     void (async () => {
       if (!loadView || !createRow) return;
       const viewId = await getViewIdFromDatabaseId?.(relationOption.database_id);
 
-      if (!viewId) return;
+      if (cancelled || !viewId) return;
       const relatedDoc = await loadView(viewId);
 
-      if (!relatedDoc) return;
+      if (cancelled || !relatedDoc) return;
       const docGuid = relatedDoc.guid;
       const handleRelatedSchemaChange = () => {
         invalidateRollupCell(cellId);
         void readRollupCell(rollupContext);
       };
 
-      relatedDoc.getMap(YjsEditorKey.data_section).observeDeep(handleRelatedSchemaChange);
-      observers.push({ doc: relatedDoc, handler: handleRelatedSchemaChange });
+      observerCleanups.push(
+        subscribeSharedYjsDeep(relatedDoc.getMap(YjsEditorKey.data_section), handleRelatedSchemaChange)
+      );
 
       for (const relatedRowId of relatedRowIds) {
         if (cancelled) return;
         const rowDoc = await createRow(getRowKey(docGuid, relatedRowId));
 
+        if (cancelled) return;
         if (!rowDoc) continue;
         const handler = () => {
           invalidateRollupCell(cellId);
           void readRollupCell(rollupContext);
         };
 
-        rowDoc.getMap(YjsEditorKey.data_section).observeDeep(handler);
-        observers.push({ doc: rowDoc, handler });
+        observerCleanups.push(subscribeSharedYjsDeep(rowDoc.getMap(YjsEditorKey.data_section), handler));
       }
     })();
 
     return () => {
       cancelled = true;
-      observers.forEach(({ doc, handler }) => {
-        doc.getMap(YjsEditorKey.data_section).unobserveDeep(handler);
-      });
+      observerCleanups.forEach((cleanup) => cleanup());
     };
   }, [
     rollupContext,

--- a/src/application/database-yjs/shared-yjs-observer.ts
+++ b/src/application/database-yjs/shared-yjs-observer.ts
@@ -1,0 +1,50 @@
+import * as Y from 'yjs';
+
+type YjsDeepObservable = Pick<Y.AbstractType<unknown>, 'observeDeep' | 'unobserveDeep'>;
+type YjsDeepObserver = Parameters<YjsDeepObservable['observeDeep']>[0];
+
+type SharedObserverEntry = {
+  observer: YjsDeepObserver;
+  subscribers: Set<() => void>;
+};
+
+const sharedObserverEntries = new WeakMap<YjsDeepObservable, SharedObserverEntry>();
+
+/**
+ * Shares one underlying Yjs deep observer across all consumers of the same
+ * collaborative type. Each subscriber still receives every change and can
+ * unsubscribe independently.
+ */
+export function subscribeSharedYjsDeep(target: YjsDeepObservable, subscriber: () => void): () => void {
+  let entry = sharedObserverEntries.get(target);
+
+  if (!entry) {
+    const subscribers = new Set<() => void>();
+    const observer: YjsDeepObserver = () => {
+      Array.from(subscribers).forEach((notify) => notify());
+    };
+
+    entry = { observer, subscribers };
+    sharedObserverEntries.set(target, entry);
+    target.observeDeep(observer);
+  }
+
+  // Wrap the callback so subscribing the same function more than once still
+  // produces independent subscriptions and cleanups.
+  const notify = () => subscriber();
+
+  entry.subscribers.add(notify);
+
+  let active = true;
+
+  return () => {
+    if (!active) return;
+    active = false;
+
+    entry?.subscribers.delete(notify);
+    if (entry && entry.subscribers.size === 0) {
+      target.unobserveDeep(entry.observer);
+      sharedObserverEntries.delete(target);
+    }
+  };
+}

--- a/src/application/services/js-services/cache/index.ts
+++ b/src/application/services/js-services/cache/index.ts
@@ -1,5 +1,6 @@
 import * as Y from 'yjs';
 
+import { installLegacyCellFieldTypeNormalizer } from '@/application/database-yjs/cell.field-type';
 import { invalidateRowConditionCache } from '@/application/database-yjs/condition-value-cache';
 import { migrateDatabaseFieldTypes } from '@/application/database-yjs/migrations/rollup_fieldtype';
 import { getRowKey } from '@/application/database-yjs/row_meta';
@@ -783,6 +784,8 @@ async function getOrCreateRowDocEntry(rowKey: string): Promise<RowDocEntry> {
 async function _createRowDocEntry(rowKey: string, rowObjectId: string): Promise<RowDocEntry> {
   const startedAt = Date.now();
   const { doc, provider } = await openRowCollabDBWithProvider(rowObjectId, { awaitSync: false });
+
+  installLegacyCellFieldTypeNormalizer(doc);
 
   // Check initial state immediately after opening
   const initialSharedRoot = doc.getMap(YjsEditorKey.data_section);

--- a/src/components/database/chart/ChartRowListPopup.tsx
+++ b/src/components/database/chart/ChartRowListPopup.tsx
@@ -2,14 +2,10 @@ import { Dialog, DialogContent, DialogTitle } from '@mui/material';
 import { useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import {
-  useFieldSelector,
-  usePrimaryFieldId,
-  useRowMap,
-} from '@/application/database-yjs';
-import { parseYDatabaseCellToCell } from '@/application/database-yjs/cell.parse';
+import { useFieldSelector, usePrimaryFieldId, useRowMap } from '@/application/database-yjs';
 import { ChartDataItem } from '@/application/database-yjs/chart.type';
 import { getCell } from '@/application/database-yjs/const';
+import { decodeCellToText } from '@/application/database-yjs/decode';
 import { YjsDatabaseKey } from '@/application/types';
 import { ReactComponent as CloseIcon } from '@/assets/icons/close.svg';
 import { useChartContext } from '@/components/database/chart/useChartContext';
@@ -32,14 +28,14 @@ interface RowItem {
  * `ChartRowListPopup`: header (label + count), filter chip
  * "<x-axis field>: <category>", and a scrollable list of rows.
  *
- * Web shows the primary-field text per row (using `parseYDatabaseCellToCell`
- * so RichText deltas are decoded). Clicking a row opens the row detail modal.
+ * Web shows the primary-field text per row using the current field schema.
+ * Clicking a row opens the row detail modal.
  */
 export function ChartRowListPopup({ open, onClose, item }: ChartRowListPopupProps) {
   const { t } = useTranslation();
   const rowMetas = useRowMap();
   const primaryFieldId = usePrimaryFieldId();
-  const { field: primaryField } = useFieldSelector(primaryFieldId ?? '');
+  const { field: primaryField, clock: primaryFieldClock } = useFieldSelector(primaryFieldId ?? '');
   const { xAxisField } = useChartContext();
 
   const xAxisName = xAxisField ? String(xAxisField.get(YjsDatabaseKey.name) || '') : '';
@@ -47,6 +43,8 @@ export function ChartRowListPopup({ open, onClose, item }: ChartRowListPopupProp
   const [selectedRowId, setSelectedRowId] = useState<string | null>(null);
 
   const rows = useMemo<RowItem[]>(() => {
+    void primaryFieldClock;
+
     return item.rowIds.map((rowId) => {
       if (!rowMetas || !primaryFieldId || !primaryField) {
         return { id: rowId, primaryValue: '' };
@@ -55,12 +53,9 @@ export function ChartRowListPopup({ open, onClose, item }: ChartRowListPopupProp
       const cell = getCell(rowId, primaryFieldId, rowMetas);
 
       if (!cell) return { id: rowId, primaryValue: '' };
-      const parsed = parseYDatabaseCellToCell(cell, primaryField);
-      const text = typeof parsed?.data === 'string' ? parsed.data : '';
-
-      return { id: rowId, primaryValue: text };
+      return { id: rowId, primaryValue: decodeCellToText(cell, primaryField) };
     });
-  }, [item.rowIds, rowMetas, primaryFieldId, primaryField]);
+  }, [item.rowIds, rowMetas, primaryFieldId, primaryField, primaryFieldClock]);
 
   return (
     <>
@@ -73,7 +68,7 @@ export function ChartRowListPopup({ open, onClose, item }: ChartRowListPopupProp
         // editor host) on close — that element has `scroll-mt-[300px]`, which
         // causes the browser to scroll the document to put it in view.
         disableRestoreFocus
-        maxWidth="sm"
+        maxWidth='sm'
         PaperProps={{
           sx: {
             maxWidth: 560,
@@ -89,62 +84,48 @@ export function ChartRowListPopup({ open, onClose, item }: ChartRowListPopupProp
           },
         }}
       >
-        <DialogTitle className="flex items-center justify-between border-b border-border-primary px-4 py-3">
-          <div className="flex items-center gap-3">
-            <div
-              className="h-4 w-4 rounded-sm"
-              style={{ backgroundColor: item.color }}
-            />
-            <span className="text-base font-medium text-text-primary">
-              {item.label}
-            </span>
-            <span className="text-sm text-text-secondary">
+        <DialogTitle className='flex items-center justify-between border-b border-border-primary px-4 py-3'>
+          <div className='flex items-center gap-3'>
+            <div className='h-4 w-4 rounded-sm' style={{ backgroundColor: item.color }} />
+            <span className='text-base font-medium text-text-primary'>{item.label}</span>
+            <span className='text-sm text-text-secondary'>
               ({t('chart.drilldown.rowCount', { count: item.rowIds.length })})
             </span>
           </div>
-          <Button
-            size="icon-sm"
-            variant="ghost"
-            onClick={onClose}
-          >
-            <CloseIcon className="h-4 w-4" />
+          <Button size='icon-sm' variant='ghost' onClick={onClose}>
+            <CloseIcon className='h-4 w-4' />
           </Button>
         </DialogTitle>
 
         {/* Filter chip — mirrors desktop's `ChartFilterChip` */}
         {xAxisName && !item.isEmptyCategory && (
-          <div className="flex items-center gap-2 border-b border-border-primary px-4 py-2 text-xs text-text-secondary">
-            <span className="rounded bg-fill-list-hover px-2 py-1 text-text-primary">
-              {xAxisName}
-            </span>
+          <div className='flex items-center gap-2 border-b border-border-primary px-4 py-2 text-xs text-text-secondary'>
+            <span className='rounded bg-fill-list-hover px-2 py-1 text-text-primary'>{xAxisName}</span>
             <span>:</span>
-            <span
-              className="rounded px-2 py-1 text-text-primary"
-              style={{ backgroundColor: item.color }}
-            >
+            <span className='rounded px-2 py-1 text-text-primary' style={{ backgroundColor: item.color }}>
               {item.label}
             </span>
           </div>
         )}
 
         <DialogContent
-          className="flex-1 overflow-y-auto p-0"
+          className='flex-1 overflow-y-auto p-0'
           sx={{ padding: 0, '&.MuiDialogContent-root': { padding: 0 } }}
         >
-          <div className="flex flex-col">
+          <div className='flex flex-col'>
             {rows.length === 0 ? (
-              <div className="flex items-center justify-center py-8 text-sm text-text-secondary">
+              <div className='flex items-center justify-center py-8 text-sm text-text-secondary'>
                 {t('chart.drilldown.noRows', 'No rows in this category')}
               </div>
             ) : (
               rows.map((row) => (
                 <button
-                  type="button"
+                  type='button'
                   key={row.id}
                   onClick={() => setSelectedRowId(row.id)}
-                  className="flex w-full cursor-pointer items-center gap-3 border-b border-border-primary px-4 py-3 text-left transition-colors hover:bg-fill-content-hover"
+                  className='flex w-full cursor-pointer items-center gap-3 border-b border-border-primary px-4 py-3 text-left transition-colors hover:bg-fill-content-hover'
                 >
-                  <span className="flex-1 truncate text-sm text-text-primary">
+                  <span className='flex-1 truncate text-sm text-text-primary'>
                     {row.primaryValue || t('grid.title.placeholder')}
                   </span>
                 </button>

--- a/src/components/database/chart/hooks/useChartData.test.tsx
+++ b/src/components/database/chart/hooks/useChartData.test.tsx
@@ -1,0 +1,117 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import * as Y from 'yjs';
+
+jest.mock('@/utils/runtime-config', () => ({
+  getConfigValue: (_key: string, defaultValue: string) => defaultValue,
+}));
+
+jest.mock('@/application/database-yjs', () => {
+  const actual = jest.requireActual('@/application/database-yjs');
+
+  return {
+    ...actual,
+    useDatabaseContext: jest.fn(),
+    useDatabaseFields: jest.fn(),
+    useRowMap: jest.fn(),
+    useRowOrdersSelector: jest.fn(),
+  };
+});
+
+jest.mock('./useChartColors', () => ({
+  useChartColors: () => ({
+    emptyColor: '#empty',
+    getColorForCategory: () => '#category',
+  }),
+}));
+
+import { useDatabaseContext, useDatabaseFields, useRowMap, useRowOrdersSelector } from '@/application/database-yjs';
+import { ChartAggregationType, ChartLayoutSettings, ChartType } from '@/application/database-yjs/chart.type';
+import { DateGroupCondition, FieldType } from '@/application/database-yjs/database.type';
+import {
+  YDatabaseField,
+  YDatabaseFields,
+  YDatabaseFieldTypeOption,
+  YjsDatabaseKey,
+  YMapFieldTypeOption,
+} from '@/application/types';
+
+import { createCell, createRowDoc } from '@/application/database-yjs/__tests__/test-helpers';
+
+import { useChartData } from './useChartData';
+
+function addField(
+  fields: YDatabaseFields,
+  id: string,
+  type: FieldType,
+  options?: Array<{ id: string; name: string; color: number }>
+): YDatabaseField {
+  const field = new Y.Map() as YDatabaseField;
+
+  fields.set(id, field);
+  field.set(YjsDatabaseKey.id, id);
+  field.set(YjsDatabaseKey.name, id);
+  field.set(YjsDatabaseKey.type, type);
+
+  if (options) {
+    const typeOptions = new Y.Map() as YDatabaseFieldTypeOption;
+    const typeOption = new Y.Map() as YMapFieldTypeOption;
+
+    field.set(YjsDatabaseKey.type_option, typeOptions);
+    typeOptions.set(String(type), typeOption);
+    typeOption.set(YjsDatabaseKey.content, JSON.stringify({ options, disable_color: false }));
+  }
+
+  return field;
+}
+
+describe('useChartData desktop-model field conversion', () => {
+  it('parses both chart axes with the current fields and reacts to schema-only changes', async () => {
+    const databaseId = 'chart-database';
+    const rowId = 'row-a';
+    const xFieldId = 'x-field';
+    const yFieldId = 'y-field';
+    const databaseDoc = new Y.Doc();
+    const fields = databaseDoc.getMap('fields') as YDatabaseFields;
+    const xField = addField(fields, xFieldId, FieldType.MultiSelect, [{ id: 'opt-yes', name: 'Yes', color: 0 }]);
+    const yField = addField(fields, yFieldId, FieldType.Number);
+    const rowMetas = {
+      [rowId]: createRowDoc(rowId, databaseId, {
+        [xFieldId]: createCell(FieldType.RichText, 'Yes'),
+        [yFieldId]: createCell(FieldType.RichText, 'true'),
+      }),
+    };
+    const ensureRow = jest.fn().mockResolvedValue(undefined);
+    const settings: ChartLayoutSettings = {
+      chartType: ChartType.Bar,
+      xFieldId,
+      yFieldId,
+      showEmptyValues: true,
+      aggregationType: ChartAggregationType.Sum,
+      cumulative: false,
+      dateCondition: DateGroupCondition.Month,
+    };
+
+    (useDatabaseFields as jest.Mock).mockReturnValue(fields);
+    (useRowOrdersSelector as jest.Mock).mockReturnValue([{ id: rowId }]);
+    (useRowMap as jest.Mock).mockReturnValue(rowMetas);
+    (useDatabaseContext as jest.Mock).mockReturnValue({ ensureRow });
+
+    const { result } = renderHook(() => useChartData({ settings }));
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.chartData).toEqual([expect.objectContaining({ label: 'Yes', value: 0, rowIds: [rowId] })]);
+
+    act(() => {
+      databaseDoc.transact(() => {
+        xField.set(YjsDatabaseKey.type, FieldType.Checkbox);
+        yField.set(YjsDatabaseKey.type, FieldType.Checkbox);
+      });
+    });
+
+    await waitFor(() => {
+      expect(result.current.chartData).toEqual([
+        expect.objectContaining({ label: 'Checked', value: 1, rowIds: [rowId] }),
+      ]);
+    });
+  });
+});

--- a/src/components/database/chart/hooks/useChartData.ts
+++ b/src/components/database/chart/hooks/useChartData.ts
@@ -1,12 +1,7 @@
 import dayjs, { Dayjs } from 'dayjs';
 import { useEffect, useMemo, useRef, useState } from 'react';
 
-import {
-  useDatabaseContext,
-  useDatabaseFields,
-  useRowMap,
-  useRowOrdersSelector,
-} from '@/application/database-yjs';
+import { useDatabaseContext, useDatabaseFields, useRowMap, useRowOrdersSelector } from '@/application/database-yjs';
 import {
   ChartAggregationType,
   ChartDataItem,
@@ -14,11 +9,20 @@ import {
   isDateGroupableFieldType,
   isGroupableFieldType,
 } from '@/application/database-yjs/chart.type';
-import { getCellData } from '@/application/database-yjs/const';
+import { parseYDatabaseCellToCell } from '@/application/database-yjs/cell.parse';
+import { getCell } from '@/application/database-yjs/const';
 import { DateGroupCondition, FieldType } from '@/application/database-yjs/database.type';
 import { parseSelectOptionTypeOptions, SelectOption } from '@/application/database-yjs/fields';
 import { safeParseTimestamp } from '@/application/database-yjs/fields/date/utils';
-import { YjsDatabaseKey, YjsEditorKey, YDatabaseField, YDatabaseFields, YDatabaseRow, RowId, YDoc } from '@/application/types';
+import {
+  YjsDatabaseKey,
+  YjsEditorKey,
+  YDatabaseField,
+  YDatabaseFields,
+  YDatabaseRow,
+  RowId,
+  YDoc,
+} from '@/application/types';
 
 import { useChartColors, UseChartColorsReturn } from './useChartColors';
 
@@ -49,9 +53,7 @@ function bucketDate(date: Dayjs, condition: DateGroupCondition): GroupValue {
 
     case DateGroupCondition.Week: {
       // Week of year (ISO-style): start on Monday
-      const monday = date.day() === 0
-        ? date.subtract(6, 'day')
-        : date.subtract(date.day() - 1, 'day');
+      const monday = date.day() === 0 ? date.subtract(6, 'day') : date.subtract(date.day() - 1, 'day');
       const key = monday.format('YYYY-MM-DD');
 
       return { label: `Week of ${key}`, groupKey: key, sortKey: key };
@@ -94,17 +96,18 @@ function bucketDate(date: Dayjs, condition: DateGroupCondition): GroupValue {
  */
 function getCellGroupValue(
   rowId: string,
-  fieldId: string,
-  fieldType: FieldType,
+  field: YDatabaseField,
   rowMetas: Record<RowId, YDoc>,
   dateCondition: DateGroupCondition
 ): GroupValue[] {
+  const fieldId = field.get(YjsDatabaseKey.id);
+  const fieldType = Number(field.get(YjsDatabaseKey.type)) as FieldType;
   const rowDoc = rowMetas[rowId];
   const dataSection = rowDoc?.getMap(YjsEditorKey.data_section);
   const databaseRow = dataSection?.get(YjsEditorKey.database_row) as YDatabaseRow | undefined;
   const cells = databaseRow?.get(YjsDatabaseKey.cells);
   const cell = cells?.get(fieldId);
-  const data = cell?.get(YjsDatabaseKey.data);
+  const data = cell ? parseYDatabaseCellToCell(cell, field).data : undefined;
 
   switch (fieldType) {
     case FieldType.SingleSelect: {
@@ -117,7 +120,10 @@ function getCellGroupValue(
 
     case FieldType.MultiSelect: {
       if (typeof data === 'string' && data.length > 0) {
-        return data.split(',').filter(Boolean).map((id) => ({ label: id, groupKey: id }));
+        return data
+          .split(',')
+          .filter(Boolean)
+          .map((id) => ({ label: id, groupKey: id }));
       }
 
       return [];
@@ -145,9 +151,10 @@ function getCellGroupValue(
       } else {
         // YDatabaseRow has overloaded `.get` per key, so the lookup must use
         // a literal `YjsDatabaseKey` member rather than a computed variable.
-        const v = fieldType === FieldType.CreatedTime
-          ? databaseRow?.get(YjsDatabaseKey.created_at)
-          : databaseRow?.get(YjsDatabaseKey.last_modified);
+        const v =
+          fieldType === FieldType.CreatedTime
+            ? databaseRow?.get(YjsDatabaseKey.created_at)
+            : databaseRow?.get(YjsDatabaseKey.last_modified);
 
         raw = v !== undefined && v !== null ? String(v) : undefined;
       }
@@ -172,13 +179,11 @@ function getCellGroupValue(
  * yields 0/1, and date-typed fields yield "days since epoch" so Min/Max/Avg
  * make sense on a human scale.
  */
-function getCellNumericValue(
-  rowId: string,
-  fieldId: string,
-  fieldType: FieldType | null,
-  rowMetas: Record<RowId, YDoc>
-): number | null {
-  const data = getCellData(rowId, fieldId, rowMetas);
+function getCellNumericValue(rowId: string, field: YDatabaseField, rowMetas: Record<RowId, YDoc>): number | null {
+  const fieldId = field.get(YjsDatabaseKey.id);
+  const fieldType = Number(field.get(YjsDatabaseKey.type)) as FieldType;
+  const cell = getCell(rowId, fieldId, rowMetas);
+  const data = cell ? parseYDatabaseCellToCell(cell, field).data : undefined;
 
   switch (fieldType) {
     case FieldType.Checkbox: {
@@ -211,10 +216,7 @@ function getCellNumericValue(
 /**
  * Compute aggregation on an array of values
  */
-function computeAggregation(
-  values: number[],
-  aggregationType: ChartAggregationType
-): number {
+function computeAggregation(values: number[], aggregationType: ChartAggregationType): number {
   if (values.length === 0) {
     return 0;
   }
@@ -308,7 +310,7 @@ function computeChartData({
 
   rowOrders.forEach((row) => {
     const rowId = row.id;
-    const groupValues = getCellGroupValue(rowId, resolvedXFieldId, fieldType, rowMetas, dateCondition);
+    const groupValues = getCellGroupValue(rowId, xAxisField, rowMetas, dateCondition);
 
     if (groupValues.length === 0) {
       emptyGroup.rowIds.push(rowId);
@@ -344,9 +346,6 @@ function computeChartData({
   }
 
   const yField = yFieldId && fields ? fields.get(yFieldId) : undefined;
-  const yFieldType = yField
-    ? (Number(yField.get(YjsDatabaseKey.type)) as FieldType)
-    : null;
 
   const data: ChartDataItem[] = [];
   let colorIndex = 0;
@@ -357,9 +356,11 @@ function computeChartData({
     if (aggregationType === ChartAggregationType.Count) {
       value = group.rowIds.length;
     } else if (yFieldId) {
-      const numericValues = group.rowIds
-        .map((rowId) => getCellNumericValue(rowId, yFieldId, yFieldType, rowMetas))
-        .filter((v): v is number => v !== null);
+      const numericValues = yField
+        ? group.rowIds
+            .map((rowId) => getCellNumericValue(rowId, yField, rowMetas))
+            .filter((v): v is number => v !== null)
+        : [];
 
       value = computeAggregation(numericValues, aggregationType);
     } else {
@@ -488,10 +489,7 @@ export function useChartData({ settings }: UseChartDataOptions): UseChartDataRet
   // Stable string representation of the row order. Yjs often returns a fresh
   // array reference even when the contents are unchanged, so we depend on the
   // joined ids in effects instead of the array identity.
-  const rowIdsKey = useMemo(
-    () => (rowOrders?.map((r) => r.id).join(',') ?? ''),
-    [rowOrders]
-  );
+  const rowIdsKey = useMemo(() => rowOrders?.map((r) => r.id).join(',') ?? '', [rowOrders]);
 
   const loadedRowIdsRef = useRef<Set<string>>(new Set());
   // Always start in the loading state. The effect below decides when to
@@ -603,15 +601,8 @@ export function useChartData({ settings }: UseChartDataOptions): UseChartDataRet
     return groupableFields[0].id;
   }, [settings?.xFieldId, groupableFields, hasGroupableFields]);
 
-  const xAxisField = useMemo<YDatabaseField | null>(() => {
-    if (!resolvedXFieldId || !fields) return null;
-    return fields.get(resolvedXFieldId) ?? null;
-  }, [resolvedXFieldId, fields]);
-
-  const fieldType = useMemo<FieldType | null>(() => {
-    if (!xAxisField) return null;
-    return Number(xAxisField.get(YjsDatabaseKey.type)) as FieldType;
-  }, [xAxisField]);
+  const xAxisField = resolvedXFieldId && fields ? fields.get(resolvedXFieldId) ?? null : null;
+  const fieldType = xAxisField ? (Number(xAxisField.get(YjsDatabaseKey.type)) as FieldType) : null;
 
   const selectOptions = useMemo<SelectOption[]>(() => {
     if (!xAxisField) return [];
@@ -620,7 +611,8 @@ export function useChartData({ settings }: UseChartDataOptions): UseChartDataRet
     }
 
     return parseSelectOptionTypeOptions(xAxisField)?.options ?? [];
-  }, [xAxisField, fieldType]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [xAxisField, fieldType, fieldsClock]);
 
   const colors = useChartColors({ fieldType, selectOptions });
 
@@ -641,6 +633,10 @@ export function useChartData({ settings }: UseChartDataOptions): UseChartDataRet
   // widgets are wrapped in `React.memo(..., chartDataEqual)`, so re-renders
   // are skipped when the resulting bars are unchanged.
   const chartData = useMemo<ChartDataItem[]>(() => {
+    // Yjs mutates field maps in place, so their identity cannot invalidate this
+    // memo after a schema-only field-type switch.
+    void fieldsClock;
+
     if (!rowsLoaded) return EMPTY_CHART_DATA;
 
     return computeChartData({
@@ -663,6 +659,7 @@ export function useChartData({ settings }: UseChartDataOptions): UseChartDataRet
     xAxisField,
     fieldType,
     fields,
+    fieldsClock,
     optionIdToName,
     colors,
   ]);

--- a/src/components/database/components/cell/relation/RelationCellMenuContent.tsx
+++ b/src/components/database/components/cell/relation/RelationCellMenuContent.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { getPrimaryFieldId, useDatabaseContext } from '@/application/database-yjs';
-import { parseYDatabaseCellToCell } from '@/application/database-yjs/cell.parse';
+import { decodeCellToText } from '@/application/database-yjs/decode';
 import { createRowInRelatedDatabase } from '@/application/database-yjs/dispatch/relation';
 import { getRowKey } from '@/application/database-yjs/row_meta';
 import { View, YDatabase, YDatabaseField, YDatabaseRow, YDoc, YjsDatabaseKey, YjsEditorKey } from '@/application/types';
@@ -96,6 +96,7 @@ function RelationCellMenuContent({
   const [searchInput, setSearchInput] = useState<string>('');
   const [primaryFieldId, setPrimaryFieldId] = useState<string | null>(null);
   const [primaryField, setPrimaryField] = useState<YDatabaseField | null>(null);
+  const [primaryFieldClock, setPrimaryFieldClock] = useState(0);
   const [guid, setGuid] = useState<string | null>(null);
   const [noAccess, setNoAccess] = useState(false);
   const [rowIds, setRowIds] = useState<string[]>([]);
@@ -155,8 +156,23 @@ function RelationCellMenuContent({
     })();
   }, [loadView, selectedViewId]);
 
+  useEffect(() => {
+    if (!primaryField) return;
+
+    const onPrimaryFieldChange = () => {
+      setPrimaryFieldClock((clock) => clock + 1);
+    };
+
+    primaryField.observeDeep(onPrimaryFieldChange);
+    return () => {
+      primaryField.unobserveDeep(onPrimaryFieldChange);
+    };
+  }, [primaryField]);
+
   const getContent = useCallback(
     (rowId: string) => {
+      void primaryFieldClock;
+
       const rowDoc = rowDocsRef.current.get(rowId);
 
       if (!rowDoc || !primaryFieldId) {
@@ -168,11 +184,9 @@ function RelationCellMenuContent({
       const cell = row?.get(YjsDatabaseKey.cells)?.get(primaryFieldId);
 
       if (!cell) return '';
-      const cellValue = parseYDatabaseCellToCell(cell, primaryField || undefined);
-
-      return (cellValue?.data as string) || '';
+      return primaryField ? decodeCellToText(cell, primaryField) : '';
     },
-    [primaryFieldId, primaryField]
+    [primaryFieldId, primaryField, primaryFieldClock]
   );
 
   useEffect(() => {
@@ -290,7 +304,7 @@ function RelationCellMenuContent({
                 size={'icon'}
                 className={cn(
                   'shrink-0 opacity-0 transition-opacity',
-                  (selectedId === id) && 'opacity-100',
+                  selectedId === id && 'opacity-100',
                   'group-hover:opacity-100'
                 )}
               >

--- a/src/components/database/components/cell/relation/RelationItems.tsx
+++ b/src/components/database/components/cell/relation/RelationItems.tsx
@@ -9,6 +9,7 @@ import {
 } from '@/application/database-yjs';
 import { RelationCell, RelationCellData } from '@/application/database-yjs/cell.type';
 import { getRowKey } from '@/application/database-yjs/row_meta';
+import { subscribeSharedYjsDeep } from '@/application/database-yjs/shared-yjs-observer';
 import { YDatabaseField, YDoc, YjsDatabaseKey, YjsEditorKey } from '@/application/types';
 import { notify } from '@/components/_shared/notify';
 import { RelationPrimaryValue } from '@/components/database/components/cell/relation/RelationPrimaryValue';
@@ -160,11 +161,8 @@ function RelationItems({
     observerEvent();
 
     // The primary field can change type without replacing the database map.
-    // Observe deeply so a primary-field reassignment also refreshes this link.
-    sharedRoot.observeDeep(observerEvent);
-    return () => {
-      sharedRoot.unobserveDeep(observerEvent);
-    };
+    // Share the deep observer across rendered relation cells for this database.
+    return subscribeSharedYjsDeep(sharedRoot, observerEvent);
   }, [databaseDoc]);
 
   return (

--- a/src/components/database/components/cell/relation/RelationItems.tsx
+++ b/src/components/database/components/cell/relation/RelationItems.tsx
@@ -9,7 +9,7 @@ import {
 } from '@/application/database-yjs';
 import { RelationCell, RelationCellData } from '@/application/database-yjs/cell.type';
 import { getRowKey } from '@/application/database-yjs/row_meta';
-import { YDoc, YjsEditorKey } from '@/application/types';
+import { YDatabaseField, YDoc, YjsDatabaseKey, YjsEditorKey } from '@/application/types';
 import { notify } from '@/components/_shared/notify';
 import { RelationPrimaryValue } from '@/components/database/components/cell/relation/RelationPrimaryValue';
 import { cn } from '@/lib/utils';
@@ -42,6 +42,7 @@ function RelationItems({
 
   const [docGuid, setDocGuid] = useState<string | null>(null);
   const [databaseDoc, setDatabaseDoc] = useState<YDoc | null>(null);
+  const [relatedField, setRelatedField] = useState<YDatabaseField | undefined>();
 
   const [rowIds, setRowIds] = useState([] as string[]);
 
@@ -152,14 +153,17 @@ function RelationItems({
       const fieldId = getPrimaryFieldId(database);
 
       setRelatedFieldId(fieldId);
+      setRelatedField(fieldId ? database?.get(YjsDatabaseKey.fields)?.get(fieldId) : undefined);
       setNoAccess(!fieldId);
     };
 
     observerEvent();
 
-    sharedRoot.observe(observerEvent);
+    // The primary field can change type without replacing the database map.
+    // Observe deeply so a primary-field reassignment also refreshes this link.
+    sharedRoot.observeDeep(observerEvent);
     return () => {
-      sharedRoot.unobserve(observerEvent);
+      sharedRoot.unobserveDeep(observerEvent);
     };
   }, [databaseDoc]);
 
@@ -201,7 +205,7 @@ function RelationItems({
                 relatedViewId ? 'cursor-pointer hover:text-text-action' : ''
               }`}
             >
-              <RelationPrimaryValue fieldId={relatedFieldId} rowDoc={rowDoc} />
+              <RelationPrimaryValue field={relatedField} fieldId={relatedFieldId} rowDoc={rowDoc} />
             </div>
           );
         })

--- a/src/components/database/components/cell/relation/RelationPrimaryValue.test.tsx
+++ b/src/components/database/components/cell/relation/RelationPrimaryValue.test.tsx
@@ -1,0 +1,66 @@
+import { act, render, waitFor } from '@testing-library/react';
+import * as Y from 'yjs';
+
+import { FieldType, SelectOptionColor } from '@/application/database-yjs';
+import { createRowDoc } from '@/application/database-yjs/__tests__/test-helpers';
+import {
+  YDatabaseField,
+  YDatabaseRow,
+  YjsDatabaseKey,
+  YjsEditorKey,
+} from '@/application/types';
+import { RelationPrimaryValue } from '@/components/database/components/cell/relation/RelationPrimaryValue';
+
+jest.mock('@/utils/runtime-config', () => ({
+  getConfigValue: (_key: string, fallback: string) => fallback,
+}));
+
+describe('RelationPrimaryValue', () => {
+  it('reacts to schema-only switches and keeps the stored cell payload readable', async () => {
+    const fieldId = 'primary-field';
+    const fieldDoc = new Y.Doc();
+    const field = fieldDoc.getMap('field') as YDatabaseField;
+    const typeOptions = new Y.Map();
+    const multiSelectOption = new Y.Map();
+
+    multiSelectOption.set(
+      YjsDatabaseKey.content,
+      JSON.stringify({
+        options: [
+          {
+            id: 'option-a',
+            name: 'Alpha',
+            color: SelectOptionColor.OptionColor1,
+          },
+        ],
+      })
+    );
+    typeOptions.set(String(FieldType.MultiSelect), multiSelectOption);
+    field.set(YjsDatabaseKey.type, FieldType.MultiSelect);
+    field.set(YjsDatabaseKey.type_option, typeOptions);
+
+    const rowDoc = createRowDoc('row-id', 'database-id', {
+      [fieldId]: { fieldType: FieldType.MultiSelect, data: 'option-a' },
+    });
+    const row = rowDoc
+      .getMap(YjsEditorKey.data_section)
+      .get(YjsEditorKey.database_row) as YDatabaseRow;
+    const cell = row.get(YjsDatabaseKey.cells).get(fieldId);
+    const { container } = render(<RelationPrimaryValue field={field} fieldId={fieldId} rowDoc={rowDoc} />);
+
+    await waitFor(() => expect(container.textContent).toBe('Alpha'));
+
+    act(() => {
+      field.set(YjsDatabaseKey.type, FieldType.RichText);
+    });
+
+    await waitFor(() => expect(container.textContent).toBe('Alpha'));
+
+    act(() => {
+      cell.set(YjsDatabaseKey.data, 'Edited');
+      cell.set(YjsDatabaseKey.field_type, FieldType.RichText);
+    });
+
+    await waitFor(() => expect(container.textContent).toBe('Edited'));
+  });
+});

--- a/src/components/database/components/cell/relation/RelationPrimaryValue.tsx
+++ b/src/components/database/components/cell/relation/RelationPrimaryValue.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from 'react';
 import { FieldType } from '@/application/database-yjs';
 import { parseYDatabaseCellToCell } from '@/application/database-yjs/cell.parse';
 import { decodeCellToText } from '@/application/database-yjs/decode';
+import { subscribeSharedYjsDeep } from '@/application/database-yjs/shared-yjs-observer';
 import {
   FieldId,
   YDatabaseCell,
@@ -33,10 +34,7 @@ export function RelationPrimaryValue({
     };
 
     onRowChange();
-    data?.observeDeep(onRowChange);
-    return () => {
-      data?.unobserveDeep(onRowChange);
-    };
+    return subscribeSharedYjsDeep(data, onRowChange);
   }, [rowDoc]);
 
   useEffect(() => {
@@ -75,11 +73,13 @@ export function RelationPrimaryValue({
 
     observeHandler();
 
-    primaryCell?.observeDeep(observeHandler);
-    field?.observeDeep(observeHandler);
+    const observerCleanups: Array<() => void> = [];
+
+    if (primaryCell) observerCleanups.push(subscribeSharedYjsDeep(primaryCell, observeHandler));
+    if (field) observerCleanups.push(subscribeSharedYjsDeep(field, observeHandler));
+
     return () => {
-      primaryCell?.unobserveDeep(observeHandler);
-      field?.unobserveDeep(observeHandler);
+      observerCleanups.forEach((cleanup) => cleanup());
     };
   }, [row, fieldId, field]);
 

--- a/src/components/database/components/cell/relation/RelationPrimaryValue.tsx
+++ b/src/components/database/components/cell/relation/RelationPrimaryValue.tsx
@@ -2,10 +2,26 @@ import { useEffect, useState } from 'react';
 
 import { FieldType } from '@/application/database-yjs';
 import { parseYDatabaseCellToCell } from '@/application/database-yjs/cell.parse';
-import { FieldId, YDatabaseCell, YDatabaseRow, YDoc, YjsDatabaseKey, YjsEditorKey } from '@/application/types';
+import { decodeCellToText } from '@/application/database-yjs/decode';
+import {
+  FieldId,
+  YDatabaseCell,
+  YDatabaseField,
+  YDatabaseRow,
+  YDoc,
+  YjsDatabaseKey,
+  YjsEditorKey,
+} from '@/application/types';
 
-
-export function RelationPrimaryValue ({ rowDoc, fieldId }: { rowDoc: YDoc; fieldId?: FieldId }) {
+export function RelationPrimaryValue({
+  rowDoc,
+  fieldId,
+  field,
+}: {
+  rowDoc: YDoc;
+  fieldId?: FieldId;
+  field?: YDatabaseField;
+}) {
   const [text, setText] = useState<string | null>(null);
   const [row, setRow] = useState<YDatabaseRow | null>(null);
 
@@ -24,7 +40,11 @@ export function RelationPrimaryValue ({ rowDoc, fieldId }: { rowDoc: YDoc; field
   }, [rowDoc]);
 
   useEffect(() => {
-    if (!row) return;
+    if (!row) {
+      setText('');
+      return;
+    }
+
     const cells = row.get(YjsDatabaseKey.cells);
 
     let primaryCell: YDatabaseCell | undefined;
@@ -32,10 +52,10 @@ export function RelationPrimaryValue ({ rowDoc, fieldId }: { rowDoc: YDoc; field
     if (fieldId) {
       primaryCell = cells?.get(fieldId);
     } else {
-      const fieldId = Array.from(cells.keys()).find((key) => {
+      const fieldId = Array.from(cells?.keys() ?? []).find((key) => {
         const fieldType = cells.get(key)?.get(YjsDatabaseKey.field_type);
 
-        if (!fieldType) return false;
+        if (fieldType === undefined || fieldType === null) return false;
         return Number(fieldType) === FieldType.RichText;
       });
 
@@ -45,17 +65,23 @@ export function RelationPrimaryValue ({ rowDoc, fieldId }: { rowDoc: YDoc; field
     }
 
     const observeHandler = () => {
-      if (!primaryCell) return;
-      setText(parseYDatabaseCellToCell(primaryCell).data as string);
+      if (!primaryCell) {
+        setText('');
+        return;
+      }
+
+      setText(field ? decodeCellToText(primaryCell, field) : String(parseYDatabaseCellToCell(primaryCell).data ?? ''));
     };
 
     observeHandler();
 
-    primaryCell?.observe(observeHandler);
+    primaryCell?.observeDeep(observeHandler);
+    field?.observeDeep(observeHandler);
     return () => {
-      primaryCell?.unobserve(observeHandler);
+      primaryCell?.unobserveDeep(observeHandler);
+      field?.unobserveDeep(observeHandler);
     };
-  }, [row, fieldId]);
+  }, [row, fieldId, field]);
 
   return <div>{text}</div>;
 }

--- a/src/components/database/components/property/PropertyMenu.tsx
+++ b/src/components/database/components/property/PropertyMenu.tsx
@@ -39,6 +39,7 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+import { Log } from '@/utils/log';
 
 function PropertyMenu({
   fieldId,
@@ -74,17 +75,22 @@ function PropertyMenu({
   }, [onOpenChange]);
 
   const handleCreateRelation = useCallback(
-    (result: RelationCreationResult) => {
+    async (result: RelationCreationResult) => {
       setRelationDialogOpen(false);
-      switchType(fieldId, FieldType.Relation);
-      updatePropertyName(result.fieldName);
-      void updateRelationTypeOption({
-        database_id: result.relatedDatabaseId,
-        is_two_way: result.isTwoWay,
-        reciprocal_field_name: result.reciprocalFieldName,
-        source_limit: result.sourceLimit,
-        target_limit: RelationLimit.NoLimit,
-      });
+
+      try {
+        await switchType(fieldId, FieldType.Relation);
+        updatePropertyName(result.fieldName);
+        await updateRelationTypeOption({
+          database_id: result.relatedDatabaseId,
+          is_two_way: result.isTwoWay,
+          reciprocal_field_name: result.reciprocalFieldName,
+          source_limit: result.sourceLimit,
+          target_limit: RelationLimit.NoLimit,
+        });
+      } catch (error) {
+        Log.warn('[PropertyMenu] Failed to create relation field', { fieldId, error });
+      }
     },
     [fieldId, switchType, updatePropertyName, updateRelationTypeOption]
   );

--- a/src/components/database/components/property/PropertySelectTrigger.tsx
+++ b/src/components/database/components/property/PropertySelectTrigger.tsx
@@ -16,6 +16,7 @@ import {
   DropdownMenuSubTrigger,
 } from '@/components/ui/dropdown-menu';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+import { Log } from '@/utils/log';
 
 const properties = [
   FieldType.RichText,
@@ -59,10 +60,15 @@ export function PropertySelectTrigger({
     [aiEnabled]
   );
 
-  const handleSelect = (property: FieldType) => {
+  const handleSelect = async (property: FieldType) => {
     if (disabled) return;
     if (!aiEnabled && isAIFieldType(property)) return;
-    switchType(fieldId, property);
+
+    try {
+      await switchType(fieldId, property);
+    } catch (error) {
+      Log.warn('[PropertySelectTrigger] Failed to switch field type', { fieldId, property, error });
+    }
   };
 
   const propertyTooltip: {
@@ -124,7 +130,7 @@ export function PropertySelectTrigger({
                             return;
                           }
 
-                          handleSelect(property);
+                          void handleSelect(property);
                           if ([FieldType.Translate].includes(property)) {
                             e.preventDefault();
                             setOpen(false);


### PR DESCRIPTION
### **Description**

Align Web database field-type switching and cell decoding with the Desktop data model.

#### Root cause

Web previously overwrote `cell.field_type` during a schema switch and stored the original payload type in the Web-only `source_field_type` key. Desktop does not use that key: it treats `cell.field_type` as the raw payload encoding and the field schema type as the current presentation/edit type. This caused encoded select IDs, blank values, and inconsistent content across clients.

Some secondary readers also bypassed lazy conversion, and data-dependent switches only scanned the currently loaded Web row map, omitting off-screen rows.

#### Changes

- Keep `cell.field_type` aligned with the preserved raw payload while `field.type` controls presentation.
- Apply the Desktop lazy-conversion matrix when reading cells; commit the current type only after a user edit.
- Normalize legacy `source_field_type` metadata through schema migration and a runtime row normalizer.
- Preserve raw values across ordinary field switches, duplication, card moves, relations, filters, groups, sorts, charts, rollups, and calendar/primary-value readers.
- Materialize Created Time and Last Edited Time row metadata before leaving those field types.
- Hydrate all rows across every view before data-dependent switches, re-enumerating until the row set is stable so off-screen or concurrently inserted rows are not missed.
- Make field switching awaitable so relation setup cannot race an asynchronous switch.
- Match Desktop parsing/formatting behavior for dates, numbers, checkboxes, time, checklists, and select options.

---

### **Checklist**

#### **General**
- [x] I have included relevant documentation or comments for the changes introduced.
- [ ] I have tested the changes in multiple environments such as different browsers or operating systems.

#### **Testing**
- [x] I have added or updated tests to validate the changes introduced for AppFlowy Web.

#### **Feature-Specific**
- [x] Not applicable: this is a data-consistency bug fix and does not introduce new UI.
- [x] I have verified that this change integrates with existing database readers and mutation paths.

### Testing

- `pnpm jest src/application/database-yjs/__tests__ src/components/database/chart/hooks/useChartData.test.tsx src/components/database/components/cell/relation/RelationPrimaryValue.test.tsx --runInBand --no-coverage`
  - 32 suites passed
  - 537 tests passed
- `pnpm type-check`
- ESLint on every touched TypeScript file
- `git diff --check`

A final independent audit found no remaining correctness blocker.