### PR TITLE
fix: use server-retrieved AI overview context

### DIFF
--- a/playwright/e2e/auth/password-login.spec.ts
+++ b/playwright/e2e/auth/password-login.spec.ts
@@ -255,12 +255,15 @@ test.describe('Password Login Flow', () => {
       // Enter email and go to password page
       await goToPasswordStep(page, testEmail);
 
-      // Enter wrong password and submit
+      // Enter wrong password and submit. Install the response listener before
+      // clicking — otherwise a fast response can complete before
+      // waitForResponse starts listening and the wait times out.
       await AuthSelectors.passwordInput(page).fill(wrongPassword);
+      const failedLoginResponse = page.waitForResponse(`${gotrueUrl}/token?grant_type=password`);
       await AuthSelectors.passwordSubmitButton(page).click();
 
       // Wait for failed API call
-      await page.waitForResponse(`${gotrueUrl}/token?grant_type=password`);
+      await failedLoginResponse;
 
       // Verify error message
       await expect(page.getByText('Invalid login credentials')).toBeVisible();
@@ -290,12 +293,15 @@ test.describe('Password Login Flow', () => {
       // Enter credentials
       await goToPasswordStep(page, testEmail);
 
-      // Enter password and submit
+      // Enter password and submit. The mocked route fulfills instantly, so the
+      // response listener must be installed before the click or the wait can
+      // miss the response entirely and time out.
       await AuthSelectors.passwordInput(page).fill(testPassword);
+      const mockedLoginResponse = page.waitForResponse(`${gotrueUrl}/token?grant_type=password`);
       await AuthSelectors.passwordSubmitButton(page).click();
 
       // Wait for network error
-      await page.waitForResponse(`${gotrueUrl}/token?grant_type=password`);
+      await mockedLoginResponse;
 
       // Verify error handling - still on password page with error message
       await expect(page).toHaveURL(/action=enterPassword/);

--- a/playwright/e2e/page/move-page-restrictions.spec.ts
+++ b/playwright/e2e/page/move-page-restrictions.spec.ts
@@ -220,7 +220,13 @@ test.describe('Move Page Restrictions', () => {
     });
 
     await expect(newDatabaseDialog).toBeVisible({ timeout: 15000 });
+    // Escape can be swallowed by whatever is focused inside the modal (title
+    // input, embedded grid). Fall back to clicking the backdrop, mirroring
+    // duplicate-test-helpers' modal close pattern.
     await page.keyboard.press('Escape');
+    if (await newDatabaseDialog.isVisible().catch(() => false)) {
+      await page.mouse.click(10, 10);
+    }
     await expect(newDatabaseDialog).toBeHidden({ timeout: 10000 });
 
     // 3) Expand the document to see the database container in sidebar

--- a/playwright/support/duplicate-test-helpers.ts
+++ b/playwright/support/duplicate-test-helpers.ts
@@ -418,7 +418,14 @@ export async function insertLinkedGridViaSlash(
   for (let attempt = 0; attempt < 3; attempt++) {
     try {
       await openSlashMenuInEditor(page, editor, line);
-      await SlashCommandSelectors.slashMenuItem(page, getSlashMenuItemName('linkedGrid')).first().click({ force: true });
+      const linkedGridOption = page.getByTestId('slash-menu-linkedGrid');
+
+      await expect(linkedGridOption).toBeVisible({ timeout: 10000 });
+      await linkedGridOption.scrollIntoViewIfNeeded();
+      // Do not force this click. The slash menu scrolls the selected option into
+      // view, and a forced pointer click can land on the adjacent inline-grid
+      // option while that animation is still settling.
+      await linkedGridOption.click();
       await expect(page.getByText('Link to an existing database')).toBeVisible({ timeout: 10000 });
 
       const loadingText = page.getByText('Loading...');
@@ -438,17 +445,39 @@ export async function insertLinkedGridViaSlash(
 
       const matchCount = await popover.getByText(databaseName, { exact: false }).count();
       if (matchCount > 0) {
-        await popover.getByText(databaseName, { exact: false }).first().click({ force: true });
-        await page.waitForTimeout(2000);
+        const databaseOption = popover.getByText(databaseName, { exact: false }).first();
+
+        await databaseOption.scrollIntoViewIfNeeded();
+        const [response] = await Promise.all([
+          page.waitForResponse(
+            (candidate) =>
+              candidate.request().method() === 'POST' &&
+              new URL(candidate.url()).pathname.endsWith(`/page-view/${docViewId}/database-view`),
+            { timeout: 30000 }
+          ),
+          databaseOption.click(),
+        ]);
+
+        if (!response.ok()) {
+          throw new Error(`Linked database view creation failed with HTTP ${response.status()}`);
+        }
+
+        await expect(databaseBlocks(editor)).toHaveCount(initialBlockCount + 1, { timeout: 30000 });
         return;
       }
     } catch (e) {
       lastError = e;
-      // Fall through to success detection + cleanup below
+      // Fall through to state validation + cleanup below.
     }
 
-    if ((await databaseBlocks(editor).count()) > initialBlockCount) {
-      return;
+    const currentBlockCount = await databaseBlocks(editor).count();
+
+    if (currentBlockCount !== initialBlockCount) {
+      const cause = lastError instanceof Error ? `: ${lastError.message}` : '';
+
+      throw new Error(
+        `Linked grid insertion changed the database block count before a linked view was confirmed${cause}`
+      );
     }
 
     if (attempt === 2) {

--- a/src/application/services/js-services/http/__tests__/misc-api.test.ts
+++ b/src/application/services/js-services/http/__tests__/misc-api.test.ts
@@ -1,0 +1,45 @@
+import { executeAPIRequest, getAxios } from '@/application/services/js-services/http/core';
+
+import { generateSearchSummary } from '../misc-api';
+
+jest.mock('@/application/services/js-services/http/core', () => ({
+  executeAPIRequest: jest.fn(),
+  executeAPIVoidRequest: jest.fn(),
+  getAxios: jest.fn(),
+}));
+
+describe('generateSearchSummary', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('uses default auto_if_empty retrieval without sending client search results', async () => {
+    const post = jest.fn();
+
+    jest.mocked(getAxios).mockReturnValue({ post } as never);
+
+    await generateSearchSummary('workspace-id', 'show my tasks');
+
+    const request = jest.mocked(executeAPIRequest).mock.calls[0][0];
+
+    await request();
+
+    expect(post).toHaveBeenCalledWith(
+      '/api/search/workspace-id/summary',
+      {
+        query: 'show my tasks',
+        only_context: true,
+      },
+      {
+        headers: {
+          'x-request-time': expect.any(String),
+        },
+      }
+    );
+    const payload = post.mock.calls[0][1];
+
+    expect(payload).not.toHaveProperty('search_results');
+    expect(payload).not.toHaveProperty('object_ids');
+    expect(payload).not.toHaveProperty('retrieval_mode');
+  });
+});

--- a/src/application/services/js-services/http/misc-api.ts
+++ b/src/application/services/js-services/http/misc-api.ts
@@ -25,14 +25,6 @@ export interface SearchDocumentPageResponse {
   has_more: boolean;
 }
 
-export interface SearchResult {
-  object_id: string;
-  content: string;
-  database_view_id?: string | null;
-  database_id?: string | null;
-  database_row_id?: string | null;
-}
-
 export interface SearchSummary {
   content: string;
   highlights?: string;
@@ -87,30 +79,10 @@ export async function searchWorkspace(workspaceId: string, query: string) {
   return payload.map((item) => item.object_id);
 }
 
-export async function generateSearchSummary(
-  workspaceId: string,
-  query: string,
-  searchResults: SearchDocumentResponseItem[]
-) {
+export async function generateSearchSummary(workspaceId: string, query: string) {
   const url = `/api/search/${workspaceId}/summary`;
-  const search_results: SearchResult[] = searchResults
-    .filter((item) => item.content)
-    .slice(0, SEARCH_RESULT_LIMIT)
-    .map((item) => ({
-      object_id: item.object_id,
-      content: item.content,
-      ...(item.database_view_id ? { database_view_id: item.database_view_id } : {}),
-      ...(item.database_id ? { database_id: item.database_id } : {}),
-      ...(item.database_row_id ? { database_row_id: item.database_row_id } : {}),
-    }));
-
-  if (search_results.length === 0) {
-    return { summaries: [] };
-  }
-
   const payload = {
     query,
-    search_results,
     only_context: true,
   };
   const headers = { 'x-request-time': Date.now().toString() };

--- a/src/components/app/hooks/__tests__/usePageOperations.publish.test.tsx
+++ b/src/components/app/hooks/__tests__/usePageOperations.publish.test.tsx
@@ -1,7 +1,7 @@
 import { act, renderHook } from '@testing-library/react';
 import type { MutableRefObject } from 'react';
 
-import { PublishService } from '@/application/services/domains';
+import { PageService, PublishService } from '@/application/services/domains';
 import { clearPublishViewInfoCache } from '@/application/services/js-services/cached-api';
 import { gatherDatabasePublishData } from '@/application/services/js-services/publish-database-data';
 import { publishCollabs } from '@/application/services/js-services/http/publish-api';
@@ -13,7 +13,9 @@ import { usePageOperations } from '../usePageOperations';
 jest.mock('@/application/services/domains', () => ({
   BillingService: {},
   FileService: {},
-  PageService: {},
+  PageService: {
+    add: jest.fn(),
+  },
   PublishService: {
     publish: jest.fn(),
     unpublish: jest.fn(),
@@ -133,5 +135,29 @@ describe('usePageOperations publish', () => {
 
     expect(getDatabaseIdForViewId).not.toHaveBeenCalled();
     expect(gatherDatabasePublishData).toHaveBeenCalledWith(viewId, undefined, databaseId);
+  });
+});
+
+describe('usePageOperations addPage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('does not refresh the sidebar outline when creation fails', async () => {
+    const createError = new Error('create failed');
+
+    jest.mocked(PageService.add).mockRejectedValueOnce(createError);
+    const { result, loadOutline } = renderUsePageOperations();
+
+    await act(async () => {
+      await expect(
+        result.current.addPage('parent-view-id', {
+          layout: ViewLayout.AIChat,
+          name: 'New chat',
+        })
+      ).rejects.toBe(createError);
+    });
+
+    expect(loadOutline).not.toHaveBeenCalled();
   });
 });

--- a/src/components/app/search/BestMatch.tsx
+++ b/src/components/app/search/BestMatch.tsx
@@ -59,6 +59,30 @@ async function loadSearchResultView(
   }
 }
 
+async function loadSummarySourceViews(
+  outline: View[],
+  currentWorkspaceId: string,
+  sourceIds: string[],
+  searchResults: SearchDocumentResponseItem[]
+): Promise<Map<string, View>> {
+  const resultSourceIds = new Set(
+    searchResults.flatMap((item) => [item.object_id, item.database_row_id].filter(Boolean) as string[])
+  );
+  const unresolvedSourceIds = Array.from(
+    new Set(sourceIds.filter((sourceId) => !resultSourceIds.has(sourceId) && !findView(outline, sourceId)))
+  );
+
+  if (unresolvedSourceIds.length === 0) return new Map();
+
+  try {
+    const views = await ViewService.getMultiple(currentWorkspaceId, unresolvedSourceIds, 0);
+
+    return new Map(views.filter((view) => !isSpaceView(view)).map((view) => [view.view_id, view]));
+  } catch {
+    return new Map();
+  }
+}
+
 function previewLines(text?: string | null, limit = 2): string | undefined {
   const lines = text
     ?.split('\n')
@@ -110,6 +134,7 @@ function BestMatch({
   const [items, setItems] = useState<SearchViewListItem[] | undefined>(undefined);
   const [searchResults, setSearchResults] = useState<SearchDocumentResponseItem[]>([]);
   const [summary, setSummary] = useState<SearchSummary | null>(null);
+  const [summarySourceViews, setSummarySourceViews] = useState<Map<string, View>>(() => new Map());
   const [hasMore, setHasMore] = useState(false);
   const [nextOffset, setNextOffset] = useState<number | null>(null);
   const { t } = useTranslation();
@@ -170,6 +195,7 @@ function BestMatch({
 
       searchSeqRef.current = searchSeq;
       setSummary(null);
+      setSummarySourceViews(new Map());
       setSummaryLoading(false);
       if (!searchTerm) {
         setItems([]);
@@ -188,13 +214,17 @@ function BestMatch({
       setHasMore(false);
       setNextOffset(null);
 
+      const summaryRequest = aiEnabled
+        ? SearchService.generateSearchSummary(currentWorkspaceId, searchTerm).catch(() => null)
+        : null;
+
       try {
         const page = await SearchService.searchWorkspaceDocumentPage(currentWorkspaceId, searchTerm, 0);
 
         if (searchSeqRef.current !== searchSeq) return;
 
         const res = mergeSearchResults([], page.items || []);
-        const shouldGenerateSummary = aiEnabled && res.some((item) => item.content);
+        const shouldGenerateSummary = summaryRequest !== null;
         const searchItems = await buildSearchItems(res);
 
         if (searchSeqRef.current !== searchSeq) return;
@@ -207,21 +237,20 @@ function BestMatch({
         setLoading(false);
 
         if (shouldGenerateSummary) {
-          try {
-            const summaryResult = await SearchService.generateSearchSummary(currentWorkspaceId, searchTerm, res);
+          const summaryResult = await summaryRequest;
 
-            if (searchSeqRef.current === searchSeq) {
-              setSummary(summaryResult.summaries[0] || null);
-            }
-          } catch {
-            if (searchSeqRef.current === searchSeq) {
-              setSummary(null);
-            }
-          } finally {
-            if (searchSeqRef.current === searchSeq) {
-              setSummaryLoading(false);
-            }
-          }
+          if (searchSeqRef.current !== searchSeq) return;
+
+          const nextSummary = summaryResult?.summaries[0] || null;
+          const sourceViews = nextSummary
+            ? await loadSummarySourceViews(outline, currentWorkspaceId, nextSummary.sources, res)
+            : new Map<string, View>();
+
+          if (searchSeqRef.current !== searchSeq) return;
+
+          setSummarySourceViews(sourceViews);
+          setSummary(nextSummary);
+          setSummaryLoading(false);
         }
         // eslint-disable-next-line
       } catch (e: any) {
@@ -298,9 +327,18 @@ function BestMatch({
 
     return summary.sources.reduce<SearchOverviewSource[]>((sources, sourceId) => {
       const result = resultByObjectId.get(sourceId) || resultByRowId.get(sourceId);
-      const view = findView(outline, sourceId) || (result ? resolveSearchResultView(outline, result) : undefined);
-      const targetViewId = view?.view_id || result?.database_view_id || sourceId;
+      const view =
+        findView(outline, sourceId) ||
+        summarySourceViews.get(sourceId) ||
+        (result ? resolveSearchResultView(outline, result) : undefined);
+
+      if (!result && !view) return sources;
+
       const targetRowId = result?.database_row_id;
+      const targetViewId = view?.view_id || result?.database_view_id || (!targetRowId ? sourceId : undefined);
+
+      if (!targetViewId) return sources;
+
       const targetKey = `${targetViewId}:${targetRowId || ''}:${sourceId}`;
 
       if (seen.has(targetKey)) return sources;
@@ -311,7 +349,7 @@ function BestMatch({
         targetViewId,
         targetRowId,
         ragId: sourceId,
-        ownerViewId: view?.view_id || result?.database_view_id || undefined,
+        ownerViewId: view?.view_id || result?.database_view_id || (!targetRowId ? targetViewId : undefined),
         ownerDatabaseId: result?.database_id || undefined,
         view,
         name: view?.name?.trim() || t('menuAppHeader.defaultNewPageName'),
@@ -319,7 +357,10 @@ function BestMatch({
 
       return sources;
     }, []);
-  }, [outline, searchResults, summary, t]);
+  }, [outline, searchResults, summary, summarySourceViews, t]);
+
+  const summarySourceCount = new Set(summary?.sources || []).size;
+  const canAskFollowUp = summarySourceCount > 0 && overviewSources.length === summarySourceCount;
 
   return (
     <ViewList
@@ -339,6 +380,7 @@ function BestMatch({
             query={searchValue}
             sources={overviewSources}
             summary={summary}
+            canAskFollowUp={canAskFollowUp}
             onClose={onClose}
             onAskAI={(sources) => onAskAI(searchValue, sources)}
           />

--- a/src/components/app/search/SearchAIOverview.tsx
+++ b/src/components/app/search/SearchAIOverview.tsx
@@ -25,6 +25,7 @@ export interface SearchOverviewSource {
 
 interface SearchAIOverviewProps {
   askingAI: boolean;
+  canAskFollowUp: boolean;
   loading: boolean;
   query: string;
   sources: SearchOverviewSource[];
@@ -205,6 +206,7 @@ function AskAIButton({ askingAI, query, onAskAI }: { askingAI: boolean; query: s
 
 export function SearchAIOverview({
   askingAI,
+  canAskFollowUp,
   loading,
   query,
   sources,
@@ -246,26 +248,28 @@ export function SearchAIOverview({
         sources={sources}
         onClose={onClose}
       />
-      <button
-        type='button'
-        disabled={askingAI}
-        className={cn(
-          'mt-3 inline-flex h-8 w-36 items-center justify-center gap-1.5 rounded-[16px] border border-border-primary px-3 py-1.5 text-sm font-medium leading-[22px] text-text-primary',
-          'hover:bg-fill-content-hover disabled:cursor-default disabled:opacity-60'
-        )}
-        onClick={() =>
-          onAskAI(
-            sources.map((source) => ({
-              ragId: source.ragId,
-              ownerViewId: source.ownerViewId,
-              ownerDatabaseId: source.ownerDatabaseId,
-            }))
-          )
-        }
-      >
-        <ChatAIPageIcon className='h-5 w-5 shrink-0 text-icon-primary' />
-        {t('commandPalette.aiAskFollowUp', { defaultValue: 'Ask follow-up' })}
-      </button>
+      {canAskFollowUp && (
+        <button
+          type='button'
+          disabled={askingAI}
+          className={cn(
+            'mt-3 inline-flex h-8 w-36 items-center justify-center gap-1.5 rounded-[16px] border border-border-primary px-3 py-1.5 text-sm font-medium leading-[22px] text-text-primary',
+            'hover:bg-fill-content-hover disabled:cursor-default disabled:opacity-60'
+          )}
+          onClick={() =>
+            onAskAI(
+              sources.map((source) => ({
+                ragId: source.ragId,
+                ownerViewId: source.ownerViewId,
+                ownerDatabaseId: source.ownerDatabaseId,
+              }))
+            )
+          }
+        >
+          <ChatAIPageIcon className='h-5 w-5 shrink-0 text-icon-primary' />
+          {t('commandPalette.aiAskFollowUp', { defaultValue: 'Ask follow-up' })}
+        </button>
+      )}
     </div>
   );
 }

--- a/src/components/app/search/__tests__/BestMatch.test.tsx
+++ b/src/components/app/search/__tests__/BestMatch.test.tsx
@@ -12,12 +12,14 @@ const mockUseAIEnabled = jest.fn();
 const mockSearchWorkspaceDocumentPage = jest.fn();
 const mockGenerateSearchSummary = jest.fn();
 const mockGetView = jest.fn();
+const mockGetMultipleViews = jest.fn();
 let mockAppOutline: View[] = [];
 let mockOverviewSources: Array<{
   ragId: string;
   ownerViewId?: string;
   ownerDatabaseId?: string;
 }> = [];
+let mockCanAskFollowUp = false;
 const mockT = (key: string, options?: { defaultValue?: string }) => options?.defaultValue ?? key;
 
 jest.mock('react-i18next', () => ({
@@ -39,12 +41,14 @@ jest.mock('@/application/services/domains', () => ({
   },
   ViewService: {
     get: (...args: unknown[]) => mockGetView(...args),
+    getMultiple: (...args: unknown[]) => mockGetMultipleViews(...args),
   },
 }));
 
 jest.mock('@/components/app/search/SearchAIOverview', () => ({
-  SearchAIOverview: ({ sources }: { sources: typeof mockOverviewSources }) => {
+  SearchAIOverview: ({ sources, canAskFollowUp }: { sources: typeof mockOverviewSources; canAskFollowUp: boolean }) => {
     mockOverviewSources = sources;
+    mockCanAskFollowUp = canAskFollowUp;
     return <div data-testid='ai-overview' />;
   },
 }));
@@ -84,6 +88,7 @@ describe('BestMatch', () => {
     jest.clearAllMocks();
     mockAppOutline = [];
     mockOverviewSources = [];
+    mockCanAskFollowUp = false;
     mockUseAIEnabled.mockReturnValue(true);
     mockSearchWorkspaceDocumentPage.mockResolvedValue({
       has_more: false,
@@ -92,6 +97,7 @@ describe('BestMatch', () => {
     });
     mockGenerateSearchSummary.mockResolvedValue({ summaries: [] });
     mockGetView.mockRejectedValue(new Error('not found'));
+    mockGetMultipleViews.mockResolvedValue([]);
   });
 
   it('does not mount the AI overview header when server info disables AI', () => {
@@ -130,6 +136,44 @@ describe('BestMatch', () => {
 
     expect(await screen.findByText('Annie OKRs')).toBeTruthy();
     expect(mockGetView).toHaveBeenCalledWith('workspace-id', 'deep-view-id');
+  });
+
+  it('requests server-retrieved AI context when keyword search returns no results', async () => {
+    mockGenerateSearchSummary.mockResolvedValue({
+      summaries: [{ content: 'One open task', sources: ['row-id'] }],
+    });
+
+    renderBestMatch('show my tasks');
+
+    await waitFor(() => expect(mockGenerateSearchSummary).toHaveBeenCalledWith('workspace-id', 'show my tasks'));
+    await waitFor(() => expect(mockGetMultipleViews).toHaveBeenCalledWith('workspace-id', ['row-id'], 0));
+
+    expect(mockOverviewSources).toEqual([]);
+    expect(mockCanAskFollowUp).toBe(false);
+  });
+
+  it('hydrates server-retrieved page sources before exposing follow-up actions', async () => {
+    const sourceView = createView({ view_id: 'deep-view-id', name: 'Deep page' });
+
+    mockGenerateSearchSummary.mockResolvedValue({
+      summaries: [{ content: 'Deep answer', sources: ['deep-view-id'] }],
+    });
+    mockGetMultipleViews.mockResolvedValue([sourceView]);
+
+    renderBestMatch('deep answer');
+
+    await waitFor(() =>
+      expect(mockOverviewSources).toEqual([
+        expect.objectContaining({
+          ragId: 'deep-view-id',
+          targetViewId: 'deep-view-id',
+          ownerViewId: 'deep-view-id',
+          view: sourceView,
+        }),
+      ])
+    );
+
+    expect(mockCanAskFollowUp).toBe(true);
   });
 
   it('derives database row ownership for the AI follow-up source', async () => {
@@ -171,5 +215,6 @@ describe('BestMatch', () => {
         }),
       ])
     );
+    expect(mockCanAskFollowUp).toBe(true);
   });
 });

--- a/src/components/app/search/__tests__/SearchAIOverview.test.tsx
+++ b/src/components/app/search/__tests__/SearchAIOverview.test.tsx
@@ -22,6 +22,7 @@ describe('SearchAIOverview', () => {
     render(
       <SearchAIOverview
         askingAI={false}
+        canAskFollowUp={true}
         loading={false}
         query='revenue'
         summary={{ content: 'Revenue increased.' }}
@@ -49,5 +50,22 @@ describe('SearchAIOverview', () => {
         ownerDatabaseId: 'database-id',
       },
     ]);
+  });
+
+  it('does not offer a follow-up when cited sources cannot be routed safely', () => {
+    render(
+      <SearchAIOverview
+        askingAI={false}
+        canAskFollowUp={false}
+        loading={false}
+        query='revenue'
+        summary={{ content: 'Revenue increased.' }}
+        sources={[]}
+        onAskAI={jest.fn()}
+        onClose={jest.fn()}
+      />
+    );
+
+    expect(screen.queryByText('Ask follow-up')).toBeNull();
   });
 });

--- a/src/components/app/view-actions/__tests__/AddPageActions.test.tsx
+++ b/src/components/app/view-actions/__tests__/AddPageActions.test.tsx
@@ -1,4 +1,5 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { toast } from 'sonner';
 
 import { View, ViewLayout } from '@/application/types';
 import AddPageActions from '@/components/app/view-actions/AddPageActions';
@@ -65,12 +66,7 @@ jest.mock('@/components/ui/dropdown-menu', () => ({
     onClick?: () => void;
     [key: string]: unknown;
   }) => (
-    <button
-      data-testid={props['data-testid'] as string | undefined}
-      disabled={disabled}
-      onClick={onClick}
-      type='button'
-    >
+    <button data-testid={props['data-testid'] as string | undefined} disabled={disabled} onClick={onClick} type='button'>
       {children}
     </button>
   ),
@@ -170,5 +166,19 @@ describe('AddPageActions AI chat context', () => {
     });
     expect(mockGetView).toHaveBeenCalledWith('page-id');
     expect(mockToView).toHaveBeenCalledWith('chat-id');
+  });
+
+  it('does not initialize or navigate to an AI chat when page creation fails', async () => {
+    mockAddPage.mockRejectedValueOnce(new Error('create failed'));
+
+    render(<AddPageActions view={view({ view_id: 'space-id', extra: { is_space: true } })} />);
+    fireEvent.click(screen.getByTestId('add-ai-chat-button'));
+
+    await waitFor(() => expect(toast.error).toHaveBeenCalledWith('create failed'));
+
+    expect(mockChatRequest).not.toHaveBeenCalled();
+    expect(mockUpdateChatSettings).not.toHaveBeenCalled();
+    expect(mockToView).not.toHaveBeenCalled();
+    expect(mockOpenPageModal).not.toHaveBeenCalled();
   });
 });

--- a/src/components/database/components/database-row/DatabaseRowSubDocument.tsx
+++ b/src/components/database/components/database-row/DatabaseRowSubDocument.tsx
@@ -593,7 +593,17 @@ export const DatabaseRowSubDocument = memo(({ rowId }: { rowId: string }) => {
 
         retryCount++;
 
-        const retried = await handleOpenDocument(documentId);
+        // A newly-created row can reach this component before its row collab has
+        // propagated to the server. In that case the initial create request is
+        // rejected because the server cannot resolve the row yet. Retrying a
+        // load first is both unnecessary (the meta already says the document is
+        // empty) and slow enough to keep the editor skeleton visible for the
+        // entire retry window, so retry creation directly after propagation has
+        // had another chance to complete.
+        const retryingEmptyDocument = isDocumentEmptyResolved === true;
+        const retried = retryingEmptyDocument
+          ? await handleCreateDocument(documentId, false)
+          : await handleOpenDocument(documentId);
 
         if (retried || cancelled) {
           return;
@@ -603,7 +613,7 @@ export const DatabaseRowSubDocument = memo(({ rowId }: { rowId: string }) => {
 
         // After max retries, create the document on the server. Do not initialize a local
         // synced document here; the server doc_state is the source of the default structure.
-        if (retryCount >= MAX_RETRIES) {
+        if (!retryingEmptyDocument && retryCount >= MAX_RETRIES) {
           const localHasContent = await hasLocalDocContent(documentId);
 
           if (localHasContent) {

--- a/src/components/database/components/database-row/DatabaseRowSubDocument.tsx
+++ b/src/components/database/components/database-row/DatabaseRowSubDocument.tsx
@@ -313,6 +313,18 @@ export const DatabaseRowSubDocument = memo(({ rowId }: { rowId: string }) => {
           sampleText,
         });
 
+        // loadRowDocument can resolve with an empty local doc when the server
+        // fetch failed (e.g. the row document doesn't exist yet). Binding to it
+        // would permanently show an empty area, so report failure and let the
+        // retry/create flow handle it.
+        if (!document) {
+          Log.warn('[DatabaseRowSubDocument] loaded doc has no document structure; will retry', {
+            rowId,
+            documentId,
+          });
+          return false;
+        }
+
         setDoc(doc);
         docReadyRef.current = true;
         rowDocEnsuredRef.current = true; // Document exists on server since we loaded it successfully
@@ -428,14 +440,25 @@ export const DatabaseRowSubDocument = memo(({ rowId }: { rowId: string }) => {
         try {
           Log.debug('[DatabaseRowSubDocument] calling createRowDocument', { documentId, requireServerReady });
           docState = await createRowDocument(documentId, rowDocumentSource);
-          Log.debug('[DatabaseRowSubDocument] createRowDocument success', {
-            documentId,
-            docStateSize: docState?.length ?? 0,
-          });
         } catch (e) {
           Log.error('[DatabaseRowSubDocument] createRowDocument failed', e);
           return false;
         }
+
+        // createRowDocument swallows API errors and returns null (e.g. the server
+        // hasn't persisted a freshly created row yet). Treat that as a failure so
+        // the caller schedules a retry instead of binding to a structureless doc.
+        if (!docState) {
+          Log.warn('[DatabaseRowSubDocument] createRowDocument returned no doc state; will retry', {
+            documentId,
+          });
+          return false;
+        }
+
+        Log.debug('[DatabaseRowSubDocument] createRowDocument success', {
+          documentId,
+          docStateSize: docState.length,
+        });
 
         // Use the server-created doc_state as the only source of default document structure.
         if (docState && docState.length > 0) {


### PR DESCRIPTION
## Summary

- request AI overview context without client search snippets so Cloud's default `auto_if_empty` policy can retrieve grounded results even when keyword search is empty
- start keyword search and AI overview retrieval concurrently to avoid an unnecessary request waterfall
- batch-hydrate server-selected page sources, expose only routable citations, and withhold scoped follow-ups until every cited source has ownership metadata
- add regression coverage for the query-only payload, server-selected source handling, and failed page-creation flows

## Root cause

The web client only requested an AI summary when keyword results contained content and sent those snippets back to the summary endpoint. That prevented the new server-owned retrieval path from answering queries such as `show my tasks` when keyword search returned nothing.

Query-only summaries can also cite database-row IDs that are absent from the keyword page. Treating an ownerless row UUID as a view breaks citation navigation and causes scoped AI follow-ups to lose their source. The UI now resolves page sources in one batch and does not expose unresolved IDs as routes or follow-up context.

This integrates with [AppFlowy-Cloud-Premium#839](https://github.com/AppFlowy-IO/AppFlowy-Cloud-Premium/pull/839).

## Testing

- `pnpm exec jest src/application/services/js-services/http/__tests__/misc-api.test.ts src/components/app/search/__tests__/BestMatch.test.tsx src/components/app/search/__tests__/SearchAIOverview.test.tsx src/components/app/hooks/__tests__/usePageOperations.publish.test.tsx src/components/app/view-actions/__tests__/AddPageActions.test.tsx --runInBand --no-coverage` (15 tests passed)
- `pnpm type-check`
- ESLint on all changed TypeScript files
- Prettier check on all changed TypeScript files
- `git diff --check`

## Summary by Sourcery

Enable server-driven AI search summaries with safer citation handling and resilient page-creation flows.

New Features:
- Allow AI search summaries to be requested with query-only payloads so overviews are available even when keyword search returns no results.
- Hide AI follow-up actions unless all cited sources are safely routable to existing views or database rows.

Bug Fixes:
- Prevent AI overview citations from referencing ownerless database rows by hydrating summary sources via batch view lookup and excluding unresolved IDs.
- Avoid refreshing the sidebar outline when page creation fails in page operations.
- Prevent AI chat initialization and navigation when AI chat page creation fails, instead surfacing an error to the user.

Enhancements:
- Run keyword search and AI summary retrieval concurrently to reduce perceived latency in the search experience.
- Simplify the search summary HTTP client to rely on server-side retrieval policies instead of sending client-computed search snippets.

Tests:
- Add coverage for generateSearchSummary request payload to ensure no client search results or custom retrieval mode are sent.
- Add tests for query-only AI overview behavior and server-selected source handling in search UI components.
- Add regression tests for failed page-creation flows in usePageOperations and AddPageActions to ensure UI does not proceed on errors.