### PR TITLE
Fix empty filter behavior and debounce input

### DIFF
--- a/src/application/database-yjs/__tests__/filter.test.ts
+++ b/src/application/database-yjs/__tests__/filter.test.ts
@@ -183,6 +183,18 @@ describe('number filter tests', () => {
     expect(numberFilterCheck('0', '0', NumberFilterCondition.Equal)).toBe(true);
   });
 
+  it.each([
+    ['equal', NumberFilterCondition.Equal],
+    ['not equal', NumberFilterCondition.NotEqual],
+    ['greater than', NumberFilterCondition.GreaterThan],
+    ['greater than or equal', NumberFilterCondition.GreaterThanOrEqualTo],
+    ['less than', NumberFilterCondition.LessThan],
+    ['less than or equal', NumberFilterCondition.LessThanOrEqualTo],
+  ])('does not apply %s until a comparison value is provided', (_label, condition) => {
+    expect(numberFilterCheck('10', '', condition)).toBe(true);
+    expect(numberFilterCheck('', '   ', condition)).toBe(true);
+  });
+
   it('handles NaN values', () => {
     expect(numberFilterCheck('NaN', '5', NumberFilterCondition.Equal)).toBe(false);
     expect(numberFilterCheck('NaN', '5', NumberFilterCondition.NumberIsNotEmpty)).toBe(true);
@@ -475,6 +487,21 @@ describe('advanced filter tests', () => {
     ]);
 
     const result = filterBy(rows, filters, fields, rowMetas).map((row) => row.id);
+    expect(result).toEqual(['row-a', 'row-b', 'row-c']);
+  });
+
+  it('keeps all rows until a number filter comparison value is entered', () => {
+    const filters = createFilters([
+      {
+        fieldId: numberFieldId,
+        fieldType: FieldType.Number,
+        condition: NumberFilterCondition.Equal,
+        content: '',
+      },
+    ]);
+
+    const result = filterBy(rows, filters, fields, rowMetas).map((row) => row.id);
+
     expect(result).toEqual(['row-a', 'row-b', 'row-c']);
   });
 });

--- a/src/application/database-yjs/__tests__/filter.test.ts
+++ b/src/application/database-yjs/__tests__/filter.test.ts
@@ -1602,6 +1602,28 @@ describe('desktop grid filter parity', () => {
     expect(result).toEqual([fixture.rowIds[0], fixture.rowIds[1], fixture.rowIds[3], fixture.rowIds[5]]);
   });
 
