### PR TITLE
Fix search, sync, and retry races

### DIFF
--- a/playwright/support/duplicate-test-helpers.ts
+++ b/playwright/support/duplicate-test-helpers.ts
@@ -1,4 +1,5 @@
 import { expect, Locator, Page } from '@playwright/test';
+import * as Y from 'yjs';
 import {
   AddPageSelectors,
   BlockSelectors,
@@ -280,6 +281,83 @@ export function databaseBlocks(editor: Locator): Locator {
   return editor.locator(BlockSelectors.blockSelector('grid'));
 }
 
+async function getServerDocumentDatabaseBlockCount(
+  page: Page,
+  apiOrigin: string,
+  docViewId: string
+): Promise<number> {
+  const [, workspaceId] = new URL(page.url()).pathname.split('/').filter(Boolean);
+
+  if (!workspaceId) return -1;
+
+  const token = await page.evaluate(() => localStorage.getItem('af_auth_token'));
+
+  if (!token) return -1;
+
+  let encodedCollab: number[] | null = null;
+
+  try {
+    const url = new URL(`/api/workspace/${workspaceId}/page-view/${docViewId}`, apiOrigin);
+
+    url.searchParams.set('_t', Date.now().toString());
+    const response = await page.request.get(url.toString(), {
+      failOnStatusCode: false,
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Cache-Control': 'no-cache',
+      },
+    });
+
+    if (!response.ok()) return -1;
+
+    const payload = (await response.json()) as {
+      data?: { data?: { encoded_collab?: number[] } };
+    };
+
+    encodedCollab = payload.data?.data?.encoded_collab ?? null;
+  } catch {
+    return -1;
+  }
+
+  if (!encodedCollab) return -1;
+
+  const doc = new Y.Doc();
+
+  try {
+    Y.applyUpdate(doc, new Uint8Array(encodedCollab));
+    const document = doc.getMap('data').get('document') as Y.Map<unknown> | undefined;
+    const blocks = document?.get('blocks') as Y.Map<Y.Map<unknown>> | undefined;
+    let count = 0;
+
+    blocks?.forEach((block) => {
+      if (block.get('ty') === 'grid') {
+        count++;
+      }
+    });
+
+    return count;
+  } catch {
+    return -1;
+  } finally {
+    doc.destroy();
+  }
+}
+
+async function waitForDocumentDatabaseBlocksOnServer(
+  page: Page,
+  apiOrigin: string,
+  docViewId: string,
+  expectedCount: number
+): Promise<void> {
+  await expect
+    .poll(() => getServerDocumentDatabaseBlockCount(page, apiOrigin, docViewId), {
+      timeout: 30000,
+      intervals: [250, 500, 1000],
+      message: `Expected document ${docViewId} to persist ${expectedCount} database block(s) before duplication`,
+    })
+    .toBe(expectedCount);
+}
+
 async function focusEditorForSlash(page: Page, editor: Locator): Promise<void> {
   let slateEditor = editor.locator('[data-slate-editor="true"]').first();
 
@@ -462,7 +540,11 @@ export async function insertLinkedGridViaSlash(
           throw new Error(`Linked database view creation failed with HTTP ${response.status()}`);
         }
 
-        await expect(databaseBlocks(editor)).toHaveCount(initialBlockCount + 1, { timeout: 30000 });
+        const expectedBlockCount = initialBlockCount + 1;
+        const apiOrigin = new URL(response.url()).origin;
+
+        await expect(databaseBlocks(editor)).toHaveCount(expectedBlockCount, { timeout: 30000 });
+        await waitForDocumentDatabaseBlocksOnServer(page, apiOrigin, docViewId, expectedBlockCount);
         return;
       }
     } catch (e) {

--- a/src/application/services/js-services/http/__tests__/misc-api.test.ts
+++ b/src/application/services/js-services/http/__tests__/misc-api.test.ts
@@ -1,6 +1,6 @@
 import { executeAPIRequest, getAxios } from '@/application/services/js-services/http/core';
 
-import { generateSearchSummary } from '../misc-api';
+import { generateSearchSummary, searchWorkspaceDocumentPage } from '../misc-api';
 
 jest.mock('@/application/services/js-services/http/core', () => ({
   executeAPIRequest: jest.fn(),
@@ -41,5 +41,33 @@ describe('generateSearchSummary', () => {
     expect(payload).not.toHaveProperty('search_results');
     expect(payload).not.toHaveProperty('object_ids');
     expect(payload).not.toHaveProperty('retrieval_mode');
+  });
+});
+
+describe('searchWorkspaceDocumentPage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('forwards the caller stream id so keyword and summary retrieval stay isolated', async () => {
+    const get = jest.fn();
+
+    jest.mocked(getAxios).mockReturnValue({ get } as never);
+
+    await searchWorkspaceDocumentPage('workspace-id', 'show my tasks', 0, 'keyword-stream-id');
+
+    const request = jest.mocked(executeAPIRequest).mock.calls[0][0];
+
+    await request();
+
+    expect(get).toHaveBeenCalledWith(
+      '/api/search/workspace-id/page',
+      expect.objectContaining({
+        headers: {
+          'x-request-time': expect.any(String),
+          'x-request-stream-id': 'keyword-stream-id',
+        },
+      })
+    );
   });
 });

