### PR TITLE
Feat/open in desktop app not installed

### DIFF
--- a/src/@types/translations/en.json
+++ b/src/@types/translations/en.json
@@ -3691,6 +3691,12 @@
       "description": "Make sure the desktop app is installed, or keep using AppFlowy in your browser.",
       "download": "Download",
       "continueInBrowser": "Continue in browser"
+    },
+    "prompt": {
+      "title": "Open in the AppFlowy desktop app?",
+      "description": "You can change this anytime in Settings.",
+      "open": "Open in app",
+      "stay": "Stay in browser"
     }
   },
   "comments": "Comments",

--- a/src/@types/translations/en.json
+++ b/src/@types/translations/en.json
@@ -855,6 +855,10 @@
       "language": {
         "title": "Language"
       },
+      "openInDesktopApp": {
+        "title": "Open links in desktop app",
+        "description": "When enabled, opening AppFlowy invitations and shared links hands off to the desktop app if it's installed."
+      },
       "password": {
         "title": "Password",
         "description": "Your account password for signing in.",

--- a/src/@types/translations/en.json
+++ b/src/@types/translations/en.json
@@ -3681,6 +3681,14 @@
   "here": "here",
   "openInBrowser": "Open in browser",
   "openInApp": "Open in app",
+  "openInDesktopApp": {
+    "notInstalled": {
+      "title": "Couldn't open the AppFlowy desktop app",
+      "description": "Make sure the desktop app is installed, or keep using AppFlowy in your browser.",
+      "download": "Download",
+      "continueInBrowser": "Continue in browser"
+    }
+  },
   "comments": "Comments",
   "duplicateAsTemplate": "Duplicate as template",
   "embedVideo": "Embed video",

--- a/src/application/user-metadata.ts
+++ b/src/application/user-metadata.ts
@@ -21,6 +21,8 @@ export enum MetadataKey {
   TimeFormat = 'time_format',
   StartWeekOn = 'start_week_on',
   IconUrl = 'icon_url',
+  // Per-user, synced preference: when enabled, opening AppFlowy links hands off to the desktop app.
+  OpenInDesktopApp = 'open_in_desktop_app',
 }
 
 /**
@@ -33,6 +35,7 @@ export interface MetadataValues {
   [MetadataKey.TimeFormat]: TimeFormat;
   [MetadataKey.StartWeekOn]: number;
   [MetadataKey.IconUrl]: string;
+  [MetadataKey.OpenInDesktopApp]: boolean;
 }
 
 /**
@@ -45,6 +48,7 @@ export const MetadataDefaults: Partial<MetadataValues> = {
   [MetadataKey.TimeFormat]: TimeFormat.TwelveHour,
   [MetadataKey.StartWeekOn]: 0,
   [MetadataKey.IconUrl]: '',
+  [MetadataKey.OpenInDesktopApp]: false,
 };
 
 /**
@@ -82,6 +86,14 @@ export class UserMetadataBuilder {
    */
   setIconUrl(url: string): this {
     this.metadata[MetadataKey.IconUrl] = url;
+    return this;
+  }
+
+  /**
+   * Set the "open links in desktop app" preference
+   */
+  setOpenInDesktopApp(value: boolean): this {
+    this.metadata[MetadataKey.OpenInDesktopApp] = value;
     return this;
   }
 

--- a/src/components/app/components/AppContextConsumer.tsx
+++ b/src/components/app/components/AppContextConsumer.tsx
@@ -4,9 +4,11 @@ import { useSearchParams } from 'react-router-dom';
 import { AIChatProvider } from '@/components/ai-chat/AIChatProvider';
 import { AppOverlayProvider } from '@/components/app/app-overlay/AppOverlayProvider';
 import { useAppViewId, useCurrentWorkspaceId } from '@/components/app/app.hooks';
+import { useOpenInDesktopApp } from '@/components/app/hooks/useOpenInDesktopApp';
 import { RequestAccessError } from '@/components/app/hooks/useWorkspaceData';
 import RequestAccess from '@/components/app/landing-pages/RequestAccess';
 import { useCurrentUser } from '@/components/main/app.hooks';
+import { openInDesktopApp } from '@/utils/open_desktop_app';
 
 const ViewModal = React.lazy(() => import('@/components/app/ViewModal'));
 
@@ -42,6 +44,24 @@ export const AppContextConsumer: React.FC<AppContextConsumerProps> = memo(
   }
 );
 
+// Captured once per full document load: whether the app was opened directly on a specific page URL
+// (i.e. a shared page link). Used so the preference-driven desktop handoff fires only for share
+// links opened from outside, not for internal client-side navigation.
+const landedOnSpecificPage =
+  typeof window !== 'undefined' && /^\/app\/[^/]+\/[^/]+/.test(window.location.pathname);
+let didAttemptPreferenceHandoff = false;
+
+function buildOpenPageScheme(
+  workspaceId: string,
+  viewId: string,
+  email: string | null | undefined,
+  rowId: string | null
+): string {
+  return `appflowy-flutter://open-page?workspace_id=${workspaceId}&view_id=${viewId}&email=${encodeURIComponent(
+    email ?? ''
+  )}${rowId ? `&row_id=${rowId}` : ''}`;
+}
+
 function OpenClient() {
   const currentWorkspaceId = useCurrentWorkspaceId();
   const viewId = useAppViewId();
@@ -49,6 +69,7 @@ function OpenClient() {
   const openClient = searchParams.get('is_desktop') === 'true';
   const rowId = searchParams.get('r');
   const currentUser = useCurrentUser();
+  const { enabled } = useOpenInDesktopApp();
 
   const [isTabVisible, setIsTabVisible] = useState(true);
   const hasOpenedRef = useRef(false);
@@ -67,22 +88,29 @@ function OpenClient() {
     };
   }, []);
 
+  // Explicit ?is_desktop=true links (e.g. notification emails) always attempt the deep link.
   useEffect(() => {
     if (!openClient) {
       hasOpenedRef.current = false;
       return;
     }
 
-    if (isTabVisible && currentUser && !hasOpenedRef.current) {
-      window.open(
-        `appflowy-flutter://open-page?workspace_id=${currentWorkspaceId}&view_id=${viewId}&email=${currentUser.email}${
-          rowId ? `&row_id=${rowId}` : ''
-        }`,
-        '_self'
-      );
+    if (isTabVisible && currentUser && currentWorkspaceId && viewId && !hasOpenedRef.current) {
+      window.open(buildOpenPageScheme(currentWorkspaceId, viewId, currentUser.email, rowId), '_self');
       hasOpenedRef.current = true;
     }
   }, [currentWorkspaceId, viewId, currentUser, openClient, rowId, isTabVisible]);
+
+  // Preference-driven share-link handoff: when the user prefers the desktop app and this document
+  // was opened directly from a shared page link, attempt to open the page in the desktop app once.
+  // If the app isn't installed, openInDesktopApp keeps the user on the already-rendered web page.
+  useEffect(() => {
+    if (openClient || !enabled || !landedOnSpecificPage || didAttemptPreferenceHandoff) return;
+    if (!isTabVisible || !currentUser || !currentWorkspaceId || !viewId) return;
+
+    didAttemptPreferenceHandoff = true;
+    openInDesktopApp(buildOpenPageScheme(currentWorkspaceId, viewId, currentUser.email, rowId));
+  }, [openClient, enabled, currentWorkspaceId, viewId, currentUser, rowId, isTabVisible]);
 
   return <></>;
 }