+  it('ignores blank input filters inside OR groups', () => {
+    const { makeDataFilter, makeGroupFilter, makeFilters } = buildFilterHarness();
+    const blankTextFilter = makeDataFilter(
+      fixture.fieldIds.text,
+      FieldType.RichText,
+      TextFilterCondition.TextContains,
+      ''
+    );
+    const checkboxFilter = makeDataFilter(
+      fixture.fieldIds.checkbox,
+      FieldType.Checkbox,
+      CheckboxFilterCondition.IsChecked
+    );
+    const orGroup = makeGroupFilter(FilterType.Or, [blankTextFilter, checkboxFilter]);
+
+    expect(applyFilters(makeFilters([orGroup]))).toEqual([
+      fixture.rowIds[0],
+      fixture.rowIds[1],
+      fixture.rowIds[5],
+    ]);
+  });
+
   it('applies nested filters with mixed group order', () => {
     const { makeDataFilter, makeGroupFilter, makeFilters } = buildFilterHarness();
     const checkboxFilter = makeDataFilter(

--- a/src/application/database-yjs/__tests__/useRowOrdersSelector.test.tsx
+++ b/src/application/database-yjs/__tests__/useRowOrdersSelector.test.tsx
@@ -179,6 +179,7 @@ describe('useRowOrdersSelector', () => {
 
   it('keeps current rows visible when a blank filter is created', async () => {
     const fixture = createDatabaseFixture();
+    const filterBySpy = jest.spyOn(databaseFilter, 'filterBy');
     const renderedOrders: Array<string[] | undefined> = [];
     const { result } = renderHook(
       () => {
@@ -196,14 +197,18 @@ describe('useRowOrdersSelector', () => {
       expect(result.current?.map((row) => row.id)).toEqual(['row-c', 'row-a', 'row-b']);
     });
 
+    filterBySpy.mockClear();
     const renderCountBeforeFilter = renderedOrders.length;
+    const rowsBeforeFilter = result.current;
 
     act(() => {
       fixture.filters.push([createTextFilter('')]);
     });
 
+    expect(result.current).toBe(rowsBeforeFilter);
     expect(result.current?.map((row) => row.id)).toEqual(['row-c', 'row-a', 'row-b']);
     expect(renderedOrders.slice(renderCountBeforeFilter)).not.toContain(undefined);
+    expect(filterBySpy).not.toHaveBeenCalled();
 
     act(() => {
       jest.advanceTimersByTime(250);
@@ -212,6 +217,9 @@ describe('useRowOrdersSelector', () => {
     await waitFor(() => {
       expect(result.current?.map((row) => row.id)).toEqual(['row-c', 'row-a', 'row-b']);
     });
+
+    expect(filterBySpy).not.toHaveBeenCalled();
+    filterBySpy.mockRestore();
   });
 
   it('computes each filter change once', async () => {
@@ -240,6 +248,27 @@ describe('useRowOrdersSelector', () => {
 
     expect(filterBySpy).toHaveBeenCalledTimes(1);
     filterBySpy.mockRestore();
+  });
+
+  it('applies conditions that do not require an input value', async () => {
+    const fixture = createDatabaseFixture();
+    const emptyFilter = createTextFilter('');
+
+    emptyFilter.set(YjsDatabaseKey.condition, TextFilterCondition.TextIsEmpty);
+
+    const { result } = renderHook(() => useRowOrdersSelector(), {
+      wrapper: createWrapper(fixture),
+    });
+
+    await waitFor(() => {
+      expect(result.current?.map((row) => row.id)).toEqual(['row-c', 'row-a', 'row-b']);
+    });
+
+    act(() => {
+      fixture.filters.push([emptyFilter]);
+    });
+
+    expect(result.current).toEqual([]);
   });
 
   it('updates unconditioned row order immediately when rows are added or removed', async () => {

--- a/src/application/database-yjs/__tests__/useRowOrdersSelector.test.tsx
+++ b/src/application/database-yjs/__tests__/useRowOrdersSelector.test.tsx
@@ -10,6 +10,8 @@ import {
   TextFilterCondition,
   useRowOrdersSelector,
 } from '@/application/database-yjs';
+import { useUpdateAdvancedFilter } from '@/application/database-yjs/dispatch';
+import * as databaseFilter from '@/application/database-yjs/filter';
 import {
   RowId,
   YDatabaseField,
@@ -212,6 +214,34 @@ describe('useRowOrdersSelector', () => {
     });
   });
 
+  it('computes each filter change once', async () => {
+    const fixture = createDatabaseFixture();
+    const filterBySpy = jest.spyOn(databaseFilter, 'filterBy');
+    const { result } = renderHook(() => useRowOrdersSelector(), {
+      wrapper: createWrapper(fixture),
+    });
+
+    await waitFor(() => {
+      expect(result.current?.map((row) => row.id)).toEqual(['row-c', 'row-a', 'row-b']);
+    });
+
+    filterBySpy.mockClear();
+
+    act(() => {
+      fixture.filters.push([createTextFilter('match')]);
+    });
+
+    expect(result.current?.map((row) => row.id)).toEqual(['row-a', 'row-b']);
+    expect(filterBySpy).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      jest.advanceTimersByTime(250);
+    });
+
+    expect(filterBySpy).toHaveBeenCalledTimes(1);
+    filterBySpy.mockRestore();
+  });
+
   it('updates unconditioned row order immediately when rows are added or removed', async () => {
     const fixture = createDatabaseFixture();
     const { result } = renderHook(() => useRowOrdersSelector(), {
@@ -391,5 +421,30 @@ describe('useRowOrdersSelector', () => {
     await waitFor(() => {
       expect(result.current?.map((row) => row.id)).toEqual(['row-a', 'row-b']);
     });
+  });
+});
+
+describe('useUpdateAdvancedFilter', () => {
+  it('ignores a delayed update targeting a previous field', () => {
+    const fixture = createDatabaseFixture();
+    const filter = createTextFilter('');
+
+    fixture.filters.push([filter]);
+
+    const { result } = renderHook(() => useUpdateAdvancedFilter(), {
+      wrapper: createWrapper(fixture),
+    });
+
+    act(() => {
+      filter.set(YjsDatabaseKey.field_id, 'replacement-field');
+      result.current({
+        filterId: 'filter-id',
+        fieldId,
+        content: 'stale value',
+      });
+    });
+
+    expect(filter.get(YjsDatabaseKey.field_id)).toBe('replacement-field');
+    expect(filter.get(YjsDatabaseKey.content)).toBe('');
   });
 });

--- a/src/application/database-yjs/__tests__/useRowOrdersSelector.test.tsx
+++ b/src/application/database-yjs/__tests__/useRowOrdersSelector.test.tsx
@@ -175,6 +175,43 @@ describe('useRowOrdersSelector', () => {
     });
   });
 
+  it('keeps current rows visible when a blank filter is created', async () => {
+    const fixture = createDatabaseFixture();
+    const renderedOrders: Array<string[] | undefined> = [];
+    const { result } = renderHook(
+      () => {
+        const rows = useRowOrdersSelector();
+
+        renderedOrders.push(rows?.map((row) => row.id));
+        return rows;
+      },
+      {
+        wrapper: createWrapper(fixture),
+      }
+    );
+
+    await waitFor(() => {
+      expect(result.current?.map((row) => row.id)).toEqual(['row-c', 'row-a', 'row-b']);
+    });
+
+    const renderCountBeforeFilter = renderedOrders.length;
+
+    act(() => {
+      fixture.filters.push([createTextFilter('')]);
+    });
+
+    expect(result.current?.map((row) => row.id)).toEqual(['row-c', 'row-a', 'row-b']);
+    expect(renderedOrders.slice(renderCountBeforeFilter)).not.toContain(undefined);
+
+    act(() => {
+      jest.advanceTimersByTime(250);
+    });
+
+    await waitFor(() => {
+      expect(result.current?.map((row) => row.id)).toEqual(['row-c', 'row-a', 'row-b']);
+    });
+  });
+
   it('updates unconditioned row order immediately when rows are added or removed', async () => {
     const fixture = createDatabaseFixture();
     const { result } = renderHook(() => useRowOrdersSelector(), {

--- a/src/application/database-yjs/dispatch.ts
+++ b/src/application/database-yjs/dispatch.ts
@@ -3629,8 +3629,12 @@ export function useUpdateFilter() {
               return;
             }
 
-            // Update field_id (always required)
-            filter.set(YjsDatabaseKey.field_id, fieldId);
+            // fieldId identifies the filter target; field changes use a separate
+            // rebuild path. Ignore delayed updates aimed at a previous field.
+            if (filter.get(YjsDatabaseKey.field_id) !== fieldId) {
+              Log.debug('[useUpdateFilter] Skipping stale filter update', { filterId, fieldId });
+              return;
+            }
 
             // Update condition if provided
             if (condition !== undefined) {

--- a/src/application/database-yjs/dispatch/sort-filter.ts
+++ b/src/application/database-yjs/dispatch/sort-filter.ts
@@ -798,11 +798,12 @@ export function useUpdateAdvancedFilter() {
             }
 
             if (filter) {
-              // Fast path: filter is a Yjs Map — update in-place
-              if (fieldId) {
-                filter.set(YjsDatabaseKey.field_id, fieldId);
+              if (fieldId && filter.get(YjsDatabaseKey.field_id) !== fieldId) {
+                Log.debug('[useUpdateAdvancedFilter] Skipping stale filter update', { filterId, fieldId });
+                return;
               }
 
+              // Fast path: filter is a Yjs Map — update in-place
               if (condition !== undefined) {
                 filter.set(YjsDatabaseKey.condition, condition);
               }
@@ -827,7 +828,14 @@ export function useUpdateAdvancedFilter() {
 
             const draft = { ...currentDrafts[idx] };
 
-            if (fieldId) draft.fieldId = fieldId;
+            if (fieldId && draft.fieldId !== fieldId) {
+              Log.debug('[useUpdateAdvancedFilter] Skipping stale plain-object filter update', {
+                filterId,
+                fieldId,
+              });
+              return;
+            }
+
             if (condition !== undefined) draft.condition = condition;
             if (content !== undefined) draft.content = content;
 

--- a/src/application/database-yjs/filter.ts
+++ b/src/application/database-yjs/filter.ts
@@ -158,6 +158,158 @@ function getFilterChildren(filter: YDatabaseFilter): YDatabaseFilter[] {
     .filter((node): node is YDatabaseFilter => node !== null);
 }
 
+type EffectiveFilterSnapshot = {
+  filterType: number;
+  fieldId?: string;
+  fieldType?: number;
+  condition?: number;
+  content?: unknown;
+  children?: EffectiveFilterSnapshot[];
+};
+
+function hasTextFilterContent(content: unknown) {
+  return typeof content === 'string' && content.length > 0;
+}
+
+function hasNumericFilterContent(content: unknown) {
+  return typeof content === 'string' && content.trim().length > 0;
+}
+
+function hasListFilterContent(content: unknown) {
+  if (typeof content !== 'string') return false;
+
+  const trimmed = content.trim();
+
+  if (!trimmed) return false;
+
+  try {
+    const parsed = JSON.parse(trimmed);
+
+    if (Array.isArray(parsed)) {
+      return parsed.length > 0;
+    }
+  } catch {
+    // Select filters also use comma-separated IDs.
+  }
+
+  return trimmed
+    .split(',')
+    .map((item) => item.trim())
+    .some(Boolean);
+}
+
+function isDataFilterEffective(filter: YDatabaseFilter, field: YDatabaseField) {
+  const fieldType = Number(field.get(YjsDatabaseKey.type));
+  const condition = Number(filter.get(YjsDatabaseKey.condition));
+  const content = filter.get(YjsDatabaseKey.content);
+
+  switch (fieldType) {
+    case FieldType.RichText:
+    case FieldType.URL:
+      return (
+        condition === TextFilterCondition.TextIsEmpty ||
+        condition === TextFilterCondition.TextIsNotEmpty ||
+        hasTextFilterContent(content)
+      );
+    case FieldType.Rollup:
+      return (
+        condition === TextFilterCondition.TextIsEmpty ||
+        condition === TextFilterCondition.TextIsNotEmpty ||
+        (isNumericRollupField(field) ? hasNumericFilterContent(content) : hasTextFilterContent(content))
+      );
+    case FieldType.Relation:
+      return (
+        condition === RelationFilterCondition.RelationIsEmpty ||
+        condition === RelationFilterCondition.RelationIsNotEmpty ||
+        condition === RelationFilterCondition.RelationLegacyTextIsEmpty ||
+        condition === RelationFilterCondition.RelationLegacyTextIsNotEmpty ||
+        hasListFilterContent(content)
+      );
+    case FieldType.SingleSelect:
+    case FieldType.MultiSelect:
+      return (
+        condition === SelectOptionFilterCondition.OptionIsEmpty ||
+        condition === SelectOptionFilterCondition.OptionIsNotEmpty ||
+        hasListFilterContent(content)
+      );
+    case FieldType.Person:
+      return (
+        condition === PersonFilterCondition.PersonIsEmpty ||
+        condition === PersonFilterCondition.PersonIsNotEmpty ||
+        hasListFilterContent(content)
+      );
+    case FieldType.Number:
+    case FieldType.Time:
+      return (
+        condition === NumberFilterCondition.NumberIsEmpty ||
+        condition === NumberFilterCondition.NumberIsNotEmpty ||
+        hasNumericFilterContent(content)
+      );
+    case FieldType.DateTime:
+    case FieldType.CreatedTime:
+    case FieldType.LastEditedTime:
+      return (
+        condition === DateFilterCondition.DateStartIsEmpty ||
+        condition === DateFilterCondition.DateStartIsNotEmpty ||
+        condition === DateFilterCondition.DateEndIsEmpty ||
+        condition === DateFilterCondition.DateEndIsNotEmpty ||
+        isRelativeDateCondition(condition) ||
+        hasTextFilterContent(content)
+      );
+    case FieldType.Checkbox:
+    case FieldType.Checklist:
+      return true;
+    default:
+      return false;
+  }
+}
+
+function getEffectiveFilterSnapshot(
+  filterNode: YDatabaseFilter,
+  fields: YDatabaseFields
+): EffectiveFilterSnapshot | null {
+  const node = normalizeFilterNode(filterNode);
+
+  if (!node) return null;
+
+  const filterTypeValue = Number(node.get(YjsDatabaseKey.filter_type));
+  const filterType = Number.isFinite(filterTypeValue) ? filterTypeValue : FilterType.Data;
+
+  if (filterType === FilterType.And || filterType === FilterType.Or) {
+    const children = getFilterChildren(node)
+      .map((child) => getEffectiveFilterSnapshot(child, fields))
+      .filter((child): child is EffectiveFilterSnapshot => child !== null);
+
+    return children.length > 0 ? { filterType, children } : null;
+  }
+
+  const fieldId = node.get(YjsDatabaseKey.field_id);
+  const field = fields.get(fieldId);
+
+  if (!field || !isDataFilterEffective(node, field)) return null;
+
+  return {
+    filterType,
+    fieldId,
+    fieldType: Number(field.get(YjsDatabaseKey.type)),
+    condition: Number(node.get(YjsDatabaseKey.condition)),
+    content: node.get(YjsDatabaseKey.content),
+  };
+}
+
+export function getEffectiveFiltersSnapshot(filters?: YDatabaseFilters, fields?: YDatabaseFields) {
+  if (!filters || !fields) return [];
+
+  return filters
+    .toArray()
+    .map((filterNode) => getEffectiveFilterSnapshot(filterNode, fields))
+    .filter((snapshot): snapshot is EffectiveFilterSnapshot => snapshot !== null);
+}
+
+export function hasEffectiveFilters(filters?: YDatabaseFilters, fields?: YDatabaseFields) {
+  return getEffectiveFiltersSnapshot(filters, fields).length > 0;
+}
+
 function parseRelationFilterIds(content: string): string[] | null {
   const trimmed = content.trim();
 
@@ -570,9 +722,9 @@ export function filterBy(
 
   if (filterArray.length === 0 || Object.keys(rowMetas).length === 0 || fields.size === 0) return rows;
 
-  const compileFilterPredicate = (filterNode: YDatabaseFilter): ((row: Row) => boolean) => {
+  const compileFilterPredicate = (filterNode: YDatabaseFilter): ((row: Row) => boolean) | null => {
     if (!filterNode || typeof filterNode !== 'object') {
-      return () => true;
+      return null;
     }
 
     // Wrap plain objects that lack .get() (e.g. from desktop sync)
@@ -583,9 +735,11 @@ export function filterBy(
     const filterType = Number(node.get(YjsDatabaseKey.filter_type));
 
     if (filterType === FilterType.And || filterType === FilterType.Or) {
-      const childPredicates = getFilterChildren(node).map(compileFilterPredicate);
+      const childPredicates = getFilterChildren(node)
+        .map(compileFilterPredicate)
+        .filter((predicate): predicate is (row: Row) => boolean => predicate !== null);
 
-      if (childPredicates.length === 0) return () => true;
+      if (childPredicates.length === 0) return null;
 
       if (filterType === FilterType.And) {
         return (row: Row) => every(childPredicates, (predicate) => predicate(row));
@@ -597,7 +751,7 @@ export function filterBy(
     const fieldId = node.get(YjsDatabaseKey.field_id);
     const field = fields.get(fieldId);
 
-    if (!field) return () => true;
+    if (!field || !isDataFilterEffective(node, field)) return null;
 
     const fieldType = Number(field.get(YjsDatabaseKey.type));
     const filterValue = parseFilter(fieldType, node);
@@ -700,7 +854,12 @@ export function filterBy(
     };
   };
 
-  const conditions = filterArray.map(compileFilterPredicate);
+  const conditions = filterArray
+    .map(compileFilterPredicate)
+    .filter((predicate): predicate is (row: Row) => boolean => predicate !== null);
+
+  if (conditions.length === 0) return rows;
+
   const predicate = createPredicate(conditions);
 
   return filter(rows, predicate);

--- a/src/application/database-yjs/filter.ts
+++ b/src/application/database-yjs/filter.ts
@@ -730,6 +730,14 @@ export function textFilterCheck(data: string, content: string, condition: TextFi
 }
 
 export function numberFilterCheck(data: string, content: string, condition: number) {
+  const isEmptyCondition =
+    condition === NumberFilterCondition.NumberIsEmpty ||
+    condition === NumberFilterCondition.NumberIsNotEmpty;
+
+  if (!isEmptyCondition && content.trim() === '') {
+    return true;
+  }
+
   if (isNaN(Number(data)) || isNaN(Number(content)) || data === '' || content === '') {
     if (condition === NumberFilterCondition.NumberIsEmpty) {
       return data === '';

--- a/src/application/database-yjs/selector.ts
+++ b/src/application/database-yjs/selector.ts
@@ -1617,7 +1617,7 @@ export function useRowOrdersSelector() {
       // rows with the loading placeholder. onConditionsChange still publishes
       // the loading state when row documents genuinely need hydration.
       onConditionsChange();
-      debouncedChange();
+      setRollupWatchVersion((prev) => prev + 1);
     };
 
     const handleFieldChange = () => {

--- a/src/application/database-yjs/selector.ts
+++ b/src/application/database-yjs/selector.ts
@@ -1613,15 +1613,10 @@ export function useRowOrdersSelector() {
     };
 
     const handleSortFilterChange = () => {
-      const conditionSignature = getConditionSignature(sorts, filters);
-      const conditionStateKey = `${viewId ?? ''}:${conditionSignature}`;
-
-      if (conditionSignatureRef.current !== conditionStateKey) {
-        conditionSignatureRef.current = conditionStateKey;
-        filtersAppliedRef.current = false;
-        setRowOrdersState({ rows: undefined, conditionSignature: conditionStateKey });
-      }
-
+      // Recompute immediately so a filter change does not replace already-loaded
+      // rows with the loading placeholder. onConditionsChange still publishes
+      // the loading state when row documents genuinely need hydration.
+      onConditionsChange();
       debouncedChange();
     };
 

--- a/src/application/database-yjs/selector.ts
+++ b/src/application/database-yjs/selector.ts
@@ -25,7 +25,13 @@ import {
   parseSelectOptionTypeOptions,
   SelectOption,
 } from '@/application/database-yjs/fields';
-import { filterBy, flattenFilterTree, parseFilter } from '@/application/database-yjs/filter';
+import {
+  filterBy,
+  flattenFilterTree,
+  getEffectiveFiltersSnapshot,
+  hasEffectiveFilters,
+  parseFilter,
+} from '@/application/database-yjs/filter';
 import { getGroupColumns, groupByField } from '@/application/database-yjs/group';
 import { useBackgroundRowDocLoader, useRollupFieldObservers } from '@/application/database-yjs/hooks';
 import {
@@ -53,6 +59,7 @@ import {
   YDatabase,
   YDatabaseChartLayoutSetting,
   YDatabaseField,
+  YDatabaseFields,
   YDatabaseFilters,
   YDatabaseMetas,
   YDatabaseRow,
@@ -101,13 +108,14 @@ function stringifyConditionSignature(value: unknown) {
   return JSON.stringify(value, (_key, item) => (typeof item === 'bigint' ? item.toString() : item));
 }
 
-function getConditionSignature(sorts?: YDatabaseSorts, filters?: YDatabaseFilters) {
-  const hasConditions = (sorts?.length ?? 0) > 0 || (filters?.length ?? 0) > 0;
+function getConditionSignature(sorts?: YDatabaseSorts, filters?: YDatabaseFilters, fields?: YDatabaseFields) {
+  const effectiveFilters = getEffectiveFiltersSnapshot(filters, fields);
+  const hasConditions = (sorts?.length ?? 0) > 0 || effectiveFilters.length > 0;
 
   if (!hasConditions) return '';
 
   return stringifyConditionSignature({
-    filters: filters?.toJSON?.() ?? [],
+    filters: effectiveFilters,
     sorts: sorts?.toJSON?.() ?? [],
   });
 }
@@ -1262,7 +1270,7 @@ export function useRowOrdersSelector() {
   const unavailableConditionRowsRef = useRef(new Set<string>());
 
   // Check if there are active conditions
-  const hasConditions = (sorts?.length ?? 0) > 0 || (filters?.length ?? 0) > 0;
+  const hasConditions = (sorts?.length ?? 0) > 0 || hasEffectiveFilters(filters, fields);
 
   // Background loading of row docs for sorting/filtering
   const { cachedRowDocs } = useBackgroundRowDocLoader(hasConditions);
@@ -1370,7 +1378,7 @@ export function useRowOrdersSelector() {
 
     if (!originalRowOrders) return false;
 
-    const conditionSignature = getConditionSignature(sorts, filters);
+    const conditionSignature = getConditionSignature(sorts, filters, fields);
     const conditionStateKey = `${viewId ?? ''}:${conditionSignature}`;
     const currentHasConditions = conditionSignature !== '';
 
@@ -1386,7 +1394,7 @@ export function useRowOrdersSelector() {
     filtersAppliedRef.current = false;
     setRowOrdersState({ rows: originalRowOrders, conditionSignature: conditionStateKey });
     return true;
-  }, [filters, rowOrders, sorts, viewId]);
+  }, [fields, filters, rowOrders, sorts, viewId]);
 
   // Getter for relation cell text (used in sorting/filtering)
   const relationTextGetter = useCallback(
@@ -1485,7 +1493,7 @@ export function useRowOrdersSelector() {
     // their `.length` always reflects the live document state, so this avoids
     // a stale-closure problem when the callback is invoked by a Yjs observer
     // before React has re-rendered (e.g. remote filter/sort sync from desktop).
-    const conditionSignature = getConditionSignature(sorts, filters);
+    const conditionSignature = getConditionSignature(sorts, filters, fields);
     const conditionStateKey = `${viewId ?? ''}:${conditionSignature}`;
     const currentHasConditions = conditionSignature !== '';
 
@@ -1613,6 +1621,10 @@ export function useRowOrdersSelector() {
     };
 
     const handleSortFilterChange = () => {
+      const nextConditionStateKey = `${viewId ?? ''}:${getConditionSignature(sorts, filters, fields)}`;
+
+      if (conditionSignatureRef.current === nextConditionStateKey) return;
+
       // Recompute immediately so a filter change does not replace already-loaded
       // rows with the loading placeholder. onConditionsChange still publishes
       // the loading state when row documents genuinely need hydration.
@@ -1684,7 +1696,7 @@ export function useRowOrdersSelector() {
   // Set up rollup field observers (extracted hook)
   useRollupFieldObservers(onConditionsChange, rollupWatchVersion);
 
-  const liveConditionSignature = `${viewId ?? ''}:${getConditionSignature(sorts, filters)}`;
+  const liveConditionSignature = `${viewId ?? ''}:${getConditionSignature(sorts, filters, fields)}`;
 
   return rowOrdersState.conditionSignature === liveConditionSignature ? rowOrdersState.rows : undefined;
 }
@@ -2244,8 +2256,7 @@ export const useRowMetaSelector = (rowId: string) => {
   return meta;
 };
 
-export const useFieldCellsSelector = (fieldId: string) => {
-  const rows = useRowOrdersSelector();
+export const useFieldCellsByRowsSelector = (fieldId: string, rows?: Row[]) => {
   const [cells, setCells] = useState<Map<string, unknown> | null>(null);
   const rowMap = useRowMap();
   const { field, clock: fieldClock } = useFieldSelector(fieldId);
@@ -2304,6 +2315,12 @@ export const useFieldCellsSelector = (fieldId: string) => {
   return {
     cells,
   };
+};
+
+export const useFieldCellsSelector = (fieldId: string) => {
+  const rows = useRowOrdersSelector();
+
+  return useFieldCellsByRowsSelector(fieldId, rows);
 };
 
 export const usePropertiesSelector = (isFilterHidden?: boolean) => {

--- a/src/components/database/Database.tsx
+++ b/src/components/database/Database.tsx
@@ -10,6 +10,7 @@ import {
   retainDatabaseRowDocSeedCache,
 } from '@/application/database-blob';
 import { hasRowConditionData } from '@/application/database-yjs/condition-value-cache';
+import { hasEffectiveFilters } from '@/application/database-yjs/filter';
 import { getRowKey } from '@/application/database-yjs/row_meta';
 import { getCachedRowDoc, openRowDoc } from '@/application/services/js-services/cache';
 import { SyncContext } from '@/application/services/js-services/sync-protocol';
@@ -253,8 +254,12 @@ function Database(props: Database2Props) {
     const sharedRoot = doc.getMap(YjsEditorKey.data_section);
     const database = sharedRoot?.get(YjsEditorKey.database) as YDatabase | undefined;
     const view = database?.get(YjsDatabaseKey.views)?.get(activeViewId);
+    const fields = database?.get(YjsDatabaseKey.fields);
 
-    return (view?.get(YjsDatabaseKey.filters)?.length ?? 0) > 0 || (view?.get(YjsDatabaseKey.sorts)?.length ?? 0) > 0;
+    return (
+      hasEffectiveFilters(view?.get(YjsDatabaseKey.filters), fields) ||
+      (view?.get(YjsDatabaseKey.sorts)?.length ?? 0) > 0
+    );
   }, [doc, activeViewId]);
 
   const activeViewHasConditions = useSyncExternalStore(

--- a/src/components/database/components/filters/advanced/FilterPanelRow.tsx
+++ b/src/components/database/components/filters/advanced/FilterPanelRow.tsx
@@ -1,4 +1,4 @@
-import { ChangeEvent, useCallback, useEffect, useMemo, useState } from 'react';
+import { ChangeEvent, useCallback, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import {
@@ -41,6 +41,7 @@ import RelationCellMenuContent from '@/components/database/components/cell/relat
 import PropertiesMenu from '@/components/database/components/conditions/PropertiesMenu';
 import { FieldDisplay } from '@/components/database/components/field';
 import { SelectOptionList } from '@/components/database/components/filters/filter-menu/SelectOptionList';
+import { useDebouncedFilterInput } from '@/components/database/components/filters/hooks/useDebouncedFilterInput';
 import { useRelationData } from '@/components/database/components/property/relation/useRelationData';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import {
@@ -428,12 +429,12 @@ function ValueInput({ filter, fieldType, field, disabled }: ValueInputProps) {
 function TextValueInput({ filter, disabled }: { filter: TextFilter; disabled?: boolean }) {
   const { t } = useTranslation();
   const updateFilter = useUpdateAdvancedFilter();
-  const [value, setValue] = useState<string>(filter.content || '');
-
-  // Sync local state when filter.content changes externally (e.g., from Yjs sync)
-  useEffect(() => {
-    setValue(filter.content || '');
-  }, [filter.content]);
+  const { value, updateValue } = useDebouncedFilterInput({
+    content: filter.content || '',
+    filterId: filter.id,
+    fieldId: filter.fieldId,
+    updateFilter,
+  });
 
   // Don't show input for isEmpty/isNotEmpty conditions
   const showInput = useMemo(() => {
@@ -442,14 +443,9 @@ function TextValueInput({ filter, disabled }: { filter: TextFilter; disabled?: b
 
   const handleChange = useCallback(
     (e: ChangeEvent<HTMLInputElement>) => {
-      setValue(e.target.value);
-      updateFilter({
-        filterId: filter.id,
-        fieldId: filter.fieldId,
-        content: e.target.value,
-      });
+      updateValue(e.target.value);
     },
-    [filter.id, filter.fieldId, updateFilter]
+    [updateValue]
   );
 
   if (!showInput) return <div className='min-w-0 flex-[3]' />;
@@ -560,12 +556,12 @@ function RelationValueInput({ filter, disabled }: { filter: Filter; disabled?: b
 function NumberValueInput({ filter, disabled }: { filter: NumberFilter; disabled?: boolean }) {
   const { t } = useTranslation();
   const updateFilter = useUpdateAdvancedFilter();
-  const [value, setValue] = useState<string>(filter.content || '');
-
-  // Sync local state when filter.content changes externally (e.g., from Yjs sync)
-  useEffect(() => {
-    setValue(filter.content || '');
-  }, [filter.content]);
+  const { value, updateValue } = useDebouncedFilterInput({
+    content: filter.content || '',
+    filterId: filter.id,
+    fieldId: filter.fieldId,
+    updateFilter,
+  });
 
   // Don't show input for isEmpty/isNotEmpty conditions
   const showInput = useMemo(() => {
@@ -574,14 +570,9 @@ function NumberValueInput({ filter, disabled }: { filter: NumberFilter; disabled
 
   const handleChange = useCallback(
     (e: ChangeEvent<HTMLInputElement>) => {
-      setValue(e.target.value);
-      updateFilter({
-        filterId: filter.id,
-        fieldId: filter.fieldId,
-        content: e.target.value,
-      });
+      updateValue(e.target.value);
     },
-    [filter.id, filter.fieldId, updateFilter]
+    [updateValue]
   );
 
   if (!showInput) return <div className='min-w-0 flex-[3]' />;

--- a/src/components/database/components/filters/filter-menu/NumberFilterMenu.tsx
+++ b/src/components/database/components/filters/filter-menu/NumberFilterMenu.tsx
@@ -1,24 +1,25 @@
-import React, { useMemo, useState } from 'react';
+import React, { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { NumberFilter, NumberFilterCondition, useReadOnly } from '@/application/database-yjs';
 import { useUpdateFilter } from '@/application/database-yjs/dispatch';
 import FieldMenuTitle from '@/components/database/components/filters/filter-menu/FieldMenuTitle';
 import FilterConditionsSelect from '@/components/database/components/filters/filter-menu/FilterConditionsSelect';
+import { useDebouncedFilterInput } from '@/components/database/components/filters/hooks/useDebouncedFilterInput';
 import { Input } from '@/components/ui/input';
 
 function NumberFilterMenu ({ filter }: { filter: NumberFilter }) {
   const { t } = useTranslation();
   const readOnly = useReadOnly();
   const updateFilter = useUpdateFilter();
-  const [value, setValue] = useState<string>(filter.content);
+  const { value, updateValue } = useDebouncedFilterInput({
+    content: filter.content,
+    filterId: filter.id,
+    fieldId: filter.fieldId,
+    updateFilter,
+  });
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setValue(e.target.value);
-    updateFilter({
-      filterId: filter.id,
-      fieldId: filter.fieldId,
-      content: e.target.value,
-    });
+    updateValue(e.target.value);
   };
 
   const conditions = useMemo(() => {

--- a/src/components/database/components/filters/filter-menu/TextFilterMenu.tsx
+++ b/src/components/database/components/filters/filter-menu/TextFilterMenu.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from 'react';
+import React, { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { TextFilter, TextFilterCondition, useReadOnly } from '@/application/database-yjs';
@@ -6,20 +6,21 @@ import { useUpdateFilter } from '@/application/database-yjs/dispatch';
 import FieldMenuTitle from '@/components/database/components/filters/filter-menu/FieldMenuTitle';
 import TextFilterConditionsSelect
   from '@/components/database/components/filters/filter-menu/TextFilterConditionsSelect';
+import { useDebouncedFilterInput } from '@/components/database/components/filters/hooks/useDebouncedFilterInput';
 import { Input } from '@/components/ui/input';
 
 function TextFilterMenu ({ filter }: { filter: TextFilter }) {
   const { t } = useTranslation();
   const readOnly = useReadOnly();
   const updateFilter = useUpdateFilter();
-  const [value, setValue] = useState<string>(filter.content);
+  const { value, updateValue } = useDebouncedFilterInput({
+    content: filter.content,
+    filterId: filter.id,
+    fieldId: filter.fieldId,
+    updateFilter,
+  });
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setValue(e.target.value);
-    updateFilter({
-      filterId: filter.id,
-      fieldId: filter.fieldId,
-      content: e.target.value,
-    });
+    updateValue(e.target.value);
   };
 
   const displayTextField = useMemo(() => {

--- a/src/components/database/components/filters/hooks/__tests__/useDebouncedFilterInput.test.ts
+++ b/src/components/database/components/filters/hooks/__tests__/useDebouncedFilterInput.test.ts
@@ -1,0 +1,83 @@
+import { act, renderHook } from '@testing-library/react';
+
+import {
+  FILTER_INPUT_DEBOUNCE_MS,
+  useDebouncedFilterInput,
+} from '@/components/database/components/filters/hooks/useDebouncedFilterInput';
+
+jest.mock('lodash-es', () => jest.requireActual('lodash'));
+
+describe('useDebouncedFilterInput', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('updates the local value immediately and persists only the latest value after 500 ms', () => {
+    const updateFilter = jest.fn();
+    const { result, unmount } = renderHook(() =>
+      useDebouncedFilterInput({
+        content: '',
+        filterId: 'filter-1',
+        fieldId: 'field-1',
+        updateFilter,
+      })
+    );
+
+    act(() => {
+      result.current.updateValue('1');
+      result.current.updateValue('12');
+    });
+
+    expect(result.current.value).toBe('12');
+    expect(updateFilter).not.toHaveBeenCalled();
+
+    act(() => {
+      jest.advanceTimersByTime(FILTER_INPUT_DEBOUNCE_MS - 1);
+    });
+
+    expect(updateFilter).not.toHaveBeenCalled();
+
+    act(() => {
+      jest.advanceTimersByTime(1);
+    });
+
+    expect(updateFilter).toHaveBeenCalledTimes(1);
+    expect(updateFilter).toHaveBeenCalledWith({
+      filterId: 'filter-1',
+      fieldId: 'field-1',
+      content: '12',
+    });
+
+    unmount();
+  });
+
+  it('flushes a pending value when the input unmounts', () => {
+    const updateFilter = jest.fn();
+    const { result, unmount } = renderHook(() =>
+      useDebouncedFilterInput({
+        content: '',
+        filterId: 'filter-1',
+        fieldId: 'field-1',
+        updateFilter,
+      })
+    );
+
+    act(() => {
+      result.current.updateValue('42');
+    });
+
+    expect(updateFilter).not.toHaveBeenCalled();
+
+    unmount();
+
+    expect(updateFilter).toHaveBeenCalledWith({
+      filterId: 'filter-1',
+      fieldId: 'field-1',
+      content: '42',
+    });
+  });
+});

--- a/src/components/database/components/filters/hooks/__tests__/useDebouncedFilterInput.test.ts
+++ b/src/components/database/components/filters/hooks/__tests__/useDebouncedFilterInput.test.ts
@@ -80,4 +80,80 @@ describe('useDebouncedFilterInput', () => {
       content: '42',
     });
   });
+
+  it('cancels a pending value when the filter target changes', () => {
+    const updateFilter = jest.fn();
+    const { result, rerender, unmount } = renderHook(
+      ({ fieldId }) =>
+        useDebouncedFilterInput({
+          content: '',
+          filterId: 'filter-1',
+          fieldId,
+          updateFilter,
+        }),
+      {
+        initialProps: {
+          fieldId: 'field-1',
+        },
+      }
+    );
+
+    act(() => {
+      result.current.updateValue('stale value');
+    });
+
+    rerender({
+      fieldId: 'field-2',
+    });
+
+    act(() => {
+      jest.advanceTimersByTime(FILTER_INPUT_DEBOUNCE_MS);
+    });
+
+    expect(updateFilter).not.toHaveBeenCalled();
+
+    unmount();
+
+    expect(updateFilter).not.toHaveBeenCalled();
+  });
+
+  it('uses the latest update callback without restarting the debounce', () => {
+    const firstUpdateFilter = jest.fn();
+    const latestUpdateFilter = jest.fn();
+    const { result, rerender, unmount } = renderHook(
+      ({ updateFilter }) =>
+        useDebouncedFilterInput({
+          content: '',
+          filterId: 'filter-1',
+          fieldId: 'field-1',
+          updateFilter,
+        }),
+      {
+        initialProps: {
+          updateFilter: firstUpdateFilter,
+        },
+      }
+    );
+
+    act(() => {
+      result.current.updateValue('latest value');
+    });
+
+    rerender({
+      updateFilter: latestUpdateFilter,
+    });
+
+    act(() => {
+      jest.advanceTimersByTime(FILTER_INPUT_DEBOUNCE_MS);
+    });
+
+    expect(firstUpdateFilter).not.toHaveBeenCalled();
+    expect(latestUpdateFilter).toHaveBeenCalledWith({
+      filterId: 'filter-1',
+      fieldId: 'field-1',
+      content: 'latest value',
+    });
+
+    unmount();
+  });
 });

--- a/src/components/database/components/filters/hooks/useDebouncedFilterInput.ts
+++ b/src/components/database/components/filters/hooks/useDebouncedFilterInput.ts
@@ -1,5 +1,5 @@
 import { debounce } from 'lodash-es';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 export const FILTER_INPUT_DEBOUNCE_MS = 500;
 
@@ -16,6 +16,8 @@ interface UseDebouncedFilterInputParams {
   updateFilter: UpdateFilterContent;
 }
 
+type FilterInputTarget = Pick<UseDebouncedFilterInputParams, 'filterId' | 'fieldId'>;
+
 export function useDebouncedFilterInput({
   content,
   filterId,
@@ -23,22 +25,27 @@ export function useDebouncedFilterInput({
   updateFilter,
 }: UseDebouncedFilterInputParams) {
   const [value, setValue] = useState(content);
+  const updateFilterRef = useRef(updateFilter);
+
+  useEffect(() => {
+    updateFilterRef.current = updateFilter;
+  }, [updateFilter]);
+
   const debouncedUpdate = useMemo(
     () =>
-      debounce((nextContent: string) => {
-        updateFilter({
-          filterId,
-          fieldId,
+      debounce((nextContent: string, target: FilterInputTarget) => {
+        updateFilterRef.current({
+          ...target,
           content: nextContent,
         });
       }, FILTER_INPUT_DEBOUNCE_MS),
-    [fieldId, filterId, updateFilter]
+    []
   );
 
   useEffect(() => {
     debouncedUpdate.cancel();
     setValue(content);
-  }, [content, debouncedUpdate]);
+  }, [content, debouncedUpdate, fieldId, filterId]);
 
   useEffect(() => {
     return () => {
@@ -49,9 +56,9 @@ export function useDebouncedFilterInput({
   const updateValue = useCallback(
     (nextValue: string) => {
       setValue(nextValue);
-      debouncedUpdate(nextValue);
+      debouncedUpdate(nextValue, { filterId, fieldId });
     },
-    [debouncedUpdate]
+    [debouncedUpdate, fieldId, filterId]
   );
 
   return {

--- a/src/components/database/components/filters/hooks/useDebouncedFilterInput.ts
+++ b/src/components/database/components/filters/hooks/useDebouncedFilterInput.ts
@@ -1,0 +1,61 @@
+import { debounce } from 'lodash-es';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+
+export const FILTER_INPUT_DEBOUNCE_MS = 500;
+
+type UpdateFilterContent = (params: {
+  filterId: string;
+  fieldId: string;
+  content: string;
+}) => void;
+
+interface UseDebouncedFilterInputParams {
+  content: string;
+  filterId: string;
+  fieldId: string;
+  updateFilter: UpdateFilterContent;
+}
+
+export function useDebouncedFilterInput({
+  content,
+  filterId,
+  fieldId,
+  updateFilter,
+}: UseDebouncedFilterInputParams) {
+  const [value, setValue] = useState(content);
+  const debouncedUpdate = useMemo(
+    () =>
+      debounce((nextContent: string) => {
+        updateFilter({
+          filterId,
+          fieldId,
+          content: nextContent,
+        });
+      }, FILTER_INPUT_DEBOUNCE_MS),
+    [fieldId, filterId, updateFilter]
+  );
+
+  useEffect(() => {
+    debouncedUpdate.cancel();
+    setValue(content);
+  }, [content, debouncedUpdate]);
+
+  useEffect(() => {
+    return () => {
+      debouncedUpdate.flush();
+    };
+  }, [debouncedUpdate]);
+
+  const updateValue = useCallback(
+    (nextValue: string) => {
+      setValue(nextValue);
+      debouncedUpdate(nextValue);
+    },
+    [debouncedUpdate]
+  );
+
+  return {
+    value,
+    updateValue,
+  };
+}

--- a/src/components/database/components/grid/controls/HoverControls.hooks.ts
+++ b/src/components/database/components/grid/controls/HoverControls.hooks.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
 
-import { useDatabaseViewId, useRowOrdersSelector } from '@/application/database-yjs';
+import { useDatabaseViewId } from '@/application/database-yjs';
 import { useDuplicateRowDispatch, useNewRowDispatch } from '@/application/database-yjs/dispatch';
 import { useGridContext } from '@/components/database/grid/useGridContext';
 
@@ -58,12 +58,12 @@ export function useHoverControlsActions(rowId: string) {
   const [addBelowLoading, setAddBelowLoading] = useState<boolean>(false);
   const [addAboveLoading, setAddAboveLoading] = useState<boolean>(false);
   const [duplicateLoading, setDuplicateLoading] = useState<boolean>(false);
-  const rows = useRowOrdersSelector();
+  const { rowOrders } = useGridContext();
   const onNewRow = useNewRowDispatch();
   const duplicateRow = useDuplicateRowDispatch();
 
   const onAddRowBelow = useCallback(async () => {
-    if (!rows) {
+    if (!rowOrders) {
       throw new Error('No rows');
     }
 
@@ -76,16 +76,16 @@ export function useHoverControlsActions(rowId: string) {
     } finally {
       setAddBelowLoading(false);
     }
-  }, [onNewRow, rowId, rows]);
+  }, [onNewRow, rowId, rowOrders]);
 
   const onAddRowAbove = useCallback(async () => {
-    if (!rows) {
+    if (!rowOrders) {
       throw new Error('No rows');
     }
 
     setAddAboveLoading(true);
-    const index = rows.findIndex((row) => row.id === rowId);
-    const beforeRowId = index > 0 ? rows[index - 1].id : undefined;
+    const index = rowOrders.findIndex((row) => row.id === rowId);
+    const beforeRowId = index > 0 ? rowOrders[index - 1].id : undefined;
 
     try {
       await onNewRow({ beforeRowId });
@@ -94,7 +94,7 @@ export function useHoverControlsActions(rowId: string) {
     } finally {
       setAddAboveLoading(false);
     }
-  }, [onNewRow, rowId, rows]);
+  }, [onNewRow, rowId, rowOrders]);
 
   const onDuplicateRow = useCallback(async () => {
     setDuplicateLoading(true);

--- a/src/components/database/components/grid/grid-cell/GridCalculateRowCell.tsx
+++ b/src/components/database/components/grid/grid-cell/GridCalculateRowCell.tsx
@@ -1,13 +1,14 @@
 import { useCallback, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import { useDatabaseView, useFieldCellsSelector, useReadOnly } from '@/application/database-yjs';
+import { useDatabaseView, useFieldCellsByRowsSelector, useReadOnly } from '@/application/database-yjs';
 import { CalculationType } from '@/application/database-yjs/database.type';
 import { useCalculateFieldDispatch, useClearCalculate, useUpdateCalculate } from '@/application/database-yjs/dispatch';
 import { YjsDatabaseKey } from '@/application/types';
 import { ReactComponent as DropdownIcon } from '@/assets/icons/alt_arrow_down.svg';
 import { CalculationCell, ICalculationCell } from '@/components/database/components/grid/grid-calculation-cell';
 import CalcationMenu from '@/components/database/components/grid/grid-calculation-cell/CalcationMenu';
+import { useGridContext } from '@/components/database/grid/useGridContext';
 import { cn } from '@/lib/utils';
 
 export interface GridCalculateRowCellProps {
@@ -19,7 +20,8 @@ export function GridCalculateRowCell ({ fieldId }: GridCalculateRowCellProps) {
   const [calculation, setCalculation] = useState<ICalculationCell>();
   const readOnly = useReadOnly();
   const calculate = useCalculateFieldDispatch(fieldId);
-  const { cells } = useFieldCellsSelector(fieldId);
+  const { rowOrders } = useGridContext();
+  const { cells } = useFieldCellsByRowsSelector(fieldId, rowOrders);
   const calculations = databaseView?.get(YjsDatabaseKey.calculations);
 
   const { t } = useTranslation();

--- a/src/components/database/grid/GridProvider.tsx
+++ b/src/components/database/grid/GridProvider.tsx
@@ -93,6 +93,7 @@ export const GridProvider = ({ children, rowOrders }: { children: React.ReactNod
     () => ({
       hoverRowId,
       setHoverRowId: handleHoverRowStart,
+      rowOrders,
       rows,
       setRows,
       activePropertyId,
@@ -112,6 +113,7 @@ export const GridProvider = ({ children, rowOrders }: { children: React.ReactNod
     [
       hoverRowId,
       handleHoverRowStart,
+      rowOrders,
       rows,
       activePropertyId,
       activeCell,

--- a/src/components/database/grid/useGridContext.ts
+++ b/src/components/database/grid/useGridContext.ts
@@ -1,10 +1,12 @@
 import { createContext, useContext } from 'react';
 
+import type { Row } from '@/application/database-yjs';
 import { RenderRow } from '@/components/database/components/grid/grid-row';
 
 type GridContextType = {
   hoverRowId?: string;
   setHoverRowId: (hoverRowId?: string) => void;
+  rowOrders?: Row[];
   rows: RenderRow[];
   setRows: (rows: RenderRow[]) => void;
   activePropertyId?: string;


### PR DESCRIPTION
## Summary

- Treat blank numeric comparison filters as a no-op until the user provides a value.
- Debounce text and number filter updates by 500 ms in both standard and advanced filter editors.
- Flush pending input when the editor closes so the last value is not lost.
- Recompute filter changes immediately when row documents are ready, preventing the grid from flashing a loading placeholder.
- Add regression coverage for blank filters, debounced updates, and stable row rendering.

## Root cause

A newly created numeric comparison filter stores an empty content value. The numeric predicate treated that empty comparison value as invalid and returned `false` for every row.

After correcting the predicate, filter creation still briefly cleared the grid because the sort/filter observer published `rows: undefined` and waited for a 200 ms debounced recomputation. This displayed the loading placeholder even when all row documents were already available.

## Impact

Creating a filter without entering a value now leaves database rows visible without a loading flash. Once the user types, the local input updates immediately and the filter is persisted after 500 ms. Existing `is empty` and `is not empty` conditions keep their original behavior, and genuinely missing row documents still use the loading state.

## Validation

- 213 targeted Jest tests passed.
- TypeScript type-check passed.
- Targeted ESLint completed with no errors.
- Diff checks passed.
- Live browser mutation tracing confirmed the row count remained at 3 with no loading indicator throughout blank filter creation.
- Live debounce verification confirmed rows remained unchanged immediately and at 300 ms after typing, then updated after the 500 ms debounce.

## Summary by Sourcery

Handle blank numeric filters as no-ops, debounce filter input updates, and avoid unnecessary loading states when filters change.

Bug Fixes:
- Treat numeric comparison filters with empty content as non-filtering so rows remain visible until a value is entered.
- Prevent filter changes from clearing already-loaded rows and showing the loading placeholder when row documents are ready.
- Ignore stale debounced filter updates that target a previous field to avoid overwriting current filter configuration.

Enhancements:
- Introduce a shared debounced filter input hook used by text and number filters in both standard and advanced editors to delay persistence by 500 ms while keeping local input responsive.
- Recompute row orders immediately on sort/filter changes and track rollup watch version to keep row rendering stable without extra recomputations.

Tests:
- Add unit tests covering blank numeric comparison behavior, filter application stability, and single recomputation per filter change.
- Add hook tests for debounced filter input behavior, including flushing on unmount, cancellation on target change, and using the latest update callback.
- Extend selector tests to ensure blank filter creation keeps rows visible and that filter changes do not emit undefined rows.