### PR TITLE
Fix duplicate editor placeholder

### DIFF
--- a/src/components/editor/components/blocks/text/Placeholder.tsx
+++ b/src/components/editor/components/blocks/text/Placeholder.tsx
@@ -32,6 +32,7 @@ function Placeholder({ node, ...attributes }: { node: Element; className?: strin
   }, [editor, node]);
 
   const block = getBlock();
+  const blockCount = editor.children.length;
 
   const className = useMemo(() => {
     const classList = attributes.className?.split(' ') ?? [];
@@ -61,7 +62,7 @@ function Placeholder({ node, ...attributes }: { node: Element; className?: strin
 
         // Show placeholder when the document is empty (single empty paragraph)
         // This matches the desktop "Enter a / to insert a block, or start typing" behavior
-        if(editor.children.length <= 1) {
+        if(blockCount <= 1) {
           return t('cardDetails.notesPlaceholder');
         }
 
@@ -123,7 +124,7 @@ function Placeholder({ node, ...attributes }: { node: Element; className?: strin
       default:
         return '';
     }
-  }, [block, editor, node, t]);
+  }, [block, blockCount, editor, node, t]);
 
   const isInsideTableCell = useMemo(() => {
     try {

--- a/src/components/editor/components/blocks/text/__tests__/Placeholder.test.tsx
+++ b/src/components/editor/components/blocks/text/__tests__/Placeholder.test.tsx
@@ -1,0 +1,115 @@
+import { render } from '@testing-library/react';
+import type { Editor, Element } from 'slate';
+
+import { BlockType } from '@/application/types';
+import Placeholder from '../Placeholder';
+
+const ACTIVE_PLACEHOLDER = "Type '/' to insert a block, or start typing";
+const EMPTY_DOCUMENT_PLACEHOLDER = 'Enter a / to insert a block, or start typing';
+
+const originalTextNode = {
+  type: 'text',
+  textId: 'original-text',
+  children: [{ text: '' }],
+} as unknown as Element;
+const secondTextNode = {
+  type: 'text',
+  textId: 'second-text',
+  children: [{ text: '' }],
+} as unknown as Element;
+const originalParagraph = {
+  blockId: 'original-paragraph',
+  type: BlockType.Paragraph,
+  children: [originalTextNode],
+} as unknown as Element;
+const secondParagraph = {
+  blockId: 'second-paragraph',
+  type: BlockType.Paragraph,
+  children: [secondTextNode],
+} as unknown as Element;
+const mockEditor = {
+  children: [originalParagraph],
+  selection: {
+    anchor: { path: [0, 0, 0], offset: 0 },
+    focus: { path: [0, 0, 0], offset: 0 },
+  },
+} as unknown as Editor;
+const mockEditorDom = document.createElement('div');
+const mockUseSelected = jest.fn();
+
+const translations: Record<string, string> = {
+  'cardDetails.notesPlaceholder': EMPTY_DOCUMENT_PLACEHOLDER,
+  'editor.slashPlaceHolder': ACTIVE_PLACEHOLDER,
+};
+const mockT = (key: string) => translations[key] ?? key;
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: mockT }),
+}));
+
+jest.mock('slate', () => ({
+  Editor: {
+    above: (_editor: Editor, options: { at: number[]; match: (node: Element) => boolean }) => {
+      const block = options.at[0] === 0 ? originalParagraph : secondParagraph;
+
+      return options.match(block) ? [block, [options.at[0]]] : undefined;
+    },
+    isEditor: () => false,
+  },
+  Element: {
+    isElement: () => true,
+  },
+  Range: {
+    isCollapsed: () => true,
+  },
+}));
+
+jest.mock('slate-react', () => ({
+  ReactEditor: {
+    findPath: (_editor: Editor, node: Element) => (node === originalTextNode ? [0, 0] : [1, 0]),
+    toDOMNode: () => mockEditorDom,
+  },
+  useFocused: () => true,
+  useSelected: () => mockUseSelected(),
+  useSlate: () => mockEditor,
+}));
+
+jest.mock('@/components/editor/EditorContext', () => ({
+  useEditorContext: () => ({ readOnly: false }),
+}));
+
+function PlaceholderHarness({ showSecond }: { showSecond: boolean }) {
+  return (
+    <>
+      <Placeholder node={originalTextNode} />
+      {showSecond && <Placeholder node={secondTextNode} />}
+    </>
+  );
+}
+
+function visiblePlaceholders(container: HTMLElement): string[] {
+  return Array.from(container.querySelectorAll('.text-placeholder'))
+    .map((element) => element.getAttribute('data-placeholder') ?? '')
+    .filter(Boolean);
+}
+
+describe('Placeholder', () => {
+  beforeEach(() => {
+    mockEditor.children = [originalParagraph];
+    mockUseSelected.mockReset();
+  });
+
+  it('removes the empty-document placeholder after a second paragraph is added and selected', () => {
+    mockUseSelected.mockReturnValueOnce(false);
+
+    const { container, rerender } = render(<PlaceholderHarness showSecond={false} />);
+
+    expect(visiblePlaceholders(container)).toEqual([EMPTY_DOCUMENT_PLACEHOLDER]);
+
+    mockEditor.children = [originalParagraph, secondParagraph];
+    mockUseSelected.mockReturnValueOnce(false).mockReturnValueOnce(true);
+    rerender(<PlaceholderHarness showSecond />);
+
+    expect(visiblePlaceholders(container)).toEqual([ACTIVE_PLACEHOLDER]);
+  });
+});


### PR DESCRIPTION
## Summary

- Recompute the empty-document placeholder when the editor block count changes.
- Add a component regression test covering focus changes between two empty paragraphs.

## Root cause

The unselected placeholder memo read `editor.children.length` without including that value in its dependency list. After a second paragraph was added, the first paragraph could retain the cached empty-document prompt while the focused paragraph rendered the slash-command prompt, producing duplicate placeholder text.

## Impact

Empty documents now show only the context-appropriate placeholder after blocks are added or focus changes.

## Validation

- `pnpm exec jest src/components/editor/components/blocks/text/__tests__/Placeholder.test.tsx --runInBand --no-coverage`
- `pnpm exec jest src/components/editor --runInBand --no-coverage` — 25 suites, 392 tests passed
- `pnpm exec eslint --quiet src/components/editor/components/blocks/text/Placeholder.tsx src/components/editor/components/blocks/text/__tests__/Placeholder.test.tsx`
- `pnpm type-check`

## Summary by Sourcery

Ensure editor placeholders update correctly when block count or focus changes to avoid duplicate prompts in multi-paragraph empty documents.

Bug Fixes:
- Fix stale memoization in the text block placeholder so the empty-document prompt is recomputed when the number of editor blocks changes.

Tests:
- Add a regression test verifying that the empty-document placeholder is removed when a second empty paragraph is added and selected, leaving only the active slash-command placeholder.