### PR TITLE
fix: allow Firefox text selection in database cells

### DIFF
--- a/src/components/database/components/grid/grid-row/GridVirtualRow.tsx
+++ b/src/components/database/components/grid/grid-row/GridVirtualRow.tsx
@@ -1,5 +1,5 @@
 import { combine } from '@atlaskit/pragmatic-drag-and-drop/combine';
-import { draggable, dropTargetForElements } from '@atlaskit/pragmatic-drag-and-drop/element/adapter';
+import { dropTargetForElements } from '@atlaskit/pragmatic-drag-and-drop/element/adapter';
 import { attachClosestEdge, extractClosestEdge } from '@atlaskit/pragmatic-drag-and-drop-hitbox/closest-edge';
 import { VirtualItem } from '@tanstack/react-virtual';
 import { uniqBy } from 'lodash-es';
@@ -17,6 +17,7 @@ import { RenderColumn } from '@/components/database/components/grid/grid-column'
 import GridVirtualColumn from '@/components/database/components/grid/grid-column/GridVirtualColumn';
 import { GridRowProvider } from '@/components/database/components/grid/grid-row/GridRowContext';
 import { RenderRow, RenderRowType } from '@/components/database/components/grid/grid-row/useRenderRows';
+import { useGridRowDraggable } from '@/components/database/components/grid/grid-row/useGridRowDraggable';
 import ClearSortingConfirm from '@/components/database/components/sorts/ClearSortingConfirm';
 import { useGridContext } from '@/components/database/grid/useGridContext';
 import { cn } from '@/lib/utils';
@@ -24,7 +25,6 @@ import { cn } from '@/lib/utils';
 import HoverControls from 'src/components/database/components/grid/controls/HoverControls';
 
 const idleState: ItemState = { type: GridDragState.IDLE };
