### PR TITLE
fix stale documents after websocket reconnect

### DIFF
--- a/src/application/services/js-services/sync-protocol.ts
+++ b/src/application/services/js-services/sync-protocol.ts
@@ -73,6 +73,52 @@ export enum UpdateFlags {
   Lib0v2 = 1,
 }
 
+/**
+ * Bind an existing sync context to the current realtime connection.
+ *
+ * The state-vector request starts a manifest exchange with the server. Unlike
+ * {@link initSync}, this function does not attach Y.Doc or awareness observers,
+ * so it is safe to call again whenever the WebSocket reopens.
+ */
+export const bindSyncContext = (ctx: SyncContext): void => {
+  const { doc, awareness, emit, collabType, lastMessageId } = ctx;
+
+  if (!doc) {
+    throw new Error('SyncContext must have a Y.Doc instance.');
+  }
+
+  Log.debug('[sync] binding context with manifest exchange', {
+    objectId: doc.guid,
+    collabType,
+    version: doc.version,
+  });
+  emit({
+    collabMessage: {
+      objectId: doc.guid,
+      collabType,
+      syncRequest: {
+        stateVector: Y.encodeStateVector(doc),
+        lastMessageId: lastMessageId || { timestamp: 0, counter: 0 },
+        version: doc.version,
+      },
+    },
+  });
+
+  if (awareness) {
+    const allClients = Array.from(awareness.getStates().keys());
+
+    emit({
+      collabMessage: {
+        objectId: doc.guid,
+        collabType,
+        awarenessUpdate: {
+          payload: awarenessProtocol.encodeAwarenessUpdate(awareness, allClients),
+        },
+      },
+    });
+  }
+};
+
 const handleSyncRequest = (ctx: SyncContext, message: collab.ISyncRequest): void => {
   const { doc, emit } = ctx;
   const stateVector = message.stateVector && message.stateVector.length > 0 ? message.stateVector : undefined;
@@ -176,7 +222,7 @@ const handleUpdate = (ctx: SyncContext, message: collab.IUpdate): void => {
  */
 export const initSync = (ctx: SyncContext) => {
   ctx.doc = ctx.doc || ctx.awareness?.doc;
-  const { doc, awareness, emit, collabType, lastMessageId } = ctx;
+  const { doc, awareness, emit, collabType } = ctx;
 
   if (!doc) {
     throw new Error('SyncContext must have a Y.Doc instance.');
@@ -231,20 +277,6 @@ export const initSync = (ctx: SyncContext) => {
   doc.on('update', onUpdate);
   doc.on('destroy', onDestroy);
 
-  // emit initial sync request to the server
-  Log.debug('[Version] initSync sending initial syncRequest: objectId=%s, version=%s', ctx.doc.guid, ctx.doc.version);
-  emit({
-    collabMessage: {
-      objectId: ctx.doc.guid,
-      collabType: ctx.collabType,
-      syncRequest: {
-        stateVector: Y.encodeStateVector(ctx.doc),
-        lastMessageId: lastMessageId || { timestamp: 0, counter: 0 },
-        version: ctx.doc.version,
-      },
-    },
-  });
-
   if (awareness) {
     onAwarenessChange = ({ added, updated, removed }: AwarenessEvent, _: string) => {
       const changedClients = added.concat(updated).concat(removed);
@@ -262,20 +294,11 @@ export const initSync = (ctx: SyncContext) => {
     };
 
     awareness.on('change', onAwarenessChange);
-
-    const allClients = Array.from(awareness.getStates().keys());
-
-    // emit initial awareness update with all the clients
-    emit({
-      collabMessage: {
-        objectId: ctx.doc.guid,
-        collabType: ctx.collabType,
-        awarenessUpdate: {
-          payload: awarenessProtocol.encodeAwarenessUpdate(awareness, allClients),
-        },
-      },
-    });
   }
+
+  // Attach observers once, then bind the document to the current connection.
+  // Reconnects call bindSyncContext directly to avoid duplicate observers.
+  bindSyncContext(ctx);
 
   // Build a single cleanup function that tears down all observers.
   // Note: we deliberately do NOT delete outbox records here — cleanup only

--- a/src/components/ws/__tests__/useSync.test.ts
+++ b/src/components/ws/__tests__/useSync.test.ts
@@ -12,7 +12,7 @@ import {
   collabIndexedDBExists,
 } from '@/application/db';
 import * as httpApi from '@/application/services/js-services/http/http_api';
-import { handleMessage } from '@/application/services/js-services/sync-protocol';
+import { handleMessage, type SyncContext } from '@/application/services/js-services/sync-protocol';
 import { Types, User, YDoc, YjsDatabaseKey, YjsEditorKey } from '@/application/types';
 import { Log } from '@/utils/log';
 import { useCurrentUserOptional } from '@/components/main/app.hooks';
@@ -256,6 +256,122 @@ const resetCommonMocks = () => {
   mockedCollabFullSyncBatch.mockReset();
   mockedRevertCollabVersion.mockReset();
 };
+
+describe('useSync reconnect binding', () => {
+  beforeEach(() => {
+    jest.useRealTimers();
+    resetCommonMocks();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('does not bind registered documents twice when the websocket opens for the first time', () => {
+    const ws = {
+      ...createWs(),
+      readyState: WebSocket.CONNECTING,
+    } as AppflowyWebSocketType;
+    const bc = createBroadcastChannel();
+    const doc = createDoc('03030303-0303-4303-8303-030303030303');
+    const { result, rerender, unmount } = renderHook(() =>
+      useSync(ws, bc, defaultEventEmitter, defaultWorkspaceId)
+    );
+    const sendMessage = ws.sendMessage as jest.Mock;
+    const postMessage = bc.postMessage as jest.Mock;
+
+    act(() => {
+      result.current.registerSyncContext({ doc, collabType: Types.Document });
+    });
+
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+    expect(postMessage).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      ws.readyState = WebSocket.OPEN;
+      rerender();
+    });
+
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+    expect(postMessage).toHaveBeenCalledTimes(1);
+
+    unmount();
+    doc.destroy();
+  });
+
+  it('starts a fresh manifest exchange for every registered document when the websocket reopens', () => {
+    const ws = {
+      ...createWs(),
+      readyState: WebSocket.OPEN,
+    } as AppflowyWebSocketType;
+    const bc = createBroadcastChannel();
+    const docA = createDoc('01010101-0101-4101-8101-010101010101');
+    const docB = createDoc('02020202-0202-4202-8202-020202020202');
+
+    docA.getMap('root').set('value', 'a');
+    docB.getMap('root').set('value', 'b');
+
+    const { result, rerender, unmount } = renderHook(() => useSync(ws, bc, defaultEventEmitter, defaultWorkspaceId));
+    let contextA: SyncContext | undefined;
+
+    act(() => {
+      contextA = result.current.registerSyncContext({ doc: docA, collabType: Types.Document });
+      result.current.registerSyncContext({ doc: docB, collabType: Types.DatabaseRow });
+    });
+
+    contextA!.lastMessageId = { timestamp: 42, counter: 7 };
+    const sendMessage = ws.sendMessage as jest.Mock;
+    const postMessage = bc.postMessage as jest.Mock;
+
+    sendMessage.mockClear();
+    postMessage.mockClear();
+
+    act(() => {
+      ws.readyState = WebSocket.CLOSED;
+      rerender();
+    });
+
+    expect(sendMessage).not.toHaveBeenCalled();
+
+    act(() => {
+      ws.readyState = WebSocket.OPEN;
+      rerender();
+    });
+
+    expect(sendMessage).toHaveBeenCalledTimes(2);
+    expect(postMessage).toHaveBeenCalledTimes(2);
+    expect(sendMessage.mock.calls.map(([message]) => message.collabMessage.objectId)).toEqual([docA.guid, docB.guid]);
+    expect(sendMessage.mock.calls[0][0]).toEqual({
+      collabMessage: {
+        objectId: docA.guid,
+        collabType: Types.Document,
+        syncRequest: {
+          stateVector: Y.encodeStateVector(docA),
+          lastMessageId: { timestamp: 42, counter: 7 },
+          version: docA.version,
+        },
+      },
+    });
+    expect(sendMessage.mock.calls[1][0]).toEqual({
+      collabMessage: {
+        objectId: docB.guid,
+        collabType: Types.DatabaseRow,
+        syncRequest: {
+          stateVector: Y.encodeStateVector(docB),
+          lastMessageId: { timestamp: 0, counter: 0 },
+          version: docB.version,
+        },
+      },
+    });
+
+    rerender();
+    expect(sendMessage).toHaveBeenCalledTimes(2);
+
+    unmount();
+    docA.destroy();
+    docB.destroy();
+  });
+});
 
 describe('useSync deferred cleanup', () => {
   beforeEach(() => {

--- a/src/components/ws/useSync.ts
+++ b/src/components/ws/useSync.ts
@@ -1,7 +1,8 @@
 import EventEmitter from 'events';
 
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 
+import { bindSyncContext } from '@/application/services/js-services/sync-protocol';
 import { useCurrentUserOptional } from '@/components/main/app.hooks';
 import { AppflowyWebSocketType } from '@/components/ws/useAppflowyWebSocket';
 import { BroadcastChannelType } from '@/components/ws/useBroadcastChannel';
@@ -13,6 +14,8 @@ import { useCollabVersionRevert } from './sync/useCollabVersionRevert';
 import { useSyncContextLifecycle } from './sync/useSyncContextLifecycle';
 import { useWorkspaceNotifications } from './sync/useWorkspaceNotifications';
 import { SyncContextType } from './sync/types';
+
+const WS_READY_STATE_OPEN = 1;
 
 // Re-export types so existing consumer import paths continue to work
 export type { RegisterSyncContext, SyncContextType } from './sync/types';
@@ -208,6 +211,29 @@ export const useSync = (
   // tear it down prematurely.
   const { registerSyncContext, unregisterSyncContext, scheduleDeferredCleanup } =
     useSyncContextLifecycle(refs, sendMessage, postMessage, notifyLocalEdit, notifyManifestSync);
+
+  // A reopened socket has no knowledge of messages this tab missed while it
+  // was disconnected. Re-bind every live document so the server and client
+  // exchange current state vectors and reconcile their manifests. This is not
+  // a full registration: existing observers and owner ref-counts stay intact.
+  const previousReadyStateRef = useRef(readyState);
+  const hasOpenedRef = useRef(readyState === WS_READY_STATE_OPEN);
+
+  useEffect(() => {
+    const previousReadyState = previousReadyStateRef.current;
+
+    previousReadyStateRef.current = readyState;
+    if (readyState !== WS_READY_STATE_OPEN || previousReadyState === WS_READY_STATE_OPEN) return;
+
+    if (!hasOpenedRef.current) {
+      // initSync already emitted the initial bind, which the transport queues
+      // while connecting. Only later OPEN transitions need another bind.
+      hasOpenedRef.current = true;
+      return;
+    }
+
+    refs.registeredContexts.current.forEach((context) => bindSyncContext(context));
+  }, [readyState, refs]);
 
   // ── Incoming collab messages ─────────────────────────────────────────
   // Watches wsCollabMessage / bcCollabMessage and routes them through a per-objectId


### PR DESCRIPTION
## Summary

- extract the document bind handshake from `initSync` so existing sync contexts can safely reuse it
- rebind every registered document when the realtime transport reopens, triggering a fresh state-vector and manifest exchange
- skip the first socket open because `initSync` has already queued the initial bind
- add regression coverage for both first-open deduplication and reconnect rebinding

## Root cause

Sync contexts remain registered while the websocket reconnects, but their initial bind handshake previously ran only when `initSync` attached the document observers. A replacement socket therefore had no manifest/state-vector exchange for documents that were already open, leaving those documents stale until they were reopened.

## Impact

Open documents now reconcile edits missed during a websocket outage as soon as the existing transport reconnects. The change does not add or alter websocket reconnect behavior, and it does not reattach document or awareness observers.

## Validation

- `pnpm exec jest src/components/ws/__tests__/useSync.test.ts --runInBand --coverage=false` (38 tests)
- `pnpm lint`
- `git diff --check`

## Summary by Sourcery

Ensure open collaborative documents resync their state when the websocket transport reconnects, without duplicating initial bindings or observers.

New Features:
- Add reconnect binding logic that rebinds all registered sync contexts when the websocket transitions back to open.

Enhancements:
- Extract a reusable bindSyncContext helper from the initial sync handshake so existing contexts can safely bind to new realtime connections.

Tests:
- Add regression tests verifying initial websocket opens only bind documents once and reconnects trigger fresh manifest exchanges for all registered documents.