### PR TITLE
fix: keep row page crumb when the outline refreshes

### DIFF
--- a/src/application/publish/context.tsx
+++ b/src/application/publish/context.tsx
@@ -198,29 +198,22 @@ export const PublishProvider = ({
     return crumbs.length > 0 ? crumbs : [currentView];
   }, [viewMeta, outline]);
 
-  const [breadcrumbs, setBreadcrumbs] = useState<View[]>([]);
-
-  useEffect(() => {
-    setBreadcrumbs(originalCrumbs);
-  }, [originalCrumbs]);
+  // Trailing crumb appended by pages without their own route ancestry (e.g. a
+  // database row opened as a full page). Held separately from the ancestor
+  // chain so outline updates, which rebuild originalCrumbs, cannot erase it.
+  const [appendedCrumb, setAppendedCrumb] = useState<View | undefined>(undefined);
 
   const appendBreadcrumb = useCallback((view?: View) => {
-    setBreadcrumbs((prev) => {
-      if (!view) {
-        return prev.slice(0, -1);
-      }
-
-      const index = prev.findIndex((v) => v.view_id === view.view_id);
-
-      if (index === -1) {
-        return [...prev, view];
-      }
-
-      const rest = prev.slice(0, index);
-
-      return [...rest, view];
-    });
+    setAppendedCrumb(view);
   }, []);
+
+  const breadcrumbs = useMemo(() => {
+    if (!appendedCrumb) return originalCrumbs;
+    const index = originalCrumbs.findIndex((v) => v.view_id === appendedCrumb.view_id);
+
+    if (index === -1) return [...originalCrumbs, appendedCrumb];
+    return [...originalCrumbs.slice(0, index), appendedCrumb];
+  }, [originalCrumbs, appendedCrumb]);
 
   useEffect(() => {
     rowDocumentSnapshotsRef.current = {};

--- a/src/components/app/layers/AppBusinessLayer.tsx
+++ b/src/components/app/layers/AppBusinessLayer.tsx
@@ -635,31 +635,22 @@ export const AppBusinessLayer: FC<AppBusinessLayerProps> = ({ children }) => {
 
   const sourceCrumbs = originalCrumbs.length > 0 ? originalCrumbs : fallbackCrumbs;
 
-  const [breadcrumbs, setBreadcrumbs] = useState<View[]>(sourceCrumbs);
+  // Trailing crumb appended by pages without their own route ancestry (e.g. a
+  // database row opened as a full page). Held separately from the ancestor
+  // chain so outline refreshes, which rebuild sourceCrumbs, cannot erase it.
+  const [appendedCrumb, setAppendedCrumb] = useState<View | undefined>(undefined);
 
-  // Update breadcrumbs when original crumbs change
-  useEffect(() => {
-    setBreadcrumbs(sourceCrumbs);
-  }, [sourceCrumbs]);
-
-  // Handle breadcrumb manipulation
   const appendBreadcrumb = useCallback((view?: View) => {
-    setBreadcrumbs((prev) => {
-      if (!view) {
-        return prev.slice(0, -1);
-      }
-
-      const index = prev.findIndex((v) => v.view_id === view.view_id);
-
-      if (index === -1) {
-        return [...prev, view];
-      }
-
-      const rest = prev.slice(0, index);
-
-      return [...rest, view];
-    });
+    setAppendedCrumb(view);
   }, []);
+
+  const breadcrumbs = useMemo(() => {
+    if (!appendedCrumb) return sourceCrumbs;
+    const index = sourceCrumbs.findIndex((v) => v.view_id === appendedCrumb.view_id);
+
+    if (index === -1) return [...sourceCrumbs, appendedCrumb];
+    return [...sourceCrumbs.slice(0, index), appendedCrumb];
+  }, [sourceCrumbs, appendedCrumb]);
 
   // Load view metadata — with server fallback for lazy-loaded outline
   const loadViewMeta = useCallback(


### PR DESCRIPTION
## Problem

Opening a database row as a full page adds the row to the breadcrumb (`General > … > Grid > card 1`), but for legacy databases the row crumb was missing.

## Root cause

The row page pushes its crumb onto the trail via `appendBreadcrumb` (from `DatabaseRowHeader`). In `AppBusinessLayer` the trail was plain state that got unconditionally reset to the ancestor chain whenever the folder outline recomputed:

```ts
useEffect(() => {
  setBreadcrumbs(sourceCrumbs); // wipes the appended row crumb
}, [sourceCrumbs]);
```

`DatabaseRowHeader`'s append effect doesn't re-run on outline changes (its deps are rowId/title/meta), so the crumb never came back.

This is a race, not a legacy-only path — but legacy databases hit it every time: their rows have no row document yet, so opening the row page lazily creates one on the server, which triggers a folder-outline refresh that wipes the crumb right after it was appended. Rows in newly created databases already have their document, so no refresh follows the expand and the crumb happened to survive.

## Fix

Hold the appended crumb in separate state and derive the trail with `useMemo`, so outline refreshes rebuild the ancestor chain without touching the row crumb. `appendBreadcrumb(undefined)` now clears just the appended tail instead of blindly popping the last crumb (which could drop a real ancestor if a reset had landed in between). The publish context duplicated the same pattern and gets the same fix.

## Verification

- Reproduced on a legacy board (template To-dos): opened a row as full page, forced an outline refresh via the page-view `update-name` API → row crumb was wiped before the fix, survives after.
- Row crumb still clears correctly when navigating away from the row page.
- Container database flow unchanged: `General > … > Grid > <row>` after expanding from the row modal.
- `pnpm type-check` clean; publish context, AppPage database-container, and sidebar-resolution tests pass; eslint reports only pre-existing warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Preserve database row breadcrumbs when the outline refreshes by separating appended row crumbs from the ancestor chain and deriving the final trail from both.

Bug Fixes:
- Ensure row page breadcrumbs remain visible after folder outline or publish outline recomputation instead of being reset to the ancestor-only trail.

Enhancements:
- Simplify breadcrumb manipulation by tracking only an appended crumb and recomputing the full breadcrumb list via memoization in both app and publish contexts.