### PR TITLE
Fix stale spaces loading after workspace switches

### DIFF
--- a/playwright/bdd/features/workspace/workspace-switch-race.feature
+++ b/playwright/bdd/features/workspace/workspace-switch-race.feature
@@ -1,0 +1,13 @@
+@workspace-switch-race
+Feature: Workspace switching keeps sidebar spaces scoped to the active workspace
+  A response started for the previous workspace must not replace the sidebar
+  after the user has switched to another workspace.
+
+  Scenario: A delayed previous-workspace outline never renders under the target workspace
+    Given I am signed in with isolated source and target workspaces
+    And the next source workspace outline response is delayed
+    When I reload the source workspace while its outline response is delayed
+    And I switch to the target workspace
+    Then the target workspace outline is visible
+    When the delayed source workspace outline response completes
+    Then the target workspace never renders the source workspace space

--- a/playwright/bdd/steps/workspace-switch-race.steps.ts
+++ b/playwright/bdd/steps/workspace-switch-race.steps.ts
@@ -149,8 +149,10 @@ When('I reload the source workspace while its outline response is delayed', asyn
 
 When('I switch to the target workspace', async ({ page }) => {
   const state = requireState(page);
+  const source = requireSource(state);
   const target = requireTarget(state);
 
+  await installSidebarMismatchObserver(page, target.name, source.spaceName);
   await WorkspaceSelectors.dropdownTrigger(page).click();
   await expect(WorkspaceSelectors.dropdownContent(page)).toBeVisible({ timeout: 15000 });
   await workspaceItemByName(page, target.name).click();
@@ -168,14 +170,11 @@ Then('the target workspace outline is visible', async ({ page }) => {
 
 When('the delayed source workspace outline response completes', async ({ page }) => {
   const state = requireState(page);
-  const source = requireSource(state);
-  const target = requireTarget(state);
 
   if (!state.releaseDelayedRequest || !state.delayedRequestCompleted) {
     throw new Error('The delayed source outline response was not configured');
   }
 
-  await installSidebarMismatchObserver(page, target.name, source.spaceName);
   state.releaseDelayedRequest();
   await state.delayedRequestCompleted;
   await page.waitForTimeout(1500);

--- a/playwright/bdd/steps/workspace-switch-race.steps.ts
+++ b/playwright/bdd/steps/workspace-switch-race.steps.ts
@@ -1,0 +1,439 @@
+import { APIRequestContext, expect, Page, Route } from '@playwright/test';
+import { createBdd } from 'playwright-bdd';
+
+import { signInAndWaitForApp } from '../../support/auth-flow-helpers';
+import { SpaceSelectors, WorkspaceSelectors } from '../../support/selectors';
+import { generateRandomEmail, setupPageErrorHandling, TestConfig } from '../../support/test-config';
+
+const { Given, When, Then, Before, After } = createBdd();
+
+type TestWorkspace = {
+  id: string;
+  name: string;
+  spaceName: string;
+};
+
+type WorkspaceSwitchRaceState = {
+  token?: string;
+  originalWorkspaceId?: string;
+  source?: TestWorkspace;
+  target?: TestWorkspace;
+  delayArmed: boolean;
+  delayedRequestHandled: boolean;
+  delayedRequestStarted?: Promise<void>;
+  delayedRequestCompleted?: Promise<void>;
+  releaseDelayedRequest?: () => void;
+  staleSourceSpaceObserved?: boolean;
+  observedSidebarStates?: Array<{ header: string | null; spaces: string[] }>;
+};
+
+type ApiResponse<T> = {
+  code?: number;
+  message?: string;
+  data?: T;
+};
+
+const stateByPage = new WeakMap<Page, WorkspaceSwitchRaceState>();
+
+Before(async ({ page }) => {
+  setupPageErrorHandling(page);
+  await page.setViewportSize({ width: 1440, height: 900 });
+  stateByPage.set(page, {
+    delayArmed: false,
+    delayedRequestHandled: false,
+  });
+});
+
+After(async ({ page, request }) => {
+  const state = requireState(page);
+
+  state.releaseDelayedRequest?.();
+
+  if (state.delayedRequestCompleted) {
+    await Promise.race([
+      state.delayedRequestCompleted.catch(() => undefined),
+      new Promise<void>((resolve) => setTimeout(resolve, 1000)),
+    ]);
+  }
+
+  await cleanupWorkspaces(request, state);
+});
+
+Given('I am signed in with isolated source and target workspaces', async ({ page, request }) => {
+  const state = requireState(page);
+  const runId = Date.now().toString(36);
+
+  await signInAndWaitForApp(page, request, generateRandomEmail(), 1000);
+  await expect(page).toHaveURL(/\/app/, { timeout: 30000 });
+
+  const token = await getAuthToken(page);
+
+  if (!token) {
+    throw new Error('Cannot prepare workspace switch race: no auth token in browser storage');
+  }
+
+  state.token = token;
+  state.originalWorkspaceId = workspaceIdFromUrl(page.url());
+  state.source = {
+    id: await createWorkspace(request, token, `BDD Slow Source ${runId}`),
+    name: `BDD Slow Source ${runId}`,
+    spaceName: `BDD Source Space ${runId}`,
+  };
+  state.target = {
+    id: await createWorkspace(request, token, `BDD Target ${runId}`),
+    name: `BDD Target ${runId}`,
+    spaceName: `BDD Target Space ${runId}`,
+  };
+
+  await openWorkspace(request, token, state.source.id);
+  await createSpace(request, token, state.source.id, state.source.spaceName);
+  await openWorkspace(request, token, state.target.id);
+  await createSpace(request, token, state.target.id, state.target.spaceName);
+  await openWorkspace(request, token, state.source.id);
+
+  await page.goto(`/app/${state.source.id}`, { waitUntil: 'domcontentloaded' });
+  await expect(page.getByTestId('current-workspace-name')).toHaveText(state.source.name, { timeout: 30000 });
+  await expect(spaceName(page, state.source.spaceName)).toBeVisible({ timeout: 30000 });
+});
+
+Given('the next source workspace outline response is delayed', async ({ page }) => {
+  const state = requireState(page);
+  const started = createDeferred<void>();
+  const release = createDeferred<void>();
+  const completed = createDeferred<void>();
+
+  state.delayedRequestStarted = started.promise;
+  state.delayedRequestCompleted = completed.promise;
+  state.releaseDelayedRequest = () => release.resolve();
+
+  await page.route('**/api/workspace/*/view/*', async (route) => {
+    if (!state.delayArmed || state.delayedRequestHandled || !isRootOutlineRequest(route, requireSource(state).id)) {
+      await route.continue();
+      return;
+    }
+
+    state.delayedRequestHandled = true;
+
+    try {
+      const response = await route.fetch({
+        headers: withoutConditionalRequestHeaders(route.request().headers()),
+      });
+
+      started.resolve();
+      await release.promise;
+      await route.fulfill({ response });
+      completed.resolve();
+    } catch (error) {
+      started.reject(error);
+      completed.reject(error);
+      throw error;
+    }
+  });
+});
+
+When('I reload the source workspace while its outline response is delayed', async ({ page }) => {
+  const state = requireState(page);
+
+  if (!state.delayedRequestStarted) {
+    throw new Error('The delayed source outline route was not configured');
+  }
+
+  state.delayArmed = true;
+  await Promise.all([page.reload({ waitUntil: 'domcontentloaded' }), state.delayedRequestStarted]);
+
+  await expect(page.getByTestId('current-workspace-name')).toHaveText(requireSource(state).name, {
+    timeout: 30000,
+  });
+  await expect(WorkspaceSelectors.dropdownTrigger(page)).toBeVisible({ timeout: 30000 });
+});
+
+When('I switch to the target workspace', async ({ page }) => {
+  const state = requireState(page);
+  const target = requireTarget(state);
+
+  await WorkspaceSelectors.dropdownTrigger(page).click();
+  await expect(WorkspaceSelectors.dropdownContent(page)).toBeVisible({ timeout: 15000 });
+  await workspaceItemByName(page, target.name).click();
+
+  await expect(page).toHaveURL(new RegExp(`/app/${target.id}(?:/|$)`), { timeout: 30000 });
+  await expect(page.getByTestId('current-workspace-name')).toHaveText(target.name, { timeout: 30000 });
+});
+
+Then('the target workspace outline is visible', async ({ page }) => {
+  const state = requireState(page);
+
+  await expect(spaceName(page, requireTarget(state).spaceName)).toBeVisible({ timeout: 30000 });
+  await expect(spaceName(page, requireSource(state).spaceName)).toHaveCount(0);
+});
+
+When('the delayed source workspace outline response completes', async ({ page }) => {
+  const state = requireState(page);
+  const source = requireSource(state);
+  const target = requireTarget(state);
+
+  if (!state.releaseDelayedRequest || !state.delayedRequestCompleted) {
+    throw new Error('The delayed source outline response was not configured');
+  }
+
+  await installSidebarMismatchObserver(page, target.name, source.spaceName);
+  state.releaseDelayedRequest();
+  await state.delayedRequestCompleted;
+  await page.waitForTimeout(1500);
+
+  const observation = await readSidebarMismatchObserver(page);
+
+  state.staleSourceSpaceObserved = observation.observed;
+  state.observedSidebarStates = observation.states;
+});
+
+Then('the target workspace never renders the source workspace space', async ({ page }) => {
+  const state = requireState(page);
+
+  expect(
+    state.staleSourceSpaceObserved,
+    `The previous workspace outline rendered after the switch. Observed sidebar states: ${JSON.stringify(
+      state.observedSidebarStates
+    )}`
+  ).toBe(false);
+
+  await expect(page.getByTestId('current-workspace-name')).toHaveText(requireTarget(state).name);
+  await expect(spaceName(page, requireTarget(state).spaceName)).toBeVisible();
+  await expect(spaceName(page, requireSource(state).spaceName)).toHaveCount(0);
+});
+
+async function createWorkspace(request: APIRequestContext, token: string, name: string): Promise<string> {
+  const data = await apiRequest<{ workspace_id: string }>(request, token, 'post', '/api/workspace', {
+    workspace_name: name,
+  });
+
+  if (!data.workspace_id) {
+    throw new Error(`Workspace creation returned no id for "${name}"`);
+  }
+
+  return data.workspace_id;
+}
+
+async function createSpace(request: APIRequestContext, token: string, workspaceId: string, name: string): Promise<void> {
+  await apiRequest<{ view_id: string }>(request, token, 'post', `/api/workspace/${workspaceId}/space`, {
+    name,
+    space_icon: '',
+    space_icon_color: '#00BCF0',
+    space_permission: 0,
+  });
+}
+
+async function openWorkspace(request: APIRequestContext, token: string, workspaceId: string): Promise<void> {
+  await apiRequest<unknown>(request, token, 'put', `/api/workspace/${workspaceId}/open`);
+}
+
+async function cleanupWorkspaces(request: APIRequestContext, state: WorkspaceSwitchRaceState): Promise<void> {
+  if (!state.token) return;
+
+  if (state.originalWorkspaceId) {
+    await apiRequestAllowFailure(request, state.token, 'put', `/api/workspace/${state.originalWorkspaceId}/open`);
+  }
+
+  for (const workspaceId of [state.target?.id, state.source?.id]) {
+    if (workspaceId) {
+      await apiRequestAllowFailure(request, state.token, 'delete', `/api/workspace/${workspaceId}`);
+    }
+  }
+}
+
+async function apiRequest<T>(
+  request: APIRequestContext,
+  token: string,
+  method: 'post' | 'put' | 'delete',
+  path: string,
+  data?: unknown
+): Promise<T> {
+  const response = await request[method](`${TestConfig.apiUrl}${path}`, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    },
+    data,
+    failOnStatusCode: false,
+  });
+  const text = await response.text();
+  const body = (text ? JSON.parse(text) : null) as ApiResponse<T> | null;
+
+  if (!response.ok() || body?.code !== 0) {
+    throw new Error(`${method.toUpperCase()} ${path} failed: HTTP ${response.status()} ${text}`);
+  }
+
+  return body.data as T;
+}
+
+async function apiRequestAllowFailure(
+  request: APIRequestContext,
+  token: string,
+  method: 'put' | 'delete',
+  path: string
+): Promise<void> {
+  await request[method](`${TestConfig.apiUrl}${path}`, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    },
+    failOnStatusCode: false,
+  }).catch(() => undefined);
+}
+
+function isRootOutlineRequest(route: Route, workspaceId: string): boolean {
+  const request = route.request();
+  const url = new URL(request.url());
+
+  return (
+    request.method() === 'GET' &&
+    url.pathname === `/api/workspace/${workspaceId}/view/${workspaceId}` &&
+    url.searchParams.get('depth') === '6'
+  );
+}
+
+function withoutConditionalRequestHeaders(headers: Record<string, string>): Record<string, string> {
+  const next = { ...headers };
+
+  delete next['if-modified-since'];
+  delete next['if-none-match'];
+
+  return next;
+}
+
+async function installSidebarMismatchObserver(
+  page: Page,
+  targetWorkspaceName: string,
+  sourceSpaceName: string
+): Promise<void> {
+  await page.evaluate(
+    ({ targetWorkspaceName, sourceSpaceName }) => {
+      type Observation = {
+        observed: boolean;
+        states: Array<{ header: string | null; spaces: string[] }>;
+      };
+      type ObservationWindow = Window & {
+        __bddWorkspaceSwitchRace?: Observation & { observer?: MutationObserver };
+      };
+      const observation: Observation & { observer?: MutationObserver } = {
+        observed: false,
+        states: [],
+      };
+      const sample = () => {
+        const header = document.querySelector('[data-testid="current-workspace-name"]')?.textContent?.trim() ?? null;
+        const spaces = Array.from(document.querySelectorAll('[data-testid="space-name"]')).map(
+          (element) => element.textContent?.trim() ?? ''
+        );
+        const previous = observation.states.at(-1);
+
+        if (!previous || previous.header !== header || JSON.stringify(previous.spaces) !== JSON.stringify(spaces)) {
+          observation.states.push({ header, spaces });
+        }
+
+        if (header === targetWorkspaceName && spaces.includes(sourceSpaceName)) {
+          observation.observed = true;
+        }
+      };
+
+      observation.observer = new MutationObserver(sample);
+      observation.observer.observe(document.body, { childList: true, subtree: true, characterData: true });
+      (window as ObservationWindow).__bddWorkspaceSwitchRace = observation;
+      sample();
+    },
+    { targetWorkspaceName, sourceSpaceName }
+  );
+}
+
+async function readSidebarMismatchObserver(
+  page: Page
+): Promise<{ observed: boolean; states: Array<{ header: string | null; spaces: string[] }> }> {
+  return page.evaluate(() => {
+    type ObservationWindow = Window & {
+      __bddWorkspaceSwitchRace?: {
+        observed: boolean;
+        states: Array<{ header: string | null; spaces: string[] }>;
+        observer?: MutationObserver;
+      };
+    };
+    const observation = (window as ObservationWindow).__bddWorkspaceSwitchRace;
+
+    observation?.observer?.disconnect();
+
+    return {
+      observed: observation?.observed ?? false,
+      states: observation?.states ?? [],
+    };
+  });
+}
+
+function workspaceItemByName(page: Page, name: string) {
+  return WorkspaceSelectors.item(page).filter({ hasText: name }).first();
+}
+
+function spaceName(page: Page, name: string) {
+  return SpaceSelectors.names(page).filter({ hasText: name });
+}
+
+function workspaceIdFromUrl(urlValue: string): string {
+  const workspaceId = new URL(urlValue).pathname.split('/')[2];
+
+  if (!workspaceId) {
+    throw new Error(`Could not read workspace id from URL: ${urlValue}`);
+  }
+
+  return workspaceId;
+}
+
+async function getAuthToken(page: Page): Promise<string> {
+  return page.evaluate(() => {
+    const directToken = localStorage.getItem('af_auth_token');
+
+    if (directToken) return directToken;
+
+    const rawToken = localStorage.getItem('token');
+
+    if (!rawToken) return '';
+
+    try {
+      return (JSON.parse(rawToken) as { access_token?: string }).access_token || '';
+    } catch {
+      return '';
+    }
+  });
+}
+
+function requireState(page: Page): WorkspaceSwitchRaceState {
+  const state = stateByPage.get(page);
+
+  if (!state) {
+    throw new Error('Workspace switch race scenario state was not initialized');
+  }
+
+  return state;
+}
+
+function requireSource(state: WorkspaceSwitchRaceState): TestWorkspace {
+  if (!state.source) {
+    throw new Error('Source workspace was not initialized');
+  }
+
+  return state.source;
+}
+
+function requireTarget(state: WorkspaceSwitchRaceState): TestWorkspace {
+  if (!state.target) {
+    throw new Error('Target workspace was not initialized');
+  }
+
+  return state.target;
+}
+
+function createDeferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((promiseResolve, promiseReject) => {
+    resolve = promiseResolve;
+    reject = promiseReject;
+  });
+
+  return { promise, resolve, reject };
+}

--- a/src/components/app/hooks/__tests__/useWorkspaceData.sidebarRevalidation.test.tsx
+++ b/src/components/app/hooks/__tests__/useWorkspaceData.sidebarRevalidation.test.tsx
@@ -65,7 +65,11 @@ const createView = (viewId: string, overrides: Partial<View> = {}): View => ({
   ...overrides,
 });
 
-function createWrapper(eventEmitter: EventEmitter, getWorkspaceId = () => workspaceId) {
+function createWrapper(
+  eventEmitter: EventEmitter,
+  getWorkspaceId = () => workspaceId,
+  getSelectedWorkspaceId = getWorkspaceId
+) {
   const authContext: AuthInternalContextType = {
     currentWorkspaceId: getWorkspaceId(),
     isAuthenticated: true,
@@ -73,7 +77,7 @@ function createWrapper(eventEmitter: EventEmitter, getWorkspaceId = () => worksp
     userWorkspaceInfo: {
       userId: 'user-id',
       selectedWorkspace: {
-        id: getWorkspaceId(),
+        id: getSelectedWorkspaceId(),
         databaseStorageId: 'database-storage-id',
         role: Role.Owner,
       },
@@ -94,6 +98,7 @@ function createWrapper(eventEmitter: EventEmitter, getWorkspaceId = () => worksp
 
   return function Wrapper({ children }: { children: ReactNode }) {
     const activeWorkspaceId = getWorkspaceId();
+    const selectedWorkspaceId = getSelectedWorkspaceId();
     const activeAuthContext = {
       ...authContext,
       currentWorkspaceId: activeWorkspaceId,
@@ -102,7 +107,7 @@ function createWrapper(eventEmitter: EventEmitter, getWorkspaceId = () => worksp
             ...authContext.userWorkspaceInfo,
             selectedWorkspace: {
               ...authContext.userWorkspaceInfo.selectedWorkspace,
-              id: activeWorkspaceId,
+              id: selectedWorkspaceId,
             },
           }
         : authContext.userWorkspaceInfo,
@@ -799,10 +804,10 @@ describe('useWorkspaceData sidebar outline revalidation', () => {
       return {
         outline: [
           createView('space-b', {
-            name: workspaceBOutlineCalls < 3 ? 'workspace b old' : 'workspace b new',
+            name: workspaceBOutlineCalls < 2 ? 'workspace b old' : 'workspace b new',
           }),
         ],
-        folderRid: workspaceBOutlineCalls < 3 ? '1-1' : '2-1',
+        folderRid: workspaceBOutlineCalls < 2 ? '1-1' : '2-1',
       };
     });
 
@@ -829,6 +834,136 @@ describe('useWorkspaceData sidebar outline revalidation', () => {
 
     expect(revalidationResult).toBe('changed');
     expect(result.current.outline?.[0]?.name).toBe('workspace b new');
+  });
+
+  it('ignores a delayed root outline response after the workspace changes', async () => {
+    const eventEmitter = new EventEmitter();
+    const workspaceA = 'workspace-a';
+    const workspaceB = 'workspace-b';
+    const delayedWorkspaceAResponse = createDeferred<{ outline: View[]; folderRid: string }>();
+    let activeWorkspaceId = workspaceA;
+
+    (ViewService.getOutline as jest.Mock).mockImplementation((requestedWorkspaceId: string) => {
+      if (requestedWorkspaceId === workspaceA) {
+        return delayedWorkspaceAResponse.promise;
+      }
+
+      return Promise.resolve({
+        outline: [createView('space-b', { name: 'workspace b' })],
+        folderRid: '1-1',
+      });
+    });
+
+    const { result, rerender } = renderHook(() => useWorkspaceData(), {
+      wrapper: createWrapper(eventEmitter, () => activeWorkspaceId),
+    });
+
+    await waitFor(() => {
+      expect(ViewService.getOutline).toHaveBeenCalledWith(workspaceA);
+    });
+
+    activeWorkspaceId = workspaceB;
+    rerender();
+
+    await waitFor(() => {
+      expect(result.current.outline?.[0]?.name).toBe('workspace b');
+    });
+
+    await act(async () => {
+      delayedWorkspaceAResponse.resolve({
+        outline: [createView('space-a', { name: 'stale workspace a' })],
+        folderRid: '2-1',
+      });
+      await delayedWorkspaceAResponse.promise;
+    });
+
+    expect(result.current.outline?.[0]?.name).toBe('workspace b');
+    expect(result.current.outline?.[0]?.view_id).toBe('space-b');
+  });
+
+  it('waits for the selected workspace and URL workspace to agree before reloading the outline', async () => {
+    const eventEmitter = new EventEmitter();
+    const workspaceA = 'workspace-a';
+    const workspaceB = 'workspace-b';
+    let activeWorkspaceId = workspaceA;
+    let selectedWorkspaceId = workspaceA;
+
+    (ViewService.getOutline as jest.Mock).mockResolvedValue({
+      outline: [createView('space-a', { name: 'workspace a' })],
+      folderRid: '1-1',
+    });
+
+    const { rerender } = renderHook(() => useWorkspaceData(), {
+      wrapper: createWrapper(
+        eventEmitter,
+        () => activeWorkspaceId,
+        () => selectedWorkspaceId
+      ),
+    });
+
+    await waitFor(() => {
+      expect(ViewService.getOutline).toHaveBeenCalledWith(workspaceA);
+    });
+    (ViewService.getOutline as jest.Mock).mockClear();
+
+    selectedWorkspaceId = workspaceB;
+    rerender();
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(ViewService.getOutline).not.toHaveBeenCalled();
+
+    activeWorkspaceId = workspaceB;
+    rerender();
+
+    await waitFor(() => {
+      expect(ViewService.getOutline).toHaveBeenCalledWith(workspaceB);
+    });
+    expect(ViewService.getOutline).toHaveBeenCalledTimes(1);
+  });
+
+  it('reloads the outline after a URL workspace selection catches up on the server', async () => {
+    const eventEmitter = new EventEmitter();
+    const workspaceA = 'workspace-a';
+    const workspaceB = 'workspace-b';
+    let activeWorkspaceId = workspaceA;
+    let selectedWorkspaceId = workspaceA;
+
+    (ViewService.getOutline as jest.Mock).mockImplementation(async (requestedWorkspaceId: string) => ({
+      outline: [createView(`space-${requestedWorkspaceId}`)],
+      folderRid: '1-1',
+    }));
+
+    const { rerender } = renderHook(() => useWorkspaceData(), {
+      wrapper: createWrapper(
+        eventEmitter,
+        () => activeWorkspaceId,
+        () => selectedWorkspaceId
+      ),
+    });
+
+    await waitFor(() => {
+      expect(ViewService.getOutline).toHaveBeenCalledWith(workspaceA);
+    });
+    (ViewService.getOutline as jest.Mock).mockClear();
+
+    activeWorkspaceId = workspaceB;
+    rerender();
+
+    await waitFor(() => {
+      expect(ViewService.getOutline).toHaveBeenCalledWith(workspaceB);
+    });
+    (ViewService.getOutline as jest.Mock).mockClear();
+
+    selectedWorkspaceId = workspaceB;
+    rerender();
+
+    await waitFor(() => {
+      expect(ViewService.getOutline).toHaveBeenCalledWith(workspaceB);
+    });
+    expect(ViewService.getOutline).toHaveBeenCalledTimes(1);
   });
 
   it('ignores stale revalidation results after the workspace changes', async () => {

--- a/src/components/app/hooks/__tests__/useWorkspaceData.sidebarRevalidation.test.tsx
+++ b/src/components/app/hooks/__tests__/useWorkspaceData.sidebarRevalidation.test.tsx
@@ -1090,6 +1090,75 @@ describe('useWorkspaceData sidebar outline revalidation', () => {
     expect(result.current.outline?.[0]?.view_id).toBe('space-b-new');
   });
 
+  it('keeps an older successful outline while a newer same-workspace request is pending or fails', async () => {
+    const eventEmitter = new EventEmitter();
+    const workspaceA = 'workspace-a';
+    const workspaceB = 'workspace-b';
+    const initialWorkspaceBResponse = createDeferred<{ outline: View[]; folderRid: string }>();
+    const catchUpWorkspaceBResponse = createDeferred<{ outline: View[]; folderRid: string }>();
+    let activeWorkspaceId = workspaceA;
+    let selectedWorkspaceId = workspaceA;
+    let workspaceBOutlineCalls = 0;
+
+    (ViewService.getOutline as jest.Mock).mockImplementation((requestedWorkspaceId: string) => {
+      if (requestedWorkspaceId === workspaceA) {
+        return Promise.resolve({
+          outline: [createView('space-a', { name: 'workspace a' })],
+          folderRid: '1-1',
+        });
+      }
+
+      workspaceBOutlineCalls += 1;
+      return workspaceBOutlineCalls === 1 ? initialWorkspaceBResponse.promise : catchUpWorkspaceBResponse.promise;
+    });
+
+    const { result, rerender } = renderHook(() => useWorkspaceData(), {
+      wrapper: createWrapper(
+        eventEmitter,
+        () => activeWorkspaceId,
+        () => selectedWorkspaceId
+      ),
+    });
+
+    await waitFor(() => {
+      expect(result.current.outline?.[0]?.name).toBe('workspace a');
+    });
+
+    activeWorkspaceId = workspaceB;
+    rerender();
+
+    await waitFor(() => {
+      expect(workspaceBOutlineCalls).toBe(1);
+    });
+
+    selectedWorkspaceId = workspaceB;
+    rerender();
+
+    await waitFor(() => {
+      expect(workspaceBOutlineCalls).toBe(2);
+    });
+
+    await act(async () => {
+      initialWorkspaceBResponse.resolve({
+        outline: [createView('space-b-fallback', { name: 'workspace b fallback' })],
+        folderRid: '1-1',
+      });
+      await initialWorkspaceBResponse.promise;
+      await Promise.resolve();
+    });
+
+    expect(result.current.outline?.[0]?.name).toBe('workspace b fallback');
+
+    await act(async () => {
+      catchUpWorkspaceBResponse.reject(new Error('catch-up failed'));
+      await catchUpWorkspaceBResponse.promise.catch(() => undefined);
+      await Promise.resolve();
+    });
+
+    expect(result.current.outline?.[0]?.name).toBe('workspace b fallback');
+    expect(result.current.outline?.[0]?.view_id).toBe('space-b-fallback');
+  });
+
   it('keeps forced navigation active when a newer background outline request starts', async () => {
     const eventEmitter = new EventEmitter();
     const initialForcedResponse = createDeferred<{ outline: View[]; folderRid: string }>();
@@ -1209,6 +1278,74 @@ describe('useWorkspaceData sidebar outline revalidation', () => {
 
     expect(revalidationResult).toBe('unchanged');
     expect(result.current.outline?.[0]?.name).toBe('latest outline');
+  });
+
+  it('does not apply an expanded child batch after a newer root response is accepted', async () => {
+    const eventEmitter = new EventEmitter();
+    const delayedChildResponse = createDeferred<View[]>();
+    const initialRoot = createView('space-id', {
+      children: [],
+      has_children: true,
+      name: 'initial root',
+    });
+    const revalidatedRoot = createView('space-id', {
+      children: [],
+      has_children: true,
+      name: 'revalidated root',
+    });
+    const latestRoot = createView('space-id', {
+      children: [],
+      has_children: true,
+      name: 'latest root',
+    });
+
+    (ViewService.getOutline as jest.Mock)
+      .mockResolvedValueOnce({ outline: [initialRoot], folderRid: '1-1' })
+      .mockResolvedValueOnce({ outline: [revalidatedRoot], folderRid: '2-1' })
+      .mockResolvedValueOnce({ outline: [latestRoot], folderRid: '3-1' });
+    (ViewService.getMultiple as jest.Mock).mockReturnValueOnce(delayedChildResponse.promise);
+
+    const { result } = renderHook(() => useWorkspaceData(), {
+      wrapper: createWrapper(eventEmitter),
+    });
+
+    await waitFor(() => {
+      expect(result.current.outline?.[0]?.name).toBe('initial root');
+    });
+
+    let revalidationPromise: Promise<string | undefined> = Promise.resolve(undefined);
+
+    act(() => {
+      revalidationPromise = result.current.revalidateSidebarOutline?.(['space-id']) ?? Promise.resolve(undefined);
+    });
+
+    await waitFor(() => {
+      expect(ViewService.getMultiple).toHaveBeenCalledWith(workspaceId, ['space-id'], 1);
+    });
+
+    await act(async () => {
+      await result.current.loadOutline?.(workspaceId, false);
+    });
+
+    expect(result.current.outline?.[0]?.name).toBe('latest root');
+
+    let revalidationResult: string | undefined;
+
+    await act(async () => {
+      delayedChildResponse.resolve([
+        createView('space-id', {
+          children: [createView('stale-child')],
+          folder_rid: '2-1',
+          has_children: true,
+        }),
+      ]);
+      revalidationResult = await revalidationPromise;
+    });
+
+    expect(revalidationResult).toBe('unchanged');
+    expect(result.current.outline?.[0]?.name).toBe('latest root');
+    expect(result.current.outline?.[0]?.children).toEqual([]);
+    expect(result.current.loadedViewIds?.has('space-id')).toBe(false);
   });
 
   it('ignores stale revalidation results after the workspace changes', async () => {

--- a/src/components/app/hooks/__tests__/useWorkspaceData.sidebarRevalidation.test.tsx
+++ b/src/components/app/hooks/__tests__/useWorkspaceData.sidebarRevalidation.test.tsx
@@ -2,7 +2,7 @@ import EventEmitter from 'events';
 
 import { act, renderHook, waitFor } from '@testing-library/react';
 import { type ReactNode } from 'react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter, useLocation } from 'react-router-dom';
 
 import { APP_EVENTS, ERROR_CODE } from '@/application/constants';
 import { AccessService, ViewService } from '@/application/services/domains';
@@ -881,6 +881,57 @@ describe('useWorkspaceData sidebar outline revalidation', () => {
     expect(result.current.outline?.[0]?.view_id).toBe('space-b');
   });
 
+  it('does not expose the previous outline while rendering a workspace change', async () => {
+    const eventEmitter = new EventEmitter();
+    const workspaceA = 'workspace-a';
+    const workspaceB = 'workspace-b';
+    const observedRenders: Array<{ workspaceId: string; outlineNames: string[] }> = [];
+    let activeWorkspaceId = workspaceA;
+
+    (ViewService.getOutline as jest.Mock).mockImplementation(async (requestedWorkspaceId: string) => ({
+      outline: [
+        createView(`space-${requestedWorkspaceId}`, {
+          name: requestedWorkspaceId === workspaceA ? 'workspace a' : 'workspace b',
+        }),
+      ],
+      folderRid: '1-1',
+    }));
+
+    const { result, rerender } = renderHook(
+      () => {
+        const workspaceData = useWorkspaceData();
+
+        observedRenders.push({
+          workspaceId: activeWorkspaceId,
+          outlineNames: workspaceData.outline?.map((view) => view.name) ?? [],
+        });
+        return workspaceData;
+      },
+      {
+        wrapper: createWrapper(eventEmitter, () => activeWorkspaceId),
+      }
+    );
+
+    await waitFor(() => {
+      expect(result.current.outline?.[0]?.name).toBe('workspace a');
+    });
+
+    observedRenders.length = 0;
+    activeWorkspaceId = workspaceB;
+    rerender();
+
+    await waitFor(() => {
+      expect(result.current.outline?.[0]?.name).toBe('workspace b');
+    });
+
+    expect(
+      observedRenders.some(
+        ({ workspaceId: renderedWorkspaceId, outlineNames }) =>
+          renderedWorkspaceId === workspaceB && outlineNames.includes('workspace a')
+      )
+    ).toBe(false);
+  });
+
   it('waits for the selected workspace and URL workspace to agree before reloading the outline', async () => {
     const eventEmitter = new EventEmitter();
     const workspaceA = 'workspace-a';
@@ -964,6 +1015,200 @@ describe('useWorkspaceData sidebar outline revalidation', () => {
       expect(ViewService.getOutline).toHaveBeenCalledWith(workspaceB);
     });
     expect(ViewService.getOutline).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps the latest same-workspace outline when the catch-up response resolves first', async () => {
+    const eventEmitter = new EventEmitter();
+    const workspaceA = 'workspace-a';
+    const workspaceB = 'workspace-b';
+    const initialWorkspaceBResponse = createDeferred<{ outline: View[]; folderRid: string }>();
+    const catchUpWorkspaceBResponse = createDeferred<{ outline: View[]; folderRid: string }>();
+    let activeWorkspaceId = workspaceA;
+    let selectedWorkspaceId = workspaceA;
+    let workspaceBOutlineCalls = 0;
+
+    (ViewService.getOutline as jest.Mock).mockImplementation((requestedWorkspaceId: string) => {
+      if (requestedWorkspaceId === workspaceA) {
+        return Promise.resolve({
+          outline: [createView('space-a', { name: 'workspace a' })],
+          folderRid: '1-1',
+        });
+      }
+
+      workspaceBOutlineCalls += 1;
+      return workspaceBOutlineCalls === 1 ? initialWorkspaceBResponse.promise : catchUpWorkspaceBResponse.promise;
+    });
+
+    const { result, rerender } = renderHook(() => useWorkspaceData(), {
+      wrapper: createWrapper(
+        eventEmitter,
+        () => activeWorkspaceId,
+        () => selectedWorkspaceId
+      ),
+    });
+
+    await waitFor(() => {
+      expect(result.current.outline?.[0]?.name).toBe('workspace a');
+    });
+
+    activeWorkspaceId = workspaceB;
+    rerender();
+
+    await waitFor(() => {
+      expect(workspaceBOutlineCalls).toBe(1);
+    });
+
+    selectedWorkspaceId = workspaceB;
+    rerender();
+
+    await waitFor(() => {
+      expect(workspaceBOutlineCalls).toBe(2);
+    });
+
+    await act(async () => {
+      catchUpWorkspaceBResponse.resolve({
+        outline: [createView('space-b-new', { name: 'workspace b new' })],
+        folderRid: '2-1',
+      });
+      await catchUpWorkspaceBResponse.promise;
+    });
+
+    await waitFor(() => {
+      expect(result.current.outline?.[0]?.name).toBe('workspace b new');
+    });
+
+    await act(async () => {
+      initialWorkspaceBResponse.resolve({
+        outline: [createView('space-b-old', { name: 'workspace b old' })],
+        folderRid: '1-1',
+      });
+      await initialWorkspaceBResponse.promise;
+      await Promise.resolve();
+    });
+
+    expect(result.current.outline?.[0]?.name).toBe('workspace b new');
+    expect(result.current.outline?.[0]?.view_id).toBe('space-b-new');
+  });
+
+  it('keeps forced navigation active when a newer background outline request starts', async () => {
+    const eventEmitter = new EventEmitter();
+    const initialForcedResponse = createDeferred<{ outline: View[]; folderRid: string }>();
+    let outlineCalls = 0;
+
+    localStorage.clear();
+    (ViewService.getOutline as jest.Mock).mockImplementation(() => {
+      outlineCalls += 1;
+
+      if (outlineCalls === 1) {
+        return initialForcedResponse.promise;
+      }
+
+      return Promise.resolve({
+        outline: [createView('background-view', { name: 'background outline' })],
+        folderRid: '2-1',
+      });
+    });
+
+    const { result } = renderHook(
+      () => {
+        const workspaceData = useWorkspaceData();
+        const location = useLocation();
+
+        return {
+          ...workspaceData,
+          pathname: location.pathname,
+        };
+      },
+      {
+        wrapper: createWrapper(eventEmitter),
+      }
+    );
+
+    await waitFor(() => {
+      expect(outlineCalls).toBe(1);
+    });
+
+    await act(async () => {
+      await result.current.loadOutline?.(workspaceId, false);
+    });
+
+    expect(result.current.outline?.[0]?.name).toBe('background outline');
+
+    await act(async () => {
+      initialForcedResponse.resolve({
+        outline: [createView('forced-view', { name: 'forced outline' })],
+        folderRid: '1-1',
+      });
+      await initialForcedResponse.promise;
+      await Promise.resolve();
+    });
+
+    await waitFor(() => {
+      expect(result.current.pathname).toBe(`/app/${workspaceId}/forced-view`);
+    });
+    expect(result.current.outline?.[0]?.name).toBe('background outline');
+  });
+
+  it('ignores an older same-workspace revalidation after a newer outline load', async () => {
+    const eventEmitter = new EventEmitter();
+    const delayedRevalidationResponse = createDeferred<{ outline: View[] }>();
+    let outlineCalls = 0;
+
+    (ViewService.getOutline as jest.Mock).mockImplementation(() => {
+      outlineCalls += 1;
+
+      if (outlineCalls === 1) {
+        return Promise.resolve({
+          outline: [createView('initial-view', { name: 'initial outline' })],
+          folderRid: '1-1',
+        });
+      }
+
+      if (outlineCalls === 2) {
+        return delayedRevalidationResponse.promise;
+      }
+
+      return Promise.resolve({
+        outline: [createView('latest-view', { name: 'latest outline' })],
+        folderRid: '2-1',
+      });
+    });
+
+    const { result } = renderHook(() => useWorkspaceData(), {
+      wrapper: createWrapper(eventEmitter),
+    });
+
+    await waitFor(() => {
+      expect(result.current.outline?.[0]?.name).toBe('initial outline');
+    });
+
+    let revalidationPromise: Promise<string | undefined> = Promise.resolve(undefined);
+
+    act(() => {
+      revalidationPromise = result.current.revalidateSidebarOutline?.([]) ?? Promise.resolve(undefined);
+    });
+
+    await waitFor(() => {
+      expect(outlineCalls).toBe(2);
+    });
+
+    await act(async () => {
+      await result.current.loadOutline?.(workspaceId, false);
+    });
+
+    expect(result.current.outline?.[0]?.name).toBe('latest outline');
+
+    let revalidationResult: string | undefined;
+
+    await act(async () => {
+      delayedRevalidationResponse.resolve({
+        outline: [createView('older-view', { name: 'older outline' })],
+      });
+      revalidationResult = await revalidationPromise;
+    });
+
+    expect(revalidationResult).toBe('unchanged');
+    expect(result.current.outline?.[0]?.name).toBe('latest outline');
   });
 
   it('ignores stale revalidation results after the workspace changes', async () => {

--- a/src/components/app/hooks/useWorkspaceData.ts
+++ b/src/components/app/hooks/useWorkspaceData.ts
@@ -368,6 +368,8 @@ export function useWorkspaceData() {
 
   const [outline, setOutline] = useState<View[]>();
   const stableOutlineRef = useRef<View[]>([]);
+  const stableOutlineWorkspaceIdRef = useRef(currentWorkspaceId);
+  const stableOutlineWorkspaceRevisionRef = useRef(0);
   // Global folder ordering can advance from lazy subtree fetches. Root polling
   // must compare against the root/sidebar outline snapshot we actually applied.
   const lastFolderRidRef = useRef<FolderRid | null>(null);
@@ -375,6 +377,11 @@ export function useWorkspaceData() {
   const lastAppliedRootOutlineFingerprintRef = useRef<string | null>(null);
   const currentWorkspaceIdRef = useRef(currentWorkspaceId);
   const workspaceRevisionRef = useRef(0);
+  // Root loads and periodic revalidation share one latest-request-wins sequence.
+  // Forced routing is tracked separately so a background refresh can supersede
+  // outline data without leaving a root workspace URL unresolved.
+  const rootOutlineRequestSeqRef = useRef(0);
+  const latestForcedOutlineRequestSeqRef = useRef(0);
   const [favoriteViews, setFavoriteViews] = useState<View[]>();
   const [recentViews, setRecentViews] = useState<View[]>();
   const [trashList, setTrashList] = useState<View[]>();
@@ -489,9 +496,31 @@ export function useWorkspaceData() {
     return currentWorkspaceIdRef.current !== workspaceId || workspaceRevisionRef.current !== workspaceRevision;
   }, []);
 
+  const isStaleRootOutlineRequest = useCallback(
+    (workspaceId: string, workspaceRevision: number, requestSeq: number) => {
+      return isStaleWorkspaceRequest(workspaceId, workspaceRevision) || rootOutlineRequestSeqRef.current !== requestSeq;
+    },
+    [isStaleWorkspaceRequest]
+  );
+
+  const isStaleForcedOutlineNavigation = useCallback(
+    (workspaceId: string, workspaceRevision: number, requestSeq: number) => {
+      return (
+        isStaleWorkspaceRequest(workspaceId, workspaceRevision) ||
+        latestForcedOutlineRequestSeqRef.current !== requestSeq
+      );
+    },
+    [isStaleWorkspaceRequest]
+  );
+
   const loadOutline = useCallback(
     async (workspaceId: string, force = true) => {
       const workspaceRevision = workspaceRevisionRef.current;
+      const requestSeq = ++rootOutlineRequestSeqRef.current;
+
+      if (force) {
+        latestForcedOutlineRequestSeqRef.current = requestSeq;
+      }
 
       try {
         // Parallelize API calls - both are independent and can run concurrently
@@ -529,18 +558,27 @@ export function useWorkspaceData() {
           outlineWithShareWithMe = [...res.outline, shareWithMeSpace];
         }
 
-        const mergedOutline = replaceOutlinePreservingChildren(outlineWithShareWithMe);
+        const shouldApplyOutline = rootOutlineRequestSeqRef.current === requestSeq;
+        const shouldNavigate = force && latestForcedOutlineRequestSeqRef.current === requestSeq;
 
-        updateAppliedRootOutlineSnapshot(nextFolderRid, outlineWithShareWithMe);
-
-        if (eventEmitter) {
-          eventEmitter.emit(APP_EVENTS.OUTLINE_LOADED, mergedOutline || []);
+        if (!shouldApplyOutline && !shouldNavigate) {
+          return;
         }
 
-        if (!force) return;
+        if (shouldApplyOutline) {
+          const mergedOutline = replaceOutlinePreservingChildren(outlineWithShareWithMe);
+
+          updateAppliedRootOutlineSnapshot(nextFolderRid, outlineWithShareWithMe);
+
+          if (eventEmitter) {
+            eventEmitter.emit(APP_EVENTS.OUTLINE_LOADED, mergedOutline || []);
+          }
+        }
+
+        if (!shouldNavigate) return;
 
         try {
-          if (isStaleWorkspaceRequest(workspaceId, workspaceRevision)) {
+          if (isStaleForcedOutlineNavigation(workspaceId, workspaceRevision, requestSeq)) {
             return;
           }
 
@@ -574,14 +612,14 @@ export function useWorkspaceData() {
               try {
                 await ViewService.get(workspaceId, lastViewId);
 
-                if (isStaleWorkspaceRequest(workspaceId, workspaceRevision)) {
+                if (isStaleForcedOutlineNavigation(workspaceId, workspaceRevision, requestSeq)) {
                   return;
                 }
 
                 navigate(`/app/${workspaceId}/${lastViewId}${search}`);
                 return;
               } catch {
-                if (isStaleWorkspaceRequest(workspaceId, workspaceRevision)) {
+                if (isStaleForcedOutlineNavigation(workspaceId, workspaceRevision, requestSeq)) {
                   return;
                 }
 
@@ -618,7 +656,7 @@ export function useWorkspaceData() {
                 1
               );
 
-              if (isStaleWorkspaceRequest(workspaceId, workspaceRevision)) {
+              if (isStaleForcedOutlineNavigation(workspaceId, workspaceRevision, requestSeq)) {
                 return;
               }
 
@@ -648,7 +686,7 @@ export function useWorkspaceData() {
 
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
       } catch (e: any) {
-        if (isStaleWorkspaceRequest(workspaceId, workspaceRevision)) {
+        if (isStaleRootOutlineRequest(workspaceId, workspaceRevision, requestSeq)) {
           return;
         }
 
@@ -672,7 +710,7 @@ export function useWorkspaceData() {
         if (e.code === ERROR_CODE.INVALID_FOLDER_VIEW) {
           Log.info('[Outline] Folder data not yet projected, retrying in 3s...');
           setTimeout(() => {
-            if (!isStaleWorkspaceRequest(workspaceId, workspaceRevision)) {
+            if (!isStaleRootOutlineRequest(workspaceId, workspaceRevision, requestSeq)) {
               void loadOutline(workspaceId, force);
             }
           }, 3000);
@@ -687,6 +725,8 @@ export function useWorkspaceData() {
       userWorkspaceInfo?.userId,
       replaceOutlinePreservingChildren,
       isStaleWorkspaceRequest,
+      isStaleRootOutlineRequest,
+      isStaleForcedOutlineNavigation,
     ]
   );
 
@@ -1129,17 +1169,24 @@ export function useWorkspaceData() {
 
       const workspaceId = currentWorkspaceId;
       const workspaceRevision = workspaceRevisionRef.current;
-      const res = await ViewService.getOutline(workspaceId);
+      const requestSeq = ++rootOutlineRequestSeqRef.current;
+      const res = await ViewService.getOutline(workspaceId).catch((error) => {
+        if (isStaleRootOutlineRequest(workspaceId, workspaceRevision, requestSeq)) {
+          return null;
+        }
 
-      if (!res) {
-        throw new Error('App outline not found');
-      }
+        throw error;
+      });
 
-      if (isStaleWorkspaceRequest(workspaceId, workspaceRevision)) {
-        Log.debug('[Outline] [periodic-revalidate] skipped stale workspace response', {
+      if (isStaleRootOutlineRequest(workspaceId, workspaceRevision, requestSeq)) {
+        Log.debug('[Outline] [periodic-revalidate] skipped stale root response', {
           workspaceId,
         });
         return 'unchanged';
+      }
+
+      if (!res) {
+        throw new Error('App outline not found');
       }
 
       const nextFolderRid = parseFolderRid(res.folderRid);
@@ -1191,7 +1238,7 @@ export function useWorkspaceData() {
       try {
         await loadViewChildrenBatch(refreshViewIds);
       } catch (error) {
-        if (isStaleWorkspaceRequest(workspaceId, workspaceRevision)) {
+        if (isStaleRootOutlineRequest(workspaceId, workspaceRevision, requestSeq)) {
           Log.debug('[Outline] [periodic-revalidate] skipped stale expanded refresh error', {
             workspaceId,
             refreshViewIds,
@@ -1207,7 +1254,7 @@ export function useWorkspaceData() {
         throw error;
       }
 
-      if (isStaleWorkspaceRequest(workspaceId, workspaceRevision)) {
+      if (isStaleRootOutlineRequest(workspaceId, workspaceRevision, requestSeq)) {
         Log.debug('[Outline] [periodic-revalidate] skipped stale expanded refresh response', {
           workspaceId,
           refreshViewIds,
@@ -1221,7 +1268,7 @@ export function useWorkspaceData() {
     [
       currentWorkspaceId,
       eventEmitter,
-      isStaleWorkspaceRequest,
+      isStaleRootOutlineRequest,
       loadViewChildrenBatch,
       markCachedFolderSubtreesStale,
       replaceOutlinePreservingChildren,
@@ -1709,6 +1756,8 @@ export function useWorkspaceData() {
     lastFolderRidRef.current = null;
     lastAppliedRootOutlineRidRef.current = null;
     lastAppliedRootOutlineFingerprintRef.current = null;
+    stableOutlineWorkspaceIdRef.current = currentWorkspaceId;
+    stableOutlineWorkspaceRevisionRef.current = workspaceRevisionRef.current;
     stableOutlineRef.current = [];
     setOutline([]);
     loadedViewIdsRef.current = new Set();
@@ -1779,8 +1828,16 @@ export function useWorkspaceData() {
     void enhancedLoadDatabaseRelations();
   }, [enhancedLoadDatabaseRelations]);
 
+  // Workspace reset effects run after commit. Gate the returned outline during
+  // render so a workspace change can never expose the previous workspace state.
+  const currentWorkspaceOutline =
+    stableOutlineWorkspaceIdRef.current === currentWorkspaceId &&
+    stableOutlineWorkspaceRevisionRef.current === workspaceRevisionRef.current
+      ? outline
+      : undefined;
+
   return {
-    outline,
+    outline: currentWorkspaceOutline,
     favoriteViews,
     recentViews,
     trashList,

--- a/src/components/app/hooks/useWorkspaceData.ts
+++ b/src/components/app/hooks/useWorkspaceData.ts
@@ -491,6 +491,8 @@ export function useWorkspaceData() {
 
   const loadOutline = useCallback(
     async (workspaceId: string, force = true) => {
+      const workspaceRevision = workspaceRevisionRef.current;
+
       try {
         // Parallelize API calls - both are independent and can run concurrently
         const [res, shareWithMeResult] = await Promise.all([
@@ -500,6 +502,10 @@ export function useWorkspaceData() {
             return null;
           }),
         ]);
+
+        if (isStaleWorkspaceRequest(workspaceId, workspaceRevision)) {
+          return;
+        }
 
         if (!res) {
           throw new Error('App outline not found');
@@ -534,6 +540,10 @@ export function useWorkspaceData() {
         if (!force) return;
 
         try {
+          if (isStaleWorkspaceRequest(workspaceId, workspaceRevision)) {
+            return;
+          }
+
           const wId = window.location.pathname.split('/')[2];
           const pageId = window.location.pathname.split('/')[3];
           const search = window.location.search;
@@ -563,9 +573,18 @@ export function useWorkspaceData() {
             } else {
               try {
                 await ViewService.get(workspaceId, lastViewId);
+
+                if (isStaleWorkspaceRequest(workspaceId, workspaceRevision)) {
+                  return;
+                }
+
                 navigate(`/app/${workspaceId}/${lastViewId}${search}`);
                 return;
               } catch {
+                if (isStaleWorkspaceRequest(workspaceId, workspaceRevision)) {
+                  return;
+                }
+
                 if (lastViewKey) {
                   localStorage.removeItem(lastViewKey);
                 }
@@ -598,6 +617,11 @@ export function useWorkspaceData() {
                 spaces.map((space) => space.view_id),
                 1
               );
+
+              if (isStaleWorkspaceRequest(workspaceId, workspaceRevision)) {
+                return;
+              }
+
               const spaceViewMap = new Map(spaceViews.map((spaceView) => [spaceView.view_id, spaceView]));
 
               for (const space of spaces) {
@@ -624,6 +648,10 @@ export function useWorkspaceData() {
 
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
       } catch (e: any) {
+        if (isStaleWorkspaceRequest(workspaceId, workspaceRevision)) {
+          return;
+        }
+
         Log.error('[Outline] App outline not found', e);
         if (e.code === ERROR_CODE.USER_UNAUTHORIZED || e.code === ERROR_CODE.NOT_LOGGED_IN) {
           invalidToken();
@@ -644,7 +672,9 @@ export function useWorkspaceData() {
         if (e.code === ERROR_CODE.INVALID_FOLDER_VIEW) {
           Log.info('[Outline] Folder data not yet projected, retrying in 3s...');
           setTimeout(() => {
-            void loadOutline(workspaceId, force);
+            if (!isStaleWorkspaceRequest(workspaceId, workspaceRevision)) {
+              void loadOutline(workspaceId, force);
+            }
           }, 3000);
           return;
         }
@@ -656,6 +686,7 @@ export function useWorkspaceData() {
       updateAppliedRootOutlineSnapshot,
       userWorkspaceInfo?.userId,
       replaceOutlinePreservingChildren,
+      isStaleWorkspaceRequest,
     ]
   );
 
@@ -1678,6 +1709,7 @@ export function useWorkspaceData() {
     lastFolderRidRef.current = null;
     lastAppliedRootOutlineRidRef.current = null;
     lastAppliedRootOutlineFingerprintRef.current = null;
+    stableOutlineRef.current = [];
     setOutline([]);
     loadedViewIdsRef.current = new Set();
     setLoadedViewIdsRevision((r) => r + 1);
@@ -1714,18 +1746,31 @@ export function useWorkspaceData() {
   // (`undefined → defined`) — that's already handled by the effect above.
   const selectedWorkspaceId = userWorkspaceInfo?.selectedWorkspace.id;
   const prevSelectedWorkspaceIdRef = useRef<string | undefined>(selectedWorkspaceId);
+  const workspaceAwaitingSelectionRef = useRef<string | null>(null);
 
   useEffect(() => {
     const prev = prevSelectedWorkspaceIdRef.current;
 
+    if (!selectedWorkspaceId || !currentWorkspaceId) return;
+
+    if (selectedWorkspaceId !== currentWorkspaceId) {
+      // A stable selection with a new URL is the direct-link/auto-switch path.
+      // Record it for one follow-up load after the server selection catches up.
+      // The inverse direction is a manual switch and the workspace-change
+      // effect will load the target once its URL changes.
+      workspaceAwaitingSelectionRef.current =
+        !prev || selectedWorkspaceId === prev ? currentWorkspaceId : null;
+      prevSelectedWorkspaceIdRef.current = selectedWorkspaceId;
+      return;
+    }
+
+    const shouldReload = workspaceAwaitingSelectionRef.current === currentWorkspaceId;
+
+    workspaceAwaitingSelectionRef.current = null;
     prevSelectedWorkspaceIdRef.current = selectedWorkspaceId;
+    if (!shouldReload) return;
 
-    // Only reload when transitioning between two defined values (an actual
-    // workspace switch), not on the initial load where prev was undefined.
-    if (!prev || !selectedWorkspaceId || prev === selectedWorkspaceId) return;
-    if (!currentWorkspaceId) return;
-
-    void loadOutline(currentWorkspaceId, false);
+    void loadOutline(selectedWorkspaceId, false);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selectedWorkspaceId, currentWorkspaceId]);
 

--- a/src/components/app/hooks/useWorkspaceData.ts
+++ b/src/components/app/hooks/useWorkspaceData.ts
@@ -377,10 +377,12 @@ export function useWorkspaceData() {
   const lastAppliedRootOutlineFingerprintRef = useRef<string | null>(null);
   const currentWorkspaceIdRef = useRef(currentWorkspaceId);
   const workspaceRevisionRef = useRef(0);
-  // Root loads and periodic revalidation share one latest-request-wins sequence.
-  // Forced routing is tracked separately so a background refresh can supersede
+  // Root loads and periodic revalidation share request IDs, but successful
+  // responses are superseded only after a newer response is accepted. Forced
+  // routing is tracked separately so a background refresh can supersede
   // outline data without leaving a root workspace URL unresolved.
   const rootOutlineRequestSeqRef = useRef(0);
+  const latestAcceptedRootOutlineRequestSeqRef = useRef(0);
   const latestForcedOutlineRequestSeqRef = useRef(0);
   const [favoriteViews, setFavoriteViews] = useState<View[]>();
   const [recentViews, setRecentViews] = useState<View[]>();
@@ -498,6 +500,16 @@ export function useWorkspaceData() {
 
   const isStaleRootOutlineRequest = useCallback(
     (workspaceId: string, workspaceRevision: number, requestSeq: number) => {
+      return (
+        isStaleWorkspaceRequest(workspaceId, workspaceRevision) ||
+        latestAcceptedRootOutlineRequestSeqRef.current > requestSeq
+      );
+    },
+    [isStaleWorkspaceRequest]
+  );
+
+  const isStaleRootOutlineFailure = useCallback(
+    (workspaceId: string, workspaceRevision: number, requestSeq: number) => {
       return isStaleWorkspaceRequest(workspaceId, workspaceRevision) || rootOutlineRequestSeqRef.current !== requestSeq;
     },
     [isStaleWorkspaceRequest]
@@ -558,7 +570,7 @@ export function useWorkspaceData() {
           outlineWithShareWithMe = [...res.outline, shareWithMeSpace];
         }
 
-        const shouldApplyOutline = rootOutlineRequestSeqRef.current === requestSeq;
+        const shouldApplyOutline = !isStaleRootOutlineRequest(workspaceId, workspaceRevision, requestSeq);
         const shouldNavigate = force && latestForcedOutlineRequestSeqRef.current === requestSeq;
 
         if (!shouldApplyOutline && !shouldNavigate) {
@@ -566,6 +578,7 @@ export function useWorkspaceData() {
         }
 
         if (shouldApplyOutline) {
+          latestAcceptedRootOutlineRequestSeqRef.current = requestSeq;
           const mergedOutline = replaceOutlinePreservingChildren(outlineWithShareWithMe);
 
           updateAppliedRootOutlineSnapshot(nextFolderRid, outlineWithShareWithMe);
@@ -686,7 +699,7 @@ export function useWorkspaceData() {
 
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
       } catch (e: any) {
-        if (isStaleRootOutlineRequest(workspaceId, workspaceRevision, requestSeq)) {
+        if (isStaleRootOutlineFailure(workspaceId, workspaceRevision, requestSeq)) {
           return;
         }
 
@@ -710,7 +723,7 @@ export function useWorkspaceData() {
         if (e.code === ERROR_CODE.INVALID_FOLDER_VIEW) {
           Log.info('[Outline] Folder data not yet projected, retrying in 3s...');
           setTimeout(() => {
-            if (!isStaleRootOutlineRequest(workspaceId, workspaceRevision, requestSeq)) {
+            if (!isStaleRootOutlineFailure(workspaceId, workspaceRevision, requestSeq)) {
               void loadOutline(workspaceId, force);
             }
           }, 3000);
@@ -726,6 +739,7 @@ export function useWorkspaceData() {
       replaceOutlinePreservingChildren,
       isStaleWorkspaceRequest,
       isStaleRootOutlineRequest,
+      isStaleRootOutlineFailure,
       isStaleForcedOutlineNavigation,
     ]
   );
@@ -936,11 +950,15 @@ export function useWorkspaceData() {
   );
 
   const loadViewChildrenBatch = useCallback(
-    async (viewIds: string[]): Promise<View[]> => {
+    async (viewIds: string[], rootRequestSeq?: number): Promise<View[]> => {
       if (!currentWorkspaceId || viewIds.length === 0) return [];
 
       const workspaceId = currentWorkspaceId;
       const workspaceRevision = workspaceRevisionRef.current;
+      const isStaleBatchRequest = () =>
+        rootRequestSeq === undefined
+          ? isStaleWorkspaceRequest(workspaceId, workspaceRevision)
+          : isStaleRootOutlineRequest(workspaceId, workspaceRevision, rootRequestSeq);
       const uniqueIds = Array.from(new Set(viewIds)).filter((viewId) => !loadingViewIdsRef.current.has(viewId));
 
       if (uniqueIds.length === 0) return [];
@@ -965,7 +983,7 @@ export function useWorkspaceData() {
 
         const views = await ViewService.getMultiple(workspaceId, uniqueIds, 1);
 
-        if (isStaleWorkspaceRequest(workspaceId, workspaceRevision)) {
+        if (isStaleBatchRequest()) {
           return views;
         }
 
@@ -1007,7 +1025,7 @@ export function useWorkspaceData() {
 
         return views;
       } catch (e) {
-        if (isStaleWorkspaceRequest(workspaceId, workspaceRevision)) {
+        if (isStaleBatchRequest()) {
           return [];
         }
 
@@ -1019,7 +1037,14 @@ export function useWorkspaceData() {
         }
       }
     },
-    [currentWorkspaceId, stableOutlineRef, eventEmitter, isStaleWorkspaceRequest, updateLastFolderRid]
+    [
+      currentWorkspaceId,
+      stableOutlineRef,
+      eventEmitter,
+      isStaleWorkspaceRequest,
+      isStaleRootOutlineRequest,
+      updateLastFolderRid,
+    ]
   );
 
   const markViewChildrenStale = useCallback(
@@ -1170,13 +1195,18 @@ export function useWorkspaceData() {
       const workspaceId = currentWorkspaceId;
       const workspaceRevision = workspaceRevisionRef.current;
       const requestSeq = ++rootOutlineRequestSeqRef.current;
-      const res = await ViewService.getOutline(workspaceId).catch((error) => {
-        if (isStaleRootOutlineRequest(workspaceId, workspaceRevision, requestSeq)) {
-          return null;
+      const outlineRequest = ViewService.getOutline(workspaceId);
+      let res: Awaited<typeof outlineRequest>;
+
+      try {
+        res = await outlineRequest;
+      } catch (error) {
+        if (isStaleRootOutlineFailure(workspaceId, workspaceRevision, requestSeq)) {
+          return 'unchanged';
         }
 
         throw error;
-      });
+      }
 
       if (isStaleRootOutlineRequest(workspaceId, workspaceRevision, requestSeq)) {
         Log.debug('[Outline] [periodic-revalidate] skipped stale root response', {
@@ -1188,6 +1218,8 @@ export function useWorkspaceData() {
       if (!res) {
         throw new Error('App outline not found');
       }
+
+      latestAcceptedRootOutlineRequestSeqRef.current = requestSeq;
 
       const nextFolderRid = parseFolderRid(res.folderRid);
       const currentRid = lastAppliedRootOutlineRidRef.current;
@@ -1236,7 +1268,7 @@ export function useWorkspaceData() {
       }
 
       try {
-        await loadViewChildrenBatch(refreshViewIds);
+        await loadViewChildrenBatch(refreshViewIds, requestSeq);
       } catch (error) {
         if (isStaleRootOutlineRequest(workspaceId, workspaceRevision, requestSeq)) {
           Log.debug('[Outline] [periodic-revalidate] skipped stale expanded refresh error', {
@@ -1268,6 +1300,7 @@ export function useWorkspaceData() {
     [
       currentWorkspaceId,
       eventEmitter,
+      isStaleRootOutlineFailure,
       isStaleRootOutlineRequest,
       loadViewChildrenBatch,
       markCachedFolderSubtreesStale,

--- a/src/components/app/layers/AppAuthLayer.tsx
+++ b/src/components/app/layers/AppAuthLayer.tsx
@@ -65,6 +65,7 @@ export const AppAuthLayer: React.FC<AppAuthLayerProps> = ({ children }) => {
   const [aiEnabled, setAIEnabled] = useState<boolean | undefined>(false);
   const workspaceInfoPromiseRef = useRef<Promise<UserWorkspaceInfo | undefined> | null>(null);
   const workspaceInfoRequestIdRef = useRef(0);
+  const pendingWorkspaceChangeRef = useRef<string | null>(null);
 
   // Calculate current workspace ID from URL params or user info
   const currentWorkspaceId = useMemo(
@@ -125,15 +126,35 @@ export const AppAuthLayer: React.FC<AppAuthLayerProps> = ({ children }) => {
         return;
       }
 
-      await WorkspaceService.open(workspaceId);
+      pendingWorkspaceChangeRef.current = workspaceId;
 
-      await loadUserWorkspaceInfo({ force: true });
+      try {
+        await WorkspaceService.open(workspaceId);
 
-      // Clean up old global key for backward compatibility
-      // New per-workspace-per-user keys don't need to be removed on workspace change
-      localStorage.removeItem('last_view_id');
+        const workspaceInfo = await loadUserWorkspaceInfo({ force: true });
 
-      navigate(`/app/${workspaceId}`);
+        // Clean up old global key for backward compatibility
+        // New per-workspace-per-user keys don't need to be removed on workspace change
+        localStorage.removeItem('last_view_id');
+
+        // Keep the URL transition behind the workspace-info refresh so
+        // workspace-scoped consumers never see the new URL with old metadata.
+        // pendingWorkspaceChangeRef suppresses the inverse intermediate state:
+        // the new server selection with the previous URL.
+        navigate(`/app/${workspaceId}`);
+
+        // A failed or inconsistent refresh should fall back to the URL-driven
+        // auto-switch path instead of leaving it suppressed indefinitely.
+        if (workspaceInfo?.selectedWorkspace.id !== workspaceId && pendingWorkspaceChangeRef.current === workspaceId) {
+          pendingWorkspaceChangeRef.current = null;
+        }
+      } catch (error) {
+        if (pendingWorkspaceChangeRef.current === workspaceId) {
+          pendingWorkspaceChangeRef.current = null;
+        }
+
+        throw error;
+      }
     },
     [loadUserWorkspaceInfo, navigate, userWorkspaceInfo]
   );
@@ -283,6 +304,15 @@ export const AppAuthLayer: React.FC<AppAuthLayerProps> = ({ children }) => {
     if (!isAuthenticated || !urlWorkspaceId || !userWorkspaceInfo) return;
 
     const selectedId = userWorkspaceInfo.selectedWorkspace.id;
+    const pendingWorkspaceId = pendingWorkspaceChangeRef.current;
+
+    if (pendingWorkspaceId) {
+      if (urlWorkspaceId === pendingWorkspaceId && selectedId === pendingWorkspaceId) {
+        pendingWorkspaceChangeRef.current = null;
+      } else {
+        return;
+      }
+    }
 
     // Already on the correct workspace
     if (urlWorkspaceId === selectedId) return;

--- a/src/components/app/layers/__tests__/AppAuthLayer.test.tsx
+++ b/src/components/app/layers/__tests__/AppAuthLayer.test.tsx
@@ -8,11 +8,12 @@ import { AppAuthLayer } from '@/components/app/layers/AppAuthLayer';
 import { AFConfigContext } from '@/components/main/app.hooks';
 
 const mockNavigate = jest.fn();
+let mockWorkspaceId: string | undefined;
 
 jest.mock('react-router-dom', () => ({
   useLocation: () => ({ pathname: '/login' }),
   useNavigate: () => mockNavigate,
-  useParams: () => ({}),
+  useParams: () => ({ workspaceId: mockWorkspaceId }),
 }));
 
 jest.mock('@/application/session/token', () => ({
@@ -57,6 +58,7 @@ describe('AppAuthLayer workspace info loading', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    mockWorkspaceId = undefined;
     mockGetServerInfo.mockResolvedValue({
       enable_page_history: true,
       ai_enabled: true,
@@ -121,6 +123,61 @@ describe('AppAuthLayer workspace info loading', () => {
       await staleWorkspaceInfo.promise;
     });
 
+    expect(screen.getByTestId('selected-workspace').textContent).toBe('workspace-new');
+  });
+
+  it('does not reopen the previous URL workspace while a manual switch settles', async () => {
+    const callOrder: string[] = [];
+    let latestAuthContext: AuthInternalContextType | null = null;
+
+    mockWorkspaceId = 'workspace-old';
+    mockNavigate.mockImplementation((path: string) => {
+      callOrder.push(`navigate:${path}`);
+      mockWorkspaceId = path.split('/')[2];
+    });
+    mockOpenWorkspace.mockImplementation(async (workspaceId: string) => {
+      callOrder.push(`open:${workspaceId}`);
+      return undefined as never;
+    });
+    mockGetWorkspaceInfo
+      .mockResolvedValueOnce(createWorkspaceInfo('workspace-old') as never)
+      .mockImplementationOnce(async () => {
+        callOrder.push('refresh-workspace-info');
+        return createWorkspaceInfo('workspace-new') as never;
+      });
+
+    function CaptureAuthContext() {
+      latestAuthContext = useContext(AuthInternalContext);
+
+      return (
+        <div data-testid='selected-workspace'>
+          {latestAuthContext?.userWorkspaceInfo?.selectedWorkspace.id ?? 'none'}
+        </div>
+      );
+    }
+
+    render(
+      <AFConfigContext.Provider
+        value={{
+          isAuthenticated: true,
+          updateCurrentUser: jest.fn(),
+          openLoginModal: jest.fn(),
+        }}
+      >
+        <AppAuthLayer>
+          <CaptureAuthContext />
+        </AppAuthLayer>
+      </AFConfigContext.Provider>
+    );
+
+    await waitFor(() => expect(screen.getByTestId('selected-workspace').textContent).toBe('workspace-old'));
+
+    await act(async () => {
+      await latestAuthContext!.onChangeWorkspace('workspace-new');
+    });
+
+    expect(callOrder).toEqual(['open:workspace-new', 'refresh-workspace-info', 'navigate:/app/workspace-new']);
+    expect(mockOpenWorkspace).toHaveBeenCalledTimes(1);
     expect(screen.getByTestId('selected-workspace').textContent).toBe('workspace-new');
   });
 });


### PR DESCRIPTION
## Summary

- suppress URL-driven auto-switching while a manual workspace change is settling
- scope outline loads, retries, and follow-up navigation to the workspace revision that started them
- clear workspace-scoped outline state and avoid mismatched or duplicate catch-up loads
- add a Playwright BDD regression that holds an old workspace outline response until after the target workspace has loaded

## Root cause

A manual switch could refresh `selectedWorkspace` before the URL changed. The URL reconciliation effect interpreted that intermediate state as a direct-link mismatch and reopened the workspace the user had just left. At the same time, root outline requests were not checked against the active workspace after awaiting the server, so a slow response from a content-heavy workspace could replace the target workspace sidebar.

## Impact

Workspace switches remain on the user-selected workspace, and late responses from the previous workspace can no longer render its spaces under the target workspace. Normal manual switches also avoid a duplicate target outline load, while direct shared links still revalidate once the server-side selection catches up.

## Validation

- `pnpm lint`
- `pnpm exec jest src/components/app/layers/__tests__/AppAuthLayer.test.tsx src/components/app/hooks/__tests__/useWorkspaceData.sidebarRevalidation.test.tsx --runInBand --no-coverage` (23 passed)
- `pnpm exec bddgen test -c playwright.bdd.config.ts`
- focused Playwright BDD scenario (passed)
- focused Playwright BDD scenario with `--repeat-each=3` (3 passed)

## Summary by Sourcery

Prevent stale workspace sidebar outlines and URL-driven auto-switches from overriding the active workspace during manual switches and delayed responses.

Bug Fixes:
- Ensure delayed outline responses from a previous workspace are ignored once the user has switched to a new workspace.
- Avoid reopening the previous workspace via URL reconciliation while a manual workspace change is in progress.
- Prevent duplicate or mismatched outline reloads by gating revalidation on consistent selected and URL workspaces.

Enhancements:
- Track workspace request revision and clear workspace-scoped outline state when switching to keep sidebar data aligned with the active workspace.

Tests:
- Add unit tests around outline loading behavior for stale responses and URL/selected workspace reconciliation.
- Add Jest coverage for suppressing URL-based workspace reopening during manual workspace switches.
- Introduce a Playwright BDD scenario that simulates a delayed previous-workspace outline and verifies the target workspace sidebar remains correct.