### PR TITLE
Fix filtered row deletion during hydration

### DIFF
--- a/src/application/database-yjs/__tests__/useRowOrdersSelector.test.tsx
+++ b/src/application/database-yjs/__tests__/useRowOrdersSelector.test.tsx
@@ -349,6 +349,44 @@ describe('useRowOrdersSelector', () => {
     expect(result.current?.map((row) => row.id)).toEqual(['row-a', 'row-b']);
   });
 
+  it('prunes a deleted row while another conditioned row is still hydrating', async () => {
+    const fixture = createDatabaseFixture();
+    const ensureRow = jest.fn(() => new Promise<YDoc | undefined>(() => undefined));
+    const { result } = renderHook(() => useRowOrdersSelector(), {
+      wrapper: createWrapper(fixture, { ensureRow }),
+    });
+
+    await waitFor(() => {
+      expect(result.current?.map((row) => row.id)).toEqual(['row-c', 'row-a', 'row-b']);
+    });
+
+    act(() => {
+      fixture.filters.push([createTextFilter('match')]);
+      jest.advanceTimersByTime(250);
+    });
+
+    await waitFor(() => {
+      expect(result.current?.map((row) => row.id)).toEqual(['row-a', 'row-b']);
+    });
+
+    act(() => {
+      fixture.rowOrders.push([{ id: 'row-hydrating', height: 44 }]);
+      jest.advanceTimersByTime(250);
+    });
+
+    expect(ensureRow).toHaveBeenCalledWith('row-hydrating');
+    expect(result.current?.map((row) => row.id)).toEqual(['row-a', 'row-b']);
+
+    act(() => {
+      const rowAIndex = fixture.rowOrders.toJSON().findIndex(({ id }) => id === 'row-a');
+
+      fixture.rowOrders.delete(rowAIndex);
+      jest.advanceTimersByTime(250);
+    });
+
+    expect(result.current?.map((row) => row.id)).toEqual(['row-b']);
+  });
+
   it('requests missing row docs while a conditioned view is loading', async () => {
     const fixture = createDatabaseFixture();
     const ensureRow = jest.fn(async () => undefined);

--- a/src/application/database-yjs/selector.ts
+++ b/src/application/database-yjs/selector.ts
@@ -1525,6 +1525,25 @@ export function useRowOrdersSelector() {
 
       if (!filtersAppliedRef.current) {
         setRowOrdersState({ rows: undefined, conditionSignature: conditionStateKey });
+      } else {
+        // New rows cannot be filtered until their docs load, but removals are
+        // authoritative in row_orders. Prune them from the last complete result
+        // so a remotely deleted row cannot remain visible during hydration.
+        const sourceRowIds = new Set(originalRowOrders.map(({ id }) => id));
+
+        setRowOrdersState((previousState) => {
+          if (previousState.conditionSignature !== conditionStateKey || !previousState.rows) {
+            return previousState;
+          }
+
+          const retainedRows = previousState.rows.filter(({ id }) => sourceRowIds.has(id));
+
+          if (retainedRows.length === previousState.rows.length) {
+            return previousState;
+          }
+
+          return { rows: retainedRows, conditionSignature: conditionStateKey };
+        });
       }
 
       logConditionCompute(rowsWithDocs.length);


### PR DESCRIPTION
## Summary

- Prune remotely deleted row IDs from the last complete filtered/sorted result while other row documents are hydrating.
- Continue withholding unresolved additions until they can be evaluated, preserving the existing no-flicker behavior.
- Add a regression test covering deletion from a filtered view while an unrelated row is still loading.

## Root cause

`useRowOrdersSelector` intentionally retained its previous conditioned result whenever any row document was unresolved. A remote deletion updated the authoritative Yjs `row_orders`, but the unresolved-row branch returned without reconciling the retained result, so the deleted row could remain visible and continue contributing to footer calculations.

## User impact

Filtered database views on Web now remove remotely deleted rows immediately, even when background row hydration is still in progress. Grid calculations receive the corrected row set as well.

## Validation

- `pnpm exec jest src/application/database-yjs/__tests__/useRowOrdersSelector.test.tsx src/application/database-yjs/__tests__/calculation.test.ts --runInBand --no-coverage` (32 tests passed)
- `pnpm lint`
- `git diff --check`

## Summary by Sourcery

Ensure filtered views immediately reflect remotely deleted rows even while other rows are still hydrating.

Bug Fixes:
- Prevent deleted rows from remaining visible and affecting calculations when row hydration is in progress.

Enhancements:
- Keep the last complete conditioned result while pruning rows that no longer exist in the authoritative row order during hydration.

Tests:
- Add a regression test covering deletion from a filtered view while another conditioned row is still hydrating.