### PR TITLE
fix: coordinate realtime transport across tabs

### DIFF
--- a/src/application/sync-outbox/__tests__/sync-outbox.test.ts
+++ b/src/application/sync-outbox/__tests__/sync-outbox.test.ts
@@ -141,6 +141,32 @@ describe('sync outbox live send', () => {
     expect(mockRecords).toHaveLength(0);
   });
 
+  it('notifies the socket owner only after the outbox row is durable', async () => {
+    const onPersisted = jest.fn();
+
+    configureDrain({
+      userId,
+      workspaceId,
+      send: jest.fn(),
+      isReady: () => false,
+      onPersisted,
+    });
+
+    enqueueOutboxUpdate({
+      objectId,
+      collabType: Types.Document,
+      version: null,
+      payload: makeUpdate('draft'),
+    });
+
+    expect(onPersisted).not.toHaveBeenCalled();
+
+    await flushPromises();
+
+    expect(onPersisted).toHaveBeenCalledWith(workspaceId, objectId);
+    expect(mockRecords).toHaveLength(1);
+  });
+
   it('drains queued records when startDrainAll runs after the transport becomes ready', async () => {
     let ready = false;
     const send = jest.fn();

--- a/src/application/sync-outbox/index.ts
+++ b/src/application/sync-outbox/index.ts
@@ -27,12 +27,14 @@ interface DrainConfig {
   /**
    * Best-effort send used only when the durable IndexedDB enqueue fails
    * (quota exhausted, private-mode, upgrade blocked). Unlike `send` this
-   * SHOULD tolerate a closed socket by buffering in the WebSocket library's
-   * in-memory retry queue (e.g. react-use-websocket's `keep=true`), so the
-   * edit at least reaches the server after reconnect while this tab is alive.
+   * SHOULD tolerate the absence of a direct open socket by buffering on the
+   * owning socket or relaying to the elected socket owner, so the edit can
+   * still reach the server while this browser session is alive.
    */
   sendBestEffort?: OutboxSender;
   isReady: OutboxReady;
+  /** Notifies the elected socket owner after the IndexedDB row is durable. */
+  onPersisted?: (workspaceId: string, objectId: string) => void;
 }
 
 let drainConfig: DrainConfig | null = null;
@@ -134,6 +136,10 @@ export function enqueueOutboxUpdate(record: Omit<SyncOutboxRecord, 'id' | 'creat
   let sentImmediately = false;
 
   const activeConfig = drainConfig;
+  const notifyPersisted =
+    activeConfig?.userId === enqueueUserId && activeConfig.workspaceId === enqueueWorkspaceId
+      ? activeConfig.onPersisted
+      : undefined;
 
   if (
     activeConfig &&
@@ -156,6 +162,16 @@ export function enqueueOutboxUpdate(record: Omit<SyncOutboxRecord, 'id' | 'creat
 
   addPromise
     .then(async (id) => {
+      try {
+        notifyPersisted?.(enqueueWorkspaceId, record.objectId);
+      } catch (error) {
+        Log.warn('[outbox] durable-update notification failed', {
+          workspaceId: enqueueWorkspaceId,
+          objectId: record.objectId,
+          error,
+        });
+      }
+
       if (sentImmediately) {
         if (typeof id === 'number') {
           try {
@@ -194,11 +210,7 @@ export function enqueueOutboxUpdate(record: Omit<SyncOutboxRecord, 'id' | 'creat
       // comparison would spuriously treat those rebuilds as session switches.
       const activeConfig = drainConfig;
 
-      if (
-        !activeConfig ||
-        activeConfig.userId !== enqueueUserId ||
-        activeConfig.workspaceId !== enqueueWorkspaceId
-      ) {
+      if (!activeConfig || activeConfig.userId !== enqueueUserId || activeConfig.workspaceId !== enqueueWorkspaceId) {
         Log.warn('[outbox] fallback skipped: session changed since enqueue', {
           objectId: record.objectId,
           enqueueUserId,
@@ -311,6 +323,11 @@ export function startDrainAll() {
   });
 }
 
+/** Wakes the configured transport for one object after another tab persists it. */
+export function startDrainObject(objectId: string) {
+  scheduleDrain(objectId);
+}
+
 interface WaitForDrainOptions {
   /** Max time to wait for drain completion before resolving. Default 5s. */
   timeoutMs?: number;
@@ -327,14 +344,12 @@ interface WaitForDrainOptions {
  * doc state through an alternate channel (HTTP batch) — the Yjs handshake
  * on reconnect will still reconcile any records left behind.
  */
-export async function waitForDrain(
-  objectIds?: string[],
-  opts?: WaitForDrainOptions,
-): Promise<boolean> {
+export async function waitForDrain(objectIds?: string[], opts?: WaitForDrainOptions): Promise<boolean> {
   const timeoutMs = opts?.timeoutMs ?? 5_000;
   const pollIntervalMs = opts?.pollIntervalMs ?? 150;
   const start = Date.now();
-  const ids = objectIds ?? (drainConfig ? await distinctObjectIdsForSession(drainConfig.userId, drainConfig.workspaceId) : []);
+  const ids =
+    objectIds ?? (drainConfig ? await distinctObjectIdsForSession(drainConfig.userId, drainConfig.workspaceId) : []);
 
   if (ids.length === 0) return true;
 
@@ -354,9 +369,7 @@ export async function waitForDrain(
     if (!userId || !workspaceId) return false;
 
     const remaining = await Promise.all(
-      ids.map((id) =>
-        db.sync_outbox.where('[userId+workspaceId+objectId]').equals([userId, workspaceId, id]).count(),
-      ),
+      ids.map((id) => db.sync_outbox.where('[userId+workspaceId+objectId]').equals([userId, workspaceId, id]).count())
     );
 
     if (remaining.every((count) => count === 0)) return true;
@@ -470,10 +483,7 @@ export async function deleteOutboxByObjectId(objectId: string): Promise<void> {
       return;
     }
 
-    await db.sync_outbox
-      .where('[userId+workspaceId+objectId]')
-      .equals([userId, workspaceId, objectId])
-      .delete();
+    await db.sync_outbox.where('[userId+workspaceId+objectId]').equals([userId, workspaceId, objectId]).delete();
   } finally {
     suppressedObjects.delete(objectId);
   }
@@ -492,7 +502,7 @@ async function distinctObjectIdsForSession(userId: string, workspaceId: string):
 }
 
 function buildUpdateMessage(
-  record: Pick<SyncOutboxRecord, 'objectId' | 'collabType' | 'payload' | 'version' | 'beforeStateVector'>,
+  record: Pick<SyncOutboxRecord, 'objectId' | 'collabType' | 'payload' | 'version' | 'beforeStateVector'>
 ): messages.IMessage {
   return {
     collabMessage: {
@@ -552,12 +562,11 @@ async function drainObject(objectId: string): Promise<void> {
   }
 }
 
-// Note: we deliberately do NOT use `navigator.locks.request(..., { ifAvailable: true })`
-// to coordinate drains across tabs. That approach silently skipped the drain
-// body when another tab held the lock, stranding records until some later
-// trigger re-scheduled them. Each tab now drains its own schedule; duplicate
-// sends are harmless because Yjs updates are idempotent and the post-send
-// `bulkDelete` on already-deleted ids is a no-op.
+// Cross-tab ownership lives in AppSyncLayer: only the WebSocket leader exposes
+// an OPEN drain transport, and followers wake it after their IndexedDB add is
+// durable. Keeping locks out of this low-level loop avoids the old `ifAvailable`
+// failure mode that silently skipped work. Browsers without coordinated socket
+// ownership retain the safe idempotent duplicate-send fallback.
 
 async function drainObjectWhileReady(objectId: string): Promise<void> {
   // Snapshot the drain config at loop entry. If the user switches workspace
@@ -588,9 +597,7 @@ async function drainObjectWhileReady(objectId: string): Promise<void> {
     const firstRecord = records[0];
     const lastRecord = records[records.length - 1];
 
-    const merged = records.length === 1
-      ? firstRecord.payload
-      : Y.mergeUpdates(records.map((r) => r.payload));
+    const merged = records.length === 1 ? firstRecord.payload : Y.mergeUpdates(records.map((r) => r.payload));
     const collabType = lastRecord.collabType as Types;
     const version = lastRecord.version;
     // The merged payload spans from the first queued edit to the last, so its

--- a/src/components/app/ConnectBanner.tsx
+++ b/src/components/app/ConnectBanner.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useSyncExternalStore } from 'react';
+import { useCallback, useSyncExternalStore } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { APP_EVENTS } from '@/application/constants';
@@ -6,7 +6,6 @@ import { ReactComponent as CloudOffIcon } from '@/assets/icons/cloud_off.svg';
 import type { AppEventEmitter } from '@/components/app/contexts/AppEventEmitterContext';
 import { Button } from '@/components/ui/button';
 import { Progress } from '@/components/ui/progress';
-import { Log } from '@/utils/log';
 
 import { useEventEmitter } from './app.hooks';
 
@@ -26,7 +25,6 @@ function getStoredWebSocketReadyState(eventEmitter: AppEventEmitter) {
 
 export function ConnectBanner() {
   const eventEmitter = useEventEmitter();
-  const autoReconnectAttemptedRef = useRef(0); // timestamp of last auto-reconnect attempt
   const { t } = useTranslation();
 
   // Subscribe to WebSocket status via the event emitter, which caches the
@@ -60,57 +58,6 @@ export function ConnectBanner() {
   const isClosed = readyState === READY_STATE.CLOSED;
   const isOpen = readyState === READY_STATE.OPEN;
 
-  // Reset cooldown only when connection is fully re-established.
-  useEffect(() => {
-    if (isOpen) {
-      autoReconnectAttemptedRef.current = 0;
-    }
-  }, [isOpen]);
-
-  // Automatically trigger reconnect when the user returns to the page and the socket is closed.
-  // Allows multiple attempts with a 30-second cooldown between each.
-  useEffect(() => {
-    if (!isClosed || isLoading) return;
-    if (typeof window === 'undefined' || typeof document === 'undefined') return;
-
-    const AUTO_RECONNECT_COOLDOWN_MS = 30000; // 30s cooldown between auto-reconnect attempts
-
-    const tryAutoReconnect = () => {
-      // Note: isClosed && !isLoading is guaranteed by the early return above.
-      if (typeof navigator !== 'undefined' && navigator.onLine === false) return;
-      if (document.visibilityState !== 'visible') return;
-
-      const now = Date.now();
-      const lastAttemptTime = autoReconnectAttemptedRef.current;
-
-      // Enforce cooldown between attempts
-      if (lastAttemptTime > 0 && now - lastAttemptTime < AUTO_RECONNECT_COOLDOWN_MS) return;
-
-      autoReconnectAttemptedRef.current = now;
-
-      Log.debug('Trying to auto reconnect');
-      handleReconnect();
-    };
-
-    const handleVisibilityChange = () => {
-      if (document.visibilityState === 'visible') {
-        tryAutoReconnect();
-      }
-    };
-
-    window.addEventListener('focus', tryAutoReconnect);
-    window.addEventListener('online', tryAutoReconnect);
-    document.addEventListener('visibilitychange', handleVisibilityChange);
-
-    tryAutoReconnect();
-
-    return () => {
-      window.removeEventListener('focus', tryAutoReconnect);
-      window.removeEventListener('online', tryAutoReconnect);
-      document.removeEventListener('visibilitychange', handleVisibilityChange);
-    };
-  }, [handleReconnect, isClosed, isLoading]);
-
   // Hide the banner when the connection is open and stable
   if (isOpen) {
     return (
@@ -127,20 +74,33 @@ export function ConnectBanner() {
   }
 
   return (
-    <div data-testid='connect-banner' className='absolute left-0 top-[48px] z-50 w-full bg-surface-container-layer-01 transition-all duration-300 ease-in-out'>
+    <div
+      data-testid='connect-banner'
+      className='absolute left-0 top-[48px] z-50 w-full bg-surface-container-layer-01 transition-all duration-300 ease-in-out'
+    >
       <div className='flex h-[52px] items-center px-4 py-3'>
         <div className='flex items-center space-x-2'>
           {isLoading && (
             <>
               <Progress variant={'primary'} />
-              <span data-testid='connect-banner-connecting' className='text-sm text-text-secondary'>{t('connecting')}</span>
+              <span data-testid='connect-banner-connecting' className='text-sm text-text-secondary'>
+                {t('connecting')}
+              </span>
             </>
           )}
           {isClosed && (
             <>
               <CloudOffIcon className='h-5 w-5 text-text-tertiary' />
-              <span data-testid='connect-banner-disconnected' className='text-sm text-text-secondary'>{t('disconnected')}</span>
-              <Button data-testid='connect-banner-reconnect' variant='outline' size='sm' className='ml-2' onClick={handleReconnect}>
+              <span data-testid='connect-banner-disconnected' className='text-sm text-text-secondary'>
+                {t('disconnected')}
+              </span>
+              <Button
+                data-testid='connect-banner-reconnect'
+                variant='outline'
+                size='sm'
+                className='ml-2'
+                onClick={handleReconnect}
+              >
                 {t('reconnect')}
               </Button>
             </>

--- a/src/components/app/__tests__/ConnectBanner.test.tsx
+++ b/src/components/app/__tests__/ConnectBanner.test.tsx
@@ -1,6 +1,6 @@
 import EventEmitter from 'events';
 
-import { act, render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
 
 import { APP_EVENTS } from '@/application/constants';
 import { ConnectBanner } from '@/components/app/ConnectBanner';
@@ -48,5 +48,23 @@ describe('ConnectBanner', () => {
     });
 
     expect(screen.queryByTestId('connect-banner')).toBeNull();
+  });
+
+  it('leaves automatic recovery to the websocket hook', () => {
+    const eventEmitter = createEventEmitter();
+    const reconnectSpy = jest.fn();
+
+    eventEmitter.webSocketReadyState = 3;
+    eventEmitter.on(APP_EVENTS.RECONNECT_WEBSOCKET, reconnectSpy);
+    renderConnectBanner(eventEmitter);
+
+    window.dispatchEvent(new Event('focus'));
+    window.dispatchEvent(new Event('online'));
+    document.dispatchEvent(new Event('visibilitychange'));
+
+    expect(reconnectSpy).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByTestId('connect-banner-reconnect'));
+    expect(reconnectSpy).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/components/app/layers/AppSyncLayer.tsx
+++ b/src/components/app/layers/AppSyncLayer.tsx
@@ -9,7 +9,7 @@ import { CollabService, UserService } from '@/application/services/domains';
 import { getTokenParsed } from '@/application/session/token';
 import { clearDrainConfig, configureDrain, setCurrentSession, startDrainAll } from '@/application/sync-outbox';
 import type { AppEventEmitter } from '@/components/app/contexts/AppEventEmitterContext';
-import { useAppflowyWebSocket, useBroadcastChannel, useSync } from '@/components/ws';
+import { useSync, useWorkspaceRealtimeTransport } from '@/components/ws';
 import { notification } from '@/proto/messages';
 
 import { useAuthInternal } from '../contexts/AuthInternalContext';
@@ -51,15 +51,14 @@ export const AppSyncLayer: FC<AppSyncLayerProps> = ({ children }) => {
     }
   }, [eventEmitter]);
 
-  // Initialize WebSocket connection - currentWorkspaceId and service are guaranteed to exist when this component renders
-  const webSocket = useAppflowyWebSocket({
+  // The auth layer mounts this component only after selecting a workspace.
+  // Transport ownership, failover, and cross-tab relaying stay encapsulated in
+  // one hook so this layer only coordinates application sync concerns.
+  const { webSocket, broadcastChannel, canSendToServer, sendBestEffort } = useWorkspaceRealtimeTransport({
     workspaceId: currentWorkspaceId!,
     clientId: CollabService.getClientId(),
     deviceId: CollabService.getDeviceId(),
   });
-
-  // Initialize broadcast channel for multi-tab communication
-  const broadcastChannel = useBroadcastChannel(`workspace:${currentWorkspaceId!}`);
 
   // Initialize sync context for collaborative editing
   const { registerSyncContext, flushAllSync, syncAllToServer, revertCollabVersion, scheduleDeferredCleanup } = useSync(
@@ -104,7 +103,8 @@ export const AppSyncLayer: FC<AppSyncLayerProps> = ({ children }) => {
   // round-trip (matches the behaviour of the pre-outbox `emit` callback).
   const wsSendMessage = webSocket.sendMessage;
   const wsReadyState = webSocket.readyState;
-  const bcPostMessage = broadcastChannel.postMessage;
+  const bcPostDurableMessage = broadcastChannel.postDurableMessage;
+  const bcPostOutboxReady = broadcastChannel.postOutboxReady;
 
   // Live readyState for the drain send callback. The closure capture
   // `wsReadyState` reflects the value at render time, but a drain can run
@@ -149,7 +149,7 @@ export const AppSyncLayer: FC<AppSyncLayerProps> = ({ children }) => {
       // refresh). The drain catches send failures and leaves outbox records
       // in place for retry.
       send: (message) => {
-        if (wsReadyStateRef.current !== WS_READY_STATE_OPEN) {
+        if (!canSendToServer || wsReadyStateRef.current !== WS_READY_STATE_OPEN) {
           throw new Error('[outbox] WS not OPEN at send time');
         }
 
@@ -158,23 +158,32 @@ export const AppSyncLayer: FC<AppSyncLayerProps> = ({ children }) => {
       // Sibling-tab fan-out — runs synchronously on every enqueue, regardless
       // of WS readiness, so local edits propagate across tabs even during a
       // reconnect.
-      broadcast: bcPostMessage,
-      // Best-effort fallback when the durable IDB enqueue fails. Uses
-      // `keep=true` so react-use-websocket buffers in-memory until reconnect;
-      // lost on refresh/crash, but better than silently dropping edits in
-      // the quota/private-mode/blocked-IDB failure mode.
-      sendBestEffort: (message) => wsSendMessage(message, true),
-      isReady: () => wsReadyStateRef.current === WS_READY_STATE_OPEN,
+      broadcast: bcPostDurableMessage,
+      // Best-effort fallback when the durable IDB enqueue fails. The transport
+      // buffers on the leader socket or forwards a follower update to the
+      // leader over BroadcastChannel.
+      sendBestEffort,
+      isReady: () => canSendToServer && wsReadyStateRef.current === WS_READY_STATE_OPEN,
+      onPersisted: bcPostOutboxReady,
     });
 
-    if (wsReadyState === WS_READY_STATE_OPEN) {
+    if (canSendToServer && wsReadyState === WS_READY_STATE_OPEN) {
       startDrainAll();
     }
 
     return () => {
       clearDrainConfig();
     };
-  }, [currentUserId, currentWorkspaceId, wsSendMessage, wsReadyState, bcPostMessage]);
+  }, [
+    currentUserId,
+    currentWorkspaceId,
+    wsSendMessage,
+    wsReadyState,
+    bcPostDurableMessage,
+    bcPostOutboxReady,
+    canSendToServer,
+    sendBestEffort,
+  ]);
 
   // Handle user profile change notifications
   // This provides automatic UI updates when user profile changes occur via WebSocket.
@@ -188,7 +197,7 @@ export const AppSyncLayer: FC<AppSyncLayerProps> = ({ children }) => {
   // 6. All components using currentUser automatically re-render with new data
   //
   // Multi-tab Support:
-  // - Active tab: WebSocket → useSync → this handler → database update
+  // - Leader tab: WebSocket → useSync → this handler → database update
   // - Other tabs: BroadcastChannel → useSync → this handler → database update
   // - Result: All tabs show updated profile simultaneously
   //
@@ -397,7 +406,15 @@ export const AppSyncLayer: FC<AppSyncLayerProps> = ({ children }) => {
       syncAllToServer,
       scheduleDeferredCleanup,
     }),
-    [eventEmitter, registerSyncContext, revertCollabVersion, awarenessMap, flushAllSync, syncAllToServer, scheduleDeferredCleanup]
+    [
+      eventEmitter,
+      registerSyncContext,
+      revertCollabVersion,
+      awarenessMap,
+      flushAllSync,
+      syncAllToServer,
+      scheduleDeferredCleanup,
+    ]
   );
 
   return <SyncInternalContext.Provider value={syncContextValue}>{children}</SyncInternalContext.Provider>;

--- a/src/components/app/layers/__tests__/AppSyncLayer.test.tsx
+++ b/src/components/app/layers/__tests__/AppSyncLayer.test.tsx
@@ -5,15 +5,14 @@ import { APP_EVENTS } from '@/application/constants';
 import { AuthInternalContext, type AuthInternalContextType } from '@/components/app/contexts/AuthInternalContext';
 import { useSyncInternal } from '@/components/app/contexts/SyncInternalContext';
 import { AppSyncLayer } from '@/components/app/layers/AppSyncLayer';
-import { useAppflowyWebSocket, useBroadcastChannel, useSync } from '@/components/ws';
+import { useSync, useWorkspaceRealtimeTransport } from '@/components/ws';
 import type { AppflowyWebSocketType } from '@/components/ws/useAppflowyWebSocket';
 import type { BroadcastChannelType } from '@/components/ws/useBroadcastChannel';
 import type { messages } from '@/proto/messages';
 
 jest.mock('@/components/ws', () => ({
-  useAppflowyWebSocket: jest.fn(),
-  useBroadcastChannel: jest.fn(),
   useSync: jest.fn(),
+  useWorkspaceRealtimeTransport: jest.fn(),
 }));
 
 jest.mock('@/application/services/domains', () => ({
@@ -44,18 +43,24 @@ jest.mock('@/application/db', () => ({
   },
 }));
 
-const mockUseAppflowyWebSocket = useAppflowyWebSocket as jest.Mock;
-const mockUseBroadcastChannel = useBroadcastChannel as jest.Mock;
 const mockUseSync = useSync as jest.Mock;
+const mockUseWorkspaceRealtimeTransport = useWorkspaceRealtimeTransport as jest.Mock;
 
 // Stable per-connection pieces, matching the real (memoized) hook behaviour:
 // these keep their identity across messages — only the container object and
 // lastMessage change when a message arrives.
 const stableWsSendMessage = jest.fn();
 const stableWsReconnect = jest.fn();
+const stableSendBestEffort = jest.fn();
 const stableBcValue: BroadcastChannelType = {
   lastBroadcastMessage: null,
   postMessage: jest.fn(),
+  postDurableMessage: jest.fn(),
+  subscribeProtocolMessages: jest.fn(),
+  postOutboxReady: jest.fn(),
+  subscribeOutboxReady: jest.fn(),
+  postTransportSignal: jest.fn(),
+  subscribeTransportSignals: jest.fn(),
 };
 const stableSyncValue = {
   registerSyncContext: jest.fn(),
@@ -129,9 +134,13 @@ describe('AppSyncLayer per-message churn', () => {
     consumerRenderCount = 0;
     websocketStatusEmits = 0;
     latestWebSocketReadyState = undefined;
-    mockUseBroadcastChannel.mockReturnValue(stableBcValue);
     mockUseSync.mockReturnValue(stableSyncValue);
-    mockUseAppflowyWebSocket.mockReturnValue(createWsValue(null));
+    mockUseWorkspaceRealtimeTransport.mockReturnValue({
+      webSocket: createWsValue(null),
+      broadcastChannel: stableBcValue,
+      canSendToServer: true,
+      sendBestEffort: stableSendBestEffort,
+    });
   });
 
   // Reproduces the fan-out bug: an incoming collab message produces a new
@@ -144,7 +153,12 @@ describe('AppSyncLayer per-message churn', () => {
 
     // Simulate a message arriving: same connection (stable functions and
     // readyState), new container identity with a new lastMessage.
-    mockUseAppflowyWebSocket.mockReturnValue(createWsValue({ collabMessage: {} } as unknown as messages.Message));
+    mockUseWorkspaceRealtimeTransport.mockReturnValue({
+      webSocket: createWsValue({ collabMessage: {} } as unknown as messages.Message),
+      broadcastChannel: stableBcValue,
+      canSendToServer: true,
+      sendBestEffort: stableSendBestEffort,
+    });
     rerenderLayer(rerender);
 
     expect(consumerRenderCount).toBe(rendersAfterMount);
@@ -157,7 +171,12 @@ describe('AppSyncLayer per-message churn', () => {
 
     const emitsAfterMount = websocketStatusEmits;
 
-    mockUseAppflowyWebSocket.mockReturnValue(createWsValue({ collabMessage: {} } as unknown as messages.Message));
+    mockUseWorkspaceRealtimeTransport.mockReturnValue({
+      webSocket: createWsValue({ collabMessage: {} } as unknown as messages.Message),
+      broadcastChannel: stableBcValue,
+      canSendToServer: true,
+      sendBestEffort: stableSendBestEffort,
+    });
     rerenderLayer(rerender);
 
     expect(websocketStatusEmits).toBe(emitsAfterMount);
@@ -168,7 +187,12 @@ describe('AppSyncLayer per-message churn', () => {
 
     const emitsAfterMount = websocketStatusEmits;
 
-    mockUseAppflowyWebSocket.mockReturnValue({ ...createWsValue(null), readyState: 3 });
+    mockUseWorkspaceRealtimeTransport.mockReturnValue({
+      webSocket: { ...createWsValue(null), readyState: 3 },
+      broadcastChannel: stableBcValue,
+      canSendToServer: true,
+      sendBestEffort: stableSendBestEffort,
+    });
     rerenderLayer(rerender);
 
     expect(websocketStatusEmits).toBe(emitsAfterMount + 1);

--- a/src/components/ws/__tests__/useAppflowyWebSocket.test.ts
+++ b/src/components/ws/__tests__/useAppflowyWebSocket.test.ts
@@ -8,10 +8,11 @@ import { useAppflowyWebSocket, Options } from '../useAppflowyWebSocket';
 // across renders, like the real library does for an unchanged connection.
 const stableSendMessage = jest.fn();
 const stableGetWebSocket = jest.fn(() => null);
+let mockReadyState = 1;
 const mockUseWebSocket = jest.fn(() => ({
   lastMessage: null,
   sendMessage: stableSendMessage,
-  readyState: 1,
+  readyState: mockReadyState,
   getWebSocket: stableGetWebSocket,
 }));
 
@@ -41,16 +42,27 @@ const setStoredToken = (accessToken: string) => {
   });
 };
 
-const lastSocketUrl = (): string => {
-  const calls = mockUseWebSocket.mock.calls as unknown as [string][];
+type SocketUrl = string | (() => string | Promise<string>);
+
+const lastSocketInput = (): SocketUrl => {
+  const calls = mockUseWebSocket.mock.calls as unknown as [SocketUrl][];
 
   return calls[calls.length - 1][0];
+};
+
+const resolveLastSocketUrl = async (): Promise<string> => {
+  const input = lastSocketInput();
+
+  return typeof input === 'function' ? input() : input;
 };
 
 const lastSocketOptions = () => {
   const calls = mockUseWebSocket.mock.calls as unknown as [
     string,
-    { shouldReconnect?: (event: CloseEvent) => boolean }
+    {
+      shouldReconnect?: (event: CloseEvent) => boolean;
+      reconnectInterval?: (attemptNumber: number) => number;
+    }
   ][];
 
   return calls[calls.length - 1][1];
@@ -65,35 +77,36 @@ const baseOptions: Options = {
 describe('useAppflowyWebSocket', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockReadyState = 1;
     setStoredToken('token-A');
   });
 
-  it('connects with the session token in the socket URL', () => {
+  it('connects with the session token in the socket URL', async () => {
     renderHook(() => useAppflowyWebSocket(baseOptions));
 
-    expect(lastSocketUrl()).toContain('token=token-A');
-    expect(lastSocketUrl()).toContain('/workspace-1/');
+    expect(await resolveLastSocketUrl()).toContain('token=token-A');
+    expect(await resolveLastSocketUrl()).toContain('/workspace-1/');
   });
 
-  // Reproduces the silent-reconnect bug: the HTTP layer refreshing the stored
-  // token must NOT change the socket URL on the next render — a URL change
-  // makes react-use-websocket tear down and reopen the connection, bypassing
-  // the throttled nonce reconnect path entirely.
-  it('keeps the socket URL stable when the stored token is refreshed mid-session', () => {
+  // A token rotation must not replace the URL callback during a live session,
+  // but the next actual connection attempt must read the rotated token.
+  it('keeps the socket input stable while resolving the freshest token', async () => {
     const { rerender } = renderHook(() => useAppflowyWebSocket(baseOptions));
 
-    const initialUrl = lastSocketUrl();
+    const initialInput = lastSocketInput();
 
     setStoredToken('token-B');
     rerender();
 
-    expect(lastSocketUrl()).toBe(initialUrl);
+    expect(lastSocketInput()).toBe(initialInput);
+    expect(await resolveLastSocketUrl()).toContain('token=token-B');
   });
 
   // Guards the load-bearing counterpart of the test above: an explicit
   // reconnect MUST pick up the freshest stored token, since the old one may
   // have been rotated or expired while the socket was down.
   it('uses the freshest stored token when a reconnect is triggered', async () => {
+    mockReadyState = 3;
     const { result } = renderHook(() => useAppflowyWebSocket(baseOptions));
 
     setStoredToken('token-B');
@@ -102,15 +115,16 @@ describe('useAppflowyWebSocket', () => {
       result.current.reconnect();
     });
 
-    await waitFor(() => {
-      expect(lastSocketUrl()).toContain('_rc=1');
+    await waitFor(async () => {
+      expect(await resolveLastSocketUrl()).toContain('_rc=1');
     });
 
-    expect(lastSocketUrl()).toContain('token=token-B');
+    expect(await resolveLastSocketUrl()).toContain('token=token-B');
   });
 
   it('uses the freshest stored token when react-use-websocket schedules an automatic retry', async () => {
     renderHook(() => useAppflowyWebSocket(baseOptions));
+    const initialInput = lastSocketInput();
 
     setStoredToken('token-B');
 
@@ -118,11 +132,45 @@ describe('useAppflowyWebSocket', () => {
       expect(lastSocketOptions().shouldReconnect?.({ code: 1006, reason: 'abnormal close' } as CloseEvent)).toBe(true);
     });
 
-    await waitFor(() => {
-      expect(lastSocketUrl()).toContain('token=token-B');
+    expect(lastSocketInput()).toBe(initialInput);
+    expect(await resolveLastSocketUrl()).toContain('token=token-B');
+    expect(await resolveLastSocketUrl()).not.toContain('_rc=');
+  });
+
+  it('does not start a nonce reconnect while an automatic retry is pending', async () => {
+    mockReadyState = 3;
+    const { result } = renderHook(() => useAppflowyWebSocket(baseOptions));
+    const socketOptions = lastSocketOptions();
+
+    act(() => {
+      expect(socketOptions.shouldReconnect?.({ code: 1006, reason: 'abnormal close' } as CloseEvent)).toBe(true);
+      socketOptions.reconnectInterval?.(0);
     });
 
-    expect(lastSocketUrl()).not.toContain('_rc=');
+    act(() => {
+      result.current.reconnect();
+    });
+
+    expect(await resolveLastSocketUrl()).not.toContain('_rc=');
+  });
+
+  it('does not let browser recovery events bypass a scheduled retry', async () => {
+    mockReadyState = 3;
+    renderHook(() => useAppflowyWebSocket(baseOptions));
+    const socketOptions = lastSocketOptions();
+
+    act(() => {
+      expect(socketOptions.shouldReconnect?.({ code: 1006, reason: 'abnormal close' } as CloseEvent)).toBe(true);
+      socketOptions.reconnectInterval?.(0);
+      window.dispatchEvent(new Event('online'));
+      document.dispatchEvent(new Event('visibilitychange'));
+    });
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(await resolveLastSocketUrl()).not.toContain('_rc=');
   });
 
   // Reproduces the per-message fan-out amplifier: the hook returned a fresh
@@ -153,5 +201,40 @@ describe('useAppflowyWebSocket', () => {
 
     expect(result.current.sendMessage).toBe(sendMessage);
     expect(result.current.reconnect).toBe(reconnect);
+  });
+
+  it('does not open or buffer a websocket from a follower tab', () => {
+    const { result } = renderHook(() => useAppflowyWebSocket({ ...baseOptions, connect: false }));
+
+    act(() => {
+      result.current.sendMessage({ collabMessage: {} }, true);
+    });
+
+    const calls = mockUseWebSocket.mock.calls as unknown as [SocketUrl, unknown, boolean][];
+
+    expect(calls[calls.length - 1][2]).toBe(false);
+    expect(stableSendMessage).toHaveBeenCalledWith(expect.anything(), false);
+  });
+
+  it('keeps retained senders stable and adopts the latest leadership buffering policy', () => {
+    const { result, rerender } = renderHook(
+      ({ connect }) => useAppflowyWebSocket({ ...baseOptions, connect }),
+      { initialProps: { connect: false } }
+    );
+    const retainedSendMessage = result.current.sendMessage;
+
+    act(() => {
+      retainedSendMessage({ collabMessage: {} }, true);
+    });
+    expect(stableSendMessage).toHaveBeenLastCalledWith(expect.anything(), false);
+
+    stableSendMessage.mockClear();
+    rerender({ connect: true });
+
+    expect(result.current.sendMessage).toBe(retainedSendMessage);
+    act(() => {
+      retainedSendMessage({ collabMessage: {} }, true);
+    });
+    expect(stableSendMessage).toHaveBeenCalledWith(expect.anything(), true);
   });
 });

--- a/src/components/ws/__tests__/useBroadcastChannel.test.ts
+++ b/src/components/ws/__tests__/useBroadcastChannel.test.ts
@@ -1,4 +1,5 @@
 import { act, renderHook } from '@testing-library/react';
+import { useLayoutEffect } from 'react';
 
 import { messages } from '@/proto/messages';
 
@@ -45,7 +46,7 @@ class MockBroadcastChannel {
     this.closed = true;
   }
 
-  emitMessage(data: ArrayBuffer | Uint8Array) {
+  emitMessage(data: unknown) {
     for (const listener of this.listeners.get('message') ?? []) {
       listener({ data } as MessageEvent);
     }
@@ -84,6 +85,21 @@ describe('useBroadcastChannel', () => {
     expect(typeof payload.byteLength).toBe('number');
   });
 
+  it('flushes protocol messages emitted before the channel effect opens', () => {
+    renderHook(() => {
+      const channel = useBroadcastChannel('workspace:A');
+
+      useLayoutEffect(() => {
+        channel.postMessage(message);
+      }, [channel.postMessage]);
+
+      return channel;
+    });
+
+    expect(MockBroadcastChannel.instances).toHaveLength(1);
+    expect(MockBroadcastChannel.instances[0].postMessage).toHaveBeenCalledTimes(1);
+  });
+
   it('exposes received messages as lastBroadcastMessage', () => {
     const { result } = renderHook(({ name }) => useBroadcastChannel(name), {
       initialProps: { name: 'workspace:A' },
@@ -98,10 +114,115 @@ describe('useBroadcastChannel', () => {
     expect(result.current.lastBroadcastMessage).toBeInstanceOf(messages.Message);
   });
 
-  it('closes the previous channel when the channel name changes', () => {
-    const { rerender } = renderHook(({ name }) => useBroadcastChannel(name), {
+  it('notifies transport subscribers for every received message', () => {
+    const { result } = renderHook(({ name }) => useBroadcastChannel(name), {
       initialProps: { name: 'workspace:A' },
     });
+    const listener = jest.fn();
+    const unsubscribe = result.current.subscribeProtocolMessages(listener);
+    const encoded = messages.Message.encode(message).finish();
+
+    act(() => {
+      MockBroadcastChannel.instances[0].emitMessage(encoded);
+    });
+
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(listener.mock.calls[0][0]).toBeInstanceOf(messages.Message);
+
+    unsubscribe();
+    act(() => {
+      MockBroadcastChannel.instances[0].emitMessage(encoded);
+    });
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  it('routes durable-outbox signals without decoding them as protobuf messages', () => {
+    const { result } = renderHook(({ name }) => useBroadcastChannel(name), {
+      initialProps: { name: 'workspace:A' },
+    });
+    const listener = jest.fn();
+
+    result.current.subscribeOutboxReady(listener);
+    act(() => {
+      result.current.postOutboxReady('workspace-1', 'object-1');
+    });
+
+    expect(MockBroadcastChannel.instances[0].postMessage).toHaveBeenCalledWith({
+      type: 'outbox-ready',
+      workspaceId: 'workspace-1',
+      objectId: 'object-1',
+    });
+
+    act(() => {
+      MockBroadcastChannel.instances[0].emitMessage({
+        type: 'outbox-ready',
+        workspaceId: 'workspace-1',
+        objectId: 'object-1',
+      });
+    });
+
+    expect(listener).toHaveBeenCalledWith('workspace-1', 'object-1');
+    expect(result.current.lastBroadcastMessage).toBeNull();
+  });
+
+  it('routes transport signals without exposing them as protocol messages', () => {
+    const { result } = renderHook(({ name }) => useBroadcastChannel(name), {
+      initialProps: { name: 'workspace:A' },
+    });
+    const listener = jest.fn();
+    const signal = {
+      type: 'transport-status' as const,
+      workspaceId: 'A',
+      readyState: WebSocket.OPEN,
+    };
+
+    result.current.subscribeTransportSignals(listener);
+    act(() => {
+      result.current.postTransportSignal(signal);
+      MockBroadcastChannel.instances[0].emitMessage(signal);
+    });
+
+    expect(MockBroadcastChannel.instances[0].postMessage).toHaveBeenCalledWith(signal);
+    expect(listener).toHaveBeenCalledWith(signal);
+    expect(result.current.lastBroadcastMessage).toBeNull();
+  });
+
+  it('applies durable messages locally without forwarding them as protocol traffic', () => {
+    const { result } = renderHook(({ name }) => useBroadcastChannel(name), {
+      initialProps: { name: 'workspace:A' },
+    });
+    const protocolListener = jest.fn();
+
+    result.current.subscribeProtocolMessages(protocolListener);
+    act(() => {
+      result.current.postDurableMessage(message);
+    });
+
+    const signal = MockBroadcastChannel.instances[0].postMessage.mock.calls[0][0] as {
+      type: string;
+      payload: Uint8Array;
+    };
+
+    expect(signal.type).toBe('durable-message');
+
+    act(() => {
+      MockBroadcastChannel.instances[0].emitMessage(signal);
+    });
+
+    expect(result.current.lastBroadcastMessage).toBeInstanceOf(messages.Message);
+    expect(protocolListener).not.toHaveBeenCalled();
+  });
+
+  it('closes the previous channel when the channel name changes', () => {
+    const { result, rerender } = renderHook(({ name }) => useBroadcastChannel(name), {
+      initialProps: { name: 'workspace:A' },
+    });
+    const encoded = messages.Message.encode(message).finish();
+
+    act(() => {
+      MockBroadcastChannel.instances[0].emitMessage(encoded);
+    });
+    expect(result.current.lastBroadcastMessage).not.toBeNull();
 
     rerender({ name: 'workspace:B' });
 
@@ -110,6 +231,7 @@ describe('useBroadcastChannel', () => {
     expect(MockBroadcastChannel.instances).toHaveLength(2);
     expect(first.closed).toBe(true);
     expect(second.closed).toBe(false);
+    expect(result.current.lastBroadcastMessage).toBeNull();
   });
 
   // Reproduces the workspace-switch bug: the closed flag set during the old
@@ -136,12 +258,39 @@ describe('useBroadcastChannel', () => {
     expect(second.postMessage).toHaveBeenCalledTimes(1);
   });
 
+  it('posts a delayed outbox notification on the workspace channel captured before a switch', () => {
+    const { result, rerender } = renderHook(({ name }) => useBroadcastChannel(name), {
+      initialProps: { name: 'workspace:A' },
+    });
+    const postWorkspaceAOutboxReady = result.current.postOutboxReady;
+
+    rerender({ name: 'workspace:B' });
+
+    act(() => {
+      postWorkspaceAOutboxReady('A', 'object-1');
+    });
+
+    const [workspaceA, workspaceB, delayedWorkspaceA] = MockBroadcastChannel.instances;
+    const signal = {
+      type: 'outbox-ready',
+      workspaceId: 'A',
+      objectId: 'object-1',
+    };
+
+    expect(workspaceA.closed).toBe(true);
+    expect(workspaceB.postMessage).not.toHaveBeenCalledWith(signal);
+    expect(delayedWorkspaceA.name).toBe('workspace:A');
+    expect(delayedWorkspaceA.postMessage).toHaveBeenCalledWith(signal);
+    expect(delayedWorkspaceA.closed).toBe(true);
+  });
+
   it('keeps postMessage referentially stable across channel switches and sends', () => {
     const { result, rerender } = renderHook(({ name }) => useBroadcastChannel(name), {
       initialProps: { name: 'workspace:A' },
     });
 
     const initialPostMessage = result.current.postMessage;
+    const initialSubscribe = result.current.subscribeProtocolMessages;
 
     act(() => {
       result.current.postMessage(message);
@@ -150,6 +299,7 @@ describe('useBroadcastChannel', () => {
     rerender({ name: 'workspace:B' });
 
     expect(result.current.postMessage).toBe(initialPostMessage);
+    expect(result.current.subscribeProtocolMessages).toBe(initialSubscribe);
   });
 
   it('drops sends without throwing after the channel is closed underneath', () => {

--- a/src/components/ws/__tests__/useWorkspaceRealtimeTransport.test.ts
+++ b/src/components/ws/__tests__/useWorkspaceRealtimeTransport.test.ts
@@ -1,0 +1,221 @@
+import { act, renderHook } from '@testing-library/react';
+
+import { startDrainObject } from '@/application/sync-outbox';
+import type { messages } from '@/proto/messages';
+
+import { useAppflowyWebSocket, type AppflowyWebSocketType } from '../useAppflowyWebSocket';
+import {
+  useBroadcastChannel,
+  type BroadcastChannelType,
+  type WorkspaceTransportSignal,
+} from '../useBroadcastChannel';
+import { useWorkspaceRealtimeTransport } from '../useWorkspaceRealtimeTransport';
+import { useWorkspaceWebSocketLeader } from '../useWorkspaceWebSocketLeader';
+
+jest.mock('@/application/sync-outbox', () => ({
+  startDrainObject: jest.fn(),
+}));
+
+jest.mock('../useAppflowyWebSocket', () => ({
+  useAppflowyWebSocket: jest.fn(),
+}));
+
+jest.mock('../useBroadcastChannel', () => ({
+  useBroadcastChannel: jest.fn(),
+}));
+
+jest.mock('../useWorkspaceWebSocketLeader', () => ({
+  useWorkspaceWebSocketLeader: jest.fn(),
+}));
+
+const mockUseAppflowyWebSocket = useAppflowyWebSocket as jest.Mock;
+const mockUseBroadcastChannel = useBroadcastChannel as jest.Mock;
+const mockUseWorkspaceWebSocketLeader = useWorkspaceWebSocketLeader as jest.Mock;
+const mockStartDrainObject = startDrainObject as jest.Mock;
+
+const sendWebSocketMessage = jest.fn();
+const reconnect = jest.fn();
+const postMessage = jest.fn();
+const postDurableMessage = jest.fn();
+const subscribeProtocolMessages = jest.fn();
+const postOutboxReady = jest.fn();
+const subscribeOutboxReady = jest.fn();
+const postTransportSignal = jest.fn();
+const subscribeTransportSignals = jest.fn();
+
+const createWebSocket = (lastMessage: messages.Message | null, readyState = WebSocket.OPEN): AppflowyWebSocketType => ({
+  lastMessage,
+  sendMessage: sendWebSocketMessage,
+  readyState,
+  options: { workspaceId: 'workspace-1' },
+  reconnectAttempt: 0,
+  reconnect,
+});
+
+const broadcastChannel: BroadcastChannelType = {
+  lastBroadcastMessage: null,
+  postMessage,
+  postDurableMessage,
+  subscribeProtocolMessages,
+  postOutboxReady,
+  subscribeOutboxReady,
+  postTransportSignal,
+  subscribeTransportSignals,
+};
+
+const renderTransport = () =>
+  renderHook(() =>
+    useWorkspaceRealtimeTransport({
+      workspaceId: 'workspace-1',
+      clientId: 7,
+      deviceId: 'device-1',
+    })
+  );
+
+describe('useWorkspaceRealtimeTransport', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    subscribeProtocolMessages.mockReturnValue(jest.fn());
+    subscribeOutboxReady.mockReturnValue(jest.fn());
+    subscribeTransportSignals.mockReturnValue(jest.fn());
+    mockUseBroadcastChannel.mockReturnValue(broadcastChannel);
+    mockUseAppflowyWebSocket.mockReturnValue(createWebSocket(null));
+  });
+
+  it('routes follower traffic and server messages through the coordinated leader', () => {
+    const serverMessage = { notification: { folderChanged: {} } } as messages.Message;
+    const followerMessage = { collabMessage: { objectId: 'object-1' } } as messages.Message;
+    const unsubscribeProtocol = jest.fn();
+    const unsubscribeOutbox = jest.fn();
+    const unsubscribeTransport = jest.fn();
+    let forwardProtocolMessage: ((message: messages.Message) => void) | undefined;
+    let notifyOutboxReady: ((workspaceId: string, objectId: string) => void) | undefined;
+    let handleTransportSignal: ((signal: WorkspaceTransportSignal) => void) | undefined;
+
+    mockUseWorkspaceWebSocketLeader.mockReturnValue({ isLeader: true, isCoordinated: true });
+    mockUseAppflowyWebSocket.mockReturnValue(createWebSocket(serverMessage));
+    subscribeProtocolMessages.mockImplementation((listener) => {
+      forwardProtocolMessage = listener;
+      return unsubscribeProtocol;
+    });
+    subscribeOutboxReady.mockImplementation((listener) => {
+      notifyOutboxReady = listener;
+      return unsubscribeOutbox;
+    });
+    subscribeTransportSignals.mockImplementation((listener) => {
+      handleTransportSignal = listener;
+      return unsubscribeTransport;
+    });
+
+    const { result, unmount } = renderTransport();
+
+    expect(mockUseAppflowyWebSocket).toHaveBeenCalledWith({
+      workspaceId: 'workspace-1',
+      clientId: 7,
+      deviceId: 'device-1',
+      connect: true,
+      reconnectWhenHidden: true,
+    });
+    expect(result.current.canSendToServer).toBe(true);
+    expect(postMessage).toHaveBeenCalledWith(serverMessage);
+    expect(postTransportSignal).toHaveBeenCalledWith({
+      type: 'transport-status',
+      workspaceId: 'workspace-1',
+      readyState: WebSocket.OPEN,
+    });
+
+    act(() => {
+      result.current.sendBestEffort(followerMessage);
+      forwardProtocolMessage?.(followerMessage);
+      notifyOutboxReady?.('other-workspace', 'ignored-object');
+      notifyOutboxReady?.('workspace-1', 'object-1');
+      handleTransportSignal?.({ type: 'transport-status-request', workspaceId: 'workspace-1' });
+      handleTransportSignal?.({ type: 'transport-reconnect-request', workspaceId: 'workspace-1' });
+    });
+
+    expect(sendWebSocketMessage).toHaveBeenCalledTimes(2);
+    expect(sendWebSocketMessage).toHaveBeenNthCalledWith(1, followerMessage, true);
+    expect(sendWebSocketMessage).toHaveBeenNthCalledWith(2, followerMessage, true);
+    expect(mockStartDrainObject).toHaveBeenCalledTimes(1);
+    expect(mockStartDrainObject).toHaveBeenCalledWith('object-1');
+    expect(postTransportSignal).toHaveBeenLastCalledWith({
+      type: 'transport-status',
+      workspaceId: 'workspace-1',
+      readyState: WebSocket.OPEN,
+    });
+    expect(reconnect).toHaveBeenCalledTimes(1);
+
+    unmount();
+    expect(unsubscribeProtocol).toHaveBeenCalledTimes(1);
+    expect(unsubscribeOutbox).toHaveBeenCalledTimes(1);
+    expect(unsubscribeTransport).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses the leader status and reconnect control path for a coordinated follower', () => {
+    const serverMessage = { notification: { folderChanged: {} } } as messages.Message;
+    let handleTransportSignal: ((signal: WorkspaceTransportSignal) => void) | undefined;
+
+    mockUseWorkspaceWebSocketLeader.mockReturnValue({ isLeader: false, isCoordinated: true });
+    mockUseAppflowyWebSocket.mockReturnValue(createWebSocket(serverMessage, -1));
+    subscribeTransportSignals.mockImplementation((listener) => {
+      handleTransportSignal = listener;
+      return jest.fn();
+    });
+
+    const { result } = renderTransport();
+
+    expect(mockUseAppflowyWebSocket).toHaveBeenCalledWith(
+      expect.objectContaining({ connect: false, reconnectWhenHidden: true })
+    );
+    expect(result.current.canSendToServer).toBe(false);
+    expect(result.current.webSocket.lastMessage).toBeNull();
+    expect(result.current.webSocket.readyState).toBe(WebSocket.CONNECTING);
+    expect(subscribeProtocolMessages).not.toHaveBeenCalled();
+    expect(subscribeOutboxReady).not.toHaveBeenCalled();
+    expect(postMessage).not.toHaveBeenCalled();
+    expect(postTransportSignal).toHaveBeenCalledWith({
+      type: 'transport-status-request',
+      workspaceId: 'workspace-1',
+    });
+
+    act(() => {
+      handleTransportSignal?.({
+        type: 'transport-status',
+        workspaceId: 'workspace-1',
+        readyState: WebSocket.OPEN,
+      });
+    });
+
+    expect(result.current.webSocket.readyState).toBe(WebSocket.OPEN);
+
+    const followerMessage = { collabMessage: { objectId: 'object-1' } } as messages.Message;
+
+    act(() => {
+      result.current.sendBestEffort(followerMessage);
+      result.current.webSocket.reconnect();
+    });
+
+    expect(postMessage).toHaveBeenCalledWith(followerMessage);
+    expect(postTransportSignal).toHaveBeenCalledWith({
+      type: 'transport-reconnect-request',
+      workspaceId: 'workspace-1',
+    });
+    expect(sendWebSocketMessage).not.toHaveBeenCalled();
+    expect(reconnect).not.toHaveBeenCalled();
+  });
+
+  it('uses an independent socket when browser lock coordination is unavailable', () => {
+    mockUseWorkspaceWebSocketLeader.mockReturnValue({ isLeader: true, isCoordinated: false });
+
+    const { result } = renderTransport();
+
+    expect(mockUseAppflowyWebSocket).toHaveBeenCalledWith(
+      expect.objectContaining({ connect: true, reconnectWhenHidden: false })
+    );
+    expect(result.current.canSendToServer).toBe(true);
+    expect(subscribeProtocolMessages).not.toHaveBeenCalled();
+    expect(subscribeOutboxReady).not.toHaveBeenCalled();
+    expect(subscribeTransportSignals).not.toHaveBeenCalled();
+    expect(postTransportSignal).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/ws/__tests__/useWorkspaceWebSocketLeader.test.ts
+++ b/src/components/ws/__tests__/useWorkspaceWebSocketLeader.test.ts
@@ -1,0 +1,135 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+
+import { useWorkspaceWebSocketLeader } from '../useWorkspaceWebSocketLeader';
+
+interface PendingLockRequest {
+  name: string;
+  callback: LockGrantedCallback;
+  signal?: AbortSignal;
+  resolve: (value: unknown) => void;
+  reject: (reason?: unknown) => void;
+}
+
+class MockLockManager {
+  private held = false;
+  private pending: PendingLockRequest[] = [];
+
+  request(name: string, options: LockOptions, callback: LockGrantedCallback): Promise<unknown> {
+    return new Promise((resolve, reject) => {
+      const request = { name, callback, signal: options.signal, resolve, reject };
+
+      options.signal?.addEventListener(
+        'abort',
+        () => {
+          const index = this.pending.indexOf(request);
+
+          if (index >= 0) {
+            this.pending.splice(index, 1);
+            reject(new DOMException('The lock request was aborted', 'AbortError'));
+          }
+        },
+        { once: true }
+      );
+      this.pending.push(request);
+      this.grantNext();
+    });
+  }
+
+  private grantNext() {
+    if (this.held) return;
+
+    const request = this.pending.shift();
+
+    if (!request) return;
+    if (request.signal?.aborted) {
+      request.reject(new DOMException('The lock request was aborted', 'AbortError'));
+      this.grantNext();
+      return;
+    }
+
+    this.held = true;
+    const lock = { name: request.name, mode: 'exclusive' } as Lock;
+
+    void Promise.resolve(request.callback(lock)).then(
+      (value) => {
+        this.held = false;
+        request.resolve(value);
+        this.grantNext();
+      },
+      (error) => {
+        this.held = false;
+        request.reject(error);
+        this.grantNext();
+      }
+    );
+  }
+}
+
+describe('useWorkspaceWebSocketLeader', () => {
+  const originalLocksDescriptor = Object.getOwnPropertyDescriptor(navigator, 'locks');
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    if (originalLocksDescriptor) {
+      Object.defineProperty(navigator, 'locks', originalLocksDescriptor);
+    } else {
+      delete (navigator as Navigator & { locks?: LockManager }).locks;
+    }
+  });
+
+  it('allows only one tab to lead and hands ownership to the next waiter', async () => {
+    const locks = new MockLockManager();
+
+    Object.defineProperty(navigator, 'locks', {
+      configurable: true,
+      value: locks,
+    });
+
+    const first = renderHook(() => useWorkspaceWebSocketLeader('workspace-1'));
+    const second = renderHook(() => useWorkspaceWebSocketLeader('workspace-1'));
+
+    await waitFor(() => {
+      expect(first.result.current).toEqual({ isLeader: true, isCoordinated: true });
+    });
+    expect(second.result.current).toEqual({ isLeader: false, isCoordinated: true });
+
+    act(() => {
+      first.unmount();
+    });
+
+    await waitFor(() => {
+      expect(second.result.current).toEqual({ isLeader: true, isCoordinated: true });
+    });
+
+    second.unmount();
+  });
+
+  it('keeps realtime available when Web Locks are unavailable', () => {
+    Object.defineProperty(navigator, 'locks', {
+      configurable: true,
+      value: undefined,
+    });
+
+    const { result } = renderHook(() => useWorkspaceWebSocketLeader('workspace-1'));
+
+    expect(result.current).toEqual({ isLeader: true, isCoordinated: false });
+  });
+
+  it('falls back instead of leaving realtime disabled when lock acquisition fails', async () => {
+    jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const locks = {
+      request: jest.fn().mockRejectedValue(new Error('lock manager unavailable')),
+    } as unknown as LockManager;
+
+    Object.defineProperty(navigator, 'locks', {
+      configurable: true,
+      value: locks,
+    });
+
+    const { result } = renderHook(() => useWorkspaceWebSocketLeader('workspace-1'));
+
+    await waitFor(() => {
+      expect(result.current).toEqual({ isLeader: true, isCoordinated: false });
+    });
+  });
+});

--- a/src/components/ws/index.ts
+++ b/src/components/ws/index.ts
@@ -1,3 +1,5 @@
 export * from './useAppflowyWebSocket';
 export * from './useBroadcastChannel';
 export * from './useSync';
+export * from './useWorkspaceRealtimeTransport';
+export * from './useWorkspaceWebSocketLeader';

--- a/src/components/ws/useAppflowyWebSocket.ts
+++ b/src/components/ws/useAppflowyWebSocket.ts
@@ -1,5 +1,5 @@
 import * as random from 'lib0/random';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import useWebSocket from 'react-use-websocket';
 
 import { refreshToken } from '@/application/services/js-services/http/gotrue';
@@ -34,6 +34,7 @@ const FIRST_ATTEMPT_MAX_DELAY = 5000; // Random 5-10s before first attempt (thun
 const JITTER_FACTOR = 0.3; // 30% jitter to prevent thundering herd
 const SLOW_POLL_INTERVAL = 60000; // 60s slow-poll after exhausting fast attempts
 const RECONNECT_NONCE_COOLDOWN = 5000; // 5s minimum between nonce-based reconnections
+const WS_READY_STATE_CONNECTING = 0;
 const WS_READY_STATE_CLOSED = 3;
 const AUTH_FAILURE_STATUS_CODES = new Set([400, 401, 403]);
 const AUTH_FAILURE_ERROR_MARKERS = [
@@ -180,49 +181,63 @@ export interface Options {
    * Token used for authentication. If not provided, the token will be fetched from the session.
    */
   token?: string;
+  /** Whether this tab currently owns the workspace WebSocket. */
+  connect?: boolean;
+  /** Keep the elected cross-tab socket alive while its owner tab is hidden. */
+  reconnectWhenHidden?: boolean;
 }
 
 export const useAppflowyWebSocket = (options: Options): AppflowyWebSocketType => {
   const wsUrl = options.url || wsURL;
-  // The token is captured in state rather than read from the session on every
-  // render: a mid-session refresh by the HTTP layer must not change the socket
-  // URL (which would force a silent reconnect outside the throttled nonce
-  // path). Reconnects re-read the freshest token in bumpReconnectNonce.
-  const [token, setToken] = useState(() => options.token || getTokenParsed()?.access_token);
+  const shouldConnect = options.connect ?? true;
+  const shouldConnectRef = useRef(shouldConnect);
   // Stable across re-renders: generate once via lazy initializer, not on every render.
   const [clientId] = useState(() => options.clientId || random.uint32());
   const [deviceId] = useState(() => options.deviceId || random.uuidv4());
 
+  useLayoutEffect(() => {
+    shouldConnectRef.current = shouldConnect;
+  }, [shouldConnect]);
+
   useEffect(() => {
+    if (!shouldConnect) return;
+
     Log.debug('🔗 Start WebSocket connection', {
       url: wsUrl,
       workspaceId: options.workspaceId,
       deviceId,
     });
-  }, [wsUrl, options.workspaceId, deviceId]);
+  }, [wsUrl, options.workspaceId, deviceId, shouldConnect]);
 
   // Reconnect nonce: changing this forces react-use-websocket to close the old
   // connection and open a new one, without reloading the page.
   const [reconnectNonce, setReconnectNonce] = useState(0);
-  const baseUrl = `${wsUrl}/${options.workspaceId}/?clientId=${clientId}&deviceId=${deviceId}&token=${token}&cv=0.10.0&cp=web`;
-  const url = reconnectNonce > 0 ? `${baseUrl}&_rc=${reconnectNonce}` : baseUrl;
+  // react-use-websocket invokes URL functions for the initial connection and
+  // every automatic retry. Reading the token here keeps the hook input stable
+  // during normal renders while ensuring each actual connection uses the
+  // freshest session token.
+  const socketUrl = useCallback(() => {
+    const token = options.token || getTokenParsed()?.access_token;
+    const baseUrl = `${wsUrl}/${options.workspaceId}/?clientId=${clientId}&deviceId=${deviceId}&token=${token}&cv=0.10.0&cp=web`;
+
+    return reconnectNonce > 0 ? `${baseUrl}&_rc=${reconnectNonce}` : baseUrl;
+  }, [wsUrl, options.workspaceId, options.token, clientId, deviceId, reconnectNonce]);
 
   const [reconnectAttempt, setReconnectAttempt] = useState(0);
-  const reconnectStoppedRef = useRef(false);
+  const [retryScheduled, setRetryScheduled] = useState(false);
   const slowPollTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const lastNonceBumpRef = useRef(0);
   const lastCloseCodeRef = useRef<number | null>(null);
   const tokenRefreshInFlightRef = useRef<Promise<ReconnectAuthStatus> | null>(null);
+  const retryScheduledRef = useRef(false);
   const isMountedRef = useRef(true);
 
-  const syncTokenForReconnect = useCallback(() => {
-    const nextToken = options.token || getTokenParsed()?.access_token;
-
-    setToken((currentToken) => (currentToken === nextToken ? currentToken : nextToken));
-  }, [options.token]);
+  const setAutomaticRetryScheduled = useCallback((scheduled: boolean) => {
+    retryScheduledRef.current = scheduled;
+    setRetryScheduled(scheduled);
+  }, []);
 
   const clearSlowPollRecovery = useCallback(() => {
-    reconnectStoppedRef.current = false;
     if (slowPollTimerRef.current) {
       clearInterval(slowPollTimerRef.current);
       slowPollTimerRef.current = null;
@@ -241,12 +256,8 @@ export const useAppflowyWebSocket = (options: Options): AppflowyWebSocketType =>
     }
 
     lastNonceBumpRef.current = now;
-    // The stored token may have been rotated (e.g. refreshed by
-    // ensureFreshTokenForReconnect or the HTTP layer) while the socket was
-    // down; the new connection must authenticate with the freshest one.
-    syncTokenForReconnect();
     setReconnectNonce((n) => n + 1);
-  }, [syncTokenForReconnect]);
+  }, []);
 
   const ensureFreshTokenForReconnect = useCallback(async (): Promise<ReconnectAuthStatus> => {
     // If token is explicitly provided by caller, we can't refresh it from session state.
@@ -330,129 +341,142 @@ export const useAppflowyWebSocket = (options: Options): AppflowyWebSocketType =>
 
   triggerNonceReconnectRef.current = triggerNonceReconnect;
 
-  const { lastMessage, sendMessage, readyState, getWebSocket } = useWebSocket(url, {
-    share: true,
-    heartbeat: {
-      message: 'echo',
-      returnMessage: 'echo',
-      timeout: 90000, // 90s: more tolerant of slow/congested networks (was 45s)
-      interval: 30000, // Match desktop: 30s ping interval (balances NAT keep-alive with power efficiency)
+  const { lastMessage, sendMessage, readyState, getWebSocket } = useWebSocket(
+    socketUrl,
+    {
+      share: true,
+      heartbeat: {
+        message: 'echo',
+        returnMessage: 'echo',
+        timeout: 90000, // 90s: more tolerant of slow/congested networks (was 45s)
+        interval: 30000, // Match desktop: 30s ping interval (balances NAT keep-alive with power efficiency)
+      },
+      // Reconnect configuration
+      shouldReconnect: (closeEvent) => {
+        Log.info('Connection closed, code:', closeEvent.code, 'reason:', closeEvent.reason);
+
+        // Normal close — intentional disconnect, don't reconnect
+        if (closeEvent.code === CloseCode.NormalClose) {
+          Log.debug('Normal close, no reconnect');
+          setAutomaticRetryScheduled(false);
+          return false;
+        }
+
+        if (!shouldConnect) {
+          setAutomaticRetryScheduled(false);
+          return false;
+        }
+
+        // Don't waste reconnect attempts when the browser is offline.
+        // The 'online' event listener will trigger reconnection when network returns.
+        if (typeof navigator !== 'undefined' && !navigator.onLine) {
+          Log.debug('Browser is offline, deferring reconnect to online event');
+          setAutomaticRetryScheduled(false);
+          return false;
+        }
+
+        // Per-tab fallback sockets pause in the background. A lock-elected
+        // workspace socket stays alive because it also serves visible followers.
+        if (!options.reconnectWhenHidden && typeof document !== 'undefined' && document.visibilityState === 'hidden') {
+          Log.debug('Tab is hidden, deferring reconnect to visibility change');
+          setAutomaticRetryScheduled(false);
+          return false;
+        }
+
+        return true;
+      },
+
+      reconnectAttempts: RECONNECT_ATTEMPTS,
+
+      // Exponential backoff reconnect interval with jitter (match desktop PR #294)
+      reconnectInterval: (attemptNumber) => {
+        setAutomaticRetryScheduled(true);
+        setReconnectAttempt(attemptNumber);
+
+        // First attempt: random 5-10s delay (thundering herd prevention)
+        if (attemptNumber === 0) {
+          const firstDelay = 5000 + Math.random() * FIRST_ATTEMPT_MAX_DELAY;
+
+          Log.info(`Reconnect attempt ${attemptNumber}, first attempt delay ${Math.round(firstDelay)}ms`);
+
+          return firstDelay;
+        }
+
+        // Exponential backoff with 2x multiplier (was 1.5x)
+        const baseDelay = RECONNECT_INTERVAL * Math.pow(2, attemptNumber - 1);
+        const cappedDelay = Math.min(baseDelay, MAX_RECONNECT_DELAY);
+
+        // Add 30% jitter to prevent thundering herd
+        const jitter = cappedDelay * JITTER_FACTOR * (Math.random() * 2 - 1);
+        const finalDelay = Math.max(0, cappedDelay + jitter);
+
+        Log.info(`Reconnect attempt ${attemptNumber}, delay ${Math.round(finalDelay)}ms (base: ${cappedDelay}ms)`);
+        return finalDelay;
+      },
+
+      // Connection event callback
+      onOpen: () => {
+        Log.info('✅ WebSocket connection opened');
+        setAutomaticRetryScheduled(false);
+        setReconnectAttempt(0);
+        lastCloseCodeRef.current = null;
+        clearSlowPollRecovery();
+
+        const websocket = getWebSocket() as WebSocket | null;
+
+        if (websocket && websocket.binaryType !== 'arraybuffer') {
+          websocket.binaryType = 'arraybuffer';
+        }
+      },
+
+      onClose: (event) => {
+        lastCloseCodeRef.current = event.code;
+        Log.info('❌ WebSocket connection closed', event);
+      },
+
+      onError: (event) => {
+        Log.error('❌ WebSocket error', { event, deviceId });
+      },
+
+      onReconnectStop: (numAttempts) => {
+        Log.info('❌ Reconnect stopped after', numAttempts, 'attempts. Starting slow-poll recovery.');
+        setAutomaticRetryScheduled(false);
+
+        // Start slow-poll: every 60s, check if we're online and try to reconnect.
+        // Uses triggerNonceReconnectRef to avoid capturing a stale closure.
+        if (!slowPollTimerRef.current) {
+          slowPollTimerRef.current = setInterval(() => {
+            if (navigator.onLine && (options.reconnectWhenHidden || document.visibilityState === 'visible')) {
+              Log.info('Slow-poll: transport eligible, attempting graceful reconnect');
+              triggerNonceReconnectRef.current('slow-poll', true);
+            }
+          }, SLOW_POLL_INTERVAL);
+        }
+      },
     },
-    // Reconnect configuration
-    shouldReconnect: (closeEvent) => {
-      Log.info('Connection closed, code:', closeEvent.code, 'reason:', closeEvent.reason);
-
-      // Normal close — intentional disconnect, don't reconnect
-      if (closeEvent.code === CloseCode.NormalClose) {
-        Log.debug('Normal close, no reconnect');
-        return false;
-      }
-
-      // Don't waste reconnect attempts when the browser is offline.
-      // The 'online' event listener will trigger reconnection when network returns.
-      if (typeof navigator !== 'undefined' && !navigator.onLine) {
-        Log.debug('Browser is offline, deferring reconnect to online event');
-        return false;
-      }
-
-      // Don't reconnect when the tab is in the background.
-      // Background reconnects drain battery and waste attempts against potentially-dead
-      // connections. The visibilitychange listener in ConnectBanner will reconnect
-      // when the user returns.
-      if (typeof document !== 'undefined' && document.visibilityState === 'hidden') {
-        Log.debug('Tab is hidden, deferring reconnect to visibility change');
-        return false;
-      }
-
-      // Automatic react-use-websocket retries reuse the current URL prop. If
-      // the HTTP layer rotated the stored token while this socket was open,
-      // refresh our URL token before the scheduled retry starts.
-      syncTokenForReconnect();
-      return true;
-    },
-
-    reconnectAttempts: RECONNECT_ATTEMPTS,
-
-    // Exponential backoff reconnect interval with jitter (match desktop PR #294)
-    reconnectInterval: (attemptNumber) => {
-      setReconnectAttempt(attemptNumber);
-
-      // First attempt: random 5-10s delay (thundering herd prevention)
-      if (attemptNumber === 0) {
-        const firstDelay = 5000 + Math.random() * FIRST_ATTEMPT_MAX_DELAY;
-
-        Log.info(`Reconnect attempt ${attemptNumber}, first attempt delay ${Math.round(firstDelay)}ms`);
-
-        return firstDelay;
-      }
-
-      // Exponential backoff with 2x multiplier (was 1.5x)
-      const baseDelay = RECONNECT_INTERVAL * Math.pow(2, attemptNumber - 1);
-      const cappedDelay = Math.min(baseDelay, MAX_RECONNECT_DELAY);
-
-      // Add 30% jitter to prevent thundering herd
-      const jitter = cappedDelay * JITTER_FACTOR * (Math.random() * 2 - 1);
-      const finalDelay = Math.max(0, cappedDelay + jitter);
-
-      Log.info(`Reconnect attempt ${attemptNumber}, delay ${Math.round(finalDelay)}ms (base: ${cappedDelay}ms)`);
-      return finalDelay;
-    },
-
-    // Connection event callback
-    onOpen: () => {
-      Log.info('✅ WebSocket connection opened');
-      setReconnectAttempt(0);
-      lastCloseCodeRef.current = null;
-      clearSlowPollRecovery();
-
-      const websocket = getWebSocket() as WebSocket | null;
-
-      if (websocket && websocket.binaryType !== 'arraybuffer') {
-        websocket.binaryType = 'arraybuffer';
-      }
-    },
-
-    onClose: (event) => {
-      lastCloseCodeRef.current = event.code;
-      Log.info('❌ WebSocket connection closed', event);
-    },
-
-    onError: (event) => {
-      Log.error('❌ WebSocket error', { event, deviceId });
-    },
-
-    onReconnectStop: (numAttempts) => {
-      Log.info('❌ Reconnect stopped after', numAttempts, 'attempts. Starting slow-poll recovery.');
-      reconnectStoppedRef.current = true;
-
-      // Start slow-poll: every 60s, check if we're online and try to reconnect.
-      // Uses triggerNonceReconnectRef to avoid capturing a stale closure.
-      if (!slowPollTimerRef.current) {
-        slowPollTimerRef.current = setInterval(() => {
-          if (navigator.onLine && document.visibilityState === 'visible') {
-            Log.info('Slow-poll: online and visible, attempting graceful reconnect');
-            triggerNonceReconnectRef.current('slow-poll', true);
-          }
-        }, SLOW_POLL_INTERVAL);
-      }
-    },
-  });
+    shouldConnect
+  );
 
   const tryDeferredReconnect = useCallback(
     (reason: 'online' | 'visibility') => {
       if (typeof navigator !== 'undefined' && !navigator.onLine) return;
-      if (typeof document !== 'undefined' && document.visibilityState === 'hidden') return;
+      if (!options.reconnectWhenHidden && typeof document !== 'undefined' && document.visibilityState === 'hidden')
+        return;
+      if (!shouldConnect) return;
       if (readyState !== WS_READY_STATE_CLOSED) return;
       if (lastCloseCodeRef.current === CloseCode.NormalClose) return;
+      if (retryScheduledRef.current) return;
 
       Log.info(`Deferred reconnect trigger (${reason}), attempting graceful reconnect`);
       triggerNonceReconnect(`deferred-${reason}`, true);
     },
-    [readyState, triggerNonceReconnect]
+    [readyState, triggerNonceReconnect, shouldConnect, options.reconnectWhenHidden]
   );
 
   // Listen for browser online/visibility events to recover when reconnect was deferred.
   useEffect(() => {
+    if (!shouldConnect) return;
+
     const handleOnline = () => {
       tryDeferredReconnect('online');
     };
@@ -475,10 +499,19 @@ export const useAppflowyWebSocket = (options: Options): AppflowyWebSocketType =>
         slowPollTimerRef.current = null;
       }
     };
-  }, [tryDeferredReconnect]);
+  }, [tryDeferredReconnect, shouldConnect]);
+
+  useEffect(() => {
+    if (shouldConnect) return;
+
+    setAutomaticRetryScheduled(false);
+    clearSlowPollRecovery();
+  }, [shouldConnect, setAutomaticRetryScheduled, clearSlowPollRecovery]);
 
   // Mark unmounted so async callbacks (triggerNonceReconnect) can bail out.
   useEffect(() => {
+    isMountedRef.current = true;
+
     return () => {
       isMountedRef.current = false;
     };
@@ -490,12 +523,23 @@ export const useAppflowyWebSocket = (options: Options): AppflowyWebSocketType =>
 
       const protobufMessage = messages.Message.encode(message).finish();
 
-      sendMessage(protobufMessage, keep);
+      // Followers route protocol messages through BroadcastChannel. Do not
+      // retain a second in-memory socket queue while this tab is not leader.
+      // The latest-value ref keeps this callback stable for SyncContexts that
+      // outlive a follower-to-leader handoff while still enabling buffering as
+      // soon as this tab owns the replacement socket.
+      sendMessage(protobufMessage, shouldConnectRef.current ? keep : false);
     },
     [sendMessage]
   );
 
   const manualReconnect = useCallback(() => {
+    if (!shouldConnect || readyState !== WS_READY_STATE_CLOSED) return;
+    if (retryScheduledRef.current) {
+      Log.debug('Manual reconnect ignored because an automatic retry is already scheduled');
+      return;
+    }
+
     Log.debug('Manual reconnect triggered — graceful reconnection (no page reload)');
     // Manual reconnect should override previous close-code suppression.
     lastCloseCodeRef.current = null;
@@ -503,7 +547,7 @@ export const useAppflowyWebSocket = (options: Options): AppflowyWebSocketType =>
     // Bump the nonce to force a new WebSocket URL, causing react-use-websocket
     // to close the old connection and open a fresh one without page reload.
     triggerNonceReconnect('manual', true);
-  }, [triggerNonceReconnect]);
+  }, [triggerNonceReconnect, shouldConnect, readyState]);
 
   const lastProtobufMessage = useMemo(
     () => (lastMessage ? messages.Message.decode(new Uint8Array(lastMessage.data)) : null),
@@ -519,9 +563,14 @@ export const useAppflowyWebSocket = (options: Options): AppflowyWebSocketType =>
       url: wsUrl,
       clientId,
       deviceId,
+      connect: shouldConnect,
+      reconnectWhenHidden: options.reconnectWhenHidden,
     }),
-    [options.workspaceId, options.token, wsUrl, clientId, deviceId]
+    [options.workspaceId, options.token, options.reconnectWhenHidden, wsUrl, clientId, deviceId, shouldConnect]
   );
+
+  const effectiveReadyState =
+    retryScheduled && readyState === WS_READY_STATE_CLOSED ? WS_READY_STATE_CONNECTING : readyState;
 
   // Memoized so consumers (and context values built from this) only re-render
   // when something actually changed, not on every render of the host component.
@@ -529,11 +578,11 @@ export const useAppflowyWebSocket = (options: Options): AppflowyWebSocketType =>
     () => ({
       lastMessage: lastProtobufMessage,
       sendMessage: sendProtobufMessage,
-      readyState,
+      readyState: effectiveReadyState,
       options: resolvedOptions,
       reconnectAttempt,
       reconnect: manualReconnect,
     }),
-    [lastProtobufMessage, sendProtobufMessage, readyState, resolvedOptions, reconnectAttempt, manualReconnect]
+    [lastProtobufMessage, sendProtobufMessage, effectiveReadyState, resolvedOptions, reconnectAttempt, manualReconnect]
   );
 };

--- a/src/components/ws/useBroadcastChannel.ts
+++ b/src/components/ws/useBroadcastChannel.ts
@@ -6,6 +6,108 @@ import { Log } from '@/utils/log';
 export type BroadcastChannelType = {
   lastBroadcastMessage: messages.Message | null;
   postMessage: (msg: messages.IMessage, keep?: boolean) => void;
+  postDurableMessage: (msg: messages.IMessage) => void;
+  subscribeProtocolMessages: (listener: (message: messages.Message) => void) => () => void;
+  postOutboxReady: (workspaceId: string, objectId: string) => void;
+  subscribeOutboxReady: (listener: (workspaceId: string, objectId: string) => void) => () => void;
+  postTransportSignal: (signal: WorkspaceTransportSignal) => void;
+  subscribeTransportSignals: (listener: (signal: WorkspaceTransportSignal) => void) => () => void;
+};
+
+export type WorkspaceTransportSignal =
+  | {
+      type: 'transport-status';
+      workspaceId: string;
+      readyState: number;
+    }
+  | {
+      type: 'transport-status-request' | 'transport-reconnect-request';
+      workspaceId: string;
+    };
+
+interface DurableMessageSignal {
+  type: 'durable-message';
+  payload: ArrayBufferView;
+}
+
+interface OutboxReadySignal {
+  type: 'outbox-ready';
+  workspaceId: string;
+  objectId: string;
+}
+
+interface ChannelMessageState {
+  channelName: string;
+  message: messages.Message;
+}
+
+const WS_READY_STATE_CONNECTING = 0;
+const WS_READY_STATE_CLOSED = 3;
+
+const isOutboxReadySignal = (value: unknown): value is OutboxReadySignal => {
+  if (!value || typeof value !== 'object') return false;
+
+  const signal = value as Partial<OutboxReadySignal>;
+
+  return signal.type === 'outbox-ready' && typeof signal.workspaceId === 'string' && typeof signal.objectId === 'string';
+};
+
+const isDurableMessageSignal = (value: unknown): value is DurableMessageSignal => {
+  if (!value || typeof value !== 'object') return false;
+
+  const signal = value as Partial<DurableMessageSignal>;
+
+  return (
+    signal.type === 'durable-message' && (signal.payload instanceof Uint8Array || ArrayBuffer.isView(signal.payload))
+  );
+};
+
+const isWorkspaceTransportSignal = (value: unknown): value is WorkspaceTransportSignal => {
+  if (!value || typeof value !== 'object') return false;
+
+  const signal = value as {
+    type?: unknown;
+    workspaceId?: unknown;
+    readyState?: unknown;
+  };
+
+  if (typeof signal.workspaceId !== 'string') return false;
+
+  if (signal.type === 'transport-status') {
+    return (
+      typeof signal.readyState === 'number' &&
+      Number.isInteger(signal.readyState) &&
+      signal.readyState >= WS_READY_STATE_CONNECTING &&
+      signal.readyState <= WS_READY_STATE_CLOSED
+    );
+  }
+
+  return signal.type === 'transport-status-request' || signal.type === 'transport-reconnect-request';
+};
+
+const postOutboxReadyOnTemporaryChannel = (channelName: string, signal: OutboxReadySignal) => {
+  let temporaryChannel: BroadcastChannel | null = null;
+
+  try {
+    temporaryChannel = new BroadcastChannel(channelName);
+    temporaryChannel.postMessage(signal);
+  } catch (error) {
+    Log.warn('Failed to notify the WebSocket leader about a durable outbox update', {
+      workspaceId: signal.workspaceId,
+      objectId: signal.objectId,
+      error,
+    });
+  } finally {
+    temporaryChannel?.close();
+  }
+};
+
+const toUint8Array = (value: ArrayBuffer | ArrayBufferView): Uint8Array => {
+  if (value instanceof ArrayBuffer) {
+    return new Uint8Array(value);
+  }
+
+  return new Uint8Array(value.buffer, value.byteOffset, value.byteLength);
 };
 
 /**
@@ -15,37 +117,87 @@ export type BroadcastChannelType = {
  * to ensure consistent real-time updates across all tabs.
  *
  * Multi-tab Architecture:
- * - Only one tab per workspace maintains active WebSocket connection
- * - That "active" tab receives server notifications directly
- * - Active tab broadcasts messages to other tabs via BroadcastChannel
+ * - Only one tab per workspace maintains the WebSocket connection
+ * - That leader tab receives server notifications directly
+ * - The leader broadcasts messages to other tabs via BroadcastChannel
  * - Other tabs receive and process broadcasted messages identically
  *
  * Example: User profile change notification
- * 1. Server → WebSocket → Tab A (active)
+ * 1. Server → WebSocket → Tab A (leader)
  * 2. Tab A processes notification + updates its UI
  * 3. Tab A broadcasts message to BroadcastChannel
  * 4. Tab B & C receive broadcast + update their UI
  * 5. Result: All tabs show updated profile simultaneously
  *
  * @param channelName - Unique channel identifier (typically workspace-scoped)
- * @returns Object with lastBroadcastMessage and postMessage function
+ * The channel also multiplexes durable-update readiness and transport status
+ * without exposing that control traffic to the Yjs message handler.
  */
 export const useBroadcastChannel = (channelName: string): BroadcastChannelType => {
   // The live channel for the current channelName. Closed-ness is tracked per
   // channel instance (not React state) so a workspace switch can never leak a
   // stale "closed" flag into the replacement channel and silently drop sends.
   const channelRef = useRef<BroadcastChannel | null>(null);
-  const [lastMessage, setLastMessage] = useState<messages.Message | null>(null);
+  const activeChannelNameRef = useRef<string | null>(null);
+  // Protocol messages can be emitted by child layout effects before this hook's
+  // passive channel-creation effect runs. Queue only during that initial gap;
+  // sends after cleanup remain intentionally dropped.
+  const pendingInitialPostsRef = useRef<unknown[] | null>([]);
+  const protocolMessageListenersRef = useRef(new Set<(message: messages.Message) => void>());
+  const outboxReadyListenersRef = useRef(new Set<(workspaceId: string, objectId: string) => void>());
+  const transportSignalListenersRef = useRef(new Set<(signal: WorkspaceTransportSignal) => void>());
+  const [lastMessageState, setLastMessageState] = useState<ChannelMessageState | null>(null);
 
   useEffect(() => {
     const channel = new BroadcastChannel(channelName);
 
     channelRef.current = channel;
+    activeChannelNameRef.current = channelName;
+    const pendingInitialPosts = pendingInitialPostsRef.current ?? [];
+
+    pendingInitialPostsRef.current = null;
+    pendingInitialPosts.forEach((data) => {
+      try {
+        channel.postMessage(data);
+      } catch (error) {
+        Log.warn('Failed to flush an initial BroadcastChannel message', error);
+      }
+    });
 
     const handleMessage = (event: MessageEvent) => {
-      const message = messages.Message.decode(new Uint8Array(event.data));
+      if (isOutboxReadySignal(event.data)) {
+        outboxReadyListenersRef.current.forEach((listener) => listener(event.data.workspaceId, event.data.objectId));
+        return;
+      }
 
-      setLastMessage(message);
+      if (isWorkspaceTransportSignal(event.data)) {
+        transportSignalListenersRef.current.forEach((listener) => listener(event.data));
+        return;
+      }
+
+      const isDurableMessage = isDurableMessageSignal(event.data);
+      const isBinaryMessage = event.data instanceof ArrayBuffer || ArrayBuffer.isView(event.data);
+
+      if (!isDurableMessage && !isBinaryMessage) {
+        Log.warn('Ignored an unknown workspace BroadcastChannel message');
+        return;
+      }
+
+      let message: messages.Message;
+
+      try {
+        const payload = toUint8Array(isDurableMessage ? event.data.payload : event.data);
+
+        message = messages.Message.decode(payload);
+      } catch (error) {
+        Log.warn('Failed to decode a workspace BroadcastChannel message', error);
+        return;
+      }
+
+      setLastMessageState({ channelName, message });
+      if (!isDurableMessage) {
+        protocolMessageListenersRef.current.forEach((listener) => listener(message));
+      }
     };
 
     channel.addEventListener('message', handleMessage);
@@ -55,6 +207,7 @@ export const useBroadcastChannel = (channelName: string): BroadcastChannelType =
 
       if (channelRef.current === channel) {
         channelRef.current = null;
+        activeChannelNameRef.current = null;
       }
 
       channel.close();
@@ -63,15 +216,21 @@ export const useBroadcastChannel = (channelName: string): BroadcastChannelType =
 
   const sendMessage = useCallback((msg: messages.IMessage) => {
     const channel = channelRef.current;
+    const payload = messages.Message.encode(msg).finish();
 
     if (!channel) {
+      if (pendingInitialPostsRef.current) {
+        pendingInitialPostsRef.current.push(payload);
+        return;
+      }
+
       // Fail silently instead of showing warning - this is normal during cleanup
       Log.debug('BroadcastChannel closed, skipping message send');
       return;
     }
 
     try {
-      channel.postMessage(messages.Message.encode(msg).finish());
+      channel.postMessage(payload);
     } catch (error) {
       if (error instanceof Error && error.name === 'InvalidStateError') {
         if (channelRef.current === channel) {
@@ -85,5 +244,129 @@ export const useBroadcastChannel = (channelName: string): BroadcastChannelType =
     }
   }, []);
 
-  return { lastBroadcastMessage: lastMessage, postMessage: sendMessage };
+  const postDurableMessage = useCallback((msg: messages.IMessage) => {
+    const channel = channelRef.current;
+
+    const signal: DurableMessageSignal = {
+      type: 'durable-message',
+      payload: messages.Message.encode(msg).finish(),
+    };
+
+    if (!channel) {
+      pendingInitialPostsRef.current?.push(signal);
+      return;
+    }
+
+    try {
+      channel.postMessage(signal);
+    } catch (error) {
+      Log.warn('Failed to broadcast a durable collab update', error);
+    }
+  }, []);
+
+  const subscribeProtocolMessages = useCallback((listener: (message: messages.Message) => void) => {
+    protocolMessageListenersRef.current.add(listener);
+
+    return () => {
+      protocolMessageListenersRef.current.delete(listener);
+    };
+  }, []);
+
+  const postOutboxReady = useCallback((workspaceId: string, objectId: string) => {
+    const signal: OutboxReadySignal = {
+      type: 'outbox-ready',
+      workspaceId,
+      objectId,
+    };
+
+    const channel = channelRef.current;
+
+    if (!channel) {
+      if (pendingInitialPostsRef.current) {
+        pendingInitialPostsRef.current.push(signal);
+        return;
+      }
+
+      // `enqueueOutboxUpdate` invokes this callback after IndexedDB commits.
+      // If its workspace switched while the add was in flight, the bound
+      // channel may no longer be mounted. A short-lived sender still targets
+      // the workspace that originated the durable row.
+      postOutboxReadyOnTemporaryChannel(channelName, signal);
+
+      return;
+    }
+
+    if (activeChannelNameRef.current !== channelName) {
+      postOutboxReadyOnTemporaryChannel(channelName, signal);
+
+      return;
+    }
+
+    try {
+      channel.postMessage(signal);
+    } catch (error) {
+      if (error instanceof Error && error.name === 'InvalidStateError') {
+        if (channelRef.current === channel) {
+          channelRef.current = null;
+          activeChannelNameRef.current = null;
+        }
+
+        postOutboxReadyOnTemporaryChannel(channelName, signal);
+        return;
+      }
+
+      Log.warn('Failed to notify the WebSocket leader about a durable outbox update', {
+        workspaceId,
+        objectId,
+        error,
+      });
+    }
+  }, [channelName]);
+
+  const subscribeOutboxReady = useCallback((listener: (workspaceId: string, objectId: string) => void) => {
+    outboxReadyListenersRef.current.add(listener);
+
+    return () => {
+      outboxReadyListenersRef.current.delete(listener);
+    };
+  }, []);
+
+  const postTransportSignal = useCallback((signal: WorkspaceTransportSignal) => {
+    const channel = channelRef.current;
+
+    if (!channel) {
+      pendingInitialPostsRef.current?.push(signal);
+      return;
+    }
+
+    try {
+      channel.postMessage(signal);
+    } catch (error) {
+      Log.warn('Failed to post a workspace transport control signal', {
+        signal,
+        error,
+      });
+    }
+  }, []);
+
+  const subscribeTransportSignals = useCallback((listener: (signal: WorkspaceTransportSignal) => void) => {
+    transportSignalListenersRef.current.add(listener);
+
+    return () => {
+      transportSignalListenersRef.current.delete(listener);
+    };
+  }, []);
+
+  const lastBroadcastMessage = lastMessageState?.channelName === channelName ? lastMessageState.message : null;
+
+  return {
+    lastBroadcastMessage,
+    postMessage: sendMessage,
+    postDurableMessage,
+    subscribeProtocolMessages,
+    postOutboxReady,
+    subscribeOutboxReady,
+    postTransportSignal,
+    subscribeTransportSignals,
+  };
 };

--- a/src/components/ws/useWorkspaceRealtimeTransport.ts
+++ b/src/components/ws/useWorkspaceRealtimeTransport.ts
@@ -1,0 +1,203 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+
+import { startDrainObject } from '@/application/sync-outbox';
+import type { messages } from '@/proto/messages';
+
+import { useAppflowyWebSocket, type AppflowyWebSocketType } from './useAppflowyWebSocket';
+import { useBroadcastChannel, type BroadcastChannelType } from './useBroadcastChannel';
+import { useWorkspaceWebSocketLeader } from './useWorkspaceWebSocketLeader';
+
+const WS_READY_STATE_CONNECTING = 0;
+
+interface WorkspaceRealtimeTransportOptions {
+  workspaceId: string;
+  clientId: number;
+  deviceId: string;
+}
+
+export interface WorkspaceRealtimeTransport {
+  webSocket: AppflowyWebSocketType;
+  broadcastChannel: BroadcastChannelType;
+  canSendToServer: boolean;
+  sendBestEffort: (message: messages.IMessage) => void;
+}
+
+interface RemoteTransportState {
+  workspaceId: string;
+  readyState: number;
+}
+
+/**
+ * Owns the workspace's complete cross-tab realtime transport policy.
+ *
+ * With Web Locks support, one tab owns the WebSocket and relays protocol
+ * traffic for its followers over BroadcastChannel. Without Web Locks, each
+ * tab keeps its own socket so realtime sync remains available.
+ */
+export function useWorkspaceRealtimeTransport({
+  workspaceId,
+  clientId,
+  deviceId,
+}: WorkspaceRealtimeTransportOptions): WorkspaceRealtimeTransport {
+  const leadership = useWorkspaceWebSocketLeader(workspaceId);
+  const broadcastChannel = useBroadcastChannel(`workspace:${workspaceId}`);
+  const localWebSocket = useAppflowyWebSocket({
+    workspaceId,
+    clientId,
+    deviceId,
+    connect: leadership.isLeader,
+    // The elected owner may be hidden while serving visible follower tabs.
+    reconnectWhenHidden: leadership.isCoordinated,
+  });
+
+  const isCoordinatedLeader = leadership.isCoordinated && leadership.isLeader;
+  const canSendToServer = !leadership.isCoordinated || leadership.isLeader;
+  const sendWebSocketMessage = localWebSocket.sendMessage;
+  const lastWebSocketMessage = localWebSocket.lastMessage;
+  const localReadyState = localWebSocket.readyState;
+  const localReconnect = localWebSocket.reconnect;
+  const postBroadcastMessage = broadcastChannel.postMessage;
+  const subscribeProtocolMessages = broadcastChannel.subscribeProtocolMessages;
+  const subscribeOutboxReady = broadcastChannel.subscribeOutboxReady;
+  const postTransportSignal = broadcastChannel.postTransportSignal;
+  const subscribeTransportSignals = broadcastChannel.subscribeTransportSignals;
+  const [remoteTransportState, setRemoteTransportState] = useState<RemoteTransportState | null>(null);
+
+  useEffect(() => {
+    if (!leadership.isCoordinated) return;
+
+    return subscribeTransportSignals((signal) => {
+      if (signal.workspaceId !== workspaceId) return;
+
+      if (signal.type === 'transport-status') {
+        if (!isCoordinatedLeader) {
+          setRemoteTransportState((current) => {
+            if (current?.workspaceId === workspaceId && current.readyState === signal.readyState) {
+              return current;
+            }
+
+            return { workspaceId, readyState: signal.readyState };
+          });
+        }
+
+        return;
+      }
+
+      if (!isCoordinatedLeader) return;
+
+      if (signal.type === 'transport-status-request') {
+        postTransportSignal({
+          type: 'transport-status',
+          workspaceId,
+          readyState: localReadyState,
+        });
+        return;
+      }
+
+      localReconnect();
+    });
+  }, [
+    leadership.isCoordinated,
+    isCoordinatedLeader,
+    localReadyState,
+    localReconnect,
+    postTransportSignal,
+    subscribeTransportSignals,
+    workspaceId,
+  ]);
+
+  // Publish every leader state transition and answer late-joining followers'
+  // status requests so a socketless tab never has to infer transport health
+  // from react-use-websocket's local UNINSTANTIATED state.
+  useEffect(() => {
+    if (!isCoordinatedLeader) return;
+
+    postTransportSignal({
+      type: 'transport-status',
+      workspaceId,
+      readyState: localReadyState,
+    });
+  }, [isCoordinatedLeader, localReadyState, postTransportSignal, workspaceId]);
+
+  useEffect(() => {
+    if (!leadership.isCoordinated || leadership.isLeader) return;
+
+    postTransportSignal({
+      type: 'transport-status-request',
+      workspaceId,
+    });
+  }, [leadership.isCoordinated, leadership.isLeader, postTransportSignal, workspaceId]);
+
+  const requestLeaderReconnect = useCallback(() => {
+    postTransportSignal({
+      type: 'transport-reconnect-request',
+      workspaceId,
+    });
+  }, [postTransportSignal, workspaceId]);
+
+  const transportReadyState = canSendToServer
+    ? localReadyState
+    : remoteTransportState?.workspaceId === workspaceId
+      ? remoteTransportState.readyState
+      : WS_READY_STATE_CONNECTING;
+
+  const webSocket = useMemo<AppflowyWebSocketType>(() => {
+    if (canSendToServer) return localWebSocket;
+
+    return {
+      ...localWebSocket,
+      // Followers consume server messages from BroadcastChannel only. Clearing
+      // the local value also prevents a previous workspace's final socket
+      // message from leaking through during a leadership/workspace transition.
+      lastMessage: null,
+      readyState: transportReadyState,
+      reconnectAttempt: 0,
+      reconnect: requestLeaderReconnect,
+    };
+  }, [canSendToServer, localWebSocket, requestLeaderReconnect, transportReadyState]);
+
+  const sendBestEffort = useCallback(
+    (message: messages.IMessage) => {
+      if (canSendToServer) {
+        sendWebSocketMessage(message, true);
+      } else {
+        // A coordinated follower has no socket. Raw protocol traffic is picked
+        // up by the leader's subscription above and forwarded to the server.
+        postBroadcastMessage(message);
+      }
+    },
+    [canSendToServer, postBroadcastMessage, sendWebSocketMessage]
+  );
+
+  // Followers send ephemeral sync and awareness traffic through the leader.
+  // keep=true preserves messages emitted while its socket is still connecting.
+  useEffect(() => {
+    if (!isCoordinatedLeader) return;
+
+    return subscribeProtocolMessages((message) => {
+      sendWebSocketMessage(message, true);
+    });
+  }, [isCoordinatedLeader, sendWebSocketMessage, subscribeProtocolMessages]);
+
+  // Durable rows are announced only after IndexedDB commits. The leader can
+  // then read the shared row and drain it through the sole workspace socket.
+  useEffect(() => {
+    if (!isCoordinatedLeader) return;
+
+    return subscribeOutboxReady((signalWorkspaceId, objectId) => {
+      if (signalWorkspaceId === workspaceId) {
+        startDrainObject(objectId);
+      }
+    });
+  }, [isCoordinatedLeader, subscribeOutboxReady, workspaceId]);
+
+  // BroadcastChannel does not echo to its sender, so the leader processes the
+  // WebSocket copy once while followers receive the relayed server message.
+  useEffect(() => {
+    if (!isCoordinatedLeader || !lastWebSocketMessage) return;
+
+    postBroadcastMessage(lastWebSocketMessage);
+  }, [isCoordinatedLeader, lastWebSocketMessage, postBroadcastMessage]);
+
+  return { webSocket, broadcastChannel, canSendToServer, sendBestEffort };
+}

--- a/src/components/ws/useWorkspaceWebSocketLeader.ts
+++ b/src/components/ws/useWorkspaceWebSocketLeader.ts
@@ -1,0 +1,98 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+
+import { Log } from '@/utils/log';
+
+type LeadershipStatus = 'waiting' | 'leader' | 'fallback';
+
+interface LeadershipState {
+  lockName: string;
+  status: LeadershipStatus;
+}
+
+export interface WorkspaceWebSocketLeadership {
+  /** Whether this tab owns the workspace WebSocket. */
+  isLeader: boolean;
+  /** Whether Web Locks are enforcing single-tab ownership. */
+  isCoordinated: boolean;
+}
+
+const lockManager = (): LockManager | null => {
+  if (typeof navigator === 'undefined') return null;
+
+  return navigator.locks ?? null;
+};
+
+/**
+ * Elects one browser tab to own the WebSocket for a workspace.
+ *
+ * The lock is held for the lifetime of the mounted workspace layer. Waiting
+ * tabs automatically take over when the owner closes or switches workspace.
+ * If Web Locks are unavailable (or fail), each tab keeps its own socket so
+ * realtime sync remains available instead of failing closed.
+ */
+export function useWorkspaceWebSocketLeader(workspaceId: string): WorkspaceWebSocketLeadership {
+  const lockName = useMemo(() => `appflowy:websocket:${workspaceId}`, [workspaceId]);
+  const [state, setState] = useState<LeadershipState>(() => ({
+    lockName,
+    status: lockManager() ? 'waiting' : 'fallback',
+  }));
+  const requestGenerationRef = useRef(0);
+
+  useEffect(() => {
+    const locks = lockManager();
+    const generation = ++requestGenerationRef.current;
+
+    if (!locks) {
+      setState({ lockName, status: 'fallback' });
+      return;
+    }
+
+    setState({ lockName, status: 'waiting' });
+
+    const abortController = new AbortController();
+    let releaseLock: (() => void) | undefined;
+    const lockLifetime = new Promise<void>((resolve) => {
+      releaseLock = resolve;
+    });
+
+    void locks
+      .request(
+        lockName,
+        {
+          mode: 'exclusive',
+          signal: abortController.signal,
+        },
+        async (lock) => {
+          if (!lock || requestGenerationRef.current !== generation) return;
+
+          setState({ lockName, status: 'leader' });
+          await lockLifetime;
+        }
+      )
+      .catch((error: unknown) => {
+        if (abortController.signal.aborted || requestGenerationRef.current !== generation) return;
+
+        Log.warn('WebSocket leader election failed; falling back to a socket per tab', {
+          workspaceId,
+          error,
+        });
+        setState({ lockName, status: 'fallback' });
+      });
+
+    return () => {
+      if (requestGenerationRef.current === generation) {
+        requestGenerationRef.current += 1;
+      }
+
+      abortController.abort();
+      releaseLock?.();
+    };
+  }, [lockName, workspaceId]);
+
+  const status = state.lockName === lockName ? state.status : lockManager() ? 'waiting' : 'fallback';
+
+  return {
+    isLeader: status === 'leader' || status === 'fallback',
+    isCoordinated: status !== 'fallback',
+  };
+}


### PR DESCRIPTION
### **Description**

Coordinate workspace realtime transport across browser tabs so a single leader owns the server WebSocket while follower tabs accurately mirror readiness, queue outgoing updates, and request reconnects through the leader.

#### Root cause

- Follower tabs exposed their local disconnected WebSocket state even though the elected leader owned the live connection.
- Delayed IndexedDB outbox notifications could be sent through a newer workspace channel after navigation.
- Stable protobuf send callbacks captured the initial `shouldConnect` value, so a promoted follower could continue using follower-only buffering behavior.

#### Changes

- Add workspace-scoped WebSocket leader election and a shared realtime transport hook.
- Broadcast leader transport status and relay follower reconnect requests.
- Bind outbox-ready notifications to the originating workspace channel.
- Read the latest connection ownership state from a ref inside stable send callbacks.
- Update the connection banner and sync layer to use the coordinated transport.
- Add focused tests for leader election, transport coordination, outbox signaling, reconnect behavior, and ownership transitions.

#### Impact

This prevents follower tabs from showing stale connection state, avoids unnecessary HTTP full-sync fallbacks, keeps delayed outbox signals workspace-safe, and lets promoted tabs send through the WebSocket immediately.

#### Validation

- [x] `pnpm type-check`
- [x] ESLint on all changed source and test files
- [x] 8 targeted Vitest suites (78 tests)
- [x] `git diff --check`

---

### **Checklist**

#### **General**

- [x] I've included relevant documentation or comments for the changes introduced.
- [ ] I've tested the changes in multiple environments (e.g., different browsers, operating systems).

#### **Testing**

- [x] I've added or updated tests to validate the changes introduced for AppFlowy Web.

#### **Feature-Specific**

- [ ] Not applicable; this is a bug fix without a new user-facing feature.

## Summary by Sourcery

Coordinate workspace realtime transport across browser tabs so a single elected leader manages the WebSocket while follower tabs mirror its state, relay traffic via BroadcastChannel, and trigger reconnects through the leader.

Bug Fixes:
- Prevent follower tabs from exposing stale or incorrect connection status when another tab owns the workspace WebSocket.
- Ensure delayed IndexedDB outbox notifications are delivered to the correct workspace channel after navigation or workspace switching.
- Avoid double reconnects and conflicting retry paths by centralizing reconnect behavior in the WebSocket hook and leader transport.

Enhancements:
- Introduce workspace-scoped WebSocket leader election based on Web Locks with a fallback to independent sockets when coordination is unavailable.
- Add a shared workspace realtime transport hook that centralizes WebSocket ownership, cross-tab protocol routing, transport status signaling, and reconnect requests.
- Extend the broadcast channel layer to multiplex protocol messages, durable outbox readiness, and transport control signals without leaking control traffic to sync consumers.
- Improve WebSocket token handling and reconnect scheduling so new connections always use the freshest token while keeping hook inputs stable across renders.
- Expose a more accurate connecting state when automatic retries are pending, and respect per-transport rules for reconnecting when tabs are hidden.
- Wire the sync outbox to notify the elected transport owner after durable persistence and allow targeted drain of individual objects.
- Refine the connection banner to rely solely on the websocket layer for automatic recovery while retaining explicit manual reconnect control.

Tests:
- Add comprehensive tests for the broadcast channel’s new durable message, outbox-ready, and transport-signal routing semantics.
- Add tests for WebSocket URL resolution, token freshness on reconnect, retry scheduling, follower buffering behavior, and leadership transitions.
- Add tests for the outbox’s persisted-notification hook into the transport layer and targeted object draining.
- Add tests for the workspace realtime transport hook’s leader/follower coordination, reconnect signaling, and fallback behavior.
- Add tests for WebSocket leader election via Web Locks, handoff between tabs, and graceful fallback when locks are unavailable.
- Update ConnectBanner tests to verify that automatic recovery is delegated to the websocket layer while manual reconnect remains functional.