### PR TITLE
fix row document initial load

### DIFF
--- a/src/application/__tests__/view-loader.test.ts
+++ b/src/application/__tests__/view-loader.test.ts
@@ -2,10 +2,11 @@ import { expect } from '@jest/globals';
 import * as Y from 'yjs';
 
 import { openCollabDB, openCollabDBWithProvider } from '@/application/db';
+import { getOrCreateRowSubDoc } from '@/application/services/js-services/cache';
 import { fetchPageCollab } from '@/application/services/js-services/fetch';
 import { enqueueOutboxUpdate } from '@/application/sync-outbox';
 import { Types, ViewLayout, YDoc, YjsDatabaseKey, YjsEditorKey } from '@/application/types';
-import { getDatabaseIdFromDoc, openView } from '@/application/view-loader';
+import { getDatabaseIdFromDoc, openRowSubDocument, openView } from '@/application/view-loader';
 
 jest.mock('@/application/db', () => ({
   openCollabDB: jest.fn(),
@@ -31,6 +32,7 @@ jest.mock('@/application/sync-outbox', () => ({
 
 const mockOpenCollabDB = openCollabDB as jest.MockedFunction<typeof openCollabDB>;
 const mockOpenCollabDBWithProvider = openCollabDBWithProvider as jest.MockedFunction<typeof openCollabDBWithProvider>;
+const mockGetOrCreateRowSubDoc = getOrCreateRowSubDoc as jest.MockedFunction<typeof getOrCreateRowSubDoc>;
 const mockFetchPageCollab = fetchPageCollab as jest.MockedFunction<typeof fetchPageCollab>;
 const mockEnqueueOutboxUpdate = enqueueOutboxUpdate as jest.MockedFunction<typeof enqueueOutboxUpdate>;
 
@@ -154,5 +156,47 @@ describe('view-loader database cache identity', () => {
     expect(result.doc).toBe(canonicalDoc);
     expect(result.fromCache).toBe(true);
     expect(getDatabaseIdFromDoc(canonicalDoc)).toBe(databaseId);
+  });
+});
+
+describe('view-loader row document retry policy', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('keeps the default retry budget for a row document that may still be created', async () => {
+    const documentId = '00000000-0000-4000-8000-000000000007';
+    const doc = createEmptyDoc(documentId);
+
+    mockGetOrCreateRowSubDoc.mockResolvedValue(doc);
+    mockFetchPageCollab.mockRejectedValue(new Error('row document is not ready'));
+
+    const resultPromise = openRowSubDocument('workspace-id', documentId);
+
+    await jest.runAllTimersAsync();
+
+    const result = await resultPromise;
+
+    expect(result.doc).toBe(doc);
+    expect(mockFetchPageCollab).toHaveBeenCalledTimes(6);
+  });
+
+  it('honors a one-attempt limit when existence was already confirmed', async () => {
+    const documentId = '00000000-0000-4000-8000-000000000008';
+    const doc = createEmptyDoc(documentId);
+
+    mockGetOrCreateRowSubDoc.mockResolvedValue(doc);
+    mockFetchPageCollab.mockRejectedValue(new Error('page view is not registered yet'));
+
+    const result = await openRowSubDocument('workspace-id', documentId, { maxAttempts: 1 });
+
+    expect(result.doc).toBe(doc);
+    expect(mockFetchPageCollab).toHaveBeenCalledTimes(1);
+    expect(jest.getTimerCount()).toBe(0);
   });
 });

--- a/src/application/database-yjs/context.ts
+++ b/src/application/database-yjs/context.ts
@@ -13,6 +13,7 @@ import {
   GenerateAISummaryRowPayload,
   GenerateAITranslateRowPayload,
   LoadDatabasePrompts,
+  LoadRowDocument,
   LoadView,
   LoadViewMeta,
   RowId,
@@ -79,7 +80,7 @@ export interface DatabaseContextState {
    * In app mode: loads from server via authenticated API.
    * In publish mode: loads from published cache.
    */
-  loadRowDocument?: (documentId: string) => Promise<YDoc | null>;
+  loadRowDocument?: LoadRowDocument;
   /**
    * Create a row document on the server (orphaned view).
    * Only available in app mode - not provided in publish mode.

--- a/src/application/publish/context.tsx
+++ b/src/application/publish/context.tsx
@@ -11,7 +11,17 @@ import {
   createDocumentYjsRenderDocFromSnapshot,
 } from '@/application/publish-snapshot/document-yjs-render-bridge';
 import type { PublishedDocumentRaw, PublishedPageSnapshot, PublishedView } from '@/application/publish-snapshot/types';
-import { AppendBreadcrumb, CreateRow, LoadView, LoadViewMeta, View, ViewInfo, ViewLayout, YDoc } from '@/application/types';
+import {
+  AppendBreadcrumb,
+  CreateRow,
+  LoadRowDocument,
+  LoadView,
+  LoadViewMeta,
+  View,
+  ViewInfo,
+  ViewLayout,
+  YDoc,
+} from '@/application/types';
 import { notify } from '@/components/_shared/notify';
 import { findAncestors, findView } from '@/components/_shared/outline/utils';
 import { PublishService, RowService } from '@/application/services/domains';
@@ -102,7 +112,7 @@ export interface PublishContextType {
   loadViewMeta: LoadViewMeta;
   createRow?: CreateRow;
   loadView: LoadView;
-  loadRowDocument?: (documentId: string) => Promise<YDoc | null>;
+  loadRowDocument?: LoadRowDocument;
   outline?: View[];
   appendBreadcrumb?: AppendBreadcrumb;
   breadcrumbs: View[];

--- a/src/application/types.ts
+++ b/src/application/types.ts
@@ -1018,6 +1018,12 @@ export type LoadView = (
   options?: LoadViewOptions
 ) => Promise<YDoc>;
 
+export interface LoadRowDocumentOptions {
+  maxAttempts?: number;
+}
+
+export type LoadRowDocument = (documentId: string, options?: LoadRowDocumentOptions) => Promise<YDoc | null>;
+
 export type LoadViewMeta = (viewId: string, onChange?: (meta: View | null) => void) => Promise<View | null>;
 
 export type DatabaseRelations = Record<DatabaseId, ViewId>;
@@ -1408,7 +1414,7 @@ export interface ViewComponentProps {
    * In app mode: loads from server via authenticated API.
    * In publish mode: loads from published cache.
    */
-  loadRowDocument?: (documentId: string) => Promise<YDoc | null>;
+  loadRowDocument?: LoadRowDocument;
   /**
    * Create a row document on the server (orphaned view).
    * Only available in app mode - not provided in publish mode.

--- a/src/application/view-loader/index.ts
+++ b/src/application/view-loader/index.ts
@@ -14,7 +14,15 @@ import { openCollabDB, openCollabDBWithProvider } from '@/application/db';
 import { getOrCreateRowSubDoc, hasCollabCache } from '@/application/services/js-services/cache';
 import { fetchPageCollab } from '@/application/services/js-services/fetch';
 import { enqueueOutboxUpdate } from '@/application/sync-outbox';
-import { Types, ViewLayout, YDoc, YjsDatabaseKey, YjsEditorKey, YSharedRoot } from '@/application/types';
+import {
+  LoadRowDocumentOptions,
+  Types,
+  ViewLayout,
+  YDoc,
+  YjsDatabaseKey,
+  YjsEditorKey,
+  YSharedRoot,
+} from '@/application/types';
 import { applyYDoc } from '@/application/ydoc/apply';
 import { Log } from '@/utils/log';
 import * as Y from 'yjs';
@@ -33,6 +41,8 @@ export interface OpenViewOptions {
   databaseId?: string | null;
   forceFetch?: boolean;
 }
+
+const DEFAULT_ROW_DOCUMENT_MAX_ATTEMPTS = 6;
 
 // ============================================================================
 // Layout to CollabType Mapping
@@ -370,8 +380,13 @@ export function getDatabaseIdFromDoc(doc: YDoc): string | null {
  *
  * @param workspaceId - The workspace ID
  * @param documentId - The row sub-document ID
+ * @param options - Controls the bounded server fetch attempts
  */
-export async function openRowSubDocument(workspaceId: string, documentId: string): Promise<ViewLoaderResult> {
+export async function openRowSubDocument(
+  workspaceId: string,
+  documentId: string,
+  options: LoadRowDocumentOptions = {}
+): Promise<ViewLoaderResult> {
   const startedAt = Date.now();
 
   Log.debug('[ViewLoader] openRowSubDocument start', { workspaceId, documentId });
@@ -426,10 +441,10 @@ export async function openRowSubDocument(workspaceId: string, documentId: string
   // Retry with backoff — the server-side worker may need a moment to create
   // the document after a row duplication.
   if (!fromCache) {
-    const MAX_RETRIES = 6;
+    const maxAttempts = Math.max(1, Math.floor(options.maxAttempts ?? DEFAULT_ROW_DOCUMENT_MAX_ATTEMPTS));
     let fetched = false;
 
-    for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
+    for (let attempt = 1; attempt <= maxAttempts; attempt++) {
       try {
         await fetchAndApply(workspaceId, documentId, doc);
         fetched = true;
@@ -438,11 +453,11 @@ export async function openRowSubDocument(workspaceId: string, documentId: string
         Log.debug('[ViewLoader] rowSubDoc fetch failed', {
           documentId,
           attempt,
-          maxRetries: MAX_RETRIES,
+          maxAttempts,
           error: e instanceof Error ? e.message : String(e),
         });
 
-        if (attempt < MAX_RETRIES) {
+        if (attempt < maxAttempts) {
           await new Promise((resolve) => setTimeout(resolve, 1000 * attempt));
         }
       }

--- a/src/components/app/contexts/AppOperationsContext.ts
+++ b/src/components/app/contexts/AppOperationsContext.ts
@@ -16,6 +16,7 @@ import {
   GenerateAISummaryRowPayload,
   GenerateAITranslateRowPayload,
   LoadDatabasePrompts,
+  LoadRowDocument,
   LoadView,
   LoadViewMeta,
   RowDocumentSourcePayload,
@@ -129,7 +130,7 @@ export interface AppOperationsContextType {
   /** Check whether a row document exists (for inline row detail). */
   checkIfRowDocumentExists?: (documentId: string) => Promise<boolean>;
   /** Load an existing row document. */
-  loadRowDocument?: (documentId: string) => Promise<YDoc | null>;
+  loadRowDocument?: LoadRowDocument;
   /** Create a new row document (returns encoded initial state). */
   createRowDocument?: (documentId: string, source?: RowDocumentSourcePayload) => Promise<Uint8Array | null>;
   /** Fire-and-forget: ask the server to duplicate the row document with inline DB deep copy. */

--- a/src/components/app/hooks/useDatabaseOperations.ts
+++ b/src/components/app/hooks/useDatabaseOperations.ts
@@ -11,6 +11,7 @@ import {
   DatabasePromptRow,
   GenerateAISummaryRowPayload,
   GenerateAITranslateRowPayload,
+  LoadRowDocumentOptions,
   RowDocumentSourcePayload,
   Types,
   YDatabase,
@@ -297,14 +298,14 @@ export function useDatabaseOperations(
 
   // Load a row sub-document (document content inside a database row)
   const loadRowDocument = useCallback(
-    async (documentId: string): Promise<YDoc | null> => {
+    async (documentId: string, options?: LoadRowDocumentOptions): Promise<YDoc | null> => {
       if (!currentWorkspaceId) {
         Log.warn('[loadRowDocument] workspaceId not available');
         return null;
       }
 
       try {
-        const { doc } = await openRowSubDocument(currentWorkspaceId, documentId);
+        const { doc } = await openRowSubDocument(currentWorkspaceId, documentId, options);
 
         // Set metadata for sync binding
         const docWithMeta = doc as YDoc & {

--- a/src/components/database/Database.tsx
+++ b/src/components/database/Database.tsx
@@ -24,6 +24,7 @@ import {
   DatabaseRelations,
   GenerateAISummaryRowPayload,
   GenerateAITranslateRowPayload,
+  LoadRowDocument,
   LoadView,
   LoadViewMeta,
   RowId,
@@ -70,7 +71,7 @@ export interface Database2Props {
    * In app mode: loads from server via authenticated API.
    * In publish mode: loads from published cache.
    */
-  loadRowDocument?: (documentId: string) => Promise<YDoc | null>;
+  loadRowDocument?: LoadRowDocument;
   /**
    * Create a row document on the server (orphaned view).
    * Only available in app mode - not provided in publish mode.

--- a/src/components/database/components/database-row/DatabaseRowSubDocument.tsx
+++ b/src/components/database/components/database-row/DatabaseRowSubDocument.tsx
@@ -19,6 +19,7 @@ import { dataStringTOJson } from '@/application/slate-yjs/utils/yjs';
 import {
   BlockType,
   CollabOrigin,
+  LoadRowDocumentOptions,
   Types,
   YDatabaseCell,
   YDatabaseField,
@@ -264,7 +265,7 @@ export const DatabaseRowSubDocument = memo(({ rowId }: { rowId: string }) => {
   );
 
   const handleOpenDocument = useCallback(
-    async (documentId: string): Promise<boolean> => {
+    async (documentId: string, options?: LoadRowDocumentOptions): Promise<boolean> => {
       Log.debug('[DatabaseRowSubDocument] handleOpenDocument start', { rowId, documentId });
       setLoading(true);
       try {
@@ -276,7 +277,7 @@ export const DatabaseRowSubDocument = memo(({ rowId }: { rowId: string }) => {
           return false;
         }
 
-        const doc = await loadRowDocument(documentId);
+        const doc = await loadRowDocument(documentId, options);
 
         if (!doc) {
           Log.debug('[DatabaseRowSubDocument] loadRowDocument returned null', { documentId });
@@ -747,22 +748,22 @@ export const DatabaseRowSubDocument = memo(({ rowId }: { rowId: string }) => {
             return;
           }
 
-          const success = await handleOpenDocument(documentId);
+          // A positive existence check means the collab object is already
+          // present. Do one read attempt, then repair its row-document
+          // registration and open the returned state instead of waiting
+          // through the duplication-oriented backoff loop.
+          const success = await handleOpenDocument(documentId, { maxAttempts: 1 });
 
           if (!success) {
-            if (createRowDocument) {
-              try {
-                Log.debug('[DatabaseRowSubDocument] createRowDocument after load failure', {
-                  rowId,
-                  documentId,
-                });
-                await createRowDocument(documentId, rowDocumentSource);
-              } catch {
-                // Ignore; we'll retry loading below.
-              }
-            }
+            Log.debug('[DatabaseRowSubDocument] repairing row document after load failure', {
+              rowId,
+              documentId,
+            });
+            const repaired = await handleCreateDocument(documentId, true);
 
-            scheduleRetry();
+            if (!repaired && !cancelled) {
+              scheduleRetry();
+            }
           }
 
           return;
@@ -795,8 +796,6 @@ export const DatabaseRowSubDocument = memo(({ rowId }: { rowId: string }) => {
     checkIfRowDocumentExists,
     isDocumentEmptyResolved,
     hasLocalDocContent,
-    createRowDocument,
-    rowDocumentSource,
     rowId,
     doc,
   ]);

--- a/src/components/database/components/database-row/DatabaseRowSubDocument.tsx
+++ b/src/components/database/components/database-row/DatabaseRowSubDocument.tsx
@@ -43,6 +43,11 @@ type ContentNode = {
   data?: Record<string, unknown>;
 };
 
+type IsCurrentRowDocumentRequest = () => boolean;
+
+const ALWAYS_CURRENT_ROW_DOCUMENT_REQUEST = () => true;
+const CONFIRMED_ROW_DOCUMENT_LOAD_OPTIONS: LoadRowDocumentOptions = { maxAttempts: 1 };
+
 function hasNonEmptyString(value: unknown) {
   return typeof value === 'string' && value.length > 0;
 }
@@ -199,6 +204,7 @@ export const DatabaseRowSubDocument = memo(({ rowId }: { rowId: string }) => {
   const [doc, setDoc] = useState<YDoc | null>(null);
   const retryLoadTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const ensureDocRetryTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const loadRequestGenerationRef = useRef(0);
 
   const document = doc?.getMap(YjsEditorKey.data_section)?.get(YjsEditorKey.document);
   // undefined = meta hasn't loaded from Yjs yet (wait)
@@ -265,7 +271,13 @@ export const DatabaseRowSubDocument = memo(({ rowId }: { rowId: string }) => {
   );
 
   const handleOpenDocument = useCallback(
-    async (documentId: string, options?: LoadRowDocumentOptions): Promise<boolean> => {
+    async (
+      documentId: string,
+      options?: LoadRowDocumentOptions,
+      isCurrent: IsCurrentRowDocumentRequest = ALWAYS_CURRENT_ROW_DOCUMENT_REQUEST
+    ): Promise<boolean> => {
+      if (!isCurrent()) return false;
+
       Log.debug('[DatabaseRowSubDocument] handleOpenDocument start', { rowId, documentId });
       setLoading(true);
       try {
@@ -278,6 +290,8 @@ export const DatabaseRowSubDocument = memo(({ rowId }: { rowId: string }) => {
         }
 
         const doc = await loadRowDocument(documentId, options);
+
+        if (!isCurrent()) return false;
 
         if (!doc) {
           Log.debug('[DatabaseRowSubDocument] loadRowDocument returned null', { documentId });
@@ -326,6 +340,8 @@ export const DatabaseRowSubDocument = memo(({ rowId }: { rowId: string }) => {
           return false;
         }
 
+        if (!isCurrent()) return false;
+
         setDoc(doc);
         docReadyRef.current = true;
         rowDocEnsuredRef.current = true; // Document exists on server since we loaded it successfully
@@ -336,15 +352,21 @@ export const DatabaseRowSubDocument = memo(({ rowId }: { rowId: string }) => {
         });
         return false;
       } finally {
-        setLoading(false);
+        if (isCurrent()) {
+          setLoading(false);
+        }
       }
     },
     [loadRowDocument, rowId]
   );
   // Open document with server-provided doc_state (Y.js update)
   const openDocumentWithState = useCallback(
-    async (documentId: string, docState: Uint8Array): Promise<boolean> => {
-      if (!documentId) return false;
+    async (
+      documentId: string,
+      docState: Uint8Array,
+      isCurrent: IsCurrentRowDocumentRequest = ALWAYS_CURRENT_ROW_DOCUMENT_REQUEST
+    ): Promise<boolean> => {
+      if (!documentId || !isCurrent()) return false;
       try {
         docReadyRef.current = false;
         setDoc(null);
@@ -360,6 +382,8 @@ export const DatabaseRowSubDocument = memo(({ rowId }: { rowId: string }) => {
 
         // Use cached doc to preserve sync state across reopens
         const doc = await getOrCreateRowSubDoc(documentId);
+
+        if (!isCurrent()) return false;
 
         // Apply the server's doc_state to initialize the document
         // This ensures the document structure matches what the server created
@@ -378,6 +402,8 @@ export const DatabaseRowSubDocument = memo(({ rowId }: { rowId: string }) => {
           });
           return false;
         }
+
+        if (!isCurrent()) return false;
 
         // Store metadata for sync binding
         const docWithMeta = doc as YDocWithMeta;
@@ -406,8 +432,12 @@ export const DatabaseRowSubDocument = memo(({ rowId }: { rowId: string }) => {
   );
 
   const handleCreateDocument = useCallback(
-    async (documentId: string, requireServerReady: boolean = false): Promise<boolean> => {
-      if (!documentId) return false;
+    async (
+      documentId: string,
+      requireServerReady: boolean = false,
+      isCurrent: IsCurrentRowDocumentRequest = ALWAYS_CURRENT_ROW_DOCUMENT_REQUEST
+    ): Promise<boolean> => {
+      if (!documentId || !isCurrent()) return false;
       setLoading(true);
       let docState: Uint8Array | null = null;
 
@@ -422,6 +452,8 @@ export const DatabaseRowSubDocument = memo(({ rowId }: { rowId: string }) => {
         setDoc(null);
 
         const localHasContent = await hasLocalDocContent(documentId);
+
+        if (!isCurrent()) return false;
 
         if (localHasContent) {
           Log.debug('[DatabaseRowSubDocument] local doc has content; creating server collab before binding', {
@@ -446,6 +478,8 @@ export const DatabaseRowSubDocument = memo(({ rowId }: { rowId: string }) => {
           return false;
         }
 
+        if (!isCurrent()) return false;
+
         // createRowDocument swallows API errors and returns null (e.g. the server
         // hasn't persisted a freshly created row yet). Treat that as a failure so
         // the caller schedules a retry instead of binding to a structureless doc.
@@ -463,7 +497,7 @@ export const DatabaseRowSubDocument = memo(({ rowId }: { rowId: string }) => {
 
         // Use the server-created doc_state as the only source of default document structure.
         if (docState && docState.length > 0) {
-          const success = await openDocumentWithState(documentId, docState);
+          const success = await openDocumentWithState(documentId, docState, isCurrent);
 
           if (success) {
             return true;
@@ -476,7 +510,7 @@ export const DatabaseRowSubDocument = memo(({ rowId }: { rowId: string }) => {
         }
 
         if (loadRowDocument) {
-          const loaded = await handleOpenDocument(documentId);
+          const loaded = await handleOpenDocument(documentId, undefined, isCurrent);
 
           if (loaded) {
             return true;
@@ -488,7 +522,9 @@ export const DatabaseRowSubDocument = memo(({ rowId }: { rowId: string }) => {
         });
         return false;
       } finally {
-        setLoading(false);
+        if (isCurrent()) {
+          setLoading(false);
+        }
       }
     },
     [
@@ -566,6 +602,8 @@ export const DatabaseRowSubDocument = memo(({ rowId }: { rowId: string }) => {
     rowDocEnsuredRef.current = false;
 
     let cancelled = false;
+    const requestGeneration = ++loadRequestGenerationRef.current;
+    const isCurrentRequest = () => !cancelled && loadRequestGenerationRef.current === requestGeneration;
     let retryCount = 0;
     const MAX_RETRIES = 3;
 
@@ -576,10 +614,10 @@ export const DatabaseRowSubDocument = memo(({ rowId }: { rowId: string }) => {
       }
     };
 
-    const scheduleRetry = () => {
+    const scheduleRetry = (loadOptions?: LoadRowDocumentOptions) => {
       if (retryLoadTimerRef.current) return;
       retryLoadTimerRef.current = setTimeout(async () => {
-        if (cancelled) return;
+        if (!isCurrentRequest()) return;
 
         // If doc is already loaded (e.g., by handleCreateDocument), skip retry
         // This prevents resetting the editor mid-typing
@@ -603,10 +641,10 @@ export const DatabaseRowSubDocument = memo(({ rowId }: { rowId: string }) => {
         // had another chance to complete.
         const retryingEmptyDocument = isDocumentEmptyResolved === true;
         const retried = retryingEmptyDocument
-          ? await handleCreateDocument(documentId, false)
-          : await handleOpenDocument(documentId);
+          ? await handleCreateDocument(documentId, false, isCurrentRequest)
+          : await handleOpenDocument(documentId, loadOptions, isCurrentRequest);
 
-        if (retried || cancelled) {
+        if (retried || !isCurrentRequest()) {
           return;
         }
 
@@ -630,6 +668,8 @@ export const DatabaseRowSubDocument = memo(({ rowId }: { rowId: string }) => {
           // of the default document structure.
           const localHasContent = await hasLocalDocContent(documentId);
 
+          if (!isCurrentRequest()) return;
+
           if (localHasContent) {
             Log.debug('[DatabaseRowSubDocument] max retries reached; local content found, creating server doc before binding', {
               rowId,
@@ -643,9 +683,9 @@ export const DatabaseRowSubDocument = memo(({ rowId }: { rowId: string }) => {
             documentId,
             retryCount,
           });
-          const created = await handleCreateDocument(documentId, true);
+          const created = await handleCreateDocument(documentId, true, isCurrentRequest);
 
-          if (!created && !cancelled) {
+          if (!created && isCurrentRequest()) {
             Log.warn('[DatabaseRowSubDocument] final row document creation attempt rejected', {
               rowId,
               documentId,
@@ -656,7 +696,7 @@ export const DatabaseRowSubDocument = memo(({ rowId }: { rowId: string }) => {
           return;
         }
 
-        scheduleRetry();
+        scheduleRetry(loadOptions);
       }, 2000); // Reduced from 5000ms to 2000ms for faster response
     };
 
@@ -698,9 +738,9 @@ export const DatabaseRowSubDocument = memo(({ rowId }: { rowId: string }) => {
           rowId,
           documentId,
         });
-        const created = await handleCreateDocument(documentId, false);
+        const created = await handleCreateDocument(documentId, false, isCurrentRequest);
 
-        if (!created && !cancelled) {
+        if (!created && isCurrentRequest()) {
           scheduleRetry();
         }
 
@@ -712,6 +752,8 @@ export const DatabaseRowSubDocument = memo(({ rowId }: { rowId: string }) => {
       if (!checkIfRowDocumentExists) {
         const localHasContent = await hasLocalDocContent(documentId);
 
+        if (!isCurrentRequest()) return;
+
         if (localHasContent) {
           Log.debug('[DatabaseRowSubDocument] doc not found; local content found, creating server doc before binding', {
             rowId,
@@ -720,9 +762,9 @@ export const DatabaseRowSubDocument = memo(({ rowId }: { rowId: string }) => {
         }
 
         void (async () => {
-          const created = await handleCreateDocument(documentId, true);
+          const created = await handleCreateDocument(documentId, true, isCurrentRequest);
 
-          if (!created && !cancelled) {
+          if (!created && isCurrentRequest()) {
             scheduleRetry();
           }
         })();
@@ -732,6 +774,8 @@ export const DatabaseRowSubDocument = memo(({ rowId }: { rowId: string }) => {
 
       try {
         const exists = await checkIfRowDocumentExists(documentId);
+
+        if (!isCurrentRequest()) return;
 
         Log.debug('[DatabaseRowSubDocument] checkIfRowDocumentExists', {
           rowId,
@@ -752,17 +796,17 @@ export const DatabaseRowSubDocument = memo(({ rowId }: { rowId: string }) => {
           // present. Do one read attempt, then repair its row-document
           // registration and open the returned state instead of waiting
           // through the duplication-oriented backoff loop.
-          const success = await handleOpenDocument(documentId, { maxAttempts: 1 });
+          const success = await handleOpenDocument(documentId, CONFIRMED_ROW_DOCUMENT_LOAD_OPTIONS, isCurrentRequest);
 
-          if (!success) {
+          if (!success && isCurrentRequest()) {
             Log.debug('[DatabaseRowSubDocument] repairing row document after load failure', {
               rowId,
               documentId,
             });
-            const repaired = await handleCreateDocument(documentId, true);
+            const repaired = await handleCreateDocument(documentId, true, isCurrentRequest);
 
-            if (!repaired && !cancelled) {
-              scheduleRetry();
+            if (!repaired && isCurrentRequest()) {
+              scheduleRetry(CONFIRMED_ROW_DOCUMENT_LOAD_OPTIONS);
             }
           }
 
@@ -777,6 +821,8 @@ export const DatabaseRowSubDocument = memo(({ rowId }: { rowId: string }) => {
         // Retry a few times in case of race condition, will create after max retries
         scheduleRetry();
       } catch (e) {
+        if (!isCurrentRequest()) return;
+
         Log.debug('[DatabaseRowSubDocument] checkIfRowDocumentExists failed; will retry', {
           rowId,
           documentId,

--- a/src/components/database/components/database-row/__tests__/DatabaseRowSubDocument.test.tsx
+++ b/src/components/database/components/database-row/__tests__/DatabaseRowSubDocument.test.tsx
@@ -1,0 +1,138 @@
+import { render, screen } from '@testing-library/react';
+import * as Y from 'yjs';
+
+import {
+  useDatabase,
+  useDatabaseContextOptional,
+  useRowData,
+  useRowMetaSelector,
+} from '@/application/database-yjs';
+import { useUpdateRowMetaDispatch } from '@/application/database-yjs/dispatch';
+import { openCollabDB } from '@/application/db';
+import { getCachedRowSubDoc, getOrCreateRowSubDoc } from '@/application/services/js-services/cache';
+import { YDatabase, YDatabaseRow, YDoc, YjsDatabaseKey, YjsEditorKey } from '@/application/types';
+import { useCurrentWorkspaceIdOptional } from '@/components/app/app.hooks';
+import { useCurrentUserOptional } from '@/components/main/app.hooks';
+
+import { DatabaseRowSubDocument } from '../DatabaseRowSubDocument';
+
+jest.mock('@/application/database-yjs', () => ({
+  ...jest.requireActual('@/application/database-yjs'),
+  useDatabase: jest.fn(),
+  useDatabaseContextOptional: jest.fn(),
+  useRowData: jest.fn(),
+  useRowMetaSelector: jest.fn(),
+}));
+
+jest.mock('@/application/database-yjs/dispatch', () => ({
+  useUpdateRowMetaDispatch: jest.fn(),
+}));
+
+jest.mock('@/application/db', () => ({
+  openCollabDB: jest.fn(),
+}));
+
+jest.mock('@/application/services/js-services/cache', () => ({
+  getCachedRowSubDoc: jest.fn(),
+  getOrCreateRowSubDoc: jest.fn(),
+  trackRowDocEnsure: jest.fn(),
+}));
+
+jest.mock('@/components/app/app.hooks', () => ({
+  useCurrentWorkspaceIdOptional: jest.fn(),
+}));
+
+jest.mock('@/components/main/app.hooks', () => ({
+  useCurrentUserOptional: jest.fn(),
+}));
+
+jest.mock('@/components/_shared/skeleton/EditorSkeleton', () => ({
+  EditorSkeleton: () => <div data-testid="editor-skeleton" />,
+}));
+
+jest.mock('@/components/editor', () => ({
+  Editor: () => <div data-testid="row-document-editor" />,
+}));
+
+const mockUseDatabase = useDatabase as jest.MockedFunction<typeof useDatabase>;
+const mockUseDatabaseContextOptional = useDatabaseContextOptional as jest.MockedFunction<
+  typeof useDatabaseContextOptional
+>;
+const mockUseRowData = useRowData as jest.MockedFunction<typeof useRowData>;
+const mockUseRowMetaSelector = useRowMetaSelector as jest.MockedFunction<typeof useRowMetaSelector>;
+const mockUseUpdateRowMetaDispatch = useUpdateRowMetaDispatch as jest.MockedFunction<
+  typeof useUpdateRowMetaDispatch
+>;
+const mockOpenCollabDB = openCollabDB as jest.MockedFunction<typeof openCollabDB>;
+const mockGetCachedRowSubDoc = getCachedRowSubDoc as jest.MockedFunction<typeof getCachedRowSubDoc>;
+const mockGetOrCreateRowSubDoc = getOrCreateRowSubDoc as jest.MockedFunction<typeof getOrCreateRowSubDoc>;
+const mockUseCurrentWorkspaceIdOptional = useCurrentWorkspaceIdOptional as jest.MockedFunction<
+  typeof useCurrentWorkspaceIdOptional
+>;
+const mockUseCurrentUserOptional = useCurrentUserOptional as jest.MockedFunction<typeof useCurrentUserOptional>;
+
+function createRowDocumentState(documentId: string) {
+  const doc = new Y.Doc({ guid: documentId });
+  const root = doc.getMap(YjsEditorKey.data_section);
+
+  root.set(YjsEditorKey.document, new Y.Map());
+  return Y.encodeStateAsUpdate(doc);
+}
+
+describe('DatabaseRowSubDocument', () => {
+  it('repairs and opens an existing row document immediately after one failed page fetch', async () => {
+    const rowId = 'row-id';
+    const documentId = 'document-id';
+    const databaseDoc = new Y.Doc({ guid: 'database-id' }) as YDoc;
+    const database = databaseDoc.getMap('database') as YDatabase;
+    const fields = new Y.Map();
+    const rowDoc = new Y.Doc({ guid: rowId });
+    const row = rowDoc.getMap('row') as YDatabaseRow;
+    const cachedDoc = new Y.Doc({ guid: documentId }) as YDoc;
+    const loadRowDocument = jest.fn().mockResolvedValue(cachedDoc);
+    const createRowDocument = jest.fn().mockResolvedValue(createRowDocumentState(documentId));
+    const checkIfRowDocumentExists = jest.fn().mockResolvedValue(true);
+
+    database.set(YjsDatabaseKey.id, 'database-id');
+    database.set(YjsDatabaseKey.fields, fields);
+    row.set(YjsDatabaseKey.cells, new Y.Map());
+
+    mockUseDatabase.mockReturnValue(database);
+    mockUseRowData.mockReturnValue(row);
+    mockUseRowMetaSelector.mockReturnValue({
+      documentId,
+      isEmptyDocument: false,
+    });
+    mockUseUpdateRowMetaDispatch.mockReturnValue(jest.fn());
+    mockUseCurrentWorkspaceIdOptional.mockReturnValue('workspace-id');
+    mockUseCurrentUserOptional.mockReturnValue(undefined);
+    mockGetCachedRowSubDoc.mockReturnValue(cachedDoc);
+    mockGetOrCreateRowSubDoc.mockResolvedValue(cachedDoc);
+    mockOpenCollabDB.mockResolvedValue(cachedDoc);
+    mockUseDatabaseContextOptional.mockReturnValue({
+      activeViewId: 'database-view-id',
+      databaseDoc,
+      databasePageId: 'database-page-id',
+      loadRowDocument,
+      createRowDocument,
+      checkIfRowDocumentExists,
+      readOnly: false,
+      rowMap: null,
+      workspaceId: 'workspace-id',
+    });
+
+    render(<DatabaseRowSubDocument rowId={rowId} />);
+
+    expect(await screen.findByTestId('row-document-editor')).not.toBeNull();
+    expect(screen.queryByTestId('editor-skeleton')).toBeNull();
+    expect(checkIfRowDocumentExists).toHaveBeenCalledTimes(1);
+    expect(loadRowDocument).toHaveBeenCalledWith(documentId, { maxAttempts: 1 });
+    expect(loadRowDocument).toHaveBeenCalledTimes(1);
+    expect(createRowDocument).toHaveBeenCalledWith(documentId, {
+      database_id: 'database-id',
+      database_view_id: 'database-view-id',
+      row_id: rowId,
+    });
+    expect(createRowDocument).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/database/components/database-row/__tests__/DatabaseRowSubDocument.test.tsx
+++ b/src/components/database/components/database-row/__tests__/DatabaseRowSubDocument.test.tsx
@@ -1,12 +1,7 @@
-import { render, screen } from '@testing-library/react';
+import { act, render, screen, waitFor } from '@testing-library/react';
 import * as Y from 'yjs';
 
-import {
-  useDatabase,
-  useDatabaseContextOptional,
-  useRowData,
-  useRowMetaSelector,
-} from '@/application/database-yjs';
+import { useDatabase, useDatabaseContextOptional, useRowData, useRowMetaSelector } from '@/application/database-yjs';
 import { useUpdateRowMetaDispatch } from '@/application/database-yjs/dispatch';
 import { openCollabDB } from '@/application/db';
 import { getCachedRowSubDoc, getOrCreateRowSubDoc } from '@/application/services/js-services/cache';
@@ -47,11 +42,13 @@ jest.mock('@/components/main/app.hooks', () => ({
 }));
 
 jest.mock('@/components/_shared/skeleton/EditorSkeleton', () => ({
-  EditorSkeleton: () => <div data-testid="editor-skeleton" />,
+  EditorSkeleton: () => <div data-testid='editor-skeleton' />,
 }));
 
 jest.mock('@/components/editor', () => ({
-  Editor: () => <div data-testid="row-document-editor" />,
+  Editor: ({ viewId, doc }: { viewId: string; doc: { guid: string } }) => (
+    <div data-testid='row-document-editor' data-view-id={viewId} data-doc-id={doc.guid} />
+  ),
 }));
 
 const mockUseDatabase = useDatabase as jest.MockedFunction<typeof useDatabase>;
@@ -60,9 +57,7 @@ const mockUseDatabaseContextOptional = useDatabaseContextOptional as jest.Mocked
 >;
 const mockUseRowData = useRowData as jest.MockedFunction<typeof useRowData>;
 const mockUseRowMetaSelector = useRowMetaSelector as jest.MockedFunction<typeof useRowMetaSelector>;
-const mockUseUpdateRowMetaDispatch = useUpdateRowMetaDispatch as jest.MockedFunction<
-  typeof useUpdateRowMetaDispatch
->;
+const mockUseUpdateRowMetaDispatch = useUpdateRowMetaDispatch as jest.MockedFunction<typeof useUpdateRowMetaDispatch>;
 const mockOpenCollabDB = openCollabDB as jest.MockedFunction<typeof openCollabDB>;
 const mockGetCachedRowSubDoc = getCachedRowSubDoc as jest.MockedFunction<typeof getCachedRowSubDoc>;
 const mockGetOrCreateRowSubDoc = getOrCreateRowSubDoc as jest.MockedFunction<typeof getOrCreateRowSubDoc>;
@@ -79,46 +74,108 @@ function createRowDocumentState(documentId: string) {
   return Y.encodeStateAsUpdate(doc);
 }
 
+function createDeferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+
+  return { promise, resolve };
+}
+
+async function flushAsyncWork() {
+  for (let index = 0; index < 10; index++) {
+    await Promise.resolve();
+  }
+}
+
+function configureRowDocumentTest({
+  documentIds,
+  cachedDocs,
+  loadRowDocument,
+  createRowDocument,
+  checkIfRowDocumentExists,
+}: {
+  documentIds: Record<string, string>;
+  cachedDocs: Map<string, YDoc>;
+  loadRowDocument: jest.Mock;
+  createRowDocument: jest.Mock;
+  checkIfRowDocumentExists: jest.Mock;
+}) {
+  const databaseDoc = new Y.Doc({ guid: 'database-id' }) as YDoc;
+  const database = databaseDoc.getMap('database') as YDatabase;
+  const fields = new Y.Map();
+  const rows = new Map<string, YDatabaseRow>();
+
+  database.set(YjsDatabaseKey.id, 'database-id');
+  database.set(YjsDatabaseKey.fields, fields);
+
+  for (const rowId of Object.keys(documentIds)) {
+    const rowDoc = new Y.Doc({ guid: rowId });
+    const row = rowDoc.getMap('row') as YDatabaseRow;
+
+    row.set(YjsDatabaseKey.cells, new Y.Map());
+    rows.set(rowId, row);
+  }
+
+  mockUseDatabase.mockReturnValue(database);
+  mockUseRowData.mockImplementation((rowId) => rows.get(rowId));
+  mockUseRowMetaSelector.mockImplementation((rowId) => ({
+    documentId: documentIds[rowId],
+    isEmptyDocument: false,
+  }));
+  mockUseUpdateRowMetaDispatch.mockReturnValue(jest.fn());
+  mockUseCurrentWorkspaceIdOptional.mockReturnValue('workspace-id');
+  mockUseCurrentUserOptional.mockReturnValue(undefined);
+  mockGetCachedRowSubDoc.mockImplementation((documentId) => cachedDocs.get(documentId));
+  mockGetOrCreateRowSubDoc.mockImplementation(async (documentId) => {
+    const doc = cachedDocs.get(documentId);
+
+    if (!doc) throw new Error(`Missing cached document ${documentId}`);
+    return doc;
+  });
+  mockOpenCollabDB.mockImplementation(async (documentId) => {
+    const doc = cachedDocs.get(documentId);
+
+    if (!doc) throw new Error(`Missing cached document ${documentId}`);
+    return doc;
+  });
+  mockUseDatabaseContextOptional.mockReturnValue({
+    activeViewId: 'database-view-id',
+    databaseDoc,
+    databasePageId: 'database-page-id',
+    loadRowDocument,
+    createRowDocument,
+    checkIfRowDocumentExists,
+    readOnly: false,
+    rowMap: null,
+    workspaceId: 'workspace-id',
+  });
+}
+
 describe('DatabaseRowSubDocument', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
   it('repairs and opens an existing row document immediately after one failed page fetch', async () => {
     const rowId = 'row-id';
     const documentId = 'document-id';
-    const databaseDoc = new Y.Doc({ guid: 'database-id' }) as YDoc;
-    const database = databaseDoc.getMap('database') as YDatabase;
-    const fields = new Y.Map();
-    const rowDoc = new Y.Doc({ guid: rowId });
-    const row = rowDoc.getMap('row') as YDatabaseRow;
     const cachedDoc = new Y.Doc({ guid: documentId }) as YDoc;
     const loadRowDocument = jest.fn().mockResolvedValue(cachedDoc);
     const createRowDocument = jest.fn().mockResolvedValue(createRowDocumentState(documentId));
     const checkIfRowDocumentExists = jest.fn().mockResolvedValue(true);
 
-    database.set(YjsDatabaseKey.id, 'database-id');
-    database.set(YjsDatabaseKey.fields, fields);
-    row.set(YjsDatabaseKey.cells, new Y.Map());
-
-    mockUseDatabase.mockReturnValue(database);
-    mockUseRowData.mockReturnValue(row);
-    mockUseRowMetaSelector.mockReturnValue({
-      documentId,
-      isEmptyDocument: false,
-    });
-    mockUseUpdateRowMetaDispatch.mockReturnValue(jest.fn());
-    mockUseCurrentWorkspaceIdOptional.mockReturnValue('workspace-id');
-    mockUseCurrentUserOptional.mockReturnValue(undefined);
-    mockGetCachedRowSubDoc.mockReturnValue(cachedDoc);
-    mockGetOrCreateRowSubDoc.mockResolvedValue(cachedDoc);
-    mockOpenCollabDB.mockResolvedValue(cachedDoc);
-    mockUseDatabaseContextOptional.mockReturnValue({
-      activeViewId: 'database-view-id',
-      databaseDoc,
-      databasePageId: 'database-page-id',
+    configureRowDocumentTest({
+      documentIds: { [rowId]: documentId },
+      cachedDocs: new Map([[documentId, cachedDoc]]),
       loadRowDocument,
       createRowDocument,
       checkIfRowDocumentExists,
-      readOnly: false,
-      rowMap: null,
-      workspaceId: 'workspace-id',
     });
 
     render(<DatabaseRowSubDocument rowId={rowId} />);
@@ -134,5 +191,94 @@ describe('DatabaseRowSubDocument', () => {
       row_id: rowId,
     });
     expect(createRowDocument).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps the one-attempt load policy when repair fails and a retry is scheduled', async () => {
+    jest.useFakeTimers();
+
+    const rowId = 'row-id';
+    const documentId = 'document-id';
+    const cachedDoc = new Y.Doc({ guid: documentId }) as YDoc;
+    const loadRowDocument = jest.fn().mockResolvedValue(cachedDoc);
+    const createRowDocument = jest.fn().mockResolvedValue(null);
+    const checkIfRowDocumentExists = jest.fn().mockResolvedValue(true);
+
+    configureRowDocumentTest({
+      documentIds: { [rowId]: documentId },
+      cachedDocs: new Map([[documentId, cachedDoc]]),
+      loadRowDocument,
+      createRowDocument,
+      checkIfRowDocumentExists,
+    });
+
+    render(<DatabaseRowSubDocument rowId={rowId} />);
+
+    await act(flushAsyncWork);
+
+    expect(loadRowDocument).toHaveBeenNthCalledWith(1, documentId, { maxAttempts: 1 });
+    expect(createRowDocument).toHaveBeenCalledTimes(1);
+    expect(jest.getTimerCount()).toBe(1);
+
+    await act(async () => {
+      await jest.advanceTimersByTimeAsync(2000);
+      await flushAsyncWork();
+    });
+
+    expect(loadRowDocument).toHaveBeenNthCalledWith(2, documentId, { maxAttempts: 1 });
+  });
+
+  it('ignores a stale repair response after switching rows', async () => {
+    const firstRowId = 'row-a';
+    const secondRowId = 'row-b';
+    const firstDocumentId = 'document-a';
+    const secondDocumentId = 'document-b';
+    const firstCachedDoc = new Y.Doc({ guid: firstDocumentId }) as YDoc;
+    const secondCachedDoc = new Y.Doc({ guid: secondDocumentId }) as YDoc;
+    const cachedDocs = new Map([
+      [firstDocumentId, firstCachedDoc],
+      [secondDocumentId, secondCachedDoc],
+    ]);
+    const firstRepair = createDeferred<Uint8Array | null>();
+    const loadRowDocument = jest.fn((documentId: string) => Promise.resolve(cachedDocs.get(documentId) ?? null));
+    const createRowDocument = jest.fn((documentId: string) => {
+      if (documentId === firstDocumentId) return firstRepair.promise;
+      return Promise.resolve(createRowDocumentState(documentId));
+    });
+    const checkIfRowDocumentExists = jest.fn().mockResolvedValue(true);
+
+    configureRowDocumentTest({
+      documentIds: {
+        [firstRowId]: firstDocumentId,
+        [secondRowId]: secondDocumentId,
+      },
+      cachedDocs,
+      loadRowDocument,
+      createRowDocument,
+      checkIfRowDocumentExists,
+    });
+
+    const { rerender } = render(<DatabaseRowSubDocument rowId={firstRowId} />);
+
+    await waitFor(() => expect(createRowDocument).toHaveBeenCalledWith(firstDocumentId, expect.any(Object)));
+
+    rerender(<DatabaseRowSubDocument rowId={secondRowId} />);
+
+    await waitFor(() => {
+      const editor = screen.getByTestId('row-document-editor');
+
+      expect(editor.getAttribute('data-view-id')).toBe(secondDocumentId);
+      expect(editor.getAttribute('data-doc-id')).toBe(secondDocumentId);
+    });
+
+    await act(async () => {
+      firstRepair.resolve(createRowDocumentState(firstDocumentId));
+      await flushAsyncWork();
+    });
+
+    const editor = screen.getByTestId('row-document-editor');
+
+    expect(editor.getAttribute('data-view-id')).toBe(secondDocumentId);
+    expect(editor.getAttribute('data-doc-id')).toBe(secondDocumentId);
+    expect(firstCachedDoc.getMap(YjsEditorKey.data_section).has(YjsEditorKey.document)).toBe(false);
   });
 });

--- a/src/components/editor/EditorContext.tsx
+++ b/src/components/editor/EditorContext.tsx
@@ -20,6 +20,7 @@ import {
   DuplicatePageOperationOptions,
   TextCount,
   LoadDatabasePrompts,
+  LoadRowDocument,
   TestDatabasePromptConfig,
   Subscription,
   MentionablePerson,
@@ -76,7 +77,7 @@ export interface EditorContextState {
   navigateToView?: (viewId: string, blockOrRowId?: string) => Promise<void>;
   loadViewMeta?: LoadViewMeta;
   loadView?: LoadView;
-  loadRowDocument?: (documentId: string) => Promise<YDoc | null>;
+  loadRowDocument?: LoadRowDocument;
   checkIfRowDocumentExists?: (documentId: string) => Promise<boolean>;
   createRowDocument?: (documentId: string, source?: RowDocumentSourcePayload) => Promise<Uint8Array | null>;
   createRow?: CreateRow;

--- a/src/components/publish/DatabaseView.tsx
+++ b/src/components/publish/DatabaseView.tsx
@@ -7,6 +7,7 @@ import { resolveActiveDatabaseViewId } from '@/application/view-utils';
 import type {
   AppendBreadcrumb,
   CreateRow,
+  LoadRowDocument,
   LoadView,
   LoadViewMeta,
   RowId,
@@ -35,7 +36,7 @@ export interface DatabaseProps {
   /**
    * Load a row sub-document from published cache.
    */
-  loadRowDocument?: (documentId: string) => Promise<YDoc | null>;
+  loadRowDocument?: LoadRowDocument;
   navigateToView?: (viewId: string, blockId?: string) => Promise<void>;
   loadViewMeta?: LoadViewMeta;
   viewMeta: ViewMetaProps;


### PR DESCRIPTION
## What changed

- Add a configurable attempt limit to the row-document loader.
- After `collab-exists` confirms the document exists, make one `page-view` attempt and then immediately use the idempotent row-document repair/create flow.
- Apply the repair endpoint's returned Yjs document state immediately so the editor can render without a refresh.
- Preserve the existing six-attempt retry budget for row documents that may genuinely still be created by the duplication worker.
- Add loader-level and component-level regression tests.

## Why

A Desktop-created row document can exist as a collab before its row-page registration is ready. Web sees `collab-exists = true`, but the `page-view` request can still return an application-level failure inside an HTTP 200 response. The existing loader retried six times with incremental backoff, and the row component added another retry layer. This kept the editor on its skeleton until a refresh occurred after the backend became ready.

## Impact

Existing row pages now make one read attempt after existence is confirmed. If that read is not usable, Web repairs the row-document registration and opens the returned state immediately. Delayed duplication behavior retains its longer retry budget.

## Validation

- `pnpm jest src/components/database/components/database-row/__tests__/DatabaseRowSubDocument.test.tsx src/application/__tests__/view-loader.test.ts --runInBand --no-coverage --silent`
- `pnpm type-check`
- ESLint on all changed TypeScript files
- `git diff --check`

## Summary by Sourcery

Tighten row sub-document loading so confirmed row documents make a single bounded read attempt before falling back to an immediate repair-and-open flow, while preserving the existing longer retry behavior for documents that may still be created asynchronously.

Enhancements:
- Introduce configurable row-document load options with a max-attempts budget and propagate them through view-loader and database operations.
- Guard row sub-document load, create, and repair flows against stale requests when switching rows to avoid applying outdated states.

Tests:
- Add view-loader tests to verify row document fetch retries respect configurable attempt limits and preserve the legacy six-attempt behavior for unconfirmed documents.
- Add DatabaseRowSubDocument component tests covering immediate repair on failed loads, retry scheduling with one-attempt policy, and ignoring stale repair results after row changes.