### PR TITLE
fix excessive database open requests

### DIFF
--- a/src/application/database-blob/__tests__/prefetch-dedup.test.ts
+++ b/src/application/database-blob/__tests__/prefetch-dedup.test.ts
@@ -1,0 +1,111 @@
+import { prefetchDatabaseBlobDiff, clearDatabaseRowDocSeedCache } from '@/application/database-blob';
+import { databaseBlobDiff } from '@/application/services/js-services/http/http_api';
+import { database_blob } from '@/proto/database_blob';
+
+jest.mock('@/application/db', () => ({
+  getCachedProviderDoc: jest.fn(),
+  openCollabDBWithProvider: jest.fn(),
+  openRowCollabDBWithProvider: jest.fn(),
+}));
+
+jest.mock('@/application/services/js-services/cache', () => ({
+  getCachedRowDoc: jest.fn(),
+}));
+
+jest.mock('@/application/services/js-services/http/http_api', () => ({
+  databaseBlobDiff: jest.fn(),
+}));
+
+jest.mock('@/utils/log', () => ({
+  Log: {
+    debug: jest.fn(),
+    warn: jest.fn(),
+  },
+}));
+
+const mockedDatabaseBlobDiff = databaseBlobDiff as jest.MockedFunction<typeof databaseBlobDiff>;
+const databaseIds = new Set<string>();
+
+function createDeferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((promiseResolve) => {
+    resolve = promiseResolve;
+  });
+
+  return { promise, resolve };
+}
+
+function readyDiff() {
+  return database_blob.DatabaseBlobDiffResponse.create({
+    status: database_blob.DiffStatus.READY,
+    creates: [],
+    updates: [],
+    deletes: [],
+  });
+}
+
+describe('database blob prefetch deduplication', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    databaseIds.forEach(clearDatabaseRowDocSeedCache);
+    databaseIds.clear();
+  });
+
+  it('reuses an in-flight cold delta request for a concurrent full prefetch', async () => {
+    const workspaceId = 'workspace-cold';
+    const databaseId = 'database-cold';
+    const deferred = createDeferred<database_blob.DatabaseBlobDiffResponse>();
+    const deltaSeedsReady = jest.fn();
+    const fullSeedsReady = jest.fn();
+
+    databaseIds.add(databaseId);
+    mockedDatabaseBlobDiff.mockReturnValueOnce(deferred.promise);
+
+    const deltaPrefetch = prefetchDatabaseBlobDiff(workspaceId, databaseId, {
+      onSeedsReady: deltaSeedsReady,
+    });
+    const fullPrefetch = prefetchDatabaseBlobDiff(workspaceId, databaseId, {
+      forceFullSync: true,
+      onSeedsReady: fullSeedsReady,
+    });
+
+    deferred.resolve(readyDiff());
+    await Promise.all([deltaPrefetch, fullPrefetch]);
+
+    expect(mockedDatabaseBlobDiff).toHaveBeenCalledTimes(1);
+    expect(mockedDatabaseBlobDiff.mock.calls[0][2].maxKnownRid).toBeNull();
+    expect(deltaSeedsReady).toHaveBeenCalledTimes(1);
+    expect(fullSeedsReady).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps an incremental delta separate from a full prefetch', async () => {
+    const workspaceId = 'workspace-incremental';
+    const databaseId = 'database-incremental';
+    const deltaDeferred = createDeferred<database_blob.DatabaseBlobDiffResponse>();
+    const fullDeferred = createDeferred<database_blob.DatabaseBlobDiffResponse>();
+
+    databaseIds.add(databaseId);
+    localStorage.setItem(`af_database_blob_rid:${databaseId}`, JSON.stringify({ timestamp: 1_721_800_000, seqNo: 7 }));
+    mockedDatabaseBlobDiff.mockReturnValueOnce(deltaDeferred.promise).mockReturnValueOnce(fullDeferred.promise);
+
+    const deltaPrefetch = prefetchDatabaseBlobDiff(workspaceId, databaseId);
+    const fullPrefetch = prefetchDatabaseBlobDiff(workspaceId, databaseId, {
+      forceFullSync: true,
+    });
+
+    deltaDeferred.resolve(readyDiff());
+    fullDeferred.resolve(readyDiff());
+    await Promise.all([deltaPrefetch, fullPrefetch]);
+
+    expect(mockedDatabaseBlobDiff).toHaveBeenCalledTimes(2);
+    expect(mockedDatabaseBlobDiff.mock.calls[0][2].maxKnownRid).toMatchObject({
+      timestamp: 1_721_800_000,
+      seqNo: 7,
+    });
+    expect(mockedDatabaseBlobDiff.mock.calls[1][2].maxKnownRid).toBeNull();
+  });
+});