--- a/src/components/app/components/AppContextConsumer.tsx
+++ b/src/components/app/components/AppContextConsumer.tsx
@@ -8,7 +8,7 @@ import { useOpenInDesktopApp } from '@/components/app/hooks/useOpenInDesktopApp'
 import { RequestAccessError } from '@/components/app/hooks/useWorkspaceData';
 import RequestAccess from '@/components/app/landing-pages/RequestAccess';
 import { useCurrentUser } from '@/components/main/app.hooks';
-import { buildOpenPageLink, openInDesktopApp } from '@/utils/open_desktop_app';
+import { buildOpenPageLink, isSpecificPagePath, openInDesktopApp } from '@/utils/open_desktop_app';
 
 const ViewModal = React.lazy(() => import('@/components/app/ViewModal'));
 
@@ -48,7 +48,7 @@ export const AppContextConsumer: React.FC<AppContextConsumerProps> = memo(
 // (i.e. a shared page link). Used so the preference-driven desktop handoff fires only for share
 // links opened from outside, not for internal client-side navigation.
 const landedOnSpecificPage =
-  typeof window !== 'undefined' && /^\/app\/[^/]+\/[^/]+/.test(window.location.pathname);
+  typeof window !== 'undefined' && isSpecificPagePath(window.location.pathname);
 let didAttemptPreferenceHandoff = false;
 
 function OpenClient() {

--- a/src/components/app/components/AppContextConsumer.tsx
+++ b/src/components/app/components/AppContextConsumer.tsx
@@ -8,7 +8,7 @@ import { useOpenInDesktopApp } from '@/components/app/hooks/useOpenInDesktopApp'
 import { RequestAccessError } from '@/components/app/hooks/useWorkspaceData';
 import RequestAccess from '@/components/app/landing-pages/RequestAccess';
 import { useCurrentUser } from '@/components/main/app.hooks';
-import { openInDesktopApp } from '@/utils/open_desktop_app';
+import { buildOpenPageLink, openInDesktopApp } from '@/utils/open_desktop_app';
 
 const ViewModal = React.lazy(() => import('@/components/app/ViewModal'));
 
@@ -51,17 +51,6 @@ const landedOnSpecificPage =
   typeof window !== 'undefined' && /^\/app\/[^/]+\/[^/]+/.test(window.location.pathname);
 let didAttemptPreferenceHandoff = false;
 
-function buildOpenPageScheme(
-  workspaceId: string,
-  viewId: string,
-  email: string | null | undefined,
-  rowId: string | null
-): string {
-  return `appflowy-flutter://open-page?workspace_id=${workspaceId}&view_id=${viewId}&email=${encodeURIComponent(
-    email ?? ''
-  )}${rowId ? `&row_id=${rowId}` : ''}`;
-}
-
 function OpenClient() {
   const currentWorkspaceId = useCurrentWorkspaceId();
   const viewId = useAppViewId();
@@ -96,7 +85,10 @@ function OpenClient() {
     }
 
     if (isTabVisible && currentUser && currentWorkspaceId && viewId && !hasOpenedRef.current) {
-      window.open(buildOpenPageScheme(currentWorkspaceId, viewId, currentUser.email, rowId), '_self');
+      window.open(
+        buildOpenPageLink({ workspaceId: currentWorkspaceId, viewId, email: currentUser.email, rowId }),
+        '_self'
+      );
       hasOpenedRef.current = true;
     }
   }, [currentWorkspaceId, viewId, currentUser, openClient, rowId, isTabVisible]);
@@ -109,7 +101,7 @@ function OpenClient() {
     if (!isTabVisible || !currentUser || !currentWorkspaceId || !viewId) return;
 
     didAttemptPreferenceHandoff = true;
-    openInDesktopApp(buildOpenPageScheme(currentWorkspaceId, viewId, currentUser.email, rowId));
+    openInDesktopApp(buildOpenPageLink({ workspaceId: currentWorkspaceId, viewId, email: currentUser.email, rowId }));
   }, [openClient, enabled, currentWorkspaceId, viewId, currentUser, rowId, isTabVisible]);
 
   return <></>;

--- a/src/components/app/components/AppContextConsumer.tsx
+++ b/src/components/app/components/AppContextConsumer.tsx
@@ -4,11 +4,11 @@ import { useSearchParams } from 'react-router-dom';
 import { AIChatProvider } from '@/components/ai-chat/AIChatProvider';
 import { AppOverlayProvider } from '@/components/app/app-overlay/AppOverlayProvider';
 import { useAppViewId, useCurrentWorkspaceId } from '@/components/app/app.hooks';
-import { useOpenInDesktopApp } from '@/components/app/hooks/useOpenInDesktopApp';
+import { useDesktopHandoff } from '@/components/app/hooks/useDesktopHandoff';
 import { RequestAccessError } from '@/components/app/hooks/useWorkspaceData';
 import RequestAccess from '@/components/app/landing-pages/RequestAccess';
 import { useCurrentUser } from '@/components/main/app.hooks';
-import { buildOpenPageLink, isSpecificPagePath, openInDesktopApp } from '@/utils/open_desktop_app';
+import { buildOpenPageLink, isSpecificPagePath } from '@/utils/open_desktop_app';
 
 const ViewModal = React.lazy(() => import('@/components/app/ViewModal'));
 
@@ -58,7 +58,7 @@ function OpenClient() {
   const openClient = searchParams.get('is_desktop') === 'true';
   const rowId = searchParams.get('r');
   const currentUser = useCurrentUser();
-  const { enabled } = useOpenInDesktopApp();
+  const { handoff } = useDesktopHandoff();
 
   const [isTabVisible, setIsTabVisible] = useState(true);
   const hasOpenedRef = useRef(false);
@@ -93,16 +93,16 @@ function OpenClient() {
     }
   }, [currentWorkspaceId, viewId, currentUser, openClient, rowId, isTabVisible]);
 
-  // Preference-driven share-link handoff: when the user prefers the desktop app and this document
-  // was opened directly from a shared page link, attempt to open the page in the desktop app once.
-  // If the app isn't installed, openInDesktopApp keeps the user on the already-rendered web page.
+  // Share-link handoff: when this document was opened directly from a shared page link, route it
+  // through the preference-gated handoff once. Preference on → opens the desktop app; unset → shows
+  // the first-time prompt; off → stays on the already-rendered web page.
   useEffect(() => {
-    if (openClient || !enabled || !landedOnSpecificPage || didAttemptPreferenceHandoff) return;
+    if (openClient || !landedOnSpecificPage || didAttemptPreferenceHandoff) return;
     if (!isTabVisible || !currentUser || !currentWorkspaceId || !viewId) return;
 
     didAttemptPreferenceHandoff = true;
-    openInDesktopApp(buildOpenPageLink({ workspaceId: currentWorkspaceId, viewId, email: currentUser.email, rowId }));
-  }, [openClient, enabled, currentWorkspaceId, viewId, currentUser, rowId, isTabVisible]);
+    handoff(buildOpenPageLink({ workspaceId: currentWorkspaceId, viewId, email: currentUser.email, rowId }));
+  }, [handoff, openClient, currentWorkspaceId, viewId, currentUser, rowId, isTabVisible]);
 
   return <></>;
 }

