### PR TITLE
feat: support paged database diffs and oversized collab sync

### DIFF
--- a/src/application/database-blob/__tests__/page-stage.test.ts
+++ b/src/application/database-blob/__tests__/page-stage.test.ts
@@ -1,0 +1,229 @@
+import {
+  createDatabaseBlobDiffPageStage,
+  DatabaseBlobDiffPageStageCapacityError,
+} from '@/application/database-blob/page-stage';
+
+type TestRange = { kind: 'only'; value: string } | { kind: 'upperBound'; value: number };
+
+type TestRecord = {
+  walkId: string;
+  pageIndex: number;
+  bytes: Uint8Array;
+  createdAt: number;
+};
+
+function createIndexedDBHarness() {
+  const records = new Map<string, TestRecord>();
+  let storeCreated = false;
+  let closed = false;
+
+  const recordKey = (walkId: string, pageIndex: number) => `${walkId}:${pageIndex}`;
+  const createTransaction = () => {
+    const transaction = {
+      error: null,
+      oncomplete: null as (() => void) | null,
+      onerror: null as (() => void) | null,
+      onabort: null as (() => void) | null,
+      objectStore: () => ({
+        put: (record: TestRecord) => {
+          records.set(recordKey(record.walkId, record.pageIndex), {
+            ...record,
+            // IndexedDB uses structured cloning. Model that here so the test
+            // catches accidental retention of the caller's page buffer.
+            bytes: record.bytes.slice(),
+          });
+          queueMicrotask(() => transaction.oncomplete?.());
+        },
+        get: ([walkId, pageIndex]: [string, number]) => {
+          const request = {
+            result: undefined as TestRecord | undefined,
+            error: null,
+            onsuccess: null as (() => void) | null,
+            onerror: null as (() => void) | null,
+          };
+
+          queueMicrotask(() => {
+            const record = records.get(recordKey(walkId, pageIndex));
+
+            request.result = record
+              ? {
+                  ...record,
+                  bytes: record.bytes.slice(),
+                }
+              : undefined;
+            request.onsuccess?.();
+          });
+
+          return request;
+        },
+        index: () => ({
+          openCursor: (range: TestRange) => {
+            const matchingKeys = Array.from(records.entries())
+              .filter(([, record]) =>
+                range.kind === 'only' ? record.walkId === range.value : record.createdAt <= range.value
+              )
+              .map(([key]) => key);
+            let cursorIndex = 0;
+            const request = {
+              result: null as {
+                delete: () => void;
+                continue: () => void;
+              } | null,
+              error: null,
+              onsuccess: null as (() => void) | null,
+              onerror: null as (() => void) | null,
+            };
+            const advance = () => {
+              const key = matchingKeys[cursorIndex];
+
+              if (!key) {
+                request.result = null;
+                request.onsuccess?.();
+                queueMicrotask(() => transaction.oncomplete?.());
+                return;
+              }
+
+              request.result = {
+                delete: () => {
+                  records.delete(key);
+                },
+                continue: () => {
+                  cursorIndex += 1;
+                  queueMicrotask(advance);
+                },
+              };
+              request.onsuccess?.();
+            };
+
+            queueMicrotask(advance);
+            return request;
+          },
+        }),
+      }),
+    };
+
+    return transaction;
+  };
+  const database = {
+    objectStoreNames: {
+      contains: () => storeCreated,
+    },
+    createObjectStore: () => {
+      storeCreated = true;
+      return {
+        createIndex: jest.fn(),
+      };
+    },
+    transaction: createTransaction,
+    close: () => {
+      closed = true;
+    },
+    onversionchange: null as (() => void) | null,
+  };
+  const factory = {
+    open: () => {
+      const request = {
+        result: database,
+        error: null,
+        onerror: null as (() => void) | null,
+        onblocked: null as (() => void) | null,
+        onupgradeneeded: null as (() => void) | null,
+        onsuccess: null as (() => void) | null,
+      };
+
+      queueMicrotask(() => {
+        if (!storeCreated) request.onupgradeneeded?.();
+        request.onsuccess?.();
+      });
+
+      return request;
+    },
+  };
+  const keyRange = {
+    only: (value: string): TestRange => ({ kind: 'only', value }),
+    upperBound: (value: number): TestRange => ({ kind: 'upperBound', value }),
+  };
+
+  return { factory, keyRange, records, isClosed: () => closed };
+}
+
+describe('database blob diff page stage', () => {
+  const originalIndexedDB = Object.getOwnPropertyDescriptor(globalThis, 'indexedDB');
+  const originalIDBKeyRange = Object.getOwnPropertyDescriptor(globalThis, 'IDBKeyRange');
+
+  afterAll(() => {
+    if (originalIndexedDB) {
+      Object.defineProperty(globalThis, 'indexedDB', originalIndexedDB);
+    } else {
+      Reflect.deleteProperty(globalThis, 'indexedDB');
+    }
+
+    if (originalIDBKeyRange) {
+      Object.defineProperty(globalThis, 'IDBKeyRange', originalIDBKeyRange);
+    } else {
+      Reflect.deleteProperty(globalThis, 'IDBKeyRange');
+    }
+  });
+
+  it('hard-limits the in-memory fallback and releases it on clear', async () => {
+    Object.defineProperty(globalThis, 'indexedDB', {
+      configurable: true,
+      value: undefined,
+    });
+    const memoryLimitBytes = 4;
+    const stage = createDatabaseBlobDiffPageStage({ memoryLimitBytes });
+    const halfLimit = memoryLimitBytes / 2;
+    const firstPage = new Uint8Array(halfLimit);
+    const secondPage = new Uint8Array(halfLimit);
+
+    await stage.append(firstPage);
+    await stage.append(secondPage);
+
+    expect(stage.pageCount).toBe(2);
+    expect(stage.byteLength).toBe(memoryLimitBytes);
+    await expect(stage.append(new Uint8Array([1]))).rejects.toBeInstanceOf(DatabaseBlobDiffPageStageCapacityError);
+    await expect(stage.read(0)).resolves.toEqual(firstPage);
+    await expect(stage.read(1)).resolves.toEqual(secondPage);
+
+    await stage.clear();
+
+    expect(stage.pageCount).toBe(0);
+    expect(stage.byteLength).toBe(0);
+    await expect(stage.read(0)).rejects.toThrow('out of range');
+  });
+
+  it('stages multiple pages in IndexedDB and deletes them after use', async () => {
+    const harness = createIndexedDBHarness();
+
+    Object.defineProperty(globalThis, 'indexedDB', {
+      configurable: true,
+      value: harness.factory,
+    });
+    Object.defineProperty(globalThis, 'IDBKeyRange', {
+      configurable: true,
+      value: harness.keyRange,
+    });
+
+    const stage = createDatabaseBlobDiffPageStage();
+    const firstPage = new Uint8Array([1, 2, 3]);
+    const secondPage = new Uint8Array([4, 5]);
+
+    await stage.append(firstPage);
+    await stage.append(secondPage);
+    firstPage.fill(9);
+    secondPage.fill(9);
+
+    expect(stage.pageCount).toBe(2);
+    expect(stage.byteLength).toBe(5);
+    expect(harness.records.size).toBe(2);
+    await expect(stage.read(0)).resolves.toEqual(new Uint8Array([1, 2, 3]));
+    await expect(stage.read(1)).resolves.toEqual(new Uint8Array([4, 5]));
+
+    await stage.clear();
+
+    expect(harness.records.size).toBe(0);
+    expect(stage.pageCount).toBe(0);
+    expect(stage.byteLength).toBe(0);
+    expect(harness.isClosed()).toBe(false);
+  });
+});

--- a/src/application/database-blob/__tests__/prefetch-dedup.test.ts
+++ b/src/application/database-blob/__tests__/prefetch-dedup.test.ts
@@ -1,19 +1,34 @@
 import { prefetchDatabaseBlobDiff, clearDatabaseRowDocSeedCache } from '@/application/database-blob';
+import { deleteCollabDB, openRowCollabDBWithProvider } from '@/application/db';
+import { deleteRow } from '@/application/services/js-services/cache';
 import { databaseBlobDiff } from '@/application/services/js-services/http/http_api';
+import { deleteOutboxByObjectId } from '@/application/sync-outbox';
 import { database_blob } from '@/proto/database_blob';
 
 jest.mock('@/application/db', () => ({
+  deleteCollabDB: jest.fn(),
   getCachedProviderDoc: jest.fn(),
   openCollabDBWithProvider: jest.fn(),
   openRowCollabDBWithProvider: jest.fn(),
 }));
 
 jest.mock('@/application/services/js-services/cache', () => ({
+  deleteRow: jest.fn(),
   getCachedRowDoc: jest.fn(),
 }));
 
 jest.mock('@/application/services/js-services/http/http_api', () => ({
   databaseBlobDiff: jest.fn(),
+}));
+
+jest.mock('@/application/sync-outbox', () => ({
+  deleteOutboxByObjectId: jest.fn(),
+}));
+
+// Persist assertions only care about control flow, not Yjs decoding, so the
+// tests can hand IndexedDB a stub doc.
+jest.mock('@/application/ydoc/apply', () => ({
+  applyYDoc: jest.fn(),
 }));
 
 jest.mock('@/utils/log', () => ({
@@ -24,7 +39,16 @@ jest.mock('@/utils/log', () => ({
 }));
 
 const mockedDatabaseBlobDiff = databaseBlobDiff as jest.MockedFunction<typeof databaseBlobDiff>;
+const mockedDeleteCollabDB = deleteCollabDB as jest.MockedFunction<typeof deleteCollabDB>;
+const mockedOpenRowCollabDB = openRowCollabDBWithProvider as jest.MockedFunction<typeof openRowCollabDBWithProvider>;
+const mockedDeleteRow = deleteRow as jest.MockedFunction<typeof deleteRow>;
+const mockedDeleteOutbox = deleteOutboxByObjectId as jest.MockedFunction<typeof deleteOutboxByObjectId>;
 const databaseIds = new Set<string>();
+
+/** Drains the promise chain the page walk runs on, without advancing timers. */
+function flushPendingWork() {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
 
 function createDeferred<T>() {
   let resolve!: (value: T) => void;
@@ -80,10 +104,82 @@ function pageDiff(options: {
   });
 }
 
+// Version 4 / variant 10xx bytes, so decodeRowId can stringify them.
+const VALID_ROW_ID_BYTES = Uint8Array.from([
+  0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x47, 0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff, 0x00,
+]);
+const VALID_ROW_ID = '11223344-5566-4788-99aa-bbccddeeff00';
+const SECOND_VALID_ROW_ID_BYTES = Uint8Array.from([
+  0x21, 0x22, 0x33, 0x44, 0x55, 0x66, 0x47, 0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff, 0x01,
+]);
+const SECOND_VALID_ROW_ID = '21223344-5566-4788-99aa-bbccddeeff01';
+
+/**
+ * A page whose row is well-formed enough to reach IndexedDB, so that failing the
+ * collab open below makes the page's persist fail rather than skip.
+ */
+function persistablePage(
+  rid: { timestamp: number; seqNo: number },
+  page: {
+    hasMore?: boolean;
+    nextCursor?: Uint8Array;
+  } = {}
+) {
+  return database_blob.DatabaseBlobDiffResponse.create({
+    status: database_blob.DiffStatus.READY,
+    creates: [
+      {
+        rowId: VALID_ROW_ID_BYTES,
+        rid,
+        docState: { docState: new Uint8Array([1, 2, 3]), encoderVersion: 1 },
+      },
+    ],
+    updates: [],
+    deletes: [],
+    page: {
+      hasMore: page.hasMore ?? false,
+      nextCursor: page.nextCursor ?? new Uint8Array(),
+      restartRequired: false,
+    },
+  });
+}
+
+function deletePage(
+  rid: { timestamp: number; seqNo: number },
+  options: {
+    rowId?: Uint8Array;
+    hasMore?: boolean;
+    nextCursor?: Uint8Array;
+  } = {}
+) {
+  return database_blob.DatabaseBlobDiffResponse.create({
+    status: database_blob.DiffStatus.READY,
+    creates: [],
+    updates: [],
+    deletes: [
+      {
+        rowId: options.rowId ?? VALID_ROW_ID_BYTES,
+        rid,
+      },
+    ],
+    page: {
+      hasMore: options.hasMore ?? false,
+      nextCursor: options.nextCursor ?? new Uint8Array(),
+      restartRequired: false,
+    },
+  });
+}
+
 describe('database blob prefetch deduplication', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     localStorage.clear();
+    mockedDeleteCollabDB.mockResolvedValue(true);
+    mockedDeleteOutbox.mockResolvedValue(undefined);
+    mockedOpenRowCollabDB.mockResolvedValue({
+      doc: { destroy: jest.fn() },
+      provider: { destroy: jest.fn().mockResolvedValue(undefined) },
+    } as unknown as Awaited<ReturnType<typeof openRowCollabDBWithProvider>>);
   });
 
   afterEach(() => {
@@ -265,11 +361,13 @@ describe('database blob prefetch deduplication', () => {
     databaseIds.add(databaseId);
     mockedDatabaseBlobDiff
       .mockResolvedValueOnce(
-        pageDiff({
-          hasMore: true,
-          nextCursor,
-          rid: { timestamp: 20, seqNo: 1 },
-        })
+        persistablePage(
+          { timestamp: 20, seqNo: 1 },
+          {
+            hasMore: true,
+            nextCursor,
+          }
+        )
       )
       .mockResolvedValueOnce(pendingPage)
       .mockResolvedValueOnce(pendingPage);
@@ -284,6 +382,7 @@ describe('database blob prefetch deduplication', () => {
     expect(result).toBe(pendingPage);
     expect(localStorage.getItem(`af_database_blob_rid:${databaseId}`)).toBeNull();
     expect(onSeedsReady).toHaveBeenCalledTimes(1);
+    expect(mockedOpenRowCollabDB).not.toHaveBeenCalled();
 
     mockedDatabaseBlobDiff.mockResolvedValueOnce(readyDiff());
     await prefetchDatabaseBlobDiff(workspaceId, databaseId, {
@@ -297,11 +396,13 @@ describe('database blob prefetch deduplication', () => {
     const workspaceId = 'workspace-restart';
     const databaseId = 'database-restart';
     const nextCursor = new Uint8Array([4, 5, 6]);
-    const abandonedPage = pageDiff({
-      hasMore: true,
-      nextCursor,
-      rid: { timestamp: 99, seqNo: 0 },
-    });
+    const abandonedPage = persistablePage(
+      { timestamp: 99, seqNo: 0 },
+      {
+        hasMore: true,
+        nextCursor,
+      }
+    );
     const restartResponse = pageDiff({
       restartRequired: true,
     });
@@ -326,5 +427,314 @@ describe('database blob prefetch deduplication', () => {
       timestamp: 7,
       seqNo: 3,
     });
+    expect(mockedOpenRowCollabDB).not.toHaveBeenCalled();
+  });
+
+  it('withholds delta seeds and persistence until the terminal page', async () => {
+    const workspaceId = 'workspace-stream-delta';
+    const databaseId = 'database-stream-delta';
+    const onSeedsReady = jest.fn();
+    const finalPage = createDeferred<database_blob.DatabaseBlobDiffResponse>();
+
+    databaseIds.add(databaseId);
+    mockedDatabaseBlobDiff
+      .mockResolvedValueOnce(
+        persistablePage(
+          { timestamp: 400, seqNo: 1 },
+          {
+            hasMore: true,
+            nextCursor: new Uint8Array([1]),
+          }
+        )
+      )
+      .mockReturnValueOnce(finalPage.promise);
+
+    const prefetch = prefetchDatabaseBlobDiff(workspaceId, databaseId, { onSeedsReady });
+
+    await flushPendingWork();
+
+    expect(mockedDatabaseBlobDiff).toHaveBeenCalledTimes(2);
+    expect(onSeedsReady).not.toHaveBeenCalled();
+    expect(mockedOpenRowCollabDB).not.toHaveBeenCalled();
+
+    finalPage.resolve(readyDiff());
+    await prefetch;
+
+    expect(onSeedsReady).toHaveBeenCalledTimes(1);
+    expect(mockedOpenRowCollabDB).toHaveBeenCalledTimes(1);
+  });
+
+  it('withholds full-sync seeds until the terminal page', async () => {
+    const workspaceId = 'workspace-stream-full';
+    const databaseId = 'database-stream-full';
+    const onSeedsReady = jest.fn();
+    const finalPage = createDeferred<database_blob.DatabaseBlobDiffResponse>();
+
+    databaseIds.add(databaseId);
+    mockedDatabaseBlobDiff
+      .mockResolvedValueOnce(pageDiff({ hasMore: true, nextCursor: new Uint8Array([1]) }))
+      .mockReturnValueOnce(finalPage.promise);
+
+    const prefetch = prefetchDatabaseBlobDiff(workspaceId, databaseId, {
+      forceFullSync: true,
+      onSeedsReady,
+    });
+
+    await flushPendingWork();
+
+    expect(mockedDatabaseBlobDiff).toHaveBeenCalledTimes(2);
+    expect(onSeedsReady).not.toHaveBeenCalled();
+
+    finalPage.resolve(readyDiff());
+    await prefetch;
+
+    expect(onSeedsReady).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects a final page that carries a continuation cursor', async () => {
+    const databaseId = 'database-final-cursor';
+
+    databaseIds.add(databaseId);
+    mockedDatabaseBlobDiff.mockResolvedValueOnce(pageDiff({ hasMore: false, nextCursor: new Uint8Array([1]) }));
+
+    await expect(prefetchDatabaseBlobDiff('workspace-final-cursor', databaseId)).rejects.toThrow(
+      'final page contained a continuation cursor'
+    );
+    expect(localStorage.getItem(`af_database_blob_rid:${databaseId}`)).toBeNull();
+  });
+
+  it('rejects a non-final page that omits its continuation cursor', async () => {
+    const databaseId = 'database-missing-cursor';
+
+    databaseIds.add(databaseId);
+    mockedDatabaseBlobDiff.mockResolvedValueOnce(pageDiff({ hasMore: true, nextCursor: new Uint8Array() }));
+
+    await expect(prefetchDatabaseBlobDiff('workspace-missing-cursor', databaseId)).rejects.toThrow(
+      'non-final page omitted its continuation cursor'
+    );
+  });
+
+  it('rejects a repeated continuation cursor', async () => {
+    const databaseId = 'database-repeated-cursor';
+    const repeatedCursor = new Uint8Array([5]);
+
+    databaseIds.add(databaseId);
+    mockedDatabaseBlobDiff
+      .mockResolvedValueOnce(pageDiff({ hasMore: true, nextCursor: repeatedCursor }))
+      .mockResolvedValueOnce(pageDiff({ hasMore: true, nextCursor: repeatedCursor }));
+
+    await expect(prefetchDatabaseBlobDiff('workspace-repeated-cursor', databaseId)).rejects.toThrow(
+      'server repeated a continuation cursor'
+    );
+    expect(mockedDatabaseBlobDiff).toHaveBeenCalledTimes(2);
+  });
+
+  it('falls back to row sync once restarts are exhausted', async () => {
+    const workspaceId = 'workspace-restart-loop';
+    const databaseId = 'database-restart-loop';
+    const onSeedsReady = jest.fn();
+    const restartResponse = pageDiff({ restartRequired: true });
+
+    databaseIds.add(databaseId);
+    mockedDatabaseBlobDiff
+      .mockResolvedValueOnce(restartResponse)
+      .mockResolvedValueOnce(restartResponse)
+      .mockResolvedValueOnce(restartResponse);
+
+    const result = await prefetchDatabaseBlobDiff(workspaceId, databaseId, { onSeedsReady });
+
+    expect(result).toBe(restartResponse);
+    expect(mockedDatabaseBlobDiff).toHaveBeenCalledTimes(3);
+    expect(localStorage.getItem(`af_database_blob_rid:${databaseId}`)).toBeNull();
+    expect(onSeedsReady).toHaveBeenCalledTimes(1);
+
+    // An exhausted walk holds no complete seed set, so it must not be reused.
+    mockedDatabaseBlobDiff.mockResolvedValueOnce(readyDiff());
+    await prefetchDatabaseBlobDiff(workspaceId, databaseId, { forceFullSync: true });
+
+    expect(mockedDatabaseBlobDiff).toHaveBeenCalledTimes(4);
+  });
+
+  it('leaves the RID unadvanced when a page fails to persist', async () => {
+    const workspaceId = 'workspace-persist-failure';
+    const databaseId = 'database-persist-failure';
+
+    databaseIds.add(databaseId);
+    mockedDatabaseBlobDiff.mockResolvedValueOnce(persistablePage({ timestamp: 500, seqNo: 4 }));
+    mockedOpenRowCollabDB.mockRejectedValueOnce(new Error('indexeddb unavailable'));
+
+    await prefetchDatabaseBlobDiff(workspaceId, databaseId);
+
+    expect(mockedOpenRowCollabDB).toHaveBeenCalledTimes(1);
+    expect(localStorage.getItem(`af_database_blob_rid:${databaseId}`)).toBeNull();
+  });
+
+  it('advances the RID when the same page persists cleanly', async () => {
+    const workspaceId = 'workspace-persist-success';
+    const databaseId = 'database-persist-success';
+
+    databaseIds.add(databaseId);
+    mockedDatabaseBlobDiff.mockResolvedValueOnce(persistablePage({ timestamp: 500, seqNo: 4 }));
+    mockedOpenRowCollabDB.mockResolvedValueOnce({
+      doc: { destroy: jest.fn() },
+      provider: { destroy: jest.fn().mockResolvedValue(undefined) },
+    } as unknown as Awaited<ReturnType<typeof openRowCollabDBWithProvider>>);
+
+    await prefetchDatabaseBlobDiff(workspaceId, databaseId);
+
+    expect(JSON.parse(localStorage.getItem(`af_database_blob_rid:${databaseId}`) ?? 'null')).toEqual({
+      timestamp: 500,
+      seqNo: 4,
+    });
+  });
+
+  it('applies an authoritative row tombstone before advancing the RID', async () => {
+    const databaseId = 'database-delete-success';
+
+    databaseIds.add(databaseId);
+    mockedDatabaseBlobDiff.mockResolvedValueOnce(deletePage({ timestamp: 600, seqNo: 2 }));
+
+    await prefetchDatabaseBlobDiff('workspace-delete-success', databaseId);
+
+    expect(mockedDeleteOutbox).toHaveBeenCalledWith(VALID_ROW_ID);
+    expect(mockedDeleteCollabDB).toHaveBeenCalledWith(VALID_ROW_ID, { destroyDoc: false });
+    expect(mockedDeleteCollabDB).toHaveBeenCalledWith(`${databaseId}_rows_${VALID_ROW_ID}`);
+    expect(mockedDeleteRow).toHaveBeenCalledWith(`${databaseId}_rows_${VALID_ROW_ID}`);
+    expect(JSON.parse(localStorage.getItem(`af_database_blob_rid:${databaseId}`) ?? 'null')).toEqual({
+      timestamp: 600,
+      seqNo: 2,
+    });
+  });
+
+  it('does not apply a non-terminal row tombstone', async () => {
+    const databaseId = 'database-delete-terminal-gate';
+    const terminalPage = createDeferred<database_blob.DatabaseBlobDiffResponse>();
+
+    databaseIds.add(databaseId);
+    mockedDatabaseBlobDiff
+      .mockResolvedValueOnce(
+        deletePage(
+          { timestamp: 700, seqNo: 1 },
+          {
+            hasMore: true,
+            nextCursor: new Uint8Array([4]),
+          }
+        )
+      )
+      .mockReturnValueOnce(terminalPage.promise);
+
+    const prefetch = prefetchDatabaseBlobDiff('workspace-delete-terminal-gate', databaseId);
+
+    await flushPendingWork();
+
+    expect(mockedDeleteOutbox).not.toHaveBeenCalled();
+    expect(mockedDeleteCollabDB).not.toHaveBeenCalled();
+    expect(mockedDeleteRow).not.toHaveBeenCalled();
+
+    terminalPage.resolve(readyDiff());
+    await prefetch;
+
+    expect(mockedDeleteCollabDB).toHaveBeenCalledTimes(2);
+    expect(mockedDeleteRow).toHaveBeenCalledTimes(1);
+  });
+
+  it('leaves the RID unchanged when a row tombstone cannot be persisted', async () => {
+    const databaseId = 'database-delete-failure';
+    const cachedRid = { timestamp: 10, seqNo: 3 };
+
+    databaseIds.add(databaseId);
+    localStorage.setItem(`af_database_blob_rid:${databaseId}`, JSON.stringify(cachedRid));
+    mockedDatabaseBlobDiff.mockResolvedValueOnce(deletePage({ timestamp: 800, seqNo: 5 }));
+    mockedDeleteCollabDB.mockResolvedValueOnce(false);
+
+    await prefetchDatabaseBlobDiff('workspace-delete-failure', databaseId);
+
+    expect(mockedDeleteRow).toHaveBeenCalledWith(`${databaseId}_rows_${VALID_ROW_ID}`);
+    expect(JSON.parse(localStorage.getItem(`af_database_blob_rid:${databaseId}`) ?? 'null')).toEqual(cachedRid);
+  });
+
+  it('leaves the RID unchanged when legacy row storage cannot be deleted', async () => {
+    const databaseId = 'database-legacy-delete-failure';
+
+    databaseIds.add(databaseId);
+    mockedDatabaseBlobDiff.mockResolvedValueOnce(deletePage({ timestamp: 850, seqNo: 1 }));
+    mockedDeleteCollabDB.mockResolvedValueOnce(true).mockResolvedValueOnce(false);
+
+    await prefetchDatabaseBlobDiff('workspace-legacy-delete-failure', databaseId);
+
+    expect(mockedDeleteCollabDB).toHaveBeenNthCalledWith(1, VALID_ROW_ID, { destroyDoc: false });
+    expect(mockedDeleteCollabDB).toHaveBeenNthCalledWith(2, `${databaseId}_rows_${VALID_ROW_ID}`);
+    expect(localStorage.getItem(`af_database_blob_rid:${databaseId}`)).toBeNull();
+  });
+
+  it('waits for every tombstone in a failed delete batch to settle', async () => {
+    const databaseId = 'database-delete-batch-failure';
+    const delayedDelete = createDeferred<boolean>();
+    let settled = false;
+
+    databaseIds.add(databaseId);
+    mockedDatabaseBlobDiff.mockResolvedValueOnce(
+      database_blob.DatabaseBlobDiffResponse.create({
+        status: database_blob.DiffStatus.READY,
+        creates: [],
+        updates: [],
+        deletes: [
+          {
+            rowId: VALID_ROW_ID_BYTES,
+            rid: { timestamp: 875, seqNo: 1 },
+          },
+          {
+            rowId: SECOND_VALID_ROW_ID_BYTES,
+            rid: { timestamp: 875, seqNo: 2 },
+          },
+        ],
+        page: {
+          hasMore: false,
+          nextCursor: new Uint8Array(),
+          restartRequired: false,
+        },
+      })
+    );
+    mockedDeleteCollabDB.mockImplementation((name) => {
+      if (name === VALID_ROW_ID) return Promise.reject(new Error('current row delete failed'));
+      if (name === SECOND_VALID_ROW_ID) return delayedDelete.promise;
+      return Promise.resolve(true);
+    });
+
+    const prefetch = prefetchDatabaseBlobDiff('workspace-delete-batch-failure', databaseId).finally(() => {
+      settled = true;
+    });
+
+    await flushPendingWork();
+
+    expect(settled).toBe(false);
+    expect(mockedDeleteCollabDB).toHaveBeenCalledWith(SECOND_VALID_ROW_ID, { destroyDoc: false });
+
+    delayedDelete.resolve(true);
+    await prefetch;
+
+    expect(settled).toBe(true);
+    expect(mockedDeleteRow).toHaveBeenCalledWith(`${databaseId}_rows_${VALID_ROW_ID}`);
+    expect(mockedDeleteRow).toHaveBeenCalledWith(`${databaseId}_rows_${SECOND_VALID_ROW_ID}`);
+    expect(localStorage.getItem(`af_database_blob_rid:${databaseId}`)).toBeNull();
+  });
+
+  it('does not advance the RID for a malformed row tombstone', async () => {
+    const databaseId = 'database-delete-invalid';
+
+    databaseIds.add(databaseId);
+    mockedDatabaseBlobDiff.mockResolvedValueOnce(
+      deletePage(
+        { timestamp: 900, seqNo: 1 },
+        {
+          rowId: new Uint8Array([1, 2, 3]),
+        }
+      )
+    );
+
+    await prefetchDatabaseBlobDiff('workspace-delete-invalid', databaseId);
+
+    expect(mockedDeleteCollabDB).not.toHaveBeenCalled();
+    expect(localStorage.getItem(`af_database_blob_rid:${databaseId}`)).toBeNull();
   });
 });

--- a/src/application/database-blob/__tests__/prefetch-dedup.test.ts
+++ b/src/application/database-blob/__tests__/prefetch-dedup.test.ts
@@ -2,7 +2,7 @@ import { prefetchDatabaseBlobDiff, clearDatabaseRowDocSeedCache } from '@/applic
 import { deleteCollabDB, openRowCollabDBWithProvider } from '@/application/db';
 import { deleteRow } from '@/application/services/js-services/cache';
 import { databaseBlobDiff } from '@/application/services/js-services/http/http_api';
-import { deleteOutboxByObjectId } from '@/application/sync-outbox';
+import { deleteOutboxByObjectId, getCurrentOutboxSession } from '@/application/sync-outbox';
 import { database_blob } from '@/proto/database_blob';
 
 jest.mock('@/application/db', () => ({
@@ -23,6 +23,7 @@ jest.mock('@/application/services/js-services/http/http_api', () => ({
 
 jest.mock('@/application/sync-outbox', () => ({
   deleteOutboxByObjectId: jest.fn(),
+  getCurrentOutboxSession: jest.fn((workspaceId: string) => ({ userId: 'user-1', workspaceId })),
 }));
 
 // Persist assertions only care about control flow, not Yjs decoding, so the
@@ -43,6 +44,7 @@ const mockedDeleteCollabDB = deleteCollabDB as jest.MockedFunction<typeof delete
 const mockedOpenRowCollabDB = openRowCollabDBWithProvider as jest.MockedFunction<typeof openRowCollabDBWithProvider>;
 const mockedDeleteRow = deleteRow as jest.MockedFunction<typeof deleteRow>;
 const mockedDeleteOutbox = deleteOutboxByObjectId as jest.MockedFunction<typeof deleteOutboxByObjectId>;
+const mockedGetCurrentOutboxSession = getCurrentOutboxSession as jest.MockedFunction<typeof getCurrentOutboxSession>;
 const databaseIds = new Set<string>();
 
 /** Drains the promise chain the page walk runs on, without advancing timers. */
@@ -176,6 +178,10 @@ describe('database blob prefetch deduplication', () => {
     localStorage.clear();
     mockedDeleteCollabDB.mockResolvedValue(true);
     mockedDeleteOutbox.mockResolvedValue(undefined);
+    mockedGetCurrentOutboxSession.mockImplementation((workspaceId) => ({
+      userId: 'user-1',
+      workspaceId: workspaceId ?? 'workspace-1',
+    }));
     mockedOpenRowCollabDB.mockResolvedValue({
       doc: { destroy: jest.fn() },
       provider: { destroy: jest.fn().mockResolvedValue(undefined) },
@@ -596,7 +602,9 @@ describe('database blob prefetch deduplication', () => {
 
     await prefetchDatabaseBlobDiff('workspace-delete-success', databaseId);
 
-    expect(mockedDeleteOutbox).toHaveBeenCalledWith(VALID_ROW_ID);
+    expect(mockedDeleteOutbox).toHaveBeenCalledWith(VALID_ROW_ID, {
+      session: { userId: 'user-1', workspaceId: 'workspace-delete-success' },
+    });
     expect(mockedDeleteCollabDB).toHaveBeenCalledWith(VALID_ROW_ID, { destroyDoc: false });
     expect(mockedDeleteCollabDB).toHaveBeenCalledWith(`${databaseId}_rows_${VALID_ROW_ID}`);
     expect(mockedDeleteRow).toHaveBeenCalledWith(`${databaseId}_rows_${VALID_ROW_ID}`);
@@ -636,6 +644,37 @@ describe('database blob prefetch deduplication', () => {
 
     expect(mockedDeleteCollabDB).toHaveBeenCalledTimes(2);
     expect(mockedDeleteRow).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses the session captured before a paged tombstone finishes', async () => {
+    const workspaceId = 'workspace-origin';
+    const databaseId = 'database-delete-session-scope';
+    const originSession = { userId: 'user-1', workspaceId };
+    const terminalPage = createDeferred<database_blob.DatabaseBlobDiffResponse>();
+
+    databaseIds.add(databaseId);
+    mockedGetCurrentOutboxSession.mockReturnValueOnce(originSession);
+    mockedDatabaseBlobDiff
+      .mockResolvedValueOnce(
+        deletePage(
+          { timestamp: 750, seqNo: 1 },
+          {
+            hasMore: true,
+            nextCursor: new Uint8Array([5]),
+          }
+        )
+      )
+      .mockReturnValueOnce(terminalPage.promise);
+
+    const prefetch = prefetchDatabaseBlobDiff(workspaceId, databaseId);
+
+    await flushPendingWork();
+    mockedGetCurrentOutboxSession.mockReturnValue({ userId: 'user-1', workspaceId: 'workspace-replacement' });
+    terminalPage.resolve(readyDiff());
+    await prefetch;
+
+    expect(mockedGetCurrentOutboxSession).toHaveBeenCalledTimes(1);
+    expect(mockedDeleteOutbox).toHaveBeenCalledWith(VALID_ROW_ID, { session: originSession });
   });
 
   it('leaves the RID unchanged when a row tombstone cannot be persisted', async () => {

--- a/src/application/database-blob/__tests__/prefetch-dedup.test.ts
+++ b/src/application/database-blob/__tests__/prefetch-dedup.test.ts
@@ -41,6 +41,42 @@ function readyDiff() {
     creates: [],
     updates: [],
     deletes: [],
+    page: {
+      hasMore: false,
+      nextCursor: new Uint8Array(),
+      restartRequired: false,
+    },
+  });
+}
+
+function pageDiff(options: {
+  status?: database_blob.DiffStatus;
+  hasMore?: boolean;
+  nextCursor?: Uint8Array;
+  restartRequired?: boolean;
+  retryAfterSecs?: number;
+  rid?: { timestamp: number; seqNo: number };
+}) {
+  return database_blob.DatabaseBlobDiffResponse.create({
+    status: options.status ?? database_blob.DiffStatus.READY,
+    retryAfterSecs: options.retryAfterSecs,
+    creates: options.rid
+      ? [
+          {
+            // An invalid row ID keeps persistence side-effect free while still
+            // exercising watermark selection across pages.
+            rowId: new Uint8Array(),
+            rid: options.rid,
+          },
+        ]
+      : [],
+    updates: [],
+    deletes: [],
+    page: {
+      hasMore: options.hasMore ?? false,
+      nextCursor: options.nextCursor ?? new Uint8Array(),
+      restartRequired: options.restartRequired ?? false,
+    },
   });
 }
 
@@ -51,6 +87,7 @@ describe('database blob prefetch deduplication', () => {
   });
 
   afterEach(() => {
+    jest.useRealTimers();
     databaseIds.forEach(clearDatabaseRowDocSeedCache);
     databaseIds.clear();
   });
@@ -107,5 +144,187 @@ describe('database blob prefetch deduplication', () => {
       seqNo: 7,
     });
     expect(mockedDatabaseBlobDiff.mock.calls[1][2].maxKnownRid).toBeNull();
+  });
+
+  it('shares one multi-page walk among three concurrent consumers', async () => {
+    const workspaceId = 'workspace-three-consumers';
+    const databaseId = 'database-three-consumers';
+    const firstPage = createDeferred<database_blob.DatabaseBlobDiffResponse>();
+    const callbacks = [jest.fn(), jest.fn(), jest.fn()];
+
+    databaseIds.add(databaseId);
+    mockedDatabaseBlobDiff
+      .mockReturnValueOnce(firstPage.promise)
+      .mockResolvedValueOnce(readyDiff());
+
+    const prefetches = callbacks.map((onSeedsReady) =>
+      prefetchDatabaseBlobDiff(workspaceId, databaseId, { onSeedsReady })
+    );
+
+    firstPage.resolve(
+      pageDiff({
+        hasMore: true,
+        nextCursor: new Uint8Array([1]),
+      })
+    );
+    await Promise.all(prefetches);
+
+    expect(mockedDatabaseBlobDiff).toHaveBeenCalledTimes(2);
+    callbacks.forEach((callback) => {
+      expect(callback).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('walks every page with fixed limits and the original RID', async () => {
+    const workspaceId = 'workspace-paged';
+    const databaseId = 'database-paged';
+    const nextCursor = new Uint8Array([1, 2, 3]);
+    const originalRid = { timestamp: 1_721_800_000, seqNo: 7 };
+    const firstPage = pageDiff({
+      hasMore: true,
+      nextCursor,
+      rid: { timestamp: 1_721_800_001, seqNo: 1 },
+    });
+    const finalPage = pageDiff({
+      rid: { timestamp: 1_721_800_002, seqNo: 2 },
+    });
+
+    databaseIds.add(databaseId);
+    localStorage.setItem(`af_database_blob_rid:${databaseId}`, JSON.stringify(originalRid));
+    mockedDatabaseBlobDiff.mockResolvedValueOnce(firstPage).mockResolvedValueOnce(finalPage);
+
+    const result = await prefetchDatabaseBlobDiff(workspaceId, databaseId);
+
+    expect(result).toBe(finalPage);
+    expect(mockedDatabaseBlobDiff).toHaveBeenCalledTimes(2);
+
+    const firstRequest = mockedDatabaseBlobDiff.mock.calls[0][2];
+    const finalRequest = mockedDatabaseBlobDiff.mock.calls[1][2];
+
+    expect(firstRequest).toMatchObject({
+      version: 3,
+      maxKnownRid: originalRid,
+      page: {
+        maxItems: 256,
+        maxBytes: 16 * 1024 * 1024,
+      },
+    });
+    expect(Array.from(firstRequest.page?.cursor ?? [])).toEqual([]);
+    expect(finalRequest.maxKnownRid).toMatchObject(originalRid);
+    expect(Array.from(finalRequest.page?.cursor ?? [])).toEqual(Array.from(nextCursor));
+    expect(JSON.parse(localStorage.getItem(`af_database_blob_rid:${databaseId}`) ?? 'null')).toEqual({
+      timestamp: 1_721_800_002,
+      seqNo: 2,
+    });
+  });
+
+  it('retries a Pending page with the same cursor', async () => {
+    jest.useFakeTimers();
+
+    const workspaceId = 'workspace-pending';
+    const databaseId = 'database-pending';
+    const nextCursor = new Uint8Array([9, 8, 7]);
+
+    databaseIds.add(databaseId);
+    mockedDatabaseBlobDiff
+      .mockResolvedValueOnce(pageDiff({ hasMore: true, nextCursor }))
+      .mockResolvedValueOnce(
+        pageDiff({
+          status: database_blob.DiffStatus.PENDING,
+          hasMore: true,
+          nextCursor,
+          retryAfterSecs: 1,
+        })
+      )
+      .mockResolvedValueOnce(readyDiff());
+
+    const prefetch = prefetchDatabaseBlobDiff(workspaceId, databaseId);
+
+    await jest.advanceTimersByTimeAsync(1000);
+    await prefetch;
+
+    expect(mockedDatabaseBlobDiff).toHaveBeenCalledTimes(3);
+    expect(Array.from(mockedDatabaseBlobDiff.mock.calls[1][2].page?.cursor ?? [])).toEqual(Array.from(nextCursor));
+    expect(Array.from(mockedDatabaseBlobDiff.mock.calls[2][2].page?.cursor ?? [])).toEqual(Array.from(nextCursor));
+  });
+
+  it('does not advance the RID when a continuation remains Pending', async () => {
+    jest.useFakeTimers();
+
+    const workspaceId = 'workspace-still-pending';
+    const databaseId = 'database-still-pending';
+    const nextCursor = new Uint8Array([3, 2, 1]);
+    const onSeedsReady = jest.fn();
+    const pendingPage = pageDiff({
+      status: database_blob.DiffStatus.PENDING,
+      hasMore: true,
+      nextCursor,
+      retryAfterSecs: 1,
+    });
+
+    databaseIds.add(databaseId);
+    mockedDatabaseBlobDiff
+      .mockResolvedValueOnce(
+        pageDiff({
+          hasMore: true,
+          nextCursor,
+          rid: { timestamp: 20, seqNo: 1 },
+        })
+      )
+      .mockResolvedValueOnce(pendingPage)
+      .mockResolvedValueOnce(pendingPage);
+
+    const prefetch = prefetchDatabaseBlobDiff(workspaceId, databaseId, {
+      onSeedsReady,
+    });
+
+    await jest.advanceTimersByTimeAsync(1000);
+    const result = await prefetch;
+
+    expect(result).toBe(pendingPage);
+    expect(localStorage.getItem(`af_database_blob_rid:${databaseId}`)).toBeNull();
+    expect(onSeedsReady).toHaveBeenCalledTimes(1);
+
+    mockedDatabaseBlobDiff.mockResolvedValueOnce(readyDiff());
+    await prefetchDatabaseBlobDiff(workspaceId, databaseId, {
+      forceFullSync: true,
+    });
+
+    expect(mockedDatabaseBlobDiff).toHaveBeenCalledTimes(4);
+  });
+
+  it('discards collected pages and restarts from the original RID', async () => {
+    const workspaceId = 'workspace-restart';
+    const databaseId = 'database-restart';
+    const nextCursor = new Uint8Array([4, 5, 6]);
+    const abandonedPage = pageDiff({
+      hasMore: true,
+      nextCursor,
+      rid: { timestamp: 99, seqNo: 0 },
+    });
+    const restartResponse = pageDiff({
+      restartRequired: true,
+    });
+    const replacementPage = pageDiff({
+      rid: { timestamp: 7, seqNo: 3 },
+    });
+
+    databaseIds.add(databaseId);
+    mockedDatabaseBlobDiff
+      .mockResolvedValueOnce(abandonedPage)
+      .mockResolvedValueOnce(restartResponse)
+      .mockResolvedValueOnce(replacementPage);
+
+    await prefetchDatabaseBlobDiff(workspaceId, databaseId);
+
+    expect(mockedDatabaseBlobDiff).toHaveBeenCalledTimes(3);
+    expect(Array.from(mockedDatabaseBlobDiff.mock.calls[0][2].page?.cursor ?? [])).toEqual([]);
+    expect(Array.from(mockedDatabaseBlobDiff.mock.calls[1][2].page?.cursor ?? [])).toEqual(Array.from(nextCursor));
+    expect(Array.from(mockedDatabaseBlobDiff.mock.calls[2][2].page?.cursor ?? [])).toEqual([]);
+    expect(mockedDatabaseBlobDiff.mock.calls.map(([, , request]) => request.maxKnownRid)).toEqual([null, null, null]);
+    expect(JSON.parse(localStorage.getItem(`af_database_blob_rid:${databaseId}`) ?? 'null')).toEqual({
+      timestamp: 7,
+      seqNo: 3,
+    });
   });
 });

--- a/src/application/database-blob/__tests__/prefetch-dedup.test.ts
+++ b/src/application/database-blob/__tests__/prefetch-dedup.test.ts
@@ -1,4 +1,10 @@
-import { prefetchDatabaseBlobDiff, clearDatabaseRowDocSeedCache } from '@/application/database-blob';
+import {
+  prefetchDatabaseBlobDiff,
+  clearDatabaseRowDocSeedCache,
+  takeDatabaseRowDocSeed,
+} from '@/application/database-blob';
+import * as pageStageModule from '@/application/database-blob/page-stage';
+import type { DatabaseBlobDiffPageStage } from '@/application/database-blob/page-stage';
 import { deleteCollabDB, openRowCollabDBWithProvider } from '@/application/db';
 import { deleteRow } from '@/application/services/js-services/cache';
 import { databaseBlobDiff } from '@/application/services/js-services/http/http_api';
@@ -59,6 +65,36 @@ function createDeferred<T>() {
   });
 
   return { promise, resolve };
+}
+
+function createMockPageStage(options?: { failAppend?: boolean }) {
+  const pages: Uint8Array[] = [];
+  const append = jest.fn(async (bytes: Uint8Array) => {
+    if (options?.failAppend) throw new Error('page stage unavailable');
+    pages.push(bytes);
+  });
+  const read = jest.fn(async (pageIndex: number) => {
+    const page = pages[pageIndex];
+
+    if (!page) throw new Error(`missing test page ${pageIndex}`);
+    return page;
+  });
+  const clear = jest.fn(async () => {
+    pages.length = 0;
+  });
+  const stage: DatabaseBlobDiffPageStage = {
+    get pageCount() {
+      return pages.length;
+    },
+    get byteLength() {
+      return pages.reduce((total, page) => total + page.byteLength, 0);
+    },
+    append,
+    read,
+    clear,
+  };
+
+  return { stage, append, read, clear };
 }
 
 function readyDiff() {
@@ -190,6 +226,7 @@ describe('database blob prefetch deduplication', () => {
 
   afterEach(() => {
     jest.useRealTimers();
+    jest.restoreAllMocks();
     databaseIds.forEach(clearDatabaseRowDocSeedCache);
     databaseIds.clear();
   });
@@ -255,9 +292,7 @@ describe('database blob prefetch deduplication', () => {
     const callbacks = [jest.fn(), jest.fn(), jest.fn()];
 
     databaseIds.add(databaseId);
-    mockedDatabaseBlobDiff
-      .mockReturnValueOnce(firstPage.promise)
-      .mockResolvedValueOnce(readyDiff());
+    mockedDatabaseBlobDiff.mockReturnValueOnce(firstPage.promise).mockResolvedValueOnce(readyDiff());
 
     const prefetches = callbacks.map((onSeedsReady) =>
       prefetchDatabaseBlobDiff(workspaceId, databaseId, { onSeedsReady })
@@ -497,8 +532,74 @@ describe('database blob prefetch deduplication', () => {
     expect(onSeedsReady).toHaveBeenCalledTimes(1);
   });
 
+  it('stages ready pages and reads them one at a time after the terminal page', async () => {
+    const databaseId = 'database-staged-pages';
+    const firstPage = pageDiff({
+      hasMore: true,
+      nextCursor: new Uint8Array([1]),
+      rid: { timestamp: 10, seqNo: 1 },
+    });
+    const finalPage = pageDiff({ rid: { timestamp: 10, seqNo: 2 } });
+    const { stage, append, read, clear } = createMockPageStage();
+    const stageSpy = jest.spyOn(pageStageModule, 'createDatabaseBlobDiffPageStage').mockReturnValueOnce(stage);
+
+    databaseIds.add(databaseId);
+    mockedDatabaseBlobDiff.mockResolvedValueOnce(firstPage).mockResolvedValueOnce(finalPage);
+
+    await prefetchDatabaseBlobDiff('workspace-staged-pages', databaseId);
+
+    expect(append).toHaveBeenCalledTimes(2);
+    expect(read.mock.calls.map(([pageIndex]) => pageIndex)).toEqual([0, 1, 0, 1]);
+    expect(clear).toHaveBeenCalledTimes(1);
+    expect(localStorage.getItem(`af_database_blob_rid:${databaseId}`)).toBe(JSON.stringify({ timestamp: 10, seqNo: 2 }));
+
+    stageSpy.mockRestore();
+  });
+
+  it('copies cached row seed bytes out of the decoded page buffer', async () => {
+    const databaseId = 'database-owned-seed';
+
+    databaseIds.add(databaseId);
+    mockedDatabaseBlobDiff.mockResolvedValueOnce(persistablePage({ timestamp: 15, seqNo: 1 }));
+
+    await prefetchDatabaseBlobDiff('workspace-owned-seed', databaseId);
+
+    const seed = takeDatabaseRowDocSeed(`${databaseId}_rows_${VALID_ROW_ID}`);
+
+    expect(Array.from(seed?.bytes ?? [])).toEqual([1, 2, 3]);
+    expect(seed?.bytes.byteLength).toBe(3);
+    expect(seed?.bytes.buffer.byteLength).toBe(3);
+  });
+
+  it('falls back to row sync when provisional page staging fails', async () => {
+    const databaseId = 'database-stage-failure';
+    const diff = pageDiff({
+      hasMore: true,
+      nextCursor: new Uint8Array([1]),
+      rid: { timestamp: 20, seqNo: 1 },
+    });
+    const onSeedsReady = jest.fn();
+    const { stage, append, read, clear } = createMockPageStage({ failAppend: true });
+    const stageSpy = jest.spyOn(pageStageModule, 'createDatabaseBlobDiffPageStage').mockReturnValueOnce(stage);
+
+    databaseIds.add(databaseId);
+    mockedDatabaseBlobDiff.mockResolvedValueOnce(diff);
+
+    await expect(prefetchDatabaseBlobDiff('workspace-stage-failure', databaseId, { onSeedsReady })).resolves.toBe(diff);
+
+    expect(append).toHaveBeenCalledTimes(1);
+    expect(read).not.toHaveBeenCalled();
+    expect(clear).toHaveBeenCalledTimes(1);
+    expect(onSeedsReady).toHaveBeenCalledTimes(1);
+    expect(localStorage.getItem(`af_database_blob_rid:${databaseId}`)).toBeNull();
+
+    stageSpy.mockRestore();
+  });
+
   it('rejects a final page that carries a continuation cursor', async () => {
     const databaseId = 'database-final-cursor';
+    const { stage, clear } = createMockPageStage();
+    const stageSpy = jest.spyOn(pageStageModule, 'createDatabaseBlobDiffPageStage').mockReturnValueOnce(stage);
 
     databaseIds.add(databaseId);
     mockedDatabaseBlobDiff.mockResolvedValueOnce(pageDiff({ hasMore: false, nextCursor: new Uint8Array([1]) }));
@@ -506,7 +607,10 @@ describe('database blob prefetch deduplication', () => {
     await expect(prefetchDatabaseBlobDiff('workspace-final-cursor', databaseId)).rejects.toThrow(
       'final page contained a continuation cursor'
     );
+    expect(clear).toHaveBeenCalledTimes(1);
     expect(localStorage.getItem(`af_database_blob_rid:${databaseId}`)).toBeNull();
+
+    stageSpy.mockRestore();
   });
 
   it('rejects a non-final page that omits its continuation cursor', async () => {

--- a/src/application/database-blob/index.ts
+++ b/src/application/database-blob/index.ts
@@ -1,12 +1,17 @@
 import { stringify as uuidStringify } from 'uuid';
-
 import * as Y from 'yjs';
 
 import { hasRowConditionData, invalidateRowConditionCache } from '@/application/database-yjs/condition-value-cache';
 import { getRowKey } from '@/application/database-yjs/row_meta';
-import { getCachedProviderDoc, openCollabDBWithProvider, openRowCollabDBWithProvider } from '@/application/db';
-import { getCachedRowDoc } from '@/application/services/js-services/cache';
+import {
+  deleteCollabDB,
+  getCachedProviderDoc,
+  openCollabDBWithProvider,
+  openRowCollabDBWithProvider,
+} from '@/application/db';
+import { deleteRow as deleteCachedRow, getCachedRowDoc } from '@/application/services/js-services/cache';
 import { databaseBlobDiff } from '@/application/services/js-services/http/http_api';
+import { deleteOutboxByObjectId } from '@/application/sync-outbox';
 import { YDoc, YjsEditorKey } from '@/application/types';
 import { applyYDoc } from '@/application/ydoc/apply';
 import { database_blob } from '@/proto/database_blob';
@@ -31,7 +36,7 @@ type PrefetchOptions = {
   forceFullSync?: boolean;
   /** Allow the next caller to reuse this entry after it settles. */
   reuseSettled?: boolean;
-  /** Called immediately after seeds are cached (before IndexedDB persist). */
+  /** Called after a terminal page makes the cached seeds committable. */
   onSeedsReady?: () => void;
 };
 
@@ -50,7 +55,12 @@ type SharedPrefetchEntry = {
 type FetchDiffResult = {
   diff: database_blob.DatabaseBlobDiffResponse;
   ready: boolean;
-  pages: database_blob.DatabaseBlobDiffResponse[];
+  /**
+   * Provisional pages are encoded immediately so the walk does not retain the
+   * much larger decoded protobuf object graphs. They remain invisible until a
+   * terminal Ready page validates the complete walk.
+   */
+  encodedPages: Uint8Array[];
 };
 
 const RID_CACHE_PREFIX = 'af_database_blob_rid:';
@@ -212,13 +222,26 @@ function latestRid(current: DatabaseBlobRowRid | null, candidate: DatabaseBlobRo
 }
 
 function cursorKey(cursor: Uint8Array) {
-  return Array.from(cursor).join(',');
+  return cursor.join(',');
 }
 
 const rowDocSeedCache = new Map<string, RowDocSeed>();
 const rowDocSeedLookup = new Map<string, RowDocSeed>();
 const rowDocSeedDocCache = new Map<string, YDoc>();
 const rowDocSeedCacheRetainCounts = new Map<string, number>();
+
+function clearRowDocSeeds(databaseId: string, rowId: string) {
+  const rowKey = getRowKey(databaseId, rowId);
+  const seedDoc = rowDocSeedDocCache.get(rowKey);
+
+  rowDocSeedCache.delete(rowKey);
+  rowDocSeedLookup.delete(rowKey);
+
+  if (seedDoc) {
+    seedDoc.destroy();
+    rowDocSeedDocCache.delete(rowKey);
+  }
+}
 
 function applySeedToSharedRowDoc(rowKey: string, seed: RowDocSeed) {
   const doc = rowDocSeedDocCache.get(rowKey);
@@ -459,6 +482,7 @@ function summarizeDiff(diff: database_blob.DatabaseBlobDiffResponse) {
     deletes,
     rowDocStates,
     documentDocStates,
+    missingRowIds: diff.missingRowIds.length,
   };
 }
 
@@ -488,16 +512,13 @@ function applySeedToCachedDoc(rowKey: string, seed: RowDocSeed) {
 function seedRowDocCacheFromDiff(databaseId: string, diff: database_blob.DatabaseBlobDiffResponse, options?: PrefetchOptions) {
   const updates = [...diff.creates, ...diff.updates];
 
-  if (updates.length === 0) {
-    return { seeded: 0, prioritized: 0, priorityRequested: 0, appliedToCached: 0 };
-  }
-
   const priorityRowIds = options?.priorityRowIds ?? [];
   const prioritySet = new Set(priorityRowIds);
   const updatesByRowId = priorityRowIds.length > 0 ? new Map<string, database_blob.IDatabaseBlobRowUpdate>() : null;
   let seeded = 0;
   let prioritized = 0;
   let appliedToCached = 0;
+  let deleted = 0;
 
   updates.forEach((update) => {
     const rowId = decodeRowId(update.rowId);
@@ -574,11 +595,20 @@ function seedRowDocCacheFromDiff(databaseId: string, diff: database_blob.Databas
     }
   });
 
+  diff.deletes.forEach((del) => {
+    const rowId = decodeRowId(del.rowId);
+
+    if (!rowId) return;
+    clearRowDocSeeds(databaseId, rowId);
+    deleted += 1;
+  });
+
   return {
     seeded,
     prioritized,
     priorityRequested: priorityRowIds.length,
     appliedToCached,
+    deleted,
   };
 }
 
@@ -781,6 +811,53 @@ async function applyRowUpdate(
   });
 }
 
+async function applyRowDelete(databaseId: string, deletion: database_blob.IDatabaseBlobRowDelete) {
+  const rowId = decodeRowId(deletion.rowId);
+
+  if (!rowId) {
+    throw new Error('database blob diff contained a delete with an invalid row ID');
+  }
+
+  const rowKey = getRowKey(databaseId, rowId);
+
+  clearRowDocSeeds(databaseId, rowId);
+
+  try {
+    await deleteOutboxByObjectId(rowId);
+    const storageDeletes = await Promise.allSettled([
+      deleteCollabDB(rowId, { destroyDoc: false }),
+      // Older Web clients persisted rows under the composite row key. Leaving
+      // that database behind lets legacy backfill resurrect a tombstoned row.
+      deleteCollabDB(rowKey),
+    ]);
+    const rejectedDelete = storageDeletes.find(
+      (result): result is PromiseRejectedResult => result.status === 'rejected'
+    );
+
+    if (rejectedDelete) {
+      throw rejectedDelete.reason;
+    }
+
+    if (storageDeletes.some((result) => result.status === 'fulfilled' && !result.value)) {
+      throw new Error(`failed to delete local database row ${rowId}`);
+    }
+  } finally {
+    // deleteCollabDB must dispose its provider before deleteCachedRow evicts
+    // that provider entry. The cached Y.Doc is removed even when storage
+    // deletion fails, and the unchanged RID makes the next diff retry it.
+    deleteCachedRow(rowKey);
+  }
+}
+
+async function awaitBatch(operations: Promise<void>[]) {
+  const results = await Promise.allSettled(operations);
+  const rejected = results.find((result): result is PromiseRejectedResult => result.status === 'rejected');
+
+  if (rejected) {
+    throw rejected.reason;
+  }
+}
+
 async function applyDiff(
   databaseId: string,
   diff: database_blob.DatabaseBlobDiffResponse,
@@ -788,7 +865,9 @@ async function applyDiff(
 ) {
   const updates = [...diff.creates, ...diff.updates];
   const totalUpdates = updates.length;
-  const totalBatches = Math.ceil(totalUpdates / APPLY_CONCURRENCY);
+  const deletes = diff.deletes;
+  const totalBatches =
+    Math.ceil(totalUpdates / APPLY_CONCURRENCY) + Math.ceil(deletes.length / APPLY_CONCURRENCY);
 
   Log.debug('[Database] applyDiff start', {
     databaseId,
@@ -797,6 +876,7 @@ async function applyDiff(
     concurrency: APPLY_CONCURRENCY,
     creates: diff.creates.length,
     updates: diff.updates.length,
+    deletes: deletes.length,
     seedCache: options?.seedCache !== false,
   });
 
@@ -814,7 +894,7 @@ async function applyDiff(
       progress: `${i}/${totalUpdates}`,
     });
 
-    await Promise.all(batch.map((update) => applyRowUpdate(databaseId, update, options)));
+    await awaitBatch(batch.map((update) => applyRowUpdate(databaseId, update, options)));
 
     Log.debug('[Database] applyDiff batch completed', {
       databaseId,
@@ -825,9 +905,16 @@ async function applyDiff(
     });
   }
 
+  for (let i = 0; i < deletes.length; i += APPLY_CONCURRENCY) {
+    const batch = deletes.slice(i, i + APPLY_CONCURRENCY);
+
+    await awaitBatch(batch.map((deletion) => applyRowDelete(databaseId, deletion)));
+  }
+
   Log.debug('[Database] applyDiff completed', {
     databaseId,
     totalUpdates,
+    totalDeletes: deletes.length,
     totalBatches,
     totalDurationMs: Date.now() - startedAt,
   });
@@ -870,7 +957,7 @@ async function fetchReadyDiff(
   const cachedRid = options.cachedRid;
   const maxKnownRid = cachedRid ? { timestamp: cachedRid.timestamp, seqNo: cachedRid.seqNo } : undefined;
   let cursor = new Uint8Array();
-  let pages: database_blob.DatabaseBlobDiffResponse[] = [];
+  let encodedPages: Uint8Array[] = [];
   let seenCursors = new Set([cursorKey(cursor)]);
   let restartCount = 0;
 
@@ -900,18 +987,15 @@ async function fetchReadyDiff(
       },
     });
 
-    let diff: database_blob.DatabaseBlobDiffResponse | null = null;
-
     for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
       const attemptStartedAt = Date.now();
-
-      diff = await databaseBlobDiff(workspaceId, databaseId, request);
+      const diff = await databaseBlobDiff(workspaceId, databaseId, request);
 
       Log.debug('[Database] blob diff page response', {
         databaseId,
         status: diff.status,
         retryAfterSecs: diff.retryAfterSecs ?? null,
-        pageNumber: pages.length + 1,
+        pageNumber: encodedPages.length + 1,
         attempt,
         durationMs: Date.now() - attemptStartedAt,
         totalDurationMs: Date.now() - walkStartedAt,
@@ -944,12 +1028,12 @@ async function fetchReadyDiff(
             restartCount,
             totalDurationMs: Date.now() - walkStartedAt,
           });
-          return { diff, ready: false, pages: [] };
+          return { diff, ready: false, encodedPages: [] };
         }
 
         restartCount += 1;
         cursor = new Uint8Array();
-        pages = [];
+        encodedPages = [];
         seenCursors = new Set([cursorKey(cursor)]);
         Log.warn('[Database] blob diff page walk restarted', {
           databaseId,
@@ -960,17 +1044,18 @@ async function fetchReadyDiff(
       }
 
       if (diff.status === readyStatus) {
-        pages.push(diff);
+        const nextCursor = page.nextCursor ?? new Uint8Array();
 
+        // Validate the continuation contract before handing the page over, so a
+        // misbehaving server cannot get its payload seeded or persisted.
         if (!page.hasMore) {
-          if ((page.nextCursor?.length ?? 0) > 0) {
+          if (nextCursor.length > 0) {
             throw new Error('database blob diff paging protocol error: final page contained a continuation cursor');
           }
 
-          return { diff, ready: true, pages };
+          encodedPages.push(database_blob.DatabaseBlobDiffResponse.encode(diff).finish());
+          return { diff, ready: true, encodedPages };
         }
-
-        const nextCursor = page.nextCursor ?? new Uint8Array();
 
         if (nextCursor.length === 0) {
           throw new Error('database blob diff paging protocol error: non-final page omitted its continuation cursor');
@@ -982,6 +1067,7 @@ async function fetchReadyDiff(
           throw new Error('database blob diff paging protocol error: server repeated a continuation cursor');
         }
 
+        encodedPages.push(database_blob.DatabaseBlobDiffResponse.encode(diff).finish());
         seenCursors.add(nextCursorKey);
         cursor = new Uint8Array(nextCursor);
         break;
@@ -994,21 +1080,22 @@ async function fetchReadyDiff(
       }
 
       if (attempt === maxAttempts) {
-        Log.warn('[Database] blob diff still pending; discarding page walk and falling back to row sync', {
+        Log.warn('[Database] blob diff still pending; abandoning page walk and falling back to row sync', {
           databaseId,
-          pageNumber: pages.length + 1,
+          pageNumber: encodedPages.length + 1,
+          stagedPages: encodedPages.length,
           attempts: attempt,
           message: diff.message ?? null,
           ...summarizeDiff(diff),
         });
-        return { diff, ready: false, pages: [] };
+        return { diff, ready: false, encodedPages: [] };
       }
 
       const delayMs = retryDelayMs(diff.retryAfterSecs);
 
       Log.debug('[Database] blob diff page pending; retrying unchanged cursor', {
         databaseId,
-        pageNumber: pages.length + 1,
+        pageNumber: encodedPages.length + 1,
         attempt,
         nextAttempt: attempt + 1,
         delayMs,
@@ -1016,10 +1103,6 @@ async function fetchReadyDiff(
       });
 
       await sleep(delayMs);
-    }
-
-    if (!diff) {
-      throw new Error('database blob diff page request returned no response');
     }
   }
 }
@@ -1084,7 +1167,8 @@ export async function prefetchDatabaseBlobDiff(
   };
 
   const promise = (async () => {
-    const { diff, ready, pages } = await fetchReadyDiff(workspaceId, databaseId, {
+    const sourceLabel = options?.forceFullSync ? 'ready full' : 'ready delta';
+    const { diff, ready, encodedPages } = await fetchReadyDiff(workspaceId, databaseId, {
       cachedRid,
       forceFullSync: options?.forceFullSync,
     });
@@ -1094,28 +1178,31 @@ export async function prefetchDatabaseBlobDiff(
       return diff;
     }
 
-    pages.forEach((page, index) => {
-      seedDiff(page, `ready page ${index + 1}/${pages.length}`);
-    });
-
-    // A page walk is only usable after its terminal Ready page. Expose the
-    // complete seed set before the slower IndexedDB writes begin.
-    entry.hasCompleteSeedSet = true;
-    notifySeedsReady(entry);
-
     let allPagesPersisted = true;
     let maxRid: DatabaseBlobRowRid | null = null;
 
-    for (let index = 0; index < pages.length; index += 1) {
-      const page = pages[index];
+    // Decode one provisional page at a time only after the terminal page made
+    // the walk committable. This preserves atomic visibility while keeping the
+    // decoded working set bounded to one page.
+    encodedPages.forEach((encodedPage, index) => {
+      const page = database_blob.DatabaseBlobDiffResponse.decode(encodedPage);
+
+      seedDiff(page, `ready page ${index + 1}/${encodedPages.length}`);
+      maxRid = latestRid(maxRid, maxRidFromDiff(page));
+    });
+
+    entry.hasCompleteSeedSet = true;
+    notifySeedsReady(entry);
+
+    for (let index = 0; index < encodedPages.length; index += 1) {
+      const page = database_blob.DatabaseBlobDiffResponse.decode(encodedPages[index]);
       const persisted = await persistDiffToIndexedDB(
         databaseId,
         page,
-        `${options?.forceFullSync ? 'ready full' : 'ready delta'} page ${index + 1}/${pages.length}`
+        `${sourceLabel} page ${index + 1}/${encodedPages.length}`
       );
 
       allPagesPersisted = persisted && allPagesPersisted;
-      maxRid = latestRid(maxRid, maxRidFromDiff(page));
     }
 
     if (!options?.forceFullSync && allPagesPersisted && maxRid) {
@@ -1123,12 +1210,12 @@ export async function prefetchDatabaseBlobDiff(
       Log.debug('[Database] blob updated rid cache after terminal page', {
         databaseId,
         maxRid,
-        pageCount: pages.length,
+        pageCount: encodedPages.length,
       });
     } else if (!allPagesPersisted) {
       Log.warn('[Database] blob rid cache unchanged because one or more pages failed to persist', {
         databaseId,
-        pageCount: pages.length,
+        pageCount: encodedPages.length,
       });
     }
 

--- a/src/application/database-blob/index.ts
+++ b/src/application/database-blob/index.ts
@@ -11,7 +11,11 @@ import {
 } from '@/application/db';
 import { deleteRow as deleteCachedRow, getCachedRowDoc } from '@/application/services/js-services/cache';
 import { databaseBlobDiff } from '@/application/services/js-services/http/http_api';
-import { deleteOutboxByObjectId } from '@/application/sync-outbox';
+import {
+  deleteOutboxByObjectId,
+  getCurrentOutboxSession,
+  type SyncOutboxSession,
+} from '@/application/sync-outbox';
 import { YDoc, YjsEditorKey } from '@/application/types';
 import { applyYDoc } from '@/application/ydoc/apply';
 import { database_blob } from '@/proto/database_blob';
@@ -811,7 +815,11 @@ async function applyRowUpdate(
   });
 }
 
-async function applyRowDelete(databaseId: string, deletion: database_blob.IDatabaseBlobRowDelete) {
+async function applyRowDelete(
+  databaseId: string,
+  deletion: database_blob.IDatabaseBlobRowDelete,
+  outboxSession: SyncOutboxSession | null
+) {
   const rowId = decodeRowId(deletion.rowId);
 
   if (!rowId) {
@@ -823,7 +831,11 @@ async function applyRowDelete(databaseId: string, deletion: database_blob.IDatab
   clearRowDocSeeds(databaseId, rowId);
 
   try {
-    await deleteOutboxByObjectId(rowId);
+    if (!outboxSession) {
+      throw new Error(`cannot persist database row tombstone ${rowId} without its originating outbox session`);
+    }
+
+    await deleteOutboxByObjectId(rowId, { session: outboxSession });
     const storageDeletes = await Promise.allSettled([
       deleteCollabDB(rowId, { destroyDoc: false }),
       // Older Web clients persisted rows under the composite row key. Leaving
@@ -861,7 +873,7 @@ async function awaitBatch(operations: Promise<void>[]) {
 async function applyDiff(
   databaseId: string,
   diff: database_blob.DatabaseBlobDiffResponse,
-  options?: { seedCache?: boolean }
+  options?: { seedCache?: boolean; outboxSession?: SyncOutboxSession | null }
 ) {
   const updates = [...diff.creates, ...diff.updates];
   const totalUpdates = updates.length;
@@ -908,7 +920,7 @@ async function applyDiff(
   for (let i = 0; i < deletes.length; i += APPLY_CONCURRENCY) {
     const batch = deletes.slice(i, i + APPLY_CONCURRENCY);
 
-    await awaitBatch(batch.map((deletion) => applyRowDelete(databaseId, deletion)));
+    await awaitBatch(batch.map((deletion) => applyRowDelete(databaseId, deletion, options?.outboxSession ?? null)));
   }
 
   Log.debug('[Database] applyDiff completed', {
@@ -923,12 +935,13 @@ async function applyDiff(
 async function persistDiffToIndexedDB(
   databaseId: string,
   diff: database_blob.DatabaseBlobDiffResponse,
-  source: string
+  source: string,
+  outboxSession: SyncOutboxSession | null
 ): Promise<boolean> {
   const applyStartedAt = Date.now();
 
   try {
-    await applyDiff(databaseId, diff, { seedCache: false });
+    await applyDiff(databaseId, diff, { seedCache: false, outboxSession });
     Log.debug('[Database] blob diff persisted to IndexedDB', {
       databaseId,
       source,
@@ -1138,6 +1151,10 @@ export async function prefetchDatabaseBlobDiff(
     sharedPrefetchEntries.delete(sharedKey);
   }
 
+  // The page walk can finish after a workspace switch. Capture its owner now
+  // and thread it through tombstone persistence instead of consulting the
+  // sync-outbox module's replacement session at completion time.
+  const outboxSession = getCurrentOutboxSession(workspaceId);
   const cachedRid = options?.forceFullSync ? null : readCachedRid(databaseId);
   const entry: SharedPrefetchEntry = {
     priorityRowIds: new Set(),
@@ -1199,7 +1216,8 @@ export async function prefetchDatabaseBlobDiff(
       const persisted = await persistDiffToIndexedDB(
         databaseId,
         page,
-        `${sourceLabel} page ${index + 1}/${encodedPages.length}`
+        `${sourceLabel} page ${index + 1}/${encodedPages.length}`,
+        outboxSession
       );
 
       allPagesPersisted = persisted && allPagesPersisted;

--- a/src/application/database-blob/index.ts
+++ b/src/application/database-blob/index.ts
@@ -39,6 +39,7 @@ type SharedPrefetchEntry = {
   priorityRowIds: Set<string>;
   onSeedsReadyCallbacks: Set<() => void>;
   seedsReady: boolean;
+  hasCompleteSeedSet: boolean;
   coversFullSnapshot: boolean;
   reuseSettled?: boolean;
   settled?: boolean;
@@ -49,6 +50,7 @@ type SharedPrefetchEntry = {
 type FetchDiffResult = {
   diff: database_blob.DatabaseBlobDiffResponse;
   ready: boolean;
+  pages: database_blob.DatabaseBlobDiffResponse[];
 };
 
 const RID_CACHE_PREFIX = 'af_database_blob_rid:';
@@ -58,6 +60,9 @@ const MAX_ROW_DOC_SEEDS_LOOKUP = 10000;
 const BLOB_DIFF_PENDING_RETRIES = 1;
 const BLOB_DIFF_DEFAULT_RETRY_MS = 1000;
 const BLOB_DIFF_MAX_RETRY_MS = 5000;
+const BLOB_DIFF_PAGE_MAX_ITEMS = 256;
+const BLOB_DIFF_PAGE_MAX_BYTES = 16 * 1024 * 1024;
+const BLOB_DIFF_MAX_RESTARTS = 2;
 
 const readyStatus = database_blob.DiffStatus.READY;
 const pendingStatus = database_blob.DiffStatus.PENDING;
@@ -199,6 +204,15 @@ function compareRid(a: DatabaseBlobRowRid, b: DatabaseBlobRowRid) {
   }
 
   return a.timestamp > b.timestamp ? 1 : -1;
+}
+
+function latestRid(current: DatabaseBlobRowRid | null, candidate: DatabaseBlobRowRid | null) {
+  if (!candidate || (current && compareRid(current, candidate) >= 0)) return current;
+  return candidate;
+}
+
+function cursorKey(cursor: Uint8Array) {
+  return Array.from(cursor).join(',');
 }
 
 const rowDocSeedCache = new Map<string, RowDocSeed>();
@@ -822,33 +836,26 @@ async function applyDiff(
 async function persistDiffToIndexedDB(
   databaseId: string,
   diff: database_blob.DatabaseBlobDiffResponse,
-  options: { source: string; writeRid: boolean }
-) {
+  source: string
+): Promise<boolean> {
   const applyStartedAt = Date.now();
 
   try {
     await applyDiff(databaseId, diff, { seedCache: false });
     Log.debug('[Database] blob diff persisted to IndexedDB', {
       databaseId,
-      source: options.source,
+      source,
       durationMs: Date.now() - applyStartedAt,
       ...summarizeDiff(diff),
     });
-
-    if (!options.writeRid) return;
-
-    const maxRid = maxRidFromDiff(diff);
-
-    if (maxRid) {
-      writeCachedRid(databaseId, maxRid);
-      Log.debug('[Database] blob updated rid cache', { databaseId, maxRid });
-    }
+    return true;
   } catch (error) {
     Log.warn('[Database] blob diff persist failed', {
       databaseId,
-      source: options.source,
+      source,
       error,
     });
+    return false;
   }
 }
 
@@ -858,75 +865,163 @@ async function fetchReadyDiff(
   options: {
     cachedRid: DatabaseBlobRowRid | null;
     forceFullSync?: boolean;
-    onPendingDiff?: (diff: database_blob.DatabaseBlobDiffResponse, attempt: number) => void;
   }
 ): Promise<FetchDiffResult> {
   const cachedRid = options.cachedRid;
-  const request = database_blob.DatabaseBlobDiffRequest.create({
-    maxKnownRid: cachedRid ? { timestamp: cachedRid.timestamp, seqNo: cachedRid.seqNo } : undefined,
-    version: 1,
-  });
+  const maxKnownRid = cachedRid ? { timestamp: cachedRid.timestamp, seqNo: cachedRid.seqNo } : undefined;
+  let cursor = new Uint8Array();
+  let pages: database_blob.DatabaseBlobDiffResponse[] = [];
+  let seenCursors = new Set([cursorKey(cursor)]);
+  let restartCount = 0;
 
   Log.debug('[Database] blob diff request', {
     workspaceId,
     databaseId,
     forceFullSync: options?.forceFullSync ?? false,
     maxKnownRid: cachedRid ?? null,
+    version: 3,
+    pageMaxItems: BLOB_DIFF_PAGE_MAX_ITEMS,
+    pageMaxBytes: BLOB_DIFF_PAGE_MAX_BYTES,
   });
 
-  const firstAttemptStartedAt = Date.now();
+  const walkStartedAt = Date.now();
   const maxAttempts = BLOB_DIFF_PENDING_RETRIES + 1;
 
-  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
-    const attemptStartedAt = Date.now();
-    const diff = await databaseBlobDiff(workspaceId, databaseId, request);
-
-    Log.debug('[Database] blob diff response', {
-      databaseId,
-      status: diff.status,
-      retryAfterSecs: diff.retryAfterSecs ?? null,
-      attempt,
-      durationMs: Date.now() - attemptStartedAt,
-      totalDurationMs: Date.now() - firstAttemptStartedAt,
-      ...summarizeDiff(diff),
+  for (;;) {
+    const request = database_blob.DatabaseBlobDiffRequest.create({
+      maxKnownRid,
+      version: 3,
+      // The existing RID cache is document-aware. Keep this field absent so
+      // its RID domain remains compatible with legacy requests.
+      page: {
+        maxItems: BLOB_DIFF_PAGE_MAX_ITEMS,
+        maxBytes: BLOB_DIFF_PAGE_MAX_BYTES,
+        cursor,
+      },
     });
 
-    if (diff.status === readyStatus) {
-      return { diff, ready: true };
-    }
+    let diff: database_blob.DatabaseBlobDiffResponse | null = null;
 
-    if (diff.status !== pendingStatus) {
-      throw new Error(
-        `database blob diff failed: status=${diff.status}, attempts=${attempt}, message=${diff.message ?? 'none'}`
-      );
-    }
+    for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+      const attemptStartedAt = Date.now();
 
-    options?.onPendingDiff?.(diff, attempt);
+      diff = await databaseBlobDiff(workspaceId, databaseId, request);
 
-    if (attempt === maxAttempts) {
-      Log.warn('[Database] blob diff still pending; falling back to row sync', {
+      Log.debug('[Database] blob diff page response', {
         databaseId,
-        attempts: attempt,
-        message: diff.message ?? null,
+        status: diff.status,
+        retryAfterSecs: diff.retryAfterSecs ?? null,
+        pageNumber: pages.length + 1,
+        attempt,
+        durationMs: Date.now() - attemptStartedAt,
+        totalDurationMs: Date.now() - walkStartedAt,
         ...summarizeDiff(diff),
       });
-      return { diff, ready: false };
+
+      const page = diff.page;
+
+      if (!page) {
+        throw new Error('database blob diff paging protocol error: version 3 response omitted page metadata');
+      }
+
+      if (page.restartRequired) {
+        if (
+          page.hasMore ||
+          (page.nextCursor?.length ?? 0) > 0 ||
+          diff.creates.length > 0 ||
+          diff.updates.length > 0 ||
+          diff.deletes.length > 0 ||
+          diff.missingRowIds.length > 0
+        ) {
+          throw new Error(
+            'database blob diff paging protocol error: restart response contained payload or a continuation cursor'
+          );
+        }
+
+        if (restartCount >= BLOB_DIFF_MAX_RESTARTS) {
+          Log.warn('[Database] blob diff page walk kept restarting; falling back to row sync', {
+            databaseId,
+            restartCount,
+            totalDurationMs: Date.now() - walkStartedAt,
+          });
+          return { diff, ready: false, pages: [] };
+        }
+
+        restartCount += 1;
+        cursor = new Uint8Array();
+        pages = [];
+        seenCursors = new Set([cursorKey(cursor)]);
+        Log.warn('[Database] blob diff page walk restarted', {
+          databaseId,
+          restartCount,
+          totalDurationMs: Date.now() - walkStartedAt,
+        });
+        break;
+      }
+
+      if (diff.status === readyStatus) {
+        pages.push(diff);
+
+        if (!page.hasMore) {
+          if ((page.nextCursor?.length ?? 0) > 0) {
+            throw new Error('database blob diff paging protocol error: final page contained a continuation cursor');
+          }
+
+          return { diff, ready: true, pages };
+        }
+
+        const nextCursor = page.nextCursor ?? new Uint8Array();
+
+        if (nextCursor.length === 0) {
+          throw new Error('database blob diff paging protocol error: non-final page omitted its continuation cursor');
+        }
+
+        const nextCursorKey = cursorKey(nextCursor);
+
+        if (seenCursors.has(nextCursorKey)) {
+          throw new Error('database blob diff paging protocol error: server repeated a continuation cursor');
+        }
+
+        seenCursors.add(nextCursorKey);
+        cursor = new Uint8Array(nextCursor);
+        break;
+      }
+
+      if (diff.status !== pendingStatus) {
+        throw new Error(
+          `database blob diff failed: status=${diff.status}, attempts=${attempt}, message=${diff.message ?? 'none'}`
+        );
+      }
+
+      if (attempt === maxAttempts) {
+        Log.warn('[Database] blob diff still pending; discarding page walk and falling back to row sync', {
+          databaseId,
+          pageNumber: pages.length + 1,
+          attempts: attempt,
+          message: diff.message ?? null,
+          ...summarizeDiff(diff),
+        });
+        return { diff, ready: false, pages: [] };
+      }
+
+      const delayMs = retryDelayMs(diff.retryAfterSecs);
+
+      Log.debug('[Database] blob diff page pending; retrying unchanged cursor', {
+        databaseId,
+        pageNumber: pages.length + 1,
+        attempt,
+        nextAttempt: attempt + 1,
+        delayMs,
+        message: diff.message ?? null,
+      });
+
+      await sleep(delayMs);
     }
 
-    const delayMs = retryDelayMs(diff.retryAfterSecs);
-
-    Log.debug('[Database] blob diff pending; retrying', {
-      databaseId,
-      attempt,
-      nextAttempt: attempt + 1,
-      delayMs,
-      message: diff.message ?? null,
-    });
-
-    await sleep(delayMs);
+    if (!diff) {
+      throw new Error('database blob diff page request returned no response');
+    }
   }
-
-  throw new Error('database blob diff is not ready');
 }
 
 export async function prefetchDatabaseBlobDiff(
@@ -937,8 +1032,12 @@ export async function prefetchDatabaseBlobDiff(
   const { sharedKey, entry: existingEntry } = findSharedPrefetchEntry(workspaceId, databaseId, options);
 
   if (existingEntry?.promise) {
-    const canReuseSettledFullSeed = Boolean(options?.forceFullSync && existingEntry.settled && existingEntry.seedsReady);
-    const canReuseSettledSeed = Boolean(existingEntry.reuseSettled && existingEntry.settled && existingEntry.seedsReady);
+    const canReuseSettledFullSeed = Boolean(
+      options?.forceFullSync && existingEntry.settled && existingEntry.hasCompleteSeedSet
+    );
+    const canReuseSettledSeed = Boolean(
+      existingEntry.reuseSettled && existingEntry.settled && existingEntry.hasCompleteSeedSet
+    );
 
     if (!existingEntry.settled || canReuseSettledFullSeed || canReuseSettledSeed) {
       applyPrefetchOptions(existingEntry, options);
@@ -961,12 +1060,11 @@ export async function prefetchDatabaseBlobDiff(
     priorityRowIds: new Set(),
     onSeedsReadyCallbacks: new Set(),
     seedsReady: false,
+    hasCompleteSeedSet: false,
     coversFullSnapshot: cachedRid === null,
   };
 
   applyPrefetchOptions(entry, options);
-
-  let pendingPersistQueue: Promise<void> = Promise.resolve();
 
   const seedDiff = (diff: database_blob.DatabaseBlobDiffResponse, source: string) => {
     const seedSummary = seedRowDocCacheFromDiff(databaseId, diff, {
@@ -982,49 +1080,57 @@ export async function prefetchDatabaseBlobDiff(
       lookupCount: rowDocSeedLookup.size,
     });
 
-    // Signal that seeds are available before the slow IndexedDB persist.
-    notifySeedsReady(entry);
-
     return seedSummary;
   };
 
-  const handlePendingDiff = (diff: database_blob.DatabaseBlobDiffResponse, attempt: number) => {
-    const summary = summarizeDiff(diff);
-
-    if (summary.rowDocStates === 0) return;
-
-    seedDiff(diff, 'pending');
-
-    pendingPersistQueue = pendingPersistQueue.then(() =>
-      persistDiffToIndexedDB(databaseId, diff, {
-        source: `pending attempt ${attempt}`,
-        writeRid: false,
-      })
-    );
-  };
-
   const promise = (async () => {
-    const { diff, ready } = await fetchReadyDiff(workspaceId, databaseId, {
+    const { diff, ready, pages } = await fetchReadyDiff(workspaceId, databaseId, {
       cachedRid,
       forceFullSync: options?.forceFullSync,
-      onPendingDiff: handlePendingDiff,
     });
 
     if (!ready) {
-      if (!entry.seedsReady) {
-        notifySeedsReady(entry);
-      }
-
-      await pendingPersistQueue;
+      notifySeedsReady(entry);
       return diff;
     }
 
-    seedDiff(diff, 'ready');
-    await pendingPersistQueue;
-    await persistDiffToIndexedDB(databaseId, diff, {
-      source: options?.forceFullSync ? 'ready full' : 'ready delta',
-      writeRid: !options?.forceFullSync,
+    pages.forEach((page, index) => {
+      seedDiff(page, `ready page ${index + 1}/${pages.length}`);
     });
+
+    // A page walk is only usable after its terminal Ready page. Expose the
+    // complete seed set before the slower IndexedDB writes begin.
+    entry.hasCompleteSeedSet = true;
+    notifySeedsReady(entry);
+
+    let allPagesPersisted = true;
+    let maxRid: DatabaseBlobRowRid | null = null;
+
+    for (let index = 0; index < pages.length; index += 1) {
+      const page = pages[index];
+      const persisted = await persistDiffToIndexedDB(
+        databaseId,
+        page,
+        `${options?.forceFullSync ? 'ready full' : 'ready delta'} page ${index + 1}/${pages.length}`
+      );
+
+      allPagesPersisted = persisted && allPagesPersisted;
+      maxRid = latestRid(maxRid, maxRidFromDiff(page));
+    }
+
+    if (!options?.forceFullSync && allPagesPersisted && maxRid) {
+      writeCachedRid(databaseId, maxRid);
+      Log.debug('[Database] blob updated rid cache after terminal page', {
+        databaseId,
+        maxRid,
+        pageCount: pages.length,
+      });
+    } else if (!allPagesPersisted) {
+      Log.warn('[Database] blob rid cache unchanged because one or more pages failed to persist', {
+        databaseId,
+        pageCount: pages.length,
+      });
+    }
 
     return diff;
   })().finally(() => {

--- a/src/application/database-blob/index.ts
+++ b/src/application/database-blob/index.ts
@@ -11,15 +11,13 @@ import {
 } from '@/application/db';
 import { deleteRow as deleteCachedRow, getCachedRowDoc } from '@/application/services/js-services/cache';
 import { databaseBlobDiff } from '@/application/services/js-services/http/http_api';
-import {
-  deleteOutboxByObjectId,
-  getCurrentOutboxSession,
-  type SyncOutboxSession,
-} from '@/application/sync-outbox';
+import { deleteOutboxByObjectId, getCurrentOutboxSession, type SyncOutboxSession } from '@/application/sync-outbox';
 import { YDoc, YjsEditorKey } from '@/application/types';
 import { applyYDoc } from '@/application/ydoc/apply';
 import { database_blob } from '@/proto/database_blob';
 import { Log } from '@/utils/log';
+
+import { createDatabaseBlobDiffPageStage, type DatabaseBlobDiffPageStage } from './page-stage';
 
 type DatabaseBlobRowRid = {
   timestamp: number;
@@ -60,11 +58,10 @@ type FetchDiffResult = {
   diff: database_blob.DatabaseBlobDiffResponse;
   ready: boolean;
   /**
-   * Provisional pages are encoded immediately so the walk does not retain the
-   * much larger decoded protobuf object graphs. They remain invisible until a
-   * terminal Ready page validates the complete walk.
+   * Provisional pages are encoded and staged outside the JS heap. They remain
+   * invisible until a terminal Ready page validates the complete walk.
    */
-  encodedPages: Uint8Array[];
+  stagedPages: DatabaseBlobDiffPageStage | null;
 };
 
 const RID_CACHE_PREFIX = 'af_database_blob_rid:';
@@ -95,7 +92,9 @@ function fullSharedPrefetchKey(workspaceId: string, databaseId: string) {
 }
 
 function sharedPrefetchKeyForOptions(workspaceId: string, databaseId: string, options?: PrefetchOptions) {
-  return options?.forceFullSync ? fullSharedPrefetchKey(workspaceId, databaseId) : sharedPrefetchKey(workspaceId, databaseId);
+  return options?.forceFullSync
+    ? fullSharedPrefetchKey(workspaceId, databaseId)
+    : sharedPrefetchKey(workspaceId, databaseId);
 }
 
 function findSharedPrefetchEntry(
@@ -160,21 +159,19 @@ function notifySeedsReady(entry: SharedPrefetchEntry) {
   callbacks.forEach((callback) => callback());
 }
 
-function clearSharedPrefetchEntryAfterSettle(
-  databaseId: string,
-  sharedKey: string,
-  entry: SharedPrefetchEntry
-) {
+function clearSharedPrefetchEntryAfterSettle(databaseId: string, sharedKey: string, entry: SharedPrefetchEntry) {
   if (entry.clearWhenSettled) return;
   entry.clearWhenSettled = true;
 
-  entry.promise?.finally(() => {
-    entry.clearWhenSettled = false;
+  entry.promise
+    ?.finally(() => {
+      entry.clearWhenSettled = false;
 
-    if ((rowDocSeedCacheRetainCounts.get(databaseId) ?? 0) === 0 && sharedPrefetchEntries.get(sharedKey) === entry) {
-      clearDatabaseRowDocSeedCache(databaseId);
-    }
-  }).catch(() => undefined);
+      if ((rowDocSeedCacheRetainCounts.get(databaseId) ?? 0) === 0 && sharedPrefetchEntries.get(sharedKey) === entry) {
+        clearDatabaseRowDocSeedCache(databaseId);
+      }
+    })
+    .catch(() => undefined);
 }
 
 function parseRid(rid?: database_blob.IDatabaseBlobRowRid | null): DatabaseBlobRowRid | null {
@@ -493,7 +490,10 @@ function summarizeDiff(diff: database_blob.DatabaseBlobDiffResponse) {
 function getDocState(state?: database_blob.ICollabDocState | null) {
   if (!state?.docState || state.docState.length === 0) return null;
   return {
-    bytes: state.docState,
+    // protobuf.js decodes bytes as a view into the complete response buffer.
+    // Cache an owned copy so one small row seed cannot pin an entire staged
+    // page in the browser heap after that page has been processed.
+    bytes: new Uint8Array(state.docState),
     encoderVersion: typeof state.encoderVersion === 'number' ? state.encoderVersion : 1,
   };
 }
@@ -513,7 +513,11 @@ function applySeedToCachedDoc(rowKey: string, seed: RowDocSeed) {
   return true;
 }
 
-function seedRowDocCacheFromDiff(databaseId: string, diff: database_blob.DatabaseBlobDiffResponse, options?: PrefetchOptions) {
+function seedRowDocCacheFromDiff(
+  databaseId: string,
+  diff: database_blob.DatabaseBlobDiffResponse,
+  options?: PrefetchOptions
+) {
   const updates = [...diff.creates, ...diff.updates];
 
   const priorityRowIds = options?.priorityRowIds ?? [];
@@ -616,7 +620,10 @@ function seedRowDocCacheFromDiff(databaseId: string, diff: database_blob.Databas
   };
 }
 
-function inspectDocRowData(doc: YDoc, objectId: string): {
+function inspectDocRowData(
+  doc: YDoc,
+  objectId: string
+): {
   hasDataSection: boolean;
   hasDatabaseRow: boolean;
   rowKeys: string[];
@@ -878,8 +885,7 @@ async function applyDiff(
   const updates = [...diff.creates, ...diff.updates];
   const totalUpdates = updates.length;
   const deletes = diff.deletes;
-  const totalBatches =
-    Math.ceil(totalUpdates / APPLY_CONCURRENCY) + Math.ceil(deletes.length / APPLY_CONCURRENCY);
+  const totalBatches = Math.ceil(totalUpdates / APPLY_CONCURRENCY) + Math.ceil(deletes.length / APPLY_CONCURRENCY);
 
   Log.debug('[Database] applyDiff start', {
     databaseId,
@@ -970,7 +976,7 @@ async function fetchReadyDiff(
   const cachedRid = options.cachedRid;
   const maxKnownRid = cachedRid ? { timestamp: cachedRid.timestamp, seqNo: cachedRid.seqNo } : undefined;
   let cursor = new Uint8Array();
-  let encodedPages: Uint8Array[] = [];
+  const stagedPages = createDatabaseBlobDiffPageStage();
   let seenCursors = new Set([cursorKey(cursor)]);
   let restartCount = 0;
 
@@ -987,144 +993,159 @@ async function fetchReadyDiff(
   const walkStartedAt = Date.now();
   const maxAttempts = BLOB_DIFF_PENDING_RETRIES + 1;
 
-  for (;;) {
-    const request = database_blob.DatabaseBlobDiffRequest.create({
-      maxKnownRid,
-      version: 3,
-      // The existing RID cache is document-aware. Keep this field absent so
-      // its RID domain remains compatible with legacy requests.
-      page: {
-        maxItems: BLOB_DIFF_PAGE_MAX_ITEMS,
-        maxBytes: BLOB_DIFF_PAGE_MAX_BYTES,
-        cursor,
-      },
-    });
-
-    for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
-      const attemptStartedAt = Date.now();
-      const diff = await databaseBlobDiff(workspaceId, databaseId, request);
-
-      Log.debug('[Database] blob diff page response', {
-        databaseId,
-        status: diff.status,
-        retryAfterSecs: diff.retryAfterSecs ?? null,
-        pageNumber: encodedPages.length + 1,
-        attempt,
-        durationMs: Date.now() - attemptStartedAt,
-        totalDurationMs: Date.now() - walkStartedAt,
-        ...summarizeDiff(diff),
+  try {
+    for (;;) {
+      const request = database_blob.DatabaseBlobDiffRequest.create({
+        maxKnownRid,
+        version: 3,
+        // The existing RID cache is document-aware. Keep this field absent so
+        // its RID domain remains compatible with legacy requests.
+        page: {
+          maxItems: BLOB_DIFF_PAGE_MAX_ITEMS,
+          maxBytes: BLOB_DIFF_PAGE_MAX_BYTES,
+          cursor,
+        },
       });
 
-      const page = diff.page;
+      for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+        const attemptStartedAt = Date.now();
+        const diff = await databaseBlobDiff(workspaceId, databaseId, request);
 
-      if (!page) {
-        throw new Error('database blob diff paging protocol error: version 3 response omitted page metadata');
-      }
+        Log.debug('[Database] blob diff page response', {
+          databaseId,
+          status: diff.status,
+          retryAfterSecs: diff.retryAfterSecs ?? null,
+          pageNumber: stagedPages.pageCount + 1,
+          attempt,
+          durationMs: Date.now() - attemptStartedAt,
+          totalDurationMs: Date.now() - walkStartedAt,
+          ...summarizeDiff(diff),
+        });
 
-      if (page.restartRequired) {
-        if (
-          page.hasMore ||
-          (page.nextCursor?.length ?? 0) > 0 ||
-          diff.creates.length > 0 ||
-          diff.updates.length > 0 ||
-          diff.deletes.length > 0 ||
-          diff.missingRowIds.length > 0
-        ) {
-          throw new Error(
-            'database blob diff paging protocol error: restart response contained payload or a continuation cursor'
-          );
+        const page = diff.page;
+
+        if (!page) {
+          throw new Error('database blob diff paging protocol error: version 3 response omitted page metadata');
         }
 
-        if (restartCount >= BLOB_DIFF_MAX_RESTARTS) {
-          Log.warn('[Database] blob diff page walk kept restarting; falling back to row sync', {
+        if (page.restartRequired) {
+          if (
+            page.hasMore ||
+            (page.nextCursor?.length ?? 0) > 0 ||
+            diff.creates.length > 0 ||
+            diff.updates.length > 0 ||
+            diff.deletes.length > 0 ||
+            diff.missingRowIds.length > 0
+          ) {
+            throw new Error(
+              'database blob diff paging protocol error: restart response contained payload or a continuation cursor'
+            );
+          }
+
+          if (restartCount >= BLOB_DIFF_MAX_RESTARTS) {
+            Log.warn('[Database] blob diff page walk kept restarting; falling back to row sync', {
+              databaseId,
+              restartCount,
+              totalDurationMs: Date.now() - walkStartedAt,
+            });
+            await stagedPages.clear();
+            return { diff, ready: false, stagedPages: null };
+          }
+
+          restartCount += 1;
+          cursor = new Uint8Array();
+          await stagedPages.clear();
+          seenCursors = new Set([cursorKey(cursor)]);
+          Log.warn('[Database] blob diff page walk restarted', {
             databaseId,
             restartCount,
             totalDurationMs: Date.now() - walkStartedAt,
           });
-          return { diff, ready: false, encodedPages: [] };
+          break;
         }
 
-        restartCount += 1;
-        cursor = new Uint8Array();
-        encodedPages = [];
-        seenCursors = new Set([cursorKey(cursor)]);
-        Log.warn('[Database] blob diff page walk restarted', {
-          databaseId,
-          restartCount,
-          totalDurationMs: Date.now() - walkStartedAt,
-        });
-        break;
-      }
+        if (diff.status === readyStatus) {
+          const nextCursor = page.nextCursor ?? new Uint8Array();
 
-      if (diff.status === readyStatus) {
-        const nextCursor = page.nextCursor ?? new Uint8Array();
-
-        // Validate the continuation contract before handing the page over, so a
-        // misbehaving server cannot get its payload seeded or persisted.
-        if (!page.hasMore) {
-          if (nextCursor.length > 0) {
+          // Validate the continuation contract before handing the page over, so a
+          // misbehaving server cannot get its payload seeded or persisted.
+          if (!page.hasMore && nextCursor.length > 0) {
             throw new Error('database blob diff paging protocol error: final page contained a continuation cursor');
           }
 
-          encodedPages.push(database_blob.DatabaseBlobDiffResponse.encode(diff).finish());
-          return { diff, ready: true, encodedPages };
+          if (page.hasMore && nextCursor.length === 0) {
+            throw new Error('database blob diff paging protocol error: non-final page omitted its continuation cursor');
+          }
+
+          const nextCursorKey = cursorKey(nextCursor);
+
+          if (page.hasMore && seenCursors.has(nextCursorKey)) {
+            throw new Error('database blob diff paging protocol error: server repeated a continuation cursor');
+          }
+
+          try {
+            await stagedPages.append(database_blob.DatabaseBlobDiffResponse.encode(diff).finish());
+          } catch (error) {
+            Log.warn('[Database] blob diff page staging failed; falling back to row sync', {
+              databaseId,
+              pageNumber: stagedPages.pageCount + 1,
+              stagedPages: stagedPages.pageCount,
+              stagedBytes: stagedPages.byteLength,
+              error,
+            });
+            await stagedPages.clear();
+            return { diff, ready: false, stagedPages: null };
+          }
+
+          if (!page.hasMore) {
+            return { diff, ready: true, stagedPages };
+          }
+
+          seenCursors.add(nextCursorKey);
+          cursor = new Uint8Array(nextCursor);
+          break;
         }
 
-        if (nextCursor.length === 0) {
-          throw new Error('database blob diff paging protocol error: non-final page omitted its continuation cursor');
+        if (diff.status !== pendingStatus) {
+          throw new Error(
+            `database blob diff failed: status=${diff.status}, attempts=${attempt}, message=${diff.message ?? 'none'}`
+          );
         }
 
-        const nextCursorKey = cursorKey(nextCursor);
-
-        if (seenCursors.has(nextCursorKey)) {
-          throw new Error('database blob diff paging protocol error: server repeated a continuation cursor');
+        if (attempt === maxAttempts) {
+          Log.warn('[Database] blob diff still pending; abandoning page walk and falling back to row sync', {
+            databaseId,
+            pageNumber: stagedPages.pageCount + 1,
+            stagedPages: stagedPages.pageCount,
+            attempts: attempt,
+            message: diff.message ?? null,
+            ...summarizeDiff(diff),
+          });
+          await stagedPages.clear();
+          return { diff, ready: false, stagedPages: null };
         }
 
-        encodedPages.push(database_blob.DatabaseBlobDiffResponse.encode(diff).finish());
-        seenCursors.add(nextCursorKey);
-        cursor = new Uint8Array(nextCursor);
-        break;
-      }
+        const delayMs = retryDelayMs(diff.retryAfterSecs);
 
-      if (diff.status !== pendingStatus) {
-        throw new Error(
-          `database blob diff failed: status=${diff.status}, attempts=${attempt}, message=${diff.message ?? 'none'}`
-        );
-      }
-
-      if (attempt === maxAttempts) {
-        Log.warn('[Database] blob diff still pending; abandoning page walk and falling back to row sync', {
+        Log.debug('[Database] blob diff page pending; retrying unchanged cursor', {
           databaseId,
-          pageNumber: encodedPages.length + 1,
-          stagedPages: encodedPages.length,
-          attempts: attempt,
+          pageNumber: stagedPages.pageCount + 1,
+          attempt,
+          nextAttempt: attempt + 1,
+          delayMs,
           message: diff.message ?? null,
-          ...summarizeDiff(diff),
         });
-        return { diff, ready: false, encodedPages: [] };
+
+        await sleep(delayMs);
       }
-
-      const delayMs = retryDelayMs(diff.retryAfterSecs);
-
-      Log.debug('[Database] blob diff page pending; retrying unchanged cursor', {
-        databaseId,
-        pageNumber: encodedPages.length + 1,
-        attempt,
-        nextAttempt: attempt + 1,
-        delayMs,
-        message: diff.message ?? null,
-      });
-
-      await sleep(delayMs);
     }
+  } catch (error) {
+    await stagedPages.clear();
+    throw error;
   }
 }
 
-export async function prefetchDatabaseBlobDiff(
-  workspaceId: string,
-  databaseId: string,
-  options?: PrefetchOptions
-) {
+export async function prefetchDatabaseBlobDiff(workspaceId: string, databaseId: string, options?: PrefetchOptions) {
   const { sharedKey, entry: existingEntry } = findSharedPrefetchEntry(workspaceId, databaseId, options);
 
   if (existingEntry?.promise) {
@@ -1185,7 +1206,7 @@ export async function prefetchDatabaseBlobDiff(
 
   const promise = (async () => {
     const sourceLabel = options?.forceFullSync ? 'ready full' : 'ready delta';
-    const { diff, ready, encodedPages } = await fetchReadyDiff(workspaceId, databaseId, {
+    const { diff, ready, stagedPages } = await fetchReadyDiff(workspaceId, databaseId, {
       cachedRid,
       forceFullSync: options?.forceFullSync,
     });
@@ -1197,44 +1218,57 @@ export async function prefetchDatabaseBlobDiff(
 
     let allPagesPersisted = true;
     let maxRid: DatabaseBlobRowRid | null = null;
+    const pageCount = stagedPages?.pageCount ?? 0;
 
-    // Decode one provisional page at a time only after the terminal page made
-    // the walk committable. This preserves atomic visibility while keeping the
-    // decoded working set bounded to one page.
-    encodedPages.forEach((encodedPage, index) => {
-      const page = database_blob.DatabaseBlobDiffResponse.decode(encodedPage);
-
-      seedDiff(page, `ready page ${index + 1}/${encodedPages.length}`);
-      maxRid = latestRid(maxRid, maxRidFromDiff(page));
-    });
-
-    entry.hasCompleteSeedSet = true;
-    notifySeedsReady(entry);
-
-    for (let index = 0; index < encodedPages.length; index += 1) {
-      const page = database_blob.DatabaseBlobDiffResponse.decode(encodedPages[index]);
-      const persisted = await persistDiffToIndexedDB(
-        databaseId,
-        page,
-        `${sourceLabel} page ${index + 1}/${encodedPages.length}`,
-        outboxSession
-      );
-
-      allPagesPersisted = persisted && allPagesPersisted;
+    if (!stagedPages) {
+      throw new Error('database blob diff paging protocol error: Ready walk did not stage any pages');
     }
 
-    if (!options?.forceFullSync && allPagesPersisted && maxRid) {
-      writeCachedRid(databaseId, maxRid);
-      Log.debug('[Database] blob updated rid cache after terminal page', {
-        databaseId,
-        maxRid,
-        pageCount: encodedPages.length,
-      });
-    } else if (!allPagesPersisted) {
-      Log.warn('[Database] blob rid cache unchanged because one or more pages failed to persist', {
-        databaseId,
-        pageCount: encodedPages.length,
-      });
+    try {
+      if (pageCount === 0) {
+        throw new Error('database blob diff paging protocol error: Ready walk did not stage any pages');
+      }
+
+      // Decode one provisional page at a time only after the terminal page made
+      // the walk committable. This preserves atomic visibility while keeping both
+      // the encoded and decoded JS-heap working sets bounded to one page.
+      for (let index = 0; index < pageCount; index += 1) {
+        const page = database_blob.DatabaseBlobDiffResponse.decode(await stagedPages.read(index));
+
+        seedDiff(page, `ready page ${index + 1}/${pageCount}`);
+        maxRid = latestRid(maxRid, maxRidFromDiff(page));
+      }
+
+      entry.hasCompleteSeedSet = true;
+      notifySeedsReady(entry);
+
+      for (let index = 0; index < pageCount; index += 1) {
+        const page = database_blob.DatabaseBlobDiffResponse.decode(await stagedPages.read(index));
+        const persisted = await persistDiffToIndexedDB(
+          databaseId,
+          page,
+          `${sourceLabel} page ${index + 1}/${pageCount}`,
+          outboxSession
+        );
+
+        allPagesPersisted = persisted && allPagesPersisted;
+      }
+
+      if (!options?.forceFullSync && allPagesPersisted && maxRid) {
+        writeCachedRid(databaseId, maxRid);
+        Log.debug('[Database] blob updated rid cache after terminal page', {
+          databaseId,
+          maxRid,
+          pageCount,
+        });
+      } else if (!allPagesPersisted) {
+        Log.warn('[Database] blob rid cache unchanged because one or more pages failed to persist', {
+          databaseId,
+          pageCount,
+        });
+      }
+    } finally {
+      await stagedPages.clear();
     }
 
     return diff;

--- a/src/application/database-blob/page-stage.ts
+++ b/src/application/database-blob/page-stage.ts
@@ -1,0 +1,263 @@
+const DB_NAME = 'AppFlowyDatabaseBlobDiffPageStage';
+const DB_VERSION = 1;
+const STORE_NAME = 'pages';
+const WALK_ID_INDEX = 'walkId';
+const CREATED_AT_INDEX = 'createdAt';
+const STALE_PAGE_MAX_AGE_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * Browsers without usable IndexedDB can still complete small walks, but must
+ * never restore the old unbounded heap behaviour. Two maximum-sized pages
+ * leave enough room for ordinary pagination while providing a hard ceiling.
+ */
+export const DATABASE_BLOB_PAGE_STAGE_MEMORY_LIMIT_BYTES = 32 * 1024 * 1024;
+
+type StagedPageRecord = {
+  walkId: string;
+  pageIndex: number;
+  bytes: Uint8Array;
+  createdAt: number;
+};
+
+export interface DatabaseBlobDiffPageStage {
+  readonly pageCount: number;
+  readonly byteLength: number;
+  append(bytes: Uint8Array): Promise<void>;
+  read(pageIndex: number): Promise<Uint8Array>;
+  clear(): Promise<void>;
+}
+
+export class DatabaseBlobDiffPageStageCapacityError extends Error {
+  constructor(byteLength: number, limitBytes = DATABASE_BLOB_PAGE_STAGE_MEMORY_LIMIT_BYTES) {
+    super(`database blob diff page staging exceeded the ${limitBytes}-byte memory limit (${byteLength} bytes)`);
+    this.name = 'DatabaseBlobDiffPageStageCapacityError';
+  }
+}
+
+let databasePromise: Promise<IDBDatabase | null> | null = null;
+let walkSequence = 0;
+
+function createWalkId() {
+  walkSequence += 1;
+  return `${Date.now()}-${walkSequence}-${Math.random().toString(36).slice(2)}`;
+}
+
+function canUseIndexedDB() {
+  return typeof indexedDB !== 'undefined';
+}
+
+function deleteByCursor(database: IDBDatabase, indexName: string, range: IDBKeyRange): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const transaction = database.transaction(STORE_NAME, 'readwrite');
+    const index = transaction.objectStore(STORE_NAME).index(indexName);
+    const request = index.openCursor(range);
+
+    request.onsuccess = () => {
+      const cursor = request.result;
+
+      if (!cursor) return;
+      cursor.delete();
+      cursor.continue();
+    };
+
+    request.onerror = () => reject(request.error ?? new Error('failed to enumerate staged database blob pages'));
+    transaction.oncomplete = () => resolve();
+    transaction.onerror = () => reject(transaction.error ?? new Error('failed to delete staged database blob pages'));
+    transaction.onabort = () => reject(transaction.error ?? new Error('staged database blob page deletion aborted'));
+  });
+}
+
+function removeExpiredPages(database: IDBDatabase) {
+  const expiresBefore = Date.now() - STALE_PAGE_MAX_AGE_MS;
+
+  void deleteByCursor(database, CREATED_AT_INDEX, IDBKeyRange.upperBound(expiresBefore)).catch(() => undefined);
+}
+
+function openDatabase(): Promise<IDBDatabase | null> {
+  if (!canUseIndexedDB()) return Promise.resolve(null);
+  if (databasePromise) return databasePromise;
+
+  databasePromise = new Promise((resolve) => {
+    const request = indexedDB.open(DB_NAME, DB_VERSION);
+    let settled = false;
+
+    request.onerror = () => {
+      if (settled) {
+        databasePromise = null;
+        return;
+      }
+
+      settled = true;
+      databasePromise = null;
+      resolve(null);
+    };
+
+    request.onblocked = () => {
+      if (settled) return;
+
+      // Do not leave a page walk waiting indefinitely on another connection.
+      // This request remains the cached attempt until it eventually succeeds or
+      // errors, while the current walk uses the bounded in-memory fallback.
+      settled = true;
+      resolve(null);
+    };
+
+    request.onupgradeneeded = () => {
+      const database = request.result;
+
+      if (database.objectStoreNames.contains(STORE_NAME)) return;
+
+      const store = database.createObjectStore(STORE_NAME, {
+        keyPath: ['walkId', 'pageIndex'],
+      });
+
+      store.createIndex(WALK_ID_INDEX, WALK_ID_INDEX, { unique: false });
+      store.createIndex(CREATED_AT_INDEX, CREATED_AT_INDEX, { unique: false });
+    };
+
+    request.onsuccess = () => {
+      const database = request.result;
+
+      if (settled) {
+        database.close();
+        databasePromise = null;
+        return;
+      }
+
+      database.onversionchange = () => {
+        database.close();
+        databasePromise = null;
+      };
+
+      settled = true;
+      resolve(database);
+      removeExpiredPages(database);
+    };
+  });
+
+  return databasePromise;
+}
+
+function putPage(database: IDBDatabase, record: StagedPageRecord): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const transaction = database.transaction(STORE_NAME, 'readwrite');
+
+    transaction.objectStore(STORE_NAME).put(record);
+
+    transaction.oncomplete = () => resolve();
+    transaction.onerror = () => reject(transaction.error ?? new Error('failed to stage database blob page'));
+    transaction.onabort = () => reject(transaction.error ?? new Error('database blob page staging aborted'));
+  });
+}
+
+function getPage(database: IDBDatabase, walkId: string, pageIndex: number): Promise<Uint8Array> {
+  return new Promise((resolve, reject) => {
+    const transaction = database.transaction(STORE_NAME, 'readonly');
+    const request = transaction.objectStore(STORE_NAME).get([walkId, pageIndex]);
+
+    request.onsuccess = () => {
+      const record = request.result as StagedPageRecord | undefined;
+
+      if (!record) {
+        reject(new Error(`database blob diff staged page ${pageIndex} is missing`));
+        return;
+      }
+
+      resolve(record.bytes instanceof Uint8Array ? record.bytes : new Uint8Array(record.bytes));
+    };
+
+    request.onerror = () => reject(request.error ?? new Error('failed to read staged database blob page'));
+  });
+}
+
+class PageStage implements DatabaseBlobDiffPageStage {
+  private readonly walkId = createWalkId();
+  private readonly memoryPages = new Map<number, Uint8Array>();
+  private backend: 'unknown' | 'indexeddb' | 'memory' = 'unknown';
+  private count = 0;
+  private bytes = 0;
+
+  constructor(private readonly memoryLimitBytes: number) {}
+
+  get pageCount() {
+    return this.count;
+  }
+
+  get byteLength() {
+    return this.bytes;
+  }
+
+  async append(bytes: Uint8Array) {
+    const nextByteLength = this.bytes + bytes.byteLength;
+    const database = this.backend === 'memory' ? null : await openDatabase();
+
+    if (database) {
+      await putPage(database, {
+        walkId: this.walkId,
+        pageIndex: this.count,
+        bytes,
+        createdAt: Date.now(),
+      });
+      this.backend = 'indexeddb';
+    } else {
+      if (this.backend === 'indexeddb') {
+        throw new Error('database blob diff page stage became unavailable');
+      }
+
+      if (nextByteLength > this.memoryLimitBytes) {
+        throw new DatabaseBlobDiffPageStageCapacityError(nextByteLength, this.memoryLimitBytes);
+      }
+
+      this.backend = 'memory';
+      // Own exactly these bytes; Buffer/typed-array views can otherwise keep a
+      // much larger pooled backing buffer alive than their byteLength reports.
+      this.memoryPages.set(this.count, new Uint8Array(bytes));
+    }
+
+    this.count += 1;
+    this.bytes = nextByteLength;
+  }
+
+  async read(pageIndex: number) {
+    if (!Number.isInteger(pageIndex) || pageIndex < 0 || pageIndex >= this.count) {
+      throw new Error(`database blob diff staged page ${pageIndex} is out of range`);
+    }
+
+    if (this.backend === 'memory') {
+      const page = this.memoryPages.get(pageIndex);
+
+      if (!page) throw new Error(`database blob diff staged page ${pageIndex} is missing`);
+      return page;
+    }
+
+    const database = await openDatabase();
+
+    if (!database) throw new Error('database blob diff page stage is unavailable');
+    return getPage(database, this.walkId, pageIndex);
+  }
+
+  async clear() {
+    this.memoryPages.clear();
+
+    try {
+      if (this.backend === 'indexeddb') {
+        const database = await openDatabase();
+
+        if (database) {
+          await deleteByCursor(database, WALK_ID_INDEX, IDBKeyRange.only(this.walkId));
+        }
+      }
+    } catch {
+      // Staged pages are disposable. Expiration cleanup removes leftovers from
+      // interrupted walks without making a successful prefetch fail.
+    } finally {
+      this.backend = 'unknown';
+      this.count = 0;
+      this.bytes = 0;
+    }
+  }
+}
+
+export function createDatabaseBlobDiffPageStage(options?: { memoryLimitBytes?: number }): DatabaseBlobDiffPageStage {
+  return new PageStage(options?.memoryLimitBytes ?? DATABASE_BLOB_PAGE_STAGE_MEMORY_LIMIT_BYTES);
+}

--- a/src/application/db/tables/sync_outbox.ts
+++ b/src/application/db/tables/sync_outbox.ts
@@ -15,6 +15,12 @@ export interface SyncOutboxRecord {
   // schema version bump is needed. We intentionally don't store an after vector —
   // the server derives the post-update state itself and never trusts a client one.
   beforeStateVector?: Uint8Array;
+  /**
+   * Server-directed manifest snapshots supersede older pending manifest
+   * snapshots for the same object. Local edit records intentionally leave this
+   * unset so they are never removed by manifest coalescing.
+   */
+  source?: 'manifest';
 }
 
 export type SyncOutboxTable = {

--- a/src/application/services/js-services/__tests__/sync.test.ts
+++ b/src/application/services/js-services/__tests__/sync.test.ts
@@ -32,6 +32,7 @@ jest.mock('@/application/sync-outbox', () => {
       };
 
       peers.forEach((peer) => peer.emit(message));
+      return Promise.resolve(true);
     }),
     deleteOutboxByObjectId: jest.fn(async () => undefined),
     waitForDrain: jest.fn(async () => true),
@@ -368,10 +369,12 @@ describe('sync protocol', () => {
   it('persists an oversized manifest response instead of emitting it on WebSocket', () => {
     const doc = new Y.Doc({ guid: random.uuidv4() });
     const emit = jest.fn();
+    const onManifestSync = jest.fn();
     const ctx: SyncContext = {
       doc,
       collabType: Types.Database,
       emit,
+      onManifestSync,
     };
 
     doc.getMap('root').set('large-history', 'value');
@@ -393,7 +396,8 @@ describe('sync protocol', () => {
         collabType: Types.Database,
         payload: expect.any(Uint8Array),
       }),
-      { broadcast: false }
+      { broadcast: false, source: 'manifest' }
     );
+    expect(onManifestSync).toHaveBeenCalledWith(doc.guid, expect.any(Promise));
   });
 });

--- a/src/application/services/js-services/__tests__/sync.test.ts
+++ b/src/application/services/js-services/__tests__/sync.test.ts
@@ -35,6 +35,7 @@ jest.mock('@/application/sync-outbox', () => {
     }),
     deleteOutboxByObjectId: jest.fn(async () => undefined),
     waitForDrain: jest.fn(async () => true),
+    shouldRouteUpdateThroughOutbox: jest.fn(() => false),
     configureDrain: jest.fn(),
     clearDrainConfig: jest.fn(),
     startDrainAll: jest.fn(),
@@ -362,5 +363,37 @@ describe('sync protocol', () => {
     drain();
 
     expectTextConvergence(texts, 'ABC');
+  });
+
+  it('persists an oversized manifest response instead of emitting it on WebSocket', () => {
+    const doc = new Y.Doc({ guid: random.uuidv4() });
+    const emit = jest.fn();
+    const ctx: SyncContext = {
+      doc,
+      collabType: Types.Database,
+      emit,
+    };
+
+    doc.getMap('root').set('large-history', 'value');
+    outboxMock.shouldRouteUpdateThroughOutbox.mockReturnValueOnce(true);
+
+    handleMessage(ctx, {
+      objectId: doc.guid,
+      collabType: Types.Database,
+      syncRequest: {
+        stateVector: Y.encodeStateVector(new Y.Doc()),
+        version: doc.version,
+      },
+    });
+
+    expect(emit).not.toHaveBeenCalled();
+    expect(outboxMock.enqueueOutboxUpdate).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        objectId: doc.guid,
+        collabType: Types.Database,
+        payload: expect.any(Uint8Array),
+      }),
+      { broadcast: false }
+    );
   });
 });

--- a/src/application/services/js-services/http/__tests__/collab-api.test.ts
+++ b/src/application/services/js-services/http/__tests__/collab-api.test.ts
@@ -11,7 +11,12 @@ import { collab } from '@/proto/messages';
 import { database_blob } from '@/proto/database_blob';
 import { getAxios } from '@/application/services/js-services/http/core';
 
-import { collabFullSyncBatch, databaseBlobDiff } from '../collab-api';
+import {
+  collabFullSyncBatch,
+  databaseBlobDiff,
+  getSlowSyncUploadTimeoutMs,
+  SLOW_SYNC_PROBE_TIMEOUT_MS,
+} from '../collab-api';
 
 jest.mock('@/application/services/js-services/device-id', () => ({
   getOrCreateDeviceId: jest.fn(() => 'test-device-id'),
@@ -103,6 +108,40 @@ describe('collabFullSyncBatch', () => {
     expect(config.transformRequest[0](requestBody)).toBe(requestBody);
   });
 
+  it('bounds a lightweight probe without marking it as a slow-lane upload', async () => {
+    const responseBody = collab.CollabBatchSyncResponse.encode(
+      collab.CollabBatchSyncResponse.create({
+        results: [],
+        responseCompression: collab.PayloadCompressionType.COMPRESSION_NONE,
+      })
+    ).finish();
+    const post = jest.fn().mockResolvedValue({
+      status: 200,
+      data: responseBody,
+      headers: {},
+    });
+
+    mockGetAxios.mockReturnValue({ post });
+
+    await collabFullSyncBatch(
+      'workspace-id',
+      [
+        {
+          objectId: 'object-id',
+          collabType: 0,
+          stateVector: new Uint8Array([1]),
+          docState: new Uint8Array(),
+        },
+      ],
+      { timeoutMs: SLOW_SYNC_PROBE_TIMEOUT_MS }
+    );
+
+    const config = post.mock.calls[0][2];
+
+    expect(config.timeout).toBe(SLOW_SYNC_PROBE_TIMEOUT_MS);
+    expect(config.headers['x-appflowy-sync-lane']).toBeUndefined();
+  });
+
   it('forces gzip for one slow-lane object and decodes both compressed result payloads', async () => {
     const missingUpdate = new Uint8Array([3, 4, 5]);
     const serverStateVector = new Uint8Array([6, 7]);
@@ -149,7 +188,7 @@ describe('collabFullSyncBatch', () => {
     const item = request.items[0];
 
     expect(config.headers['x-appflowy-sync-lane']).toBe('slow');
-    expect(config.timeout).toBe(120_000);
+    expect(config.timeout).toBe(getSlowSyncUploadTimeoutMs(2));
     expect(config.signal).toBe(controller.signal);
     expect(request.items).toHaveLength(1);
     expect(item.compression).toBe(collab.PayloadCompressionType.COMPRESSION_GZIP);
@@ -165,6 +204,16 @@ describe('collabFullSyncBatch', () => {
     expect(results[0].messageId?.counter).toBe(1);
     expect(Array.from(results[0].missingUpdate)).toEqual(Array.from(missingUpdate));
     expect(Array.from(results[0].serverStateVector)).toEqual(Array.from(serverStateVector));
+  });
+
+  it('leaves upload and server-processing headroom for large slow-sync payloads', () => {
+    const sixteenMiBTimeout = getSlowSyncUploadTimeoutMs(16 * 1024 * 1024);
+    const sixtyFourMiBTimeout = getSlowSyncUploadTimeoutMs(64 * 1024 * 1024);
+
+    // 16 MiB takes about 90 seconds at 1.5 Mbps before the server's 60-second
+    // processing budget. The deadline must cover both plus response headroom.
+    expect(sixteenMiBTimeout).toBeGreaterThan(150_000);
+    expect(sixtyFourMiBTimeout).toBeGreaterThan(sixteenMiBTimeout);
   });
 
   it('preserves explicit server errors instead of trying to decompress raw error vectors', async () => {

--- a/src/application/services/js-services/http/__tests__/collab-api.test.ts
+++ b/src/application/services/js-services/http/__tests__/collab-api.test.ts
@@ -1,3 +1,12 @@
+import { Blob as NodeBlob } from 'node:buffer';
+import {
+  CompressionStream as NodeCompressionStream,
+  DecompressionStream as NodeDecompressionStream,
+  ReadableStream as NodeReadableStream,
+  WritableStream as NodeWritableStream,
+} from 'node:stream/web';
+import { gunzipSync, gzipSync } from 'node:zlib';
+
 import { collab } from '@/proto/messages';
 import { database_blob } from '@/proto/database_blob';
 import { getAxios } from '@/application/services/js-services/http/core';
@@ -17,9 +26,49 @@ jest.mock('@/application/services/js-services/http/core', () => ({
 
 const mockGetAxios = getAxios as unknown as jest.Mock;
 
+function installStalledGzipTransform(name: 'CompressionStream' | 'DecompressionStream') {
+  let markStarted!: () => void;
+  const started = new Promise<void>((resolve) => {
+    markStarted = resolve;
+  });
+  const cancelled = jest.fn();
+
+  class StalledGzipTransform {
+    readonly readable = new NodeReadableStream<Uint8Array>({
+      start() {
+        markStarted();
+      },
+      cancel(reason) {
+        cancelled(reason);
+      },
+    });
+
+    readonly writable = new NodeWritableStream<Uint8Array>();
+  }
+
+  Object.defineProperty(globalThis, name, {
+    configurable: true,
+    value: StalledGzipTransform,
+  });
+
+  return { cancelled, started };
+}
+
 describe('collabFullSyncBatch', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    Object.defineProperty(globalThis, 'CompressionStream', {
+      configurable: true,
+      value: NodeCompressionStream,
+    });
+    Object.defineProperty(globalThis, 'DecompressionStream', {
+      configurable: true,
+      value: NodeDecompressionStream,
+    });
+    Object.defineProperty(globalThis, 'Blob', {
+      configurable: true,
+      value: NodeBlob,
+    });
   });
 
   it('sends the encoded protobuf view instead of the pooled backing buffer', async () => {
@@ -50,7 +99,218 @@ describe('collabFullSyncBatch', () => {
 
     expect(ArrayBuffer.isView(requestBody)).toBe(true);
     expect(requestBody.byteLength).toBeLessThan(requestBody.buffer.byteLength);
+    expect(config.timeout).toBeUndefined();
     expect(config.transformRequest[0](requestBody)).toBe(requestBody);
+  });
+
+  it('forces gzip for one slow-lane object and decodes both compressed result payloads', async () => {
+    const missingUpdate = new Uint8Array([3, 4, 5]);
+    const serverStateVector = new Uint8Array([6, 7]);
+    const responseBody = collab.CollabBatchSyncResponse.encode(
+      collab.CollabBatchSyncResponse.create({
+        results: [
+          {
+            objectId: 'object-id',
+            collabType: 0,
+            compression: collab.PayloadCompressionType.COMPRESSION_GZIP,
+            missingUpdate: gzipSync(missingUpdate),
+            serverStateVector: gzipSync(serverStateVector),
+            collabVersion: 'version-1',
+            messageId: { timestamp: 42, counter: 1 },
+          },
+        ],
+        responseCompression: collab.PayloadCompressionType.COMPRESSION_NONE,
+      })
+    ).finish();
+    const post = jest.fn().mockResolvedValue({
+      status: 200,
+      data: responseBody,
+      headers: {},
+    });
+
+    mockGetAxios.mockReturnValue({ post });
+    const controller = new AbortController();
+
+    const results = await collabFullSyncBatch(
+      'workspace-id',
+      [
+        {
+          objectId: 'object-id',
+          collabType: 0,
+          stateVector: new Uint8Array([1]),
+          docState: new Uint8Array([2]),
+          collabVersion: 'version-1',
+        },
+      ],
+      { syncLane: 'slow', signal: controller.signal }
+    );
+    const [, requestBody, config] = post.mock.calls[0];
+    const request = collab.CollabBatchSyncRequest.decode(requestBody);
+    const item = request.items[0];
+
+    expect(config.headers['x-appflowy-sync-lane']).toBe('slow');
+    expect(config.timeout).toBe(120_000);
+    expect(config.signal).toBe(controller.signal);
+    expect(request.items).toHaveLength(1);
+    expect(item.compression).toBe(collab.PayloadCompressionType.COMPRESSION_GZIP);
+    expect(item.collabVersion).toBe('version-1');
+    expect(Array.from(gunzipSync(item.sv))).toEqual([1]);
+    expect(Array.from(gunzipSync(item.docState))).toEqual([2]);
+    expect(results[0]).toMatchObject({
+      objectId: 'object-id',
+      collabType: 0,
+      collabVersion: 'version-1',
+    });
+    expect(Number(results[0].messageId?.timestamp)).toBe(42);
+    expect(results[0].messageId?.counter).toBe(1);
+    expect(Array.from(results[0].missingUpdate)).toEqual(Array.from(missingUpdate));
+    expect(Array.from(results[0].serverStateVector)).toEqual(Array.from(serverStateVector));
+  });
+
+  it('preserves explicit server errors instead of trying to decompress raw error vectors', async () => {
+    const responseBody = collab.CollabBatchSyncResponse.encode(
+      collab.CollabBatchSyncResponse.create({
+        results: [
+          {
+            objectId: 'object-id',
+            collabType: 0,
+            compression: collab.PayloadCompressionType.COMPRESSION_GZIP,
+            missingUpdate: new Uint8Array(),
+            serverStateVector: new Uint8Array([0]),
+            error: 'permission_denied',
+          },
+        ],
+      })
+    ).finish();
+    const post = jest.fn().mockResolvedValue({
+      status: 200,
+      data: responseBody,
+      headers: {},
+    });
+
+    mockGetAxios.mockReturnValue({ post });
+
+    const results = await collabFullSyncBatch('workspace-id', [
+      {
+        objectId: 'object-id',
+        collabType: 0,
+        stateVector: new Uint8Array([1]),
+        docState: new Uint8Array([2]),
+      },
+    ]);
+
+    expect(results[0].error).toBe('permission_denied');
+    expect(Array.from(results[0].serverStateVector)).toEqual([0]);
+  });
+
+  it('fails closed when the slow lane cannot gzip the request', async () => {
+    const compressionStream = globalThis.CompressionStream;
+    const decompressionStream = globalThis.DecompressionStream;
+
+    Object.defineProperty(globalThis, 'CompressionStream', { configurable: true, value: undefined });
+    Object.defineProperty(globalThis, 'DecompressionStream', { configurable: true, value: undefined });
+
+    try {
+      await expect(
+        collabFullSyncBatch(
+          'workspace-id',
+          [
+            {
+              objectId: 'object-id',
+              collabType: 0,
+              stateVector: new Uint8Array([1]),
+              docState: new Uint8Array([2]),
+            },
+          ],
+          { syncLane: 'slow' }
+        )
+      ).rejects.toThrow('requires browser gzip compression support');
+    } finally {
+      Object.defineProperty(globalThis, 'CompressionStream', { configurable: true, value: compressionStream });
+      Object.defineProperty(globalThis, 'DecompressionStream', { configurable: true, value: decompressionStream });
+    }
+  });
+
+  it('rejects a multi-object slow-lane request before sending it', async () => {
+    const item = {
+      objectId: 'object-id',
+      collabType: 0,
+      stateVector: new Uint8Array([1]),
+      docState: new Uint8Array([2]),
+    };
+
+    await expect(
+      collabFullSyncBatch('workspace-id', [item, { ...item, objectId: 'other-id' }], { syncLane: 'slow' })
+    ).rejects.toThrow('requires exactly one collab item');
+    expect(mockGetAxios).not.toHaveBeenCalled();
+  });
+
+  it('cancels browser gzip compression before Axios starts', async () => {
+    const { cancelled, started } = installStalledGzipTransform('CompressionStream');
+    const controller = new AbortController();
+    const request = collabFullSyncBatch(
+      'workspace-id',
+      [
+        {
+          objectId: 'object-id',
+          collabType: 0,
+          stateVector: new Uint8Array([1]),
+          docState: new Uint8Array([2]),
+        },
+      ],
+      { syncLane: 'slow', signal: controller.signal }
+    );
+
+    await started;
+    controller.abort();
+
+    await expect(request).rejects.toMatchObject({ name: 'AbortError' });
+    expect(cancelled).toHaveBeenCalled();
+    expect(mockGetAxios).not.toHaveBeenCalled();
+  });
+
+  it('cancels browser gzip decompression after Axios responds', async () => {
+    const { cancelled, started } = installStalledGzipTransform('DecompressionStream');
+    const responseBody = collab.CollabBatchSyncResponse.encode(
+      collab.CollabBatchSyncResponse.create({
+        results: [
+          {
+            objectId: 'object-id',
+            collabType: 0,
+            compression: collab.PayloadCompressionType.COMPRESSION_GZIP,
+            missingUpdate: new Uint8Array([1]),
+            serverStateVector: new Uint8Array([2]),
+          },
+        ],
+      })
+    ).finish();
+    const post = jest.fn().mockResolvedValue({
+      status: 200,
+      data: responseBody,
+      headers: {},
+    });
+
+    mockGetAxios.mockReturnValue({ post });
+    const controller = new AbortController();
+    const request = collabFullSyncBatch(
+      'workspace-id',
+      [
+        {
+          objectId: 'object-id',
+          collabType: 0,
+          stateVector: new Uint8Array([1]),
+          docState: new Uint8Array(),
+        },
+      ],
+      { signal: controller.signal }
+    );
+
+    await started;
+    controller.abort();
+
+    await expect(request).rejects.toMatchObject({ name: 'AbortError' });
+    expect(post).toHaveBeenCalledTimes(1);
+    expect(cancelled).toHaveBeenCalled();
   });
 });
 

--- a/src/application/services/js-services/http/__tests__/collab-api.test.ts
+++ b/src/application/services/js-services/http/__tests__/collab-api.test.ts
@@ -1,7 +1,8 @@
 import { collab } from '@/proto/messages';
+import { database_blob } from '@/proto/database_blob';
 import { getAxios } from '@/application/services/js-services/http/core';
 
-import { collabFullSyncBatch } from '../collab-api';
+import { collabFullSyncBatch, databaseBlobDiff } from '../collab-api';
 
 jest.mock('@/application/services/js-services/device-id', () => ({
   getOrCreateDeviceId: jest.fn(() => 'test-device-id'),
@@ -50,5 +51,62 @@ describe('collabFullSyncBatch', () => {
     expect(ArrayBuffer.isView(requestBody)).toBe(true);
     expect(requestBody.byteLength).toBeLessThan(requestBody.buffer.byteLength);
     expect(config.transformRequest[0](requestBody)).toBe(requestBody);
+  });
+});
+
+describe('databaseBlobDiff', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('round-trips a paged protobuf request and response', async () => {
+    const responseBody = database_blob.DatabaseBlobDiffResponse.encode(
+      database_blob.DatabaseBlobDiffResponse.create({
+        status: database_blob.DiffStatus.READY,
+        page: {
+          hasMore: true,
+          nextCursor: new Uint8Array([7, 8, 9]),
+          restartRequired: false,
+        },
+      })
+    ).finish();
+    const post = jest.fn().mockResolvedValue({
+      status: 200,
+      data: responseBody,
+      headers: {},
+    });
+
+    mockGetAxios.mockReturnValue({ post });
+
+    const response = await databaseBlobDiff(
+      'workspace-id',
+      'database-id',
+      database_blob.DatabaseBlobDiffRequest.create({
+        maxKnownRid: { timestamp: 100, seqNo: 2 },
+        version: 3,
+        page: {
+          maxItems: 256,
+          maxBytes: 16 * 1024 * 1024,
+          cursor: new Uint8Array([1, 2, 3]),
+        },
+      })
+    );
+
+    const [url, requestBody, config] = post.mock.calls[0];
+    const decodedRequest = database_blob.DatabaseBlobDiffRequest.decode(requestBody);
+
+    expect(url).toBe('/api/workspace/workspace-id/database/database-id/blob/diff');
+    expect(decodedRequest.version).toBe(3);
+    expect(Number(decodedRequest.maxKnownRid?.timestamp)).toBe(100);
+    expect(decodedRequest.maxKnownRid?.seqNo).toBe(2);
+    expect(decodedRequest.page?.maxItems).toBe(256);
+    expect(Number(decodedRequest.page?.maxBytes)).toBe(16 * 1024 * 1024);
+    expect(Array.from(decodedRequest.page?.cursor ?? [])).toEqual([1, 2, 3]);
+    expect(config.headers['Content-Type']).toBe('application/octet-stream');
+    expect(response.page).toMatchObject({
+      hasMore: true,
+      restartRequired: false,
+    });
+    expect(Array.from(response.page?.nextCursor ?? [])).toEqual([7, 8, 9]);
   });
 });

--- a/src/application/services/js-services/http/__tests__/http_api.test.ts
+++ b/src/application/services/js-services/http/__tests__/http_api.test.ts
@@ -93,9 +93,10 @@ describe('http_api client (unit)', () => {
     expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/server-info/auth-providers');
   });
 
-  it('identifies server-info requests as web so page history is not hidden by native client gates', async () => {
+  it('bounds and cancels server-info requests while identifying the web platform', async () => {
     const module = await import('../http_api');
     module.initAPIService(baseConfig);
+    const abortController = new AbortController();
 
     mockAxiosInstance.get.mockResolvedValueOnce({
       data: {
@@ -107,7 +108,7 @@ describe('http_api client (unit)', () => {
       },
     });
 
-    await expect(module.getServerInfo()).resolves.toEqual({
+    await expect(module.getServerInfo(abortController.signal)).resolves.toEqual({
       enable_page_history: true,
       ai_enabled: true,
     });
@@ -115,6 +116,8 @@ describe('http_api client (unit)', () => {
       headers: {
         'x-platform': 'web',
       },
+      signal: abortController.signal,
+      timeout: 10_000,
     });
   });
 

--- a/src/application/services/js-services/http/auth-api.ts
+++ b/src/application/services/js-services/http/auth-api.ts
@@ -10,7 +10,16 @@ export { verifyToken } from './cloud-auth';
 export interface ServerInfo {
   enable_page_history: boolean;
   ai_enabled?: boolean;
+  /** Maximum raw Yjs update accepted by the realtime WebSocket fast lane. */
+  max_update_bytes?: number;
+  /**
+   * Maximum raw Yjs update accepted by the opt-in HTTP slow lane.
+   * Older servers omit this field, which keeps the slow lane disabled.
+   */
+  max_slow_sync_update_bytes?: number;
 }
+
+const SERVER_INFO_REQUEST_TIMEOUT_MS = 10_000;
 
 export async function signInWithUrl(url: string) {
   Log.info('[Auth] signInWithUrl: processing OAuth callback');
@@ -65,21 +74,18 @@ export async function signInWithUrl(url: string) {
   });
 }
 
-export async function getServerInfo(): Promise<ServerInfo> {
+export async function getServerInfo(signal?: AbortSignal): Promise<ServerInfo> {
   const url = '/api/server-info';
 
-  try {
-    return await executeAPIRequest<ServerInfo>(() =>
-      getAxios()?.get<APIResponse<ServerInfo>>(url, {
-        headers: {
-          'x-platform': 'web',
-        },
-      })
-    );
-  } catch (error) {
-    console.warn('Server info API returned error:', (error as APIError)?.message);
-    return { enable_page_history: true, ai_enabled: true };
-  }
+  return executeAPIRequest<ServerInfo>(() =>
+    getAxios()?.get<APIResponse<ServerInfo>>(url, {
+      headers: {
+        'x-platform': 'web',
+      },
+      timeout: SERVER_INFO_REQUEST_TIMEOUT_MS,
+      ...(signal ? { signal } : {}),
+    })
+  );
 }
 
 export async function getAuthProviders(): Promise<AuthProvider[]> {

--- a/src/application/services/js-services/http/collab-api.ts
+++ b/src/application/services/js-services/http/collab-api.ts
@@ -26,9 +26,32 @@ export interface CollabFullSyncBatchOptions {
   syncLane?: 'slow';
   /** Cancels an in-flight request when its owning workspace/session changes. */
   signal?: AbortSignal;
+  /** Bounds ordinary requests that participate in a serialized workflow. */
+  timeoutMs?: number;
 }
 
-const SLOW_SYNC_TIMEOUT_MS = 120_000;
+export const SLOW_SYNC_PROBE_TIMEOUT_MS = 120_000;
+const SLOW_SYNC_SERVER_PROCESSING_BUDGET_MS = 60_000;
+const SLOW_SYNC_NETWORK_HEADROOM_MS = 30_000;
+const SLOW_SYNC_MIN_UPLOAD_BITS_PER_SECOND = 1_500_000;
+const SLOW_SYNC_PROTOBUF_HEADROOM_BYTES = 64 * 1024;
+
+/**
+ * Budget upload time at 1.5 Mbps, then leave the server's full processing
+ * window plus transport/metadata headroom. The probe keeps its smaller fixed
+ * timeout because it carries no document state.
+ */
+export function getSlowSyncUploadTimeoutMs(payloadBytes: number): number {
+  const boundedPayloadBytes = Math.max(0, Number.isFinite(payloadBytes) ? payloadBytes : 0);
+  const uploadMs = Math.ceil(
+    ((boundedPayloadBytes + SLOW_SYNC_PROTOBUF_HEADROOM_BYTES) * 8 * 1_000) / SLOW_SYNC_MIN_UPLOAD_BITS_PER_SECOND
+  );
+
+  return Math.max(
+    SLOW_SYNC_PROBE_TIMEOUT_MS,
+    uploadMs + SLOW_SYNC_SERVER_PROCESSING_BUDGET_MS + SLOW_SYNC_NETWORK_HEADROOM_MS
+  );
+}
 
 function canUseStreamingGzip(): boolean {
   return typeof globalThis.CompressionStream === 'function' && typeof globalThis.DecompressionStream === 'function';
@@ -171,6 +194,10 @@ export async function collabFullSyncBatch(
 ): Promise<CollabFullSyncBatchResult[]> {
   const url = `/api/workspace/v1/${workspaceId}/collab/full-sync/batch`;
   const streamingGzipAvailable = canUseStreamingGzip();
+  const slowSyncPayloadBytes = items.reduce(
+    (total, item) => total + item.stateVector.byteLength + item.docState.byteLength,
+    0
+  );
 
   if (options?.syncLane === 'slow' && !streamingGzipAvailable) {
     throw new Error('HTTP slow-sync requires browser gzip compression support');
@@ -217,6 +244,8 @@ export async function collabFullSyncBatch(
 
   const deviceId = getOrCreateDeviceId();
   const axiosInstance = getAxios();
+  const timeoutMs =
+    options?.timeoutMs ?? (options?.syncLane === 'slow' ? getSlowSyncUploadTimeoutMs(slowSyncPayloadBytes) : undefined);
 
   // Send the request with protobuf content type.
   // Use validateStatus to prevent axios from throwing on 429/503 so we can
@@ -230,8 +259,9 @@ export async function collabFullSyncBatch(
     },
     responseType: 'arraybuffer',
     signal: options?.signal,
-    // A slow upload must not hold the module-global serialized queue forever.
-    ...(options?.syncLane === 'slow' ? { timeout: SLOW_SYNC_TIMEOUT_MS } : {}),
+    // A slow upload or its lightweight probe must not hold the serialized
+    // workspace lane forever.
+    ...(timeoutMs !== undefined ? { timeout: timeoutMs } : {}),
     // Axios' default transform sends typed-array `.buffer`, which can include
     // protobufjs' pooled zero padding beyond this Uint8Array view.
     transformRequest: [(data: Uint8Array) => data],

--- a/src/application/services/js-services/http/collab-api.ts
+++ b/src/application/services/js-services/http/collab-api.ts
@@ -1,12 +1,7 @@
 import { toBase64 } from 'lib0/buffer';
 
 import { getOrCreateDeviceId } from '@/application/services/js-services/device-id';
-import {
-  RowId,
-  Types,
-  User,
-  View,
-} from '@/application/types';
+import { RowId, Types, User, View } from '@/application/types';
 import { database_blob } from '@/proto/database_blob';
 import { collab } from '@/proto/messages';
 import { Log } from '@/utils/log';
@@ -18,7 +13,109 @@ export interface CollabFullSyncBatchResult {
   collabType: Types;
   missingUpdate: Uint8Array;
   serverStateVector: Uint8Array;
+  collabVersion?: string;
+  messageId?: collab.IRid;
   error?: string;
+}
+
+export interface CollabFullSyncBatchOptions {
+  /**
+   * Marks a single oversized item for the server's bounded slow-sync lane.
+   * Ordinary batch requests intentionally omit this header.
+   */
+  syncLane?: 'slow';
+  /** Cancels an in-flight request when its owning workspace/session changes. */
+  signal?: AbortSignal;
+}
+
+const SLOW_SYNC_TIMEOUT_MS = 120_000;
+
+function canUseStreamingGzip(): boolean {
+  return typeof globalThis.CompressionStream === 'function' && typeof globalThis.DecompressionStream === 'function';
+}
+
+function throwIfAborted(signal?: AbortSignal): void {
+  if (!signal?.aborted) return;
+
+  const reason = (signal as AbortSignal & { reason?: unknown }).reason;
+
+  if (reason !== undefined) throw reason;
+
+  const error = new Error('The operation was aborted');
+
+  error.name = 'AbortError';
+  throw error;
+}
+
+async function transformGzip(
+  payload: Uint8Array,
+  mode: 'compress' | 'decompress',
+  signal?: AbortSignal
+): Promise<Uint8Array> {
+  throwIfAborted(signal);
+  if (payload.byteLength === 0) return payload;
+
+  const transformer = mode === 'compress' ? new CompressionStream('gzip') : new DecompressionStream('gzip');
+  // Copy into a plain ArrayBuffer so TypeScript and Blob do not have to account
+  // for a SharedArrayBuffer-backed Uint8Array.
+  const input = new Blob([payload.slice().buffer]).stream();
+  const output = input.pipeThrough(transformer);
+  const reader = output.getReader();
+  const chunks: Uint8Array[] = [];
+  let totalBytes = 0;
+  const cancelReader = () => {
+    void reader.cancel(signal?.reason).catch(() => undefined);
+  };
+
+  signal?.addEventListener('abort', cancelReader, { once: true });
+
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+
+      throwIfAborted(signal);
+      if (done) break;
+      chunks.push(value);
+      totalBytes += value.byteLength;
+    }
+
+    const result = new Uint8Array(totalBytes);
+    let offset = 0;
+
+    for (const chunk of chunks) {
+      result.set(chunk, offset);
+      offset += chunk.byteLength;
+    }
+
+    throwIfAborted(signal);
+    return result;
+  } finally {
+    signal?.removeEventListener('abort', cancelReader);
+    reader.releaseLock();
+  }
+}
+
+async function decodeFullSyncResultPayload(
+  payload: Uint8Array,
+  compression: collab.PayloadCompressionType,
+  signal?: AbortSignal
+): Promise<Uint8Array> {
+  throwIfAborted(signal);
+
+  switch (compression) {
+    case collab.PayloadCompressionType.COMPRESSION_NONE:
+      return payload;
+    case collab.PayloadCompressionType.COMPRESSION_GZIP:
+      if (!canUseStreamingGzip()) {
+        throw new Error('Server returned a gzip full-sync result, but this browser cannot decompress gzip streams');
+      }
+
+      return transformGzip(payload, 'decompress', signal);
+    case collab.PayloadCompressionType.COMPRESSION_ZSTD:
+      throw new Error('Server returned a zstd full-sync result, but the Web client has no zstd decoder');
+    default:
+      throw new Error(`Unsupported full-sync result compression: ${compression}`);
+  }
 }
 
 export async function updateCollab(
@@ -68,18 +165,49 @@ export async function collabFullSyncBatch(
     collabType: Types;
     stateVector: Uint8Array;
     docState: Uint8Array;
-  }>
+    collabVersion?: string | null;
+  }>,
+  options?: CollabFullSyncBatchOptions
 ): Promise<CollabFullSyncBatchResult[]> {
   const url = `/api/workspace/v1/${workspaceId}/collab/full-sync/batch`;
+  const streamingGzipAvailable = canUseStreamingGzip();
+
+  if (options?.syncLane === 'slow' && !streamingGzipAvailable) {
+    throw new Error('HTTP slow-sync requires browser gzip compression support');
+  }
+
+  if (options?.syncLane === 'slow' && items.length !== 1) {
+    throw new Error('HTTP slow-sync requires exactly one collab item');
+  }
+
+  const compression =
+    options?.syncLane === 'slow'
+      ? collab.PayloadCompressionType.COMPRESSION_GZIP
+      : collab.PayloadCompressionType.COMPRESSION_NONE;
+  const preparedItems = await Promise.all(
+    items.map(async (item) => {
+      if (compression !== collab.PayloadCompressionType.COMPRESSION_GZIP) {
+        return { ...item, compression };
+      }
+
+      const [stateVector, docState] = await Promise.all([
+        transformGzip(item.stateVector, 'compress', options?.signal),
+        transformGzip(item.docState, 'compress', options?.signal),
+      ]);
+
+      return { ...item, stateVector, docState, compression };
+    })
+  );
 
   // Build the protobuf request
   const request = collab.CollabBatchSyncRequest.create({
-    items: items.map((item) => ({
+    items: preparedItems.map((item) => ({
       objectId: item.objectId,
       collabType: item.collabType,
-      compression: collab.PayloadCompressionType.COMPRESSION_NONE,
+      compression: item.compression,
       sv: item.stateVector,
       docState: item.docState,
+      collabVersion: item.collabVersion ?? undefined,
     })),
     responseCompression: collab.PayloadCompressionType.COMPRESSION_NONE,
   });
@@ -98,8 +226,12 @@ export async function collabFullSyncBatch(
       'Content-Type': 'application/octet-stream',
       'client-version': 'web',
       'device-id': deviceId,
+      ...(options?.syncLane ? { 'x-appflowy-sync-lane': options.syncLane } : {}),
     },
     responseType: 'arraybuffer',
+    signal: options?.signal,
+    // A slow upload must not hold the module-global serialized queue forever.
+    ...(options?.syncLane === 'slow' ? { timeout: SLOW_SYNC_TIMEOUT_MS } : {}),
     // Axios' default transform sends typed-array `.buffer`, which can include
     // protobufjs' pooled zero padding beyond this Uint8Array view.
     transformRequest: [(data: Uint8Array) => data],
@@ -136,11 +268,24 @@ export async function collabFullSyncBatch(
       });
     }
 
+    // Error results can use the request compression enum while carrying raw
+    // default vectors. Preserve the explicit server error instead of masking
+    // it with a decompression exception.
+    const resultCompression = result.error
+      ? collab.PayloadCompressionType.COMPRESSION_NONE
+      : result.compression ?? collab.PayloadCompressionType.COMPRESSION_NONE;
+    const [missingUpdate, serverStateVector] = await Promise.all([
+      decodeFullSyncResultPayload(result.missingUpdate ?? new Uint8Array(), resultCompression, options?.signal),
+      decodeFullSyncResultPayload(result.serverStateVector ?? new Uint8Array(), resultCompression, options?.signal),
+    ]);
+
     results.push({
       objectId: result.objectId ?? '',
       collabType: result.collabType as Types,
-      missingUpdate: result.missingUpdate ?? new Uint8Array(),
-      serverStateVector: result.serverStateVector ?? new Uint8Array(),
+      missingUpdate,
+      serverStateVector,
+      collabVersion: result.collabVersion || undefined,
+      messageId: result.messageId ?? undefined,
       error: result.error || undefined,
     });
   }
@@ -155,10 +300,12 @@ export async function getCollab(workspaceId: string, objectId: string, collabTyp
     doc_state: number[];
     object_id: string;
   }>(() =>
-    getAxios()?.get<APIResponse<{
-      doc_state: number[];
-      object_id: string;
-    }>>(url, {
+    getAxios()?.get<
+      APIResponse<{
+        doc_state: number[];
+        object_id: string;
+      }>
+    >(url, {
       params: {
         collab_type: collabType,
       },
@@ -182,15 +329,17 @@ export async function getPageCollab(workspaceId: string, viewId: string) {
       last_editor?: User;
     };
   }>(() =>
-    getAxios()?.get<APIResponse<{
-      view: View;
-      data: {
-        encoded_collab: number[];
-        row_data: Record<RowId, number[]>;
-        owner?: User;
-        last_editor?: User;
-      };
-    }>>(url)
+    getAxios()?.get<
+      APIResponse<{
+        view: View;
+        data: {
+          encoded_collab: number[];
+          row_data: Record<RowId, number[]>;
+          owner?: User;
+          last_editor?: User;
+        };
+      }>
+    >(url)
   );
 
   const { encoded_collab, row_data, owner, last_editor } = response.data;
@@ -208,7 +357,7 @@ export async function duplicateRowDocument(
   databaseId: string,
   sourceRowId: string,
   newRowId: string,
-  clientDocStateB64?: string,
+  clientDocStateB64?: string
 ): Promise<void> {
   const url = `/api/workspace/${workspaceId}/database/${databaseId}/row/${sourceRowId}/duplicate-document`;
 
@@ -254,18 +403,8 @@ export async function databaseBlobDiff(
 export async function getCollabVersions(workspaceId: string, objectId: string, since?: Date) {
   const url = `/api/workspace/${workspaceId}/collab/${objectId}/history`;
   const from = since?.getTime() || null;
-  const data = await executeAPIRequest<Array<{
-    version: string;
-    parent: string | null;
-    name: string | null;
-    created_at: string;
-    created_by: number | null;
-    deleted_at?: string | null;
-    // Backward compatibility for older server payloads.
-    is_deleted?: boolean;
-    editors: number[];
-  }>>(() =>
-    getAxios()?.get<APIResponse<Array<{
+  const data = await executeAPIRequest<
+    Array<{
       version: string;
       parent: string | null;
       name: string | null;
@@ -275,7 +414,23 @@ export async function getCollabVersions(workspaceId: string, objectId: string, s
       // Backward compatibility for older server payloads.
       is_deleted?: boolean;
       editors: number[];
-    }>>>(url, {
+    }>
+  >(() =>
+    getAxios()?.get<
+      APIResponse<
+        Array<{
+          version: string;
+          parent: string | null;
+          name: string | null;
+          created_at: string;
+          created_by: number | null;
+          deleted_at?: string | null;
+          // Backward compatibility for older server payloads.
+          is_deleted?: boolean;
+          editors: number[];
+        }>
+      >
+    >(url, {
       params: {
         since: from,
       },
@@ -288,7 +443,7 @@ export async function getCollabVersions(workspaceId: string, objectId: string, s
       parentId: data.parent,
       name: data.name,
       createdAt: new Date(data.created_at),
-      deletedAt: data.deleted_at ? new Date(data.deleted_at) : (data.is_deleted ? new Date(0) : null),
+      deletedAt: data.deleted_at ? new Date(data.deleted_at) : data.is_deleted ? new Date(0) : null,
       editors: data.editors,
     };
   });
@@ -298,7 +453,7 @@ export async function previewCollabVersion(workspaceId: string, objectId: string
   const url = `/api/workspace/${workspaceId}/collab/${objectId}/history/${version}?collab_type=${collabType}`;
 
   const response = await getAxios()?.get(url, {
-    responseType: 'arraybuffer'
+    responseType: 'arraybuffer',
   });
 
   if (!response) {
@@ -348,12 +503,14 @@ export async function revertCollabVersion(workspaceId: string, objectId: string,
     collab_version: string | null;
     version: number; // this is encoder version (lib0 v1 encoding is 0, while lib0 v2 encoding is 1, we only use 0 atm.)
   }>(() =>
-    getAxios()?.post<APIResponse<{
-      state_vector: number[];
-      doc_state: number[];
-      collab_version: string | null;
-      version: number;
-    }>>(url, {
+    getAxios()?.post<
+      APIResponse<{
+        state_vector: number[];
+        doc_state: number[];
+        collab_version: string | null;
+        version: number;
+      }>
+    >(url, {
       version,
       collab_type: collabType,
     })

--- a/src/application/services/js-services/sync-protocol.ts
+++ b/src/application/services/js-services/sync-protocol.ts
@@ -5,6 +5,7 @@ import { deleteCollabDB } from '@/application/db';
 import {
   deleteOutboxByObjectId,
   enqueueOutboxUpdate,
+  shouldRouteUpdateThroughOutbox,
   waitForDrain,
 } from '@/application/sync-outbox';
 import { Types, YDoc } from '@/application/types';
@@ -39,7 +40,7 @@ export interface SyncContext {
    * Drop queued local updates without sending them.
    * Used by version reset flows where pending updates are stale and must be discarded.
    */
-  discardPendingUpdates?: () => Promise<void>;
+  discardPendingUpdates?: (options?: { skipActiveDrain?: boolean }) => Promise<void>;
   /**
    * Called after a local Yjs update is observed. The WebSocket path still owns
    * immediate delivery; this hook lets the app schedule a debounced HTTP full
@@ -130,6 +131,25 @@ const handleSyncRequest = (ctx: SyncContext, message: collab.ISyncRequest): void
     version: doc.version,
     bytes: update.byteLength,
   });
+
+  // A manifest response can contain years of locally retained Yjs history.
+  // If it exceeds the server-advertised realtime frame limit, persist it and
+  // let the serialized outbox use the bounded HTTP slow lane. Emitting here
+  // would close the WebSocket before any fallback could run.
+  if (shouldRouteUpdateThroughOutbox(update.byteLength)) {
+    enqueueOutboxUpdate(
+      {
+        objectId: doc.guid,
+        collabType: ctx.collabType,
+        version: doc.version ?? null,
+        payload: update,
+        beforeStateVector: stateVector,
+      },
+      { broadcast: false }
+    );
+    return;
+  }
+
   // send the update containing new data back to the server. This is a
   // manifest-style diff, so the causal `before` vector is the server's own
   // advertised state (what it told us it has). No after vector — the server
@@ -241,7 +261,7 @@ export const initSync = (ctx: SyncContext) => {
   // crash, and modal-unmount races because IndexedDB is the source of truth.
   ctx.flush = () => waitForDrain([doc.guid]);
 
-  ctx.discardPendingUpdates = () => deleteOutboxByObjectId(doc.guid);
+  ctx.discardPendingUpdates = (options) => deleteOutboxByObjectId(doc.guid, options);
 
   const onUpdate = (update: Uint8Array, origin: string, _doc: Y.Doc, transaction: Y.Transaction) => {
     if (origin === 'remote') {

--- a/src/application/services/js-services/sync-protocol.ts
+++ b/src/application/services/js-services/sync-protocol.ts
@@ -48,12 +48,11 @@ export interface SyncContext {
    */
   onLocalUpdate?: (objectId: string) => void;
   /**
-   * Called after this context participates in a WebSocket state-vector sync
-   * exchange. A completed manifest-style exchange reconciles the full Yjs
-   * state, so HTTP fallback dirty markers for the object can be cleared when
-   * the socket is open.
+   * Called after this context participates in a state-vector sync exchange.
+   * Routed manifests pass their IndexedDB persistence promise so consumers can
+   * clear only the dirty generation durably owned by the outbox.
    */
-  onManifestSync?: (objectId: string) => void;
+  onManifestSync?: (objectId: string, persisted?: Promise<boolean>) => void;
   /**
    * Cleanup function to remove update/awareness observers and cancel debounced sends.
    * Set by initSync, called during deferred sync context cleanup.
@@ -137,7 +136,7 @@ const handleSyncRequest = (ctx: SyncContext, message: collab.ISyncRequest): void
   // let the serialized outbox use the bounded HTTP slow lane. Emitting here
   // would close the WebSocket before any fallback could run.
   if (shouldRouteUpdateThroughOutbox(update.byteLength)) {
-    enqueueOutboxUpdate(
+    const persisted = enqueueOutboxUpdate(
       {
         objectId: doc.guid,
         collabType: ctx.collabType,
@@ -145,8 +144,10 @@ const handleSyncRequest = (ctx: SyncContext, message: collab.ISyncRequest): void
         payload: update,
         beforeStateVector: stateVector,
       },
-      { broadcast: false }
+      { broadcast: false, source: 'manifest' }
     );
+
+    ctx.onManifestSync?.(doc.guid, persisted);
     return;
   }
 
@@ -275,7 +276,7 @@ export const initSync = (ctx: SyncContext) => {
     // post-update state from the update bytes itself), so it would be wasted work.
     const beforeStateVector = Y.encodeStateVector(transaction.beforeState);
 
-    enqueueOutboxUpdate({
+    void enqueueOutboxUpdate({
       objectId: doc.guid,
       collabType,
       version: doc.version ?? null,

--- a/src/application/sync-outbox/__tests__/sync-outbox.test.ts
+++ b/src/application/sync-outbox/__tests__/sync-outbox.test.ts
@@ -26,6 +26,10 @@ function mockMatchesIndex(index: string, key: unknown[], record: MockSyncOutboxR
     return record.userId === key[0] && record.workspaceId === key[1] && record.objectId === key[2];
   }
 
+  if (index === '[userId+workspaceId+objectId+id]') {
+    return record.userId === key[0] && record.workspaceId === key[1] && record.objectId === key[2];
+  }
+
   throw new Error(`Unsupported mock index: ${index}`);
 }
 
@@ -59,6 +63,16 @@ const mockSyncOutboxTable = {
           .slice()
           .sort((a, b) => Number(a[field] ?? 0) - Number(b[field] ?? 0)),
     }),
+    between: (lower: unknown[]) => ({
+      limit: (count: number) => ({
+        toArray: async () =>
+          mockRecords
+            .filter((record) => mockMatchesIndex(index, lower, record))
+            .slice()
+            .sort((a, b) => Number(a.id ?? 0) - Number(b.id ?? 0))
+            .slice(0, count),
+      }),
+    }),
   })),
 };
 
@@ -79,8 +93,11 @@ jest.mock('@/utils/log', () => ({
 import {
   clearDrainConfig,
   configureDrain,
+  deleteOutboxByObjectId,
   enqueueOutboxUpdate,
+  purgeAllOutbox,
   setCurrentSession,
+  shouldRouteUpdateThroughOutbox,
   startDrainAll,
 } from '@/application/sync-outbox';
 
@@ -96,21 +113,36 @@ function makeUpdate(value: string) {
 }
 
 async function flushPromises() {
-  for (let i = 0; i < 5; i += 1) {
+  for (let i = 0; i < 12; i += 1) {
     await Promise.resolve();
   }
 }
 
 describe('sync outbox live send', () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     jest.clearAllMocks();
     mockRecords = [];
     mockNextId = 1;
     clearDrainConfig();
     setCurrentSession({ userId, workspaceId });
+
+    // Most tests model the steady state after the one-time persisted-backlog
+    // discovery. Dedicated startup tests reset the session and exercise the
+    // barrier itself.
+    configureDrain({
+      userId,
+      workspaceId,
+      send: jest.fn(),
+      isReady: () => false,
+    });
+    startDrainAll();
+    await flushPromises();
+    clearDrainConfig();
+    jest.clearAllMocks();
   });
 
-  afterEach(() => {
+  afterEach(async () => {
+    await purgeAllOutbox();
     clearDrainConfig();
     setCurrentSession(null);
   });
@@ -335,6 +367,683 @@ describe('sync outbox live send', () => {
     await flushPromises();
 
     expect(send).toHaveBeenCalledTimes(2);
+    expect(mockRecords).toHaveLength(0);
+  });
+
+  it('keeps an individually oversized update off WebSocket and retires it only after slow-sync success', async () => {
+    const send = jest.fn();
+    const slowSync = jest.fn().mockResolvedValue({
+      outcome: 'confirmed',
+      messageId: { timestamp: 1, counter: 0 },
+    });
+    const payload = makeUpdate('oversized');
+
+    configureDrain({
+      userId,
+      workspaceId,
+      send,
+      isReady: () => true,
+      maxUpdateBytes: payload.byteLength - 1,
+      maxSlowSyncUpdateBytes: payload.byteLength + 1_024,
+      slowSync,
+    });
+
+    enqueueOutboxUpdate({
+      objectId,
+      collabType: Types.Document,
+      version: 'version-1',
+      payload,
+    });
+
+    expect(send).not.toHaveBeenCalled();
+    expect(mockRecords).toHaveLength(1);
+
+    await flushPromises();
+
+    expect(send).not.toHaveBeenCalled();
+    expect(slowSync).toHaveBeenCalledWith(
+      expect.objectContaining({
+        objectId,
+        collabType: Types.Document,
+        version: 'version-1',
+        docState: payload,
+        stateVector: expect.any(Uint8Array),
+      })
+    );
+    expect(mockRecords).toHaveLength(0);
+  });
+
+  it('budgets the advertised slow limit against doc_state without charging the state vector twice', async () => {
+    const payload = makeUpdate('exact slow limit');
+    const slowSync = jest.fn().mockResolvedValue({
+      outcome: 'confirmed',
+      messageId: { timestamp: 1, counter: 0 },
+    });
+
+    configureDrain({
+      userId,
+      workspaceId,
+      send: jest.fn(),
+      isReady: () => true,
+      maxUpdateBytes: payload.byteLength - 1,
+      maxSlowSyncUpdateBytes: payload.byteLength,
+      slowSync,
+    });
+    enqueueOutboxUpdate({
+      objectId,
+      collabType: Types.Document,
+      version: null,
+      payload,
+    });
+    await flushPromises();
+
+    expect(slowSync).toHaveBeenCalledTimes(1);
+    expect(slowSync.mock.calls[0][0].docState.byteLength).toBe(payload.byteLength);
+    expect(slowSync.mock.calls[0][0].stateVector.byteLength).toBeGreaterThan(0);
+    expect(mockRecords).toHaveLength(0);
+  });
+
+  it('holds a fresh edit behind a persisted oversized predecessor during startup discovery', async () => {
+    const persisted = makeUpdate('x'.repeat(512));
+    const fresh = makeUpdate('fresh');
+    const persistedStateVector = Y.encodeStateVector(Y.parseUpdateMeta(persisted).to);
+    const events: string[] = [];
+    const send = jest.fn(() => {
+      events.push('send');
+    });
+    const slowSync = jest.fn(async () => {
+      events.push('slow');
+      return {
+        outcome: 'confirmed' as const,
+        messageId: { timestamp: 1, counter: 0 },
+      };
+    });
+
+    clearDrainConfig();
+    setCurrentSession(null);
+    mockRecords = [
+      {
+        id: 1,
+        userId,
+        workspaceId,
+        objectId,
+        collabType: Types.Document,
+        version: null,
+        payload: persisted,
+        createdAt: 1,
+      },
+    ];
+    mockNextId = 2;
+    setCurrentSession({ userId, workspaceId });
+    configureDrain({
+      userId,
+      workspaceId,
+      send,
+      isReady: () => true,
+      maxUpdateBytes: persisted.byteLength - 1,
+      // Both records can share one ordered slow-sync prefix. The key invariant
+      // is that the fresh edit cannot take the immediate WebSocket path first.
+      maxSlowSyncUpdateBytes: Y.mergeUpdates([persisted, fresh]).byteLength + persistedStateVector.byteLength + 1_024,
+      slowSync,
+    });
+
+    startDrainAll();
+    expect(shouldRouteUpdateThroughOutbox(fresh.byteLength)).toBe(true);
+    enqueueOutboxUpdate({
+      objectId,
+      collabType: Types.Document,
+      version: null,
+      payload: fresh,
+    });
+
+    expect(send).not.toHaveBeenCalled();
+    expect(slowSync).not.toHaveBeenCalled();
+
+    await flushPromises();
+
+    expect(events).toEqual(['slow']);
+    expect(slowSync.mock.calls[0][0].docState).toEqual(Y.mergeUpdates([persisted, fresh]));
+    expect(shouldRouteUpdateThroughOutbox(fresh.byteLength)).toBe(false);
+    expect(mockRecords).toHaveLength(0);
+  });
+
+  it('uses the safe realtime fallback while server-info is unresolved', async () => {
+    const send = jest.fn();
+    const payload = makeUpdate('limits are loading');
+
+    configureDrain({
+      userId,
+      workspaceId,
+      send,
+      isReady: () => true,
+      syncLimitsLoaded: false,
+    });
+
+    expect(shouldRouteUpdateThroughOutbox(payload.byteLength)).toBe(false);
+
+    enqueueOutboxUpdate({
+      objectId,
+      collabType: Types.Database,
+      version: null,
+      payload,
+    });
+    await flushPromises();
+
+    expect(send).toHaveBeenCalledTimes(1);
+    expect(mockRecords).toHaveLength(0);
+
+    expect(shouldRouteUpdateThroughOutbox(4 * 1024 * 1024 + 1)).toBe(true);
+  });
+
+  it('drains a persisted small update while server-info is unresolved', async () => {
+    let ready = false;
+    const send = jest.fn();
+    const payload = makeUpdate('persisted while limits load');
+
+    configureDrain({
+      userId,
+      workspaceId,
+      send,
+      isReady: () => ready,
+      syncLimitsLoaded: false,
+    });
+    enqueueOutboxUpdate({
+      objectId,
+      collabType: Types.Database,
+      version: null,
+      payload,
+    });
+    await flushPromises();
+
+    expect(send).not.toHaveBeenCalled();
+    expect(mockRecords).toHaveLength(1);
+
+    ready = true;
+    startDrainAll();
+    await flushPromises();
+
+    expect(send).toHaveBeenCalledTimes(1);
+    expect(mockRecords).toHaveLength(0);
+  });
+
+  it('uses the safe 4 MiB realtime limit when an older server omits the optional limit', () => {
+    configureDrain({
+      userId,
+      workspaceId,
+      send: jest.fn(),
+      isReady: () => true,
+      syncLimitsLoaded: true,
+    });
+
+    expect(shouldRouteUpdateThroughOutbox(4 * 1024 * 1024 + 1)).toBe(true);
+  });
+
+  it('honours an explicitly advertised zero realtime limit as unlimited', () => {
+    configureDrain({
+      userId,
+      workspaceId,
+      send: jest.fn(),
+      isReady: () => true,
+      maxUpdateBytes: 0,
+    });
+
+    expect(shouldRouteUpdateThroughOutbox(8 * 1024 * 1024)).toBe(false);
+  });
+
+  it('keeps an oversized update pending when the server does not advertise a slow lane', async () => {
+    const send = jest.fn();
+    const slowSync = jest.fn();
+    const payload = makeUpdate('oversized');
+
+    configureDrain({
+      userId,
+      workspaceId,
+      send,
+      isReady: () => true,
+      maxUpdateBytes: payload.byteLength - 1,
+      slowSync,
+    });
+
+    enqueueOutboxUpdate({
+      objectId,
+      collabType: Types.Document,
+      version: null,
+      payload,
+    });
+    await flushPromises();
+
+    expect(send).not.toHaveBeenCalled();
+    expect(slowSync).not.toHaveBeenCalled();
+    expect(mockRecords).toHaveLength(1);
+  });
+
+  it('drains a merged oversized backlog in realtime prefixes when each atomic record fits', async () => {
+    let ready = false;
+    const send = jest.fn();
+    const slowSync = jest.fn();
+    const first = makeUpdate('first');
+    const second = makeUpdate('second');
+    const merged = Y.mergeUpdates([first, second]);
+    const maxIndividualBytes = Math.max(first.byteLength, second.byteLength);
+
+    expect(merged.byteLength).toBeGreaterThan(maxIndividualBytes);
+
+    configureDrain({
+      userId,
+      workspaceId,
+      send,
+      isReady: () => ready,
+      maxUpdateBytes: maxIndividualBytes,
+      maxSlowSyncUpdateBytes: merged.byteLength + 1_024,
+      slowSync,
+    });
+
+    enqueueOutboxUpdate({
+      objectId,
+      collabType: Types.Document,
+      version: null,
+      payload: first,
+    });
+    enqueueOutboxUpdate({
+      objectId,
+      collabType: Types.Document,
+      version: null,
+      payload: second,
+    });
+    await flushPromises();
+
+    expect(send).not.toHaveBeenCalled();
+    expect(slowSync).not.toHaveBeenCalled();
+    expect(mockRecords).toHaveLength(2);
+
+    ready = true;
+    startDrainAll();
+    await flushPromises();
+
+    expect(send).toHaveBeenCalledTimes(2);
+    expect(slowSync).not.toHaveBeenCalled();
+    expect(mockRecords).toHaveLength(0);
+  });
+
+  it('deletes only the exact records acknowledged by an in-flight slow-sync', async () => {
+    let resolveFirst!: (result: { outcome: 'confirmed'; messageId: { timestamp: number; counter: number } }) => void;
+    const firstResult = new Promise<{
+      outcome: 'confirmed';
+      messageId: { timestamp: number; counter: number };
+    }>((resolve) => {
+      resolveFirst = resolve;
+    });
+    const slowSync = jest
+      .fn()
+      .mockImplementationOnce(() => firstResult)
+      .mockRejectedValueOnce(new Error('second request stays pending'));
+    const first = makeUpdate('first oversized');
+    const second = makeUpdate('newer oversized');
+    const slowLimit = Math.max(first.byteLength, second.byteLength) + 1_024;
+
+    configureDrain({
+      userId,
+      workspaceId,
+      send: jest.fn(),
+      isReady: () => true,
+      maxUpdateBytes: 1,
+      maxSlowSyncUpdateBytes: slowLimit,
+      slowSync,
+    });
+
+    enqueueOutboxUpdate({
+      objectId,
+      collabType: Types.Document,
+      version: null,
+      payload: first,
+    });
+    await flushPromises();
+    expect(slowSync).toHaveBeenCalledTimes(1);
+
+    enqueueOutboxUpdate({
+      objectId,
+      collabType: Types.Document,
+      version: null,
+      payload: second,
+    });
+    await flushPromises();
+    expect(mockRecords.map((record) => record.id)).toEqual([1, 2]);
+
+    resolveFirst({ outcome: 'confirmed', messageId: { timestamp: 3, counter: 0 } });
+    await flushPromises();
+
+    expect(mockSyncOutboxTable.bulkDelete).toHaveBeenCalledWith([1]);
+    expect(mockRecords.map((record) => record.id)).toEqual([2]);
+  });
+
+  it('keeps the locked reread, oversized upload, and exact-ID delete in one cross-tab critical section', async () => {
+    const originalLocksDescriptor = Object.getOwnPropertyDescriptor(globalThis.navigator, 'locks');
+    let lockHeld = false;
+    const requestLock = jest.fn(async (_name: string, _options: LockOptions, callback: () => Promise<unknown>) => {
+      lockHeld = true;
+      try {
+        return await callback();
+      } finally {
+        lockHeld = false;
+      }
+    });
+
+    Object.defineProperty(globalThis.navigator, 'locks', {
+      configurable: true,
+      value: { request: requestLock },
+    });
+
+    try {
+      const payload = makeUpdate('locked oversized');
+      const slowSync = jest.fn(async () => {
+        expect(lockHeld).toBe(true);
+        return {
+          outcome: 'confirmed' as const,
+          messageId: { timestamp: 3, counter: 0 },
+        };
+      });
+
+      mockSyncOutboxTable.bulkDelete.mockImplementationOnce(async (ids: number[]) => {
+        expect(lockHeld).toBe(true);
+        const idsToDelete = new Set(ids);
+
+        mockRecords = mockRecords.filter((record) => !idsToDelete.has(record.id ?? -1));
+      });
+      configureDrain({
+        userId,
+        workspaceId,
+        send: jest.fn(),
+        isReady: () => true,
+        maxUpdateBytes: payload.byteLength - 1,
+        maxSlowSyncUpdateBytes: payload.byteLength + 1_024,
+        slowSync,
+      });
+
+      enqueueOutboxUpdate({
+        objectId,
+        collabType: Types.Document,
+        version: null,
+        payload,
+      });
+      await flushPromises();
+
+      expect(requestLock).toHaveBeenCalledTimes(1);
+      expect(slowSync).toHaveBeenCalledTimes(1);
+      expect(mockRecords).toHaveLength(0);
+    } finally {
+      if (originalLocksDescriptor) {
+        Object.defineProperty(globalThis.navigator, 'locks', originalLocksDescriptor);
+      } else {
+        Reflect.deleteProperty(globalThis.navigator, 'locks');
+      }
+    }
+  });
+
+  it('re-reads after acquiring the cross-tab lock and skips a stale batch already retired by another tab', async () => {
+    const originalLocksDescriptor = Object.getOwnPropertyDescriptor(globalThis.navigator, 'locks');
+    const requestLock = jest.fn(async (_name: string, _options: LockOptions, callback: () => Promise<unknown>) => {
+      // Simulate the previous lock owner completing this exact prefix while
+      // the current tab was waiting to acquire ownership.
+      mockRecords = [];
+      return callback();
+    });
+
+    Object.defineProperty(globalThis.navigator, 'locks', {
+      configurable: true,
+      value: { request: requestLock },
+    });
+
+    try {
+      const payload = makeUpdate('stale oversized');
+      const slowSync = jest.fn();
+
+      configureDrain({
+        userId,
+        workspaceId,
+        send: jest.fn(),
+        isReady: () => true,
+        maxUpdateBytes: payload.byteLength - 1,
+        maxSlowSyncUpdateBytes: payload.byteLength + 1_024,
+        slowSync,
+      });
+      enqueueOutboxUpdate({
+        objectId,
+        collabType: Types.Document,
+        version: null,
+        payload,
+      });
+      await flushPromises();
+
+      expect(requestLock).toHaveBeenCalledTimes(1);
+      expect(slowSync).not.toHaveBeenCalled();
+      expect(mockRecords).toHaveLength(0);
+    } finally {
+      if (originalLocksDescriptor) {
+        Object.defineProperty(globalThis.navigator, 'locks', originalLocksDescriptor);
+      } else {
+        Reflect.deleteProperty(globalThis.navigator, 'locks');
+      }
+    }
+  });
+
+  it('derives the desired state vector from a nonzero-clock incremental update', async () => {
+    const doc = new Y.Doc({ guid: objectId });
+    const values = doc.getArray<number>('values');
+
+    values.insert(
+      0,
+      Array.from({ length: 10 }, (_, index) => index)
+    );
+    const beforeStateVector = Y.encodeStateVector(doc);
+    let incremental = new Uint8Array();
+
+    doc.once('update', (update: Uint8Array) => {
+      incremental = update;
+    });
+    values.insert(10, [10]);
+    const expectedAfterStateVector = Y.encodeStateVector(doc);
+    const slowSync = jest.fn().mockResolvedValue({ outcome: 'confirmed' });
+
+    configureDrain({
+      userId,
+      workspaceId,
+      send: jest.fn(),
+      isReady: () => true,
+      maxUpdateBytes: incremental.byteLength - 1,
+      maxSlowSyncUpdateBytes: incremental.byteLength + expectedAfterStateVector.byteLength + 1_024,
+      slowSync,
+    });
+
+    enqueueOutboxUpdate({
+      objectId,
+      collabType: Types.Document,
+      version: null,
+      payload: incremental,
+      beforeStateVector,
+    });
+    await flushPromises();
+
+    const desiredStateVector = slowSync.mock.calls[0][0].stateVector as Uint8Array;
+
+    expect(Y.decodeStateVector(desiredStateVector)).toEqual(Y.decodeStateVector(expectedAfterStateVector));
+    expect(mockRecords).toHaveLength(0);
+  });
+
+  it('reads and retires a long backlog in bounded compound-index prefixes', async () => {
+    let ready = false;
+    const send = jest.fn();
+
+    configureDrain({
+      userId,
+      workspaceId,
+      send,
+      isReady: () => ready,
+      maxUpdateBytes: 0,
+    });
+
+    for (let index = 0; index < 65; index += 1) {
+      enqueueOutboxUpdate({
+        objectId,
+        collabType: Types.Document,
+        version: null,
+        payload: makeUpdate(`queued-${index}`),
+      });
+    }
+
+    await flushPromises();
+    ready = true;
+    startDrainAll();
+    await flushPromises();
+
+    expect(send).toHaveBeenCalledTimes(2);
+    expect(mockSyncOutboxTable.where).toHaveBeenCalledWith('[userId+workspaceId+objectId+id]');
+    expect(mockSyncOutboxTable.bulkDelete.mock.calls[0][0]).toHaveLength(64);
+    expect(mockSyncOutboxTable.bulkDelete.mock.calls[1][0]).toEqual([65]);
+    expect(mockRecords).toHaveLength(0);
+  });
+
+  it('keeps a terminally blocked oversized update without scheduling another upload', async () => {
+    const payload = makeUpdate('blocked');
+    const slowSync = jest.fn().mockResolvedValue({
+      outcome: 'blocked',
+      reason: 'permission_denied',
+    });
+
+    configureDrain({
+      userId,
+      workspaceId,
+      send: jest.fn(),
+      isReady: () => true,
+      maxUpdateBytes: payload.byteLength - 1,
+      maxSlowSyncUpdateBytes: payload.byteLength + 1_024,
+      slowSync,
+    });
+
+    enqueueOutboxUpdate({
+      objectId,
+      collabType: Types.Document,
+      version: null,
+      payload,
+    });
+    await flushPromises();
+    startDrainAll();
+    await flushPromises();
+
+    expect(slowSync).toHaveBeenCalledTimes(1);
+    expect(mockRecords).toHaveLength(1);
+  });
+
+  it('honours the server retry delay for a retryable slow-sync failure', async () => {
+    jest.useFakeTimers();
+
+    try {
+      const payload = makeUpdate('retry later');
+      const retryableError = Object.assign(new Error('busy'), { retryAfterSecs: 7 });
+      const slowSync = jest
+        .fn()
+        .mockRejectedValueOnce(retryableError)
+        .mockResolvedValueOnce({ outcome: 'blocked', reason: 'permission_denied' });
+
+      configureDrain({
+        userId,
+        workspaceId,
+        send: jest.fn(),
+        isReady: () => true,
+        maxUpdateBytes: payload.byteLength - 1,
+        maxSlowSyncUpdateBytes: payload.byteLength + 1_024,
+        slowSync,
+      });
+
+      enqueueOutboxUpdate({
+        objectId,
+        collabType: Types.Document,
+        version: null,
+        payload,
+      });
+      await flushPromises();
+
+      expect(slowSync).toHaveBeenCalledTimes(1);
+
+      await jest.advanceTimersByTimeAsync(6_999);
+      await flushPromises();
+      expect(slowSync).toHaveBeenCalledTimes(1);
+
+      await jest.advanceTimersByTimeAsync(1);
+      await flushPromises();
+      expect(slowSync).toHaveBeenCalledTimes(2);
+      expect(mockRecords).toHaveLength(1);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('allows an authoritative version reset to discard rows from inside the active slow drain', async () => {
+    const payload = makeUpdate('stale version');
+    const slowSync = jest.fn(async () => {
+      await deleteOutboxByObjectId(objectId, { skipActiveDrain: true });
+      return { outcome: 'confirmed' as const };
+    });
+
+    configureDrain({
+      userId,
+      workspaceId,
+      send: jest.fn(),
+      isReady: () => true,
+      maxUpdateBytes: payload.byteLength - 1,
+      maxSlowSyncUpdateBytes: payload.byteLength + 1_024,
+      slowSync,
+    });
+
+    enqueueOutboxUpdate({
+      objectId,
+      collabType: Types.Document,
+      version: 'old-version',
+      payload,
+    });
+    await flushPromises();
+
+    expect(slowSync).toHaveBeenCalledTimes(1);
+    expect(mockRecords).toHaveLength(0);
+  });
+
+  it('retires exact confirmed IDs after a same-session drain configuration rebuild', async () => {
+    let resolveSlowSync!: (result: { outcome: 'confirmed' }) => void;
+    const pending = new Promise<{ outcome: 'confirmed' }>((resolve) => {
+      resolveSlowSync = resolve;
+    });
+    const payload = makeUpdate('slow across reconnect');
+    const slowSync = jest.fn(() => pending);
+
+    configureDrain({
+      userId,
+      workspaceId,
+      send: jest.fn(),
+      isReady: () => true,
+      maxUpdateBytes: payload.byteLength - 1,
+      maxSlowSyncUpdateBytes: payload.byteLength + 1_024,
+      slowSync,
+    });
+    enqueueOutboxUpdate({
+      objectId,
+      collabType: Types.Document,
+      version: null,
+      payload,
+    });
+    await flushPromises();
+
+    configureDrain({
+      userId,
+      workspaceId,
+      send: jest.fn(),
+      isReady: () => false,
+      maxUpdateBytes: payload.byteLength - 1,
+      maxSlowSyncUpdateBytes: payload.byteLength + 1_024,
+      slowSync,
+    });
+    resolveSlowSync({ outcome: 'confirmed' });
+    await flushPromises();
+
+    expect(mockSyncOutboxTable.bulkDelete).toHaveBeenCalledWith([1]);
     expect(mockRecords).toHaveLength(0);
   });
 });

--- a/src/application/sync-outbox/__tests__/sync-outbox.test.ts
+++ b/src/application/sync-outbox/__tests__/sync-outbox.test.ts
@@ -12,10 +12,12 @@ interface MockSyncOutboxRecord {
   payload: Uint8Array;
   createdAt: number;
   beforeStateVector?: Uint8Array;
+  source?: 'manifest';
 }
 
 let mockRecords: MockSyncOutboxRecord[] = [];
 let mockNextId = 1;
+let mockTransactionQueue: Promise<unknown> = Promise.resolve();
 
 function mockMatchesIndex(index: string, key: unknown[], record: MockSyncOutboxRecord) {
   if (index === '[userId+workspaceId]') {
@@ -76,9 +78,20 @@ const mockSyncOutboxTable = {
   })),
 };
 
+const mockTransaction = jest.fn(
+  (_mode: string, _table: typeof mockSyncOutboxTable, callback: () => Promise<unknown>) => {
+    const transaction = mockTransactionQueue.then(callback);
+
+    // IndexedDB serializes read-write transactions that touch the same store.
+    mockTransactionQueue = transaction.catch(() => undefined);
+    return transaction;
+  }
+);
+
 jest.mock('@/application/db', () => ({
   db: {
     sync_outbox: mockSyncOutboxTable,
+    transaction: mockTransaction,
   },
 }));
 
@@ -95,7 +108,9 @@ import {
   configureDrain,
   deleteOutboxByObjectId,
   enqueueOutboxUpdate,
+  getCurrentOutboxSession,
   purgeAllOutbox,
+  resumePermissionBlockedSync,
   setCurrentSession,
   shouldRouteUpdateThroughOutbox,
   startDrainAll,
@@ -118,11 +133,21 @@ async function flushPromises() {
   }
 }
 
+function createDeferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((promiseResolve) => {
+    resolve = promiseResolve;
+  });
+
+  return { promise, resolve };
+}
+
 describe('sync outbox live send', () => {
   beforeEach(async () => {
     jest.clearAllMocks();
     mockRecords = [];
     mockNextId = 1;
+    mockTransactionQueue = Promise.resolve();
     clearDrainConfig();
     setCurrentSession({ userId, workspaceId });
 
@@ -197,6 +222,57 @@ describe('sync outbox live send', () => {
 
     expect(onPersisted).toHaveBeenCalledWith(workspaceId, objectId);
     expect(mockRecords).toHaveLength(1);
+  });
+
+  it('atomically replaces older manifests without removing local edit records', async () => {
+    const firstManifest = makeUpdate('first manifest');
+    const localEdit = makeUpdate('local edit');
+    const latestManifest = makeUpdate('latest manifest');
+
+    configureDrain({
+      userId,
+      workspaceId,
+      send: jest.fn(),
+      isReady: () => false,
+    });
+
+    const [firstPersisted, localPersisted, latestPersisted] = await Promise.all([
+      enqueueOutboxUpdate(
+        {
+          objectId,
+          collabType: Types.Database,
+          version: null,
+          payload: firstManifest,
+        },
+        { broadcast: false, source: 'manifest' }
+      ),
+      enqueueOutboxUpdate({
+        objectId,
+        collabType: Types.Database,
+        version: null,
+        payload: localEdit,
+      }),
+      enqueueOutboxUpdate(
+        {
+          objectId,
+          collabType: Types.Database,
+          version: null,
+          payload: latestManifest,
+        },
+        { broadcast: false, source: 'manifest' }
+      ),
+    ]);
+
+    await flushPromises();
+
+    expect([firstPersisted, localPersisted, latestPersisted]).toEqual([true, true, true]);
+    expect(mockRecords).toHaveLength(2);
+    expect(mockRecords.filter((record) => record.source === 'manifest')).toEqual([
+      expect.objectContaining({ payload: latestManifest }),
+    ]);
+    expect(mockRecords.filter((record) => record.source === undefined)).toEqual([
+      expect.objectContaining({ payload: localEdit }),
+    ]);
   });
 
   it('drains queued records when startDrainAll runs after the transport becomes ready', async () => {
@@ -408,7 +484,8 @@ describe('sync outbox live send', () => {
         version: 'version-1',
         docState: payload,
         stateVector: expect.any(Uint8Array),
-      })
+      }),
+      expect.any(AbortSignal)
     );
     expect(mockRecords).toHaveLength(0);
   });
@@ -826,6 +903,127 @@ describe('sync outbox live send', () => {
     }
   });
 
+  it('cancels a pending cross-tab lock when the object is discarded', async () => {
+    const originalLocksDescriptor = Object.getOwnPropertyDescriptor(globalThis.navigator, 'locks');
+    const requestLock = jest.fn((_name: string, options: LockOptions) => {
+      const signal = options.signal;
+
+      if (!signal) throw new Error('expected a cancellable Web Lock request');
+
+      return new Promise<never>((_resolve, reject) => {
+        signal.addEventListener('abort', () => reject(signal.reason), { once: true });
+      });
+    });
+
+    Object.defineProperty(globalThis.navigator, 'locks', {
+      configurable: true,
+      value: { request: requestLock },
+    });
+
+    try {
+      const payload = makeUpdate('discard while waiting for lock');
+      const slowSync = jest.fn();
+
+      configureDrain({
+        userId,
+        workspaceId,
+        send: jest.fn(),
+        isReady: () => true,
+        maxUpdateBytes: payload.byteLength - 1,
+        maxSlowSyncUpdateBytes: payload.byteLength + 1_024,
+        slowSync,
+      });
+
+      await enqueueOutboxUpdate({
+        objectId,
+        collabType: Types.Document,
+        version: null,
+        payload,
+      });
+      await flushPromises();
+
+      const signal = requestLock.mock.calls[0]?.[1].signal;
+
+      expect(signal).toEqual(expect.any(AbortSignal));
+      expect(signal?.aborted).toBe(false);
+
+      await deleteOutboxByObjectId(objectId);
+
+      expect(signal?.aborted).toBe(true);
+      expect(slowSync).not.toHaveBeenCalled();
+      expect(mockRecords).toHaveLength(0);
+    } finally {
+      if (originalLocksDescriptor) {
+        Object.defineProperty(globalThis.navigator, 'locks', originalLocksDescriptor);
+      } else {
+        Reflect.deleteProperty(globalThis.navigator, 'locks');
+      }
+    }
+  });
+
+  it('cancels a pending cross-tab lock before purging on logout', async () => {
+    const originalLocksDescriptor = Object.getOwnPropertyDescriptor(globalThis.navigator, 'locks');
+    const requestLock = jest.fn((_name: string, options: LockOptions) => {
+      const signal = options.signal;
+
+      if (!signal) throw new Error('expected a cancellable Web Lock request');
+
+      return new Promise<never>((_resolve, reject) => {
+        signal.addEventListener('abort', () => reject(signal.reason), { once: true });
+      });
+    });
+
+    Object.defineProperty(globalThis.navigator, 'locks', {
+      configurable: true,
+      value: { request: requestLock },
+    });
+
+    try {
+      const payload = makeUpdate('logout while waiting for lock');
+
+      configureDrain({
+        userId,
+        workspaceId,
+        send: jest.fn(),
+        isReady: () => true,
+        maxUpdateBytes: payload.byteLength - 1,
+        maxSlowSyncUpdateBytes: payload.byteLength + 1_024,
+        slowSync: jest.fn(),
+      });
+
+      await enqueueOutboxUpdate({
+        objectId,
+        collabType: Types.Document,
+        version: null,
+        payload,
+      });
+      await flushPromises();
+
+      const signal = requestLock.mock.calls[0]?.[1].signal;
+
+      await purgeAllOutbox();
+
+      expect(signal?.aborted).toBe(true);
+      expect(mockRecords).toHaveLength(0);
+
+      clearDrainConfig();
+      await expect(
+        enqueueOutboxUpdate({
+          objectId,
+          collabType: Types.Document,
+          version: null,
+          payload: makeUpdate('new session work'),
+        })
+      ).resolves.toBe(true);
+    } finally {
+      if (originalLocksDescriptor) {
+        Object.defineProperty(globalThis.navigator, 'locks', originalLocksDescriptor);
+      } else {
+        Reflect.deleteProperty(globalThis.navigator, 'locks');
+      }
+    }
+  });
+
   it('derives the desired state vector from a nonzero-clock incremental update', async () => {
     const doc = new Y.Doc({ guid: objectId });
     const values = doc.getArray<number>('values');
@@ -931,6 +1129,127 @@ describe('sync outbox live send', () => {
 
     expect(slowSync).toHaveBeenCalledTimes(1);
     expect(mockRecords).toHaveLength(1);
+  });
+
+  it('retries a permission-blocked oversized update after access changes', async () => {
+    const payload = makeUpdate('permission restored');
+    const slowSync = jest
+      .fn()
+      .mockResolvedValueOnce({ outcome: 'blocked', reason: 'permission_denied' })
+      .mockResolvedValueOnce({ outcome: 'confirmed', messageId: { timestamp: 1, counter: 0 } });
+
+    configureDrain({
+      userId,
+      workspaceId,
+      send: jest.fn(),
+      isReady: () => true,
+      maxUpdateBytes: payload.byteLength - 1,
+      maxSlowSyncUpdateBytes: payload.byteLength + 1_024,
+      slowSync,
+    });
+
+    await enqueueOutboxUpdate({
+      objectId,
+      collabType: Types.Document,
+      version: null,
+      payload,
+    });
+    await flushPromises();
+
+    expect(slowSync).toHaveBeenCalledTimes(1);
+    expect(mockRecords).toHaveLength(1);
+
+    resumePermissionBlockedSync(objectId);
+    await flushPromises();
+
+    expect(slowSync).toHaveBeenCalledTimes(2);
+    expect(mockRecords).toHaveLength(0);
+  });
+
+  it('invalidates an update-too-large block when a newer manifest replaces its records', async () => {
+    const rejected = createDeferred<{
+      outcome: 'blocked';
+      reason: 'update_too_large';
+    }>();
+    const oversizedManifest = makeUpdate('x'.repeat(4_096));
+    const replacementManifest = makeUpdate('smaller manifest');
+    const send = jest.fn();
+    const slowSync = jest.fn(() => rejected.promise);
+
+    expect(oversizedManifest.byteLength).toBeGreaterThan(replacementManifest.byteLength);
+    configureDrain({
+      userId,
+      workspaceId,
+      send,
+      isReady: () => true,
+      maxUpdateBytes: replacementManifest.byteLength,
+      maxSlowSyncUpdateBytes: oversizedManifest.byteLength + 1_024,
+      slowSync,
+    });
+
+    await enqueueOutboxUpdate(
+      {
+        objectId,
+        collabType: Types.Database,
+        version: null,
+        payload: oversizedManifest,
+      },
+      { broadcast: false, source: 'manifest' }
+    );
+    await flushPromises();
+
+    expect(slowSync).toHaveBeenCalledTimes(1);
+
+    await enqueueOutboxUpdate(
+      {
+        objectId,
+        collabType: Types.Database,
+        version: null,
+        payload: replacementManifest,
+      },
+      { broadcast: false, source: 'manifest' }
+    );
+    expect(mockRecords).toEqual([expect.objectContaining({ id: 2, payload: replacementManifest })]);
+
+    rejected.resolve({ outcome: 'blocked', reason: 'update_too_large' });
+    await flushPromises();
+
+    expect(slowSync).toHaveBeenCalledTimes(1);
+    expect(send).toHaveBeenCalledTimes(1);
+    expect(mockRecords).toHaveLength(0);
+  });
+
+  it('deletes an object only from an explicitly captured session', async () => {
+    const originSession = { userId, workspaceId };
+    const replacementSession = { userId, workspaceId: 'workspace-2' };
+
+    clearDrainConfig();
+    setCurrentSession(originSession);
+    await enqueueOutboxUpdate({
+      objectId,
+      collabType: Types.Document,
+      version: null,
+      payload: makeUpdate('workspace one'),
+    });
+
+    setCurrentSession(replacementSession);
+    await enqueueOutboxUpdate({
+      objectId,
+      collabType: Types.Document,
+      version: null,
+      payload: makeUpdate('workspace two'),
+    });
+
+    expect(getCurrentOutboxSession()).toEqual(replacementSession);
+    await deleteOutboxByObjectId(objectId, { session: originSession });
+
+    expect(mockRecords).toEqual([
+      expect.objectContaining({
+        objectId,
+        userId: replacementSession.userId,
+        workspaceId: replacementSession.workspaceId,
+      }),
+    ]);
   });
 
   it('honours the server retry delay for a retryable slow-sync failure', async () => {

--- a/src/application/sync-outbox/index.ts
+++ b/src/application/sync-outbox/index.ts
@@ -1,3 +1,4 @@
+import BaseDexie from 'dexie';
 import * as Y from 'yjs';
 
 import { db } from '@/application/db';
@@ -13,6 +14,27 @@ const FLAGS_LIB0V1 = 0;
 export type OutboxSender = (message: messages.IMessage) => void;
 
 export type OutboxReady = () => boolean;
+
+export interface SlowSyncOutboxItem {
+  objectId: string;
+  collabType: Types;
+  version?: string | null;
+  stateVector: Uint8Array;
+  docState: Uint8Array;
+}
+
+export type SlowSyncBlockedReason = 'permission_denied' | 'update_too_large';
+
+export type SlowSyncOutboxResult =
+  | {
+      outcome: 'confirmed';
+      /** An authoritative collab-version supersession needs no RID. */
+      messageId?: collab.IRid;
+    }
+  | {
+      outcome: 'blocked';
+      reason: SlowSyncBlockedReason;
+    };
 
 interface DrainConfig {
   userId: string;
@@ -35,6 +57,23 @@ interface DrainConfig {
   isReady: OutboxReady;
   /** Notifies the elected socket owner after the IndexedDB row is durable. */
   onPersisted?: (workspaceId: string, objectId: string) => void;
+  /** Realtime raw-update cap advertised by the server. */
+  maxUpdateBytes?: number;
+  /** Optional raw-update cap for the backward-compatible HTTP slow lane. */
+  maxSlowSyncUpdateBytes?: number;
+  /**
+   * False only while server-info is unresolved. The realtime lane still uses
+   * its conservative legacy limit; the HTTP slow lane remains disabled.
+   */
+  syncLimitsLoaded?: boolean;
+  /** Cancels an in-flight slow request before logout waits for drains. */
+  abortSlowSync?: () => void;
+  /**
+   * Persists one oversized object through the authenticated HTTP full-sync
+   * endpoint. Confirmation requires a durable RID unless an authoritative
+   * collab-version change supersedes the queued update.
+   */
+  slowSync?: (item: SlowSyncOutboxItem) => Promise<SlowSyncOutboxResult>;
 }
 
 let drainConfig: DrainConfig | null = null;
@@ -43,6 +82,12 @@ let drainConfig: DrainConfig | null = null;
 let currentUserId: string | null = null;
 let currentWorkspaceId: string | null = null;
 const draining = new Map<string, Promise<void>>();
+const slowSyncRetryTimers = new Map<string, ReturnType<typeof setTimeout>>();
+const slowSyncRetryAttempts = new Map<string, number>();
+const oversizedDiagnostics = new Map<string, string>();
+const blockedSlowSyncObjects = new Map<string, SlowSyncBlockedReason>();
+const serializedSlowSyncObjects = new Set<string>();
+let slowSyncQueue: Promise<void> = Promise.resolve();
 // Object ids whose records were enqueued while a drain was already in flight.
 // Processed in the drain's finally block so the race between the drain loop's
 // "nothing left" exit and a concurrent enqueue cannot leave records stranded.
@@ -65,6 +110,28 @@ let isPurging = false;
 // IndexedDB finishes.
 let pendingPurge: Promise<void> | null = null;
 let startDrainAllQueued = false;
+// A newly mounted session must discover persisted predecessors before any
+// fresh update can take the immediate WebSocket path. Otherwise a small edit
+// can leapfrog an oversized record left in IndexedDB by a prior page load.
+let discoveredOutboxSessionKey: string | null = null;
+
+const SLOW_SYNC_RETRY_DELAYS_MS = [5_000, 30_000, 2 * 60_000, 5 * 60_000];
+const DEFAULT_REALTIME_UPDATE_BYTES = 4 * 1024 * 1024;
+const OUTBOX_READ_BATCH_SIZE = 64;
+const SLOW_SYNC_LOCK_PREFIX = 'appflowy:sync-outbox:slow';
+
+interface EnqueueOutboxOptions {
+  /** Manifest replies are server-directed and do not need sibling-tab fan-out. */
+  broadcast?: boolean;
+}
+
+function sessionObjectKey(userId: string, workspaceId: string, objectId: string): string {
+  return `${userId}\u0000${workspaceId}\u0000${objectId}`;
+}
+
+function sessionKey(userId: string, workspaceId: string): string {
+  return `${userId}\u0000${workspaceId}`;
+}
 
 /**
  * Set (or clear) the session that subsequent enqueues will be stamped with.
@@ -74,11 +141,23 @@ let startDrainAllQueued = false;
  * `(userId, workspaceId)`.
  */
 export function setCurrentSession(session: { userId: string; workspaceId: string } | null) {
-  currentUserId = session?.userId ?? null;
-  currentWorkspaceId = session?.workspaceId ?? null;
+  const nextUserId = session?.userId ?? null;
+  const nextWorkspaceId = session?.workspaceId ?? null;
+  const nextSessionKey = nextUserId && nextWorkspaceId ? sessionKey(nextUserId, nextWorkspaceId) : null;
+  const currentSessionKey = currentUserId && currentWorkspaceId ? sessionKey(currentUserId, currentWorkspaceId) : null;
+
+  if (nextSessionKey !== currentSessionKey) {
+    discoveredOutboxSessionKey = null;
+  }
+
+  currentUserId = nextUserId;
+  currentWorkspaceId = nextWorkspaceId;
 }
 
-export function enqueueOutboxUpdate(record: Omit<SyncOutboxRecord, 'id' | 'createdAt' | 'workspaceId' | 'userId'>) {
+export function enqueueOutboxUpdate(
+  record: Omit<SyncOutboxRecord, 'id' | 'createdAt' | 'workspaceId' | 'userId'>,
+  options?: EnqueueOutboxOptions
+) {
   if (isPurging) {
     // Logout / session-change in progress — drop. A new session will
     // re-enqueue any genuinely-pending edits through its own lifecycle.
@@ -116,7 +195,7 @@ export function enqueueOutboxUpdate(record: Omit<SyncOutboxRecord, 'id' | 'creat
   // the durable outbox row remains the fallback when it is not.
   const broadcast = drainConfig?.broadcast;
 
-  if (broadcast && drainConfig?.workspaceId === workspaceId) {
+  if (options?.broadcast !== false && broadcast && drainConfig?.workspaceId === workspaceId) {
     try {
       broadcast(buildUpdateMessage(record));
     } catch (error) {
@@ -130,24 +209,37 @@ export function enqueueOutboxUpdate(record: Omit<SyncOutboxRecord, 'id' | 'creat
   // WebSocket.
   const enqueueUserId = userId;
   const enqueueWorkspaceId = workspaceId;
+  const objectSessionKey = sessionObjectKey(userId, workspaceId, record.objectId);
+  const isIndividuallyOversized = exceedsRealtimeLimit(record.payload.byteLength, drainConfig?.maxUpdateBytes);
+
+  if (isIndividuallyOversized) {
+    serializedSlowSyncObjects.add(objectSessionKey);
+  }
 
   const addPromise: Promise<unknown> = db.sync_outbox.add(row as SyncOutboxRecord);
   const set = inflightAdds.get(record.objectId) ?? new Set<Promise<unknown>>();
   let sentImmediately = false;
-
   const activeConfig = drainConfig;
   const notifyPersisted =
     activeConfig?.userId === enqueueUserId && activeConfig.workspaceId === enqueueWorkspaceId
       ? activeConfig.onPersisted
       : undefined;
 
+  // Preserve the low-latency realtime path for ordinary edits. Oversized
+  // updates are different: they must first become durable, then the serialized
+  // drain routes them through HTTP. Sending one here would exceed the server
+  // frame limit before the slow lane gets a chance to run.
   if (
     activeConfig &&
     activeConfig.userId === enqueueUserId &&
     activeConfig.workspaceId === enqueueWorkspaceId &&
     !isPurging &&
+    discoveredOutboxSessionKey === sessionKey(enqueueUserId, enqueueWorkspaceId) &&
     !suppressedObjects.has(record.objectId) &&
-    activeConfig.isReady()
+    !draining.has(record.objectId) &&
+    activeConfig.isReady() &&
+    !isIndividuallyOversized &&
+    !serializedSlowSyncObjects.has(objectSessionKey)
   ) {
     try {
       activeConfig.send(buildUpdateMessage(record));
@@ -194,7 +286,7 @@ export function enqueueOutboxUpdate(record: Omit<SyncOutboxRecord, 'id' | 'creat
 
       scheduleDrain(record.objectId);
     })
-    .catch((error) => {
+    .catch(async (error) => {
       if (sentImmediately) {
         Log.warn('[outbox] enqueue failed after immediate send', { objectId: record.objectId, error });
         return;
@@ -226,6 +318,35 @@ export function enqueueOutboxUpdate(record: Omit<SyncOutboxRecord, 'id' | 'creat
       // state has since changed — drop the fallback to honour the boundary.
       if (isPurging || suppressedObjects.has(record.objectId)) {
         Log.debug('[outbox] fallback skipped: purge/discard in progress', { objectId: record.objectId });
+        return;
+      }
+
+      // An update above the realtime limit must never leak onto WebSocket.
+      // Without a durable row there is no safe way to retry the slow lane
+      // after a refresh, so fail visibly and let the next manifest exchange
+      // reconstruct the diff instead of closing the socket with an oversize
+      // frame.
+      if (exceedsRealtimeLimit(record.payload.byteLength, activeConfig.maxUpdateBytes)) {
+        Log.error('[outbox] oversized update could not be persisted; WebSocket fallback suppressed', {
+          objectId: record.objectId,
+          payloadBytes: record.payload.byteLength,
+          maxUpdateBytes: activeConfig.maxUpdateBytes,
+        });
+
+        try {
+          const remaining = await db.sync_outbox
+            .where('[userId+workspaceId+objectId]')
+            .equals([enqueueUserId, enqueueWorkspaceId, record.objectId])
+            .count();
+
+          if (remaining === 0) {
+            serializedSlowSyncObjects.delete(objectSessionKey);
+          }
+        } catch {
+          // Keep the serialization guard when IndexedDB itself is unavailable.
+          // The next manifest can reconstruct the update after storage recovers.
+        }
+
         return;
       }
 
@@ -280,12 +401,39 @@ async function awaitInflightAdds(objectId: string): Promise<void> {
 }
 
 export function configureDrain(config: DrainConfig) {
+  // A meaningful owner/capability rebuild is the point at which a previously
+  // terminal server decision may have changed (permission grant or larger
+  // advertised limit). Ordinary readyState transitions no longer rebuild.
+  for (const key of blockedSlowSyncObjects.keys()) {
+    if (key.startsWith(`${config.userId}\u0000${config.workspaceId}\u0000`)) {
+      blockedSlowSyncObjects.delete(key);
+    }
+  }
+
   drainConfig = config;
 }
 
 export function clearDrainConfig() {
   drainConfig = null;
   pendingRerun.clear();
+  oversizedDiagnostics.clear();
+  // Retry state is session-object keyed and intentionally survives a
+  // same-session transport/config rebuild. Purge owns the hard reset.
+}
+
+/**
+ * Returns true when a raw Yjs update cannot use the realtime lane.
+ *
+ * A conservative 4 MiB fallback protects both unresolved server-info requests
+ * and older servers that omit the field. An explicitly advertised zero means
+ * unlimited.
+ */
+export function shouldRouteUpdateThroughOutbox(updateBytes: number): boolean {
+  if (drainConfig && discoveredOutboxSessionKey !== sessionKey(drainConfig.userId, drainConfig.workspaceId)) {
+    return true;
+  }
+
+  return exceedsRealtimeLimit(updateBytes, drainConfig?.maxUpdateBytes);
 }
 
 /**
@@ -309,14 +457,22 @@ export function startDrainAll() {
       await pendingPurge.catch(() => undefined);
     }
 
-    if (!drainConfig) return;
+    const config = drainConfig;
+
+    if (!config) return;
 
     try {
-      const objectIds = await distinctObjectIdsForSession(drainConfig.userId, drainConfig.workspaceId);
+      const objectIds = await distinctObjectIdsForSession(config.userId, config.workspaceId);
 
+      if (!sameDrainSession(drainConfig, config)) return;
       for (const objectId of objectIds) {
         scheduleDrain(objectId);
       }
+
+      // scheduleDrain synchronously installs the per-object drain promise, so
+      // an edit arriving after this assignment is still held behind any
+      // discovered predecessor for that object.
+      discoveredOutboxSessionKey = sessionKey(config.userId, config.workspaceId);
     } catch (error) {
       Log.warn('[outbox] startDrainAll failed', error);
     }
@@ -404,6 +560,9 @@ export function purgeAllOutbox(): Promise<void> {
   // — e.g. from a React render triggered by `SESSION_INVALID` — is dropped
   // before it can add new rows behind the purge.
   isPurging = true;
+  // Abort HTTP before runPurge awaits the active drain; otherwise a slow or
+  // stalled request can delay logout until its transport timeout expires.
+  drainConfig?.abortSlowSync?.();
 
   const purge = runPurge();
 
@@ -429,6 +588,11 @@ async function runPurge(): Promise<void> {
     // doesn't pick up stale bookkeeping.
     pendingRerun.clear();
     inflightAdds.clear();
+    serializedSlowSyncObjects.clear();
+    oversizedDiagnostics.clear();
+    blockedSlowSyncObjects.clear();
+    discoveredOutboxSessionKey = null;
+    clearAllSlowSyncRetries();
 
     try {
       await db.sync_outbox.clear();
@@ -441,7 +605,17 @@ async function runPurge(): Promise<void> {
   }
 }
 
-export async function deleteOutboxByObjectId(objectId: string): Promise<void> {
+export async function deleteOutboxByObjectId(
+  objectId: string,
+  options?: {
+    /**
+     * Used only by an HTTP result being applied from inside this object's
+     * active drain. Waiting for that drain here would await the current
+     * promise and deadlock the version-reset path.
+     */
+    skipActiveDrain?: boolean;
+  }
+): Promise<void> {
   // Synchronously suppress any in-flight drain iteration for this objectId
   // BEFORE yielding to the event loop. A drain that has already read records
   // into memory checks this set just before sending, so a concurrent discard
@@ -456,7 +630,7 @@ export async function deleteOutboxByObjectId(objectId: string): Promise<void> {
     // we guarantee no further stale sends can fire.
     const existingDrain = draining.get(objectId);
 
-    if (existingDrain) {
+    if (existingDrain && !options?.skipActiveDrain) {
       await existingDrain.catch(() => undefined);
     }
 
@@ -484,6 +658,12 @@ export async function deleteOutboxByObjectId(objectId: string): Promise<void> {
     }
 
     await db.sync_outbox.where('[userId+workspaceId+objectId]').equals([userId, workspaceId, objectId]).delete();
+    const objectSessionKey = sessionObjectKey(userId, workspaceId, objectId);
+
+    serializedSlowSyncObjects.delete(objectSessionKey);
+    oversizedDiagnostics.delete(objectSessionKey);
+    blockedSlowSyncObjects.delete(objectSessionKey);
+    clearSlowSyncRetry(objectSessionKey);
   } finally {
     suppressedObjects.delete(objectId);
   }
@@ -516,6 +696,226 @@ function buildUpdateMessage(
       } as collab.IUpdate,
     },
   };
+}
+
+function validByteLimit(value: number | undefined): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) && value > 0 ? Math.floor(value) : undefined;
+}
+
+function realtimeByteLimit(value: number | undefined): number | undefined {
+  // The protocol's established frame limit protects older servers that omit
+  // the optional field. A server can explicitly advertise 0 to opt out.
+  if (value === 0) return undefined;
+
+  return validByteLimit(value) ?? DEFAULT_REALTIME_UPDATE_BYTES;
+}
+
+function exceedsRealtimeLimit(payloadBytes: number, maxUpdateBytes: number | undefined): boolean {
+  const limit = realtimeByteLimit(maxUpdateBytes);
+
+  return limit !== undefined && payloadBytes > limit;
+}
+
+async function readOutboxPrefix(userId: string, workspaceId: string, objectId: string): Promise<SyncOutboxRecord[]> {
+  // The four-part index is naturally ordered by the auto-incremented id. A
+  // fixed prefix bound prevents one long-offline object from being read into
+  // memory in a single drain iteration.
+  return db.sync_outbox
+    .where('[userId+workspaceId+objectId+id]')
+    .between([userId, workspaceId, objectId, BaseDexie.minKey], [userId, workspaceId, objectId, BaseDexie.maxKey])
+    .limit(OUTBOX_READ_BATCH_SIZE)
+    .toArray();
+}
+
+function mergeRecordPrefix(records: SyncOutboxRecord[], count = records.length): Uint8Array {
+  if (count === 1) return records[0].payload;
+
+  return Y.mergeUpdates(records.slice(0, count).map((record) => record.payload));
+}
+
+function selectRecordsForRealtime(
+  records: SyncOutboxRecord[],
+  limit: number | undefined
+): { records: SyncOutboxRecord[]; merged: Uint8Array } {
+  if (limit === undefined) {
+    return { records, merged: mergeRecordPrefix(records) };
+  }
+
+  // Conservatively budget by raw bytes, then merge once. If encoding overhead
+  // still crosses the cap, halve the bounded prefix rather than repeatedly
+  // merging every growing prefix (the old quadratic path).
+  let count = 0;
+  let rawBytes = 0;
+
+  for (const record of records) {
+    if (count > 0 && rawBytes + record.payload.byteLength > limit) break;
+    rawBytes += record.payload.byteLength;
+    count += 1;
+  }
+
+  count = Math.max(1, count);
+  let merged = mergeRecordPrefix(records, count);
+
+  while (count > 1 && merged.byteLength > limit) {
+    count = Math.max(1, Math.floor(count / 2));
+    merged = mergeRecordPrefix(records, count);
+  }
+
+  return { records: records.slice(0, count), merged };
+}
+
+function selectRecordsForSlowSync(
+  records: SyncOutboxRecord[],
+  limit: number
+): { records: SyncOutboxRecord[]; merged: Uint8Array; stateVector: Uint8Array } {
+  // Server-info advertises the raw doc_state cap. The state vector has its own
+  // server-side bound, so charging it against this limit would reject a valid
+  // update whose doc_state is exactly at the advertised maximum.
+  const buildCandidate = (count: number) => {
+    const merged = mergeRecordPrefix(records, count);
+    const stateVector = postUpdateStateVector(records[0].beforeStateVector, merged);
+
+    return {
+      records: records.slice(0, count),
+      merged,
+      stateVector,
+    };
+  };
+
+  const wholePrefix = buildCandidate(records.length);
+
+  if (wholePrefix.merged.byteLength <= limit || records.length === 1) {
+    return wholePrefix;
+  }
+
+  // The prefix is bounded by OUTBOX_READ_BATCH_SIZE. Binary search gives us a
+  // near-maximal request with O(log n) merges instead of O(n) successively
+  // larger merges that repeatedly reparse the same Yjs structs.
+  let low = 1;
+  let high = records.length - 1;
+  let best = buildCandidate(1);
+
+  while (low <= high) {
+    const midpoint = Math.floor((low + high) / 2);
+    const candidate = buildCandidate(midpoint);
+
+    if (candidate.merged.byteLength <= limit) {
+      best = candidate;
+      low = midpoint + 1;
+    } else {
+      high = midpoint - 1;
+    }
+  }
+
+  return best;
+}
+
+function recordIds(records: SyncOutboxRecord[]): number[] {
+  return records.map((record) => record.id).filter((id): id is number => id !== undefined);
+}
+
+function postUpdateStateVector(beforeStateVector: Uint8Array | undefined, update: Uint8Array): Uint8Array {
+  const state = beforeStateVector?.byteLength ? Y.decodeStateVector(beforeStateVector) : new Map<number, number>();
+  // encodeStateVectorFromUpdate omits clients whose structs start at a
+  // non-zero clock. parseUpdateMeta().to contains the actual post-update clock
+  // for both full snapshots and incremental updates.
+  const updateState = Y.parseUpdateMeta(update).to;
+
+  for (const [clientId, clock] of updateState) {
+    state.set(clientId, Math.max(state.get(clientId) ?? 0, clock));
+  }
+
+  return Y.encodeStateVector(state);
+}
+
+function clearSlowSyncRetry(objectSessionKey: string) {
+  const timer = slowSyncRetryTimers.get(objectSessionKey);
+
+  if (timer) clearTimeout(timer);
+  slowSyncRetryTimers.delete(objectSessionKey);
+  slowSyncRetryAttempts.delete(objectSessionKey);
+}
+
+function clearAllSlowSyncRetries() {
+  for (const timer of slowSyncRetryTimers.values()) {
+    clearTimeout(timer);
+  }
+
+  slowSyncRetryTimers.clear();
+  slowSyncRetryAttempts.clear();
+}
+
+function scheduleSlowSyncRetry(userId: string, workspaceId: string, objectId: string, retryAfterSecs?: number) {
+  const objectSessionKey = sessionObjectKey(userId, workspaceId, objectId);
+
+  if (slowSyncRetryTimers.has(objectSessionKey)) return;
+
+  const attempt = slowSyncRetryAttempts.get(objectSessionKey) ?? 0;
+  const advertisedDelay =
+    typeof retryAfterSecs === 'number' && Number.isFinite(retryAfterSecs) && retryAfterSecs > 0
+      ? Math.ceil(retryAfterSecs * 1_000)
+      : undefined;
+  const delay = advertisedDelay ?? SLOW_SYNC_RETRY_DELAYS_MS[Math.min(attempt, SLOW_SYNC_RETRY_DELAYS_MS.length - 1)];
+
+  slowSyncRetryAttempts.set(objectSessionKey, attempt + 1);
+  slowSyncRetryTimers.set(
+    objectSessionKey,
+    setTimeout(() => {
+      slowSyncRetryTimers.delete(objectSessionKey);
+      const config = drainConfig;
+
+      if (!config || config.userId !== userId || config.workspaceId !== workspaceId) return;
+      scheduleDrain(objectId);
+    }, delay)
+  );
+}
+
+async function runSlowSyncSerialized<T>(task: () => Promise<T>): Promise<T> {
+  const previous = slowSyncQueue;
+  let release!: () => void;
+
+  slowSyncQueue = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+
+  await previous.catch(() => undefined);
+
+  try {
+    return await task();
+  } finally {
+    release();
+  }
+}
+
+async function runSlowSyncCoordinated<T>(userId: string, workspaceId: string, task: () => Promise<T>): Promise<T> {
+  const lockManager = globalThis.navigator?.locks;
+
+  if (lockManager) {
+    const lockName = `${SLOW_SYNC_LOCK_PREFIX}:${userId}:${workspaceId}`;
+
+    return lockManager.request(lockName, { mode: 'exclusive' }, task);
+  }
+
+  return runSlowSyncSerialized(task);
+}
+
+function retryAfterSecsFromError(error: unknown): number | undefined {
+  const retryAfterSecs = (error as { retryAfterSecs?: unknown })?.retryAfterSecs;
+
+  return typeof retryAfterSecs === 'number' && Number.isFinite(retryAfterSecs) && retryAfterSecs > 0
+    ? retryAfterSecs
+    : undefined;
+}
+
+function sameDrainSession(left: DrainConfig | null, right: DrainConfig | null): boolean {
+  return Boolean(left && right && left.userId === right.userId && left.workspaceId === right.workspaceId);
+}
+
+function logOversizedOnce(objectSessionKey: string, reason: string, details: Record<string, unknown>) {
+  if (oversizedDiagnostics.get(objectSessionKey) === reason) return;
+
+  oversizedDiagnostics.set(objectSessionKey, reason);
+  Log.warn('[outbox] oversized update remains durable', { reason, ...details });
 }
 
 function scheduleDrain(objectId: string) {
@@ -562,11 +962,10 @@ async function drainObject(objectId: string): Promise<void> {
   }
 }
 
-// Cross-tab ownership lives in AppSyncLayer: only the WebSocket leader exposes
-// an OPEN drain transport, and followers wake it after their IndexedDB add is
-// durable. Keeping locks out of this low-level loop avoids the old `ifAvailable`
-// failure mode that silently skipped work. Browsers without coordinated socket
-// ownership retain the safe idempotent duplicate-send fallback.
+// Cross-tab ownership keeps ordinary WebSocket draining on one leader. The
+// oversized HTTP path additionally takes a blocking workspace lock because a
+// leader handoff can otherwise upload the same multi-megabyte IndexedDB prefix
+// twice. Browsers without Web Locks retain the server-idempotent fallback.
 
 async function drainObjectWhileReady(objectId: string): Promise<void> {
   // Snapshot the drain config at loop entry. If the user switches workspace
@@ -577,45 +976,156 @@ async function drainObjectWhileReady(objectId: string): Promise<void> {
   // eslint-disable-next-line no-constant-condition
   for (;;) {
     // Re-read the module config each iteration and abort if it has been
-    // swapped out (workspace change / sign-out) or is not ready (WS closed).
+    // swapped out (workspace change / sign-out).
     const config = drainConfig;
 
     if (!config || config !== initialConfig) return;
 
-    if (!config.isReady()) return;
-
     const userId = config.userId;
     const workspaceId = config.workspaceId;
-    const records = await db.sync_outbox
-      .where('[userId+workspaceId+objectId]')
-      .equals([userId, workspaceId, objectId])
-      .sortBy('id');
+    const objectSessionKey = sessionObjectKey(userId, workspaceId, objectId);
 
-    if (records.length === 0) return;
+    if (slowSyncRetryTimers.has(objectSessionKey)) return;
+    if (blockedSlowSyncObjects.has(objectSessionKey)) return;
 
-    // Records are sorted by id (insertion order), so first/last bound the batch.
+    const records = await readOutboxPrefix(userId, workspaceId, objectId);
+
+    if (records.length === 0) {
+      serializedSlowSyncObjects.delete(objectSessionKey);
+      clearSlowSyncRetry(objectSessionKey);
+      return;
+    }
+
+    const realtimeLimit = realtimeByteLimit(config.maxUpdateBytes);
     const firstRecord = records[0];
-    const lastRecord = records[records.length - 1];
+    // A backlog of individually valid updates must stay on the realtime lane
+    // in bounded prefixes. Only an atomic head update that can never fit the
+    // WebSocket frame needs the slow HTTP lane.
+    const useSlowLane = realtimeLimit !== undefined && firstRecord.payload.byteLength > realtimeLimit;
 
-    const merged = records.length === 1 ? firstRecord.payload : Y.mergeUpdates(records.map((r) => r.payload));
-    const collabType = lastRecord.collabType as Types;
-    const version = lastRecord.version;
-    // The merged payload spans from the first queued edit to the last, so its
-    // causal `before` is the first record's before-vector.
-    const beforeStateVector = firstRecord.beforeStateVector;
+    if (useSlowLane) {
+      serializedSlowSyncObjects.add(objectSessionKey);
+      const slowLimit =
+        config.syncLimitsLoaded === false ? undefined : validByteLimit(config.maxSlowSyncUpdateBytes);
 
-    const message: messages.IMessage = {
-      collabMessage: {
-        objectId,
-        collabType,
-        update: {
-          flags: FLAGS_LIB0V1,
-          payload: merged,
-          version: version ?? undefined,
-          beforeStateVector,
-        } as collab.IUpdate,
-      },
-    };
+      if (!slowLimit || !config.slowSync) {
+        logOversizedOnce(objectSessionKey, !slowLimit ? 'slow_lane_not_advertised' : 'slow_lane_not_owned_by_this_tab', {
+          objectId,
+          payloadBytes: firstRecord.payload.byteLength,
+          maxUpdateBytes: realtimeLimit,
+          maxSlowSyncUpdateBytes: slowLimit,
+        });
+        return;
+      }
+
+      try {
+        const coordinated = await runSlowSyncCoordinated(userId, workspaceId, async () => {
+          if (suppressedObjects.has(objectId) || !sameDrainSession(drainConfig, initialConfig) || isPurging) {
+            return { status: 'aborted' as const };
+          }
+
+          // Another tab may have completed the prefix while this tab waited
+          // for the lock. Re-read and select under the lock so the upload and
+          // its exact-ID retirement operate on one authoritative snapshot.
+          const lockedRecords = await readOutboxPrefix(userId, workspaceId, objectId);
+
+          if (suppressedObjects.has(objectId) || !sameDrainSession(drainConfig, initialConfig) || isPurging) {
+            return { status: 'aborted' as const };
+          }
+
+          if (lockedRecords.length === 0) {
+            return { status: 'rescan' as const };
+          }
+
+          const lockedFirstRecord = lockedRecords[0];
+          const lockedHeadNeedsSlowLane =
+            realtimeLimit !== undefined && lockedFirstRecord.payload.byteLength > realtimeLimit;
+
+          if (!lockedHeadNeedsSlowLane) {
+            return { status: 'rescan' as const };
+          }
+
+          const lockedBatch = selectRecordsForSlowSync(lockedRecords, slowLimit);
+
+          if (lockedBatch.merged.byteLength > slowLimit) {
+            logOversizedOnce(objectSessionKey, 'update_exceeds_slow_lane_limit', {
+              objectId,
+              payloadBytes: lockedBatch.merged.byteLength,
+              stateVectorBytes: lockedBatch.stateVector.byteLength,
+              maxUpdateBytes: realtimeLimit,
+              maxSlowSyncUpdateBytes: slowLimit,
+            });
+            return { status: 'stalled' as const };
+          }
+
+          const lockedLastRecord = lockedBatch.records[lockedBatch.records.length - 1];
+          const lockedIds = recordIds(lockedBatch.records);
+          const result = await config.slowSync!({
+            objectId,
+            collabType: lockedLastRecord.collabType as Types,
+            version: lockedLastRecord.version,
+            stateVector: lockedBatch.stateVector,
+            docState: lockedBatch.merged,
+          });
+
+          if (result.outcome === 'blocked') {
+            return {
+              status: 'blocked' as const,
+              reason: result.reason,
+              recordCount: lockedIds.length,
+              payloadBytes: lockedBatch.merged.byteLength,
+            };
+          }
+
+          if (suppressedObjects.has(objectId) || !sameDrainSession(drainConfig, initialConfig) || isPurging) {
+            return { status: 'aborted' as const };
+          }
+
+          // Keep retirement inside the same lock as the upload. A successor
+          // tab therefore observes either the old prefix (and waits) or the
+          // post-confirmation state, never the stale in-between snapshot.
+          await db.sync_outbox.bulkDelete(lockedIds);
+          return { status: 'confirmed' as const };
+        });
+
+        if (coordinated.status === 'aborted' || coordinated.status === 'stalled') return;
+        if (coordinated.status === 'rescan') continue;
+        if (coordinated.status === 'blocked') {
+          blockedSlowSyncObjects.set(objectSessionKey, coordinated.reason);
+          logOversizedOnce(objectSessionKey, coordinated.reason, {
+            objectId,
+            recordCount: coordinated.recordCount,
+            payloadBytes: coordinated.payloadBytes,
+          });
+          return;
+        }
+      } catch (error) {
+        Log.warn('[outbox] HTTP slow-sync transaction failed; leaving records queued', {
+          objectId,
+          headPayloadBytes: firstRecord.payload.byteLength,
+          error,
+        });
+        scheduleSlowSyncRetry(userId, workspaceId, objectId, retryAfterSecsFromError(error));
+        return;
+      }
+
+      clearSlowSyncRetry(objectSessionKey);
+      oversizedDiagnostics.delete(objectSessionKey);
+      blockedSlowSyncObjects.delete(objectSessionKey);
+      continue;
+    }
+
+    if (!config.isReady()) return;
+
+    const realtimeBatch = selectRecordsForRealtime(records, realtimeLimit);
+    const lastRecord = realtimeBatch.records[realtimeBatch.records.length - 1];
+    const message = buildUpdateMessage({
+      objectId,
+      collabType: lastRecord.collabType,
+      payload: realtimeBatch.merged,
+      version: lastRecord.version,
+      beforeStateVector: firstRecord.beforeStateVector,
+    });
 
     // Synchronous gate right before the send. Abort if a discard is in
     // progress for this objectId, the drain config has been swapped out
@@ -633,7 +1143,7 @@ async function drainObjectWhileReady(objectId: string): Promise<void> {
       return;
     }
 
-    const ids = records.map((r) => r.id).filter((id): id is number => id !== undefined);
+    const ids = recordIds(realtimeBatch.records);
 
     try {
       await db.sync_outbox.bulkDelete(ids);

--- a/src/application/sync-outbox/index.ts
+++ b/src/application/sync-outbox/index.ts
@@ -15,6 +15,11 @@ export type OutboxSender = (message: messages.IMessage) => void;
 
 export type OutboxReady = () => boolean;
 
+export interface SyncOutboxSession {
+  userId: string;
+  workspaceId: string;
+}
+
 export interface SlowSyncOutboxItem {
   objectId: string;
   collabType: Types;
@@ -24,6 +29,8 @@ export interface SlowSyncOutboxItem {
 }
 
 export type SlowSyncBlockedReason = 'permission_denied' | 'update_too_large';
+
+type SlowSyncBlock = { reason: 'permission_denied' } | { reason: 'update_too_large'; recordIds: number[] };
 
 export type SlowSyncOutboxResult =
   | {
@@ -66,14 +73,12 @@ interface DrainConfig {
    * its conservative legacy limit; the HTTP slow lane remains disabled.
    */
   syncLimitsLoaded?: boolean;
-  /** Cancels an in-flight slow request before logout waits for drains. */
-  abortSlowSync?: () => void;
   /**
    * Persists one oversized object through the authenticated HTTP full-sync
    * endpoint. Confirmation requires a durable RID unless an authoritative
    * collab-version change supersedes the queued update.
    */
-  slowSync?: (item: SlowSyncOutboxItem) => Promise<SlowSyncOutboxResult>;
+  slowSync?: (item: SlowSyncOutboxItem, signal: AbortSignal) => Promise<SlowSyncOutboxResult>;
 }
 
 let drainConfig: DrainConfig | null = null;
@@ -85,8 +90,9 @@ const draining = new Map<string, Promise<void>>();
 const slowSyncRetryTimers = new Map<string, ReturnType<typeof setTimeout>>();
 const slowSyncRetryAttempts = new Map<string, number>();
 const oversizedDiagnostics = new Map<string, string>();
-const blockedSlowSyncObjects = new Map<string, SlowSyncBlockedReason>();
+const blockedSlowSyncObjects = new Map<string, SlowSyncBlock>();
 const serializedSlowSyncObjects = new Set<string>();
+const slowSyncAbortControllers = new Map<string, AbortController>();
 let slowSyncQueue: Promise<void> = Promise.resolve();
 // Object ids whose records were enqueued while a drain was already in flight.
 // Processed in the drain's finally block so the race between the drain loop's
@@ -96,9 +102,9 @@ const pendingRerun = new Set<string>();
 // `discardPendingUpdates()` await these before proceeding so a record whose
 // IDB write is still pending cannot be missed by a flush or survive a discard.
 const inflightAdds = new Map<string, Set<Promise<unknown>>>();
-// Object ids currently being discarded. A drain loop that has already loaded
-// records for one of these into memory must abort before sending — otherwise a
-// pre-reset edit can slip through after `discardPendingUpdates()` resolves.
+// Session-object keys currently being discarded. Scoping suppression prevents
+// stale async cleanup from workspace A from dropping edits in workspace B.
+// A drain loop that already loaded records must abort before sending.
 const suppressedObjects = new Set<string>();
 // When `purgeAllOutbox` is running, both new enqueues and new drain iterations
 // are blocked so we can quiesce the outbox across a logout boundary without
@@ -123,6 +129,8 @@ const SLOW_SYNC_LOCK_PREFIX = 'appflowy:sync-outbox:slow';
 interface EnqueueOutboxOptions {
   /** Manifest replies are server-directed and do not need sibling-tab fan-out. */
   broadcast?: boolean;
+  /** Coalesce older server-directed manifests without touching local edits. */
+  source?: 'manifest';
 }
 
 function sessionObjectKey(userId: string, workspaceId: string, objectId: string): string {
@@ -154,15 +162,28 @@ export function setCurrentSession(session: { userId: string; workspaceId: string
   currentWorkspaceId = nextWorkspaceId;
 }
 
+/**
+ * Capture the session that owns newly enqueued records. Passing an expected
+ * workspace prevents async work from accidentally snapshotting a replacement
+ * workspace during a route/session transition.
+ */
+export function getCurrentOutboxSession(expectedWorkspaceId?: string): SyncOutboxSession | null {
+  if (!currentUserId || !currentWorkspaceId) return null;
+  if (expectedWorkspaceId && currentWorkspaceId !== expectedWorkspaceId) return null;
+
+  return { userId: currentUserId, workspaceId: currentWorkspaceId };
+}
+
+/** Resolves true only after the update has been written to IndexedDB. */
 export function enqueueOutboxUpdate(
-  record: Omit<SyncOutboxRecord, 'id' | 'createdAt' | 'workspaceId' | 'userId'>,
+  record: Omit<SyncOutboxRecord, 'id' | 'createdAt' | 'workspaceId' | 'userId' | 'source'>,
   options?: EnqueueOutboxOptions
-) {
+): Promise<boolean> {
   if (isPurging) {
     // Logout / session-change in progress — drop. A new session will
     // re-enqueue any genuinely-pending edits through its own lifecycle.
     Log.debug('[outbox] enqueue dropped: purge in progress', { objectId: record.objectId });
-    return;
+    return Promise.resolve(false);
   }
 
   const userId = currentUserId;
@@ -170,17 +191,19 @@ export function enqueueOutboxUpdate(
 
   if (!userId || !workspaceId) {
     Log.warn('[outbox] enqueue skipped: no session configured', { objectId: record.objectId });
-    return;
+    return Promise.resolve(false);
   }
+
+  const objectSessionKey = sessionObjectKey(userId, workspaceId, record.objectId);
 
   // A discard is in progress for this objectId (version reset / revert).
   // Refuse to add new rows so a local edit landing mid-discard cannot slip
   // past `deleteOutboxByObjectId()`'s inflight-snapshot wait and later drain
   // onto the rebuilt doc. The doc whose observers produced this update is
   // about to be destroyed; the rebuilt doc starts from server state.
-  if (suppressedObjects.has(record.objectId)) {
+  if (suppressedObjects.has(objectSessionKey)) {
     Log.debug('[outbox] enqueue dropped: discard in progress', { objectId: record.objectId });
-    return;
+    return Promise.resolve(false);
   }
 
   const row: Omit<SyncOutboxRecord, 'id'> = {
@@ -188,6 +211,7 @@ export function enqueueOutboxUpdate(
     userId,
     workspaceId,
     createdAt: Date.now(),
+    source: options?.source,
   };
 
   // Fan out to sibling tabs immediately, regardless of WebSocket state. The
@@ -209,14 +233,13 @@ export function enqueueOutboxUpdate(
   // WebSocket.
   const enqueueUserId = userId;
   const enqueueWorkspaceId = workspaceId;
-  const objectSessionKey = sessionObjectKey(userId, workspaceId, record.objectId);
   const isIndividuallyOversized = exceedsRealtimeLimit(record.payload.byteLength, drainConfig?.maxUpdateBytes);
 
   if (isIndividuallyOversized) {
     serializedSlowSyncObjects.add(objectSessionKey);
   }
 
-  const addPromise: Promise<unknown> = db.sync_outbox.add(row as SyncOutboxRecord);
+  const addPromise: Promise<unknown> = persistOutboxRow(row as SyncOutboxRecord);
   const set = inflightAdds.get(record.objectId) ?? new Set<Promise<unknown>>();
   let sentImmediately = false;
   const activeConfig = drainConfig;
@@ -235,7 +258,7 @@ export function enqueueOutboxUpdate(
     activeConfig.workspaceId === enqueueWorkspaceId &&
     !isPurging &&
     discoveredOutboxSessionKey === sessionKey(enqueueUserId, enqueueWorkspaceId) &&
-    !suppressedObjects.has(record.objectId) &&
+    !suppressedObjects.has(objectSessionKey) &&
     !draining.has(record.objectId) &&
     activeConfig.isReady() &&
     !isIndividuallyOversized &&
@@ -252,7 +275,7 @@ export function enqueueOutboxUpdate(
   set.add(addPromise);
   inflightAdds.set(record.objectId, set);
 
-  addPromise
+  return addPromise
     .then(async (id) => {
       try {
         notifyPersisted?.(enqueueWorkspaceId, record.objectId);
@@ -281,15 +304,16 @@ export function enqueueOutboxUpdate(
         // normal drain so those older rows are reconciled instead of waiting
         // for refresh/reconnect.
         scheduleDrain(record.objectId);
-        return;
+        return true;
       }
 
       scheduleDrain(record.objectId);
+      return true;
     })
     .catch(async (error) => {
       if (sentImmediately) {
         Log.warn('[outbox] enqueue failed after immediate send', { objectId: record.objectId, error });
-        return;
+        return false;
       }
 
       Log.error('[outbox] enqueue failed', { objectId: record.objectId, error });
@@ -310,15 +334,15 @@ export function enqueueOutboxUpdate(
           currentUserId: activeConfig?.userId,
           currentWorkspaceId: activeConfig?.workspaceId,
         });
-        return;
+        return false;
       }
 
       // A purge (logout) or version-reset discard started while the IDB write
       // was in flight. The synchronous guard at enqueue time passed, but the
       // state has since changed — drop the fallback to honour the boundary.
-      if (isPurging || suppressedObjects.has(record.objectId)) {
+      if (isPurging || suppressedObjects.has(objectSessionKey)) {
         Log.debug('[outbox] fallback skipped: purge/discard in progress', { objectId: record.objectId });
-        return;
+        return false;
       }
 
       // An update above the realtime limit must never leak onto WebSocket.
@@ -347,7 +371,7 @@ export function enqueueOutboxUpdate(
           // The next manifest can reconstruct the update after storage recovers.
         }
 
-        return;
+        return false;
       }
 
       const directMessage: messages.IMessage = {
@@ -369,7 +393,7 @@ export function enqueueOutboxUpdate(
         Log.warn('[outbox] cannot fall back: no sendBestEffort and WS not OPEN', {
           objectId: record.objectId,
         });
-        return;
+        return false;
       }
 
       try {
@@ -380,6 +404,8 @@ export function enqueueOutboxUpdate(
           error: sendError,
         });
       }
+
+      return false;
     })
     .finally(() => {
       const current = inflightAdds.get(record.objectId);
@@ -392,6 +418,36 @@ export function enqueueOutboxUpdate(
     });
 }
 
+/**
+ * Atomically replace older pending manifest snapshots for one session/object.
+ * IndexedDB serializes read-write transactions across tabs, so concurrent
+ * manifest replies cannot both observe an empty prefix and commit duplicates.
+ */
+async function persistOutboxRow(row: SyncOutboxRecord): Promise<number> {
+  if (row.source !== 'manifest') {
+    return db.sync_outbox.add(row);
+  }
+
+  return db.transaction('rw', db.sync_outbox, async () => {
+    const supersededIds: number[] = [];
+
+    await db.sync_outbox
+      .where('[userId+workspaceId+objectId]')
+      .equals([row.userId, row.workspaceId, row.objectId])
+      .each((pending) => {
+        if (pending.source === 'manifest' && pending.id !== undefined) {
+          supersededIds.push(pending.id);
+        }
+      });
+
+    if (supersededIds.length > 0) {
+      await db.sync_outbox.bulkDelete(supersededIds);
+    }
+
+    return db.sync_outbox.add(row);
+  });
+}
+
 async function awaitInflightAdds(objectId: string): Promise<void> {
   const pending = inflightAdds.get(objectId);
 
@@ -401,6 +457,12 @@ async function awaitInflightAdds(objectId: string): Promise<void> {
 }
 
 export function configureDrain(config: DrainConfig) {
+  const previousConfig = drainConfig;
+
+  if (previousConfig && (previousConfig.userId !== config.userId || previousConfig.workspaceId !== config.workspaceId)) {
+    abortSlowSyncCoordinations(previousConfig.userId, previousConfig.workspaceId);
+  }
+
   // A meaningful owner/capability rebuild is the point at which a previously
   // terminal server decision may have changed (permission grant or larger
   // advertised limit). Ordinary readyState transitions no longer rebuild.
@@ -414,11 +476,32 @@ export function configureDrain(config: DrainConfig) {
 }
 
 export function clearDrainConfig() {
+  const previousConfig = drainConfig;
+
   drainConfig = null;
+  if (previousConfig) {
+    abortSlowSyncCoordinations(previousConfig.userId, previousConfig.workspaceId);
+  }
+
   pendingRerun.clear();
   oversizedDiagnostics.clear();
   // Retry state is session-object keyed and intentionally survives a
   // same-session transport/config rebuild. Purge owns the hard reset.
+}
+
+/** Retry only objects whose slow upload was terminally blocked by access. */
+export function resumePermissionBlockedSync(objectId: string): void {
+  const config = drainConfig;
+
+  if (!config) return;
+
+  const objectSessionKey = sessionObjectKey(config.userId, config.workspaceId, objectId);
+
+  if (blockedSlowSyncObjects.get(objectSessionKey)?.reason !== 'permission_denied') return;
+
+  blockedSlowSyncObjects.delete(objectSessionKey);
+  oversizedDiagnostics.delete(objectSessionKey);
+  scheduleDrain(objectId);
 }
 
 /**
@@ -560,9 +643,8 @@ export function purgeAllOutbox(): Promise<void> {
   // — e.g. from a React render triggered by `SESSION_INVALID` — is dropped
   // before it can add new rows behind the purge.
   isPurging = true;
-  // Abort HTTP before runPurge awaits the active drain; otherwise a slow or
-  // stalled request can delay logout until its transport timeout expires.
-  drainConfig?.abortSlowSync?.();
+  // Abort lock acquisition and HTTP before runPurge awaits active drains.
+  abortSlowSyncCoordinations();
 
   const purge = runPurge();
 
@@ -591,6 +673,7 @@ async function runPurge(): Promise<void> {
     serializedSlowSyncObjects.clear();
     oversizedDiagnostics.clear();
     blockedSlowSyncObjects.clear();
+    slowSyncAbortControllers.clear();
     discoveredOutboxSessionKey = null;
     clearAllSlowSyncRetries();
 
@@ -614,13 +697,29 @@ export async function deleteOutboxByObjectId(
      * promise and deadlock the version-reset path.
      */
     skipActiveDrain?: boolean;
+    /**
+     * Explicit owner for async work that can outlive its originating
+     * workspace. When omitted, the active session is captured at call time.
+     */
+    session?: SyncOutboxSession;
   }
 ): Promise<void> {
-  // Synchronously suppress any in-flight drain iteration for this objectId
-  // BEFORE yielding to the event loop. A drain that has already read records
-  // into memory checks this set just before sending, so a concurrent discard
-  // cannot race past a drain that was already mid-iteration.
-  suppressedObjects.add(objectId);
+  const targetSession = options?.session ?? getCurrentOutboxSession();
+  const userId = targetSession?.userId;
+  const workspaceId = targetSession?.workspaceId;
+
+  if (!userId || !workspaceId) {
+    Log.debug('[outbox] deleteOutboxByObjectId skipped: no session configured', { objectId });
+    return;
+  }
+
+  const objectSessionKey = sessionObjectKey(userId, workspaceId, objectId);
+
+  // Synchronously suppress in-flight work for this exact session/object BEFORE
+  // yielding. A stale cleanup from another workspace must not drop current
+  // edits that happen to use the same object ID.
+  suppressedObjects.add(objectSessionKey);
+  abortSlowSyncCoordination(objectSessionKey);
 
   try {
     // Wait for a drain that's already in flight to finish. New drain iterations
@@ -643,29 +742,14 @@ export async function deleteOutboxByObjectId(
     // to ensure stale rows are gone before rebuilding the doc. Silently
     // resolving here would let a blocked/closing IDB leave stale records that
     // then drain onto the newly rebuilt document.
-    const userId = currentUserId;
-    const workspaceId = currentWorkspaceId;
-
-    if (!userId || !workspaceId) {
-      // No active session — nothing the current user could have enqueued
-      // against this objectId, and the sync_outbox v6 schema only indexes
-      // the compound `[userId+workspaceId+objectId]` key, so there's no
-      // cheap way (and no need) to touch IDB here. Rows from a prior
-      // session are scoped to their own userId and will never drain
-      // against another user's WebSocket.
-      Log.debug('[outbox] deleteOutboxByObjectId skipped: no session configured', { objectId });
-      return;
-    }
-
     await db.sync_outbox.where('[userId+workspaceId+objectId]').equals([userId, workspaceId, objectId]).delete();
-    const objectSessionKey = sessionObjectKey(userId, workspaceId, objectId);
 
     serializedSlowSyncObjects.delete(objectSessionKey);
     oversizedDiagnostics.delete(objectSessionKey);
     blockedSlowSyncObjects.delete(objectSessionKey);
     clearSlowSyncRetry(objectSessionKey);
   } finally {
-    suppressedObjects.delete(objectId);
+    suppressedObjects.delete(objectSessionKey);
   }
 }
 
@@ -870,33 +954,113 @@ function scheduleSlowSyncRetry(userId: string, workspaceId: string, objectId: st
   );
 }
 
-async function runSlowSyncSerialized<T>(task: () => Promise<T>): Promise<T> {
-  const previous = slowSyncQueue;
-  let release!: () => void;
+function abortReason(signal: AbortSignal): unknown {
+  if (signal.reason !== undefined) return signal.reason;
 
-  slowSyncQueue = new Promise<void>((resolve) => {
+  const error = new Error('The operation was aborted');
+
+  error.name = 'AbortError';
+  return error;
+}
+
+function throwIfAborted(signal: AbortSignal): void {
+  if (signal.aborted) throw abortReason(signal);
+}
+
+function isAbortError(error: unknown): boolean {
+  return (error as { name?: unknown })?.name === 'AbortError';
+}
+
+function waitForAbort<T>(promise: Promise<T>, signal: AbortSignal): Promise<T> {
+  if (signal.aborted) return Promise.reject(abortReason(signal));
+
+  return new Promise<T>((resolve, reject) => {
+    const onAbort = () => {
+      reject(abortReason(signal));
+    };
+
+    signal.addEventListener('abort', onAbort, { once: true });
+    promise.then(
+      (value) => {
+        signal.removeEventListener('abort', onAbort);
+        resolve(value);
+      },
+      (error) => {
+        signal.removeEventListener('abort', onAbort);
+        reject(error);
+      }
+    );
+  });
+}
+
+function abortSlowSyncCoordination(objectSessionKey: string): void {
+  slowSyncAbortControllers.get(objectSessionKey)?.abort();
+}
+
+function abortSlowSyncCoordinations(userId?: string, workspaceId?: string): void {
+  const prefix = userId && workspaceId ? `${userId}\u0000${workspaceId}\u0000` : null;
+
+  for (const [key, controller] of slowSyncAbortControllers) {
+    if (!prefix || key.startsWith(prefix)) {
+      controller.abort();
+    }
+  }
+}
+
+async function runSlowSyncSerialized<T>(task: () => Promise<T>, signal: AbortSignal): Promise<T> {
+  const previous = slowSyncQueue.catch(() => undefined);
+  let release!: () => void;
+  const turnComplete = new Promise<void>((resolve) => {
     release = resolve;
   });
 
-  await previous.catch(() => undefined);
+  // Keep the queue chained to its predecessor even if this waiter is aborted;
+  // otherwise a later task could leapfrog the still-active predecessor.
+  slowSyncQueue = previous.then(() => turnComplete);
 
   try {
+    await waitForAbort(previous, signal);
+    throwIfAborted(signal);
     return await task();
   } finally {
     release();
   }
 }
 
-async function runSlowSyncCoordinated<T>(userId: string, workspaceId: string, task: () => Promise<T>): Promise<T> {
-  const lockManager = globalThis.navigator?.locks;
+async function runSlowSyncCoordinated<T>(
+  userId: string,
+  workspaceId: string,
+  objectSessionKey: string,
+  task: (signal: AbortSignal) => Promise<T>
+): Promise<T> {
+  abortSlowSyncCoordination(objectSessionKey);
+  const controller = new AbortController();
 
-  if (lockManager) {
-    const lockName = `${SLOW_SYNC_LOCK_PREFIX}:${userId}:${workspaceId}`;
+  slowSyncAbortControllers.set(objectSessionKey, controller);
 
-    return lockManager.request(lockName, { mode: 'exclusive' }, task);
+  try {
+    const lockManager = globalThis.navigator?.locks;
+
+    if (lockManager) {
+      const lockName = `${SLOW_SYNC_LOCK_PREFIX}:${userId}:${workspaceId}`;
+
+      return await lockManager.request(lockName, { mode: 'exclusive', signal: controller.signal }, () =>
+        task(controller.signal)
+      );
+    }
+
+    return await runSlowSyncSerialized(() => task(controller.signal), controller.signal);
+  } catch (error) {
+    // Axios reports an aborted request as CanceledError rather than
+    // AbortError. Normalize any failure observed after lifecycle cancellation
+    // so teardown does not log it as a transport failure or schedule a retry.
+    if (controller.signal.aborted) throw abortReason(controller.signal);
+    throw error;
+  } finally {
+    if (slowSyncAbortControllers.get(objectSessionKey) === controller) {
+      slowSyncAbortControllers.delete(objectSessionKey);
+    }
   }
-
-  return runSlowSyncSerialized(task);
 }
 
 function retryAfterSecsFromError(error: unknown): number | undefined {
@@ -918,8 +1082,31 @@ function logOversizedOnce(objectSessionKey: string, reason: string, details: Rec
   Log.warn('[outbox] oversized update remains durable', { reason, ...details });
 }
 
+function isSlowSyncBlockedForRecords(objectSessionKey: string, records: SyncOutboxRecord[]): boolean {
+  const block = blockedSlowSyncObjects.get(objectSessionKey);
+
+  if (!block) return false;
+  if (block.reason === 'permission_denied') return true;
+
+  const sameRejectedPrefix =
+    block.recordIds.length > 0 && block.recordIds.every((id, index) => records[index]?.id === id);
+
+  if (sameRejectedPrefix) return true;
+
+  // The rejected record generation was deleted or replaced (for example by a
+  // newer manifest). Re-evaluate the new prefix instead of retaining a stale
+  // object-wide size block.
+  blockedSlowSyncObjects.delete(objectSessionKey);
+  oversizedDiagnostics.delete(objectSessionKey);
+  return false;
+}
+
 function scheduleDrain(objectId: string) {
-  if (!drainConfig) return;
+  const config = drainConfig;
+
+  if (!config) return;
+
+  const objectSessionKey = sessionObjectKey(config.userId, config.workspaceId, objectId);
 
   // Refuse to spawn a drain while a discard or purge is in progress. Without
   // this gate, an in-flight `db.sync_outbox.add()` can resolve mid-discard
@@ -932,7 +1119,7 @@ function scheduleDrain(objectId: string) {
   // Gating at schedule time prevents that drain from ever existing; the
   // row is removed by the pending delete/clear and the scheduling is
   // re-entered normally after the flag flips back off via a fresh enqueue.
-  if (isPurging || suppressedObjects.has(objectId)) return;
+  if (isPurging || suppressedObjects.has(objectSessionKey)) return;
 
   if (draining.has(objectId)) {
     // Another drain is in flight for this objectId. Mark it so the in-flight
@@ -986,7 +1173,6 @@ async function drainObjectWhileReady(objectId: string): Promise<void> {
     const objectSessionKey = sessionObjectKey(userId, workspaceId, objectId);
 
     if (slowSyncRetryTimers.has(objectSessionKey)) return;
-    if (blockedSlowSyncObjects.has(objectSessionKey)) return;
 
     const records = await readOutboxPrefix(userId, workspaceId, objectId);
 
@@ -995,6 +1181,8 @@ async function drainObjectWhileReady(objectId: string): Promise<void> {
       clearSlowSyncRetry(objectSessionKey);
       return;
     }
+
+    if (isSlowSyncBlockedForRecords(objectSessionKey, records)) return;
 
     const realtimeLimit = realtimeByteLimit(config.maxUpdateBytes);
     const firstRecord = records[0];
@@ -1005,8 +1193,7 @@ async function drainObjectWhileReady(objectId: string): Promise<void> {
 
     if (useSlowLane) {
       serializedSlowSyncObjects.add(objectSessionKey);
-      const slowLimit =
-        config.syncLimitsLoaded === false ? undefined : validByteLimit(config.maxSlowSyncUpdateBytes);
+      const slowLimit = config.syncLimitsLoaded === false ? undefined : validByteLimit(config.maxSlowSyncUpdateBytes);
 
       if (!slowLimit || !config.slowSync) {
         logOversizedOnce(objectSessionKey, !slowLimit ? 'slow_lane_not_advertised' : 'slow_lane_not_owned_by_this_tab', {
@@ -1019,8 +1206,8 @@ async function drainObjectWhileReady(objectId: string): Promise<void> {
       }
 
       try {
-        const coordinated = await runSlowSyncCoordinated(userId, workspaceId, async () => {
-          if (suppressedObjects.has(objectId) || !sameDrainSession(drainConfig, initialConfig) || isPurging) {
+        const coordinated = await runSlowSyncCoordinated(userId, workspaceId, objectSessionKey, async (signal) => {
+          if (suppressedObjects.has(objectSessionKey) || !sameDrainSession(drainConfig, initialConfig) || isPurging) {
             return { status: 'aborted' as const };
           }
 
@@ -1029,7 +1216,7 @@ async function drainObjectWhileReady(objectId: string): Promise<void> {
           // its exact-ID retirement operate on one authoritative snapshot.
           const lockedRecords = await readOutboxPrefix(userId, workspaceId, objectId);
 
-          if (suppressedObjects.has(objectId) || !sameDrainSession(drainConfig, initialConfig) || isPurging) {
+          if (suppressedObjects.has(objectSessionKey) || !sameDrainSession(drainConfig, initialConfig) || isPurging) {
             return { status: 'aborted' as const };
           }
 
@@ -1060,24 +1247,28 @@ async function drainObjectWhileReady(objectId: string): Promise<void> {
 
           const lockedLastRecord = lockedBatch.records[lockedBatch.records.length - 1];
           const lockedIds = recordIds(lockedBatch.records);
-          const result = await config.slowSync!({
-            objectId,
-            collabType: lockedLastRecord.collabType as Types,
-            version: lockedLastRecord.version,
-            stateVector: lockedBatch.stateVector,
-            docState: lockedBatch.merged,
-          });
+          const result = await config.slowSync!(
+            {
+              objectId,
+              collabType: lockedLastRecord.collabType as Types,
+              version: lockedLastRecord.version,
+              stateVector: lockedBatch.stateVector,
+              docState: lockedBatch.merged,
+            },
+            signal
+          );
 
           if (result.outcome === 'blocked') {
             return {
               status: 'blocked' as const,
               reason: result.reason,
+              recordIds: lockedIds,
               recordCount: lockedIds.length,
               payloadBytes: lockedBatch.merged.byteLength,
             };
           }
 
-          if (suppressedObjects.has(objectId) || !sameDrainSession(drainConfig, initialConfig) || isPurging) {
+          if (suppressedObjects.has(objectSessionKey) || !sameDrainSession(drainConfig, initialConfig) || isPurging) {
             return { status: 'aborted' as const };
           }
 
@@ -1091,7 +1282,12 @@ async function drainObjectWhileReady(objectId: string): Promise<void> {
         if (coordinated.status === 'aborted' || coordinated.status === 'stalled') return;
         if (coordinated.status === 'rescan') continue;
         if (coordinated.status === 'blocked') {
-          blockedSlowSyncObjects.set(objectSessionKey, coordinated.reason);
+          blockedSlowSyncObjects.set(
+            objectSessionKey,
+            coordinated.reason === 'update_too_large'
+              ? { reason: coordinated.reason, recordIds: coordinated.recordIds }
+              : { reason: coordinated.reason }
+          );
           logOversizedOnce(objectSessionKey, coordinated.reason, {
             objectId,
             recordCount: coordinated.recordCount,
@@ -1100,6 +1296,8 @@ async function drainObjectWhileReady(objectId: string): Promise<void> {
           return;
         }
       } catch (error) {
+        if (isAbortError(error)) return;
+
         Log.warn('[outbox] HTTP slow-sync transaction failed; leaving records queued', {
           objectId,
           headPayloadBytes: firstRecord.payload.byteLength,
@@ -1132,7 +1330,7 @@ async function drainObjectWhileReady(objectId: string): Promise<void> {
     // (workspace change), or a purge is quiescing the outbox (logout).
     // Records stay in IDB (if any still exist after a concurrent delete)
     // and will be picked up by a future drain.
-    if (suppressedObjects.has(objectId) || drainConfig !== initialConfig || isPurging) return;
+    if (suppressedObjects.has(objectSessionKey) || drainConfig !== initialConfig || isPurging) return;
 
     if (!config.isReady()) return;
 

--- a/src/application/view-loader/index.ts
+++ b/src/application/view-loader/index.ts
@@ -149,7 +149,7 @@ async function mergeLegacyDatabaseViewCache(viewId: string, databaseId: string, 
     }
 
     applyYDoc(targetDoc, missingUpdate);
-    enqueueOutboxUpdate({
+    void enqueueOutboxUpdate({
       objectId: databaseId,
       collabType: Types.Database,
       version: targetDoc.version ?? null,

--- a/src/components/app/contexts/AuthInternalContext.ts
+++ b/src/components/app/contexts/AuthInternalContext.ts
@@ -34,6 +34,16 @@ export interface AuthInternalContextType {
   enablePageHistory?: boolean;
   /** Whether server-backed AI features are enabled for this deployment/workspace. */
   aiEnabled?: boolean;
+  /** Maximum raw Yjs update accepted by the realtime WebSocket lane. */
+  maxUpdateBytes?: number;
+  /** Maximum raw Yjs update accepted by the opt-in HTTP slow lane. */
+  maxSlowSyncUpdateBytes?: number;
+  /**
+   * Whether the server-info request that owns the sync limits completed.
+   * `false` is distinct from an older server successfully omitting the
+   * optional limit fields.
+   */
+  syncLimitsLoaded?: boolean;
   /** Switch the active workspace. Triggers full data reload. */
   onChangeWorkspace: (workspaceId: string) => Promise<void>;
   /** Error from loading workspace info — allows consumers to show error/retry UI. */

--- a/src/components/app/layers/AppAuthLayer.tsx
+++ b/src/components/app/layers/AppAuthLayer.tsx
@@ -63,6 +63,9 @@ export const AppAuthLayer: React.FC<AppAuthLayerProps> = ({ children }) => {
   const [workspaceInfoError, setWorkspaceInfoError] = useState<Error | undefined>(undefined);
   const [enablePageHistory, setEnablePageHistory] = useState<boolean | undefined>(undefined);
   const [aiEnabled, setAIEnabled] = useState<boolean | undefined>(false);
+  const [maxUpdateBytes, setMaxUpdateBytes] = useState<number | undefined>(undefined);
+  const [maxSlowSyncUpdateBytes, setMaxSlowSyncUpdateBytes] = useState<number | undefined>(undefined);
+  const [syncLimitsLoaded, setSyncLimitsLoaded] = useState(false);
   const workspaceInfoPromiseRef = useRef<Promise<UserWorkspaceInfo | undefined> | null>(null);
   const workspaceInfoRequestIdRef = useRef(0);
   const pendingWorkspaceChangeRef = useRef<string | null>(null);
@@ -240,19 +243,58 @@ export const AppAuthLayer: React.FC<AppAuthLayerProps> = ({ children }) => {
   // Load user workspace info and server info on mount
   useEffect(() => {
     if (!isAuthenticated) {
+      setMaxUpdateBytes(undefined);
+      setMaxSlowSyncUpdateBytes(undefined);
+      setSyncLimitsLoaded(false);
       return;
     }
 
     void loadUserWorkspaceInfo();
 
-    void AuthService.getServerInfo().then((info) => {
-      setEnablePageHistory(info.enable_page_history);
-      setAIEnabled(info.ai_enabled ?? true);
-    }).catch((e) => {
-      console.error('[AppAuthLayer] Failed to load server info:', e);
-      setEnablePageHistory(true);
-      setAIEnabled(true);
-    });
+    let cancelled = false;
+    let retryTimer: ReturnType<typeof setTimeout> | undefined;
+    let retryAttempt = 0;
+    const serverInfoAbortController = new AbortController();
+
+    const loadServerInfo = () => {
+      void AuthService.getServerInfo(serverInfoAbortController.signal)
+        .then((info) => {
+          if (cancelled) return;
+
+          setEnablePageHistory(info.enable_page_history);
+          setAIEnabled(info.ai_enabled ?? true);
+          setMaxUpdateBytes(info.max_update_bytes);
+          setMaxSlowSyncUpdateBytes(info.max_slow_sync_update_bytes);
+          // A successful response that omits the optional fields is an older
+          // server, not a loading state. The outbox can now safely use its
+          // legacy realtime default while keeping the HTTP slow lane disabled.
+          setSyncLimitsLoaded(true);
+        })
+        .catch((e) => {
+          if (cancelled) return;
+
+          console.error('[AppAuthLayer] Failed to load server info:', e);
+          setEnablePageHistory(true);
+          setAIEnabled(true);
+          setMaxUpdateBytes(undefined);
+          setMaxSlowSyncUpdateBytes(undefined);
+          setSyncLimitsLoaded(false);
+
+          const delayMs = Math.min(30_000, 1_000 * 2 ** retryAttempt);
+
+          retryAttempt += 1;
+          retryTimer = setTimeout(loadServerInfo, delayMs);
+        });
+    };
+
+    setSyncLimitsLoaded(false);
+    loadServerInfo();
+
+    return () => {
+      cancelled = true;
+      serverInfoAbortController.abort();
+      if (retryTimer) clearTimeout(retryTimer);
+    };
   }, [loadUserWorkspaceInfo, isAuthenticated]);
 
   // If the app boots while the server is down, the first workspace-info request
@@ -338,11 +380,26 @@ export const AppAuthLayer: React.FC<AppAuthLayerProps> = ({ children }) => {
       isAuthenticated: !!isAuthenticated,
       enablePageHistory,
       aiEnabled,
+      maxUpdateBytes,
+      maxSlowSyncUpdateBytes,
+      syncLimitsLoaded,
       onChangeWorkspace,
       workspaceInfoError,
       retryLoadWorkspaceInfo,
     }),
-    [userWorkspaceInfo, currentWorkspaceId, isAuthenticated, enablePageHistory, aiEnabled, onChangeWorkspace, workspaceInfoError, retryLoadWorkspaceInfo]
+    [
+      userWorkspaceInfo,
+      currentWorkspaceId,
+      isAuthenticated,
+      enablePageHistory,
+      aiEnabled,
+      maxUpdateBytes,
+      maxSlowSyncUpdateBytes,
+      syncLimitsLoaded,
+      onChangeWorkspace,
+      workspaceInfoError,
+      retryLoadWorkspaceInfo,
+    ]
   );
 
   return <AuthInternalContext.Provider value={authContextValue}>{children}</AuthInternalContext.Provider>;

--- a/src/components/app/layers/AppAuthLayer.tsx
+++ b/src/components/app/layers/AppAuthLayer.tsx
@@ -1,8 +1,8 @@
 import React, { useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
 import { useLocation, useNavigate, useParams } from 'react-router-dom';
 
-import { invalidToken, isTokenValid } from '@/application/session/token';
 import { AuthService, UserService, WorkspaceService } from '@/application/services/domains';
+import { invalidToken, isTokenValid } from '@/application/session/token';
 import { UserWorkspaceInfo } from '@/application/types';
 import { determineErrorType, ErrorType } from '@/application/utils/error-utils';
 import { AFConfigContext } from '@/components/main/app.hooks';

--- a/src/components/app/layers/AppSyncLayer.tsx
+++ b/src/components/app/layers/AppSyncLayer.tsx
@@ -55,6 +55,16 @@ function hasDurableMessageId(result: CollabFullSyncBatchResult): boolean {
   return Boolean(result.messageId && Number(result.messageId.timestamp ?? 0) > 0);
 }
 
+function throwIfAborted(signal: AbortSignal): void {
+  if (!signal.aborted) return;
+  if (signal.reason !== undefined) throw signal.reason;
+
+  const error = new Error('The operation was aborted');
+
+  error.name = 'AbortError';
+  throw error;
+}
+
 function isAuthoritativeVersionChange(
   result: CollabFullSyncBatchResult,
   requestedVersion: string | null | undefined
@@ -202,8 +212,12 @@ export const AppSyncLayer: FC<AppSyncLayerProps> = ({ children }) => {
             }
           )
         );
-      const applyResult = (result: CollabFullSyncBatchResult) =>
-        applyHttpFullSyncResult(
+      const applyResult = async (result: CollabFullSyncBatchResult) => {
+        // Axios cannot cancel a response that has already resolved. Recheck
+        // the outbox lifecycle at the last possible point before enqueueing,
+        // then carry the same signal through the per-object apply queue.
+        throwIfAborted(signal);
+        await applyHttpFullSyncResult(
           {
             objectId: result.objectId,
             collabType: result.collabType,
@@ -212,8 +226,11 @@ export const AppSyncLayer: FC<AppSyncLayerProps> = ({ children }) => {
             collabVersion: result.collabVersion,
             messageId: result.messageId,
           },
-          item.version
+          item.version,
+          signal
         );
+        throwIfAborted(signal);
+      };
 
       // Pull server-side changes through the ordinary lightweight lane before
       // attempting the oversized upload. A state-vector match is not proof
@@ -248,6 +265,24 @@ export const AppSyncLayer: FC<AppSyncLayerProps> = ({ children }) => {
       return { outcome: 'confirmed' as const, messageId: uploaded.messageId };
     },
     [applyHttpFullSyncResult, currentWorkspaceId]
+  );
+
+  // `clearDrainConfig` aborts in-flight oversized uploads, so anything in the
+  // configuration effect's dep array can kill a multi-MB request mid-flight.
+  // `slowSync`'s identity is derived through five useCallback hops
+  // (applyHttpFullSyncResult -> enqueueIncomingCollabMessage -> ... ->
+  // registerSyncContext), all stable today but not enforced by anything. Route
+  // it through a latest-ref so the drain rebuilds only when ownership actually
+  // changes (user, workspace, leadership, advertised limits).
+  const slowSyncRef = useRef(slowSync);
+
+  useLayoutEffect(() => {
+    slowSyncRef.current = slowSync;
+  }, [slowSync]);
+
+  const stableSlowSync = useCallback(
+    (item: SlowSyncOutboxItem, signal: AbortSignal) => slowSyncRef.current(item, signal),
+    []
   );
 
   useLayoutEffect(() => {
@@ -300,7 +335,7 @@ export const AppSyncLayer: FC<AppSyncLayerProps> = ({ children }) => {
       // IndexedDB is shared by sibling tabs. Only the elected socket owner
       // may run the global low-concurrency HTTP lane; followers persist and
       // wake that owner through onPersisted.
-      slowSync: syncLimitsLoaded && canSendToServer ? slowSync : undefined,
+      slowSync: syncLimitsLoaded && canSendToServer ? stableSlowSync : undefined,
     });
 
     return () => {
@@ -317,25 +352,32 @@ export const AppSyncLayer: FC<AppSyncLayerProps> = ({ children }) => {
     maxUpdateBytes,
     maxSlowSyncUpdateBytes,
     syncLimitsLoaded,
-    slowSync,
+    stableSlowSync,
   ]);
 
   // Transport readiness only wakes the already-configured drain. Keeping it
   // out of the configuration effect avoids aborting slow HTTP work and
   // resetting retry state on every CONNECTING/OPEN/CLOSED transition.
+  //
+  // The wake key is a dep the effect body does not read: every value in it can
+  // make a previously undrainable record drainable, so the drain must be poked
+  // when any of them changes. Keeping them in one named key stops
+  // `react-hooks/exhaustive-deps` autofix from silently stripping them as
+  // unused.
+  const drainWakeKey = [
+    currentUserId,
+    currentWorkspaceId,
+    maxUpdateBytes,
+    maxSlowSyncUpdateBytes,
+    syncLimitsLoaded,
+    wsReadyState,
+  ].join('|');
+
   useEffect(() => {
     if (canSendToServer) {
       startDrainAll();
     }
-  }, [
-    canSendToServer,
-    currentUserId,
-    currentWorkspaceId,
-    maxSlowSyncUpdateBytes,
-    maxUpdateBytes,
-    syncLimitsLoaded,
-    wsReadyState,
-  ]);
+  }, [canSendToServer, drainWakeKey]);
 
   // Access changes do not rebuild the transport configuration. Wake only a
   // permission-blocked object so a restored grant can retry immediately,

--- a/src/components/app/layers/AppSyncLayer.tsx
+++ b/src/components/app/layers/AppSyncLayer.tsx
@@ -6,11 +6,17 @@ import { Awareness } from 'y-protocols/awareness';
 import { APP_EVENTS } from '@/application/constants';
 import { db } from '@/application/db';
 import { CollabService, UserService } from '@/application/services/domains';
-import { collabFullSyncBatch, type CollabFullSyncBatchResult } from '@/application/services/js-services/http/collab-api';
+import {
+  collabFullSyncBatch,
+  getSlowSyncUploadTimeoutMs,
+  SLOW_SYNC_PROBE_TIMEOUT_MS,
+  type CollabFullSyncBatchResult,
+} from '@/application/services/js-services/http/collab-api';
 import { getTokenParsed } from '@/application/session/token';
 import {
   clearDrainConfig,
   configureDrain,
+  resumePermissionBlockedSync,
   setCurrentSession,
   type SlowSyncBlockedReason,
   type SlowSyncOutboxItem,
@@ -186,7 +192,14 @@ export const AppSyncLayer: FC<AppSyncLayerProps> = ({ children }) => {
                 collabVersion: item.version,
               },
             ],
-            { syncLane, signal }
+            {
+              syncLane,
+              signal,
+              timeoutMs:
+                syncLane === 'slow'
+                  ? getSlowSyncUploadTimeoutMs(item.stateVector.byteLength + docState.byteLength)
+                  : SLOW_SYNC_PROBE_TIMEOUT_MS,
+            }
           )
         );
       const applyResult = (result: CollabFullSyncBatchResult) =>
@@ -237,7 +250,7 @@ export const AppSyncLayer: FC<AppSyncLayerProps> = ({ children }) => {
     [applyHttpFullSyncResult, currentWorkspaceId]
   );
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (currentUserId && currentWorkspaceId) {
       setCurrentSession({ userId: currentUserId, workspaceId: currentWorkspaceId });
     } else {
@@ -253,8 +266,6 @@ export const AppSyncLayer: FC<AppSyncLayerProps> = ({ children }) => {
 
   useEffect(() => {
     if (!currentWorkspaceId || !currentUserId) return;
-
-    const slowSyncAbortController = new AbortController();
 
     configureDrain({
       userId: currentUserId,
@@ -286,16 +297,13 @@ export const AppSyncLayer: FC<AppSyncLayerProps> = ({ children }) => {
       maxUpdateBytes,
       maxSlowSyncUpdateBytes,
       syncLimitsLoaded,
-      abortSlowSync: () => slowSyncAbortController.abort(),
       // IndexedDB is shared by sibling tabs. Only the elected socket owner
       // may run the global low-concurrency HTTP lane; followers persist and
       // wake that owner through onPersisted.
-      slowSync:
-        syncLimitsLoaded && canSendToServer ? (item) => slowSync(item, slowSyncAbortController.signal) : undefined,
+      slowSync: syncLimitsLoaded && canSendToServer ? slowSync : undefined,
     });
 
     return () => {
-      slowSyncAbortController.abort();
       clearDrainConfig();
     };
   }, [
@@ -328,6 +336,23 @@ export const AppSyncLayer: FC<AppSyncLayerProps> = ({ children }) => {
     syncLimitsLoaded,
     wsReadyState,
   ]);
+
+  // Access changes do not rebuild the transport configuration. Wake only a
+  // permission-blocked object so a restored grant can retry immediately,
+  // while update-too-large blocks remain terminal until limits change.
+  useEffect(() => {
+    const handlePermissionChange = (permissionChange: notification.IPermissionChanged) => {
+      if (permissionChange.objectId) {
+        resumePermissionBlockedSync(permissionChange.objectId);
+      }
+    };
+
+    eventEmitter.on(APP_EVENTS.PERMISSION_CHANGED, handlePermissionChange);
+
+    return () => {
+      eventEmitter.off(APP_EVENTS.PERMISSION_CHANGED, handlePermissionChange);
+    };
+  }, [eventEmitter]);
 
   // Handle user profile change notifications
   // This provides automatic UI updates when user profile changes occur via WebSocket.

--- a/src/components/app/layers/AppSyncLayer.tsx
+++ b/src/components/app/layers/AppSyncLayer.tsx
@@ -1,13 +1,21 @@
 import EventEmitter from 'events';
 
-import { type FC, type ReactNode, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import { type FC, type ReactNode, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { Awareness } from 'y-protocols/awareness';
 
 import { APP_EVENTS } from '@/application/constants';
 import { db } from '@/application/db';
 import { CollabService, UserService } from '@/application/services/domains';
+import { collabFullSyncBatch, type CollabFullSyncBatchResult } from '@/application/services/js-services/http/collab-api';
 import { getTokenParsed } from '@/application/session/token';
-import { clearDrainConfig, configureDrain, setCurrentSession, startDrainAll } from '@/application/sync-outbox';
+import {
+  clearDrainConfig,
+  configureDrain,
+  setCurrentSession,
+  type SlowSyncBlockedReason,
+  type SlowSyncOutboxItem,
+  startDrainAll,
+} from '@/application/sync-outbox';
 import type { AppEventEmitter } from '@/components/app/contexts/AppEventEmitterContext';
 import { useSync, useWorkspaceRealtimeTransport } from '@/components/ws';
 import { notification } from '@/proto/messages';
@@ -21,11 +29,44 @@ interface AppSyncLayerProps {
 
 const WS_READY_STATE_OPEN = 1;
 
+function exactSlowSyncResult(item: SlowSyncOutboxItem, results: CollabFullSyncBatchResult[]): CollabFullSyncBatchResult {
+  if (results.length !== 1 || results[0].objectId !== item.objectId || results[0].collabType !== item.collabType) {
+    throw new Error(`Slow-sync response did not exactly match collab ${item.objectId}`);
+  }
+
+  return results[0];
+}
+
+function blockedSlowSyncReason(error: string | undefined): SlowSyncBlockedReason | undefined {
+  const normalized = error?.trim().toLowerCase();
+
+  if (normalized?.includes('permission_denied')) return 'permission_denied';
+  if (normalized?.includes('update_too_large')) return 'update_too_large';
+  return undefined;
+}
+
+function hasDurableMessageId(result: CollabFullSyncBatchResult): boolean {
+  return Boolean(result.messageId && Number(result.messageId.timestamp ?? 0) > 0);
+}
+
+function isAuthoritativeVersionChange(
+  result: CollabFullSyncBatchResult,
+  requestedVersion: string | null | undefined
+): boolean {
+  return Boolean(result.collabVersion && result.collabVersion !== requestedVersion);
+}
+
 // Second layer: WebSocket connection and synchronization
 // Handles WebSocket connection, broadcast channel, sync context, and event management
 // Depends on workspace ID and service from auth layer
 export const AppSyncLayer: FC<AppSyncLayerProps> = ({ children }) => {
-  const { currentWorkspaceId, isAuthenticated } = useAuthInternal();
+  const {
+    currentWorkspaceId,
+    isAuthenticated,
+    maxUpdateBytes,
+    maxSlowSyncUpdateBytes,
+    syncLimitsLoaded = false,
+  } = useAuthInternal();
   const [awarenessMap] = useState<Record<string, Awareness>>({});
   // Lazy-init so a throwaway EventEmitter isn't constructed on every render
   // (useRef keeps only the first value but still evaluates its argument each time).
@@ -61,12 +102,14 @@ export const AppSyncLayer: FC<AppSyncLayerProps> = ({ children }) => {
   });
 
   // Initialize sync context for collaborative editing
-  const { registerSyncContext, flushAllSync, syncAllToServer, revertCollabVersion, scheduleDeferredCleanup } = useSync(
-    webSocket,
-    broadcastChannel,
-    eventEmitter,
-    currentWorkspaceId!
-  );
+  const {
+    registerSyncContext,
+    flushAllSync,
+    syncAllToServer,
+    applyHttpFullSyncResult,
+    revertCollabVersion,
+    scheduleDeferredCleanup,
+  } = useSync(webSocket, broadcastChannel, eventEmitter, currentWorkspaceId!);
 
   // Handle WebSocket reconnection. Depend on the stable `reconnect` function,
   // not the webSocket container whose identity changes per incoming message.
@@ -94,10 +137,11 @@ export const AppSyncLayer: FC<AppSyncLayerProps> = ({ children }) => {
     currentEventEmitter.emit(APP_EVENTS.WEBSOCKET_STATUS, webSocketReadyState);
   }, [eventEmitter, webSocketReadyState]);
 
-  // Wire the persistent sync_outbox drain to this WebSocket. The drain loop
-  // runs whenever a record is enqueued AND the socket is OPEN. The drain is
-  // scoped to `currentWorkspaceId` so pending rows from one workspace are not
-  // accidentally replayed on a different workspace's WebSocket after switch.
+  // Wire the persistent sync_outbox drain to the active transport owner. Fast
+  // records still wait for an OPEN WebSocket, while oversized records may use
+  // the HTTP slow lane during reconnects. The drain is scoped to
+  // `currentWorkspaceId` so pending rows from one workspace are not
+  // accidentally replayed on a different workspace's transport after switch.
   // The drain also fans out to BroadcastChannel so sibling tabs in the same
   // workspace receive local edits immediately, without waiting for a server
   // round-trip (matches the behaviour of the pre-outbox `emit` callback).
@@ -122,6 +166,76 @@ export const AppSyncLayer: FC<AppSyncLayerProps> = ({ children }) => {
   // burns a localStorage read + JSON.parse. Token-refresh still flows in
   // because `isAuthenticated` gates AppSyncLayer's mount via the auth layer.
   const currentUserId = useMemo(() => (isAuthenticated ? getTokenParsed()?.user?.id ?? null : null), [isAuthenticated]);
+  const slowSync = useCallback(
+    async (item: SlowSyncOutboxItem, signal: AbortSignal) => {
+      if (!currentWorkspaceId) {
+        throw new Error('Cannot slow-sync without an active workspace');
+      }
+
+      const request = async (docState: Uint8Array, syncLane?: 'slow') =>
+        exactSlowSyncResult(
+          item,
+          await collabFullSyncBatch(
+            currentWorkspaceId,
+            [
+              {
+                objectId: item.objectId,
+                collabType: item.collabType,
+                stateVector: item.stateVector,
+                docState,
+                collabVersion: item.version,
+              },
+            ],
+            { syncLane, signal }
+          )
+        );
+      const applyResult = (result: CollabFullSyncBatchResult) =>
+        applyHttpFullSyncResult(
+          {
+            objectId: result.objectId,
+            collabType: result.collabType,
+            missingUpdate: result.missingUpdate,
+            serverStateVector: result.serverStateVector,
+            collabVersion: result.collabVersion,
+            messageId: result.messageId,
+          },
+          item.version
+        );
+
+      // Pull server-side changes through the ordinary lightweight lane before
+      // attempting the oversized upload. A state-vector match is not proof
+      // that the queued update is durable: Yjs deletions do not advance state
+      // vectors. Only an authoritative collab-version change can supersede it.
+      const probe = await request(new Uint8Array());
+      const probeBlocked = blockedSlowSyncReason(probe.error);
+
+      if (probeBlocked) return { outcome: 'blocked' as const, reason: probeBlocked };
+      if (probe.error) throw new Error(`Slow-sync probe failed for ${item.objectId}: ${probe.error}`);
+
+      const probeSuperseded = isAuthoritativeVersionChange(probe, item.version);
+
+      await applyResult(probe);
+      if (probeSuperseded) {
+        return { outcome: 'confirmed' as const, messageId: probe.messageId };
+      }
+
+      const uploaded = await request(item.docState, 'slow');
+      const uploadBlocked = blockedSlowSyncReason(uploaded.error);
+
+      if (uploadBlocked) return { outcome: 'blocked' as const, reason: uploadBlocked };
+      if (uploaded.error) throw new Error(`Slow-sync upload failed for ${item.objectId}: ${uploaded.error}`);
+
+      const uploadSuperseded = isAuthoritativeVersionChange(uploaded, item.version);
+
+      await applyResult(uploaded);
+      if (!uploadSuperseded && !hasDurableMessageId(uploaded)) {
+        throw new Error(`Slow-sync response for ${item.objectId} did not include a durable message id`);
+      }
+
+      return { outcome: 'confirmed' as const, messageId: uploaded.messageId };
+    },
+    [applyHttpFullSyncResult, currentWorkspaceId]
+  );
 
   useEffect(() => {
     if (currentUserId && currentWorkspaceId) {
@@ -139,6 +253,8 @@ export const AppSyncLayer: FC<AppSyncLayerProps> = ({ children }) => {
 
   useEffect(() => {
     if (!currentWorkspaceId || !currentUserId) return;
+
+    const slowSyncAbortController = new AbortController();
 
     configureDrain({
       userId: currentUserId,
@@ -163,26 +279,54 @@ export const AppSyncLayer: FC<AppSyncLayerProps> = ({ children }) => {
       // buffers on the leader socket or forwards a follower update to the
       // leader over BroadcastChannel.
       sendBestEffort,
+      // The conservative realtime fallback remains usable while server-info
+      // loads; only the opt-in HTTP slow lane depends on advertised limits.
       isReady: () => canSendToServer && wsReadyStateRef.current === WS_READY_STATE_OPEN,
       onPersisted: bcPostOutboxReady,
+      maxUpdateBytes,
+      maxSlowSyncUpdateBytes,
+      syncLimitsLoaded,
+      abortSlowSync: () => slowSyncAbortController.abort(),
+      // IndexedDB is shared by sibling tabs. Only the elected socket owner
+      // may run the global low-concurrency HTTP lane; followers persist and
+      // wake that owner through onPersisted.
+      slowSync:
+        syncLimitsLoaded && canSendToServer ? (item) => slowSync(item, slowSyncAbortController.signal) : undefined,
     });
 
-    if (canSendToServer && wsReadyState === WS_READY_STATE_OPEN) {
-      startDrainAll();
-    }
-
     return () => {
+      slowSyncAbortController.abort();
       clearDrainConfig();
     };
   }, [
     currentUserId,
     currentWorkspaceId,
     wsSendMessage,
-    wsReadyState,
     bcPostDurableMessage,
     bcPostOutboxReady,
     canSendToServer,
     sendBestEffort,
+    maxUpdateBytes,
+    maxSlowSyncUpdateBytes,
+    syncLimitsLoaded,
+    slowSync,
+  ]);
+
+  // Transport readiness only wakes the already-configured drain. Keeping it
+  // out of the configuration effect avoids aborting slow HTTP work and
+  // resetting retry state on every CONNECTING/OPEN/CLOSED transition.
+  useEffect(() => {
+    if (canSendToServer) {
+      startDrainAll();
+    }
+  }, [
+    canSendToServer,
+    currentUserId,
+    currentWorkspaceId,
+    maxSlowSyncUpdateBytes,
+    maxUpdateBytes,
+    syncLimitsLoaded,
+    wsReadyState,
   ]);
 
   // Handle user profile change notifications

--- a/src/components/app/layers/__tests__/AppAuthLayer.test.tsx
+++ b/src/components/app/layers/__tests__/AppAuthLayer.test.tsx
@@ -180,4 +180,92 @@ describe('AppAuthLayer workspace info loading', () => {
     expect(mockOpenWorkspace).toHaveBeenCalledTimes(1);
     expect(screen.getByTestId('selected-workspace').textContent).toBe('workspace-new');
   });
+
+  it('keeps sync limits unresolved and retries after a transient server-info failure', async () => {
+    jest.useFakeTimers();
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+    let latestAuthContext: AuthInternalContextType | null = null;
+
+    mockGetWorkspaceInfo.mockResolvedValue(createWorkspaceInfo('workspace-old') as never);
+    mockGetServerInfo
+      .mockReset()
+      .mockRejectedValueOnce(new Error('server unavailable'))
+      .mockResolvedValueOnce({
+        enable_page_history: true,
+        ai_enabled: true,
+        max_update_bytes: 8_000_000,
+        max_slow_sync_update_bytes: 64_000_000,
+      } as never);
+
+    function CaptureAuthContext() {
+      latestAuthContext = useContext(AuthInternalContext);
+      return null;
+    }
+
+    const view = render(
+      <AFConfigContext.Provider
+        value={{
+          isAuthenticated: true,
+          updateCurrentUser: jest.fn(),
+          openLoginModal: jest.fn(),
+        }}
+      >
+        <AppAuthLayer>
+          <CaptureAuthContext />
+        </AppAuthLayer>
+      </AFConfigContext.Provider>
+    );
+
+    try {
+      await act(async () => {
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      expect(mockGetServerInfo).toHaveBeenCalledTimes(1);
+      expect(latestAuthContext?.syncLimitsLoaded).toBe(false);
+
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(1_000);
+      });
+
+      expect(mockGetServerInfo).toHaveBeenCalledTimes(2);
+      expect(latestAuthContext?.syncLimitsLoaded).toBe(true);
+      expect(latestAuthContext?.maxUpdateBytes).toBe(8_000_000);
+      expect(latestAuthContext?.maxSlowSyncUpdateBytes).toBe(64_000_000);
+    } finally {
+      view.unmount();
+      errorSpy.mockRestore();
+      jest.useRealTimers();
+    }
+  });
+
+  it('aborts an in-flight server-info request when the auth layer unmounts', async () => {
+    const serverInfo = createDeferred<Awaited<ReturnType<typeof AuthService.getServerInfo>>>();
+
+    mockGetWorkspaceInfo.mockResolvedValue(createWorkspaceInfo('workspace-old') as never);
+    mockGetServerInfo.mockReset().mockReturnValue(serverInfo.promise);
+
+    const view = render(
+      <AFConfigContext.Provider
+        value={{
+          isAuthenticated: true,
+          updateCurrentUser: jest.fn(),
+          openLoginModal: jest.fn(),
+        }}
+      >
+        <AppAuthLayer>
+          <div />
+        </AppAuthLayer>
+      </AFConfigContext.Provider>
+    );
+
+    await waitFor(() => expect(mockGetServerInfo).toHaveBeenCalledTimes(1));
+
+    const signal = mockGetServerInfo.mock.calls[0][0];
+
+    expect(signal?.aborted).toBe(false);
+    view.unmount();
+    expect(signal?.aborted).toBe(true);
+  });
 });

--- a/src/components/app/layers/__tests__/AppSyncLayer.test.tsx
+++ b/src/components/app/layers/__tests__/AppSyncLayer.test.tsx
@@ -4,6 +4,7 @@ import * as Y from 'yjs';
 
 import { APP_EVENTS } from '@/application/constants';
 import { collabFullSyncBatch } from '@/application/services/js-services/http/collab-api';
+import type { AppEventEmitter } from '@/components/app/contexts/AppEventEmitterContext';
 import { AuthInternalContext, type AuthInternalContextType } from '@/components/app/contexts/AuthInternalContext';
 import { useSyncInternal } from '@/components/app/contexts/SyncInternalContext';
 import { AppSyncLayer } from '@/components/app/layers/AppSyncLayer';
@@ -29,6 +30,8 @@ jest.mock('@/application/services/domains', () => ({
 
 jest.mock('@/application/services/js-services/http/collab-api', () => ({
   collabFullSyncBatch: jest.fn(),
+  getSlowSyncUploadTimeoutMs: jest.fn(() => 240_000),
+  SLOW_SYNC_PROBE_TIMEOUT_MS: 120_000,
 }));
 
 jest.mock('@/application/session/token', () => ({
@@ -38,6 +41,7 @@ jest.mock('@/application/session/token', () => ({
 jest.mock('@/application/sync-outbox', () => ({
   clearDrainConfig: jest.fn(),
   configureDrain: jest.fn(),
+  resumePermissionBlockedSync: jest.fn(),
   setCurrentSession: jest.fn(),
   startDrainAll: jest.fn(),
 }));
@@ -99,6 +103,7 @@ const authContextValue = {
 let consumerRenderCount = 0;
 let websocketStatusEmits = 0;
 let latestWebSocketReadyState: number | undefined;
+let latestEventEmitter: AppEventEmitter | undefined;
 
 const ContextConsumer = memo(function ContextConsumer() {
   const { eventEmitter } = useSyncInternal();
@@ -111,6 +116,7 @@ const ContextConsumer = memo(function ContextConsumer() {
     };
 
     latestWebSocketReadyState = eventEmitter.webSocketReadyState;
+    latestEventEmitter = eventEmitter;
     eventEmitter.on(APP_EVENTS.WEBSOCKET_STATUS, handleStatus);
 
     return () => {
@@ -145,6 +151,7 @@ describe('AppSyncLayer per-message churn', () => {
     consumerRenderCount = 0;
     websocketStatusEmits = 0;
     latestWebSocketReadyState = undefined;
+    latestEventEmitter = undefined;
     mockUseSync.mockReturnValue(stableSyncValue);
     mockCollabFullSyncBatch.mockResolvedValue([
       {
@@ -260,6 +267,15 @@ describe('AppSyncLayer per-message churn', () => {
     expect(leaderConfig.slowSync).toEqual(expect.any(Function));
   });
 
+  it('resumes a permission-blocked object when access changes', () => {
+    const outboxMock = jest.requireMock('@/application/sync-outbox');
+
+    renderLayer();
+    latestEventEmitter?.emit(APP_EVENTS.PERMISSION_CHANGED, { objectId: 'object-1' });
+
+    expect(outboxMock.resumePermissionBlockedSync).toHaveBeenCalledWith('object-1');
+  });
+
   it('keeps the conservative realtime drain active while server-info is unresolved', () => {
     const outboxMock = jest.requireMock('@/application/sync-outbox');
 
@@ -292,13 +308,16 @@ describe('AppSyncLayer per-message churn', () => {
     expect(leaderConfig.slowSync).toEqual(expect.any(Function));
 
     await expect(
-      leaderConfig.slowSync({
-        objectId: 'object-1',
-        collabType: 0,
-        version: 'version-1',
-        stateVector: desiredStateVector,
-        docState: new Uint8Array([2]),
-      })
+      leaderConfig.slowSync(
+        {
+          objectId: 'object-1',
+          collabType: 0,
+          version: 'version-1',
+          stateVector: desiredStateVector,
+          docState: new Uint8Array([2]),
+        },
+        new AbortController().signal
+      )
     ).resolves.toMatchObject({ outcome: 'confirmed', messageId: { timestamp: 1, counter: 0 } });
     expect(mockCollabFullSyncBatch).toHaveBeenNthCalledWith(
       1,
@@ -310,7 +329,7 @@ describe('AppSyncLayer per-message churn', () => {
           docState: new Uint8Array(),
         }),
       ],
-      expect.objectContaining({ signal: expect.any(AbortSignal) })
+      expect.objectContaining({ signal: expect.any(AbortSignal), timeoutMs: 120_000 })
     );
     expect(mockCollabFullSyncBatch.mock.calls[0][2]?.syncLane).toBeUndefined();
     expect(mockCollabFullSyncBatch).toHaveBeenNthCalledWith(
@@ -323,7 +342,7 @@ describe('AppSyncLayer per-message churn', () => {
           docState: new Uint8Array([2]),
         }),
       ],
-      expect.objectContaining({ syncLane: 'slow', signal: expect.any(AbortSignal) })
+      expect.objectContaining({ syncLane: 'slow', signal: expect.any(AbortSignal), timeoutMs: 240_000 })
     );
     expect(stableSyncValue.applyHttpFullSyncResult).toHaveBeenCalledTimes(2);
 
@@ -344,13 +363,16 @@ describe('AppSyncLayer per-message churn', () => {
       },
     ]);
     await expect(
-      leaderConfig.slowSync({
-        objectId: 'object-1',
-        collabType: 0,
-        version: 'version-1',
-        stateVector: desiredStateVector,
-        docState: new Uint8Array([2]),
-      })
+      leaderConfig.slowSync(
+        {
+          objectId: 'object-1',
+          collabType: 0,
+          version: 'version-1',
+          stateVector: desiredStateVector,
+          docState: new Uint8Array([2]),
+        },
+        new AbortController().signal
+      )
     ).rejects.toThrow('did not exactly match');
 
     const noRidResult = [
@@ -364,13 +386,16 @@ describe('AppSyncLayer per-message churn', () => {
 
     mockCollabFullSyncBatch.mockResolvedValueOnce(noRidResult).mockResolvedValueOnce(noRidResult);
     await expect(
-      leaderConfig.slowSync({
-        objectId: 'object-1',
-        collabType: 0,
-        version: 'version-1',
-        stateVector: desiredStateVector,
-        docState: new Uint8Array([2]),
-      })
+      leaderConfig.slowSync(
+        {
+          objectId: 'object-1',
+          collabType: 0,
+          version: 'version-1',
+          stateVector: desiredStateVector,
+          docState: new Uint8Array([2]),
+        },
+        new AbortController().signal
+      )
     ).rejects.toThrow('did not include a durable message id');
 
     mockUseWorkspaceRealtimeTransport.mockReturnValue({
@@ -415,13 +440,16 @@ describe('AppSyncLayer per-message churn', () => {
     const leaderConfig = outboxMock.configureDrain.mock.calls.at(-1)?.[0];
 
     await expect(
-      leaderConfig.slowSync({
-        objectId: 'object-1',
-        collabType: 0,
-        version: 'version-1',
-        stateVector: desiredStateVector,
-        docState: new Uint8Array([9, 9]),
-      })
+      leaderConfig.slowSync(
+        {
+          objectId: 'object-1',
+          collabType: 0,
+          version: 'version-1',
+          stateVector: desiredStateVector,
+          docState: new Uint8Array([9, 9]),
+        },
+        new AbortController().signal
+      )
     ).resolves.toEqual({ outcome: 'confirmed', messageId: { timestamp: 5, counter: 0 } });
 
     expect(mockCollabFullSyncBatch).toHaveBeenCalledTimes(2);
@@ -446,13 +474,16 @@ describe('AppSyncLayer per-message churn', () => {
     const leaderConfig = outboxMock.configureDrain.mock.calls.at(-1)?.[0];
 
     await expect(
-      leaderConfig.slowSync({
-        objectId: 'object-1',
-        collabType: 0,
-        version: 'version-1',
-        stateVector: new Uint8Array([0]),
-        docState: new Uint8Array([9]),
-      })
+      leaderConfig.slowSync(
+        {
+          objectId: 'object-1',
+          collabType: 0,
+          version: 'version-1',
+          stateVector: new Uint8Array([0]),
+          docState: new Uint8Array([9]),
+        },
+        new AbortController().signal
+      )
     ).resolves.toEqual({ outcome: 'confirmed', messageId: undefined });
 
     expect(mockCollabFullSyncBatch).toHaveBeenCalledTimes(1);
@@ -478,13 +509,16 @@ describe('AppSyncLayer per-message churn', () => {
     const leaderConfig = outboxMock.configureDrain.mock.calls.at(-1)?.[0];
 
     await expect(
-      leaderConfig.slowSync({
-        objectId: 'object-1',
-        collabType: 0,
-        version: 'version-1',
-        stateVector: new Uint8Array([0]),
-        docState: new Uint8Array([9]),
-      })
+      leaderConfig.slowSync(
+        {
+          objectId: 'object-1',
+          collabType: 0,
+          version: 'version-1',
+          stateVector: new Uint8Array([0]),
+          docState: new Uint8Array([9]),
+        },
+        new AbortController().signal
+      )
     ).resolves.toEqual({ outcome: 'blocked', reason: 'permission_denied' });
 
     expect(stableSyncValue.applyHttpFullSyncResult).not.toHaveBeenCalled();

--- a/src/components/app/layers/__tests__/AppSyncLayer.test.tsx
+++ b/src/components/app/layers/__tests__/AppSyncLayer.test.tsx
@@ -1,7 +1,9 @@
 import { render } from '@testing-library/react';
 import { memo, useEffect } from 'react';
+import * as Y from 'yjs';
 
 import { APP_EVENTS } from '@/application/constants';
+import { collabFullSyncBatch } from '@/application/services/js-services/http/collab-api';
 import { AuthInternalContext, type AuthInternalContextType } from '@/components/app/contexts/AuthInternalContext';
 import { useSyncInternal } from '@/components/app/contexts/SyncInternalContext';
 import { AppSyncLayer } from '@/components/app/layers/AppSyncLayer';
@@ -25,6 +27,10 @@ jest.mock('@/application/services/domains', () => ({
   },
 }));
 
+jest.mock('@/application/services/js-services/http/collab-api', () => ({
+  collabFullSyncBatch: jest.fn(),
+}));
+
 jest.mock('@/application/session/token', () => ({
   getTokenParsed: jest.fn(() => ({ user: { id: 'user-1' } })),
 }));
@@ -45,6 +51,7 @@ jest.mock('@/application/db', () => ({
 
 const mockUseSync = useSync as jest.Mock;
 const mockUseWorkspaceRealtimeTransport = useWorkspaceRealtimeTransport as jest.Mock;
+const mockCollabFullSyncBatch = collabFullSyncBatch as jest.MockedFunction<typeof collabFullSyncBatch>;
 
 // Stable per-connection pieces, matching the real (memoized) hook behaviour:
 // these keep their identity across messages — only the container object and
@@ -67,6 +74,7 @@ const stableSyncValue = {
   revertCollabVersion: jest.fn(),
   flushAllSync: jest.fn(),
   syncAllToServer: jest.fn(),
+  applyHttpFullSyncResult: jest.fn(async () => undefined),
   scheduleDeferredCleanup: jest.fn(),
 };
 
@@ -83,6 +91,9 @@ const createWsValue = (lastMessage: messages.Message | null): AppflowyWebSocketT
 const authContextValue = {
   currentWorkspaceId: 'workspace-1',
   isAuthenticated: true,
+  maxUpdateBytes: 4 * 1024 * 1024,
+  maxSlowSyncUpdateBytes: 64 * 1024 * 1024,
+  syncLimitsLoaded: true,
 } as unknown as AuthInternalContextType;
 
 let consumerRenderCount = 0;
@@ -110,9 +121,9 @@ const ContextConsumer = memo(function ContextConsumer() {
   return <div data-testid='consumer' />;
 });
 
-const renderLayer = () =>
+const renderLayer = (authValue: AuthInternalContextType = authContextValue) =>
   render(
-    <AuthInternalContext.Provider value={authContextValue}>
+    <AuthInternalContext.Provider value={authValue}>
       <AppSyncLayer>
         <ContextConsumer />
       </AppSyncLayer>
@@ -135,6 +146,15 @@ describe('AppSyncLayer per-message churn', () => {
     websocketStatusEmits = 0;
     latestWebSocketReadyState = undefined;
     mockUseSync.mockReturnValue(stableSyncValue);
+    mockCollabFullSyncBatch.mockResolvedValue([
+      {
+        objectId: 'object-1',
+        collabType: 0,
+        missingUpdate: new Uint8Array(),
+        serverStateVector: new Uint8Array(),
+        messageId: { timestamp: 1, counter: 0 },
+      },
+    ]);
     mockUseWorkspaceRealtimeTransport.mockReturnValue({
       webSocket: createWsValue(null),
       broadcastChannel: stableBcValue,
@@ -202,5 +222,271 @@ describe('AppSyncLayer per-message churn', () => {
     renderLayer();
 
     expect(latestWebSocketReadyState).toBe(1);
+  });
+
+  it('does not rebuild the drain configuration for websocket readyState changes', () => {
+    const outboxMock = jest.requireMock('@/application/sync-outbox');
+    const { rerender } = renderLayer();
+    const configureCallsAfterMount = outboxMock.configureDrain.mock.calls.length;
+
+    mockUseWorkspaceRealtimeTransport.mockReturnValue({
+      webSocket: { ...createWsValue(null), readyState: 3 },
+      broadcastChannel: stableBcValue,
+      canSendToServer: true,
+      sendBestEffort: stableSendBestEffort,
+    });
+    rerenderLayer(rerender);
+
+    expect(outboxMock.configureDrain).toHaveBeenCalledTimes(configureCallsAfterMount);
+    expect(outboxMock.startDrainAll.mock.calls.length).toBeGreaterThan(1);
+  });
+
+  it('starts the leader drain while the websocket is closed so oversized records can use HTTP', () => {
+    const outboxMock = jest.requireMock('@/application/sync-outbox');
+
+    mockUseWorkspaceRealtimeTransport.mockReturnValue({
+      webSocket: { ...createWsValue(null), readyState: 3 },
+      broadcastChannel: stableBcValue,
+      canSendToServer: true,
+      sendBestEffort: stableSendBestEffort,
+    });
+
+    renderLayer();
+
+    expect(outboxMock.startDrainAll).toHaveBeenCalledTimes(1);
+    const leaderConfig = outboxMock.configureDrain.mock.calls.at(-1)?.[0];
+
+    expect(leaderConfig.isReady()).toBe(false);
+    expect(leaderConfig.slowSync).toEqual(expect.any(Function));
+  });
+
+  it('keeps the conservative realtime drain active while server-info is unresolved', () => {
+    const outboxMock = jest.requireMock('@/application/sync-outbox');
+
+    renderLayer({
+      ...authContextValue,
+      maxUpdateBytes: undefined,
+      maxSlowSyncUpdateBytes: undefined,
+      syncLimitsLoaded: false,
+    });
+
+    const config = outboxMock.configureDrain.mock.calls.at(-1)?.[0];
+
+    expect(config.isReady()).toBe(true);
+    expect(config.maxUpdateBytes).toBeUndefined();
+    expect(config.slowSync).toBeUndefined();
+    expect(outboxMock.startDrainAll).toHaveBeenCalledTimes(1);
+  });
+
+  it('configures the HTTP slow lane only on the elected transport owner', async () => {
+    const outboxMock = jest.requireMock('@/application/sync-outbox');
+    const { rerender } = renderLayer();
+    const leaderConfig = outboxMock.configureDrain.mock.calls.at(-1)?.[0];
+    const desiredDoc = new Y.Doc();
+
+    desiredDoc.getMap('root').set('value', 'desired');
+    const desiredStateVector = Y.encodeStateVector(desiredDoc);
+
+    expect(leaderConfig.maxUpdateBytes).toBe(4 * 1024 * 1024);
+    expect(leaderConfig.maxSlowSyncUpdateBytes).toBe(64 * 1024 * 1024);
+    expect(leaderConfig.slowSync).toEqual(expect.any(Function));
+
+    await expect(
+      leaderConfig.slowSync({
+        objectId: 'object-1',
+        collabType: 0,
+        version: 'version-1',
+        stateVector: desiredStateVector,
+        docState: new Uint8Array([2]),
+      })
+    ).resolves.toMatchObject({ outcome: 'confirmed', messageId: { timestamp: 1, counter: 0 } });
+    expect(mockCollabFullSyncBatch).toHaveBeenNthCalledWith(
+      1,
+      'workspace-1',
+      [
+        expect.objectContaining({
+          objectId: 'object-1',
+          collabVersion: 'version-1',
+          docState: new Uint8Array(),
+        }),
+      ],
+      expect.objectContaining({ signal: expect.any(AbortSignal) })
+    );
+    expect(mockCollabFullSyncBatch.mock.calls[0][2]?.syncLane).toBeUndefined();
+    expect(mockCollabFullSyncBatch).toHaveBeenNthCalledWith(
+      2,
+      'workspace-1',
+      [
+        expect.objectContaining({
+          objectId: 'object-1',
+          collabVersion: 'version-1',
+          docState: new Uint8Array([2]),
+        }),
+      ],
+      expect.objectContaining({ syncLane: 'slow', signal: expect.any(AbortSignal) })
+    );
+    expect(stableSyncValue.applyHttpFullSyncResult).toHaveBeenCalledTimes(2);
+
+    mockCollabFullSyncBatch.mockResolvedValueOnce([
+      {
+        objectId: 'object-1',
+        collabType: 0,
+        missingUpdate: new Uint8Array(),
+        serverStateVector: new Uint8Array(),
+        messageId: { timestamp: 2, counter: 0 },
+      },
+      {
+        objectId: 'unexpected-object',
+        collabType: 0,
+        missingUpdate: new Uint8Array(),
+        serverStateVector: new Uint8Array(),
+        messageId: { timestamp: 3, counter: 0 },
+      },
+    ]);
+    await expect(
+      leaderConfig.slowSync({
+        objectId: 'object-1',
+        collabType: 0,
+        version: 'version-1',
+        stateVector: desiredStateVector,
+        docState: new Uint8Array([2]),
+      })
+    ).rejects.toThrow('did not exactly match');
+
+    const noRidResult = [
+      {
+        objectId: 'object-1',
+        collabType: 0,
+        missingUpdate: new Uint8Array(),
+        serverStateVector: new Uint8Array(),
+      },
+    ];
+
+    mockCollabFullSyncBatch.mockResolvedValueOnce(noRidResult).mockResolvedValueOnce(noRidResult);
+    await expect(
+      leaderConfig.slowSync({
+        objectId: 'object-1',
+        collabType: 0,
+        version: 'version-1',
+        stateVector: desiredStateVector,
+        docState: new Uint8Array([2]),
+      })
+    ).rejects.toThrow('did not include a durable message id');
+
+    mockUseWorkspaceRealtimeTransport.mockReturnValue({
+      webSocket: createWsValue(null),
+      broadcastChannel: stableBcValue,
+      canSendToServer: false,
+      sendBestEffort: stableSendBestEffort,
+    });
+    rerenderLayer(rerender);
+
+    const followerConfig = outboxMock.configureDrain.mock.calls.at(-1)?.[0];
+
+    expect(followerConfig.slowSync).toBeUndefined();
+  });
+
+  it('uploads after a coverage-equivalent probe because Yjs deletes do not advance state vectors', async () => {
+    const outboxMock = jest.requireMock('@/application/sync-outbox');
+    const desiredDoc = new Y.Doc();
+
+    desiredDoc.getMap('root').set('value', 'already durable');
+    const desiredStateVector = Y.encodeStateVector(desiredDoc);
+
+    mockCollabFullSyncBatch
+      .mockResolvedValueOnce([
+        {
+          objectId: 'object-1',
+          collabType: 0,
+          missingUpdate: new Uint8Array(),
+          serverStateVector: desiredStateVector,
+        },
+      ])
+      .mockResolvedValueOnce([
+        {
+          objectId: 'object-1',
+          collabType: 0,
+          missingUpdate: new Uint8Array(),
+          serverStateVector: desiredStateVector,
+          messageId: { timestamp: 5, counter: 0 },
+        },
+      ]);
+    renderLayer();
+    const leaderConfig = outboxMock.configureDrain.mock.calls.at(-1)?.[0];
+
+    await expect(
+      leaderConfig.slowSync({
+        objectId: 'object-1',
+        collabType: 0,
+        version: 'version-1',
+        stateVector: desiredStateVector,
+        docState: new Uint8Array([9, 9]),
+      })
+    ).resolves.toEqual({ outcome: 'confirmed', messageId: { timestamp: 5, counter: 0 } });
+
+    expect(mockCollabFullSyncBatch).toHaveBeenCalledTimes(2);
+    expect(mockCollabFullSyncBatch.mock.calls[0][2]?.syncLane).toBeUndefined();
+    expect(mockCollabFullSyncBatch.mock.calls[1][2]).toMatchObject({ syncLane: 'slow' });
+    expect(stableSyncValue.applyHttpFullSyncResult).toHaveBeenCalledTimes(2);
+  });
+
+  it('treats a different authoritative server version without a RID as confirmed supersession', async () => {
+    const outboxMock = jest.requireMock('@/application/sync-outbox');
+
+    mockCollabFullSyncBatch.mockResolvedValueOnce([
+      {
+        objectId: 'object-1',
+        collabType: 0,
+        missingUpdate: new Uint8Array(),
+        serverStateVector: new Uint8Array(),
+        collabVersion: 'version-2',
+      },
+    ]);
+    renderLayer();
+    const leaderConfig = outboxMock.configureDrain.mock.calls.at(-1)?.[0];
+
+    await expect(
+      leaderConfig.slowSync({
+        objectId: 'object-1',
+        collabType: 0,
+        version: 'version-1',
+        stateVector: new Uint8Array([0]),
+        docState: new Uint8Array([9]),
+      })
+    ).resolves.toEqual({ outcome: 'confirmed', messageId: undefined });
+
+    expect(mockCollabFullSyncBatch).toHaveBeenCalledTimes(1);
+    expect(stableSyncValue.applyHttpFullSyncResult).toHaveBeenCalledWith(
+      expect.objectContaining({ collabVersion: 'version-2' }),
+      'version-1'
+    );
+  });
+
+  it('returns terminal server errors as blocked without applying the result', async () => {
+    const outboxMock = jest.requireMock('@/application/sync-outbox');
+
+    mockCollabFullSyncBatch.mockResolvedValueOnce([
+      {
+        objectId: 'object-1',
+        collabType: 0,
+        missingUpdate: new Uint8Array(),
+        serverStateVector: new Uint8Array(),
+        error: 'permission_denied',
+      },
+    ]);
+    renderLayer();
+    const leaderConfig = outboxMock.configureDrain.mock.calls.at(-1)?.[0];
+
+    await expect(
+      leaderConfig.slowSync({
+        objectId: 'object-1',
+        collabType: 0,
+        version: 'version-1',
+        stateVector: new Uint8Array([0]),
+        docState: new Uint8Array([9]),
+      })
+    ).resolves.toEqual({ outcome: 'blocked', reason: 'permission_denied' });
+
+    expect(stableSyncValue.applyHttpFullSyncResult).not.toHaveBeenCalled();
   });
 });

--- a/src/components/app/layers/__tests__/AppSyncLayer.test.tsx
+++ b/src/components/app/layers/__tests__/AppSyncLayer.test.tsx
@@ -1,4 +1,4 @@
-import { render } from '@testing-library/react';
+import { render, waitFor } from '@testing-library/react';
 import { memo, useEffect } from 'react';
 import * as Y from 'yjs';
 
@@ -56,6 +56,20 @@ jest.mock('@/application/db', () => ({
 const mockUseSync = useSync as jest.Mock;
 const mockUseWorkspaceRealtimeTransport = useWorkspaceRealtimeTransport as jest.Mock;
 const mockCollabFullSyncBatch = collabFullSyncBatch as jest.MockedFunction<typeof collabFullSyncBatch>;
+
+type Deferred<T> = {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+};
+
+const createDeferred = <T,>(): Deferred<T> => {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+
+  return { promise, resolve };
+};
 
 // Stable per-connection pieces, matching the real (memoized) hook behaviour:
 // these keep their identity across messages — only the container object and
@@ -489,8 +503,113 @@ describe('AppSyncLayer per-message churn', () => {
     expect(mockCollabFullSyncBatch).toHaveBeenCalledTimes(1);
     expect(stableSyncValue.applyHttpFullSyncResult).toHaveBeenCalledWith(
       expect.objectContaining({ collabVersion: 'version-2' }),
-      'version-1'
+      'version-1',
+      expect.any(AbortSignal)
     );
+  });
+
+  it('does not enqueue a completed probe response after cancellation', async () => {
+    const outboxMock = jest.requireMock('@/application/sync-outbox');
+    const probe = createDeferred<Awaited<ReturnType<typeof collabFullSyncBatch>>>();
+
+    mockCollabFullSyncBatch.mockImplementationOnce(() => probe.promise);
+    renderLayer();
+    const leaderConfig = outboxMock.configureDrain.mock.calls.at(-1)?.[0];
+    const controller = new AbortController();
+    const slowSyncPromise = leaderConfig.slowSync(
+      {
+        objectId: 'object-1',
+        collabType: 0,
+        version: 'version-1',
+        stateVector: new Uint8Array([0]),
+        docState: new Uint8Array([9]),
+      },
+      controller.signal
+    );
+
+    probe.resolve([
+      {
+        objectId: 'object-1',
+        collabType: 0,
+        missingUpdate: new Uint8Array(),
+        serverStateVector: new Uint8Array(),
+      },
+    ]);
+    controller.abort();
+
+    await expect(slowSyncPromise).rejects.toMatchObject({ name: 'AbortError' });
+    expect(stableSyncValue.applyHttpFullSyncResult).not.toHaveBeenCalled();
+  });
+
+  it('does not continue after cancellation while a probe result is queued for application', async () => {
+    const outboxMock = jest.requireMock('@/application/sync-outbox');
+    const applied = createDeferred<void>();
+
+    stableSyncValue.applyHttpFullSyncResult.mockImplementationOnce(() => applied.promise);
+    renderLayer();
+    const leaderConfig = outboxMock.configureDrain.mock.calls.at(-1)?.[0];
+    const controller = new AbortController();
+    const slowSyncPromise = leaderConfig.slowSync(
+      {
+        objectId: 'object-1',
+        collabType: 0,
+        version: 'version-1',
+        stateVector: new Uint8Array([0]),
+        docState: new Uint8Array([9]),
+      },
+      controller.signal
+    );
+
+    await waitFor(() => expect(stableSyncValue.applyHttpFullSyncResult).toHaveBeenCalledTimes(1));
+    controller.abort();
+    applied.resolve();
+
+    await expect(slowSyncPromise).rejects.toMatchObject({ name: 'AbortError' });
+    expect(mockCollabFullSyncBatch).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not enqueue a completed slow-lane upload after cancellation', async () => {
+    const outboxMock = jest.requireMock('@/application/sync-outbox');
+    const upload = createDeferred<Awaited<ReturnType<typeof collabFullSyncBatch>>>();
+
+    mockCollabFullSyncBatch
+      .mockResolvedValueOnce([
+        {
+          objectId: 'object-1',
+          collabType: 0,
+          missingUpdate: new Uint8Array(),
+          serverStateVector: new Uint8Array(),
+        },
+      ])
+      .mockImplementationOnce(() => upload.promise);
+    renderLayer();
+    const leaderConfig = outboxMock.configureDrain.mock.calls.at(-1)?.[0];
+    const controller = new AbortController();
+    const slowSyncPromise = leaderConfig.slowSync(
+      {
+        objectId: 'object-1',
+        collabType: 0,
+        version: 'version-1',
+        stateVector: new Uint8Array([0]),
+        docState: new Uint8Array([9]),
+      },
+      controller.signal
+    );
+
+    await waitFor(() => expect(mockCollabFullSyncBatch).toHaveBeenCalledTimes(2));
+    upload.resolve([
+      {
+        objectId: 'object-1',
+        collabType: 0,
+        missingUpdate: new Uint8Array(),
+        serverStateVector: new Uint8Array(),
+        messageId: { timestamp: 2, counter: 0 },
+      },
+    ]);
+    controller.abort();
+
+    await expect(slowSyncPromise).rejects.toMatchObject({ name: 'AbortError' });
+    expect(stableSyncValue.applyHttpFullSyncResult).toHaveBeenCalledTimes(1);
   });
 
   it('returns terminal server errors as blocked without applying the result', async () => {

--- a/src/components/database/Database.tsx
+++ b/src/components/database/Database.tsx
@@ -260,7 +260,13 @@ function Database(props: Database2Props) {
   const [blobPrefetchComplete, setBlobPrefetchComplete] = useState(false);
   const [seedsReady, setSeedsReady] = useState(false);
 
-  useEffect(() => {
+  // Layout phase, and declared before the lifecycle-reset effect below, so that
+  // in a commit where both `rowMap` and the lifecycle changed this mirror runs
+  // first and the reset's `rowMapRef.current = initialRowMap` wins. As a passive
+  // effect it ran *after* the reset and wrote the previous lifecycle's row docs
+  // back into the ref — the one path in this file not covered by the
+  // isCurrentEnsure/isCurrentLoad guards.
+  useLayoutEffect(() => {
     rowMapRef.current = rowMap;
   }, [rowMap]);
 
@@ -273,7 +279,45 @@ function Database(props: Database2Props) {
 
     return databaseId || doc.guid;
   }, [doc]);
-  const currentDatabaseId = getDatabaseId();
+
+  // Yjs mutations do not schedule a React render, so reading the id during
+  // render would only refresh it as a side effect of an unrelated re-render —
+  // and since it feeds `databaseLifecycleIdentity`, which drives a destructive
+  // teardown, that could reset the lifecycle at an arbitrary later moment.
+  // `database` is a direct key of the shared root and `id` a direct key of the
+  // database map, so shallow observers cover every way the id can change
+  // without waking React on unrelated row/field edits.
+  const subscribeToDatabaseId = useCallback(
+    (onStoreChange: () => void) => {
+      const sharedRoot = doc.getMap(YjsEditorKey.data_section);
+      let database = sharedRoot?.get(YjsEditorKey.database) as YDatabase | undefined;
+
+      // The database map can be created after the first subscribe, so re-attach
+      // the inner observer whenever the root swaps it.
+      const handleRootChange = () => {
+        const nextDatabase = sharedRoot?.get(YjsEditorKey.database) as YDatabase | undefined;
+
+        if (nextDatabase !== database) {
+          database?.unobserve(onStoreChange);
+          database = nextDatabase;
+          database?.observe(onStoreChange);
+        }
+
+        onStoreChange();
+      };
+
+      sharedRoot.observe(handleRootChange);
+      database?.observe(onStoreChange);
+
+      return () => {
+        sharedRoot.unobserve(handleRootChange);
+        database?.unobserve(onStoreChange);
+      };
+    },
+    [doc]
+  );
+
+  const currentDatabaseId = useSyncExternalStore(subscribeToDatabaseId, getDatabaseId, getDatabaseId);
   // A shared background loader can retain a callback and first invoke it after
   // reset, so invocation-time generation checks alone cannot identify stale work.
   const databaseLifecycleIdentity = useMemo(

--- a/src/components/database/Database.tsx
+++ b/src/components/database/Database.tsx
@@ -1,6 +1,6 @@
 import EventEmitter from 'events';
 
-import { useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore } from 'react';
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState, useSyncExternalStore } from 'react';
 
 import {
   getDatabaseRowDocFromSeed,
@@ -230,6 +230,18 @@ function Database(props: Database2Props) {
     return databaseId || doc.guid;
   }, [doc]);
   const currentDatabaseId = getDatabaseId();
+  // A shared background loader can retain a callback and first invoke it after
+  // reset, so invocation-time generation checks alone cannot identify stale work.
+  const databaseLifecycleIdentity = useMemo(
+    () => ({
+      workspaceId,
+      doc,
+      databaseId: currentDatabaseId,
+      hasInitialRowMap: props.initialRowMap !== undefined,
+    }),
+    [workspaceId, doc, currentDatabaseId, props.initialRowMap]
+  );
+  const activeDatabaseLifecycleRef = useRef<typeof databaseLifecycleIdentity | null>(databaseLifecycleIdentity);
 
   const getPriorityRowIds = useCallback(() => {
     const sharedRoot = doc.getMap(YjsEditorKey.data_section);
@@ -329,7 +341,17 @@ function Database(props: Database2Props) {
   const loadRowFromSeed = useCallback(
     async (rowId: string): Promise<YDoc | undefined> => {
       if (!rowId) return undefined;
-      const databaseId = getDatabaseId();
+      const loadLifecycleIdentity = databaseLifecycleIdentity;
+      const loadGeneration = blobPrefetchGenerationRef.current;
+      const gate = seedsGateRef.current;
+      const isCurrentLoad = () =>
+        activeDatabaseLifecycleRef.current === loadLifecycleIdentity &&
+        getDatabaseId() === loadLifecycleIdentity.databaseId &&
+        blobPrefetchGenerationRef.current === loadGeneration &&
+        seedsGateRef.current === gate;
+
+      if (!isCurrentLoad()) return undefined;
+      const databaseId = loadLifecycleIdentity.databaseId;
       const rowKey = getRowKey(databaseId, rowId);
       const existing = rowMapRef.current[rowId];
 
@@ -337,7 +359,11 @@ function Database(props: Database2Props) {
 
       const pending = pendingRowDocsRef.current.get(rowId);
 
-      if (pending) return pending;
+      if (pending) {
+        const rowDoc = await pending;
+
+        return isCurrentLoad() ? rowDoc : undefined;
+      }
 
       const cachedRowDoc = getCachedRowDoc(rowKey);
       const seed = peekDatabaseRowDocSeed(rowKey);
@@ -363,19 +389,21 @@ function Database(props: Database2Props) {
       try {
         const rowDoc = await promise;
 
-        if (rowDoc) {
+        if (rowDoc && isCurrentLoad()) {
           setRowMap((prev) => {
             if (prev[rowId]) return prev;
             return { ...prev, [rowId]: rowDoc };
           });
         }
 
-        return rowDoc;
+        return isCurrentLoad() ? rowDoc : undefined;
       } finally {
-        pendingRowDocsRef.current.delete(rowId);
+        if (pendingRowDocsRef.current.get(rowId) === promise) {
+          pendingRowDocsRef.current.delete(rowId);
+        }
       }
     },
-    [getDatabaseId]
+    [databaseLifecycleIdentity, getDatabaseId]
   );
 
   // Synchronous shared read-only doc for filter/sort. Reuses an existing row
@@ -585,10 +613,16 @@ function Database(props: Database2Props) {
     async (rowId: string) => {
       if (!createRow || !rowId) return;
 
+      const ensureLifecycleIdentity = databaseLifecycleIdentity;
       const ensureGeneration = blobPrefetchGenerationRef.current;
       const gate = seedsGateRef.current;
       const isCurrentEnsure = () =>
-        blobPrefetchGenerationRef.current === ensureGeneration && seedsGateRef.current === gate;
+        activeDatabaseLifecycleRef.current === ensureLifecycleIdentity &&
+        getDatabaseId() === ensureLifecycleIdentity.databaseId &&
+        blobPrefetchGenerationRef.current === ensureGeneration &&
+        seedsGateRef.current === gate;
+
+      if (!isCurrentEnsure()) return;
 
       // Fast path: row already loaded (e.g. by batch preload or previous call).
       // Check before awaiting the gate to avoid blocking on already-available rows.
@@ -686,10 +720,11 @@ function Database(props: Database2Props) {
     // Omitted deps are stable: setRowMap (useState setter), refs (rowMapRef, pendingRowDocsRef,
     // localCachePrimedRef), and module-level imports (openRowDoc, getCachedRowDoc, peekDatabaseRowDocSeed, getRowKey).
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [createRow, getDatabaseId, ensureBlobPrefetch, registerRowSync]
+    [createRow, databaseLifecycleIdentity, getDatabaseId, ensureBlobPrefetch, registerRowSync]
   );
 
-  useEffect(() => {
+  useLayoutEffect(() => {
+    activeDatabaseLifecycleRef.current = databaseLifecycleIdentity;
     const prefetchGeneration = blobPrefetchGenerationRef.current + 1;
     const previousGate = seedsGateRef.current;
 
@@ -713,13 +748,17 @@ function Database(props: Database2Props) {
     setSeedsReady(false);
 
     return () => {
+      if (activeDatabaseLifecycleRef.current === databaseLifecycleIdentity) {
+        activeDatabaseLifecycleRef.current = null;
+      }
+
       if (blobPrefetchGenerationRef.current === prefetchGeneration) {
         blobPrefetchGenerationRef.current += 1;
       }
 
       lifecycleGate.resolve();
     };
-  }, [workspaceId, doc, currentDatabaseId, props.initialRowMap]);
+  }, [databaseLifecycleIdentity, props.initialRowMap]);
 
   // Trigger blob prefetch when database opens
   useEffect(() => {

--- a/src/components/database/Database.tsx
+++ b/src/components/database/Database.tsx
@@ -58,6 +58,50 @@ function createDeferredGate() {
   return { promise, resolve };
 }
 
+type RowSyncRegistration = {
+  rowKey: string;
+  status: 'pending' | 'registered' | 'release-pending' | 'released';
+  cleanup?: (objectId: string, delayMs?: number) => void;
+};
+
+function cleanupRegisteredRowSync(registration: RowSyncRegistration) {
+  const rowId = registration.rowKey.split('_rows_')[1];
+
+  if (!rowId || !registration.cleanup) return;
+
+  try {
+    registration.cleanup(rowId);
+  } catch (error) {
+    console.error('[Database] row sync cleanup failed', rowId, error);
+  }
+}
+
+function releaseRowSyncRegistration(registration: RowSyncRegistration) {
+  if (registration.status === 'pending') {
+    // createRow registers the sync context before resolving. Defer the matching
+    // release until that async registration has actually completed.
+    registration.status = 'release-pending';
+    return;
+  }
+
+  if (registration.status !== 'registered') return;
+
+  registration.status = 'released';
+  cleanupRegisteredRowSync(registration);
+}
+
+function completeRowSyncRegistration(registration: RowSyncRegistration) {
+  if (registration.status === 'release-pending') {
+    registration.status = 'released';
+    cleanupRegisteredRowSync(registration);
+    return;
+  }
+
+  if (registration.status === 'pending') {
+    registration.status = 'registered';
+  }
+}
+
 export interface Database2Props {
   workspaceId: string;
   doc: YDoc;
@@ -206,7 +250,7 @@ function Database(props: Database2Props) {
   const prefetchPromisesRef = useRef<Map<string, Promise<void>>>(new Map());
   const blobPrefetchPromiseRef = useRef<Promise<void> | null>(null);
   const localCachePrimedRef = useRef(false);
-  const syncedRowKeysRef = useRef<Set<string>>(new Set());
+  const rowSyncRegistrationsRef = useRef<Map<string, RowSyncRegistration>>(new Map());
   const batchPreloadDoneRef = useRef(false);
   // Async blob work is scoped to one workspace/database lifecycle. A later
   // generation makes completions from the previous lifecycle inert.
@@ -313,18 +357,37 @@ function Database(props: Database2Props) {
         return;
       }
 
-      if (syncedRowKeysRef.current.has(rowKey)) {
+      if (activeDatabaseLifecycleRef.current !== databaseLifecycleIdentity) {
         return;
       }
 
-      syncedRowKeysRef.current.add(rowKey);
-      void createRow(rowKey).catch((e) => {
-        console.error('[Database] registerRowSync failed', rowKey, e);
-        // Remove from set so it can be retried
-        syncedRowKeysRef.current.delete(rowKey);
-      });
+      const lifecycleRegistrations = rowSyncRegistrationsRef.current;
+
+      if (lifecycleRegistrations.has(rowKey)) return;
+
+      const registration: RowSyncRegistration = {
+        rowKey,
+        status: 'pending',
+        cleanup: props.scheduleDeferredCleanup,
+      };
+
+      lifecycleRegistrations.set(rowKey, registration);
+      void createRow(rowKey)
+        .then(() => {
+          completeRowSyncRegistration(registration);
+        })
+        .catch((e) => {
+          registration.status = 'released';
+          console.error('[Database] registerRowSync failed', rowKey, e);
+
+          // Remove only this lifecycle's failed registration. A replacement
+          // lifecycle may already own the same row key in a different Map.
+          if (lifecycleRegistrations.get(rowKey) === registration) {
+            lifecycleRegistrations.delete(rowKey);
+          }
+        });
     },
-    [createRow]
+    [createRow, databaseLifecycleIdentity, props.scheduleDeferredCleanup]
   );
 
   const bindRowSync = useCallback(
@@ -725,6 +788,7 @@ function Database(props: Database2Props) {
 
   useLayoutEffect(() => {
     activeDatabaseLifecycleRef.current = databaseLifecycleIdentity;
+    const lifecycleRowSyncRegistrations = new Map<string, RowSyncRegistration>();
     const prefetchGeneration = blobPrefetchGenerationRef.current + 1;
     const previousGate = seedsGateRef.current;
 
@@ -737,7 +801,7 @@ function Database(props: Database2Props) {
     prefetchPromisesRef.current.clear();
     blobPrefetchPromiseRef.current = null;
     localCachePrimedRef.current = false;
-    syncedRowKeysRef.current.clear();
+    rowSyncRegistrationsRef.current = lifecycleRowSyncRegistrations;
     batchPreloadDoneRef.current = false;
     const lifecycleGate = createDeferredGate();
 
@@ -756,6 +820,8 @@ function Database(props: Database2Props) {
         blobPrefetchGenerationRef.current += 1;
       }
 
+      lifecycleRowSyncRegistrations.forEach(releaseRowSyncRegistration);
+      lifecycleRowSyncRegistrations.clear();
       lifecycleGate.resolve();
     };
   }, [databaseLifecycleIdentity, props.initialRowMap]);
@@ -768,24 +834,6 @@ function Database(props: Database2Props) {
       });
     }
   }, [workspaceId, currentDatabaseId, ensureBlobPrefetch]);
-
-  // Schedule deferred cleanup for all row sync contexts on unmount
-  useEffect(() => {
-    const syncedKeys = syncedRowKeysRef;
-    const cleanup = props.scheduleDeferredCleanup;
-
-    return () => {
-      if (!cleanup) return;
-      syncedKeys.current.forEach((rowKey) => {
-        const rowId = rowKey.split('_rows_')[1];
-
-        if (rowId) {
-          cleanup(rowId);
-        }
-      });
-    };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [props.scheduleDeferredCleanup]);
 
   // Combined modal state to avoid multiple re-renders when updating related values
   const [modalState, setModalState] = useState<{

--- a/src/components/database/Database.tsx
+++ b/src/components/database/Database.tsx
@@ -208,6 +208,9 @@ function Database(props: Database2Props) {
   const localCachePrimedRef = useRef(false);
   const syncedRowKeysRef = useRef<Set<string>>(new Set());
   const batchPreloadDoneRef = useRef(false);
+  // Async blob work is scoped to one workspace/database lifecycle. A later
+  // generation makes completions from the previous lifecycle inert.
+  const blobPrefetchGenerationRef = useRef(0);
   // Gate that ensureRow awaits. Resolves after batch preload (or immediately in readOnly).
   const seedsGateRef = useRef(createDeferredGate());
   const [blobPrefetchComplete, setBlobPrefetchComplete] = useState(false);
@@ -226,6 +229,7 @@ function Database(props: Database2Props) {
 
     return databaseId || doc.guid;
   }, [doc]);
+  const currentDatabaseId = getDatabaseId();
 
   const getPriorityRowIds = useCallback(() => {
     const sharedRoot = doc.getMap(YjsEditorKey.data_section);
@@ -388,10 +392,13 @@ function Database(props: Database2Props) {
     [getDatabaseId]
   );
 
-  const runBatchPreload = useCallback(() => {
+  const runBatchPreload = useCallback((prefetchGeneration: number) => {
+    if (blobPrefetchGenerationRef.current !== prefetchGeneration) return;
     if (batchPreloadDoneRef.current) return;
     batchPreloadDoneRef.current = true;
     const gate = seedsGateRef.current;
+    const isCurrentPreload = () =>
+      blobPrefetchGenerationRef.current === prefetchGeneration && seedsGateRef.current === gate;
     const databaseId = getDatabaseId();
     const priorityRowIds = getPriorityRowIds();
 
@@ -437,6 +444,8 @@ function Database(props: Database2Props) {
       })
     )
       .then((results) => {
+        if (!isCurrentPreload()) return;
+
         const newEntries: Record<string, YDoc> = {};
 
         for (const result of results) {
@@ -457,6 +466,8 @@ function Database(props: Database2Props) {
         gate.resolve();
       })
       .catch(() => {
+        if (!isCurrentPreload()) return;
+
         // Ensure the gate always resolves even on unexpected errors,
         // otherwise ensureRow calls would be permanently blocked.
         gate.resolve();
@@ -464,10 +475,15 @@ function Database(props: Database2Props) {
   }, [getDatabaseId, getPriorityRowIds]);
 
   const ensureBlobPrefetch = useCallback(() => {
+    const prefetchGeneration = blobPrefetchGenerationRef.current;
+    const gate = seedsGateRef.current;
+    const isCurrentPrefetch = () =>
+      blobPrefetchGenerationRef.current === prefetchGeneration && seedsGateRef.current === gate;
+
     // Skip blob prefetch in read-only mode (publish view)
     // The publish API doesn't support blob/diff endpoint
     if (readOnly) {
-      seedsGateRef.current.resolve();
+      gate.resolve();
       setBlobPrefetchComplete(true);
       setSeedsReady(true);
       return null;
@@ -476,7 +492,7 @@ function Database(props: Database2Props) {
     const databaseId = getDatabaseId();
 
     if (!workspaceId || !databaseId) {
-      seedsGateRef.current.resolve();
+      gate.resolve();
       return null;
     }
 
@@ -500,19 +516,25 @@ function Database(props: Database2Props) {
       priorityRowIds,
       forceFullSync,
       onSeedsReady: () => {
+        if (!isCurrentPrefetch()) return;
+
         // Seeds are cached — filter/sort can now build ephemeral docs from them
         // without waiting for IndexedDB persist.
         setSeedsReady(true);
         // Also kick off batch preload for visible rows (heavy IndexedDB path).
-        runBatchPreload();
+        runBatchPreload(prefetchGeneration);
       },
     })
       .then(() => {
+        if (!isCurrentPrefetch()) return;
+
         setBlobPrefetchComplete(true);
       })
       .catch(() => {
+        if (!isCurrentPrefetch()) return;
+
         prefetchPromisesRef.current.delete(prefetchKey);
-        seedsGateRef.current.resolve(); // Unblock ensureRow on failure
+        gate.resolve(); // Unblock ensureRow on failure
         setBlobPrefetchComplete(true);
         setSeedsReady(true);
       });
@@ -523,14 +545,12 @@ function Database(props: Database2Props) {
   }, [readOnly, workspaceId, getDatabaseId, getPriorityRowIds, activeViewHasConditions, runBatchPreload]);
 
   useEffect(() => {
-    const databaseId = getDatabaseId();
-
-    retainDatabaseRowDocSeedCache(databaseId);
+    retainDatabaseRowDocSeedCache(currentDatabaseId);
 
     return () => {
-      releaseDatabaseRowDocSeedCache(databaseId);
+      releaseDatabaseRowDocSeedCache(currentDatabaseId);
     };
-  }, [getDatabaseId]);
+  }, [currentDatabaseId]);
 
   const createNewRow = useCallback(
     async (rowKey: string) => {
@@ -565,6 +585,11 @@ function Database(props: Database2Props) {
     async (rowId: string) => {
       if (!createRow || !rowId) return;
 
+      const ensureGeneration = blobPrefetchGenerationRef.current;
+      const gate = seedsGateRef.current;
+      const isCurrentEnsure = () =>
+        blobPrefetchGenerationRef.current === ensureGeneration && seedsGateRef.current === gate;
+
       // Fast path: row already loaded (e.g. by batch preload or previous call).
       // Check before awaiting the gate to avoid blocking on already-available rows.
       const existing = rowMapRef.current[rowId];
@@ -579,7 +604,9 @@ function Database(props: Database2Props) {
 
       // Wait for batch preload to finish — it loads visible rows from seeds
       // in parallel. After it completes, the row may now be in rowMap.
-      await seedsGateRef.current.promise;
+      await gate.promise;
+
+      if (!isCurrentEnsure()) return;
 
       const existingAfterGate = rowMapRef.current[rowId];
 
@@ -594,7 +621,9 @@ function Database(props: Database2Props) {
       const pending = pendingRowDocsRef.current.get(rowId);
 
       if (pending) {
-        return pending;
+        const rowDoc = await pending;
+
+        return isCurrentEnsure() ? rowDoc : undefined;
       }
 
       const promise = (async () => {
@@ -611,6 +640,8 @@ function Database(props: Database2Props) {
         try {
           const rowDoc = await openRowDoc(rowKey, seed ?? undefined);
 
+          if (!isCurrentEnsure()) return undefined;
+
           // Bind sync for this row - only visible rows call ensureRow
           // Non-visible rows rely on blob diff cached data
           registerRowSync(rowKey);
@@ -622,6 +653,8 @@ function Database(props: Database2Props) {
 
           return rowDoc;
         } catch {
+          if (!isCurrentEnsure()) return undefined;
+
           if (!localCachePrimedRef.current) {
             localCachePrimedRef.current = true;
             void ensureBlobPrefetch();
@@ -636,16 +669,18 @@ function Database(props: Database2Props) {
       try {
         const rowDoc = await promise;
 
-        if (rowDoc) {
+        if (rowDoc && isCurrentEnsure()) {
           setRowMap((prev) => {
             if (prev[rowId]) return prev;
             return { ...prev, [rowId]: rowDoc };
           });
         }
 
-        return rowDoc;
+        return isCurrentEnsure() ? rowDoc : undefined;
       } finally {
-        pendingRowDocsRef.current.delete(rowId);
+        if (pendingRowDocsRef.current.get(rowId) === promise) {
+          pendingRowDocsRef.current.delete(rowId);
+        }
       }
     },
     // Omitted deps are stable: setRowMap (useState setter), refs (rowMapRef, pendingRowDocsRef,
@@ -655,6 +690,11 @@ function Database(props: Database2Props) {
   );
 
   useEffect(() => {
+    const prefetchGeneration = blobPrefetchGenerationRef.current + 1;
+    const previousGate = seedsGateRef.current;
+
+    blobPrefetchGenerationRef.current = prefetchGeneration;
+    previousGate.resolve();
     const initialRowMap = props.initialRowMap ?? {};
 
     rowMapRef.current = {};
@@ -664,23 +704,31 @@ function Database(props: Database2Props) {
     localCachePrimedRef.current = false;
     syncedRowKeysRef.current.clear();
     batchPreloadDoneRef.current = false;
-    seedsGateRef.current = createDeferredGate();
+    const lifecycleGate = createDeferredGate();
+
+    seedsGateRef.current = lifecycleGate;
     rowMapRef.current = initialRowMap;
     setRowMap(initialRowMap);
     setBlobPrefetchComplete(false);
     setSeedsReady(false);
-  }, [doc.guid, props.initialRowMap]);
+
+    return () => {
+      if (blobPrefetchGenerationRef.current === prefetchGeneration) {
+        blobPrefetchGenerationRef.current += 1;
+      }
+
+      lifecycleGate.resolve();
+    };
+  }, [workspaceId, doc, currentDatabaseId, props.initialRowMap]);
 
   // Trigger blob prefetch when database opens
   useEffect(() => {
-    const databaseId = getDatabaseId();
-
-    if (workspaceId && databaseId) {
+    if (workspaceId && currentDatabaseId) {
       ensureBlobPrefetch()?.catch((error: unknown) => {
         console.error('[Database] Failed to prefetch blob:', error);
       });
     }
-  }, [workspaceId, getDatabaseId, ensureBlobPrefetch]);
+  }, [workspaceId, currentDatabaseId, ensureBlobPrefetch]);
 
   // Schedule deferred cleanup for all row sync contexts on unmount
   useEffect(() => {

--- a/src/components/database/__tests__/Database.prefetch-lifecycle.test.tsx
+++ b/src/components/database/__tests__/Database.prefetch-lifecycle.test.tsx
@@ -1,0 +1,100 @@
+import { act, render, waitFor } from '@testing-library/react';
+import * as Y from 'yjs';
+
+import { peekDatabaseRowDocSeed, prefetchDatabaseBlobDiff } from '@/application/database-blob';
+import { YDoc, YjsDatabaseKey, YjsEditorKey } from '@/application/types';
+import Database, { Database2Props } from '@/components/database/Database';
+
+jest.mock('@/application/database-blob', () => ({
+  getDatabaseRowDocFromSeed: jest.fn(),
+  peekDatabaseRowDocSeed: jest.fn(),
+  prefetchDatabaseBlobDiff: jest.fn(),
+  releaseDatabaseRowDocSeedCache: jest.fn(),
+  retainDatabaseRowDocSeedCache: jest.fn(),
+}));
+
+jest.mock('@/components/database/DatabaseRow', () => ({
+  DatabaseRow: () => null,
+}));
+
+jest.mock('@/components/database/DatabaseRowModal', () => () => null);
+jest.mock('@/components/database/DatabaseViews', () => () => null);
+jest.mock('@/components/database/DatabaseContext', () => ({
+  DatabaseContextProvider: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+jest.mock('@/utils/runtime-config', () => ({
+  getConfigValue: (_key: string, fallback: string) => fallback,
+}));
+
+const mockedPrefetch = prefetchDatabaseBlobDiff as jest.MockedFunction<typeof prefetchDatabaseBlobDiff>;
+const mockedPeekSeed = peekDatabaseRowDocSeed as jest.MockedFunction<typeof peekDatabaseRowDocSeed>;
+
+function createDatabaseDoc(guid: string) {
+  const doc = new Y.Doc({ guid }) as YDoc;
+  const sharedRoot = doc.getMap(YjsEditorKey.data_section);
+  const database = new Y.Map();
+  const views = new Y.Map();
+  const view = new Y.Map();
+  const rowOrders = new Y.Array();
+
+  rowOrders.push([{ id: 'row-id' }]);
+  view.set(YjsDatabaseKey.row_orders, rowOrders);
+  views.set('view-id', view);
+  database.set(YjsDatabaseKey.id, 'database-id');
+  database.set(YjsDatabaseKey.views, views);
+  sharedRoot.set(YjsEditorKey.database, database);
+
+  return doc;
+}
+
+function databaseProps(doc: YDoc): Database2Props {
+  return {
+    workspaceId: 'workspace-id',
+    doc,
+    readOnly: false,
+    activeViewId: 'view-id',
+    databaseName: '',
+    databasePageId: '',
+    onChangeView: jest.fn(),
+  };
+}
+
+describe('Database blob prefetch lifecycle', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedPrefetch.mockImplementation(() => new Promise(() => undefined));
+  });
+
+  it('starts a new prefetch when the Y.Doc instance changes but its guid stays the same', async () => {
+    const firstDoc = createDatabaseDoc('database-id');
+    const secondDoc = createDatabaseDoc('database-id');
+    const { rerender, unmount } = render(<Database {...databaseProps(firstDoc)} />);
+
+    await waitFor(() => {
+      expect(mockedPrefetch).toHaveBeenCalledTimes(1);
+    });
+
+    rerender(<Database {...databaseProps(secondDoc)} />);
+
+    await waitFor(() => {
+      expect(mockedPrefetch).toHaveBeenCalledTimes(2);
+    });
+
+    act(() => {
+      mockedPrefetch.mock.calls[0][2]?.onSeedsReady?.();
+    });
+
+    expect(mockedPeekSeed).not.toHaveBeenCalled();
+
+    act(() => {
+      mockedPrefetch.mock.calls[1][2]?.onSeedsReady?.();
+    });
+
+    expect(mockedPeekSeed).toHaveBeenCalledWith('database-id_rows_row-id');
+
+    unmount();
+    firstDoc.destroy();
+    secondDoc.destroy();
+  });
+});

--- a/src/components/database/__tests__/Database.prefetch-lifecycle.test.tsx
+++ b/src/components/database/__tests__/Database.prefetch-lifecycle.test.tsx
@@ -48,7 +48,7 @@ jest.mock('@/components/database/DatabaseViews', () => {
     jest.requireActual<typeof import('@/application/database-yjs/context')>('@/application/database-yjs/context');
 
   return function MockDatabaseViews() {
-    const { loadRowFromSeed, rowMap } = useDatabaseContext();
+    const { bindRowSync, loadRowFromSeed, rowMap } = useDatabaseContext();
     const initialLoadRowFromSeed = React.useRef(loadRowFromSeed).current;
     const previousLoadRowFromSeed = React.useRef(loadRowFromSeed);
 
@@ -85,6 +85,14 @@ jest.mock('@/components/database/DatabaseViews', () => {
           type: 'button',
         },
         'Load seeded row with initial lifecycle'
+      ),
+      React.createElement(
+        'button',
+        {
+          onClick: () => bindRowSync?.('row-id'),
+          type: 'button',
+        },
+        'Bind row sync'
       )
     );
   };
@@ -328,11 +336,95 @@ describe('Database blob prefetch lifecycle', () => {
     });
 
     expect(results).toEqual([secondRowDoc]);
-    expect(screen.getByRole('button', { name: 'Load seeded row' }).getAttribute('data-row-guid')).toBe('row-b');
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Load seeded row' }).getAttribute('data-row-guid')).toBe('row-b');
+    });
 
     unmount();
     firstDoc.destroy();
     secondDoc.destroy();
     secondRowDoc.destroy();
+  });
+
+  it('releases each lifecycle row-sync owner when the Y.Doc instance changes', async () => {
+    const firstDoc = createDatabaseDoc('shared-guid');
+    const secondDoc = createDatabaseDoc('shared-guid');
+    const rowDoc = new Y.Doc({ guid: 'row-id' }) as YDoc;
+    const createRow = jest.fn().mockResolvedValue(rowDoc);
+    const scheduleDeferredCleanup = jest.fn();
+    const firstProps = {
+      ...databaseProps(firstDoc),
+      createRow,
+      scheduleDeferredCleanup,
+    };
+    const { rerender, unmount } = render(<Database {...firstProps} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Bind row sync' }));
+    await waitFor(() => expect(createRow).toHaveBeenCalledTimes(1));
+
+    rerender(
+      <Database
+        {...databaseProps(secondDoc)}
+        createRow={createRow}
+        scheduleDeferredCleanup={scheduleDeferredCleanup}
+      />
+    );
+
+    await waitFor(() => expect(scheduleDeferredCleanup).toHaveBeenCalledTimes(1));
+    expect(scheduleDeferredCleanup).toHaveBeenLastCalledWith('row-id');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Bind row sync' }));
+    await waitFor(() => expect(createRow).toHaveBeenCalledTimes(2));
+
+    unmount();
+
+    expect(scheduleDeferredCleanup).toHaveBeenCalledTimes(2);
+    expect(scheduleDeferredCleanup).toHaveBeenLastCalledWith('row-id');
+
+    firstDoc.destroy();
+    secondDoc.destroy();
+    rowDoc.destroy();
+  });
+
+  it('releases a row sync that finishes registering after its lifecycle ended', async () => {
+    const firstDoc = createDatabaseDoc('shared-guid');
+    const secondDoc = createDatabaseDoc('shared-guid');
+    const rowDoc = new Y.Doc({ guid: 'row-id' }) as YDoc;
+    const pendingRowSync = createDeferred<YDoc>();
+    const createRow = jest.fn().mockReturnValue(pendingRowSync.promise);
+    const scheduleDeferredCleanup = jest.fn();
+    const { rerender, unmount } = render(
+      <Database
+        {...databaseProps(firstDoc)}
+        createRow={createRow}
+        scheduleDeferredCleanup={scheduleDeferredCleanup}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Bind row sync' }));
+    expect(createRow).toHaveBeenCalledTimes(1);
+
+    rerender(
+      <Database
+        {...databaseProps(secondDoc)}
+        createRow={createRow}
+        scheduleDeferredCleanup={scheduleDeferredCleanup}
+      />
+    );
+
+    expect(scheduleDeferredCleanup).not.toHaveBeenCalled();
+
+    await act(async () => {
+      pendingRowSync.resolve(rowDoc);
+      await pendingRowSync.promise;
+    });
+
+    expect(scheduleDeferredCleanup).toHaveBeenCalledTimes(1);
+    expect(scheduleDeferredCleanup).toHaveBeenCalledWith('row-id');
+
+    unmount();
+    firstDoc.destroy();
+    secondDoc.destroy();
+    rowDoc.destroy();
   });
 });

--- a/src/components/database/__tests__/Database.prefetch-lifecycle.test.tsx
+++ b/src/components/database/__tests__/Database.prefetch-lifecycle.test.tsx
@@ -1,9 +1,13 @@
-import { act, render, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import * as Y from 'yjs';
 
 import { peekDatabaseRowDocSeed, prefetchDatabaseBlobDiff } from '@/application/database-blob';
+import { getCachedRowDoc, openRowDoc } from '@/application/services/js-services/cache';
 import { YDoc, YjsDatabaseKey, YjsEditorKey } from '@/application/types';
 import Database, { Database2Props } from '@/components/database/Database';
+
+const mockSeedLoadPromises: Array<Promise<YDoc | undefined>> = [];
+let mockLoadSeedOnLifecycleChange = false;
 
 jest.mock('@/application/database-blob', () => ({
   getDatabaseRowDocFromSeed: jest.fn(),
@@ -13,15 +17,78 @@ jest.mock('@/application/database-blob', () => ({
   retainDatabaseRowDocSeedCache: jest.fn(),
 }));
 
+jest.mock('@/application/services/js-services/cache', () => ({
+  getCachedRowDoc: jest.fn(),
+  openRowDoc: jest.fn(),
+}));
+
 jest.mock('@/components/database/DatabaseRow', () => ({
   DatabaseRow: () => null,
 }));
 
 jest.mock('@/components/database/DatabaseRowModal', () => () => null);
-jest.mock('@/components/database/DatabaseViews', () => () => null);
-jest.mock('@/components/database/DatabaseContext', () => ({
-  DatabaseContextProvider: ({ children }: { children: React.ReactNode }) => children,
-}));
+jest.mock('@/components/database/DatabaseContext', () => {
+  const React = jest.requireActual<typeof import('react')>('react');
+  const { DatabaseContext } =
+    jest.requireActual<typeof import('@/application/database-yjs/context')>('@/application/database-yjs/context');
+
+  return {
+    DatabaseContextProvider: ({
+      children,
+      value,
+    }: {
+      children: React.ReactNode;
+      value: React.ContextType<typeof DatabaseContext>;
+    }) => React.createElement(DatabaseContext.Provider, { value }, children),
+  };
+});
+jest.mock('@/components/database/DatabaseViews', () => {
+  const React = jest.requireActual<typeof import('react')>('react');
+  const { useDatabaseContext } =
+    jest.requireActual<typeof import('@/application/database-yjs/context')>('@/application/database-yjs/context');
+
+  return function MockDatabaseViews() {
+    const { loadRowFromSeed, rowMap } = useDatabaseContext();
+    const initialLoadRowFromSeed = React.useRef(loadRowFromSeed).current;
+    const previousLoadRowFromSeed = React.useRef(loadRowFromSeed);
+
+    React.useEffect(() => {
+      const previous = previousLoadRowFromSeed.current;
+
+      previousLoadRowFromSeed.current = loadRowFromSeed;
+      if (!mockLoadSeedOnLifecycleChange || previous === loadRowFromSeed || !loadRowFromSeed) return;
+      mockSeedLoadPromises.push(loadRowFromSeed('row-id'));
+    }, [loadRowFromSeed]);
+
+    return React.createElement(
+      React.Fragment,
+      null,
+      React.createElement(
+        'button',
+        {
+          'data-row-guid': rowMap?.['row-id']?.guid ?? '',
+          onClick: () => {
+            if (!loadRowFromSeed) throw new Error('loadRowFromSeed is not available');
+            mockSeedLoadPromises.push(loadRowFromSeed('row-id'));
+          },
+          type: 'button',
+        },
+        'Load seeded row'
+      ),
+      React.createElement(
+        'button',
+        {
+          onClick: () => {
+            if (!initialLoadRowFromSeed) throw new Error('initial loadRowFromSeed is not available');
+            mockSeedLoadPromises.push(initialLoadRowFromSeed('row-id'));
+          },
+          type: 'button',
+        },
+        'Load seeded row with initial lifecycle'
+      )
+    );
+  };
+});
 
 jest.mock('@/utils/runtime-config', () => ({
   getConfigValue: (_key: string, fallback: string) => fallback,
@@ -29,8 +96,19 @@ jest.mock('@/utils/runtime-config', () => ({
 
 const mockedPrefetch = prefetchDatabaseBlobDiff as jest.MockedFunction<typeof prefetchDatabaseBlobDiff>;
 const mockedPeekSeed = peekDatabaseRowDocSeed as jest.MockedFunction<typeof peekDatabaseRowDocSeed>;
+const mockedGetCachedRowDoc = getCachedRowDoc as jest.MockedFunction<typeof getCachedRowDoc>;
+const mockedOpenRowDoc = openRowDoc as jest.MockedFunction<typeof openRowDoc>;
 
-function createDatabaseDoc(guid: string) {
+function createDeferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((promiseResolve) => {
+    resolve = promiseResolve;
+  });
+
+  return { promise, resolve };
+}
+
+function createDatabaseDoc(guid: string, databaseId = 'database-id') {
   const doc = new Y.Doc({ guid }) as YDoc;
   const sharedRoot = doc.getMap(YjsEditorKey.data_section);
   const database = new Y.Map();
@@ -41,7 +119,7 @@ function createDatabaseDoc(guid: string) {
   rowOrders.push([{ id: 'row-id' }]);
   view.set(YjsDatabaseKey.row_orders, rowOrders);
   views.set('view-id', view);
-  database.set(YjsDatabaseKey.id, 'database-id');
+  database.set(YjsDatabaseKey.id, databaseId);
   database.set(YjsDatabaseKey.views, views);
   sharedRoot.set(YjsEditorKey.database, database);
 
@@ -60,9 +138,36 @@ function databaseProps(doc: YDoc): Database2Props {
   };
 }
 
+function requestSeedLoad() {
+  const requestIndex = mockSeedLoadPromises.length;
+
+  fireEvent.click(screen.getByRole('button', { name: 'Load seeded row' }));
+  const request = mockSeedLoadPromises[requestIndex];
+
+  if (!request) throw new Error('DatabaseViews did not request a seeded row');
+  return request;
+}
+
+function requestSeedLoadFromInitialLifecycle() {
+  const requestIndex = mockSeedLoadPromises.length;
+
+  fireEvent.click(screen.getByRole('button', { name: 'Load seeded row with initial lifecycle' }));
+  const request = mockSeedLoadPromises[requestIndex];
+
+  if (!request) throw new Error('DatabaseViews did not request a seeded row from its initial lifecycle');
+  return request;
+}
+
 describe('Database blob prefetch lifecycle', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockSeedLoadPromises.length = 0;
+    mockLoadSeedOnLifecycleChange = false;
+    mockedPeekSeed.mockReset();
+    mockedGetCachedRowDoc.mockReset();
+    mockedOpenRowDoc.mockReset();
+    mockedPrefetch.mockReset();
+    mockedGetCachedRowDoc.mockReturnValue(undefined);
     mockedPrefetch.mockImplementation(() => new Promise(() => undefined));
   });
 
@@ -96,5 +201,138 @@ describe('Database blob prefetch lifecycle', () => {
     unmount();
     firstDoc.destroy();
     secondDoc.destroy();
+  });
+
+  it('isolates pending seed loads across database lifecycles', async () => {
+    const firstDoc = createDatabaseDoc('shared-guid', 'database-a');
+    const secondDoc = createDatabaseDoc('shared-guid', 'database-b');
+    // An empty stale doc keeps the later request on the pending-load path, so
+    // stale row injection cannot mask stale cleanup deleting the newer promise.
+    const firstRowDoc = new Y.Doc({ guid: 'row-a' }) as YDoc;
+    const secondRowDoc = new Y.Doc({ guid: 'row-b' }) as YDoc;
+    const firstLoad = createDeferred<YDoc>();
+    const secondLoad = createDeferred<YDoc>();
+    const seed = { bytes: new Uint8Array([1, 2, 3]), encoderVersion: 1 };
+
+    mockedPeekSeed.mockReturnValue(seed);
+    mockedOpenRowDoc.mockImplementation((rowKey) => {
+      if (rowKey === 'database-a_rows_row-id') return firstLoad.promise;
+      if (rowKey === 'database-b_rows_row-id') return secondLoad.promise;
+      throw new Error(`unexpected row key: ${rowKey}`);
+    });
+
+    const { rerender, unmount } = render(<Database {...databaseProps(firstDoc)} />);
+    const firstOwner = requestSeedLoad();
+    const firstFollower = requestSeedLoad();
+
+    expect(mockedOpenRowDoc).toHaveBeenCalledTimes(1);
+    expect(mockedOpenRowDoc).toHaveBeenCalledWith('database-a_rows_row-id', seed);
+
+    rerender(<Database {...databaseProps(secondDoc)} />);
+
+    await waitFor(() => {
+      expect(mockedPrefetch).toHaveBeenCalledTimes(2);
+    });
+
+    const secondOwner = requestSeedLoad();
+
+    expect(mockedOpenRowDoc).toHaveBeenCalledTimes(2);
+    expect(mockedOpenRowDoc).toHaveBeenLastCalledWith('database-b_rows_row-id', seed);
+
+    let firstResults: Array<YDoc | undefined> = [];
+
+    await act(async () => {
+      firstLoad.resolve(firstRowDoc);
+      firstResults = await Promise.all([firstOwner, firstFollower]);
+    });
+
+    expect(firstResults).toEqual([undefined, undefined]);
+    expect(screen.getByRole('button', { name: 'Load seeded row' }).getAttribute('data-row-guid')).toBe('');
+
+    const secondFollower = requestSeedLoad();
+
+    expect(mockedOpenRowDoc).toHaveBeenCalledTimes(2);
+
+    let secondResults: Array<YDoc | undefined> = [];
+
+    await act(async () => {
+      secondLoad.resolve(secondRowDoc);
+      secondResults = await Promise.all([secondOwner, secondFollower]);
+    });
+
+    expect(secondResults).toEqual([secondRowDoc, secondRowDoc]);
+    expect(screen.getByRole('button', { name: 'Load seeded row' }).getAttribute('data-row-guid')).toBe('row-b');
+
+    unmount();
+    firstDoc.destroy();
+    secondDoc.destroy();
+    firstRowDoc.destroy();
+    secondRowDoc.destroy();
+  });
+
+  it('ignores a seed loader retained from a previous database lifecycle', async () => {
+    const firstDoc = createDatabaseDoc('shared-guid', 'database-a');
+    const secondDoc = createDatabaseDoc('shared-guid', 'database-b');
+    const staleRowDoc = new Y.Doc({ guid: 'row-a' }) as YDoc;
+    const seed = { bytes: new Uint8Array([1, 2, 3]), encoderVersion: 1 };
+
+    mockedPeekSeed.mockReturnValue(seed);
+    mockedOpenRowDoc.mockResolvedValue(staleRowDoc);
+
+    const { rerender, unmount } = render(<Database {...databaseProps(firstDoc)} />);
+
+    rerender(<Database {...databaseProps(secondDoc)} />);
+
+    await waitFor(() => {
+      expect(mockedPrefetch).toHaveBeenCalledTimes(2);
+    });
+
+    let staleResult: YDoc | undefined;
+
+    await act(async () => {
+      staleResult = await requestSeedLoadFromInitialLifecycle();
+    });
+
+    expect(staleResult).toBeUndefined();
+    expect(mockedOpenRowDoc).not.toHaveBeenCalled();
+    expect(screen.getByRole('button', { name: 'Load seeded row' }).getAttribute('data-row-guid')).toBe('');
+
+    unmount();
+    firstDoc.destroy();
+    secondDoc.destroy();
+    staleRowDoc.destroy();
+  });
+
+  it('activates a new seed loader before descendant effects run', async () => {
+    const firstDoc = createDatabaseDoc('shared-guid', 'database-a');
+    const secondDoc = createDatabaseDoc('shared-guid', 'database-b');
+    const secondRowDoc = new Y.Doc({ guid: 'row-b' }) as YDoc;
+    const seed = { bytes: new Uint8Array([1, 2, 3]), encoderVersion: 1 };
+
+    mockLoadSeedOnLifecycleChange = true;
+    mockedPeekSeed.mockReturnValue(seed);
+    mockedOpenRowDoc.mockResolvedValue(secondRowDoc);
+
+    const { rerender, unmount } = render(<Database {...databaseProps(firstDoc)} />);
+
+    rerender(<Database {...databaseProps(secondDoc)} />);
+
+    await waitFor(() => {
+      expect(mockedOpenRowDoc).toHaveBeenCalledWith('database-b_rows_row-id', seed);
+    });
+
+    let results: Array<YDoc | undefined> = [];
+
+    await act(async () => {
+      results = await Promise.all(mockSeedLoadPromises);
+    });
+
+    expect(results).toEqual([secondRowDoc]);
+    expect(screen.getByRole('button', { name: 'Load seeded row' }).getAttribute('data-row-guid')).toBe('row-b');
+
+    unmount();
+    firstDoc.destroy();
+    secondDoc.destroy();
+    secondRowDoc.destroy();
   });
 });

--- a/src/components/ws/__tests__/useSync.test.ts
+++ b/src/components/ws/__tests__/useSync.test.ts
@@ -96,6 +96,7 @@ jest.mock('@/application/sync-outbox', () => {
       });
       ctx.pending.set(record.objectId, queued);
       drain(record.objectId);
+      return Promise.resolve(true);
     }),
     deleteOutboxByObjectId: jest.fn(async (objectId: string) => {
       ctx.pending.delete(objectId);
@@ -1369,6 +1370,151 @@ describe('useSync public API', () => {
       });
 
       expect(mockedCollabFullSyncBatch).not.toHaveBeenCalled();
+
+      unmount();
+      doc.destroy();
+    } finally {
+      jest.runOnlyPendingTimers();
+      jest.useRealTimers();
+    }
+  });
+
+  it('clears the covered dirty edit after a routed manifest becomes durable', async () => {
+    jest.useFakeTimers();
+    mockedCollabFullSyncBatch.mockResolvedValue([]);
+
+    try {
+      const ws = {
+        ...createWs(),
+        readyState: 1,
+      } as AppflowyWebSocketType;
+      const bc = createBroadcastChannel();
+      const doc = createDoc('cfcfcfcf-4444-4444-8444-cfcfcfcfcfcf');
+      const persisted = createDeferred<boolean>();
+      const { result, rerender, unmount } = renderHook(() => useSync(ws, bc, defaultEventEmitter, defaultWorkspaceId));
+      let syncContext: SyncContext | undefined;
+
+      act(() => {
+        syncContext = result.current.registerSyncContext({ doc, collabType: Types.Document });
+        doc.getMap('root').set('covered-edit', true);
+        syncContext?.onManifestSync?.(doc.guid, persisted.promise);
+      });
+
+      await act(async () => {
+        persisted.resolve(true);
+        await flushPromises();
+      });
+
+      act(() => {
+        ws.readyState = 0;
+        rerender();
+      });
+
+      await act(async () => {
+        jest.advanceTimersByTime(5_000);
+        await flushPromises();
+      });
+
+      expect(mockedCollabFullSyncBatch).not.toHaveBeenCalled();
+
+      unmount();
+      doc.destroy();
+    } finally {
+      jest.runOnlyPendingTimers();
+      jest.useRealTimers();
+    }
+  });
+
+  it('keeps the covered dirty edit when a routed manifest cannot be persisted', async () => {
+    jest.useFakeTimers();
+    mockedCollabFullSyncBatch.mockResolvedValue([]);
+
+    try {
+      const ws = {
+        ...createWs(),
+        readyState: 1,
+      } as AppflowyWebSocketType;
+      const bc = createBroadcastChannel();
+      const doc = createDoc('cfcfcfcf-6666-4666-8666-cfcfcfcfcfcf');
+      const persisted = createDeferred<boolean>();
+      const { result, rerender, unmount } = renderHook(() => useSync(ws, bc, defaultEventEmitter, defaultWorkspaceId));
+      let syncContext: SyncContext | undefined;
+
+      act(() => {
+        syncContext = result.current.registerSyncContext({ doc, collabType: Types.Document });
+        doc.getMap('root').set('unpersisted-edit', true);
+        syncContext?.onManifestSync?.(doc.guid, persisted.promise);
+      });
+
+      await act(async () => {
+        persisted.resolve(false);
+        await flushPromises();
+      });
+
+      act(() => {
+        ws.readyState = 0;
+        rerender();
+      });
+
+      await act(async () => {
+        jest.advanceTimersByTime(5_000);
+        await flushPromises();
+      });
+
+      expect(mockedCollabFullSyncBatch).toHaveBeenCalledTimes(1);
+      expect(mockedCollabFullSyncBatch.mock.calls[0]?.[1]).toEqual([
+        expect.objectContaining({ objectId: doc.guid, collabType: Types.Document }),
+      ]);
+
+      unmount();
+      doc.destroy();
+    } finally {
+      jest.runOnlyPendingTimers();
+      jest.useRealTimers();
+    }
+  });
+
+  it('keeps a newer dirty edit when an older routed manifest becomes durable', async () => {
+    jest.useFakeTimers();
+    mockedCollabFullSyncBatch.mockResolvedValue([]);
+
+    try {
+      const ws = {
+        ...createWs(),
+        readyState: 1,
+      } as AppflowyWebSocketType;
+      const bc = createBroadcastChannel();
+      const doc = createDoc('cfcfcfcf-5555-4555-8555-cfcfcfcfcfcf');
+      const persisted = createDeferred<boolean>();
+      const { result, rerender, unmount } = renderHook(() => useSync(ws, bc, defaultEventEmitter, defaultWorkspaceId));
+      let syncContext: SyncContext | undefined;
+
+      act(() => {
+        syncContext = result.current.registerSyncContext({ doc, collabType: Types.Document });
+        doc.getMap('root').set('covered-edit', true);
+        syncContext?.onManifestSync?.(doc.guid, persisted.promise);
+        doc.getMap('root').set('newer-edit', true);
+      });
+
+      await act(async () => {
+        persisted.resolve(true);
+        await flushPromises();
+      });
+
+      act(() => {
+        ws.readyState = 0;
+        rerender();
+      });
+
+      await act(async () => {
+        jest.advanceTimersByTime(5_000);
+        await flushPromises();
+      });
+
+      expect(mockedCollabFullSyncBatch).toHaveBeenCalledTimes(1);
+      expect(mockedCollabFullSyncBatch.mock.calls[0]?.[1]).toEqual([
+        expect.objectContaining({ objectId: doc.guid, collabType: Types.Document }),
+      ]);
 
       unmount();
       doc.destroy();

--- a/src/components/ws/__tests__/useSync.test.ts
+++ b/src/components/ws/__tests__/useSync.test.ts
@@ -80,24 +80,26 @@ jest.mock('@/application/sync-outbox', () => {
   };
 
   return {
-    enqueueOutboxUpdate: jest.fn((record: { objectId: string; collabType: number; version?: string | null; payload: Uint8Array }) => {
-      const queued = ctx.pending.get(record.objectId) ?? [];
+    enqueueOutboxUpdate: jest.fn(
+      (record: { objectId: string; collabType: number; version?: string | null; payload: Uint8Array }) => {
+        const queued = ctx.pending.get(record.objectId) ?? [];
 
-      queued.push({
-        collabMessage: {
-          objectId: record.objectId,
-          collabType: record.collabType,
-          update: {
-            flags: 0,
-            payload: record.payload,
-            version: record.version ?? undefined,
+        queued.push({
+          collabMessage: {
+            objectId: record.objectId,
+            collabType: record.collabType,
+            update: {
+              flags: 0,
+              payload: record.payload,
+              version: record.version ?? undefined,
+            },
           },
-        },
-      });
-      ctx.pending.set(record.objectId, queued);
-      drain(record.objectId);
-      return Promise.resolve(true);
-    }),
+        });
+        ctx.pending.set(record.objectId, queued);
+        drain(record.objectId);
+        return Promise.resolve(true);
+      }
+    ),
     deleteOutboxByObjectId: jest.fn(async (objectId: string) => {
       ctx.pending.delete(objectId);
     }),
@@ -225,7 +227,9 @@ const flushPromises = async () => {
 
 const mockedOpenCollabDB = openCollabDB as jest.MockedFunction<typeof openCollabDB>;
 const mockedOpenCollabDBWithProvider = openCollabDBWithProvider as jest.MockedFunction<typeof openCollabDBWithProvider>;
-const mockedOpenRowCollabDBWithProvider = openRowCollabDBWithProvider as jest.MockedFunction<typeof openRowCollabDBWithProvider>;
+const mockedOpenRowCollabDBWithProvider = openRowCollabDBWithProvider as jest.MockedFunction<
+  typeof openRowCollabDBWithProvider
+>;
 const mockedListCollabIndexedDBNames = listCollabIndexedDBNames as jest.MockedFunction<typeof listCollabIndexedDBNames>;
 const mockedCollabIndexedDBExists = collabIndexedDBExists as jest.MockedFunction<typeof collabIndexedDBExists>;
 const mockedHandleMessage = handleMessage as jest.MockedFunction<typeof handleMessage>;
@@ -276,9 +280,7 @@ describe('useSync reconnect binding', () => {
     } as AppflowyWebSocketType;
     const bc = createBroadcastChannel();
     const doc = createDoc('03030303-0303-4303-8303-030303030303');
-    const { result, rerender, unmount } = renderHook(() =>
-      useSync(ws, bc, defaultEventEmitter, defaultWorkspaceId)
-    );
+    const { result, rerender, unmount } = renderHook(() => useSync(ws, bc, defaultEventEmitter, defaultWorkspaceId));
     const sendMessage = ws.sendMessage as jest.Mock;
     const postMessage = bc.postMessage as jest.Mock;
 
@@ -492,7 +494,7 @@ describe('useSync deferred cleanup', () => {
           collabType: Types.DatabaseRow,
           update: expect.any(Object),
         }),
-      }),
+      })
     );
 
     outboxMock.clearDrainConfig();
@@ -586,6 +588,155 @@ describe('useSync version-gated message handling', () => {
           stateVector: new Uint8Array([0]),
           lastMessageId: undefined,
         }),
+      })
+    );
+
+    unmount();
+    doc.destroy();
+    nextDoc.destroy();
+  });
+
+  it('does not finalize a version-only HTTP result for an inactive collab', async () => {
+    const ws = createWs();
+    const bc = createBroadcastChannel();
+    const objectId = '44444444-4444-4444-8444-444444444447';
+    const serverVersion = '018f2f9e-3f04-7c8d-8a2e-8df6dff4b512';
+    const { result, unmount } = renderHook(() => useSync(ws, bc, defaultEventEmitter, defaultWorkspaceId));
+
+    await expect(
+      act(async () => {
+        await result.current.applyHttpFullSyncResult({
+          objectId,
+          collabType: Types.Document,
+          missingUpdate: new Uint8Array(),
+          serverStateVector: new Uint8Array([0]),
+          collabVersion: serverVersion,
+        });
+      })
+    ).rejects.toThrow(`HTTP full-sync result for ${objectId} was not applied to an active sync context`);
+
+    expect(mockedHandleMessage).not.toHaveBeenCalled();
+    expect(mockedOpenCollabDB).not.toHaveBeenCalled();
+
+    unmount();
+  });
+
+  it('does not finalize a queued HTTP result when its context closes before apply', async () => {
+    const ws = createWs();
+    const bc = createBroadcastChannel();
+    const eventEmitter = new EventEmitter();
+    const objectId = '44444444-4444-4444-8444-444444444448';
+    const localVersion = '018f2f9e-3f04-7c8d-8a2e-8df6dff4b513';
+    const serverVersion = '018f2f9e-3f04-7c8d-8a2e-8df6dff4b514';
+    const doc = createDoc(objectId) as Y.Doc & { version?: string };
+    const nextDoc = createDoc(objectId) as Y.Doc & { version?: string };
+    const deferredOpen = createDeferred<Y.Doc>();
+
+    doc.version = localVersion;
+    nextDoc.version = serverVersion;
+    mockedOpenCollabDB.mockImplementationOnce(() => deferredOpen.promise as Promise<Y.Doc>);
+    eventEmitter.once(APP_EVENTS.COLLAB_DOC_RESET, (payload: { doc: Y.Doc }) => payload.doc.destroy());
+
+    const { result, rerender, unmount } = renderHook(() => useSync(ws, bc, eventEmitter, defaultWorkspaceId));
+
+    act(() => {
+      result.current.registerSyncContext({ doc, collabType: Types.Document });
+    });
+
+    let httpApply!: Promise<void>;
+
+    act(() => {
+      ws.lastMessage = {
+        collabMessage: {
+          objectId,
+          collabType: Types.Document,
+          update: { version: serverVersion },
+        },
+      } as AppflowyWebSocketType['lastMessage'];
+      rerender();
+
+      // The active context exists when this response is enqueued, but the
+      // preceding reset owns this object's queue and closes it before apply.
+      httpApply = result.current.applyHttpFullSyncResult({
+        objectId,
+        collabType: Types.Document,
+        missingUpdate: new Uint8Array(),
+        serverStateVector: new Uint8Array([0]),
+        collabVersion: serverVersion,
+      });
+    });
+
+    await waitFor(() => expect(mockedOpenCollabDB).toHaveBeenCalledTimes(1));
+
+    await act(async () => {
+      deferredOpen.resolve(nextDoc);
+      await expect(httpApply).rejects.toThrow(
+        `HTTP full-sync result for ${objectId} was not applied to an active sync context`
+      );
+    });
+
+    unmount();
+  });
+
+  it('cancels an HTTP result queued behind a version reset without waiting for that reset', async () => {
+    const ws = createWs();
+    const bc = createBroadcastChannel();
+    const objectId = '44444444-4444-4444-8444-444444444448';
+    const localVersion = '018f2f9e-3f04-7c8d-8a2e-8df6dff4b513';
+    const resetVersion = '018f2f9e-3f04-7c8d-8a2e-8df6dff4b514';
+    const staleHttpVersion = '018f2f9e-3f04-7c8d-8a2e-8df6dff4b515';
+    const doc = createDoc(objectId) as Y.Doc & { version?: string };
+    const nextDoc = createDoc(objectId) as Y.Doc & { version?: string };
+    const resetOpen = createDeferred<Y.Doc>();
+
+    doc.version = localVersion;
+    nextDoc.version = resetVersion;
+    mockedOpenCollabDB.mockImplementationOnce(() => resetOpen.promise);
+    const { result, rerender, unmount } = renderHook(() => useSync(ws, bc, defaultEventEmitter, defaultWorkspaceId));
+
+    act(() => {
+      result.current.registerSyncContext({ doc, collabType: Types.Document });
+      ws.lastMessage = {
+        collabMessage: {
+          objectId,
+          collabType: Types.Document,
+          update: { version: resetVersion },
+        },
+      } as AppflowyWebSocketType['lastMessage'];
+      rerender();
+    });
+    await waitFor(() => expect(mockedOpenCollabDB).toHaveBeenCalledTimes(1));
+
+    const controller = new AbortController();
+    const applyPromise = result.current.applyHttpFullSyncResult(
+      {
+        objectId,
+        collabType: Types.Document,
+        missingUpdate: new Uint8Array(),
+        serverStateVector: new Uint8Array([0]),
+        collabVersion: staleHttpVersion,
+      },
+      localVersion,
+      controller.signal
+    );
+    const rejection = expect(applyPromise).rejects.toMatchObject({ name: 'AbortError' });
+
+    controller.abort();
+    await rejection;
+
+    // Cancellation settles while the reset is still blocked. The stale HTTP
+    // result therefore cannot participate in the replacement context later.
+    expect(mockedHandleMessage).not.toHaveBeenCalled();
+
+    await act(async () => {
+      resetOpen.resolve(nextDoc);
+      await resetOpen.promise;
+    });
+    await waitFor(() => expect(mockedHandleMessage).toHaveBeenCalledTimes(1));
+    expect(mockedHandleMessage).not.toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        update: expect.objectContaining({ version: staleHttpVersion }),
       })
     );
 
@@ -2000,7 +2151,6 @@ describe('useSync queue guards and dedupe', () => {
 
     errorSpy.mockRestore();
   });
-
 });
 
 describe('useSync revertCollabVersion', () => {
@@ -2117,12 +2267,7 @@ describe('useSync revertCollabVersion', () => {
       await result.current.revertCollabVersion(doc.guid, targetVersion);
     });
 
-    expect(mockedRevertCollabVersion).toHaveBeenCalledWith(
-      workspaceId,
-      doc.guid,
-      Types.Document,
-      targetVersion
-    );
+    expect(mockedRevertCollabVersion).toHaveBeenCalledWith(workspaceId, doc.guid, Types.Document, targetVersion);
     expect(mockedOpenCollabDB).toHaveBeenCalledWith(doc.guid, {
       expectedVersion: targetVersion,
       currentUser: user.uid,

--- a/src/components/ws/__tests__/useSync.test.ts
+++ b/src/components/ws/__tests__/useSync.test.ts
@@ -106,6 +106,7 @@ jest.mock('@/application/sync-outbox', () => {
       for (const id of ids) drain(id);
       return true;
     }),
+    shouldRouteUpdateThroughOutbox: jest.fn(() => false),
     configureDrain: jest.fn((config: DrainConfig) => {
       ctx.config = config;
       for (const id of Array.from(ctx.pending.keys())) drain(id);
@@ -540,6 +541,56 @@ describe('useSync version-gated message handling', () => {
 
     unmount();
     doc.destroy();
+  });
+
+  it('accepts a no-RID HTTP result when an authoritative version supersedes the local doc', async () => {
+    const ws = createWs();
+    const bc = createBroadcastChannel();
+    const objectId = '44444444-4444-4444-8444-444444444446';
+    const localVersion = '018f2f9e-3f04-7c8d-8a2e-8df6dff4b510';
+    const serverVersion = '018f2f9e-3f04-7c8d-8a2e-8df6dff4b511';
+    const doc = createDoc(objectId) as Y.Doc & { version?: string };
+    const nextDoc = createDoc(objectId) as Y.Doc & { version?: string };
+
+    doc.version = localVersion;
+    nextDoc.version = serverVersion;
+    mockedOpenCollabDB.mockResolvedValueOnce(nextDoc as Y.Doc);
+    const { result, unmount } = renderHook(() => useSync(ws, bc, defaultEventEmitter, defaultWorkspaceId));
+
+    act(() => {
+      result.current.registerSyncContext({ doc, collabType: Types.Document });
+    });
+    mockedHandleMessage.mockClear();
+
+    await act(async () => {
+      await result.current.applyHttpFullSyncResult({
+        objectId,
+        collabType: Types.Document,
+        missingUpdate: new Uint8Array(),
+        serverStateVector: new Uint8Array([0]),
+        collabVersion: serverVersion,
+      });
+    });
+
+    expect(mockedOpenCollabDB).toHaveBeenCalledWith(objectId, {
+      expectedVersion: serverVersion,
+      currentUser: undefined,
+    });
+    expect(mockedHandleMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ doc: nextDoc }),
+      expect.objectContaining({
+        objectId,
+        syncRequest: expect.objectContaining({
+          version: serverVersion,
+          stateVector: new Uint8Array([0]),
+          lastMessageId: undefined,
+        }),
+      })
+    );
+
+    unmount();
+    doc.destroy();
+    nextDoc.destroy();
   });
 
   it('resets when local version is known but incoming version is missing', async () => {
@@ -1382,6 +1433,48 @@ describe('useSync public API', () => {
     });
 
     expect(localDoc.getMap('root').get('server')).toBe('value');
+  });
+
+  it('applies a slow HTTP result through the normal message path with the active version and RID', async () => {
+    const ws = createWs();
+    const bc = createBroadcastChannel();
+    const localDoc = createDoc('efefefef-2222-4222-8222-efefefefefef') as Y.Doc & { version?: string };
+    const serverDoc = createDoc(localDoc.guid);
+    const version = '018f2f9e-3f04-7c8d-8a2e-8df6dff4b500';
+    const messageId = { timestamp: 42, counter: 3 };
+    const { result } = renderHook(() => useSync(ws, bc, defaultEventEmitter, defaultWorkspaceId));
+
+    localDoc.version = version;
+    serverDoc.getMap('root').set('server', 'value');
+    const missingUpdate = Y.encodeStateAsUpdate(serverDoc, Y.encodeStateVector(localDoc));
+
+    act(() => {
+      result.current.registerSyncContext({ doc: localDoc, collabType: Types.Document });
+    });
+    mockedHandleMessage.mockClear();
+
+    await act(async () => {
+      await result.current.applyHttpFullSyncResult({
+        objectId: localDoc.guid,
+        collabType: Types.Document,
+        missingUpdate,
+        serverStateVector: Y.encodeStateVector(serverDoc),
+        messageId,
+      });
+    });
+
+    expect(mockedHandleMessage).toHaveBeenCalledTimes(1);
+    expect(mockedHandleMessage.mock.calls[0]?.[1]).toEqual(
+      expect.objectContaining({
+        objectId: localDoc.guid,
+        collabType: Types.Document,
+        update: expect.objectContaining({
+          payload: missingUpdate,
+          version,
+          messageId,
+        }),
+      })
+    );
   });
 
   it('syncAllToServer sends sync request when HTTP missing update has dependencies', async () => {

--- a/src/components/ws/sync/replayQueuedMessages.ts
+++ b/src/components/ws/sync/replayQueuedMessages.ts
@@ -18,7 +18,7 @@ export async function replayQueuedMessages(
   applyCollabMessage: (
     message: ICollabMessage,
     options?: { allowVersionReset?: boolean; user?: User }
-  ) => Promise<void>,
+  ) => Promise<unknown>,
   user?: User
 ): Promise<void> {
   let queued = queuedMessagesDuringReset.get(objectId);

--- a/src/components/ws/sync/syncRefs.ts
+++ b/src/components/ws/sync/syncRefs.ts
@@ -5,6 +5,8 @@ import { SyncContext } from '@/application/services/js-services/sync-protocol';
 import { User } from '@/application/types';
 import { collab } from '@/proto/messages';
 
+import { QueuedCollabMessage } from './types';
+
 import ICollabMessage = collab.ICollabMessage;
 
 /**
@@ -165,7 +167,7 @@ export type SyncRefs = {
    * own queue and processing flag), so a slow reset on one doc never blocks
    * updates to another.
    */
-  incomingMessageQueuesRef: React.MutableRefObject<Map<string, ICollabMessage[]>>;
+  incomingMessageQueuesRef: React.MutableRefObject<Map<string, QueuedCollabMessage[]>>;
 
   /**
    * Set of objectIds whose message queues are currently being drained.
@@ -214,7 +216,7 @@ export function useSyncRefs(): SyncRefs {
   const latestIncomingVersionRef = useRef<Map<string, string>>(new Map());
 
   // ── 4. Message queue & lifecycle ─────────────────────────────────────
-  const incomingMessageQueuesRef = useRef<Map<string, ICollabMessage[]>>(new Map());
+  const incomingMessageQueuesRef = useRef<Map<string, QueuedCollabMessage[]>>(new Map());
   const processingObjectIdsRef = useRef<Set<string>>(new Set());
   const latestUserRef = useRef<User | undefined>(undefined);
   const isDisposedRef = useRef(false);

--- a/src/components/ws/sync/types.ts
+++ b/src/components/ws/sync/types.ts
@@ -39,6 +39,17 @@ export interface ApplyCollabMessageOptions {
   user?: User;
   isCancelled?: () => boolean;
   /**
+   * Lets an HTTP slow-sync result leave the per-object queue immediately when
+   * its outbox lifecycle ends (for example, while a version reset is active).
+   */
+  signal?: AbortSignal;
+  /**
+   * HTTP full-sync callers must know that an authoritative response actually
+   * reached a live document before they retire its persisted outbox records.
+   * Ordinary WS/BC delivery remains best-effort when a collab is not open.
+   */
+  requireActiveContext?: boolean;
+  /**
    * HTTP slow-sync applies its result from inside the active outbox drain.
    * A version reset must not await that same drain promise.
    */
@@ -59,6 +70,7 @@ export interface QueuedCollabMessage {
   options?: ApplyCollabMessageOptions;
   resolve?: (applied: boolean) => void;
   reject?: (error: unknown) => void;
+  dispose?: () => void;
 }
 
 export type SyncContextType = {
@@ -82,7 +94,11 @@ export type SyncContextType = {
    * Applies one HTTP full-sync response through the same per-object,
    * version-aware queue used by WebSocket messages.
    */
-  applyHttpFullSyncResult: (result: HttpFullSyncResult, fallbackVersion?: string | null) => Promise<void>;
+  applyHttpFullSyncResult: (
+    result: HttpFullSyncResult,
+    fallbackVersion?: string | null,
+    signal?: AbortSignal
+  ) => Promise<void>;
   /**
    * Schedule deferred cleanup of a sync context after a delay.
    * If the same objectId is re-registered before the timer fires,

--- a/src/components/ws/sync/types.ts
+++ b/src/components/ws/sync/types.ts
@@ -1,7 +1,7 @@
 import * as awarenessProtocol from 'y-protocols/awareness';
 
 import { SyncContext } from '@/application/services/js-services/sync-protocol';
-import { Types, YDoc } from '@/application/types';
+import { Types, User, YDoc } from '@/application/types';
 import { collab, messages } from '@/proto/messages';
 
 const UUID_REGEX =
@@ -34,6 +34,33 @@ export interface RegisterSyncContext {
   emit?: (reply: messages.IMessage) => void;
 }
 
+export interface ApplyCollabMessageOptions {
+  allowVersionReset?: boolean;
+  user?: User;
+  isCancelled?: () => boolean;
+  /**
+   * HTTP slow-sync applies its result from inside the active outbox drain.
+   * A version reset must not await that same drain promise.
+   */
+  skipActiveDrainOnDiscard?: boolean;
+}
+
+export interface HttpFullSyncResult {
+  objectId: string;
+  collabType: Types;
+  missingUpdate: Uint8Array;
+  serverStateVector: Uint8Array;
+  collabVersion?: string;
+  messageId?: collab.IRid;
+}
+
+export interface QueuedCollabMessage {
+  message: collab.ICollabMessage;
+  options?: ApplyCollabMessageOptions;
+  resolve?: (applied: boolean) => void;
+  reject?: (error: unknown) => void;
+}
+
 export type SyncContextType = {
   registerSyncContext: (context: RegisterSyncContext) => SyncContext;
   /**
@@ -51,6 +78,11 @@ export type SyncContextType = {
    * @returns Promise that resolves when all syncs are complete
    */
   syncAllToServer: (workspaceId: string) => Promise<void>;
+  /**
+   * Applies one HTTP full-sync response through the same per-object,
+   * version-aware queue used by WebSocket messages.
+   */
+  applyHttpFullSyncResult: (result: HttpFullSyncResult, fallbackVersion?: string | null) => Promise<void>;
   /**
    * Schedule deferred cleanup of a sync context after a delay.
    * If the same objectId is re-registered before the timer fires,

--- a/src/components/ws/sync/useBatchSync.ts
+++ b/src/components/ws/sync/useBatchSync.ts
@@ -14,8 +14,8 @@ import {
   awaitPendingRowDocEnsures,
   mergeLegacyRowDocIfExists,
 } from '@/application/services/js-services/cache';
-import { collabFullSyncBatch, createOrphanedView, checkIfCollabExists } from '@/application/services/js-services/http/http_api';
 import { handleAPIError, withRetry } from '@/application/services/js-services/http/core';
+import { collabFullSyncBatch, createOrphanedView, checkIfCollabExists } from '@/application/services/js-services/http/http_api';
 import { waitForDrain } from '@/application/sync-outbox';
 import { Types, YDatabase, YjsDatabaseKey, YjsEditorKey } from '@/application/types';
 import { applyYDoc } from '@/application/ydoc/apply';

--- a/src/components/ws/sync/useBatchSync.ts
+++ b/src/components/ws/sync/useBatchSync.ts
@@ -186,10 +186,33 @@ export function useBatchSync(
     }
   }, []);
 
-  const notifyManifestSync = useCallback((objectId: string) => {
+  const notifyManifestSync = useCallback((objectId: string, persisted?: Promise<boolean>) => {
     if (wsReadyStateRef.current !== WS_READY_STATE_OPEN) return;
 
-    clearBackgroundDirtyEdits([objectId]);
+    const coveredDirtyEdit = backgroundDirtyEditsRef.current.get(objectId);
+
+    if (!coveredDirtyEdit) return;
+
+    const clearCoveredEdit = () => {
+      if (backgroundDirtyEditsRef.current.get(objectId)?.seq === coveredDirtyEdit.seq) {
+        clearBackgroundDirtyEdits([objectId]);
+      }
+    };
+
+    if (!persisted) {
+      clearCoveredEdit();
+      return;
+    }
+
+    void persisted
+      .then((isDurable) => {
+        if (isDurable) {
+          clearCoveredEdit();
+        }
+      })
+      .catch((error) => {
+        Log.warn('[sync] failed to observe durable manifest enqueue', { objectId, error });
+      });
   }, [clearBackgroundDirtyEdits]);
 
   const applyFullSyncResults = useCallback((results: Awaited<ReturnType<typeof collabFullSyncBatch>>) => {

--- a/src/components/ws/sync/useCollabMessageHandler.ts
+++ b/src/components/ws/sync/useCollabMessageHandler.ts
@@ -23,6 +23,19 @@ import {
 
 import ICollabMessage = collab.ICollabMessage;
 
+function abortReason(signal: AbortSignal): unknown {
+  if (signal.reason !== undefined) return signal.reason;
+
+  const error = new Error('The operation was aborted');
+
+  error.name = 'AbortError';
+  return error;
+}
+
+function isApplyCancelled(options?: ApplyCollabMessageOptions): boolean {
+  return Boolean(options?.signal?.aborted || options?.isCancelled?.());
+}
+
 export function useCollabMessageHandler(
   refs: SyncRefs,
   wsCollabMessage: ICollabMessage | undefined | null,
@@ -38,9 +51,17 @@ export function useCollabMessageHandler(
     async (message: ICollabMessage, options?: ApplyCollabMessageOptions) => {
       const objectId = message.objectId!;
 
+      if (isApplyCancelled(options)) {
+        return false;
+      }
+
       const incomingVersion = message.update?.version || message.syncRequest?.version || null;
 
-      Log.debug(`[Version] applyCollabMessage: objectId=${objectId}, incomingVersion=${JSON.stringify(incomingVersion)}, isCollabVersionId=${isCollabVersionId(incomingVersion)}`);
+      Log.debug(
+        `[Version] applyCollabMessage: objectId=${objectId}, incomingVersion=${JSON.stringify(
+          incomingVersion
+        )}, isCollabVersionId=${isCollabVersionId(incomingVersion)}`
+      );
 
       if (isCollabVersionId(incomingVersion)) {
         refs.latestIncomingVersionRef.current.set(objectId, incomingVersion);
@@ -61,11 +82,20 @@ export function useCollabMessageHandler(
         return false;
       }
 
-      Log.debug(`[Version] context lookup: objectId=${objectId}, hasContext=${!!context}, docVersion=${JSON.stringify(context?.doc?.version)}, isCollabVersionId(docVersion)=${context ? isCollabVersionId(context.doc.version) : 'N/A'}`);
+      Log.debug(
+        `[Version] context lookup: objectId=${objectId}, hasContext=${!!context}, docVersion=${JSON.stringify(
+          context?.doc?.version
+        )}, isCollabVersionId(docVersion)=${context ? isCollabVersionId(context.doc.version) : 'N/A'}`
+      );
+
+      let messageHandled = false;
 
       if (context) {
-        let messageHandled = false;
         const handleOnActiveContext = () => {
+          if (isApplyCancelled(options)) {
+            return false;
+          }
+
           const activeContext = refs.registeredContexts.current.get(objectId);
 
           if (!activeContext) {
@@ -77,7 +107,15 @@ export function useCollabMessageHandler(
           const activeVersionKnown = isCollabVersionId(activeVersion);
           const incomingVersionKnown = isCollabVersionId(incomingVersion);
 
-          Log.debug(`[Version] handleOnActiveContext guard: objectId=${objectId}, activeVersion=${JSON.stringify(activeVersion)}, activeVersionKnown=${activeVersionKnown}, incomingVersion=${JSON.stringify(incomingVersion)}, incomingVersionKnown=${incomingVersionKnown}, guardWillFire=${activeVersionKnown && (!incomingVersionKnown || incomingVersion !== activeVersion)}`);
+          Log.debug(
+            `[Version] handleOnActiveContext guard: objectId=${objectId}, activeVersion=${JSON.stringify(
+              activeVersion
+            )}, activeVersionKnown=${activeVersionKnown}, incomingVersion=${JSON.stringify(
+              incomingVersion
+            )}, incomingVersionKnown=${incomingVersionKnown}, guardWillFire=${
+              activeVersionKnown && (!incomingVersionKnown || incomingVersion !== activeVersion)
+            }`
+          );
 
           if (activeVersionKnown && (!incomingVersionKnown || incomingVersion !== activeVersion)) {
             Log.debug('Skipped collab message with mismatched version on active context', {
@@ -96,10 +134,12 @@ export function useCollabMessageHandler(
 
         const _versionChanged = versionChanged(context, message);
 
-        Log.debug(`[Version] versionChanged=${_versionChanged}, allowVersionReset=${options?.allowVersionReset}, objectId=${objectId}`);
+        Log.debug(
+          `[Version] versionChanged=${_versionChanged}, allowVersionReset=${options?.allowVersionReset}, objectId=${objectId}`
+        );
 
         if (options?.allowVersionReset && _versionChanged) {
-          if (options?.isCancelled?.()) {
+          if (isApplyCancelled(options)) {
             return false;
           }
 
@@ -125,17 +165,27 @@ export function useCollabMessageHandler(
               return true;
             }
 
-            if (!options?.isCancelled?.()) {
+            if (!isApplyCancelled(options)) {
               return false;
             }
 
             return !activeContext;
           };
 
-          Log.debug('[Version] Collab version changed: objectId=%s, localVersion=%s, incomingVersion=%s', objectId, context.doc.version, newVersion);
+          Log.debug(
+            '[Version] Collab version changed: objectId=%s, localVersion=%s, incomingVersion=%s',
+            objectId,
+            context.doc.version,
+            newVersion
+          );
 
           if (shouldAbortReset()) {
-            Log.debug('[Version] abort reset: objectId=%s, localVersion=%s, incomingVersion=%s', objectId, context.doc.version, newVersion);
+            Log.debug(
+              '[Version] abort reset: objectId=%s, localVersion=%s, incomingVersion=%s',
+              objectId,
+              context.doc.version,
+              newVersion
+            );
             messageHandled = handleOnActiveContext();
           } else {
             const hadPendingDeferredCleanup = refs.pendingCleanups.current.has(previousDoc.guid);
@@ -176,7 +226,8 @@ export function useCollabMessageHandler(
                   let nextDoc: YDoc & SyncDocMeta;
 
                   try {
-                    const shouldForceResetCache = !isCollabVersionId(newVersion) && isCollabVersionId(previousDoc.version);
+                    const shouldForceResetCache =
+                      !isCollabVersionId(newVersion) && isCollabVersionId(previousDoc.version);
                     const openOptions: {
                       expectedVersion?: string;
                       currentUser?: string;
@@ -191,7 +242,14 @@ export function useCollabMessageHandler(
                       openOptions.forceReset = true;
                     }
 
-                    Log.debug('[Version] opening new doc: objectId=%s, expectedVersion=%s, forceReset=%s, previousDocVersion=%s, incomingVersion=%s', objectId, openOptions.expectedVersion, openOptions.forceReset, previousDoc.version, newVersion);
+                    Log.debug(
+                      '[Version] opening new doc: objectId=%s, expectedVersion=%s, forceReset=%s, previousDocVersion=%s, incomingVersion=%s',
+                      objectId,
+                      openOptions.expectedVersion,
+                      openOptions.forceReset,
+                      previousDoc.version,
+                      newVersion
+                    );
                     nextDoc = (await openCollabDB(previousDoc.guid, {
                       ...openOptions,
                     })) as YDoc & SyncDocMeta;
@@ -200,7 +258,10 @@ export function useCollabMessageHandler(
                       // Align with desktop Option<version> semantics after mismatch reset:
                       // local doc should become version-unknown until a new authoritative version is learned.
                       nextDoc.version = undefined;
-                      Log.debug('[Version] newVersion is unknown, set nextDoc.version=undefined for objectId=%s', objectId);
+                      Log.debug(
+                        '[Version] newVersion is unknown, set nextDoc.version=undefined for objectId=%s',
+                        objectId
+                      );
                     }
                   } catch (error) {
                     // Keep the page usable if cache replacement/open fails after teardown.
@@ -228,7 +289,12 @@ export function useCollabMessageHandler(
               // a later unrelated destroy doesn't accidentally suppress flush.
               refs.skipFlushOnDestroy.current.delete(previousDoc.guid);
               refs.resettingObjectIds.current.delete(objectId);
-              await replayQueuedMessages(objectId, refs.queuedMessagesDuringReset.current, applyCollabMessage, options?.user);
+              await replayQueuedMessages(
+                objectId,
+                refs.queuedMessagesDuringReset.current,
+                applyCollabMessage,
+                options?.user
+              );
             }
           }
         }
@@ -239,59 +305,86 @@ export function useCollabMessageHandler(
       }
 
       Log.debug('Received collab message:', message.collabType, message);
-      return true;
+      return options?.requireActiveContext ? messageHandled : true;
     },
     [refs, eventEmitter, registerSyncContext, scheduleDeferredCleanup]
   );
 
-  const processIncomingMessageQueueForObject = useCallback(async (objectId: string) => {
-    if (refs.isDisposedRef.current || refs.processingObjectIdsRef.current.has(objectId)) {
-      return;
-    }
+  const processIncomingMessageQueueForObject = useCallback(
+    async (objectId: string) => {
+      if (refs.isDisposedRef.current || refs.processingObjectIdsRef.current.has(objectId)) {
+        return;
+      }
 
-    refs.processingObjectIdsRef.current.add(objectId);
+      refs.processingObjectIdsRef.current.add(objectId);
 
-    try {
-      while (!refs.isDisposedRef.current) {
+      try {
+        while (!refs.isDisposedRef.current) {
+          const queue = refs.incomingMessageQueuesRef.current.get(objectId);
+
+          if (!queue || queue.length === 0) {
+            break;
+          }
+
+          const nextTask = queue.shift();
+
+          if (!nextTask) {
+            continue;
+          }
+
+          try {
+            const signal = nextTask.options?.signal;
+
+            if (isApplyCancelled(nextTask.options)) {
+              if (signal?.aborted) {
+                nextTask.reject?.(abortReason(signal));
+              } else {
+                nextTask.resolve?.(false);
+              }
+
+              continue;
+            }
+
+            const applied = await applyCollabMessage(nextTask.message, {
+              allowVersionReset: true,
+              user: refs.latestUserRef.current,
+              ...nextTask.options,
+            });
+
+            if (signal?.aborted) {
+              nextTask.reject?.(abortReason(signal));
+            } else {
+              nextTask.resolve?.(applied);
+            }
+          } catch (error) {
+            const signal = nextTask.options?.signal;
+
+            if (signal?.aborted) {
+              nextTask.reject?.(abortReason(signal));
+            } else {
+              Log.error('Failed to apply queued collab message', error);
+              nextTask.reject?.(error);
+            }
+          } finally {
+            nextTask.dispose?.();
+          }
+        }
+      } finally {
+        refs.processingObjectIdsRef.current.delete(objectId);
         const queue = refs.incomingMessageQueuesRef.current.get(objectId);
 
-        if (!queue || queue.length === 0) {
-          break;
+        if (queue && queue.length === 0) {
+          refs.incomingMessageQueuesRef.current.delete(objectId);
         }
 
-        const nextTask = queue.shift();
-
-        if (!nextTask) {
-          continue;
-        }
-
-        try {
-          const applied = await applyCollabMessage(nextTask.message, {
-            allowVersionReset: true,
-            user: refs.latestUserRef.current,
-            ...nextTask.options,
-          });
-
-          nextTask.resolve?.(applied);
-        } catch (error) {
-          Log.error('Failed to apply queued collab message', error);
-          nextTask.reject?.(error);
+        // If new messages for this object were enqueued during the final await, keep draining.
+        if (queue && queue.length > 0 && !refs.isDisposedRef.current) {
+          void processIncomingMessageQueueForObject(objectId);
         }
       }
-    } finally {
-      refs.processingObjectIdsRef.current.delete(objectId);
-      const queue = refs.incomingMessageQueuesRef.current.get(objectId);
-
-      if (queue && queue.length === 0) {
-        refs.incomingMessageQueuesRef.current.delete(objectId);
-      }
-
-      // If new messages for this object were enqueued during the final await, keep draining.
-      if (queue && queue.length > 0 && !refs.isDisposedRef.current) {
-        void processIncomingMessageQueueForObject(objectId);
-      }
-    }
-  }, [refs, applyCollabMessage]);
+    },
+    [refs, applyCollabMessage]
+  );
 
   const enqueueIncomingCollabMessage = useCallback(
     (message: ICollabMessage, options?: ApplyCollabMessageOptions): Promise<boolean> => {
@@ -306,17 +399,61 @@ export function useCollabMessageHandler(
         return Promise.reject(new Error('Cannot enqueue collab message without objectId'));
       }
 
+      const signal = options?.signal;
+
+      if (signal?.aborted) {
+        return Promise.reject(abortReason(signal));
+      }
+
+      const queuedObjectId = objectId;
+
       return new Promise<boolean>((resolve, reject) => {
-        const task: QueuedCollabMessage = { message, options, resolve, reject };
-        const queue = refs.incomingMessageQueuesRef.current.get(objectId);
+        function dispose() {
+          signal?.removeEventListener('abort', handleAbort);
+        }
+
+        function handleAbort() {
+          if (!signal) return;
+
+          const queue = refs.incomingMessageQueuesRef.current.get(queuedObjectId);
+          const queuedIndex = queue?.indexOf(task) ?? -1;
+
+          // A task that has already been shifted is allowed to finish its
+          // structural reset safely; applyCollabMessage checks cancellation
+          // again before touching the active context. A task still waiting
+          // behind another reset can be removed immediately, breaking the
+          // reset -> drain -> queued-result wait cycle.
+          if (!queue || queuedIndex < 0) return;
+
+          queue.splice(queuedIndex, 1);
+          if (queue.length === 0) {
+            refs.incomingMessageQueuesRef.current.delete(queuedObjectId);
+          }
+
+          dispose();
+          reject(abortReason(signal));
+        }
+
+        const task: QueuedCollabMessage = { message, options, resolve, reject, dispose };
+
+        signal?.addEventListener('abort', handleAbort, { once: true });
+
+        // Close the narrow race between the initial check and listener setup.
+        if (signal?.aborted) {
+          dispose();
+          reject(abortReason(signal));
+          return;
+        }
+
+        const queue = refs.incomingMessageQueuesRef.current.get(queuedObjectId);
 
         if (queue) {
           queue.push(task);
         } else {
-          refs.incomingMessageQueuesRef.current.set(objectId, [task]);
+          refs.incomingMessageQueuesRef.current.set(queuedObjectId, [task]);
         }
 
-        void processIncomingMessageQueueForObject(objectId);
+        void processIncomingMessageQueueForObject(queuedObjectId);
       });
     },
     [refs, processIncomingMessageQueueForObject]

--- a/src/components/ws/sync/useCollabMessageHandler.ts
+++ b/src/components/ws/sync/useCollabMessageHandler.ts
@@ -5,14 +5,21 @@ import * as Y from 'yjs';
 
 import { deleteCollabDB, openCollabDB } from '@/application/db';
 import { handleMessage, SyncContext } from '@/application/services/js-services/sync-protocol';
-import { User, YDoc } from '@/application/types';
+import { YDoc } from '@/application/types';
 import { collab } from '@/proto/messages';
 import { Log } from '@/utils/log';
 
 import { rebuildCollabDoc } from './rebuildCollabDoc';
 import { replayQueuedMessages } from './replayQueuedMessages';
 import { SyncRefs } from './syncRefs';
-import { isCollabVersionId, RegisterSyncContext, SyncDocMeta, versionChanged } from './types';
+import {
+  ApplyCollabMessageOptions,
+  isCollabVersionId,
+  QueuedCollabMessage,
+  RegisterSyncContext,
+  SyncDocMeta,
+  versionChanged,
+} from './types';
 
 import ICollabMessage = collab.ICollabMessage;
 
@@ -28,14 +35,7 @@ export function useCollabMessageHandler(
   const lastHandledBcMessageRef = useRef<ICollabMessage | null>(null);
 
   const applyCollabMessage = useCallback(
-    async (
-      message: ICollabMessage,
-      options?: {
-        allowVersionReset?: boolean;
-        user?: User;
-        isCancelled?: () => boolean;
-      }
-    ) => {
+    async (message: ICollabMessage, options?: ApplyCollabMessageOptions) => {
       const objectId = message.objectId!;
 
       const incomingVersion = message.update?.version || message.syncRequest?.version || null;
@@ -58,7 +58,7 @@ export function useCollabMessageHandler(
 
         queued.push(message);
         refs.queuedMessagesDuringReset.current.set(objectId, queued);
-        return;
+        return false;
       }
 
       Log.debug(`[Version] context lookup: objectId=${objectId}, hasContext=${!!context}, docVersion=${JSON.stringify(context?.doc?.version)}, isCollabVersionId(docVersion)=${context ? isCollabVersionId(context.doc.version) : 'N/A'}`);
@@ -100,7 +100,7 @@ export function useCollabMessageHandler(
 
         if (options?.allowVersionReset && _versionChanged) {
           if (options?.isCancelled?.()) {
-            return;
+            return false;
           }
 
           const newVersion = message.update?.version || message.syncRequest?.version || undefined;
@@ -156,7 +156,9 @@ export function useCollabMessageHandler(
               // would leave the object permanently flagged as resetting —
               // `applyCollabMessage` would queue every subsequent message
               // and the doc would stay stuck until reload.
-              await context.discardPendingUpdates?.();
+              await context.discardPendingUpdates?.({
+                skipActiveDrain: options?.skipActiveDrainOnDiscard,
+              });
               await deleteCollabDB(previousDoc.guid, { destroyDoc: false });
               previousDoc.destroy();
 
@@ -237,6 +239,7 @@ export function useCollabMessageHandler(
       }
 
       Log.debug('Received collab message:', message.collabType, message);
+      return true;
     },
     [refs, eventEmitter, registerSyncContext, scheduleDeferredCleanup]
   );
@@ -256,19 +259,23 @@ export function useCollabMessageHandler(
           break;
         }
 
-        const nextMessage = queue.shift();
+        const nextTask = queue.shift();
 
-        if (!nextMessage) {
+        if (!nextTask) {
           continue;
         }
 
         try {
-          await applyCollabMessage(nextMessage, {
+          const applied = await applyCollabMessage(nextTask.message, {
             allowVersionReset: true,
             user: refs.latestUserRef.current,
+            ...nextTask.options,
           });
+
+          nextTask.resolve?.(applied);
         } catch (error) {
           Log.error('Failed to apply queued collab message', error);
+          nextTask.reject?.(error);
         }
       }
     } finally {
@@ -287,27 +294,30 @@ export function useCollabMessageHandler(
   }, [refs, applyCollabMessage]);
 
   const enqueueIncomingCollabMessage = useCallback(
-    (message: ICollabMessage) => {
+    (message: ICollabMessage, options?: ApplyCollabMessageOptions): Promise<boolean> => {
       if (refs.isDisposedRef.current) {
-        return;
+        return Promise.reject(new Error('Cannot enqueue collab message after sync disposal'));
       }
 
       const objectId = message.objectId;
 
       if (!objectId) {
         Log.warn('Received collab message without objectId; skipped queueing', message);
-        return;
+        return Promise.reject(new Error('Cannot enqueue collab message without objectId'));
       }
 
-      const queue = refs.incomingMessageQueuesRef.current.get(objectId);
+      return new Promise<boolean>((resolve, reject) => {
+        const task: QueuedCollabMessage = { message, options, resolve, reject };
+        const queue = refs.incomingMessageQueuesRef.current.get(objectId);
 
-      if (queue) {
-        queue.push(message);
-      } else {
-        refs.incomingMessageQueuesRef.current.set(objectId, [message]);
-      }
+        if (queue) {
+          queue.push(task);
+        } else {
+          refs.incomingMessageQueuesRef.current.set(objectId, [task]);
+        }
 
-      void processIncomingMessageQueueForObject(objectId);
+        void processIncomingMessageQueueForObject(objectId);
+      });
     },
     [refs, processIncomingMessageQueueForObject]
   );
@@ -320,7 +330,9 @@ export function useCollabMessageHandler(
     }
 
     lastHandledWsMessageRef.current = message;
-    enqueueIncomingCollabMessage(message);
+    void enqueueIncomingCollabMessage(message).catch((error) => {
+      Log.error('Failed to enqueue WebSocket collab message', error);
+    });
   }, [wsCollabMessage, enqueueIncomingCollabMessage]);
 
   useEffect(() => {
@@ -331,8 +343,10 @@ export function useCollabMessageHandler(
     }
 
     lastHandledBcMessageRef.current = message;
-    enqueueIncomingCollabMessage(message);
+    void enqueueIncomingCollabMessage(message).catch((error) => {
+      Log.error('Failed to enqueue BroadcastChannel collab message', error);
+    });
   }, [bcCollabMessage, enqueueIncomingCollabMessage]);
 
-  return { applyCollabMessage };
+  return { applyCollabMessage, enqueueIncomingCollabMessage };
 }

--- a/src/components/ws/sync/useCollabVersionRevert.ts
+++ b/src/components/ws/sync/useCollabVersionRevert.ts
@@ -31,7 +31,7 @@ export type CollabVersionRevertDeps = {
       user?: User;
       isCancelled?: () => boolean;
     }
-  ) => Promise<void>;
+  ) => Promise<unknown>;
 };
 
 export function useCollabVersionRevert(deps: CollabVersionRevertDeps) {

--- a/src/components/ws/sync/useSyncContextLifecycle.ts
+++ b/src/components/ws/sync/useSyncContextLifecycle.ts
@@ -41,7 +41,7 @@ export function useSyncContextLifecycle(
   sendMessage: (message: messages.IMessage) => void,
   postMessage: (message: messages.IMessage) => void,
   onLocalUpdate?: (objectId: string) => void,
-  onManifestSync?: (objectId: string) => void
+  onManifestSync?: (objectId: string, persisted?: Promise<boolean>) => void
 ) {
   const cancelDeferredCleanup = useCallback((objectId: string) => {
     const timer = refs.pendingCleanups.current.get(objectId);

--- a/src/components/ws/useSync.ts
+++ b/src/components/ws/useSync.ts
@@ -1,6 +1,6 @@
 import EventEmitter from 'events';
 
-import { useCallback, useEffect, useRef } from 'react';
+import { useCallback, useEffect, useMemo, useRef } from 'react';
 
 import { bindSyncContext, UpdateFlags } from '@/application/services/js-services/sync-protocol';
 import { useCurrentUserOptional } from '@/components/main/app.hooks';
@@ -8,12 +8,12 @@ import { AppflowyWebSocketType } from '@/components/ws/useAppflowyWebSocket';
 import { BroadcastChannelType } from '@/components/ws/useBroadcastChannel';
 
 import { useSyncRefs } from './sync/syncRefs';
+import { HttpFullSyncResult, SyncContextType } from './sync/types';
 import { useBatchSync } from './sync/useBatchSync';
 import { useCollabMessageHandler } from './sync/useCollabMessageHandler';
 import { useCollabVersionRevert } from './sync/useCollabVersionRevert';
 import { useSyncContextLifecycle } from './sync/useSyncContextLifecycle';
 import { useWorkspaceNotifications } from './sync/useWorkspaceNotifications';
-import { HttpFullSyncResult, SyncContextType } from './sync/types';
 
 const WS_READY_STATE_OPEN = 1;
 
@@ -215,8 +215,13 @@ export const useSync = (
   // Provides registerSyncContext / unregisterSyncContext / scheduleDeferredCleanup.
   // Manages ref-counting so multiple components sharing the same Y.Doc don't
   // tear it down prematurely.
-  const { registerSyncContext, unregisterSyncContext, scheduleDeferredCleanup } =
-    useSyncContextLifecycle(refs, sendMessage, postMessage, notifyLocalEdit, notifyManifestSync);
+  const { registerSyncContext, unregisterSyncContext, scheduleDeferredCleanup } = useSyncContextLifecycle(
+    refs,
+    sendMessage,
+    postMessage,
+    notifyLocalEdit,
+    notifyManifestSync
+  );
 
   // A reopened socket has no knowledge of messages this tab missed while it
   // was disconnected. Re-bind every live document so the server and client
@@ -255,7 +260,7 @@ export const useSync = (
   );
 
   const applyHttpFullSyncResult = useCallback(
-    async (result: HttpFullSyncResult, fallbackVersion?: string | null) => {
+    async (result: HttpFullSyncResult, fallbackVersion?: string | null, signal?: AbortSignal) => {
       const activeContext = refs.registeredContexts.current.get(result.objectId);
       // When the server omits a version, retain the active local version so an
       // otherwise valid HTTP response cannot look like an authoritative
@@ -263,37 +268,43 @@ export const useSync = (
       const version = result.collabVersion ?? activeContext?.doc.version ?? fallbackVersion ?? undefined;
       const hasMissingUpdate = result.missingUpdate.byteLength > 2;
       const versionDiffers = Boolean(version && activeContext?.doc.version && version !== activeContext.doc.version);
-      const collabMessage = versionDiffers && !hasMissingUpdate
-        ? {
-            objectId: result.objectId,
-            collabType: result.collabType,
-            syncRequest: {
-              stateVector: result.serverStateVector,
-              lastMessageId: result.messageId,
-              version,
-            },
-          }
-        : {
-            objectId: result.objectId,
-            collabType: result.collabType,
-            update: {
-              flags: UpdateFlags.Lib0v1,
-              // Canonical empty lib0-v1 update. This lets a same-version
-              // response advance lastMessageId without asking Yjs to decode a
-              // zero-length buffer.
-              payload: hasMissingUpdate ? result.missingUpdate : new Uint8Array([0, 0]),
-              version,
-              messageId: result.messageId,
-            },
-          };
+      const collabMessage =
+        versionDiffers && !hasMissingUpdate
+          ? {
+              objectId: result.objectId,
+              collabType: result.collabType,
+              syncRequest: {
+                stateVector: result.serverStateVector,
+                lastMessageId: result.messageId,
+                version,
+              },
+            }
+          : {
+              objectId: result.objectId,
+              collabType: result.collabType,
+              update: {
+                flags: UpdateFlags.Lib0v1,
+                // Canonical empty lib0-v1 update. This lets a same-version
+                // response advance lastMessageId without asking Yjs to decode a
+                // zero-length buffer.
+                payload: hasMissingUpdate ? result.missingUpdate : new Uint8Array([0, 0]),
+                version,
+                messageId: result.messageId,
+              },
+            };
       const applied = await enqueueIncomingCollabMessage(collabMessage, {
         allowVersionReset: true,
         user: refs.latestUserRef.current,
+        signal,
+        // Slow-sync retirement is only safe after the response reaches a live
+        // document. A persisted record can drain after reload while its collab
+        // is still closed, in which case the response must remain retryable.
+        requireActiveContext: true,
         skipActiveDrainOnDiscard: true,
       });
 
       if (!applied) {
-        throw new Error(`HTTP full-sync result for ${result.objectId} was deferred during a version reset`);
+        throw new Error(`HTTP full-sync result for ${result.objectId} was not applied to an active sync context`);
       }
     },
     [refs, enqueueIncomingCollabMessage]
@@ -313,12 +324,24 @@ export const useSync = (
     applyCollabMessage,
   });
 
-  return {
-    registerSyncContext,
-    revertCollabVersion,
-    flushAllSync,
-    syncAllToServer,
-    applyHttpFullSyncResult,
-    scheduleDeferredCleanup,
-  };
+  // Memoized so the hook is safe to consume directly, not only via the
+  // re-memoized SyncInternalContext value in AppSyncLayer.
+  return useMemo(
+    () => ({
+      registerSyncContext,
+      revertCollabVersion,
+      flushAllSync,
+      syncAllToServer,
+      applyHttpFullSyncResult,
+      scheduleDeferredCleanup,
+    }),
+    [
+      registerSyncContext,
+      revertCollabVersion,
+      flushAllSync,
+      syncAllToServer,
+      applyHttpFullSyncResult,
+      scheduleDeferredCleanup,
+    ]
+  );
 };

--- a/src/components/ws/useSync.ts
+++ b/src/components/ws/useSync.ts
@@ -1,8 +1,8 @@
 import EventEmitter from 'events';
 
-import { useEffect, useRef } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 
-import { bindSyncContext } from '@/application/services/js-services/sync-protocol';
+import { bindSyncContext, UpdateFlags } from '@/application/services/js-services/sync-protocol';
 import { useCurrentUserOptional } from '@/components/main/app.hooks';
 import { AppflowyWebSocketType } from '@/components/ws/useAppflowyWebSocket';
 import { BroadcastChannelType } from '@/components/ws/useBroadcastChannel';
@@ -13,7 +13,7 @@ import { useCollabMessageHandler } from './sync/useCollabMessageHandler';
 import { useCollabVersionRevert } from './sync/useCollabVersionRevert';
 import { useSyncContextLifecycle } from './sync/useSyncContextLifecycle';
 import { useWorkspaceNotifications } from './sync/useWorkspaceNotifications';
-import { SyncContextType } from './sync/types';
+import { HttpFullSyncResult, SyncContextType } from './sync/types';
 
 const WS_READY_STATE_OPEN = 1;
 
@@ -184,6 +184,12 @@ export const useSync = (
 
     return () => {
       refs.isDisposedRef.current = true;
+      for (const queue of refs.incomingMessageQueuesRef.current.values()) {
+        for (const task of queue) {
+          task.reject?.(new Error('Sync disposed before queued collab message was applied'));
+        }
+      }
+
       refs.incomingMessageQueuesRef.current.clear();
       refs.processingObjectIdsRef.current.clear();
     };
@@ -239,13 +245,58 @@ export const useSync = (
   // Watches wsCollabMessage / bcCollabMessage and routes them through a per-objectId
   // sequential queue.  Handles version mismatch detection and triggers doc rebuild
   // (version-reset) when the server signals a new collab version.
-  const { applyCollabMessage } = useCollabMessageHandler(
+  const { applyCollabMessage, enqueueIncomingCollabMessage } = useCollabMessageHandler(
     refs,
     wsCollabMessage,
     bcCollabMessage,
     eventEmitter,
     registerSyncContext,
     scheduleDeferredCleanup
+  );
+
+  const applyHttpFullSyncResult = useCallback(
+    async (result: HttpFullSyncResult, fallbackVersion?: string | null) => {
+      const activeContext = refs.registeredContexts.current.get(result.objectId);
+      // When the server omits a version, retain the active local version so an
+      // otherwise valid HTTP response cannot look like an authoritative
+      // version clear and trigger an unnecessary reset.
+      const version = result.collabVersion ?? activeContext?.doc.version ?? fallbackVersion ?? undefined;
+      const hasMissingUpdate = result.missingUpdate.byteLength > 2;
+      const versionDiffers = Boolean(version && activeContext?.doc.version && version !== activeContext.doc.version);
+      const collabMessage = versionDiffers && !hasMissingUpdate
+        ? {
+            objectId: result.objectId,
+            collabType: result.collabType,
+            syncRequest: {
+              stateVector: result.serverStateVector,
+              lastMessageId: result.messageId,
+              version,
+            },
+          }
+        : {
+            objectId: result.objectId,
+            collabType: result.collabType,
+            update: {
+              flags: UpdateFlags.Lib0v1,
+              // Canonical empty lib0-v1 update. This lets a same-version
+              // response advance lastMessageId without asking Yjs to decode a
+              // zero-length buffer.
+              payload: hasMissingUpdate ? result.missingUpdate : new Uint8Array([0, 0]),
+              version,
+              messageId: result.messageId,
+            },
+          };
+      const applied = await enqueueIncomingCollabMessage(collabMessage, {
+        allowVersionReset: true,
+        user: refs.latestUserRef.current,
+        skipActiveDrainOnDiscard: true,
+      });
+
+      if (!applied) {
+        throw new Error(`HTTP full-sync result for ${result.objectId} was deferred during a version reset`);
+      }
+    },
+    [refs, enqueueIncomingCollabMessage]
   );
 
   // ── User-initiated version revert ────────────────────────────────────
@@ -262,5 +313,12 @@ export const useSync = (
     applyCollabMessage,
   });
 
-  return { registerSyncContext, revertCollabVersion, flushAllSync, syncAllToServer, scheduleDeferredCleanup };
+  return {
+    registerSyncContext,
+    revertCollabVersion,
+    flushAllSync,
+    syncAllToServer,
+    applyHttpFullSyncResult,
+    scheduleDeferredCleanup,
+  };
 };

--- a/src/proto/collab.proto
+++ b/src/proto/collab.proto
@@ -134,6 +134,7 @@ message CollabDocStateParams {
     PayloadCompressionType compression = 3;
     bytes sv = 4;
     bytes doc_state = 5;
+    string collab_version = 6;
 }
 
 /**
@@ -155,6 +156,11 @@ message CollabBatchSyncResult {
     bytes missing_update = 4;
     string error = 5;
     bytes server_state_vector = 6;
+    string collab_version = 7;
+    // Redis stream message ID confirming that a non-empty client update was
+    // durably persisted. Slow-sync callers require this before retiring an
+    // upload unless an authoritative collab-version change supersedes it.
+    Rid message_id = 8;
 }
 
 /**

--- a/src/proto/database_blob.d.ts
+++ b/src/proto/database_blob.d.ts
@@ -106,6 +106,115 @@ export namespace database_blob {
         public static getTypeUrl(typeUrlPrefix?: string): string;
     }
 
+    /** Properties of a DatabaseBlobDiffPageRequest. */
+    interface IDatabaseBlobDiffPageRequest {
+
+        /** DatabaseBlobDiffPageRequest maxItems */
+        maxItems?: (number|null);
+
+        /** DatabaseBlobDiffPageRequest maxBytes */
+        maxBytes?: (number|Long|null);
+
+        /** DatabaseBlobDiffPageRequest cursor */
+        cursor?: (Uint8Array|null);
+    }
+
+    /** Represents a DatabaseBlobDiffPageRequest. */
+    class DatabaseBlobDiffPageRequest implements IDatabaseBlobDiffPageRequest {
+
+        /**
+         * Constructs a new DatabaseBlobDiffPageRequest.
+         * @param [properties] Properties to set
+         */
+        constructor(properties?: database_blob.IDatabaseBlobDiffPageRequest);
+
+        /** DatabaseBlobDiffPageRequest maxItems. */
+        public maxItems: number;
+
+        /** DatabaseBlobDiffPageRequest maxBytes. */
+        public maxBytes: (number|Long);
+
+        /** DatabaseBlobDiffPageRequest cursor. */
+        public cursor: Uint8Array;
+
+        /**
+         * Creates a new DatabaseBlobDiffPageRequest instance using the specified properties.
+         * @param [properties] Properties to set
+         * @returns DatabaseBlobDiffPageRequest instance
+         */
+        public static create(properties?: database_blob.IDatabaseBlobDiffPageRequest): database_blob.DatabaseBlobDiffPageRequest;
+
+        /**
+         * Encodes the specified DatabaseBlobDiffPageRequest message. Does not implicitly {@link database_blob.DatabaseBlobDiffPageRequest.verify|verify} messages.
+         * @param message DatabaseBlobDiffPageRequest message or plain object to encode
+         * @param [writer] Writer to encode to
+         * @returns Writer
+         */
+        public static encode(message: database_blob.IDatabaseBlobDiffPageRequest, writer?: $protobuf.Writer): $protobuf.Writer;
+
+        /**
+         * Encodes the specified DatabaseBlobDiffPageRequest message, length delimited. Does not implicitly {@link database_blob.DatabaseBlobDiffPageRequest.verify|verify} messages.
+         * @param message DatabaseBlobDiffPageRequest message or plain object to encode
+         * @param [writer] Writer to encode to
+         * @returns Writer
+         */
+        public static encodeDelimited(message: database_blob.IDatabaseBlobDiffPageRequest, writer?: $protobuf.Writer): $protobuf.Writer;
+
+        /**
+         * Decodes a DatabaseBlobDiffPageRequest message from the specified reader or buffer.
+         * @param reader Reader or buffer to decode from
+         * @param [length] Message length if known beforehand
+         * @returns DatabaseBlobDiffPageRequest
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): database_blob.DatabaseBlobDiffPageRequest;
+
+        /**
+         * Decodes a DatabaseBlobDiffPageRequest message from the specified reader or buffer, length delimited.
+         * @param reader Reader or buffer to decode from
+         * @returns DatabaseBlobDiffPageRequest
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): database_blob.DatabaseBlobDiffPageRequest;
+
+        /**
+         * Verifies a DatabaseBlobDiffPageRequest message.
+         * @param message Plain object to verify
+         * @returns `null` if valid, otherwise the reason why it is not
+         */
+        public static verify(message: { [k: string]: any }): (string|null);
+
+        /**
+         * Creates a DatabaseBlobDiffPageRequest message from a plain object. Also converts values to their respective internal types.
+         * @param object Plain object
+         * @returns DatabaseBlobDiffPageRequest
+         */
+        public static fromObject(object: { [k: string]: any }): database_blob.DatabaseBlobDiffPageRequest;
+
+        /**
+         * Creates a plain object from a DatabaseBlobDiffPageRequest message. Also converts values to other types if specified.
+         * @param message DatabaseBlobDiffPageRequest
+         * @param [options] Conversion options
+         * @returns Plain object
+         */
+        public static toObject(message: database_blob.DatabaseBlobDiffPageRequest, options?: $protobuf.IConversionOptions): { [k: string]: any };
+
+        /**
+         * Converts this DatabaseBlobDiffPageRequest to JSON.
+         * @returns JSON object
+         */
+        public toJSON(): { [k: string]: any };
+
+        /**
+         * Gets the default type url for DatabaseBlobDiffPageRequest
+         * @param [typeUrlPrefix] your custom typeUrlPrefix(default "type.googleapis.com")
+         * @returns The default type url
+         */
+        public static getTypeUrl(typeUrlPrefix?: string): string;
+    }
+
     /** Properties of a DatabaseBlobDiffRequest. */
     interface IDatabaseBlobDiffRequest {
 
@@ -114,6 +223,12 @@ export namespace database_blob {
 
         /** DatabaseBlobDiffRequest version */
         version?: (number|null);
+
+        /** DatabaseBlobDiffRequest includeDocuments */
+        includeDocuments?: (boolean|null);
+
+        /** DatabaseBlobDiffRequest page */
+        page?: (database_blob.IDatabaseBlobDiffPageRequest|null);
     }
 
     /** Represents a DatabaseBlobDiffRequest. */
@@ -131,8 +246,20 @@ export namespace database_blob {
         /** DatabaseBlobDiffRequest version. */
         public version: number;
 
+        /** DatabaseBlobDiffRequest includeDocuments. */
+        public includeDocuments?: (boolean|null);
+
+        /** DatabaseBlobDiffRequest page. */
+        public page?: (database_blob.IDatabaseBlobDiffPageRequest|null);
+
         /** DatabaseBlobDiffRequest _maxKnownRid. */
         public _maxKnownRid?: "maxKnownRid";
+
+        /** DatabaseBlobDiffRequest _includeDocuments. */
+        public _includeDocuments?: "includeDocuments";
+
+        /** DatabaseBlobDiffRequest _page. */
+        public _page?: "page";
 
         /**
          * Creates a new DatabaseBlobDiffRequest instance using the specified properties.
@@ -212,6 +339,157 @@ export namespace database_blob {
         public static getTypeUrl(typeUrlPrefix?: string): string;
     }
 
+    /** Properties of a DatabaseBlobDiffPageCursor. */
+    interface IDatabaseBlobDiffPageCursor {
+
+        /** DatabaseBlobDiffPageCursor formatVersion */
+        formatVersion?: (number|null);
+
+        /** DatabaseBlobDiffPageCursor workspaceId */
+        workspaceId?: (Uint8Array|null);
+
+        /** DatabaseBlobDiffPageCursor databaseId */
+        databaseId?: (Uint8Array|null);
+
+        /** DatabaseBlobDiffPageCursor manifestVersion */
+        manifestVersion?: (string|null);
+
+        /** DatabaseBlobDiffPageCursor maxKnownRid */
+        maxKnownRid?: (database_blob.IDatabaseBlobRowRid|null);
+
+        /** DatabaseBlobDiffPageCursor nextOffset */
+        nextOffset?: (number|Long|null);
+
+        /** DatabaseBlobDiffPageCursor planHash */
+        planHash?: (Uint8Array|null);
+
+        /** DatabaseBlobDiffPageCursor maxObservedRid */
+        maxObservedRid?: (database_blob.IDatabaseBlobRowRid|null);
+
+        /** DatabaseBlobDiffPageCursor signature */
+        signature?: (Uint8Array|null);
+    }
+
+    /** Represents a DatabaseBlobDiffPageCursor. */
+    class DatabaseBlobDiffPageCursor implements IDatabaseBlobDiffPageCursor {
+
+        /**
+         * Constructs a new DatabaseBlobDiffPageCursor.
+         * @param [properties] Properties to set
+         */
+        constructor(properties?: database_blob.IDatabaseBlobDiffPageCursor);
+
+        /** DatabaseBlobDiffPageCursor formatVersion. */
+        public formatVersion: number;
+
+        /** DatabaseBlobDiffPageCursor workspaceId. */
+        public workspaceId: Uint8Array;
+
+        /** DatabaseBlobDiffPageCursor databaseId. */
+        public databaseId: Uint8Array;
+
+        /** DatabaseBlobDiffPageCursor manifestVersion. */
+        public manifestVersion: string;
+
+        /** DatabaseBlobDiffPageCursor maxKnownRid. */
+        public maxKnownRid?: (database_blob.IDatabaseBlobRowRid|null);
+
+        /** DatabaseBlobDiffPageCursor nextOffset. */
+        public nextOffset: (number|Long);
+
+        /** DatabaseBlobDiffPageCursor planHash. */
+        public planHash: Uint8Array;
+
+        /** DatabaseBlobDiffPageCursor maxObservedRid. */
+        public maxObservedRid?: (database_blob.IDatabaseBlobRowRid|null);
+
+        /** DatabaseBlobDiffPageCursor signature. */
+        public signature: Uint8Array;
+
+        /** DatabaseBlobDiffPageCursor _maxKnownRid. */
+        public _maxKnownRid?: "maxKnownRid";
+
+        /** DatabaseBlobDiffPageCursor _maxObservedRid. */
+        public _maxObservedRid?: "maxObservedRid";
+
+        /**
+         * Creates a new DatabaseBlobDiffPageCursor instance using the specified properties.
+         * @param [properties] Properties to set
+         * @returns DatabaseBlobDiffPageCursor instance
+         */
+        public static create(properties?: database_blob.IDatabaseBlobDiffPageCursor): database_blob.DatabaseBlobDiffPageCursor;
+
+        /**
+         * Encodes the specified DatabaseBlobDiffPageCursor message. Does not implicitly {@link database_blob.DatabaseBlobDiffPageCursor.verify|verify} messages.
+         * @param message DatabaseBlobDiffPageCursor message or plain object to encode
+         * @param [writer] Writer to encode to
+         * @returns Writer
+         */
+        public static encode(message: database_blob.IDatabaseBlobDiffPageCursor, writer?: $protobuf.Writer): $protobuf.Writer;
+
+        /**
+         * Encodes the specified DatabaseBlobDiffPageCursor message, length delimited. Does not implicitly {@link database_blob.DatabaseBlobDiffPageCursor.verify|verify} messages.
+         * @param message DatabaseBlobDiffPageCursor message or plain object to encode
+         * @param [writer] Writer to encode to
+         * @returns Writer
+         */
+        public static encodeDelimited(message: database_blob.IDatabaseBlobDiffPageCursor, writer?: $protobuf.Writer): $protobuf.Writer;
+
+        /**
+         * Decodes a DatabaseBlobDiffPageCursor message from the specified reader or buffer.
+         * @param reader Reader or buffer to decode from
+         * @param [length] Message length if known beforehand
+         * @returns DatabaseBlobDiffPageCursor
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): database_blob.DatabaseBlobDiffPageCursor;
+
+        /**
+         * Decodes a DatabaseBlobDiffPageCursor message from the specified reader or buffer, length delimited.
+         * @param reader Reader or buffer to decode from
+         * @returns DatabaseBlobDiffPageCursor
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): database_blob.DatabaseBlobDiffPageCursor;
+
+        /**
+         * Verifies a DatabaseBlobDiffPageCursor message.
+         * @param message Plain object to verify
+         * @returns `null` if valid, otherwise the reason why it is not
+         */
+        public static verify(message: { [k: string]: any }): (string|null);
+
+        /**
+         * Creates a DatabaseBlobDiffPageCursor message from a plain object. Also converts values to their respective internal types.
+         * @param object Plain object
+         * @returns DatabaseBlobDiffPageCursor
+         */
+        public static fromObject(object: { [k: string]: any }): database_blob.DatabaseBlobDiffPageCursor;
+
+        /**
+         * Creates a plain object from a DatabaseBlobDiffPageCursor message. Also converts values to other types if specified.
+         * @param message DatabaseBlobDiffPageCursor
+         * @param [options] Conversion options
+         * @returns Plain object
+         */
+        public static toObject(message: database_blob.DatabaseBlobDiffPageCursor, options?: $protobuf.IConversionOptions): { [k: string]: any };
+
+        /**
+         * Converts this DatabaseBlobDiffPageCursor to JSON.
+         * @returns JSON object
+         */
+        public toJSON(): { [k: string]: any };
+
+        /**
+         * Gets the default type url for DatabaseBlobDiffPageCursor
+         * @param [typeUrlPrefix] your custom typeUrlPrefix(default "type.googleapis.com")
+         * @returns The default type url
+         */
+        public static getTypeUrl(typeUrlPrefix?: string): string;
+    }
+
     /** Properties of a CollabDocState. */
     interface ICollabDocState {
 
@@ -220,6 +498,9 @@ export namespace database_blob {
 
         /** CollabDocState encoderVersion */
         encoderVersion?: (number|null);
+
+        /** CollabDocState collabVersion */
+        collabVersion?: (string|null);
     }
 
     /** Represents a CollabDocState. */
@@ -236,6 +517,9 @@ export namespace database_blob {
 
         /** CollabDocState encoderVersion. */
         public encoderVersion: number;
+
+        /** CollabDocState collabVersion. */
+        public collabVersion: string;
 
         /**
          * Creates a new CollabDocState instance using the specified properties.
@@ -651,6 +935,115 @@ export namespace database_blob {
         public static getTypeUrl(typeUrlPrefix?: string): string;
     }
 
+    /** Properties of a DatabaseBlobDiffPageInfo. */
+    interface IDatabaseBlobDiffPageInfo {
+
+        /** DatabaseBlobDiffPageInfo nextCursor */
+        nextCursor?: (Uint8Array|null);
+
+        /** DatabaseBlobDiffPageInfo hasMore */
+        hasMore?: (boolean|null);
+
+        /** DatabaseBlobDiffPageInfo restartRequired */
+        restartRequired?: (boolean|null);
+    }
+
+    /** Represents a DatabaseBlobDiffPageInfo. */
+    class DatabaseBlobDiffPageInfo implements IDatabaseBlobDiffPageInfo {
+
+        /**
+         * Constructs a new DatabaseBlobDiffPageInfo.
+         * @param [properties] Properties to set
+         */
+        constructor(properties?: database_blob.IDatabaseBlobDiffPageInfo);
+
+        /** DatabaseBlobDiffPageInfo nextCursor. */
+        public nextCursor: Uint8Array;
+
+        /** DatabaseBlobDiffPageInfo hasMore. */
+        public hasMore: boolean;
+
+        /** DatabaseBlobDiffPageInfo restartRequired. */
+        public restartRequired: boolean;
+
+        /**
+         * Creates a new DatabaseBlobDiffPageInfo instance using the specified properties.
+         * @param [properties] Properties to set
+         * @returns DatabaseBlobDiffPageInfo instance
+         */
+        public static create(properties?: database_blob.IDatabaseBlobDiffPageInfo): database_blob.DatabaseBlobDiffPageInfo;
+
+        /**
+         * Encodes the specified DatabaseBlobDiffPageInfo message. Does not implicitly {@link database_blob.DatabaseBlobDiffPageInfo.verify|verify} messages.
+         * @param message DatabaseBlobDiffPageInfo message or plain object to encode
+         * @param [writer] Writer to encode to
+         * @returns Writer
+         */
+        public static encode(message: database_blob.IDatabaseBlobDiffPageInfo, writer?: $protobuf.Writer): $protobuf.Writer;
+
+        /**
+         * Encodes the specified DatabaseBlobDiffPageInfo message, length delimited. Does not implicitly {@link database_blob.DatabaseBlobDiffPageInfo.verify|verify} messages.
+         * @param message DatabaseBlobDiffPageInfo message or plain object to encode
+         * @param [writer] Writer to encode to
+         * @returns Writer
+         */
+        public static encodeDelimited(message: database_blob.IDatabaseBlobDiffPageInfo, writer?: $protobuf.Writer): $protobuf.Writer;
+
+        /**
+         * Decodes a DatabaseBlobDiffPageInfo message from the specified reader or buffer.
+         * @param reader Reader or buffer to decode from
+         * @param [length] Message length if known beforehand
+         * @returns DatabaseBlobDiffPageInfo
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): database_blob.DatabaseBlobDiffPageInfo;
+
+        /**
+         * Decodes a DatabaseBlobDiffPageInfo message from the specified reader or buffer, length delimited.
+         * @param reader Reader or buffer to decode from
+         * @returns DatabaseBlobDiffPageInfo
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): database_blob.DatabaseBlobDiffPageInfo;
+
+        /**
+         * Verifies a DatabaseBlobDiffPageInfo message.
+         * @param message Plain object to verify
+         * @returns `null` if valid, otherwise the reason why it is not
+         */
+        public static verify(message: { [k: string]: any }): (string|null);
+
+        /**
+         * Creates a DatabaseBlobDiffPageInfo message from a plain object. Also converts values to their respective internal types.
+         * @param object Plain object
+         * @returns DatabaseBlobDiffPageInfo
+         */
+        public static fromObject(object: { [k: string]: any }): database_blob.DatabaseBlobDiffPageInfo;
+
+        /**
+         * Creates a plain object from a DatabaseBlobDiffPageInfo message. Also converts values to other types if specified.
+         * @param message DatabaseBlobDiffPageInfo
+         * @param [options] Conversion options
+         * @returns Plain object
+         */
+        public static toObject(message: database_blob.DatabaseBlobDiffPageInfo, options?: $protobuf.IConversionOptions): { [k: string]: any };
+
+        /**
+         * Converts this DatabaseBlobDiffPageInfo to JSON.
+         * @returns JSON object
+         */
+        public toJSON(): { [k: string]: any };
+
+        /**
+         * Gets the default type url for DatabaseBlobDiffPageInfo
+         * @param [typeUrlPrefix] your custom typeUrlPrefix(default "type.googleapis.com")
+         * @returns The default type url
+         */
+        public static getTypeUrl(typeUrlPrefix?: string): string;
+    }
+
     /** Properties of a DatabaseBlobDiffResponse. */
     interface IDatabaseBlobDiffResponse {
 
@@ -677,6 +1070,12 @@ export namespace database_blob {
 
         /** DatabaseBlobDiffResponse message */
         message?: (string|null);
+
+        /** DatabaseBlobDiffResponse missingRowIds */
+        missingRowIds?: (Uint8Array[]|null);
+
+        /** DatabaseBlobDiffResponse page */
+        page?: (database_blob.IDatabaseBlobDiffPageInfo|null);
     }
 
     /** Represents a DatabaseBlobDiffResponse. */
@@ -712,6 +1111,12 @@ export namespace database_blob {
         /** DatabaseBlobDiffResponse message. */
         public message?: (string|null);
 
+        /** DatabaseBlobDiffResponse missingRowIds. */
+        public missingRowIds: Uint8Array[];
+
+        /** DatabaseBlobDiffResponse page. */
+        public page?: (database_blob.IDatabaseBlobDiffPageInfo|null);
+
         /** DatabaseBlobDiffResponse _headBlobKey. */
         public _headBlobKey?: "headBlobKey";
 
@@ -720,6 +1125,9 @@ export namespace database_blob {
 
         /** DatabaseBlobDiffResponse _message. */
         public _message?: "message";
+
+        /** DatabaseBlobDiffResponse _page. */
+        public _page?: "page";
 
         /**
          * Creates a new DatabaseBlobDiffResponse instance using the specified properties.
@@ -1055,6 +1463,9 @@ export namespace database_blob {
 
         /** ManifestRowPointer document */
         document?: (database_blob.IManifestRowDocumentPointer|null);
+
+        /** ManifestRowPointer segmentLen */
+        segmentLen?: (number|null);
     }
 
     /** Represents a ManifestRowPointer. */
@@ -1083,6 +1494,9 @@ export namespace database_blob {
 
         /** ManifestRowPointer document. */
         public document?: (database_blob.IManifestRowDocumentPointer|null);
+
+        /** ManifestRowPointer segmentLen. */
+        public segmentLen: number;
 
         /** ManifestRowPointer _document. */
         public _document?: "document";
@@ -1188,6 +1602,9 @@ export namespace database_blob {
 
         /** DatabaseBlobManifest lockEpoch */
         lockEpoch?: (number|Long|null);
+
+        /** DatabaseBlobManifest generationIncomplete */
+        generationIncomplete?: (boolean|null);
     }
 
     /** Represents a DatabaseBlobManifest. */
@@ -1219,6 +1636,9 @@ export namespace database_blob {
 
         /** DatabaseBlobManifest lockEpoch. */
         public lockEpoch: (number|Long);
+
+        /** DatabaseBlobManifest generationIncomplete. */
+        public generationIncomplete: boolean;
 
         /**
          * Creates a new DatabaseBlobManifest instance using the specified properties.

--- a/src/proto/database_blob.js
+++ b/src/proto/database_blob.js
@@ -259,6 +259,281 @@ export const database_blob = $root.database_blob = (() => {
         return DatabaseBlobRowRid;
     })();
 
+    database_blob.DatabaseBlobDiffPageRequest = (function() {
+
+        /**
+         * Properties of a DatabaseBlobDiffPageRequest.
+         * @memberof database_blob
+         * @interface IDatabaseBlobDiffPageRequest
+         * @property {number|null} [maxItems] DatabaseBlobDiffPageRequest maxItems
+         * @property {number|Long|null} [maxBytes] DatabaseBlobDiffPageRequest maxBytes
+         * @property {Uint8Array|null} [cursor] DatabaseBlobDiffPageRequest cursor
+         */
+
+        /**
+         * Constructs a new DatabaseBlobDiffPageRequest.
+         * @memberof database_blob
+         * @classdesc Represents a DatabaseBlobDiffPageRequest.
+         * @implements IDatabaseBlobDiffPageRequest
+         * @constructor
+         * @param {database_blob.IDatabaseBlobDiffPageRequest=} [properties] Properties to set
+         */
+        function DatabaseBlobDiffPageRequest(properties) {
+            if (properties)
+                for (let keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                    if (properties[keys[i]] != null)
+                        this[keys[i]] = properties[keys[i]];
+        }
+
+        /**
+         * DatabaseBlobDiffPageRequest maxItems.
+         * @member {number} maxItems
+         * @memberof database_blob.DatabaseBlobDiffPageRequest
+         * @instance
+         */
+        DatabaseBlobDiffPageRequest.prototype.maxItems = 0;
+
+        /**
+         * DatabaseBlobDiffPageRequest maxBytes.
+         * @member {number|Long} maxBytes
+         * @memberof database_blob.DatabaseBlobDiffPageRequest
+         * @instance
+         */
+        DatabaseBlobDiffPageRequest.prototype.maxBytes = $util.Long ? $util.Long.fromBits(0,0,true) : 0;
+
+        /**
+         * DatabaseBlobDiffPageRequest cursor.
+         * @member {Uint8Array} cursor
+         * @memberof database_blob.DatabaseBlobDiffPageRequest
+         * @instance
+         */
+        DatabaseBlobDiffPageRequest.prototype.cursor = $util.newBuffer([]);
+
+        /**
+         * Creates a new DatabaseBlobDiffPageRequest instance using the specified properties.
+         * @function create
+         * @memberof database_blob.DatabaseBlobDiffPageRequest
+         * @static
+         * @param {database_blob.IDatabaseBlobDiffPageRequest=} [properties] Properties to set
+         * @returns {database_blob.DatabaseBlobDiffPageRequest} DatabaseBlobDiffPageRequest instance
+         */
+        DatabaseBlobDiffPageRequest.create = function create(properties) {
+            return new DatabaseBlobDiffPageRequest(properties);
+        };
+
+        /**
+         * Encodes the specified DatabaseBlobDiffPageRequest message. Does not implicitly {@link database_blob.DatabaseBlobDiffPageRequest.verify|verify} messages.
+         * @function encode
+         * @memberof database_blob.DatabaseBlobDiffPageRequest
+         * @static
+         * @param {database_blob.IDatabaseBlobDiffPageRequest} message DatabaseBlobDiffPageRequest message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        DatabaseBlobDiffPageRequest.encode = function encode(message, writer) {
+            if (!writer)
+                writer = $Writer.create();
+            if (message.maxItems != null && Object.hasOwnProperty.call(message, "maxItems"))
+                writer.uint32(/* id 1, wireType 0 =*/8).uint32(message.maxItems);
+            if (message.maxBytes != null && Object.hasOwnProperty.call(message, "maxBytes"))
+                writer.uint32(/* id 2, wireType 0 =*/16).uint64(message.maxBytes);
+            if (message.cursor != null && Object.hasOwnProperty.call(message, "cursor"))
+                writer.uint32(/* id 3, wireType 2 =*/26).bytes(message.cursor);
+            return writer;
+        };
+
+        /**
+         * Encodes the specified DatabaseBlobDiffPageRequest message, length delimited. Does not implicitly {@link database_blob.DatabaseBlobDiffPageRequest.verify|verify} messages.
+         * @function encodeDelimited
+         * @memberof database_blob.DatabaseBlobDiffPageRequest
+         * @static
+         * @param {database_blob.IDatabaseBlobDiffPageRequest} message DatabaseBlobDiffPageRequest message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        DatabaseBlobDiffPageRequest.encodeDelimited = function encodeDelimited(message, writer) {
+            return this.encode(message, writer).ldelim();
+        };
+
+        /**
+         * Decodes a DatabaseBlobDiffPageRequest message from the specified reader or buffer.
+         * @function decode
+         * @memberof database_blob.DatabaseBlobDiffPageRequest
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @param {number} [length] Message length if known beforehand
+         * @returns {database_blob.DatabaseBlobDiffPageRequest} DatabaseBlobDiffPageRequest
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        DatabaseBlobDiffPageRequest.decode = function decode(reader, length, error) {
+            if (!(reader instanceof $Reader))
+                reader = $Reader.create(reader);
+            let end = length === undefined ? reader.len : reader.pos + length, message = new $root.database_blob.DatabaseBlobDiffPageRequest();
+            while (reader.pos < end) {
+                let tag = reader.uint32();
+                if (tag === error)
+                    break;
+                switch (tag >>> 3) {
+                case 1: {
+                        message.maxItems = reader.uint32();
+                        break;
+                    }
+                case 2: {
+                        message.maxBytes = reader.uint64();
+                        break;
+                    }
+                case 3: {
+                        message.cursor = reader.bytes();
+                        break;
+                    }
+                default:
+                    reader.skipType(tag & 7);
+                    break;
+                }
+            }
+            return message;
+        };
+
+        /**
+         * Decodes a DatabaseBlobDiffPageRequest message from the specified reader or buffer, length delimited.
+         * @function decodeDelimited
+         * @memberof database_blob.DatabaseBlobDiffPageRequest
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @returns {database_blob.DatabaseBlobDiffPageRequest} DatabaseBlobDiffPageRequest
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        DatabaseBlobDiffPageRequest.decodeDelimited = function decodeDelimited(reader) {
+            if (!(reader instanceof $Reader))
+                reader = new $Reader(reader);
+            return this.decode(reader, reader.uint32());
+        };
+
+        /**
+         * Verifies a DatabaseBlobDiffPageRequest message.
+         * @function verify
+         * @memberof database_blob.DatabaseBlobDiffPageRequest
+         * @static
+         * @param {Object.<string,*>} message Plain object to verify
+         * @returns {string|null} `null` if valid, otherwise the reason why it is not
+         */
+        DatabaseBlobDiffPageRequest.verify = function verify(message) {
+            if (typeof message !== "object" || message === null)
+                return "object expected";
+            if (message.maxItems != null && message.hasOwnProperty("maxItems"))
+                if (!$util.isInteger(message.maxItems))
+                    return "maxItems: integer expected";
+            if (message.maxBytes != null && message.hasOwnProperty("maxBytes"))
+                if (!$util.isInteger(message.maxBytes) && !(message.maxBytes && $util.isInteger(message.maxBytes.low) && $util.isInteger(message.maxBytes.high)))
+                    return "maxBytes: integer|Long expected";
+            if (message.cursor != null && message.hasOwnProperty("cursor"))
+                if (!(message.cursor && typeof message.cursor.length === "number" || $util.isString(message.cursor)))
+                    return "cursor: buffer expected";
+            return null;
+        };
+
+        /**
+         * Creates a DatabaseBlobDiffPageRequest message from a plain object. Also converts values to their respective internal types.
+         * @function fromObject
+         * @memberof database_blob.DatabaseBlobDiffPageRequest
+         * @static
+         * @param {Object.<string,*>} object Plain object
+         * @returns {database_blob.DatabaseBlobDiffPageRequest} DatabaseBlobDiffPageRequest
+         */
+        DatabaseBlobDiffPageRequest.fromObject = function fromObject(object) {
+            if (object instanceof $root.database_blob.DatabaseBlobDiffPageRequest)
+                return object;
+            let message = new $root.database_blob.DatabaseBlobDiffPageRequest();
+            if (object.maxItems != null)
+                message.maxItems = object.maxItems >>> 0;
+            if (object.maxBytes != null)
+                if ($util.Long)
+                    (message.maxBytes = $util.Long.fromValue(object.maxBytes)).unsigned = true;
+                else if (typeof object.maxBytes === "string")
+                    message.maxBytes = parseInt(object.maxBytes, 10);
+                else if (typeof object.maxBytes === "number")
+                    message.maxBytes = object.maxBytes;
+                else if (typeof object.maxBytes === "object")
+                    message.maxBytes = new $util.LongBits(object.maxBytes.low >>> 0, object.maxBytes.high >>> 0).toNumber(true);
+            if (object.cursor != null)
+                if (typeof object.cursor === "string")
+                    $util.base64.decode(object.cursor, message.cursor = $util.newBuffer($util.base64.length(object.cursor)), 0);
+                else if (object.cursor.length >= 0)
+                    message.cursor = object.cursor;
+            return message;
+        };
+
+        /**
+         * Creates a plain object from a DatabaseBlobDiffPageRequest message. Also converts values to other types if specified.
+         * @function toObject
+         * @memberof database_blob.DatabaseBlobDiffPageRequest
+         * @static
+         * @param {database_blob.DatabaseBlobDiffPageRequest} message DatabaseBlobDiffPageRequest
+         * @param {$protobuf.IConversionOptions} [options] Conversion options
+         * @returns {Object.<string,*>} Plain object
+         */
+        DatabaseBlobDiffPageRequest.toObject = function toObject(message, options) {
+            if (!options)
+                options = {};
+            let object = {};
+            if (options.defaults) {
+                object.maxItems = 0;
+                if ($util.Long) {
+                    let long = new $util.Long(0, 0, true);
+                    object.maxBytes = options.longs === String ? long.toString() : options.longs === Number ? long.toNumber() : long;
+                } else
+                    object.maxBytes = options.longs === String ? "0" : 0;
+                if (options.bytes === String)
+                    object.cursor = "";
+                else {
+                    object.cursor = [];
+                    if (options.bytes !== Array)
+                        object.cursor = $util.newBuffer(object.cursor);
+                }
+            }
+            if (message.maxItems != null && message.hasOwnProperty("maxItems"))
+                object.maxItems = message.maxItems;
+            if (message.maxBytes != null && message.hasOwnProperty("maxBytes"))
+                if (typeof message.maxBytes === "number")
+                    object.maxBytes = options.longs === String ? String(message.maxBytes) : message.maxBytes;
+                else
+                    object.maxBytes = options.longs === String ? $util.Long.prototype.toString.call(message.maxBytes) : options.longs === Number ? new $util.LongBits(message.maxBytes.low >>> 0, message.maxBytes.high >>> 0).toNumber(true) : message.maxBytes;
+            if (message.cursor != null && message.hasOwnProperty("cursor"))
+                object.cursor = options.bytes === String ? $util.base64.encode(message.cursor, 0, message.cursor.length) : options.bytes === Array ? Array.prototype.slice.call(message.cursor) : message.cursor;
+            return object;
+        };
+
+        /**
+         * Converts this DatabaseBlobDiffPageRequest to JSON.
+         * @function toJSON
+         * @memberof database_blob.DatabaseBlobDiffPageRequest
+         * @instance
+         * @returns {Object.<string,*>} JSON object
+         */
+        DatabaseBlobDiffPageRequest.prototype.toJSON = function toJSON() {
+            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+        };
+
+        /**
+         * Gets the default type url for DatabaseBlobDiffPageRequest
+         * @function getTypeUrl
+         * @memberof database_blob.DatabaseBlobDiffPageRequest
+         * @static
+         * @param {string} [typeUrlPrefix] your custom typeUrlPrefix(default "type.googleapis.com")
+         * @returns {string} The default type url
+         */
+        DatabaseBlobDiffPageRequest.getTypeUrl = function getTypeUrl(typeUrlPrefix) {
+            if (typeUrlPrefix === undefined) {
+                typeUrlPrefix = "type.googleapis.com";
+            }
+            return typeUrlPrefix + "/database_blob.DatabaseBlobDiffPageRequest";
+        };
+
+        return DatabaseBlobDiffPageRequest;
+    })();
+
     database_blob.DatabaseBlobDiffRequest = (function() {
 
         /**
@@ -267,6 +542,8 @@ export const database_blob = $root.database_blob = (() => {
          * @interface IDatabaseBlobDiffRequest
          * @property {database_blob.IDatabaseBlobRowRid|null} [maxKnownRid] DatabaseBlobDiffRequest maxKnownRid
          * @property {number|null} [version] DatabaseBlobDiffRequest version
+         * @property {boolean|null} [includeDocuments] DatabaseBlobDiffRequest includeDocuments
+         * @property {database_blob.IDatabaseBlobDiffPageRequest|null} [page] DatabaseBlobDiffRequest page
          */
 
         /**
@@ -300,6 +577,22 @@ export const database_blob = $root.database_blob = (() => {
          */
         DatabaseBlobDiffRequest.prototype.version = 0;
 
+        /**
+         * DatabaseBlobDiffRequest includeDocuments.
+         * @member {boolean|null|undefined} includeDocuments
+         * @memberof database_blob.DatabaseBlobDiffRequest
+         * @instance
+         */
+        DatabaseBlobDiffRequest.prototype.includeDocuments = null;
+
+        /**
+         * DatabaseBlobDiffRequest page.
+         * @member {database_blob.IDatabaseBlobDiffPageRequest|null|undefined} page
+         * @memberof database_blob.DatabaseBlobDiffRequest
+         * @instance
+         */
+        DatabaseBlobDiffRequest.prototype.page = null;
+
         // OneOf field names bound to virtual getters and setters
         let $oneOfFields;
 
@@ -311,6 +604,28 @@ export const database_blob = $root.database_blob = (() => {
          */
         Object.defineProperty(DatabaseBlobDiffRequest.prototype, "_maxKnownRid", {
             get: $util.oneOfGetter($oneOfFields = ["maxKnownRid"]),
+            set: $util.oneOfSetter($oneOfFields)
+        });
+
+        /**
+         * DatabaseBlobDiffRequest _includeDocuments.
+         * @member {"includeDocuments"|undefined} _includeDocuments
+         * @memberof database_blob.DatabaseBlobDiffRequest
+         * @instance
+         */
+        Object.defineProperty(DatabaseBlobDiffRequest.prototype, "_includeDocuments", {
+            get: $util.oneOfGetter($oneOfFields = ["includeDocuments"]),
+            set: $util.oneOfSetter($oneOfFields)
+        });
+
+        /**
+         * DatabaseBlobDiffRequest _page.
+         * @member {"page"|undefined} _page
+         * @memberof database_blob.DatabaseBlobDiffRequest
+         * @instance
+         */
+        Object.defineProperty(DatabaseBlobDiffRequest.prototype, "_page", {
+            get: $util.oneOfGetter($oneOfFields = ["page"]),
             set: $util.oneOfSetter($oneOfFields)
         });
 
@@ -342,6 +657,10 @@ export const database_blob = $root.database_blob = (() => {
                 $root.database_blob.DatabaseBlobRowRid.encode(message.maxKnownRid, writer.uint32(/* id 1, wireType 2 =*/10).fork()).ldelim();
             if (message.version != null && Object.hasOwnProperty.call(message, "version"))
                 writer.uint32(/* id 2, wireType 0 =*/16).int32(message.version);
+            if (message.includeDocuments != null && Object.hasOwnProperty.call(message, "includeDocuments"))
+                writer.uint32(/* id 3, wireType 0 =*/24).bool(message.includeDocuments);
+            if (message.page != null && Object.hasOwnProperty.call(message, "page"))
+                $root.database_blob.DatabaseBlobDiffPageRequest.encode(message.page, writer.uint32(/* id 4, wireType 2 =*/34).fork()).ldelim();
             return writer;
         };
 
@@ -384,6 +703,14 @@ export const database_blob = $root.database_blob = (() => {
                     }
                 case 2: {
                         message.version = reader.int32();
+                        break;
+                    }
+                case 3: {
+                        message.includeDocuments = reader.bool();
+                        break;
+                    }
+                case 4: {
+                        message.page = $root.database_blob.DatabaseBlobDiffPageRequest.decode(reader, reader.uint32());
                         break;
                     }
                 default:
@@ -433,6 +760,19 @@ export const database_blob = $root.database_blob = (() => {
             if (message.version != null && message.hasOwnProperty("version"))
                 if (!$util.isInteger(message.version))
                     return "version: integer expected";
+            if (message.includeDocuments != null && message.hasOwnProperty("includeDocuments")) {
+                properties._includeDocuments = 1;
+                if (typeof message.includeDocuments !== "boolean")
+                    return "includeDocuments: boolean expected";
+            }
+            if (message.page != null && message.hasOwnProperty("page")) {
+                properties._page = 1;
+                {
+                    let error = $root.database_blob.DatabaseBlobDiffPageRequest.verify(message.page);
+                    if (error)
+                        return "page." + error;
+                }
+            }
             return null;
         };
 
@@ -455,6 +795,13 @@ export const database_blob = $root.database_blob = (() => {
             }
             if (object.version != null)
                 message.version = object.version | 0;
+            if (object.includeDocuments != null)
+                message.includeDocuments = Boolean(object.includeDocuments);
+            if (object.page != null) {
+                if (typeof object.page !== "object")
+                    throw TypeError(".database_blob.DatabaseBlobDiffRequest.page: object expected");
+                message.page = $root.database_blob.DatabaseBlobDiffPageRequest.fromObject(object.page);
+            }
             return message;
         };
 
@@ -480,6 +827,16 @@ export const database_blob = $root.database_blob = (() => {
             }
             if (message.version != null && message.hasOwnProperty("version"))
                 object.version = message.version;
+            if (message.includeDocuments != null && message.hasOwnProperty("includeDocuments")) {
+                object.includeDocuments = message.includeDocuments;
+                if (options.oneofs)
+                    object._includeDocuments = "includeDocuments";
+            }
+            if (message.page != null && message.hasOwnProperty("page")) {
+                object.page = $root.database_blob.DatabaseBlobDiffPageRequest.toObject(message.page, options);
+                if (options.oneofs)
+                    object._page = "page";
+            }
             return object;
         };
 
@@ -512,6 +869,492 @@ export const database_blob = $root.database_blob = (() => {
         return DatabaseBlobDiffRequest;
     })();
 
+    database_blob.DatabaseBlobDiffPageCursor = (function() {
+
+        /**
+         * Properties of a DatabaseBlobDiffPageCursor.
+         * @memberof database_blob
+         * @interface IDatabaseBlobDiffPageCursor
+         * @property {number|null} [formatVersion] DatabaseBlobDiffPageCursor formatVersion
+         * @property {Uint8Array|null} [workspaceId] DatabaseBlobDiffPageCursor workspaceId
+         * @property {Uint8Array|null} [databaseId] DatabaseBlobDiffPageCursor databaseId
+         * @property {string|null} [manifestVersion] DatabaseBlobDiffPageCursor manifestVersion
+         * @property {database_blob.IDatabaseBlobRowRid|null} [maxKnownRid] DatabaseBlobDiffPageCursor maxKnownRid
+         * @property {number|Long|null} [nextOffset] DatabaseBlobDiffPageCursor nextOffset
+         * @property {Uint8Array|null} [planHash] DatabaseBlobDiffPageCursor planHash
+         * @property {database_blob.IDatabaseBlobRowRid|null} [maxObservedRid] DatabaseBlobDiffPageCursor maxObservedRid
+         * @property {Uint8Array|null} [signature] DatabaseBlobDiffPageCursor signature
+         */
+
+        /**
+         * Constructs a new DatabaseBlobDiffPageCursor.
+         * @memberof database_blob
+         * @classdesc Represents a DatabaseBlobDiffPageCursor.
+         * @implements IDatabaseBlobDiffPageCursor
+         * @constructor
+         * @param {database_blob.IDatabaseBlobDiffPageCursor=} [properties] Properties to set
+         */
+        function DatabaseBlobDiffPageCursor(properties) {
+            if (properties)
+                for (let keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                    if (properties[keys[i]] != null)
+                        this[keys[i]] = properties[keys[i]];
+        }
+
+        /**
+         * DatabaseBlobDiffPageCursor formatVersion.
+         * @member {number} formatVersion
+         * @memberof database_blob.DatabaseBlobDiffPageCursor
+         * @instance
+         */
+        DatabaseBlobDiffPageCursor.prototype.formatVersion = 0;
+
+        /**
+         * DatabaseBlobDiffPageCursor workspaceId.
+         * @member {Uint8Array} workspaceId
+         * @memberof database_blob.DatabaseBlobDiffPageCursor
+         * @instance
+         */
+        DatabaseBlobDiffPageCursor.prototype.workspaceId = $util.newBuffer([]);
+
+        /**
+         * DatabaseBlobDiffPageCursor databaseId.
+         * @member {Uint8Array} databaseId
+         * @memberof database_blob.DatabaseBlobDiffPageCursor
+         * @instance
+         */
+        DatabaseBlobDiffPageCursor.prototype.databaseId = $util.newBuffer([]);
+
+        /**
+         * DatabaseBlobDiffPageCursor manifestVersion.
+         * @member {string} manifestVersion
+         * @memberof database_blob.DatabaseBlobDiffPageCursor
+         * @instance
+         */
+        DatabaseBlobDiffPageCursor.prototype.manifestVersion = "";
+
+        /**
+         * DatabaseBlobDiffPageCursor maxKnownRid.
+         * @member {database_blob.IDatabaseBlobRowRid|null|undefined} maxKnownRid
+         * @memberof database_blob.DatabaseBlobDiffPageCursor
+         * @instance
+         */
+        DatabaseBlobDiffPageCursor.prototype.maxKnownRid = null;
+
+        /**
+         * DatabaseBlobDiffPageCursor nextOffset.
+         * @member {number|Long} nextOffset
+         * @memberof database_blob.DatabaseBlobDiffPageCursor
+         * @instance
+         */
+        DatabaseBlobDiffPageCursor.prototype.nextOffset = $util.Long ? $util.Long.fromBits(0,0,true) : 0;
+
+        /**
+         * DatabaseBlobDiffPageCursor planHash.
+         * @member {Uint8Array} planHash
+         * @memberof database_blob.DatabaseBlobDiffPageCursor
+         * @instance
+         */
+        DatabaseBlobDiffPageCursor.prototype.planHash = $util.newBuffer([]);
+
+        /**
+         * DatabaseBlobDiffPageCursor maxObservedRid.
+         * @member {database_blob.IDatabaseBlobRowRid|null|undefined} maxObservedRid
+         * @memberof database_blob.DatabaseBlobDiffPageCursor
+         * @instance
+         */
+        DatabaseBlobDiffPageCursor.prototype.maxObservedRid = null;
+
+        /**
+         * DatabaseBlobDiffPageCursor signature.
+         * @member {Uint8Array} signature
+         * @memberof database_blob.DatabaseBlobDiffPageCursor
+         * @instance
+         */
+        DatabaseBlobDiffPageCursor.prototype.signature = $util.newBuffer([]);
+
+        // OneOf field names bound to virtual getters and setters
+        let $oneOfFields;
+
+        /**
+         * DatabaseBlobDiffPageCursor _maxKnownRid.
+         * @member {"maxKnownRid"|undefined} _maxKnownRid
+         * @memberof database_blob.DatabaseBlobDiffPageCursor
+         * @instance
+         */
+        Object.defineProperty(DatabaseBlobDiffPageCursor.prototype, "_maxKnownRid", {
+            get: $util.oneOfGetter($oneOfFields = ["maxKnownRid"]),
+            set: $util.oneOfSetter($oneOfFields)
+        });
+
+        /**
+         * DatabaseBlobDiffPageCursor _maxObservedRid.
+         * @member {"maxObservedRid"|undefined} _maxObservedRid
+         * @memberof database_blob.DatabaseBlobDiffPageCursor
+         * @instance
+         */
+        Object.defineProperty(DatabaseBlobDiffPageCursor.prototype, "_maxObservedRid", {
+            get: $util.oneOfGetter($oneOfFields = ["maxObservedRid"]),
+            set: $util.oneOfSetter($oneOfFields)
+        });
+
+        /**
+         * Creates a new DatabaseBlobDiffPageCursor instance using the specified properties.
+         * @function create
+         * @memberof database_blob.DatabaseBlobDiffPageCursor
+         * @static
+         * @param {database_blob.IDatabaseBlobDiffPageCursor=} [properties] Properties to set
+         * @returns {database_blob.DatabaseBlobDiffPageCursor} DatabaseBlobDiffPageCursor instance
+         */
+        DatabaseBlobDiffPageCursor.create = function create(properties) {
+            return new DatabaseBlobDiffPageCursor(properties);
+        };
+
+        /**
+         * Encodes the specified DatabaseBlobDiffPageCursor message. Does not implicitly {@link database_blob.DatabaseBlobDiffPageCursor.verify|verify} messages.
+         * @function encode
+         * @memberof database_blob.DatabaseBlobDiffPageCursor
+         * @static
+         * @param {database_blob.IDatabaseBlobDiffPageCursor} message DatabaseBlobDiffPageCursor message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        DatabaseBlobDiffPageCursor.encode = function encode(message, writer) {
+            if (!writer)
+                writer = $Writer.create();
+            if (message.formatVersion != null && Object.hasOwnProperty.call(message, "formatVersion"))
+                writer.uint32(/* id 1, wireType 0 =*/8).uint32(message.formatVersion);
+            if (message.workspaceId != null && Object.hasOwnProperty.call(message, "workspaceId"))
+                writer.uint32(/* id 2, wireType 2 =*/18).bytes(message.workspaceId);
+            if (message.databaseId != null && Object.hasOwnProperty.call(message, "databaseId"))
+                writer.uint32(/* id 3, wireType 2 =*/26).bytes(message.databaseId);
+            if (message.manifestVersion != null && Object.hasOwnProperty.call(message, "manifestVersion"))
+                writer.uint32(/* id 4, wireType 2 =*/34).string(message.manifestVersion);
+            if (message.maxKnownRid != null && Object.hasOwnProperty.call(message, "maxKnownRid"))
+                $root.database_blob.DatabaseBlobRowRid.encode(message.maxKnownRid, writer.uint32(/* id 5, wireType 2 =*/42).fork()).ldelim();
+            if (message.nextOffset != null && Object.hasOwnProperty.call(message, "nextOffset"))
+                writer.uint32(/* id 6, wireType 0 =*/48).uint64(message.nextOffset);
+            if (message.planHash != null && Object.hasOwnProperty.call(message, "planHash"))
+                writer.uint32(/* id 7, wireType 2 =*/58).bytes(message.planHash);
+            if (message.maxObservedRid != null && Object.hasOwnProperty.call(message, "maxObservedRid"))
+                $root.database_blob.DatabaseBlobRowRid.encode(message.maxObservedRid, writer.uint32(/* id 8, wireType 2 =*/66).fork()).ldelim();
+            if (message.signature != null && Object.hasOwnProperty.call(message, "signature"))
+                writer.uint32(/* id 9, wireType 2 =*/74).bytes(message.signature);
+            return writer;
+        };
+
+        /**
+         * Encodes the specified DatabaseBlobDiffPageCursor message, length delimited. Does not implicitly {@link database_blob.DatabaseBlobDiffPageCursor.verify|verify} messages.
+         * @function encodeDelimited
+         * @memberof database_blob.DatabaseBlobDiffPageCursor
+         * @static
+         * @param {database_blob.IDatabaseBlobDiffPageCursor} message DatabaseBlobDiffPageCursor message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        DatabaseBlobDiffPageCursor.encodeDelimited = function encodeDelimited(message, writer) {
+            return this.encode(message, writer).ldelim();
+        };
+
+        /**
+         * Decodes a DatabaseBlobDiffPageCursor message from the specified reader or buffer.
+         * @function decode
+         * @memberof database_blob.DatabaseBlobDiffPageCursor
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @param {number} [length] Message length if known beforehand
+         * @returns {database_blob.DatabaseBlobDiffPageCursor} DatabaseBlobDiffPageCursor
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        DatabaseBlobDiffPageCursor.decode = function decode(reader, length, error) {
+            if (!(reader instanceof $Reader))
+                reader = $Reader.create(reader);
+            let end = length === undefined ? reader.len : reader.pos + length, message = new $root.database_blob.DatabaseBlobDiffPageCursor();
+            while (reader.pos < end) {
+                let tag = reader.uint32();
+                if (tag === error)
+                    break;
+                switch (tag >>> 3) {
+                case 1: {
+                        message.formatVersion = reader.uint32();
+                        break;
+                    }
+                case 2: {
+                        message.workspaceId = reader.bytes();
+                        break;
+                    }
+                case 3: {
+                        message.databaseId = reader.bytes();
+                        break;
+                    }
+                case 4: {
+                        message.manifestVersion = reader.string();
+                        break;
+                    }
+                case 5: {
+                        message.maxKnownRid = $root.database_blob.DatabaseBlobRowRid.decode(reader, reader.uint32());
+                        break;
+                    }
+                case 6: {
+                        message.nextOffset = reader.uint64();
+                        break;
+                    }
+                case 7: {
+                        message.planHash = reader.bytes();
+                        break;
+                    }
+                case 8: {
+                        message.maxObservedRid = $root.database_blob.DatabaseBlobRowRid.decode(reader, reader.uint32());
+                        break;
+                    }
+                case 9: {
+                        message.signature = reader.bytes();
+                        break;
+                    }
+                default:
+                    reader.skipType(tag & 7);
+                    break;
+                }
+            }
+            return message;
+        };
+
+        /**
+         * Decodes a DatabaseBlobDiffPageCursor message from the specified reader or buffer, length delimited.
+         * @function decodeDelimited
+         * @memberof database_blob.DatabaseBlobDiffPageCursor
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @returns {database_blob.DatabaseBlobDiffPageCursor} DatabaseBlobDiffPageCursor
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        DatabaseBlobDiffPageCursor.decodeDelimited = function decodeDelimited(reader) {
+            if (!(reader instanceof $Reader))
+                reader = new $Reader(reader);
+            return this.decode(reader, reader.uint32());
+        };
+
+        /**
+         * Verifies a DatabaseBlobDiffPageCursor message.
+         * @function verify
+         * @memberof database_blob.DatabaseBlobDiffPageCursor
+         * @static
+         * @param {Object.<string,*>} message Plain object to verify
+         * @returns {string|null} `null` if valid, otherwise the reason why it is not
+         */
+        DatabaseBlobDiffPageCursor.verify = function verify(message) {
+            if (typeof message !== "object" || message === null)
+                return "object expected";
+            let properties = {};
+            if (message.formatVersion != null && message.hasOwnProperty("formatVersion"))
+                if (!$util.isInteger(message.formatVersion))
+                    return "formatVersion: integer expected";
+            if (message.workspaceId != null && message.hasOwnProperty("workspaceId"))
+                if (!(message.workspaceId && typeof message.workspaceId.length === "number" || $util.isString(message.workspaceId)))
+                    return "workspaceId: buffer expected";
+            if (message.databaseId != null && message.hasOwnProperty("databaseId"))
+                if (!(message.databaseId && typeof message.databaseId.length === "number" || $util.isString(message.databaseId)))
+                    return "databaseId: buffer expected";
+            if (message.manifestVersion != null && message.hasOwnProperty("manifestVersion"))
+                if (!$util.isString(message.manifestVersion))
+                    return "manifestVersion: string expected";
+            if (message.maxKnownRid != null && message.hasOwnProperty("maxKnownRid")) {
+                properties._maxKnownRid = 1;
+                {
+                    let error = $root.database_blob.DatabaseBlobRowRid.verify(message.maxKnownRid);
+                    if (error)
+                        return "maxKnownRid." + error;
+                }
+            }
+            if (message.nextOffset != null && message.hasOwnProperty("nextOffset"))
+                if (!$util.isInteger(message.nextOffset) && !(message.nextOffset && $util.isInteger(message.nextOffset.low) && $util.isInteger(message.nextOffset.high)))
+                    return "nextOffset: integer|Long expected";
+            if (message.planHash != null && message.hasOwnProperty("planHash"))
+                if (!(message.planHash && typeof message.planHash.length === "number" || $util.isString(message.planHash)))
+                    return "planHash: buffer expected";
+            if (message.maxObservedRid != null && message.hasOwnProperty("maxObservedRid")) {
+                properties._maxObservedRid = 1;
+                {
+                    let error = $root.database_blob.DatabaseBlobRowRid.verify(message.maxObservedRid);
+                    if (error)
+                        return "maxObservedRid." + error;
+                }
+            }
+            if (message.signature != null && message.hasOwnProperty("signature"))
+                if (!(message.signature && typeof message.signature.length === "number" || $util.isString(message.signature)))
+                    return "signature: buffer expected";
+            return null;
+        };
+
+        /**
+         * Creates a DatabaseBlobDiffPageCursor message from a plain object. Also converts values to their respective internal types.
+         * @function fromObject
+         * @memberof database_blob.DatabaseBlobDiffPageCursor
+         * @static
+         * @param {Object.<string,*>} object Plain object
+         * @returns {database_blob.DatabaseBlobDiffPageCursor} DatabaseBlobDiffPageCursor
+         */
+        DatabaseBlobDiffPageCursor.fromObject = function fromObject(object) {
+            if (object instanceof $root.database_blob.DatabaseBlobDiffPageCursor)
+                return object;
+            let message = new $root.database_blob.DatabaseBlobDiffPageCursor();
+            if (object.formatVersion != null)
+                message.formatVersion = object.formatVersion >>> 0;
+            if (object.workspaceId != null)
+                if (typeof object.workspaceId === "string")
+                    $util.base64.decode(object.workspaceId, message.workspaceId = $util.newBuffer($util.base64.length(object.workspaceId)), 0);
+                else if (object.workspaceId.length >= 0)
+                    message.workspaceId = object.workspaceId;
+            if (object.databaseId != null)
+                if (typeof object.databaseId === "string")
+                    $util.base64.decode(object.databaseId, message.databaseId = $util.newBuffer($util.base64.length(object.databaseId)), 0);
+                else if (object.databaseId.length >= 0)
+                    message.databaseId = object.databaseId;
+            if (object.manifestVersion != null)
+                message.manifestVersion = String(object.manifestVersion);
+            if (object.maxKnownRid != null) {
+                if (typeof object.maxKnownRid !== "object")
+                    throw TypeError(".database_blob.DatabaseBlobDiffPageCursor.maxKnownRid: object expected");
+                message.maxKnownRid = $root.database_blob.DatabaseBlobRowRid.fromObject(object.maxKnownRid);
+            }
+            if (object.nextOffset != null)
+                if ($util.Long)
+                    (message.nextOffset = $util.Long.fromValue(object.nextOffset)).unsigned = true;
+                else if (typeof object.nextOffset === "string")
+                    message.nextOffset = parseInt(object.nextOffset, 10);
+                else if (typeof object.nextOffset === "number")
+                    message.nextOffset = object.nextOffset;
+                else if (typeof object.nextOffset === "object")
+                    message.nextOffset = new $util.LongBits(object.nextOffset.low >>> 0, object.nextOffset.high >>> 0).toNumber(true);
+            if (object.planHash != null)
+                if (typeof object.planHash === "string")
+                    $util.base64.decode(object.planHash, message.planHash = $util.newBuffer($util.base64.length(object.planHash)), 0);
+                else if (object.planHash.length >= 0)
+                    message.planHash = object.planHash;
+            if (object.maxObservedRid != null) {
+                if (typeof object.maxObservedRid !== "object")
+                    throw TypeError(".database_blob.DatabaseBlobDiffPageCursor.maxObservedRid: object expected");
+                message.maxObservedRid = $root.database_blob.DatabaseBlobRowRid.fromObject(object.maxObservedRid);
+            }
+            if (object.signature != null)
+                if (typeof object.signature === "string")
+                    $util.base64.decode(object.signature, message.signature = $util.newBuffer($util.base64.length(object.signature)), 0);
+                else if (object.signature.length >= 0)
+                    message.signature = object.signature;
+            return message;
+        };
+
+        /**
+         * Creates a plain object from a DatabaseBlobDiffPageCursor message. Also converts values to other types if specified.
+         * @function toObject
+         * @memberof database_blob.DatabaseBlobDiffPageCursor
+         * @static
+         * @param {database_blob.DatabaseBlobDiffPageCursor} message DatabaseBlobDiffPageCursor
+         * @param {$protobuf.IConversionOptions} [options] Conversion options
+         * @returns {Object.<string,*>} Plain object
+         */
+        DatabaseBlobDiffPageCursor.toObject = function toObject(message, options) {
+            if (!options)
+                options = {};
+            let object = {};
+            if (options.defaults) {
+                object.formatVersion = 0;
+                if (options.bytes === String)
+                    object.workspaceId = "";
+                else {
+                    object.workspaceId = [];
+                    if (options.bytes !== Array)
+                        object.workspaceId = $util.newBuffer(object.workspaceId);
+                }
+                if (options.bytes === String)
+                    object.databaseId = "";
+                else {
+                    object.databaseId = [];
+                    if (options.bytes !== Array)
+                        object.databaseId = $util.newBuffer(object.databaseId);
+                }
+                object.manifestVersion = "";
+                if ($util.Long) {
+                    let long = new $util.Long(0, 0, true);
+                    object.nextOffset = options.longs === String ? long.toString() : options.longs === Number ? long.toNumber() : long;
+                } else
+                    object.nextOffset = options.longs === String ? "0" : 0;
+                if (options.bytes === String)
+                    object.planHash = "";
+                else {
+                    object.planHash = [];
+                    if (options.bytes !== Array)
+                        object.planHash = $util.newBuffer(object.planHash);
+                }
+                if (options.bytes === String)
+                    object.signature = "";
+                else {
+                    object.signature = [];
+                    if (options.bytes !== Array)
+                        object.signature = $util.newBuffer(object.signature);
+                }
+            }
+            if (message.formatVersion != null && message.hasOwnProperty("formatVersion"))
+                object.formatVersion = message.formatVersion;
+            if (message.workspaceId != null && message.hasOwnProperty("workspaceId"))
+                object.workspaceId = options.bytes === String ? $util.base64.encode(message.workspaceId, 0, message.workspaceId.length) : options.bytes === Array ? Array.prototype.slice.call(message.workspaceId) : message.workspaceId;
+            if (message.databaseId != null && message.hasOwnProperty("databaseId"))
+                object.databaseId = options.bytes === String ? $util.base64.encode(message.databaseId, 0, message.databaseId.length) : options.bytes === Array ? Array.prototype.slice.call(message.databaseId) : message.databaseId;
+            if (message.manifestVersion != null && message.hasOwnProperty("manifestVersion"))
+                object.manifestVersion = message.manifestVersion;
+            if (message.maxKnownRid != null && message.hasOwnProperty("maxKnownRid")) {
+                object.maxKnownRid = $root.database_blob.DatabaseBlobRowRid.toObject(message.maxKnownRid, options);
+                if (options.oneofs)
+                    object._maxKnownRid = "maxKnownRid";
+            }
+            if (message.nextOffset != null && message.hasOwnProperty("nextOffset"))
+                if (typeof message.nextOffset === "number")
+                    object.nextOffset = options.longs === String ? String(message.nextOffset) : message.nextOffset;
+                else
+                    object.nextOffset = options.longs === String ? $util.Long.prototype.toString.call(message.nextOffset) : options.longs === Number ? new $util.LongBits(message.nextOffset.low >>> 0, message.nextOffset.high >>> 0).toNumber(true) : message.nextOffset;
+            if (message.planHash != null && message.hasOwnProperty("planHash"))
+                object.planHash = options.bytes === String ? $util.base64.encode(message.planHash, 0, message.planHash.length) : options.bytes === Array ? Array.prototype.slice.call(message.planHash) : message.planHash;
+            if (message.maxObservedRid != null && message.hasOwnProperty("maxObservedRid")) {
+                object.maxObservedRid = $root.database_blob.DatabaseBlobRowRid.toObject(message.maxObservedRid, options);
+                if (options.oneofs)
+                    object._maxObservedRid = "maxObservedRid";
+            }
+            if (message.signature != null && message.hasOwnProperty("signature"))
+                object.signature = options.bytes === String ? $util.base64.encode(message.signature, 0, message.signature.length) : options.bytes === Array ? Array.prototype.slice.call(message.signature) : message.signature;
+            return object;
+        };
+
+        /**
+         * Converts this DatabaseBlobDiffPageCursor to JSON.
+         * @function toJSON
+         * @memberof database_blob.DatabaseBlobDiffPageCursor
+         * @instance
+         * @returns {Object.<string,*>} JSON object
+         */
+        DatabaseBlobDiffPageCursor.prototype.toJSON = function toJSON() {
+            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+        };
+
+        /**
+         * Gets the default type url for DatabaseBlobDiffPageCursor
+         * @function getTypeUrl
+         * @memberof database_blob.DatabaseBlobDiffPageCursor
+         * @static
+         * @param {string} [typeUrlPrefix] your custom typeUrlPrefix(default "type.googleapis.com")
+         * @returns {string} The default type url
+         */
+        DatabaseBlobDiffPageCursor.getTypeUrl = function getTypeUrl(typeUrlPrefix) {
+            if (typeUrlPrefix === undefined) {
+                typeUrlPrefix = "type.googleapis.com";
+            }
+            return typeUrlPrefix + "/database_blob.DatabaseBlobDiffPageCursor";
+        };
+
+        return DatabaseBlobDiffPageCursor;
+    })();
+
     database_blob.CollabDocState = (function() {
 
         /**
@@ -520,6 +1363,7 @@ export const database_blob = $root.database_blob = (() => {
          * @interface ICollabDocState
          * @property {Uint8Array|null} [docState] CollabDocState docState
          * @property {number|null} [encoderVersion] CollabDocState encoderVersion
+         * @property {string|null} [collabVersion] CollabDocState collabVersion
          */
 
         /**
@@ -554,6 +1398,14 @@ export const database_blob = $root.database_blob = (() => {
         CollabDocState.prototype.encoderVersion = 0;
 
         /**
+         * CollabDocState collabVersion.
+         * @member {string} collabVersion
+         * @memberof database_blob.CollabDocState
+         * @instance
+         */
+        CollabDocState.prototype.collabVersion = "";
+
+        /**
          * Creates a new CollabDocState instance using the specified properties.
          * @function create
          * @memberof database_blob.CollabDocState
@@ -581,6 +1433,8 @@ export const database_blob = $root.database_blob = (() => {
                 writer.uint32(/* id 1, wireType 2 =*/10).bytes(message.docState);
             if (message.encoderVersion != null && Object.hasOwnProperty.call(message, "encoderVersion"))
                 writer.uint32(/* id 2, wireType 0 =*/16).int32(message.encoderVersion);
+            if (message.collabVersion != null && Object.hasOwnProperty.call(message, "collabVersion"))
+                writer.uint32(/* id 3, wireType 2 =*/26).string(message.collabVersion);
             return writer;
         };
 
@@ -625,6 +1479,10 @@ export const database_blob = $root.database_blob = (() => {
                         message.encoderVersion = reader.int32();
                         break;
                     }
+                case 3: {
+                        message.collabVersion = reader.string();
+                        break;
+                    }
                 default:
                     reader.skipType(tag & 7);
                     break;
@@ -666,6 +1524,9 @@ export const database_blob = $root.database_blob = (() => {
             if (message.encoderVersion != null && message.hasOwnProperty("encoderVersion"))
                 if (!$util.isInteger(message.encoderVersion))
                     return "encoderVersion: integer expected";
+            if (message.collabVersion != null && message.hasOwnProperty("collabVersion"))
+                if (!$util.isString(message.collabVersion))
+                    return "collabVersion: string expected";
             return null;
         };
 
@@ -688,6 +1549,8 @@ export const database_blob = $root.database_blob = (() => {
                     message.docState = object.docState;
             if (object.encoderVersion != null)
                 message.encoderVersion = object.encoderVersion | 0;
+            if (object.collabVersion != null)
+                message.collabVersion = String(object.collabVersion);
             return message;
         };
 
@@ -713,11 +1576,14 @@ export const database_blob = $root.database_blob = (() => {
                         object.docState = $util.newBuffer(object.docState);
                 }
                 object.encoderVersion = 0;
+                object.collabVersion = "";
             }
             if (message.docState != null && message.hasOwnProperty("docState"))
                 object.docState = options.bytes === String ? $util.base64.encode(message.docState, 0, message.docState.length) : options.bytes === Array ? Array.prototype.slice.call(message.docState) : message.docState;
             if (message.encoderVersion != null && message.hasOwnProperty("encoderVersion"))
                 object.encoderVersion = message.encoderVersion;
+            if (message.collabVersion != null && message.hasOwnProperty("collabVersion"))
+                object.collabVersion = message.collabVersion;
             return object;
         };
 
@@ -1606,6 +2472,267 @@ export const database_blob = $root.database_blob = (() => {
         return DatabaseBlobRowDelete;
     })();
 
+    database_blob.DatabaseBlobDiffPageInfo = (function() {
+
+        /**
+         * Properties of a DatabaseBlobDiffPageInfo.
+         * @memberof database_blob
+         * @interface IDatabaseBlobDiffPageInfo
+         * @property {Uint8Array|null} [nextCursor] DatabaseBlobDiffPageInfo nextCursor
+         * @property {boolean|null} [hasMore] DatabaseBlobDiffPageInfo hasMore
+         * @property {boolean|null} [restartRequired] DatabaseBlobDiffPageInfo restartRequired
+         */
+
+        /**
+         * Constructs a new DatabaseBlobDiffPageInfo.
+         * @memberof database_blob
+         * @classdesc Represents a DatabaseBlobDiffPageInfo.
+         * @implements IDatabaseBlobDiffPageInfo
+         * @constructor
+         * @param {database_blob.IDatabaseBlobDiffPageInfo=} [properties] Properties to set
+         */
+        function DatabaseBlobDiffPageInfo(properties) {
+            if (properties)
+                for (let keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                    if (properties[keys[i]] != null)
+                        this[keys[i]] = properties[keys[i]];
+        }
+
+        /**
+         * DatabaseBlobDiffPageInfo nextCursor.
+         * @member {Uint8Array} nextCursor
+         * @memberof database_blob.DatabaseBlobDiffPageInfo
+         * @instance
+         */
+        DatabaseBlobDiffPageInfo.prototype.nextCursor = $util.newBuffer([]);
+
+        /**
+         * DatabaseBlobDiffPageInfo hasMore.
+         * @member {boolean} hasMore
+         * @memberof database_blob.DatabaseBlobDiffPageInfo
+         * @instance
+         */
+        DatabaseBlobDiffPageInfo.prototype.hasMore = false;
+
+        /**
+         * DatabaseBlobDiffPageInfo restartRequired.
+         * @member {boolean} restartRequired
+         * @memberof database_blob.DatabaseBlobDiffPageInfo
+         * @instance
+         */
+        DatabaseBlobDiffPageInfo.prototype.restartRequired = false;
+
+        /**
+         * Creates a new DatabaseBlobDiffPageInfo instance using the specified properties.
+         * @function create
+         * @memberof database_blob.DatabaseBlobDiffPageInfo
+         * @static
+         * @param {database_blob.IDatabaseBlobDiffPageInfo=} [properties] Properties to set
+         * @returns {database_blob.DatabaseBlobDiffPageInfo} DatabaseBlobDiffPageInfo instance
+         */
+        DatabaseBlobDiffPageInfo.create = function create(properties) {
+            return new DatabaseBlobDiffPageInfo(properties);
+        };
+
+        /**
+         * Encodes the specified DatabaseBlobDiffPageInfo message. Does not implicitly {@link database_blob.DatabaseBlobDiffPageInfo.verify|verify} messages.
+         * @function encode
+         * @memberof database_blob.DatabaseBlobDiffPageInfo
+         * @static
+         * @param {database_blob.IDatabaseBlobDiffPageInfo} message DatabaseBlobDiffPageInfo message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        DatabaseBlobDiffPageInfo.encode = function encode(message, writer) {
+            if (!writer)
+                writer = $Writer.create();
+            if (message.nextCursor != null && Object.hasOwnProperty.call(message, "nextCursor"))
+                writer.uint32(/* id 1, wireType 2 =*/10).bytes(message.nextCursor);
+            if (message.hasMore != null && Object.hasOwnProperty.call(message, "hasMore"))
+                writer.uint32(/* id 2, wireType 0 =*/16).bool(message.hasMore);
+            if (message.restartRequired != null && Object.hasOwnProperty.call(message, "restartRequired"))
+                writer.uint32(/* id 3, wireType 0 =*/24).bool(message.restartRequired);
+            return writer;
+        };
+
+        /**
+         * Encodes the specified DatabaseBlobDiffPageInfo message, length delimited. Does not implicitly {@link database_blob.DatabaseBlobDiffPageInfo.verify|verify} messages.
+         * @function encodeDelimited
+         * @memberof database_blob.DatabaseBlobDiffPageInfo
+         * @static
+         * @param {database_blob.IDatabaseBlobDiffPageInfo} message DatabaseBlobDiffPageInfo message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        DatabaseBlobDiffPageInfo.encodeDelimited = function encodeDelimited(message, writer) {
+            return this.encode(message, writer).ldelim();
+        };
+
+        /**
+         * Decodes a DatabaseBlobDiffPageInfo message from the specified reader or buffer.
+         * @function decode
+         * @memberof database_blob.DatabaseBlobDiffPageInfo
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @param {number} [length] Message length if known beforehand
+         * @returns {database_blob.DatabaseBlobDiffPageInfo} DatabaseBlobDiffPageInfo
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        DatabaseBlobDiffPageInfo.decode = function decode(reader, length, error) {
+            if (!(reader instanceof $Reader))
+                reader = $Reader.create(reader);
+            let end = length === undefined ? reader.len : reader.pos + length, message = new $root.database_blob.DatabaseBlobDiffPageInfo();
+            while (reader.pos < end) {
+                let tag = reader.uint32();
+                if (tag === error)
+                    break;
+                switch (tag >>> 3) {
+                case 1: {
+                        message.nextCursor = reader.bytes();
+                        break;
+                    }
+                case 2: {
+                        message.hasMore = reader.bool();
+                        break;
+                    }
+                case 3: {
+                        message.restartRequired = reader.bool();
+                        break;
+                    }
+                default:
+                    reader.skipType(tag & 7);
+                    break;
+                }
+            }
+            return message;
+        };
+
+        /**
+         * Decodes a DatabaseBlobDiffPageInfo message from the specified reader or buffer, length delimited.
+         * @function decodeDelimited
+         * @memberof database_blob.DatabaseBlobDiffPageInfo
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @returns {database_blob.DatabaseBlobDiffPageInfo} DatabaseBlobDiffPageInfo
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        DatabaseBlobDiffPageInfo.decodeDelimited = function decodeDelimited(reader) {
+            if (!(reader instanceof $Reader))
+                reader = new $Reader(reader);
+            return this.decode(reader, reader.uint32());
+        };
+
+        /**
+         * Verifies a DatabaseBlobDiffPageInfo message.
+         * @function verify
+         * @memberof database_blob.DatabaseBlobDiffPageInfo
+         * @static
+         * @param {Object.<string,*>} message Plain object to verify
+         * @returns {string|null} `null` if valid, otherwise the reason why it is not
+         */
+        DatabaseBlobDiffPageInfo.verify = function verify(message) {
+            if (typeof message !== "object" || message === null)
+                return "object expected";
+            if (message.nextCursor != null && message.hasOwnProperty("nextCursor"))
+                if (!(message.nextCursor && typeof message.nextCursor.length === "number" || $util.isString(message.nextCursor)))
+                    return "nextCursor: buffer expected";
+            if (message.hasMore != null && message.hasOwnProperty("hasMore"))
+                if (typeof message.hasMore !== "boolean")
+                    return "hasMore: boolean expected";
+            if (message.restartRequired != null && message.hasOwnProperty("restartRequired"))
+                if (typeof message.restartRequired !== "boolean")
+                    return "restartRequired: boolean expected";
+            return null;
+        };
+
+        /**
+         * Creates a DatabaseBlobDiffPageInfo message from a plain object. Also converts values to their respective internal types.
+         * @function fromObject
+         * @memberof database_blob.DatabaseBlobDiffPageInfo
+         * @static
+         * @param {Object.<string,*>} object Plain object
+         * @returns {database_blob.DatabaseBlobDiffPageInfo} DatabaseBlobDiffPageInfo
+         */
+        DatabaseBlobDiffPageInfo.fromObject = function fromObject(object) {
+            if (object instanceof $root.database_blob.DatabaseBlobDiffPageInfo)
+                return object;
+            let message = new $root.database_blob.DatabaseBlobDiffPageInfo();
+            if (object.nextCursor != null)
+                if (typeof object.nextCursor === "string")
+                    $util.base64.decode(object.nextCursor, message.nextCursor = $util.newBuffer($util.base64.length(object.nextCursor)), 0);
+                else if (object.nextCursor.length >= 0)
+                    message.nextCursor = object.nextCursor;
+            if (object.hasMore != null)
+                message.hasMore = Boolean(object.hasMore);
+            if (object.restartRequired != null)
+                message.restartRequired = Boolean(object.restartRequired);
+            return message;
+        };
+
+        /**
+         * Creates a plain object from a DatabaseBlobDiffPageInfo message. Also converts values to other types if specified.
+         * @function toObject
+         * @memberof database_blob.DatabaseBlobDiffPageInfo
+         * @static
+         * @param {database_blob.DatabaseBlobDiffPageInfo} message DatabaseBlobDiffPageInfo
+         * @param {$protobuf.IConversionOptions} [options] Conversion options
+         * @returns {Object.<string,*>} Plain object
+         */
+        DatabaseBlobDiffPageInfo.toObject = function toObject(message, options) {
+            if (!options)
+                options = {};
+            let object = {};
+            if (options.defaults) {
+                if (options.bytes === String)
+                    object.nextCursor = "";
+                else {
+                    object.nextCursor = [];
+                    if (options.bytes !== Array)
+                        object.nextCursor = $util.newBuffer(object.nextCursor);
+                }
+                object.hasMore = false;
+                object.restartRequired = false;
+            }
+            if (message.nextCursor != null && message.hasOwnProperty("nextCursor"))
+                object.nextCursor = options.bytes === String ? $util.base64.encode(message.nextCursor, 0, message.nextCursor.length) : options.bytes === Array ? Array.prototype.slice.call(message.nextCursor) : message.nextCursor;
+            if (message.hasMore != null && message.hasOwnProperty("hasMore"))
+                object.hasMore = message.hasMore;
+            if (message.restartRequired != null && message.hasOwnProperty("restartRequired"))
+                object.restartRequired = message.restartRequired;
+            return object;
+        };
+
+        /**
+         * Converts this DatabaseBlobDiffPageInfo to JSON.
+         * @function toJSON
+         * @memberof database_blob.DatabaseBlobDiffPageInfo
+         * @instance
+         * @returns {Object.<string,*>} JSON object
+         */
+        DatabaseBlobDiffPageInfo.prototype.toJSON = function toJSON() {
+            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+        };
+
+        /**
+         * Gets the default type url for DatabaseBlobDiffPageInfo
+         * @function getTypeUrl
+         * @memberof database_blob.DatabaseBlobDiffPageInfo
+         * @static
+         * @param {string} [typeUrlPrefix] your custom typeUrlPrefix(default "type.googleapis.com")
+         * @returns {string} The default type url
+         */
+        DatabaseBlobDiffPageInfo.getTypeUrl = function getTypeUrl(typeUrlPrefix) {
+            if (typeUrlPrefix === undefined) {
+                typeUrlPrefix = "type.googleapis.com";
+            }
+            return typeUrlPrefix + "/database_blob.DatabaseBlobDiffPageInfo";
+        };
+
+        return DatabaseBlobDiffPageInfo;
+    })();
+
     database_blob.DatabaseBlobDiffResponse = (function() {
 
         /**
@@ -1620,6 +2747,8 @@ export const database_blob = $root.database_blob = (() => {
          * @property {database_blob.DiffStatus|null} [status] DatabaseBlobDiffResponse status
          * @property {number|null} [retryAfterSecs] DatabaseBlobDiffResponse retryAfterSecs
          * @property {string|null} [message] DatabaseBlobDiffResponse message
+         * @property {Array.<Uint8Array>|null} [missingRowIds] DatabaseBlobDiffResponse missingRowIds
+         * @property {database_blob.IDatabaseBlobDiffPageInfo|null} [page] DatabaseBlobDiffResponse page
          */
 
         /**
@@ -1634,6 +2763,7 @@ export const database_blob = $root.database_blob = (() => {
             this.updates = [];
             this.deletes = [];
             this.creates = [];
+            this.missingRowIds = [];
             if (properties)
                 for (let keys = Object.keys(properties), i = 0; i < keys.length; ++i)
                     if (properties[keys[i]] != null)
@@ -1704,6 +2834,22 @@ export const database_blob = $root.database_blob = (() => {
          */
         DatabaseBlobDiffResponse.prototype.message = null;
 
+        /**
+         * DatabaseBlobDiffResponse missingRowIds.
+         * @member {Array.<Uint8Array>} missingRowIds
+         * @memberof database_blob.DatabaseBlobDiffResponse
+         * @instance
+         */
+        DatabaseBlobDiffResponse.prototype.missingRowIds = $util.emptyArray;
+
+        /**
+         * DatabaseBlobDiffResponse page.
+         * @member {database_blob.IDatabaseBlobDiffPageInfo|null|undefined} page
+         * @memberof database_blob.DatabaseBlobDiffResponse
+         * @instance
+         */
+        DatabaseBlobDiffResponse.prototype.page = null;
+
         // OneOf field names bound to virtual getters and setters
         let $oneOfFields;
 
@@ -1737,6 +2883,17 @@ export const database_blob = $root.database_blob = (() => {
          */
         Object.defineProperty(DatabaseBlobDiffResponse.prototype, "_message", {
             get: $util.oneOfGetter($oneOfFields = ["message"]),
+            set: $util.oneOfSetter($oneOfFields)
+        });
+
+        /**
+         * DatabaseBlobDiffResponse _page.
+         * @member {"page"|undefined} _page
+         * @memberof database_blob.DatabaseBlobDiffResponse
+         * @instance
+         */
+        Object.defineProperty(DatabaseBlobDiffResponse.prototype, "_page", {
+            get: $util.oneOfGetter($oneOfFields = ["page"]),
             set: $util.oneOfSetter($oneOfFields)
         });
 
@@ -1783,6 +2940,11 @@ export const database_blob = $root.database_blob = (() => {
                 writer.uint32(/* id 7, wireType 0 =*/56).uint32(message.retryAfterSecs);
             if (message.message != null && Object.hasOwnProperty.call(message, "message"))
                 writer.uint32(/* id 8, wireType 2 =*/66).string(message.message);
+            if (message.missingRowIds != null && message.missingRowIds.length)
+                for (let i = 0; i < message.missingRowIds.length; ++i)
+                    writer.uint32(/* id 9, wireType 2 =*/74).bytes(message.missingRowIds[i]);
+            if (message.page != null && Object.hasOwnProperty.call(message, "page"))
+                $root.database_blob.DatabaseBlobDiffPageInfo.encode(message.page, writer.uint32(/* id 10, wireType 2 =*/82).fork()).ldelim();
             return writer;
         };
 
@@ -1855,6 +3017,16 @@ export const database_blob = $root.database_blob = (() => {
                     }
                 case 8: {
                         message.message = reader.string();
+                        break;
+                    }
+                case 9: {
+                        if (!(message.missingRowIds && message.missingRowIds.length))
+                            message.missingRowIds = [];
+                        message.missingRowIds.push(reader.bytes());
+                        break;
+                    }
+                case 10: {
+                        message.page = $root.database_blob.DatabaseBlobDiffPageInfo.decode(reader, reader.uint32());
                         break;
                     }
                 default:
@@ -1946,6 +3118,21 @@ export const database_blob = $root.database_blob = (() => {
                 if (!$util.isString(message.message))
                     return "message: string expected";
             }
+            if (message.missingRowIds != null && message.hasOwnProperty("missingRowIds")) {
+                if (!Array.isArray(message.missingRowIds))
+                    return "missingRowIds: array expected";
+                for (let i = 0; i < message.missingRowIds.length; ++i)
+                    if (!(message.missingRowIds[i] && typeof message.missingRowIds[i].length === "number" || $util.isString(message.missingRowIds[i])))
+                        return "missingRowIds: buffer[] expected";
+            }
+            if (message.page != null && message.hasOwnProperty("page")) {
+                properties._page = 1;
+                {
+                    let error = $root.database_blob.DatabaseBlobDiffPageInfo.verify(message.page);
+                    if (error)
+                        return "page." + error;
+                }
+            }
             return null;
         };
 
@@ -2015,6 +3202,21 @@ export const database_blob = $root.database_blob = (() => {
                 message.retryAfterSecs = object.retryAfterSecs >>> 0;
             if (object.message != null)
                 message.message = String(object.message);
+            if (object.missingRowIds) {
+                if (!Array.isArray(object.missingRowIds))
+                    throw TypeError(".database_blob.DatabaseBlobDiffResponse.missingRowIds: array expected");
+                message.missingRowIds = [];
+                for (let i = 0; i < object.missingRowIds.length; ++i)
+                    if (typeof object.missingRowIds[i] === "string")
+                        $util.base64.decode(object.missingRowIds[i], message.missingRowIds[i] = $util.newBuffer($util.base64.length(object.missingRowIds[i])), 0);
+                    else if (object.missingRowIds[i].length >= 0)
+                        message.missingRowIds[i] = object.missingRowIds[i];
+            }
+            if (object.page != null) {
+                if (typeof object.page !== "object")
+                    throw TypeError(".database_blob.DatabaseBlobDiffResponse.page: object expected");
+                message.page = $root.database_blob.DatabaseBlobDiffPageInfo.fromObject(object.page);
+            }
             return message;
         };
 
@@ -2035,6 +3237,7 @@ export const database_blob = $root.database_blob = (() => {
                 object.updates = [];
                 object.deletes = [];
                 object.creates = [];
+                object.missingRowIds = [];
             }
             if (options.defaults) {
                 object.manifestVersion = "";
@@ -2073,6 +3276,16 @@ export const database_blob = $root.database_blob = (() => {
                 object.message = message.message;
                 if (options.oneofs)
                     object._message = "message";
+            }
+            if (message.missingRowIds && message.missingRowIds.length) {
+                object.missingRowIds = [];
+                for (let j = 0; j < message.missingRowIds.length; ++j)
+                    object.missingRowIds[j] = options.bytes === String ? $util.base64.encode(message.missingRowIds[j], 0, message.missingRowIds[j].length) : options.bytes === Array ? Array.prototype.slice.call(message.missingRowIds[j]) : message.missingRowIds[j];
+            }
+            if (message.page != null && message.hasOwnProperty("page")) {
+                object.page = $root.database_blob.DatabaseBlobDiffPageInfo.toObject(message.page, options);
+                if (options.oneofs)
+                    object._page = "page";
             }
             return object;
         };
@@ -2742,6 +3955,7 @@ export const database_blob = $root.database_blob = (() => {
          * @property {database_blob.IDatabaseBlobRowRid|null} [rid] ManifestRowPointer rid
          * @property {boolean|null} [deleted] ManifestRowPointer deleted
          * @property {database_blob.IManifestRowDocumentPointer|null} [document] ManifestRowPointer document
+         * @property {number|null} [segmentLen] ManifestRowPointer segmentLen
          */
 
         /**
@@ -2807,6 +4021,14 @@ export const database_blob = $root.database_blob = (() => {
          */
         ManifestRowPointer.prototype.document = null;
 
+        /**
+         * ManifestRowPointer segmentLen.
+         * @member {number} segmentLen
+         * @memberof database_blob.ManifestRowPointer
+         * @instance
+         */
+        ManifestRowPointer.prototype.segmentLen = 0;
+
         // OneOf field names bound to virtual getters and setters
         let $oneOfFields;
 
@@ -2857,6 +4079,8 @@ export const database_blob = $root.database_blob = (() => {
                 writer.uint32(/* id 5, wireType 0 =*/40).bool(message.deleted);
             if (message.document != null && Object.hasOwnProperty.call(message, "document"))
                 $root.database_blob.ManifestRowDocumentPointer.encode(message.document, writer.uint32(/* id 6, wireType 2 =*/50).fork()).ldelim();
+            if (message.segmentLen != null && Object.hasOwnProperty.call(message, "segmentLen"))
+                writer.uint32(/* id 7, wireType 0 =*/56).uint32(message.segmentLen);
             return writer;
         };
 
@@ -2915,6 +4139,10 @@ export const database_blob = $root.database_blob = (() => {
                     }
                 case 6: {
                         message.document = $root.database_blob.ManifestRowDocumentPointer.decode(reader, reader.uint32());
+                        break;
+                    }
+                case 7: {
+                        message.segmentLen = reader.uint32();
                         break;
                     }
                 default:
@@ -2978,6 +4206,9 @@ export const database_blob = $root.database_blob = (() => {
                         return "document." + error;
                 }
             }
+            if (message.segmentLen != null && message.hasOwnProperty("segmentLen"))
+                if (!$util.isInteger(message.segmentLen))
+                    return "segmentLen: integer expected";
             return null;
         };
 
@@ -3021,6 +4252,8 @@ export const database_blob = $root.database_blob = (() => {
                     throw TypeError(".database_blob.ManifestRowPointer.document: object expected");
                 message.document = $root.database_blob.ManifestRowDocumentPointer.fromObject(object.document);
             }
+            if (object.segmentLen != null)
+                message.segmentLen = object.segmentLen >>> 0;
             return message;
         };
 
@@ -3053,6 +4286,7 @@ export const database_blob = $root.database_blob = (() => {
                     object.segmentOffset = options.longs === String ? "0" : 0;
                 object.rid = null;
                 object.deleted = false;
+                object.segmentLen = 0;
             }
             if (message.rowId != null && message.hasOwnProperty("rowId"))
                 object.rowId = options.bytes === String ? $util.base64.encode(message.rowId, 0, message.rowId.length) : options.bytes === Array ? Array.prototype.slice.call(message.rowId) : message.rowId;
@@ -3072,6 +4306,8 @@ export const database_blob = $root.database_blob = (() => {
                 if (options.oneofs)
                     object._document = "document";
             }
+            if (message.segmentLen != null && message.hasOwnProperty("segmentLen"))
+                object.segmentLen = message.segmentLen;
             return object;
         };
 
@@ -3117,6 +4353,7 @@ export const database_blob = $root.database_blob = (() => {
          * @property {Array.<database_blob.IManifestRowPointer>|null} [rowIndex] DatabaseBlobManifest rowIndex
          * @property {number|Long|null} [updatedAtMillis] DatabaseBlobManifest updatedAtMillis
          * @property {number|Long|null} [lockEpoch] DatabaseBlobManifest lockEpoch
+         * @property {boolean|null} [generationIncomplete] DatabaseBlobManifest generationIncomplete
          */
 
         /**
@@ -3193,6 +4430,14 @@ export const database_blob = $root.database_blob = (() => {
         DatabaseBlobManifest.prototype.lockEpoch = $util.Long ? $util.Long.fromBits(0,0,true) : 0;
 
         /**
+         * DatabaseBlobManifest generationIncomplete.
+         * @member {boolean} generationIncomplete
+         * @memberof database_blob.DatabaseBlobManifest
+         * @instance
+         */
+        DatabaseBlobManifest.prototype.generationIncomplete = false;
+
+        /**
          * Creates a new DatabaseBlobManifest instance using the specified properties.
          * @function create
          * @memberof database_blob.DatabaseBlobManifest
@@ -3232,6 +4477,8 @@ export const database_blob = $root.database_blob = (() => {
                 writer.uint32(/* id 6, wireType 0 =*/48).int64(message.updatedAtMillis);
             if (message.lockEpoch != null && Object.hasOwnProperty.call(message, "lockEpoch"))
                 writer.uint32(/* id 7, wireType 0 =*/56).uint64(message.lockEpoch);
+            if (message.generationIncomplete != null && Object.hasOwnProperty.call(message, "generationIncomplete"))
+                writer.uint32(/* id 8, wireType 0 =*/64).bool(message.generationIncomplete);
             return writer;
         };
 
@@ -3298,6 +4545,10 @@ export const database_blob = $root.database_blob = (() => {
                     }
                 case 7: {
                         message.lockEpoch = reader.uint64();
+                        break;
+                    }
+                case 8: {
+                        message.generationIncomplete = reader.bool();
                         break;
                     }
                 default:
@@ -3368,6 +4619,9 @@ export const database_blob = $root.database_blob = (() => {
             if (message.lockEpoch != null && message.hasOwnProperty("lockEpoch"))
                 if (!$util.isInteger(message.lockEpoch) && !(message.lockEpoch && $util.isInteger(message.lockEpoch.low) && $util.isInteger(message.lockEpoch.high)))
                     return "lockEpoch: integer|Long expected";
+            if (message.generationIncomplete != null && message.hasOwnProperty("generationIncomplete"))
+                if (typeof message.generationIncomplete !== "boolean")
+                    return "generationIncomplete: boolean expected";
             return null;
         };
 
@@ -3433,6 +4687,8 @@ export const database_blob = $root.database_blob = (() => {
                     message.lockEpoch = object.lockEpoch;
                 else if (typeof object.lockEpoch === "object")
                     message.lockEpoch = new $util.LongBits(object.lockEpoch.low >>> 0, object.lockEpoch.high >>> 0).toNumber(true);
+            if (object.generationIncomplete != null)
+                message.generationIncomplete = Boolean(object.generationIncomplete);
             return message;
         };
 
@@ -3479,6 +4735,7 @@ export const database_blob = $root.database_blob = (() => {
                     object.lockEpoch = options.longs === String ? long.toString() : options.longs === Number ? long.toNumber() : long;
                 } else
                     object.lockEpoch = options.longs === String ? "0" : 0;
+                object.generationIncomplete = false;
             }
             if (message.workspaceId != null && message.hasOwnProperty("workspaceId"))
                 object.workspaceId = options.bytes === String ? $util.base64.encode(message.workspaceId, 0, message.workspaceId.length) : options.bytes === Array ? Array.prototype.slice.call(message.workspaceId) : message.workspaceId;
@@ -3506,6 +4763,8 @@ export const database_blob = $root.database_blob = (() => {
                     object.lockEpoch = options.longs === String ? String(message.lockEpoch) : message.lockEpoch;
                 else
                     object.lockEpoch = options.longs === String ? $util.Long.prototype.toString.call(message.lockEpoch) : options.longs === Number ? new $util.LongBits(message.lockEpoch.low >>> 0, message.lockEpoch.high >>> 0).toNumber(true) : message.lockEpoch;
+            if (message.generationIncomplete != null && message.hasOwnProperty("generationIncomplete"))
+                object.generationIncomplete = message.generationIncomplete;
             return object;
         };
 

--- a/src/proto/database_blob.proto
+++ b/src/proto/database_blob.proto
@@ -9,14 +9,40 @@ message DatabaseBlobRowRid {
     uint32 seq_no = 2;
 }
 
+// Optional limits and continuation state for one page of a database-blob diff.
+message DatabaseBlobDiffPageRequest {
+    uint32 max_items = 1;
+    uint64 max_bytes = 2;
+    bytes cursor = 3;
+}
+
 message DatabaseBlobDiffRequest {
     optional DatabaseBlobRowRid max_known_rid = 1;
     int32 version = 2;
+    // Explicit false selects the fast row-only path. Omitted requests retain the legacy
+    // document-aware behavior so existing clients can safely reuse their watermarks.
+    optional bool include_documents = 3;
+    optional DatabaseBlobDiffPageRequest page = 4;
+}
+
+// Opaque server cursor payload. The API returns only its encoded bytes.
+message DatabaseBlobDiffPageCursor {
+    uint32 format_version = 1;
+    bytes workspace_id = 2;
+    bytes database_id = 3;
+    string manifest_version = 4;
+    optional DatabaseBlobRowRid max_known_rid = 5;
+    uint64 next_offset = 6;
+    bytes plan_hash = 7;
+    optional DatabaseBlobRowRid max_observed_rid = 8;
+    bytes signature = 9;
 }
 
 message CollabDocState {
     bytes doc_state = 1;
     int32 encoder_version = 2;
+    // Collab version known to the sender of this message.
+    string collab_version = 3;
 }
 
 message DatabaseBlobRowDocument {
@@ -38,6 +64,13 @@ message DatabaseBlobRowDelete {
     DatabaseBlobRowRid rid = 2;
 }
 
+// Continuation metadata for a paginated database-blob diff response.
+message DatabaseBlobDiffPageInfo {
+    bytes next_cursor = 1;
+    bool has_more = 2;
+    bool restart_required = 3;
+}
+
 message DatabaseBlobDiffResponse {
     string manifest_version = 1;
     optional string head_blob_key = 2;
@@ -47,6 +80,8 @@ message DatabaseBlobDiffResponse {
     DiffStatus status = 6;
     optional uint32 retry_after_secs = 7;
     optional string message = 8;
+    repeated bytes missing_row_ids = 9;
+    optional DatabaseBlobDiffPageInfo page = 10;
 }
 
 message BlobDescriptor {
@@ -70,6 +105,7 @@ message ManifestRowPointer {
     DatabaseBlobRowRid rid = 4;
     bool deleted = 5;
     optional ManifestRowDocumentPointer document = 6;
+    uint32 segment_len = 7;
 }
 
 message DatabaseBlobManifest {
@@ -80,6 +116,8 @@ message DatabaseBlobManifest {
     repeated ManifestRowPointer row_index = 5;
     int64 updated_at_millis = 6;
     uint64 lock_epoch = 7;
+    // True when generation deferred at least one canonical row and clients must keep polling.
+    bool generation_incomplete = 8;
 }
 
 enum DiffStatus {

--- a/src/proto/messages.d.ts
+++ b/src/proto/messages.d.ts
@@ -937,6 +937,9 @@ export namespace collab {
 
         /** CollabDocStateParams docState */
         docState?: (Uint8Array|null);
+
+        /** CollabDocStateParams collabVersion */
+        collabVersion?: (string|null);
     }
 
     /** Parameters for a single collab document state in batch sync. */
@@ -962,6 +965,9 @@ export namespace collab {
 
         /** CollabDocStateParams docState. */
         public docState: Uint8Array;
+
+        /** CollabDocStateParams collabVersion. */
+        public collabVersion: string;
 
         /**
          * Creates a new CollabDocStateParams instance using the specified properties.
@@ -1167,6 +1173,12 @@ export namespace collab {
 
         /** CollabBatchSyncResult serverStateVector */
         serverStateVector?: (Uint8Array|null);
+
+        /** CollabBatchSyncResult collabVersion */
+        collabVersion?: (string|null);
+
+        /** CollabBatchSyncResult messageId */
+        messageId?: (collab.IRid|null);
     }
 
     /** Result for a single collab in batch sync response. */
@@ -1195,6 +1207,12 @@ export namespace collab {
 
         /** CollabBatchSyncResult serverStateVector. */
         public serverStateVector: Uint8Array;
+
+        /** CollabBatchSyncResult collabVersion. */
+        public collabVersion: string;
+
+        /** CollabBatchSyncResult messageId. */
+        public messageId?: (collab.IRid|null);
 
         /**
          * Creates a new CollabBatchSyncResult instance using the specified properties.

--- a/src/proto/messages.js
+++ b/src/proto/messages.js
@@ -2279,6 +2279,7 @@ export const collab = $root.collab = (() => {
          * @property {collab.PayloadCompressionType|null} [compression] CollabDocStateParams compression
          * @property {Uint8Array|null} [sv] CollabDocStateParams sv
          * @property {Uint8Array|null} [docState] CollabDocStateParams docState
+         * @property {string|null} [collabVersion] CollabDocStateParams collabVersion
          */
 
         /**
@@ -2337,6 +2338,14 @@ export const collab = $root.collab = (() => {
         CollabDocStateParams.prototype.docState = $util.newBuffer([]);
 
         /**
+         * CollabDocStateParams collabVersion.
+         * @member {string} collabVersion
+         * @memberof collab.CollabDocStateParams
+         * @instance
+         */
+        CollabDocStateParams.prototype.collabVersion = "";
+
+        /**
          * Creates a new CollabDocStateParams instance using the specified properties.
          * @function create
          * @memberof collab.CollabDocStateParams
@@ -2370,6 +2379,8 @@ export const collab = $root.collab = (() => {
                 writer.uint32(/* id 4, wireType 2 =*/34).bytes(message.sv);
             if (message.docState != null && Object.hasOwnProperty.call(message, "docState"))
                 writer.uint32(/* id 5, wireType 2 =*/42).bytes(message.docState);
+            if (message.collabVersion != null && Object.hasOwnProperty.call(message, "collabVersion"))
+                writer.uint32(/* id 6, wireType 2 =*/50).string(message.collabVersion);
             return writer;
         };
 
@@ -2424,6 +2435,10 @@ export const collab = $root.collab = (() => {
                     }
                 case 5: {
                         message.docState = reader.bytes();
+                        break;
+                    }
+                case 6: {
+                        message.collabVersion = reader.string();
                         break;
                     }
                 default:
@@ -2482,6 +2497,9 @@ export const collab = $root.collab = (() => {
             if (message.docState != null && message.hasOwnProperty("docState"))
                 if (!(message.docState && typeof message.docState.length === "number" || $util.isString(message.docState)))
                     return "docState: buffer expected";
+            if (message.collabVersion != null && message.hasOwnProperty("collabVersion"))
+                if (!$util.isString(message.collabVersion))
+                    return "collabVersion: string expected";
             return null;
         };
 
@@ -2531,6 +2549,8 @@ export const collab = $root.collab = (() => {
                     $util.base64.decode(object.docState, message.docState = $util.newBuffer($util.base64.length(object.docState)), 0);
                 else if (object.docState.length >= 0)
                     message.docState = object.docState;
+            if (object.collabVersion != null)
+                message.collabVersion = String(object.collabVersion);
             return message;
         };
 
@@ -2565,6 +2585,7 @@ export const collab = $root.collab = (() => {
                     if (options.bytes !== Array)
                         object.docState = $util.newBuffer(object.docState);
                 }
+                object.collabVersion = "";
             }
             if (message.objectId != null && message.hasOwnProperty("objectId"))
                 object.objectId = message.objectId;
@@ -2576,6 +2597,8 @@ export const collab = $root.collab = (() => {
                 object.sv = options.bytes === String ? $util.base64.encode(message.sv, 0, message.sv.length) : options.bytes === Array ? Array.prototype.slice.call(message.sv) : message.sv;
             if (message.docState != null && message.hasOwnProperty("docState"))
                 object.docState = options.bytes === String ? $util.base64.encode(message.docState, 0, message.docState.length) : options.bytes === Array ? Array.prototype.slice.call(message.docState) : message.docState;
+            if (message.collabVersion != null && message.hasOwnProperty("collabVersion"))
+                object.collabVersion = message.collabVersion;
             return object;
         };
 
@@ -2895,6 +2918,8 @@ export const collab = $root.collab = (() => {
          * @property {Uint8Array|null} [missingUpdate] CollabBatchSyncResult missingUpdate
          * @property {string|null} [error] CollabBatchSyncResult error
          * @property {Uint8Array|null} [serverStateVector] CollabBatchSyncResult serverStateVector
+         * @property {string|null} [collabVersion] CollabBatchSyncResult collabVersion
+         * @property {collab.IRid|null} [messageId] CollabBatchSyncResult messageId
          */
 
         /**
@@ -2961,6 +2986,22 @@ export const collab = $root.collab = (() => {
         CollabBatchSyncResult.prototype.serverStateVector = $util.newBuffer([]);
 
         /**
+         * CollabBatchSyncResult collabVersion.
+         * @member {string} collabVersion
+         * @memberof collab.CollabBatchSyncResult
+         * @instance
+         */
+        CollabBatchSyncResult.prototype.collabVersion = "";
+
+        /**
+         * CollabBatchSyncResult messageId.
+         * @member {collab.IRid|null|undefined} messageId
+         * @memberof collab.CollabBatchSyncResult
+         * @instance
+         */
+        CollabBatchSyncResult.prototype.messageId = null;
+
+        /**
          * Creates a new CollabBatchSyncResult instance using the specified properties.
          * @function create
          * @memberof collab.CollabBatchSyncResult
@@ -2996,6 +3037,10 @@ export const collab = $root.collab = (() => {
                 writer.uint32(/* id 5, wireType 2 =*/42).string(message.error);
             if (message.serverStateVector != null && Object.hasOwnProperty.call(message, "serverStateVector"))
                 writer.uint32(/* id 6, wireType 2 =*/50).bytes(message.serverStateVector);
+            if (message.collabVersion != null && Object.hasOwnProperty.call(message, "collabVersion"))
+                writer.uint32(/* id 7, wireType 2 =*/58).string(message.collabVersion);
+            if (message.messageId != null && Object.hasOwnProperty.call(message, "messageId"))
+                $root.collab.Rid.encode(message.messageId, writer.uint32(/* id 8, wireType 2 =*/66).fork()).ldelim();
             return writer;
         };
 
@@ -3054,6 +3099,14 @@ export const collab = $root.collab = (() => {
                     }
                 case 6: {
                         message.serverStateVector = reader.bytes();
+                        break;
+                    }
+                case 7: {
+                        message.collabVersion = reader.string();
+                        break;
+                    }
+                case 8: {
+                        message.messageId = $root.collab.Rid.decode(reader, reader.uint32());
                         break;
                     }
                 default:
@@ -3115,6 +3168,14 @@ export const collab = $root.collab = (() => {
             if (message.serverStateVector != null && message.hasOwnProperty("serverStateVector"))
                 if (!(message.serverStateVector && typeof message.serverStateVector.length === "number" || $util.isString(message.serverStateVector)))
                     return "serverStateVector: buffer expected";
+            if (message.collabVersion != null && message.hasOwnProperty("collabVersion"))
+                if (!$util.isString(message.collabVersion))
+                    return "collabVersion: string expected";
+            if (message.messageId != null && message.hasOwnProperty("messageId")) {
+                let error = $root.collab.Rid.verify(message.messageId);
+                if (error)
+                    return "messageId." + error;
+            }
             return null;
         };
 
@@ -3166,6 +3227,13 @@ export const collab = $root.collab = (() => {
                     $util.base64.decode(object.serverStateVector, message.serverStateVector = $util.newBuffer($util.base64.length(object.serverStateVector)), 0);
                 else if (object.serverStateVector.length >= 0)
                     message.serverStateVector = object.serverStateVector;
+            if (object.collabVersion != null)
+                message.collabVersion = String(object.collabVersion);
+            if (object.messageId != null) {
+                if (typeof object.messageId !== "object")
+                    throw TypeError(".collab.CollabBatchSyncResult.messageId: object expected");
+                message.messageId = $root.collab.Rid.fromObject(object.messageId);
+            }
             return message;
         };
 
@@ -3201,6 +3269,8 @@ export const collab = $root.collab = (() => {
                     if (options.bytes !== Array)
                         object.serverStateVector = $util.newBuffer(object.serverStateVector);
                 }
+                object.collabVersion = "";
+                object.messageId = null;
             }
             if (message.objectId != null && message.hasOwnProperty("objectId"))
                 object.objectId = message.objectId;
@@ -3214,6 +3284,10 @@ export const collab = $root.collab = (() => {
                 object.error = message.error;
             if (message.serverStateVector != null && message.hasOwnProperty("serverStateVector"))
                 object.serverStateVector = options.bytes === String ? $util.base64.encode(message.serverStateVector, 0, message.serverStateVector.length) : options.bytes === Array ? Array.prototype.slice.call(message.serverStateVector) : message.serverStateVector;
+            if (message.collabVersion != null && message.hasOwnProperty("collabVersion"))
+                object.collabVersion = message.collabVersion;
+            if (message.messageId != null && message.hasOwnProperty("messageId"))
+                object.messageId = $root.collab.Rid.toObject(message.messageId, options);
             return object;
         };
 


### PR DESCRIPTION
## Summary

- synchronize the Web protobuf bindings with the version 3 database BLOB paging contract
- request bounded pages while preserving the original RID across continuations, retries, and restarts
- persist local Yjs updates in the IndexedDB sync outbox and keep causal state-vector metadata
- route only updates above the advertised realtime limit through a serialized HTTP slow-sync lane
- coordinate slow sync across tabs, require a durable server RID before retiring exact outbox records, and preserve queued data across refreshes
- keep the conservative 4 MiB realtime path available while server-info loads; abort timed-out server-info and slow-sync requests cleanly
- add regression coverage for paging, retries, reconnects, cross-tab ownership, version changes, logout, oversized updates, and React effect cleanup

## Root cause

A manifest response for the 5,000-row database was a 7,827,368-byte raw Yjs update. Sending it through the realtime WebSocket exceeded the server's 4 MiB update limit, so the server closed the socket with code 1009 and the UI repeatedly showed `Connecting...`.

The browser already had the database state in its local Yjs/IndexedDB cache. When the server state vector did not cover that state, the client correctly computed the missing update, but it had no bounded transport for a single atomic update larger than the WebSocket limit. The initial slow-lane implementation also risked blocking ordinary sync while server-info was unresolved.

## Design and impact

Ordinary edits continue to use the low-latency WebSocket path. A single oversized update is first made durable in IndexedDB, compressed, uploaded through the authenticated HTTP full-sync endpoint with `x-appflowy-sync-lane: slow`, and retired only after a durable acknowledgement. The server-advertised limits opt the client into this path, so older servers retain the conservative legacy behavior.

For the reproduced database, the 7,827,368-byte raw update compressed to a 3,294,591-byte HTTP request and completed successfully without closing the socket.

## Related backend change

- https://github.com/AppFlowy-IO/AppFlowy-Cloud-Premium/pull/882

## Validation

- 7 focused Jest suites passed: 101 tests
- `pnpm type-check`
- targeted ESLint completed with no errors
- `git diff --check`
- live CORS preflight returned 200 with `x-appflowy-sync-lane` allowed
- live 5,000-row slow upload returned 200 and the IndexedDB outbox drained to zero
- stable reload rendered `Grid | AppFlowy` with no `Connecting...`, console warnings, or failed sync requests