--- a/src/application/database-blob/index.ts
+++ b/src/application/database-blob/index.ts
@@ -39,6 +39,7 @@ type SharedPrefetchEntry = {
   priorityRowIds: Set<string>;
   onSeedsReadyCallbacks: Set<() => void>;
   seedsReady: boolean;
+  coversFullSnapshot: boolean;
   reuseSettled?: boolean;
   settled?: boolean;
   clearWhenSettled?: boolean;
@@ -76,6 +77,30 @@ function fullSharedPrefetchKey(workspaceId: string, databaseId: string) {
 
 function sharedPrefetchKeyForOptions(workspaceId: string, databaseId: string, options?: PrefetchOptions) {
   return options?.forceFullSync ? fullSharedPrefetchKey(workspaceId, databaseId) : sharedPrefetchKey(workspaceId, databaseId);
+}
+
+function findSharedPrefetchEntry(
+  workspaceId: string,
+  databaseId: string,
+  options?: PrefetchOptions
+): { sharedKey: string; entry?: SharedPrefetchEntry } {
+  const requestedKey = sharedPrefetchKeyForOptions(workspaceId, databaseId, options);
+  const requestedEntry = sharedPrefetchEntries.get(requestedKey);
+
+  if (requestedEntry || !options?.forceFullSync) {
+    return { sharedKey: requestedKey, entry: requestedEntry };
+  }
+
+  // A cold delta request has no RID and therefore already asks the server for
+  // the complete snapshot. A later filtered/sorted view can reuse that work.
+  const deltaKey = sharedPrefetchKey(workspaceId, databaseId);
+  const deltaEntry = sharedPrefetchEntries.get(deltaKey);
+
+  if (deltaEntry?.coversFullSnapshot) {
+    return { sharedKey: deltaKey, entry: deltaEntry };
+  }
+
+  return { sharedKey: requestedKey };
 }
 
 function sharedPrefetchEntryMatchesDatabase(sharedKey: string, databaseId: string) {
@@ -830,12 +855,13 @@ async function persistDiffToIndexedDB(
 async function fetchReadyDiff(
   workspaceId: string,
   databaseId: string,
-  options?: {
+  options: {
+    cachedRid: DatabaseBlobRowRid | null;
     forceFullSync?: boolean;
     onPendingDiff?: (diff: database_blob.DatabaseBlobDiffResponse, attempt: number) => void;
   }
 ): Promise<FetchDiffResult> {
-  const cachedRid = options?.forceFullSync ? null : readCachedRid(databaseId);
+  const cachedRid = options.cachedRid;
   const request = database_blob.DatabaseBlobDiffRequest.create({
     maxKnownRid: cachedRid ? { timestamp: cachedRid.timestamp, seqNo: cachedRid.seqNo } : undefined,
     version: 1,
@@ -908,8 +934,7 @@ export async function prefetchDatabaseBlobDiff(
   databaseId: string,
   options?: PrefetchOptions
 ) {
-  const sharedKey = sharedPrefetchKeyForOptions(workspaceId, databaseId, options);
-  const existingEntry = sharedPrefetchEntries.get(sharedKey);
+  const { sharedKey, entry: existingEntry } = findSharedPrefetchEntry(workspaceId, databaseId, options);
 
   if (existingEntry?.promise) {
     const canReuseSettledFullSeed = Boolean(options?.forceFullSync && existingEntry.settled && existingEntry.seedsReady);
@@ -931,10 +956,12 @@ export async function prefetchDatabaseBlobDiff(
     sharedPrefetchEntries.delete(sharedKey);
   }
 
+  const cachedRid = options?.forceFullSync ? null : readCachedRid(databaseId);
   const entry: SharedPrefetchEntry = {
     priorityRowIds: new Set(),
     onSeedsReadyCallbacks: new Set(),
     seedsReady: false,
+    coversFullSnapshot: cachedRid === null,
   };
 
   applyPrefetchOptions(entry, options);
@@ -978,6 +1005,7 @@ export async function prefetchDatabaseBlobDiff(
 
   const promise = (async () => {
     const { diff, ready } = await fetchReadyDiff(workspaceId, databaseId, {
+      cachedRid,
       forceFullSync: options?.forceFullSync,
       onPendingDiff: handlePendingDiff,
     });

--- a/src/components/database/Database.tsx
+++ b/src/components/database/Database.tsx
@@ -425,7 +425,7 @@ function Database(props: Database2Props) {
         try {
           const rowDoc = await openRowDoc(rowKey, seed ?? undefined);
 
-          return { rowId, rowKey, rowDoc };
+          return { rowId, rowDoc };
         } catch {
           return null;
         }
@@ -433,25 +433,19 @@ function Database(props: Database2Props) {
     )
       .then((results) => {
         const newEntries: Record<string, YDoc> = {};
-        const syncKeys: string[] = [];
 
         for (const result of results) {
           if (result?.rowDoc && !rowMapRef.current[result.rowId]) {
             newEntries[result.rowId] = result.rowDoc;
-            syncKeys.push(result.rowKey);
           }
         }
 
         const count = Object.keys(newEntries).length;
 
         if (count > 0) {
-          // Single setState to add all preloaded rows at once
+          // Keep seed-only rows local. ensureRow attaches realtime only when a
+          // row is actually rendered, preserving the viewport boundary.
           setRowMap((prev) => ({ ...prev, ...newEntries }));
-
-          // Defer sync binding — rows are hydrated from seeds, sync can wait
-          requestAnimationFrame(() => {
-            syncKeys.forEach((rowKey) => registerRowSync(rowKey));
-          });
         }
 
         // Open the gate — ensureRow calls can now proceed
@@ -462,7 +456,7 @@ function Database(props: Database2Props) {
         // otherwise ensureRow calls would be permanently blocked.
         gate.resolve();
       });
-  }, [getDatabaseId, getPriorityRowIds, registerRowSync]);
+  }, [getDatabaseId, getPriorityRowIds]);
 
   const ensureBlobPrefetch = useCallback(() => {
     // Skip blob prefetch in read-only mode (publish view)


### PR DESCRIPTION
## Summary

- keep blob-seeded database rows local until they enter the rendered viewport instead of immediately binding the whole preload batch to realtime
- reuse an in-flight cold delta blob request when a filtered or sorted view subsequently asks for the same full snapshot
- preserve separate requests when the delta has a cached RID and is genuinely incremental
- add focused regression coverage for both prefetch cases

## Root cause

Opening a filtered database could first start a delta blob prefetch and then start a forced full prefetch after the view conditions became available. With no cached RID, both requests asked for the same full snapshot but were stored under separate deduplication keys. The seed preloader then attached up to 30 hydrated rows to realtime even if they were outside the viewport, producing a burst of Manifest reads.

## Impact

In a controlled reopen of the Employees database, blob-diff requests fell from 2 to 1 and applied Manifest requests fell from 42 to 11. Realtime retry, pending retry, stale completion, and timeout counters did not increase, and the browser console remained clean.

## Validation

- `pnpm type-check`
- `pnpm exec jest src/application/database-blob/__tests__/prefetch-dedup.test.ts --runInBand --no-coverage`
- targeted ESLint for the three changed files
- `pnpm build`
- live Chrome database reopen against the local AppFlowy Cloud stack

## Summary by Sourcery

Reduce redundant database blob prefetches and avoid prematurely binding seeded rows to realtime, lowering backend load when opening databases.

New Features:
- Add support for reusing an in-flight cold delta blob prefetch when a concurrent full snapshot is requested.

Bug Fixes:
- Ensure incremental delta prefetches with a cached RID remain separate from forced full prefetches to prevent incorrect deduplication.
- Keep preloaded database rows local until they are rendered, avoiding unnecessary realtime subscriptions for off-viewport rows.

Tests:
- Add regression tests covering deduplication between cold delta and full blob prefetches, and separation of incremental delta from full prefetches.