-const draggingState: ItemState = { type: GridDragState.DRAGGING };
 
 function GridVirtualRow({
   row,
@@ -47,7 +47,7 @@ function GridVirtualRow({
   const rowIndex = row.index;
   const rowId = data[rowIndex].rowId as string;
   const rowType = data[rowIndex].type;
-  const { setHoverRowId, setResizeRow } = useGridContext();
+  const { activeCell, setHoverRowId, setResizeRow } = useGridContext();
   const databaseRow = useRowData(rowId);
   const cells = databaseRow?.get(YjsDatabaseKey.cells);
   const cellsCount = cells?.size;
@@ -68,6 +68,7 @@ function GridVirtualRow({
   );
 
   const isRegularRow = rowType === RenderRowType.Row;
+  const hasActiveCell = activeCell?.rowId === rowId;
 
   useEffect(() => {
     const element = innerRef.current;
@@ -83,21 +84,6 @@ function GridVirtualRow({
 
     return combine(
       registerRow({ rowId, element }),
-      draggable({
-        element,
-        dragHandle,
-
-        getInitialData: () => data,
-        onGenerateDragPreview() {
-          setState({ type: GridDragState.PREVIEW });
-        },
-        onDragStart() {
-          setState(draggingState);
-        },
-        onDrop() {
-          setState(idleState);
-        },
-      }),
       dropTargetForElements({
         element,
         canDrop: ({ source }) => {
@@ -136,6 +122,17 @@ function GridVirtualRow({
       })
     );
   }, [hasSorted, rowId, rowIndex, registerRow, instanceId, dragHandleRef, isRegularRow]);
+
+  useGridRowDraggable({
+    elementRef: innerRef,
+    dragHandleRef,
+    // Firefox prevents text selection inside a native draggable ancestor.
+    enabled: isRegularRow && !hasActiveCell,
+    instanceId,
+    rowId,
+    rowIndex,
+    setState,
+  });
   const readOnly = useReadOnly();
 
   const children = useMemo(() => {

--- a/src/components/database/components/grid/grid-row/__tests__/useGridRowDraggable.test.tsx
+++ b/src/components/database/components/grid/grid-row/__tests__/useGridRowDraggable.test.tsx
@@ -1,0 +1,54 @@
+import { draggable } from '@atlaskit/pragmatic-drag-and-drop/element/adapter';
+import { renderHook } from '@testing-library/react';
+
+import { useGridRowDraggable } from '@/components/database/components/grid/grid-row/useGridRowDraggable';
+
+jest.mock('@atlaskit/pragmatic-drag-and-drop/element/adapter', () => ({
+  draggable: jest.fn(({ element }: { element: HTMLElement }) => {
+    element.setAttribute('draggable', 'true');
+    return () => element.removeAttribute('draggable');
+  }),
+}));
+
+const mockDraggable = draggable as jest.MockedFunction<typeof draggable>;
+
+describe('useGridRowDraggable', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('removes draggable behavior while disabled and restores it when re-enabled', () => {
+    const element = document.createElement('div');
+    const dragHandle = document.createElement('div');
+    const elementRef = { current: element };
+    const dragHandleRef = { current: dragHandle };
+    const setState = jest.fn();
+    const { rerender } = renderHook(
+      ({ enabled }) =>
+        useGridRowDraggable({
+          elementRef,
+          dragHandleRef,
+          enabled,
+          instanceId: Symbol.for('row-instance'),
+          rowId: 'row-1',
+          rowIndex: 0,
+          setState,
+        }),
+      { initialProps: { enabled: true } }
+    );
+
+    expect(element.getAttribute('draggable')).toBe('true');
+    expect(mockDraggable).toHaveBeenCalledTimes(1);
+    expect(mockDraggable).toHaveBeenCalledWith(expect.objectContaining({ element, dragHandle }));
+
+    rerender({ enabled: false });
+
+    expect(element.getAttribute('draggable')).toBeNull();
+    expect(mockDraggable).toHaveBeenCalledTimes(1);
+
+    rerender({ enabled: true });
+
+    expect(element.getAttribute('draggable')).toBe('true');
+    expect(mockDraggable).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/components/database/components/grid/grid-row/useGridRowDraggable.ts
+++ b/src/components/database/components/grid/grid-row/useGridRowDraggable.ts
@@ -1,0 +1,53 @@
+import { draggable } from '@atlaskit/pragmatic-drag-and-drop/element/adapter';
+import { Dispatch, RefObject, SetStateAction, useEffect } from 'react';
+
+import {
+  GridDragState,
+  ItemState,
+} from '@/components/database/components/grid/drag-and-drop/GridDragContext';
+
+export function useGridRowDraggable({
+  elementRef,
+  dragHandleRef,
+  enabled,
+  instanceId,
+  rowId,
+  rowIndex,
+  setState,
+}: {
+  elementRef: RefObject<HTMLDivElement>;
+  dragHandleRef: RefObject<HTMLDivElement>;
+  enabled: boolean;
+  instanceId: symbol;
+  rowId: string;
+  rowIndex: number;
+  setState: Dispatch<SetStateAction<ItemState>>;
+}) {
+  useEffect(() => {
+    const element = elementRef.current;
+    const dragHandle = dragHandleRef.current;
+
+    if (!element || !dragHandle || !enabled) return;
+
+    const data = {
+      instanceId,
+      rowId,
+      index: rowIndex,
+    };
+
+    return draggable({
+      element,
+      dragHandle,
+      getInitialData: () => data,
+      onGenerateDragPreview() {
+        setState({ type: GridDragState.PREVIEW });
+      },
+      onDragStart() {
+        setState({ type: GridDragState.DRAGGING });
+      },
+      onDrop() {
+        setState({ type: GridDragState.IDLE });
+      },
+    });
+  }, [dragHandleRef, elementRef, enabled, instanceId, rowId, rowIndex, setState]);
+}


### PR DESCRIPTION
## Summary

- separate row drag-source registration from row and drop-target registration
- temporarily remove native draggable behavior while a cell in that row is active
- restore row dragging when editing exits
- add focused regression coverage for the draggable cleanup lifecycle

## Root cause

Firefox suppresses text drag-selection inside a native draggable ancestor. The grid drag adapter marks the whole virtual row draggable even though interaction starts from a dedicated drag handle.

## Test plan

- pnpm exec jest src/components/database/components/grid/grid-row/__tests__/useGridRowDraggable.test.tsx --runInBand --no-coverage
- pnpm exec eslint --quiet src/components/database/components/grid/grid-row/GridVirtualRow.tsx src/components/database/components/grid/grid-row/useGridRowDraggable.ts src/components/database/components/grid/grid-row/__tests__/useGridRowDraggable.test.tsx
- pnpm type-check
- verified the original mouse-drag selection in Chromium 145 and Firefox 146; both selected characters 1-15 and row dragging was restored after exiting edit mode

Fixes #417

## Summary by Sourcery

Extract row drag behavior into a dedicated hook and conditionally enable it to avoid interfering with text selection in active cells.

New Features:
- Introduce a useGridRowDraggable hook to encapsulate grid row drag behavior.

Bug Fixes:
- Allow text selection within database cells in Firefox by disabling native row dragging while a cell is active.

Tests:
- Add unit tests covering the lifecycle of the useGridRowDraggable hook, ensuring draggable behavior is removed and restored correctly.