### PR TITLE
feat: render AI overview with Markdown editor

### DIFF
--- a/src/components/app/search/SearchAIOverview.tsx
+++ b/src/components/app/search/SearchAIOverview.tsx
@@ -1,5 +1,6 @@
+import { EditorProvider } from '@appflowyinc/editor';
 import Popover from '@mui/material/Popover';
-import { Fragment, useMemo, useState } from 'react';
+import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { View } from '@/application/types';
@@ -10,6 +11,7 @@ import { ReactComponent as ToolbarLinkIcon } from '@/assets/icons/m_toolbar_link
 import PageIcon from '@/components/_shared/view-icon/PageIcon';
 import type { AIChatRagSource } from '@/components/ai-chat/rag-scope';
 import { useToView } from '@/components/app/app.hooks';
+import { AnswerMd } from '@/components/chat/components/chat-messages/answer-md';
 import { cn } from '@/lib/utils';
 
 export interface SearchOverviewSource {
@@ -37,70 +39,43 @@ interface SearchAIOverviewProps {
   onClose: () => void;
 }
 
-function escapeRegExp(value: string) {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-}
-
-function HighlightedSummary({
+function MarkdownSummary({
   content,
-  highlights,
-  query,
   sources,
   onClose,
 }: {
   content: string;
-  highlights?: string;
-  query: string;
   sources: SearchOverviewSource[];
   onClose: () => void;
 }) {
   const { t } = useTranslation();
   const [expanded, setExpanded] = useState(false);
   const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
-  const highlightText = (highlights || query).trim();
   const isLong = content.length > 520;
-  const parts = useMemo(() => {
-    if (!highlightText) return [content];
-
-    return content.split(new RegExp(`(${escapeRegExp(highlightText)})`, 'ig'));
-  }, [content, highlightText]);
   const showReference = sources.length > 0 && (!isLong || expanded);
 
   return (
     <>
       <div
-        className='whitespace-pre-wrap break-words text-sm leading-[22px] text-text-primary'
-        style={
-          !expanded && isLong
-            ? {
-                display: '-webkit-box',
-                WebkitBoxOrient: 'vertical',
-                WebkitLineClamp: 5,
-                overflow: 'hidden',
-              }
-            : undefined
-        }
+        className={cn(
+          'break-words text-sm leading-[22px] text-text-primary',
+          !expanded && isLong && 'max-h-[110px] overflow-hidden'
+        )}
       >
-        {parts.map((part, index) =>
-          highlightText && part.toLowerCase() === highlightText.toLowerCase() ? (
-            <mark key={`${part}-${index}`} className='bg-fill-theme-select px-0.5 text-text-primary'>
-              {part}
-            </mark>
-          ) : (
-            <Fragment key={`${part}-${index}`}>{part}</Fragment>
-          )
-        )}
-        {showReference && (
-          <button
-            type='button'
-            aria-label={t('commandPalette.aiOverviewSource', { defaultValue: 'Reference sources' })}
-            className='ml-1 inline-flex h-[15px] w-[21px] items-center justify-center rounded-[6px] bg-secondary align-middle text-icon-primary hover:bg-secondary'
-            onClick={(event) => setAnchorEl(event.currentTarget)}
-          >
-            <ToolbarLinkIcon className='h-2.5 w-2.5' />
-          </button>
-        )}
+        <EditorProvider>
+          <AnswerMd mdContent={content} />
+        </EditorProvider>
       </div>
+      {showReference && (
+        <button
+          type='button'
+          aria-label={t('commandPalette.aiOverviewSource', { defaultValue: 'Reference sources' })}
+          className='mt-1 inline-flex h-[15px] w-[21px] items-center justify-center rounded-[6px] bg-secondary align-middle text-icon-primary hover:bg-secondary'
+          onClick={(event) => setAnchorEl(event.currentTarget)}
+        >
+          <ToolbarLinkIcon className='h-2.5 w-2.5' />
+        </button>
+      )}
       {isLong && !expanded && (
         <button
           type='button'
@@ -241,13 +216,7 @@ export function SearchAIOverview({
         <AISearchingIcon className='h-5 w-5 shrink-0' />
         <span>{t('commandPalette.aiOverview', { defaultValue: 'AI overview' })}</span>
       </div>
-      <HighlightedSummary
-        content={summary.content}
-        highlights={summary.highlights}
-        query={query}
-        sources={sources}
-        onClose={onClose}
-      />
+      <MarkdownSummary content={summary.content} sources={sources} onClose={onClose} />
       {canAskFollowUp && (
         <button
           type='button'

--- a/src/components/app/search/__tests__/SearchAIOverview.test.tsx
+++ b/src/components/app/search/__tests__/SearchAIOverview.test.tsx
@@ -2,6 +2,18 @@ import { fireEvent, render, screen } from '@testing-library/react';
 
 import { SearchAIOverview } from '@/components/app/search/SearchAIOverview';
 
+const mockAnswerMd = jest.fn(({ mdContent }: { mdContent: string }) => (
+  <div data-testid='ai-overview-markdown'>{mdContent}</div>
+));
+
+jest.mock('@appflowyinc/editor', () => ({
+  EditorProvider: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+jest.mock('@/components/chat/components/chat-messages/answer-md', () => ({
+  AnswerMd: (props: { mdContent: string }) => mockAnswerMd(props),
+}));
+
 jest.mock('react-i18next', () => ({
   useTranslation: () => ({ t: (_key: string, options?: { defaultValue?: string }) => options?.defaultValue || _key }),
 }));
@@ -16,6 +28,30 @@ jest.mock('@/components/_shared/view-icon/PageIcon', () => ({
 }));
 
 describe('SearchAIOverview', () => {
+  beforeEach(() => {
+    mockAnswerMd.mockClear();
+  });
+
+  it('renders the complete overview with the shared Markdown editor', () => {
+    render(
+      <SearchAIOverview
+        askingAI={false}
+        canAskFollowUp={false}
+        loading={false}
+        query='revenue'
+        summary={{ content: '# Revenue\n\n**Increased.**' }}
+        sources={[]}
+        onAskAI={jest.fn()}
+        onClose={jest.fn()}
+      />
+    );
+
+    expect(mockAnswerMd).toHaveBeenCalledWith({
+      mdContent: '# Revenue\n\n**Increased.**',
+    });
+    expect(screen.getByTestId('ai-overview-markdown')).toBeTruthy();
+  });
+
   it('passes the raw row RAG ID together with its database owner', () => {
     const onAskAI = jest.fn();
 

--- a/src/components/chat/components/chat-messages/answer-md.tsx
+++ b/src/components/chat/components/chat-messages/answer-md.tsx
@@ -1,17 +1,22 @@
-import { Editor, useEditor } from '@appflowyinc/editor';
+import { AppFlowyEditor, Editor, useEditor } from '@appflowyinc/editor';
 import { useEffect } from 'react';
 import { ErrorBoundary } from 'react-error-boundary';
 
 import { Alert, AlertDescription } from '@/components/chat/components/ui/alert';
 import { useEditorContext } from '@/components/chat/provider/editor-provider';
 
-export function AnswerMd({ mdContent, id }: { mdContent: string; id: number }) {
-  const editor = useEditor();
+function RegisterMessageEditor({ editor, id }: { editor: AppFlowyEditor; id: number }) {
   const { setEditor: setMessageEditor } = useEditorContext();
 
   useEffect(() => {
     setMessageEditor(id, editor);
   }, [editor, id, setMessageEditor]);
+
+  return null;
+}
+
+export function AnswerMd({ mdContent, id }: { mdContent: string; id?: number }) {
+  const editor = useEditor();
 
   useEffect(() => {
     if (!mdContent) return;
@@ -24,14 +29,17 @@ export function AnswerMd({ mdContent, id }: { mdContent: string; id: number }) {
   }, [editor, mdContent]);
 
   return (
-    <ErrorBoundary
-      fallback={
-        <Alert variant={'destructive'}>
-          <AlertDescription>Failed to render content</AlertDescription>
-        </Alert>
-      }
-    >
-      <Editor readOnly />
-    </ErrorBoundary>
+    <>
+      {id !== undefined && <RegisterMessageEditor editor={editor} id={id} />}
+      <ErrorBoundary
+        fallback={
+          <Alert variant={'destructive'}>
+            <AlertDescription>Failed to render content</AlertDescription>
+          </Alert>
+        }
+      >
+        <Editor readOnly />
+      </ErrorBoundary>
+    </>
   );
 }


### PR DESCRIPTION
## Summary

- render AI Overview content with the same read-only `AnswerMd` editor used by chat
- allow the shared renderer to skip chat editor registration when no message ID is supplied
- keep the overview non-streaming while preserving expansion, references, and follow-up actions
- add coverage for forwarding the complete Markdown summary to the editor

## Testing

- `pnpm type-check`
- `pnpm exec eslint --quiet src/components/app/search/SearchAIOverview.tsx src/components/chat/components/chat-messages/answer-md.tsx src/components/app/search/__tests__/SearchAIOverview.test.tsx`
- `pnpm exec jest src/components/app/search/__tests__/SearchAIOverview.test.tsx src/components/app/search/__tests__/BestMatch.test.tsx --runInBand --coverage=false`

## Summary by Sourcery

Render AI search overview content using the shared read-only Markdown editor used in chat while keeping existing expansion and reference behavior.

New Features:
- Support rendering AI overview summaries as Markdown via the shared AnswerMd editor component.

Enhancements:
- Allow the shared AnswerMd renderer to be used without registering a chat message editor when no message ID is provided.
- Simplify AI overview summary layout and reference button placement while preserving expand/collapse behavior.

Tests:
- Add unit coverage to verify the AI overview forwards its full Markdown summary into the shared editor and still handles RAG source metadata.