### PR TITLE
fix: preserve page icon when locking page

### DIFF
--- a/playwright/e2e/page/lock-page.spec.ts
+++ b/playwright/e2e/page/lock-page.spec.ts
@@ -107,6 +107,19 @@ test.describe('Lock Page', () => {
     await expect(bodyEditor(page)).toHaveAttribute('contenteditable', 'false', { timeout: 10000 });
   });
 
+  test('locking preserves the page icon', async ({ page, request }) => {
+    await setup(page, request, testEmail);
+
+    const pageTitle = page.getByRole('heading', { level: 1, name: /Getting started/ });
+    await expect(pageTitle).toContainText('🌟');
+
+    await toggleLock(page, true);
+    await expect(pageTitle).toContainText('🌟');
+
+    await page.reload();
+    await expect(pageTitle).toContainText('🌟');
+  });
+
   test('the locked badge exposes an explanatory tooltip', async ({ page, request }) => {
     await setup(page, request, testEmail);
     await toggleLock(page, true);

--- a/src/components/app/header/MoreActionsContent.tsx
+++ b/src/components/app/header/MoreActionsContent.tsx
@@ -130,7 +130,11 @@ function MoreActionsContent({
     const next = !view.is_locked;
 
     try {
-      await PageService.update(workspaceId, viewId, { name: view.name, is_locked: next });
+      await PageService.update(workspaceId, viewId, {
+        name: view.name,
+        icon: view.icon ?? undefined,
+        is_locked: next,
+      });
       void refreshOutline?.();
       toast.success(next ? t('lockPage.pageLockedToast') : t('lockPage.pageUnlockedToast'));
       // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
### **Description**

Fixes #422.

The lock-page action used the composite page update endpoint without forwarding the current icon. The server interprets a missing icon as removal, so locking replaced the custom page icon with the default document icon.

This PR:
- preserves the existing page icon when toggling the lock state
- adds a Chromium regression test covering lock and reload behavior

### **Testing**

- `pnpm type-check`
- `pnpm exec eslint --quiet src/components/app/header/MoreActionsContent.tsx`
- `pnpm exec playwright test playwright/e2e/page/lock-page.spec.ts --project=chromium --workers=1` (8 passed)

---

### **Checklist**

#### **General**
- [ ] I have included relevant documentation or comments for the changes introduced.
- [ ] I have tested the changes in multiple environments (for example, different browsers or operating systems).

#### **Testing**
- [x] I have added or updated tests to validate the changes introduced for AppFlowy Web.

#### **Feature-Specific**
- [ ] For feature additions, I have added a preview in the Feature Preview section.
- [x] I have verified that this change integrates with existing lock-page functionality.

## Summary by Sourcery

Preserve the existing page icon when toggling a page's locked state and add regression coverage to ensure the icon remains after locking and reloading.

Bug Fixes:
- Ensure the page icon is retained when updating the page's lock state instead of being reset to the default.

Tests:
- Add an end-to-end test verifying that locking a page and reloading the browser preserves the custom page icon.