--- a/src/application/services/js-services/http/misc-api.ts
+++ b/src/application/services/js-services/http/misc-api.ts
@@ -55,8 +55,18 @@ export async function searchWorkspaceDocuments(workspaceId: string, query: strin
   );
 }
 
-export async function searchWorkspaceDocumentPage(workspaceId: string, query: string, offset = 0) {
+export async function searchWorkspaceDocumentPage(
+  workspaceId: string,
+  query: string,
+  offset = 0,
+  requestStreamId?: string
+) {
   const url = `/api/search/${workspaceId}/page`;
+  const headers: Record<string, string> = { 'x-request-time': Date.now().toString() };
+
+  if (requestStreamId) {
+    headers['x-request-stream-id'] = requestStreamId;
+  }
 
   return executeAPIRequest<SearchDocumentPageResponse>(() =>
     getAxios()?.get<APIResponse<SearchDocumentPageResponse>>(url, {
@@ -68,7 +78,7 @@ export async function searchWorkspaceDocumentPage(workspaceId: string, query: st
         mode: 'keyword',
         score: SEARCH_SCORE_THRESHOLD,
       },
-      headers: { 'x-request-time': Date.now().toString() },
+      headers,
     })
   );
 }

--- a/src/components/app/search/BestMatch.tsx
+++ b/src/components/app/search/BestMatch.tsx
@@ -120,6 +120,15 @@ function canLoadMoreSearchResults(page: SearchDocumentPageResponse, requestedOff
   return Boolean(page.has_more && typeof page.next_offset === 'number' && page.next_offset !== requestedOffset);
 }
 
+function createSearchStreamId(prefix: string): string {
+  const id =
+    typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function'
+      ? crypto.randomUUID()
+      : `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+
+  return `${prefix}:${id}`;
+}
+
 function BestMatch({
   onClose,
   searchValue,
@@ -145,6 +154,7 @@ function BestMatch({
   const aiEnabled = useAIEnabled();
   const currentWorkspaceId = useCurrentWorkspaceId();
   const searchSeqRef = useRef(0);
+  const [keywordSearchStreamId] = useState(() => createSearchStreamId('best-match-keyword'));
 
   const buildSearchItems = useCallback(
     async (results: SearchDocumentResponseItem[]) => {
@@ -219,7 +229,12 @@ function BestMatch({
         : null;
 
       try {
-        const page = await SearchService.searchWorkspaceDocumentPage(currentWorkspaceId, searchTerm, 0);
+        const page = await SearchService.searchWorkspaceDocumentPage(
+          currentWorkspaceId,
+          searchTerm,
+          0,
+          keywordSearchStreamId
+        );
 
         if (searchSeqRef.current !== searchSeq) return;
 
@@ -269,7 +284,7 @@ function BestMatch({
         }
       }
     },
-    [aiEnabled, buildSearchItems, currentWorkspaceId, outline]
+    [aiEnabled, buildSearchItems, currentWorkspaceId, keywordSearchStreamId, outline]
   );
 
   const handleLoadMore = useCallback(async () => {
@@ -280,7 +295,12 @@ function BestMatch({
     setLoadingMore(true);
 
     try {
-      const page = await SearchService.searchWorkspaceDocumentPage(currentWorkspaceId, searchValue, nextOffset);
+      const page = await SearchService.searchWorkspaceDocumentPage(
+        currentWorkspaceId,
+        searchValue,
+        nextOffset,
+        keywordSearchStreamId
+      );
 
       if (searchSeqRef.current !== searchSeq) return;
 
@@ -302,7 +322,17 @@ function BestMatch({
         setLoadingMore(false);
       }
     }
-  }, [buildSearchItems, currentWorkspaceId, hasMore, loading, loadingMore, nextOffset, searchResults, searchValue]);
+  }, [
+    buildSearchItems,
+    currentWorkspaceId,
+    hasMore,
+    keywordSearchStreamId,
+    loading,
+    loadingMore,
+    nextOffset,
+    searchResults,
+    searchValue,
+  ]);
 
   const debounceSearch = useMemo(() => {
     return debounce(handleSearch, 300);

--- a/src/components/app/search/__tests__/BestMatch.test.tsx
+++ b/src/components/app/search/__tests__/BestMatch.test.tsx
@@ -146,6 +146,14 @@ describe('BestMatch', () => {
     renderBestMatch('show my tasks');
 
     await waitFor(() => expect(mockGenerateSearchSummary).toHaveBeenCalledWith('workspace-id', 'show my tasks'));
+    await waitFor(() =>
+      expect(mockSearchWorkspaceDocumentPage).toHaveBeenCalledWith(
+        'workspace-id',
+        'show my tasks',
+        0,
+        expect.stringMatching(/^best-match-keyword:/)
+      )
+    );
     await waitFor(() => expect(mockGetMultipleViews).toHaveBeenCalledWith('workspace-id', ['row-id'], 0));
 
     expect(mockOverviewSources).toEqual([]);

--- a/src/components/database/components/database-row/DatabaseRowSubDocument.tsx
+++ b/src/components/database/components/database-row/DatabaseRowSubDocument.tsx
@@ -611,9 +611,22 @@ export const DatabaseRowSubDocument = memo(({ rowId }: { rowId: string }) => {
 
         retryLoadTimerRef.current = null;
 
-        // After max retries, create the document on the server. Do not initialize a local
-        // synced document here; the server doc_state is the source of the default structure.
-        if (!retryingEmptyDocument && retryCount >= MAX_RETRIES) {
+        if (retryCount >= MAX_RETRIES) {
+          // Empty documents already attempted server creation on every retry.
+          // Stop here so a permanently rejected row cannot keep issuing an
+          // orphan-creation request every two seconds while the modal is open.
+          if (retryingEmptyDocument) {
+            Log.warn('[DatabaseRowSubDocument] max retries reached; row document creation rejected', {
+              rowId,
+              documentId,
+              retryCount,
+            });
+            return;
+          }
+
+          // For non-empty documents, make one final create attempt after the
+          // bounded load retries. The server doc_state remains the only source
+          // of the default document structure.
           const localHasContent = await hasLocalDocContent(documentId);
 
           if (localHasContent) {
@@ -632,7 +645,11 @@ export const DatabaseRowSubDocument = memo(({ rowId }: { rowId: string }) => {
           const created = await handleCreateDocument(documentId, true);
 
           if (!created && !cancelled) {
-            scheduleRetry();
+            Log.warn('[DatabaseRowSubDocument] final row document creation attempt rejected', {
+              rowId,
+              documentId,
+              retryCount,
+            });
           }
 
           return;


### PR DESCRIPTION
## Summary

- Isolate paged keyword searches from AI overview retrieval with a stable request stream ID.
- Wait for linked database blocks to reach authoritative server collab state before duplication starts.
- Bound row-document creation retries when the server repeatedly rejects creation.

## Root cause

Parallel summary and keyword requests for the same query shared the backend's query-hash cancellation key. The linked-grid test helper observed only local editor state after the view-creation response, before the later document mutation was persisted. Empty row-document retries bypassed the existing maximum retry limit.

## Impact

This prevents search results from suppressing one another, duplicated documents from intermittently missing linked grids, and rejected row-document creation from generating unbounded traffic while leaving the skeleton visible.

## Validation

- `pnpm exec jest src/application/services/js-services/http/__tests__/misc-api.test.ts src/components/app/search/__tests__/BestMatch.test.tsx --runInBand --no-coverage` (8 tests passed)
- `pnpm type-check`
- Focused ESLint checks for the affected application and unit-test files
- `pnpm exec playwright test --list` (719 tests discovered)
- Targeted Playwright test discovery for both affected duplication specs
- `git diff --check`
- Live duplication E2Es were not run because the local API was unavailable

## Summary by Sourcery

Prevent search, duplication, and row-document workflows from interfering with each other by isolating keyword search streams, waiting for server-persisted linked database blocks, and bounding row-document creation retries.

New Features:
- Support a caller-provided request stream ID for paged workspace document search to isolate keyword queries from other retrieval flows.

Bug Fixes:
- Ensure linked database blocks are fully persisted on the server before starting duplication to avoid missing grids in duplicated documents.
- Stop empty row documents from issuing unbounded creation requests when the server repeatedly rejects them, and limit non-empty row document creation to a single final attempt.

Enhancements:
- Add Playwright helper utilities that read Yjs collab state from the server and poll for persisted database block counts in document views.
- Stabilize BestMatch keyword searches by generating a per-component stream ID and passing it through to paged search requests.

Tests:
- Extend HTTP misc-api tests to assert forwarding of the request stream ID header for paged search requests.
- Update BestMatch search tests to verify the presence and format of the keyword search stream identifier.