--- a/src/components/app/hooks/__tests__/useDesktopHandoff.test.tsx
+++ b/src/components/app/hooks/__tests__/useDesktopHandoff.test.tsx
@@ -1,0 +1,54 @@
+/// <reference types="jest" />
+import { renderHook } from '@testing-library/react';
+
+import { useDesktopHandoff } from '../useDesktopHandoff';
+
+const mockOpenInDesktopApp = jest.fn();
+let mockEnabled = false;
+
+jest.mock('@/utils/open_desktop_app', () => ({
+  openInDesktopApp: (...args: unknown[]) => mockOpenInDesktopApp(...args),
+}));
+
+jest.mock('@/components/app/hooks/useOpenInDesktopApp', () => ({
+  useOpenInDesktopApp: () => ({ enabled: mockEnabled, isSet: true, setEnabled: jest.fn() }),
+}));
+
+describe('useDesktopHandoff', () => {
+  beforeEach(() => {
+    mockOpenInDesktopApp.mockClear();
+    mockEnabled = false;
+  });
+
+  it('stays in the browser when the preference is off', () => {
+    mockEnabled = false;
+    const onStayInBrowser = jest.fn();
+    const { result } = renderHook(() => useDesktopHandoff());
+
+    const attempted = result.current.handoff('appflowy-flutter://open-page?workspace_id=ws1', {
+      onStayInBrowser,
+    });
+
+    expect(attempted).toBe(false);
+    expect(onStayInBrowser).toHaveBeenCalledTimes(1);
+    expect(mockOpenInDesktopApp).not.toHaveBeenCalled();
+  });
+
+  it('attempts the desktop app when the preference is on', () => {
+    mockEnabled = true;
+    const onStayInBrowser = jest.fn();
+    const { result } = renderHook(() => useDesktopHandoff());
+
+    const attempted = result.current.handoff('appflowy-flutter://open-page?workspace_id=ws1', {
+      onStayInBrowser,
+    });
+
+    expect(attempted).toBe(true);
+    expect(mockOpenInDesktopApp).toHaveBeenCalledWith('appflowy-flutter://open-page?workspace_id=ws1', {
+      onContinueInBrowser: onStayInBrowser,
+    });
+    // The web fallback only runs if the app can't be opened (handled inside openInDesktopApp),
+    // not synchronously here.
+    expect(onStayInBrowser).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/app/hooks/__tests__/useDesktopHandoff.test.tsx
+++ b/src/components/app/hooks/__tests__/useDesktopHandoff.test.tsx
@@ -4,34 +4,43 @@ import { renderHook } from '@testing-library/react';
 import { useDesktopHandoff } from '../useDesktopHandoff';
 
 const mockOpenInDesktopApp = jest.fn();
+const mockPrompt = jest.fn();
+const mockSetEnabled = jest.fn();
 let mockEnabled = false;
+let mockIsSet = true;
 
 jest.mock('@/utils/open_desktop_app', () => ({
   openInDesktopApp: (...args: unknown[]) => mockOpenInDesktopApp(...args),
+  promptOpenInDesktopApp: (...args: unknown[]) => mockPrompt(...args),
 }));
 
 jest.mock('@/components/app/hooks/useOpenInDesktopApp', () => ({
-  useOpenInDesktopApp: () => ({ enabled: mockEnabled, isSet: true, setEnabled: jest.fn() }),
+  useOpenInDesktopApp: () => ({ enabled: mockEnabled, isSet: mockIsSet, setEnabled: mockSetEnabled }),
 }));
+
+const SCHEME = 'appflowy-flutter://open-page?workspace_id=ws1';
 
 describe('useDesktopHandoff', () => {
   beforeEach(() => {
     mockOpenInDesktopApp.mockClear();
+    mockPrompt.mockClear();
+    mockSetEnabled.mockClear();
     mockEnabled = false;
+    mockIsSet = true;
   });
 
-  it('stays in the browser when the preference is off', () => {
+  it('stays in the browser when the preference is explicitly off', () => {
     mockEnabled = false;
+    mockIsSet = true;
     const onStayInBrowser = jest.fn();
     const { result } = renderHook(() => useDesktopHandoff());
 
-    const attempted = result.current.handoff('appflowy-flutter://open-page?workspace_id=ws1', {
-      onStayInBrowser,
-    });
+    const attempted = result.current.handoff(SCHEME, { onStayInBrowser });
 
     expect(attempted).toBe(false);
     expect(onStayInBrowser).toHaveBeenCalledTimes(1);
     expect(mockOpenInDesktopApp).not.toHaveBeenCalled();
+    expect(mockPrompt).not.toHaveBeenCalled();
   });
 
   it('attempts the desktop app when the preference is on', () => {
@@ -39,16 +48,41 @@ describe('useDesktopHandoff', () => {
     const onStayInBrowser = jest.fn();
     const { result } = renderHook(() => useDesktopHandoff());
 
-    const attempted = result.current.handoff('appflowy-flutter://open-page?workspace_id=ws1', {
-      onStayInBrowser,
-    });
+    const attempted = result.current.handoff(SCHEME, { onStayInBrowser });
 
     expect(attempted).toBe(true);
-    expect(mockOpenInDesktopApp).toHaveBeenCalledWith('appflowy-flutter://open-page?workspace_id=ws1', {
-      onContinueInBrowser: onStayInBrowser,
-    });
-    // The web fallback only runs if the app can't be opened (handled inside openInDesktopApp),
-    // not synchronously here.
+    expect(mockOpenInDesktopApp).toHaveBeenCalledWith(SCHEME, { onContinueInBrowser: onStayInBrowser });
+    expect(mockPrompt).not.toHaveBeenCalled();
+    // The web fallback only runs if the app can't be opened (inside openInDesktopApp), not here.
     expect(onStayInBrowser).not.toHaveBeenCalled();
+  });
+
+  it('prompts once on first use (unset) and remembers the choice', () => {
+    mockEnabled = false;
+    mockIsSet = false;
+    const onStayInBrowser = jest.fn();
+    const { result } = renderHook(() => useDesktopHandoff());
+
+    const attempted = result.current.handoff(SCHEME, { onStayInBrowser });
+
+    expect(attempted).toBe(false);
+    expect(mockPrompt).toHaveBeenCalledTimes(1);
+    expect(mockOpenInDesktopApp).not.toHaveBeenCalled();
+    expect(onStayInBrowser).not.toHaveBeenCalled();
+
+    const promptArgs = mockPrompt.mock.calls[0][0] as {
+      onOpen: () => void;
+      onStayInBrowser?: () => void;
+    };
+
+    // "Open in app" → enable the preference and attempt the handoff.
+    promptArgs.onOpen();
+    expect(mockSetEnabled).toHaveBeenCalledWith(true);
+    expect(mockOpenInDesktopApp).toHaveBeenCalledWith(SCHEME, { onContinueInBrowser: onStayInBrowser });
+
+    // "Stay in browser" → disable the preference and stay on the web.
+    promptArgs.onStayInBrowser?.();
+    expect(mockSetEnabled).toHaveBeenCalledWith(false);
+    expect(onStayInBrowser).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/components/app/hooks/useDesktopHandoff.ts
+++ b/src/components/app/hooks/useDesktopHandoff.ts
@@ -1,0 +1,40 @@
+import { useCallback } from 'react';
+
+import { useOpenInDesktopApp } from '@/components/app/hooks/useOpenInDesktopApp';
+import { openInDesktopApp } from '@/utils/open_desktop_app';
+
+interface HandoffOptions {
+  /**
+   * Called once the handoff resolves to "stay on the web": either the preference is off, or the
+   * desktop app could not be opened. NOT called when the desktop app opened. Use it to navigate to
+   * the web target (e.g. the workspace) for flows that aren't already on the destination page.
+   */
+  onStayInBrowser?: () => void;
+}
+
+/**
+ * Preference-gated handoff to the desktop app. When the user's "open links in desktop app"
+ * preference is enabled, attempts to open `scheme` in the desktop app (with the not-installed
+ * handling in `openInDesktopApp`); otherwise stays on the web.
+ */
+export function useDesktopHandoff() {
+  const { enabled } = useOpenInDesktopApp();
+
+  const handoff = useCallback(
+    (scheme: string, options: HandoffOptions = {}): boolean => {
+      if (!enabled) {
+        options.onStayInBrowser?.();
+        return false;
+      }
+
+      openInDesktopApp(scheme, {
+        // App opened — nothing to do on the web side.
+        onContinueInBrowser: options.onStayInBrowser,
+      });
+      return true;
+    },
+    [enabled]
+  );
+
+  return { enabled, handoff };
+}

--- a/src/components/app/hooks/useDesktopHandoff.ts
+++ b/src/components/app/hooks/useDesktopHandoff.ts
@@ -1,7 +1,7 @@
 import { useCallback } from 'react';
 
 import { useOpenInDesktopApp } from '@/components/app/hooks/useOpenInDesktopApp';
-import { openInDesktopApp } from '@/utils/open_desktop_app';
+import { openInDesktopApp, promptOpenInDesktopApp } from '@/utils/open_desktop_app';
 
 interface HandoffOptions {
   /**
@@ -13,28 +13,45 @@ interface HandoffOptions {
 }
 
 /**
- * Preference-gated handoff to the desktop app. When the user's "open links in desktop app"
- * preference is enabled, attempts to open `scheme` in the desktop app (with the not-installed
- * handling in `openInDesktopApp`); otherwise stays on the web.
+ * Preference-gated handoff to the desktop app:
+ * - preference ON  → attempt to open `scheme` in the desktop app (with not-installed handling);
+ * - preference UNSET (never chosen) → show a one-time prompt; the choice is remembered;
+ * - preference OFF → stay on the web.
  */
 export function useDesktopHandoff() {
-  const { enabled } = useOpenInDesktopApp();
+  const { enabled, isSet, setEnabled } = useOpenInDesktopApp();
 
   const handoff = useCallback(
     (scheme: string, options: HandoffOptions = {}): boolean => {
-      if (!enabled) {
-        options.onStayInBrowser?.();
+      if (enabled) {
+        openInDesktopApp(scheme, {
+          // App opened — nothing to do on the web side.
+          onContinueInBrowser: options.onStayInBrowser,
+        });
+        return true;
+      }
+
+      // Never asked: prompt once, and remember the choice so we don't ask again.
+      if (!isSet) {
+        promptOpenInDesktopApp({
+          onOpen: () => {
+            void setEnabled(true);
+            openInDesktopApp(scheme, { onContinueInBrowser: options.onStayInBrowser });
+          },
+          onStayInBrowser: () => {
+            void setEnabled(false);
+            options.onStayInBrowser?.();
+          },
+        });
         return false;
       }
 
-      openInDesktopApp(scheme, {
-        // App opened — nothing to do on the web side.
-        onContinueInBrowser: options.onStayInBrowser,
-      });
-      return true;
+      // Explicitly disabled — stay on the web.
+      options.onStayInBrowser?.();
+      return false;
     },
-    [enabled]
+    [enabled, isSet, setEnabled]
   );
 
-  return { enabled, handoff };
+  return { enabled, isSet, handoff };
 }

--- a/src/components/app/hooks/useOpenInDesktopApp.ts
+++ b/src/components/app/hooks/useOpenInDesktopApp.ts
@@ -1,0 +1,49 @@
+import { useCallback } from 'react';
+
+import { UserService } from '@/application/services/domains';
+import { MetadataKey } from '@/application/user-metadata';
+import { notify } from '@/components/_shared/notify';
+import { useAppConfig } from '@/components/main/app.hooks';
+
+interface UseOpenInDesktopApp {
+  /** Whether the user has enabled "open links in the desktop app". Defaults to false. */
+  enabled: boolean;
+  /** Whether the preference has ever been set (used to decide whether to show a first-time prompt). */
+  isSet: boolean;
+  /** Persist the preference: server (metadata merge) + local user cache. */
+  setEnabled: (value: boolean) => Promise<void>;
+}
+
+/**
+ * Reads/writes the per-user, server-synced "open links in desktop app" preference
+ * (`MetadataKey.OpenInDesktopApp`). Stored in the user's metadata, identical to how timezone /
+ * language / date-format preferences are persisted (server merge via `UserService.updateProfile`
+ * plus the local user cache via `updateCurrentUser`).
+ */
+export function useOpenInDesktopApp(): UseOpenInDesktopApp {
+  const { currentUser, updateCurrentUser } = useAppConfig();
+
+  const raw = currentUser?.metadata?.[MetadataKey.OpenInDesktopApp];
+  const enabled = raw === true;
+  const isSet = raw !== undefined;
+
+  const setEnabled = useCallback(
+    async (value: boolean) => {
+      try {
+        await UserService.updateProfile({ [MetadataKey.OpenInDesktopApp]: value });
+
+        if (currentUser) {
+          await updateCurrentUser({
+            ...currentUser,
+            metadata: { ...currentUser.metadata, [MetadataKey.OpenInDesktopApp]: value },
+          });
+        }
+      } catch (e) {
+        notify.error(e instanceof Error ? e.message : 'Failed to update preference');
+      }
+    },
+    [currentUser, updateCurrentUser]
+  );
+
+  return { enabled, isSet, setEnabled };
+}

--- a/src/components/app/hooks/useOpenInDesktopApp.ts
+++ b/src/components/app/hooks/useOpenInDesktopApp.ts
@@ -1,9 +1,9 @@
-import { useCallback } from 'react';
+import { useCallback, useContext } from 'react';
 
 import { UserService } from '@/application/services/domains';
 import { MetadataKey } from '@/application/user-metadata';
 import { notify } from '@/components/_shared/notify';
-import { useAppConfig } from '@/components/main/app.hooks';
+import { AFConfigContext } from '@/components/main/app.hooks';
 
 interface UseOpenInDesktopApp {
   /** Whether the user has enabled "open links in the desktop app". Defaults to false. */
@@ -19,9 +19,15 @@ interface UseOpenInDesktopApp {
  * (`MetadataKey.OpenInDesktopApp`). Stored in the user's metadata, identical to how timezone /
  * language / date-format preferences are persisted (server merge via `UserService.updateProfile`
  * plus the local user cache via `updateCurrentUser`).
+ *
+ * Reads the AFConfig context directly (rather than the strict `useAppConfig`) so it is safe to call
+ * from landing/invitation pages that may render outside the provider; it simply reports `enabled:
+ * false` there.
  */
 export function useOpenInDesktopApp(): UseOpenInDesktopApp {
-  const { currentUser, updateCurrentUser } = useAppConfig();
+  const context = useContext(AFConfigContext);
+  const currentUser = context?.currentUser;
+  const updateCurrentUser = context?.updateCurrentUser;
 
   const raw = currentUser?.metadata?.[MetadataKey.OpenInDesktopApp];
   const enabled = raw === true;
@@ -32,7 +38,7 @@ export function useOpenInDesktopApp(): UseOpenInDesktopApp {
       try {
         await UserService.updateProfile({ [MetadataKey.OpenInDesktopApp]: value });
 
-        if (currentUser) {
+        if (currentUser && updateCurrentUser) {
           await updateCurrentUser({
             ...currentUser,
             metadata: { ...currentUser.metadata, [MetadataKey.OpenInDesktopApp]: value },

--- a/src/components/app/landing-pages/AsGuest.tsx
+++ b/src/components/app/landing-pages/AsGuest.tsx
@@ -3,16 +3,18 @@ import { Trans, useTranslation } from 'react-i18next';
 import { useSearchParams } from 'react-router-dom';
 
 import { ERROR_CODE } from '@/application/constants';
+import { WorkspaceService } from '@/application/services/domains';
 import { Workspace } from '@/application/types';
 import { ReactComponent as SuccessLogo } from '@/assets/icons/success_logo.svg';
-import { WorkspaceService } from '@/application/services/domains';
-import { ErrorPage } from '@/components/_shared/landing-page/ErrorPage';
 import { LandingPageError } from '@/components/_shared/landing-page/errorContent';
+import { ErrorPage } from '@/components/_shared/landing-page/ErrorPage';
 import { InvalidLink } from '@/components/_shared/landing-page/InvalidLink';
 import LandingPage from '@/components/_shared/landing-page/LandingPage';
 import { NotInvitationAccount } from '@/components/_shared/landing-page/NotInvitationAccount';
-import { useIsAuthenticatedOptional } from '@/components/main/app.hooks';
+import { useDesktopHandoff } from '@/components/app/hooks/useDesktopHandoff';
+import { useCurrentUserOptional, useIsAuthenticatedOptional } from '@/components/main/app.hooks';
 import { Progress } from '@/components/ui/progress';
+import { buildOpenPageLink } from '@/utils/open_desktop_app';
 
 export function AsGuest() {
   const { t } = useTranslation();
@@ -33,7 +35,24 @@ export function AsGuest() {
   const [error, setError] = useState<LandingPageError>();
 
   const isAuthenticated = useIsAuthenticatedOptional();
+  const currentUser = useCurrentUserOptional();
+  const { handoff } = useDesktopHandoff();
   const url = useMemo(() => window.location.href, []);
+
+  const openPage = useCallback(() => {
+    const goWeb = () => window.open(`/app/${workspace?.id}/${page?.view_id}`, '_self');
+
+    if (!workspace?.id || !page?.view_id) {
+      goWeb();
+      return;
+    }
+
+    // Open the shared page in the desktop app if the user prefers it; otherwise stay on the web.
+    handoff(
+      buildOpenPageLink({ workspaceId: workspace.id, viewId: page.view_id, email: currentUser?.email }),
+      { onStayInBrowser: goWeb }
+    );
+  }, [handoff, workspace?.id, page?.view_id, currentUser?.email]);
 
   // Redirect unauthenticated users to login, preserving the invitation URL
   useEffect(() => {
@@ -134,9 +153,7 @@ export function AsGuest() {
         </div>
       }
       primaryAction={{
-        onClick: () => {
-          window.open(`/app/${workspace?.id}/${page?.view_id}`, '_self');
-        },
+        onClick: openPage,
         label: loading ? (
           <span className='flex items-center gap-2'>
             <Progress />

--- a/src/components/app/settings/AccountAppPanel.tsx
+++ b/src/components/app/settings/AccountAppPanel.tsx
@@ -5,15 +5,16 @@ import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 import { toast } from 'sonner';
 
+import { UserService } from '@/application/services/domains';
 import { clearRedirectTo } from '@/application/session/sign_in';
 import { invalidToken } from '@/application/session/token';
-import { UserService } from '@/application/services/domains';
 import { DateFormat, TimeFormat } from '@/application/types';
 import { MetadataKey } from '@/application/user-metadata';
 import { ReactComponent as ChevronDownIcon } from '@/assets/icons/alt_arrow_down.svg';
 import { NormalModal } from '@/components/_shared/modal';
-import { HIDDEN_BUTTON_PROPS, MODAL_CLASSES } from '@/components/app/workspaces/modal-props';
+import { useOpenInDesktopApp } from '@/components/app/hooks/useOpenInDesktopApp';
 import LogoutConfirm from '@/components/app/workspaces/LogoutConfirm';
+import { HIDDEN_BUTTON_PROPS, MODAL_CLASSES } from '@/components/app/workspaces/modal-props';
 import { useAppConfig } from '@/components/main/app.hooks';
 import { Button } from '@/components/ui/button';
 import {
@@ -23,6 +24,7 @@ import {
   DropdownMenuRadioItem,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
+import { Switch } from '@/components/ui/switch';
 import { i18nInstance } from '@/i18n/config';
 import { cn } from '@/lib/utils';
 import { getErrorMessage } from '@/utils/errors';
@@ -96,6 +98,7 @@ function formatDateTimeExample(dateFormat: DateFormat, timeFormat: TimeFormat): 
 export function AccountAppPanel() {
   const { t } = useTranslation();
   const { currentUser, updateCurrentUser } = useAppConfig();
+  const { enabled: openInDesktopApp, setEnabled: setOpenInDesktopApp } = useOpenInDesktopApp();
   const navigate = useNavigate();
 
   const [dateFormat, setDateFormat] = useState(
@@ -287,6 +290,24 @@ export function AccountAppPanel() {
           <Section title={t('settings.accountPage.language.title')}>
             <LanguageDropdown language={language} onSelect={handleSelectLanguage} />
           </Section>
+
+          <Divider />
+
+          <Row>
+            <div className='flex flex-col gap-1'>
+              <div className='text-sm font-semibold text-text-primary'>
+                {t('settings.accountPage.openInDesktopApp.title')}
+              </div>
+              <div className='text-xs text-text-secondary'>
+                {t('settings.accountPage.openInDesktopApp.description')}
+              </div>
+            </div>
+            <Switch
+              checked={openInDesktopApp}
+              onCheckedChange={(checked) => void setOpenInDesktopApp(checked)}
+              data-testid='open-in-desktop-app-toggle'
+            />
+          </Row>
 
           <Divider />
 

--- a/src/pages/AcceptInvitationPage.tsx
+++ b/src/pages/AcceptInvitationPage.tsx
@@ -16,6 +16,7 @@ import { useCurrentUser } from '@/components/main/app.hooks';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { Progress } from '@/components/ui/progress';
 import { cn } from '@/lib/utils';
+import { buildInvitationCallbackLink } from '@/utils/open_desktop_app';
 
 function AcceptInvitationPage() {
   const currentUser = useCurrentUser();
@@ -103,10 +104,9 @@ function AcceptInvitationPage() {
 
       // Hand off to the desktop app if the user prefers it; otherwise (or if the app isn't
       // installed) land on the web workspace.
-      handoff(
-        `appflowy-flutter://invitation-callback?workspace_id=${workspaceId}&email=${encodeURIComponent(currentUser?.email ?? '')}`,
-        { onStayInBrowser: goWeb }
-      );
+      handoff(buildInvitationCallbackLink({ workspaceId: workspaceId ?? '', email: currentUser?.email }), {
+        onStayInBrowser: goWeb,
+      });
       setHasJoined(true);
       // eslint-disable-next-line
     } catch (e: any) {

--- a/src/pages/AcceptInvitationPage.tsx
+++ b/src/pages/AcceptInvitationPage.tsx
@@ -4,13 +4,14 @@ import { useSearchParams } from 'react-router-dom';
 import { toast } from 'sonner';
 
 import { ERROR_CODE } from '@/application/constants';
+import { AccessService } from '@/application/services/domains';
 import { Invitation } from '@/application/types';
 import { ReactComponent as SuccessLogo } from '@/assets/icons/success_logo.svg';
-import { AccessService } from '@/application/services/domains';
 import { ErrorPage } from '@/components/_shared/landing-page/ErrorPage';
 import { InvalidLink } from '@/components/_shared/landing-page/InvalidLink';
 import LandingPage from '@/components/_shared/landing-page/LandingPage';
 import { NotInvitationAccount } from '@/components/_shared/landing-page/NotInvitationAccount';
+import { useDesktopHandoff } from '@/components/app/hooks/useDesktopHandoff';
 import { useCurrentUser } from '@/components/main/app.hooks';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { Progress } from '@/components/ui/progress';
@@ -18,6 +19,7 @@ import { cn } from '@/lib/utils';
 
 function AcceptInvitationPage() {
   const currentUser = useCurrentUser();
+  const { handoff } = useDesktopHandoff();
   const [searchParams] = useSearchParams();
   const invitationId = searchParams.get('invited_id');
   const [invitation, setInvitation] = useState<Invitation>();
@@ -96,7 +98,15 @@ function AcceptInvitationPage() {
       setLoading(true);
       await AccessService.acceptInvitation(invitationId);
       toast.success(t('invitation.successMessage'));
-      window.open(`/app/${invitation?.workspace_id}`, '_self');
+      const workspaceId = invitation?.workspace_id;
+      const goWeb = () => window.open(`/app/${workspaceId}`, '_self');
+
+      // Hand off to the desktop app if the user prefers it; otherwise (or if the app isn't
+      // installed) land on the web workspace.
+      handoff(
+        `appflowy-flutter://invitation-callback?workspace_id=${workspaceId}&email=${encodeURIComponent(currentUser?.email ?? '')}`,
+        { onStayInBrowser: goWeb }
+      );
       setHasJoined(true);
       // eslint-disable-next-line
     } catch (e: any) {
@@ -116,7 +126,7 @@ function AcceptInvitationPage() {
     } finally {
       setLoading(false);
     }
-  }, [invitationId, invitation, t]);
+  }, [invitationId, invitation, t, handoff, currentUser?.email]);
 
   const AvatarLogo = useCallback(
     (props: HTMLAttributes<HTMLDivElement>) => {

--- a/src/utils/__tests__/open_desktop_app.test.ts
+++ b/src/utils/__tests__/open_desktop_app.test.ts
@@ -1,7 +1,10 @@
 /// <reference types="jest" />
 import {
   attemptOpenDesktopApp,
+  buildInvitationCallbackLink,
+  buildOpenPageLink,
   isDesktopAppLikelyMissing,
+  isSpecificPagePath,
   openInDesktopApp,
 } from '../open_desktop_app';
 
@@ -34,6 +37,41 @@ describe('open_desktop_app — not installed handling', () => {
   afterEach(() => {
     jest.runOnlyPendingTimers();
     jest.useRealTimers();
+  });
+
+  describe('isSpecificPagePath (share-link vs internal navigation)', () => {
+    it('is true only for /app/{workspace}/{view} page links', () => {
+      // Share-page links → handoff should fire
+      expect(isSpecificPagePath('/app/ws1/view1')).toBe(true);
+      expect(isSpecificPagePath('/app/ws1/view1/block1')).toBe(true);
+      expect(isSpecificPagePath('/app/ws1/view1?r=row1')).toBe(true);
+
+      // Not specific pages → handoff should NOT fire
+      expect(isSpecificPagePath('/app')).toBe(false);
+      expect(isSpecificPagePath('/app/ws1')).toBe(false);
+      expect(isSpecificPagePath('/login')).toBe(false);
+      expect(isSpecificPagePath('/')).toBe(false);
+    });
+  });
+
+  describe('deep-link builders', () => {
+    it('builds an open-page link with the shared view and optional row', () => {
+      expect(buildOpenPageLink({ workspaceId: 'ws1', viewId: 'v1', email: 'a@b.com' })).toBe(
+        'appflowy-flutter://open-page?workspace_id=ws1&view_id=v1&email=a%40b.com'
+      );
+      expect(
+        buildOpenPageLink({ workspaceId: 'ws1', viewId: 'v1', email: 'a@b.com', rowId: 'r1' })
+      ).toBe('appflowy-flutter://open-page?workspace_id=ws1&view_id=v1&email=a%40b.com&row_id=r1');
+    });
+
+    it('builds an invitation-callback link and tolerates a missing email', () => {
+      expect(buildInvitationCallbackLink({ workspaceId: 'ws1', email: 'a@b.com' })).toBe(
+        'appflowy-flutter://invitation-callback?workspace_id=ws1&email=a%40b.com'
+      );
+      expect(buildInvitationCallbackLink({ workspaceId: 'ws1' })).toBe(
+        'appflowy-flutter://invitation-callback?workspace_id=ws1&email='
+      );
+    });
   });
 
   describe('isDesktopAppLikelyMissing', () => {

--- a/src/utils/__tests__/open_desktop_app.test.ts
+++ b/src/utils/__tests__/open_desktop_app.test.ts
@@ -1,0 +1,141 @@
+/// <reference types="jest" />
+import {
+  attemptOpenDesktopApp,
+  isDesktopAppLikelyMissing,
+  openInDesktopApp,
+} from '../open_desktop_app';
+
+const warning = jest.fn();
+
+jest.mock('sonner', () => ({
+  toast: {
+    warning: (...args: unknown[]) => warning(...args),
+  },
+}));
+
+jest.mock('@/i18n/config', () => ({
+  i18nInstance: { t: (key: string) => key },
+}));
+
+const MISSING_FLAG_KEY = 'appflowy:desktop-app-missing-at';
+
+function setHidden(hidden: boolean) {
+  Object.defineProperty(document, 'hidden', { configurable: true, get: () => hidden });
+}
+
+describe('open_desktop_app — not installed handling', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    window.localStorage.clear();
+    warning.mockClear();
+    setHidden(false);
+  });
+
+  afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+  });
+
+  describe('isDesktopAppLikelyMissing', () => {
+    it('is false with no flag', () => {
+      expect(isDesktopAppLikelyMissing()).toBe(false);
+    });
+
+    it('is true for a fresh flag and false (and cleared) once expired', () => {
+      window.localStorage.setItem(MISSING_FLAG_KEY, String(Date.now()));
+      expect(isDesktopAppLikelyMissing()).toBe(true);
+
+      const eightDaysAgo = Date.now() - 8 * 24 * 60 * 60 * 1000;
+
+      window.localStorage.setItem(MISSING_FLAG_KEY, String(eightDaysAgo));
+      expect(isDesktopAppLikelyMissing()).toBe(false);
+      expect(window.localStorage.getItem(MISSING_FLAG_KEY)).toBeNull();
+    });
+  });
+
+  describe('attemptOpenDesktopApp', () => {
+    it('reports opened and clears the missing flag when the page loses visibility', () => {
+      window.localStorage.setItem(MISSING_FLAG_KEY, String(Date.now()));
+      const onOpened = jest.fn();
+      const onNotInstalled = jest.fn();
+
+      attemptOpenDesktopApp('appflowy-flutter://open-page', { onOpened, onNotInstalled });
+
+      setHidden(true);
+      document.dispatchEvent(new Event('visibilitychange'));
+
+      expect(onOpened).toHaveBeenCalledTimes(1);
+      expect(onNotInstalled).not.toHaveBeenCalled();
+      expect(window.localStorage.getItem(MISSING_FLAG_KEY)).toBeNull();
+    });
+
+    it('reports not-installed and remembers it when the timeout elapses', () => {
+      const onOpened = jest.fn();
+      const onNotInstalled = jest.fn();
+
+      attemptOpenDesktopApp('appflowy-flutter://open-page', {
+        timeout: 2500,
+        onOpened,
+        onNotInstalled,
+      });
+
+      jest.advanceTimersByTime(2500);
+
+      expect(onNotInstalled).toHaveBeenCalledTimes(1);
+      expect(onOpened).not.toHaveBeenCalled();
+      expect(isDesktopAppLikelyMissing()).toBe(true);
+    });
+
+    it('only settles once (timeout after a success is ignored)', () => {
+      const onOpened = jest.fn();
+      const onNotInstalled = jest.fn();
+
+      attemptOpenDesktopApp('appflowy-flutter://open-page', { onOpened, onNotInstalled });
+
+      window.dispatchEvent(new Event('blur'));
+      jest.advanceTimersByTime(5000);
+
+      expect(onOpened).toHaveBeenCalledTimes(1);
+      expect(onNotInstalled).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('openInDesktopApp', () => {
+    it('skips the attempt and stays on web (no prompt) when the app is known missing', () => {
+      window.localStorage.setItem(MISSING_FLAG_KEY, String(Date.now()));
+      const onContinueInBrowser = jest.fn();
+
+      openInDesktopApp('appflowy-flutter://open-page', { onContinueInBrowser });
+
+      expect(onContinueInBrowser).toHaveBeenCalledTimes(1);
+      expect(warning).not.toHaveBeenCalled();
+    });
+
+    it('attempts even when known missing if forced', () => {
+      window.localStorage.setItem(MISSING_FLAG_KEY, String(Date.now()));
+      const onContinueInBrowser = jest.fn();
+
+      openInDesktopApp('appflowy-flutter://open-page', { force: true, onContinueInBrowser });
+
+      // forced attempt is in-flight, not the immediate skip path
+      expect(onContinueInBrowser).not.toHaveBeenCalled();
+
+      jest.advanceTimersByTime(2500);
+
+      // timeout → not installed → prompt + proceed to web
+      expect(warning).toHaveBeenCalledTimes(1);
+      expect(onContinueInBrowser).toHaveBeenCalledTimes(1);
+    });
+
+    it('shows the prompt and proceeds to web when an attempt times out', () => {
+      const onContinueInBrowser = jest.fn();
+
+      openInDesktopApp('appflowy-flutter://open-page', { onContinueInBrowser });
+
+      jest.advanceTimersByTime(2500);
+
+      expect(warning).toHaveBeenCalledTimes(1);
+      expect(onContinueInBrowser).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/src/utils/open_desktop_app.ts
+++ b/src/utils/open_desktop_app.ts
@@ -185,6 +185,27 @@ export function notifyDesktopAppNotInstalled(): void {
   });
 }
 
+/**
+ * Notion-style first-time prompt, shown when the user has not yet chosen whether AppFlowy links
+ * should open in the desktop app. The choice is remembered by the caller, so this is asked once.
+ */
+export function promptOpenInDesktopApp(options: { onOpen: () => void; onStayInBrowser?: () => void }): void {
+  const t = i18nInstance.t.bind(i18nInstance);
+
+  toast(t('openInDesktopApp.prompt.title'), {
+    description: t('openInDesktopApp.prompt.description'),
+    duration: 12000,
+    action: {
+      label: t('openInDesktopApp.prompt.open'),
+      onClick: () => options.onOpen(),
+    },
+    cancel: {
+      label: t('openInDesktopApp.prompt.stay'),
+      onClick: () => options.onStayInBrowser?.(),
+    },
+  });
+}
+
 interface OpenInDesktopOptions {
   /** Attempt even if the app was previously detected missing on this device (e.g. a button press). */
   force?: boolean;

--- a/src/utils/open_desktop_app.ts
+++ b/src/utils/open_desktop_app.ts
@@ -18,6 +18,15 @@ import { desktopDownloadLink, openAppFlowySchema } from '@/utils/url';
  * succeeds.
  */
 
+/**
+ * Whether a path points at a specific page (`/app/{workspace}/{view}`) — i.e. a shareable page
+ * link. Used to fire the preference-driven desktop handoff only when the app was opened directly
+ * from such a link, not on internal client-side navigation.
+ */
+export function isSpecificPagePath(pathname: string): boolean {
+  return /^\/app\/[^/]+\/[^/]+/.test(pathname);
+}
+
 /** Build the `open-page` deep link that opens a specific page/view in the desktop app. */
 export function buildOpenPageLink(opts: {
   workspaceId: string;

--- a/src/utils/open_desktop_app.ts
+++ b/src/utils/open_desktop_app.ts
@@ -18,6 +18,27 @@ import { desktopDownloadLink, openAppFlowySchema } from '@/utils/url';
  * succeeds.
  */
 
+/** Build the `open-page` deep link that opens a specific page/view in the desktop app. */
+export function buildOpenPageLink(opts: {
+  workspaceId: string;
+  viewId: string;
+  email?: string | null;
+  rowId?: string | null;
+}): string {
+  const { workspaceId, viewId, email, rowId } = opts;
+
+  return `appflowy-flutter://open-page?workspace_id=${workspaceId}&view_id=${viewId}&email=${encodeURIComponent(
+    email ?? ''
+  )}${rowId ? `&row_id=${rowId}` : ''}`;
+}
+
+/** Build the `invitation-callback` deep link that opens an invited workspace in the desktop app. */
+export function buildInvitationCallbackLink(opts: { workspaceId: string; email?: string | null }): string {
+  const { workspaceId, email } = opts;
+
+  return `appflowy-flutter://invitation-callback?workspace_id=${workspaceId}&email=${encodeURIComponent(email ?? '')}`;
+}
+
 const MISSING_FLAG_KEY = 'appflowy:desktop-app-missing-at';
 /** Re-probe roughly weekly in case the user installs the desktop app later. */
 const MISSING_TTL_MS = 7 * 24 * 60 * 60 * 1000;

--- a/src/utils/open_desktop_app.ts
+++ b/src/utils/open_desktop_app.ts
@@ -1,0 +1,194 @@
+import { toast } from 'sonner';
+
+import { i18nInstance } from '@/i18n/config';
+import { desktopDownloadLink, openAppFlowySchema } from '@/utils/url';
+
+/**
+ * Notion-style "open in desktop app" handling, focused on the "app not installed" case.
+ *
+ * Browsers cannot reliably tell whether a desktop app is installed, so we use the standard
+ * attempt-and-observe heuristic: fire the `appflowy-flutter://` scheme, then watch for the page
+ * losing focus/visibility within a timeout. If focus leaves, the OS launched the app; if the
+ * timeout elapses with the page still focused, we treat the app as not installed.
+ *
+ * To avoid stalling on every link for a user who turned the "open in desktop app" preference on but
+ * never installed the app, a "not detected" result is remembered per-device (localStorage) and the
+ * attempt is skipped next time — the user simply stays on the web page. The flag expires so the app
+ * is re-probed if the user installs it later, and it is cleared immediately whenever an attempt
+ * succeeds.
+ */
+
+const MISSING_FLAG_KEY = 'appflowy:desktop-app-missing-at';
+/** Re-probe roughly weekly in case the user installs the desktop app later. */
+const MISSING_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+/** How long to wait for the page to lose focus before concluding the app did not open. */
+const DEFAULT_DETECT_TIMEOUT = 2500;
+
+/**
+ * Whether we have recently detected, on this device, that the desktop app did not open. When true,
+ * callers should avoid the (slow, prompt-triggering) launch attempt and stay on the web instead.
+ */
+export function isDesktopAppLikelyMissing(): boolean {
+  try {
+    const raw = window.localStorage.getItem(MISSING_FLAG_KEY);
+
+    if (!raw) return false;
+
+    const at = Number(raw);
+
+    if (!Number.isFinite(at) || Date.now() - at > MISSING_TTL_MS) {
+      window.localStorage.removeItem(MISSING_FLAG_KEY);
+      return false;
+    }
+
+    return true;
+  } catch {
+    // localStorage may be unavailable (private mode, blocked cookies) — assume not-missing.
+    return false;
+  }
+}
+
+function rememberDesktopAppMissing(): void {
+  try {
+    window.localStorage.setItem(MISSING_FLAG_KEY, String(Date.now()));
+  } catch {
+    // ignore storage failures
+  }
+}
+
+function rememberDesktopAppPresent(): void {
+  try {
+    window.localStorage.removeItem(MISSING_FLAG_KEY);
+  } catch {
+    // ignore storage failures
+  }
+}
+
+interface AttemptOptions {
+  /** Detection window in ms; the app is considered missing if focus does not leave within it. */
+  timeout?: number;
+  /** Called when the desktop app appears to have opened (page lost focus/visibility). */
+  onOpened?: () => void;
+  /** Called when the timeout elapsed without the app taking focus. */
+  onNotInstalled?: () => void;
+}
+
+/**
+ * Fire the deep link and infer, via focus/visibility, whether the desktop app opened. Always makes
+ * an attempt; updates the per-device "missing" memory based on the result. Most callers should use
+ * {@link openInDesktopApp}, which layers the not-installed prompt and skip-when-known-missing logic
+ * on top of this.
+ */
+export function attemptOpenDesktopApp(scheme: string, options: AttemptOptions = {}): void {
+  const { timeout = DEFAULT_DETECT_TIMEOUT, onOpened, onNotInstalled } = options;
+
+  let settled = false;
+  let timer = 0;
+  const iframe = document.createElement('iframe');
+
+  const cleanup = () => {
+    window.clearTimeout(timer);
+    document.removeEventListener('visibilitychange', onVisibilityChange);
+    window.removeEventListener('blur', onWindowBlur);
+
+    if (iframe.parentNode) {
+      iframe.parentNode.removeChild(iframe);
+    }
+  };
+
+  const succeed = () => {
+    if (settled) return;
+    settled = true;
+    cleanup();
+    rememberDesktopAppPresent();
+    onOpened?.();
+  };
+
+  const fail = () => {
+    if (settled) return;
+    settled = true;
+    cleanup();
+    rememberDesktopAppMissing();
+    onNotInstalled?.();
+  };
+
+  const onVisibilityChange = () => {
+    if (document.hidden) succeed();
+  };
+
+  const onWindowBlur = () => succeed();
+
+  document.addEventListener('visibilitychange', onVisibilityChange);
+  window.addEventListener('blur', onWindowBlur);
+  timer = window.setTimeout(fail, timeout);
+
+  // Fire the scheme via a hidden iframe so that a missing protocol handler does not navigate the
+  // current page away (unlike assigning to window.location).
+  try {
+    iframe.style.display = 'none';
+    iframe.src = scheme;
+    document.body.appendChild(iframe);
+  } catch {
+    fail();
+  }
+}
+
+/**
+ * Notion-style fallback shown when the desktop app could not be opened. Non-blocking: the user stays
+ * on (or is taken to) the web experience and may download the app or dismiss.
+ */
+export function notifyDesktopAppNotInstalled(): void {
+  const t = i18nInstance.t.bind(i18nInstance);
+
+  toast.warning(t('openInDesktopApp.notInstalled.title'), {
+    description: t('openInDesktopApp.notInstalled.description'),
+    duration: 10000,
+    action: {
+      label: t('openInDesktopApp.notInstalled.download'),
+      onClick: () => window.open(desktopDownloadLink, '_blank'),
+    },
+    // sonner's cancel button simply dismisses the toast (the user is already on the web).
+    cancel: {
+      label: t('openInDesktopApp.notInstalled.continueInBrowser'),
+      onClick: () => undefined,
+    },
+  });
+}
+
+interface OpenInDesktopOptions {
+  /** Attempt even if the app was previously detected missing on this device (e.g. a button press). */
+  force?: boolean;
+  /** Called when the app appears to have opened. */
+  onOpened?: () => void;
+  /** Called when we stay on the web (app missing, skipped, or the user chose the browser). */
+  onContinueInBrowser?: () => void;
+}
+
+/**
+ * Open a target in the AppFlowy desktop app, handling "app not installed" gracefully like Notion:
+ *
+ * - If the app was already detected missing on this device, skip the attempt and stay on the web
+ *   (no repeated stall/prompt) — unless `force` is set.
+ * - Otherwise attempt to launch; on success the caller's `onOpened` runs, on failure we surface a
+ *   non-blocking download/continue prompt and remember the result for next time.
+ */
+export function openInDesktopApp(
+  scheme: string = openAppFlowySchema,
+  options: OpenInDesktopOptions = {},
+): void {
+  const { force = false, onOpened, onContinueInBrowser } = options;
+
+  if (!force && isDesktopAppLikelyMissing()) {
+    // Already learned the app isn't here on this device — proceed to web without nagging again.
+    onContinueInBrowser?.();
+    return;
+  }
+
+  attemptOpenDesktopApp(scheme, {
+    onOpened,
+    onNotInstalled: () => {
+      notifyDesktopAppNotInstalled();
+      onContinueInBrowser?.();
+    },
+  });
+}


### PR DESCRIPTION
<!---
Thank you for submitting a pull request to the AppFlowy Web! The team will dedicate their best efforts to reviewing and approving your PR. If you have any questions or feedback, feel free to join our [Discord](https://discord.gg/wdjWUXXhtw).
-->


### **Description**
<!---
Provide a clear and concise description of the changes introduced in this pull request for AppFlowy Web. What problem does it solve? What value does it add?
-->

---

### **Checklist**
<!---
Before marking your pull request as ready for review, ensure the following checklist is complete.
-->

#### **General**
- [ ] I've included relevant documentation or comments for the changes introduced.
- [ ] I've tested the changes in multiple environments (e.g., different browsers, operating systems).

#### **Testing**
- [ ] I've added or updated tests to validate the changes introduced for AppFlowy Web.

#### **Feature-Specific**
- [ ] For feature additions, I've added a preview (video, screenshot, or demo) in the "Feature Preview" section.
- [ ] I've verified that this feature integrates seamlessly with existing functionality.

## Summary by Sourcery

Add a user preference and shared utilities for opening links in the AppFlowy desktop app, and apply this behavior to invitations, shared pages, and direct desktop deep links.

New Features:
- Introduce a per-user "open in desktop app" setting stored in user metadata and exposed in the account settings UI.
- Add a reusable desktop handoff hook and deep-link utilities to open pages and invitations in the desktop app with graceful fallback when the app is not installed.
- Enable invitation acceptance and guest/shared page landing flows to optionally open in the desktop app based on the new preference, with web fallback.

Enhancements:
- Unify construction of desktop deep-link URLs and add detection to avoid repeatedly attempting to open the desktop app on devices where it appears missing.
- Extend app context handling to trigger desktop handoff for directly opened shared page URLs and explicit desktop query links.
- Add tests for the desktop handoff hook and open-desktop utility behavior, including not-installed detection and deep-link builders.

Tests:
- Add unit tests for the open_desktop_app utility to cover deep-link building, app-missing detection, and open flow behavior.
- Add unit tests for the useDesktopHandoff hook to verify preference handling and first-time prompt behavior.