### PR TITLE
fix(board): keep card clicks stable during row hydration

### DIFF
--- a/src/application/database-yjs/__tests__/group.test.ts
+++ b/src/application/database-yjs/__tests__/group.test.ts
@@ -4,20 +4,17 @@ jest.mock('@/utils/runtime-config', () => ({
   getConfigValue: (_key: string, defaultValue: string) => defaultValue,
 }));
 
-import { groupByCheckbox, groupByField, groupBySelectOption, getGroupColumns } from '@/application/database-yjs/group';
+import {
+  areGroupRowsHydrated,
+  groupByCheckbox,
+  groupByField,
+  groupBySelectOption,
+  getGroupColumns,
+} from '@/application/database-yjs/group';
 import { FieldType, FilterType } from '@/application/database-yjs/database.type';
-import {
-  CheckboxFilterCondition,
-  SelectOptionFilterCondition,
-} from '@/application/database-yjs/fields';
+import { CheckboxFilterCondition, SelectOptionFilterCondition } from '@/application/database-yjs/fields';
 import { Row } from '@/application/database-yjs/selector';
-import {
-  RowId,
-  YDatabaseFilter,
-  YDatabaseFields,
-  YDoc,
-  YjsDatabaseKey,
-} from '@/application/types';
+import { RowId, YDatabaseFilter, YDatabaseFields, YDoc, YjsDatabaseKey } from '@/application/types';
 
 import { createCell, createField, createRowDoc } from './test-helpers';
 
@@ -213,10 +210,10 @@ describe('get group columns', () => {
   });
 });
 
-describe('rows without loaded metas (board loading scenario)', () => {
+describe('rows loading in a grouped board', () => {
   const databaseId = 'db-loading-test';
 
-  it('checkbox: puts unloaded rows in No group', () => {
+  it('checkbox: omits unloaded rows instead of guessing the No group', () => {
     const fieldId = 'checkbox-field';
     const field = createField(fieldId, FieldType.Checkbox);
 
@@ -226,7 +223,6 @@ describe('rows without loaded metas (board loading scenario)', () => {
       { id: 'row-unloaded-2', height: 0 },
     ];
 
-    // Only row-loaded has meta
     const rowMetas: Record<RowId, YDoc> = {
       'row-loaded': createRowDoc('row-loaded', databaseId, {
         [fieldId]: createCell(FieldType.Checkbox, 'Yes'),
@@ -235,14 +231,12 @@ describe('rows without loaded metas (board loading scenario)', () => {
 
     const result = groupByCheckbox(rows, rowMetas, field);
 
-    // Loaded row with Yes goes to Yes group
     expect(result?.get('Yes')?.map((r) => r.id)).toEqual(['row-loaded']);
-
-    // Unloaded rows default to No group
-    expect(result?.get('No')?.map((r) => r.id)).toEqual(['row-unloaded-1', 'row-unloaded-2']);
+    expect(result?.get('No')).toEqual([]);
+    expect(areGroupRowsHydrated(rows, rowMetas)).toBe(false);
   });
 
-  it('select option: puts unloaded rows in No Status group', () => {
+  it('select option: omits unloaded rows instead of guessing No Status', () => {
     const fieldId = 'select-field';
     const field = createField(fieldId, FieldType.SingleSelect, {
       options: [
@@ -258,7 +252,6 @@ describe('rows without loaded metas (board loading scenario)', () => {
       { id: 'row-unloaded-2', height: 0 },
     ];
 
-    // Only row-loaded has meta
     const rowMetas: Record<RowId, YDoc> = {
       'row-loaded': createRowDoc('row-loaded', databaseId, {
         [fieldId]: createCell(FieldType.SingleSelect, 'opt-a'),
@@ -267,11 +260,8 @@ describe('rows without loaded metas (board loading scenario)', () => {
 
     const result = groupBySelectOption(rows, rowMetas, field);
 
-    // Loaded row goes to its option group
     expect(result?.get('opt-a')?.map((r) => r.id)).toEqual(['row-loaded']);
-
-    // Unloaded rows default to No Status group (fieldId)
-    expect(result?.get(fieldId)?.map((r) => r.id)).toEqual(['row-unloaded-1', 'row-unloaded-2']);
+    expect(result?.get(fieldId)).toEqual([]);
   });
 
   it('maintains all groups even when some are empty', () => {
@@ -293,16 +283,13 @@ describe('rows without loaded metas (board loading scenario)', () => {
 
     const result = groupBySelectOption(rows, rowMetas, field);
 
-    // All groups should exist
-    expect(result?.has(fieldId)).toBe(true); // No Status
+    expect(result?.has(fieldId)).toBe(true);
     expect(result?.has('opt-a')).toBe(true);
     expect(result?.has('opt-b')).toBe(true);
-
-    // opt-b should be empty but exist
     expect(result?.get('opt-b')).toEqual([]);
   });
 
-  it('handles all rows unloaded', () => {
+  it('keeps every group empty while all rows are unloaded', () => {
     const fieldId = 'checkbox-field';
     const field = createField(fieldId, FieldType.Checkbox);
 
@@ -311,14 +298,13 @@ describe('rows without loaded metas (board loading scenario)', () => {
       { id: 'row-2', height: 0 },
     ];
 
-    // No metas loaded
     const rowMetas: Record<RowId, YDoc> = {};
 
     const result = groupByCheckbox(rows, rowMetas, field);
 
-    // All rows should be in No group
     expect(result?.get('Yes')).toEqual([]);
-    expect(result?.get('No')?.map((r) => r.id)).toEqual(['row-1', 'row-2']);
+    expect(result?.get('No')).toEqual([]);
+    expect(areGroupRowsHydrated(rows, rowMetas)).toBe(false);
   });
 
   it('handles empty rows array', () => {
@@ -331,7 +317,7 @@ describe('rows without loaded metas (board loading scenario)', () => {
     expect(result?.get('No')).toEqual([]);
   });
 
-  it('progressively updates groups as metas load', () => {
+  it('reveals progressively hydrated rows directly in their real groups', () => {
     const fieldId = 'checkbox-field';
     const field = createField(fieldId, FieldType.Checkbox);
 
@@ -341,14 +327,12 @@ describe('rows without loaded metas (board loading scenario)', () => {
       { id: 'row-3', height: 0 },
     ];
 
-    // Simulate progressive loading: first no metas
     let rowMetas: Record<RowId, YDoc> = {};
     let result = groupByCheckbox(rows, rowMetas, field);
 
     expect(result?.get('Yes')).toEqual([]);
-    expect(result?.get('No')?.length).toBe(3);
+    expect(result?.get('No')).toEqual([]);
 
-    // Then row-1 meta loads with Yes
     rowMetas = {
       'row-1': createRowDoc('row-1', databaseId, {
         [fieldId]: createCell(FieldType.Checkbox, 'Yes'),
@@ -357,9 +341,9 @@ describe('rows without loaded metas (board loading scenario)', () => {
     result = groupByCheckbox(rows, rowMetas, field);
 
     expect(result?.get('Yes')?.map((r) => r.id)).toEqual(['row-1']);
-    expect(result?.get('No')?.length).toBe(2);
+    expect(result?.get('No')).toEqual([]);
+    expect(areGroupRowsHydrated(rows, rowMetas)).toBe(false);
 
-    // Then all metas load
     rowMetas = {
       'row-1': createRowDoc('row-1', databaseId, {
         [fieldId]: createCell(FieldType.Checkbox, 'Yes'),
@@ -375,18 +359,10 @@ describe('rows without loaded metas (board loading scenario)', () => {
 
     expect(result?.get('Yes')?.map((r) => r.id)).toEqual(['row-1', 'row-3']);
     expect(result?.get('No')?.map((r) => r.id)).toEqual(['row-2']);
+    expect(areGroupRowsHydrated(rows, rowMetas)).toBe(true);
   });
 
-  it('checkbox: treats rows with loaded metas but no checkbox cell as No, distinct from truly unloaded rows', () => {
-    /**
-     * This test distinguishes between three cases:
-     * 1. Meta loaded + cell exists with "Yes" value
-     * 2. Meta loaded + NO cell for the checkbox field (missing cell)
-     * 3. Meta NOT loaded at all (completely unloaded row)
-     *
-     * Cases 2 and 3 should both end up in "No" group, but they represent
-     * different states that the grouping logic should handle correctly.
-     */
+  it('checkbox: treats a hydrated missing cell as No while omitting an unloaded row', () => {
     const fieldId = 'checkbox-field';
     const otherFieldId = 'other-field';
     const field = createField(fieldId, FieldType.Checkbox);
@@ -398,40 +374,21 @@ describe('rows without loaded metas (board loading scenario)', () => {
     ];
 
     const rowMetas: Record<RowId, YDoc> = {
-      // Row with meta AND checkbox cell = Yes
       'row-with-checkbox-yes': createRowDoc('row-with-checkbox-yes', databaseId, {
         [fieldId]: createCell(FieldType.Checkbox, 'Yes'),
       }),
-      // Row with meta but NO checkbox cell - only has a different field
-      // This simulates a row that was created but the checkbox field was never set
       'row-with-meta-no-checkbox-cell': createRowDoc('row-with-meta-no-checkbox-cell', databaseId, {
         [otherFieldId]: createCell(FieldType.RichText, 'some text'),
       }),
-      // row-completely-unloaded intentionally not in rowMetas
     };
 
     const result = groupByCheckbox(rows, rowMetas, field);
 
-    // Row with explicit Yes goes to Yes group
     expect(result?.get('Yes')?.map((r) => r.id)).toEqual(['row-with-checkbox-yes']);
-
-    // Both rows without checkbox value go to No group:
-    // - row with meta but missing checkbox cell
-    // - row with no meta at all
-    const noGroupIds = result?.get('No')?.map((r) => r.id) ?? [];
-    expect(noGroupIds).toContain('row-with-meta-no-checkbox-cell');
-    expect(noGroupIds).toContain('row-completely-unloaded');
-    expect(noGroupIds.length).toBe(2);
+    expect(result?.get('No')?.map((r) => r.id)).toEqual(['row-with-meta-no-checkbox-cell']);
   });
 
-  it('select option: treats rows with loaded metas but no select cell as No Status, distinct from truly unloaded rows', () => {
-    /**
-     * Similar to the checkbox test above, but for select options.
-     * Tests the distinction between:
-     * 1. Meta loaded + select cell has a value
-     * 2. Meta loaded + NO select cell (missing)
-     * 3. Meta NOT loaded (completely unloaded)
-     */
+  it('select option: treats a hydrated missing cell as No Status while omitting an unloaded row', () => {
     const fieldId = 'select-field';
     const otherFieldId = 'other-field';
     const field = createField(fieldId, FieldType.SingleSelect, {
@@ -449,28 +406,17 @@ describe('rows without loaded metas (board loading scenario)', () => {
     ];
 
     const rowMetas: Record<RowId, YDoc> = {
-      // Row with meta AND select cell = opt-a
       'row-with-select-value': createRowDoc('row-with-select-value', databaseId, {
         [fieldId]: createCell(FieldType.SingleSelect, 'opt-a'),
       }),
-      // Row with meta but NO select cell - only has a different field
       'row-with-meta-no-select-cell': createRowDoc('row-with-meta-no-select-cell', databaseId, {
         [otherFieldId]: createCell(FieldType.RichText, 'some text'),
       }),
-      // row-completely-unloaded intentionally not in rowMetas
     };
 
     const result = groupBySelectOption(rows, rowMetas, field);
 
-    // Row with explicit opt-a goes to opt-a group
     expect(result?.get('opt-a')?.map((r) => r.id)).toEqual(['row-with-select-value']);
-
-    // Both rows without select value go to No Status group (fieldId):
-    // - row with meta but missing select cell
-    // - row with no meta at all
-    const noStatusGroupIds = result?.get(fieldId)?.map((r) => r.id) ?? [];
-    expect(noStatusGroupIds).toContain('row-with-meta-no-select-cell');
-    expect(noStatusGroupIds).toContain('row-completely-unloaded');
-    expect(noStatusGroupIds.length).toBe(2);
+    expect(result?.get(fieldId)?.map((r) => r.id)).toEqual(['row-with-meta-no-select-cell']);
   });
 });

--- a/src/application/database-yjs/__tests__/useGroup.test.tsx
+++ b/src/application/database-yjs/__tests__/useGroup.test.tsx
@@ -9,7 +9,7 @@ import {
   useBoardLayoutSettings,
   useGroup,
 } from '@/application/database-yjs';
-import { useToggleHideEmptyGroups } from '@/application/database-yjs/dispatch';
+import { useToggleHiddenGroupColumnDispatch, useToggleHideEmptyGroups } from '@/application/database-yjs/dispatch';
 import { YDoc, YjsDatabaseKey, YjsEditorKey } from '@/application/types';
 
 jest.mock('@/utils/runtime-config', () => ({
@@ -109,6 +109,69 @@ describe('useGroup', () => {
     expect(result.current.columns).toEqual([{ id: fieldId, visible: true }]);
   });
 
+  it('materializes fallback columns before persisting their visibility', async () => {
+    const fieldId = 'field-id';
+    const groupId = 'group-id';
+    const optionId = 'option-id';
+    const viewId = 'board-view-id';
+    const databaseDoc = createDatabaseDoc({
+      fieldId,
+      groupId,
+      groupColumns: [],
+      viewId,
+    });
+    const database = databaseDoc.getMap(YjsEditorKey.data_section).get(YjsEditorKey.database) as Y.Map<unknown>;
+    const fields = database.get(YjsDatabaseKey.fields) as Y.Map<Y.Map<unknown>>;
+    const field = fields.get(fieldId)!;
+    const typeOptions = new Y.Map();
+    const selectOptions = new Y.Map();
+
+    field.set(YjsDatabaseKey.type_option, typeOptions);
+    typeOptions.set(String(FieldType.SingleSelect), selectOptions);
+    selectOptions.set(
+      YjsDatabaseKey.content,
+      JSON.stringify({
+        disable_color: false,
+        options: [{ id: optionId, name: 'Option', color: 0 }],
+      })
+    );
+
+    const expectedColumns = [
+      { id: fieldId, visible: true },
+      { id: optionId, visible: true },
+    ];
+    const { result } = renderHook(
+      () => ({
+        group: useGroup(groupId),
+        toggleHidden: useToggleHiddenGroupColumnDispatch(groupId, fieldId),
+      }),
+      {
+        wrapper: createWrapper(databaseDoc, viewId),
+      }
+    );
+
+    await waitFor(() => {
+      expect(result.current.group.columns).toEqual(expectedColumns);
+    });
+
+    expect(() => {
+      act(() => {
+        result.current.toggleHidden(optionId, false);
+      });
+    }).not.toThrow();
+
+    await waitFor(() => {
+      expect(result.current.group.columns).toEqual(expectedColumns);
+    });
+
+    const views = database.get(YjsDatabaseKey.views) as Y.Map<Y.Map<unknown>>;
+    const view = views.get(viewId);
+    const groups = view?.get(YjsDatabaseKey.groups) as Y.Array<Y.Map<unknown>>;
+    const persistedColumns = groups.get(0).get(YjsDatabaseKey.groups) as Y.Array<unknown>;
+
+    expect(persistedColumns.toJSON()).toEqual(expectedColumns);
+  });
+
   it('normalizes Y.Map group columns from persisted collab data', async () => {
     const fieldId = 'field-id';
     const groupId = 'group-id';
@@ -135,6 +198,35 @@ describe('useGroup', () => {
     });
 
     expect(result.current.columns).toEqual([{ id: optionId, visible: false }]);
+  });
+
+  it('keeps Hidden Groups collapsed when the collapse setting is absent', async () => {
+    const fieldId = 'field-id';
+    const groupId = 'group-id';
+    const viewId = 'board-view-id';
+    const databaseDoc = createDatabaseDoc({
+      fieldId,
+      groupId,
+      groupColumns: [{ id: fieldId, visible: true }],
+      viewId,
+    });
+    const view = databaseDoc
+      .getMap(YjsEditorKey.data_section)
+      .get(YjsEditorKey.database)
+      ?.get(YjsDatabaseKey.views)
+      ?.get(viewId);
+
+    view?.get(YjsDatabaseKey.layout_settings)?.get('1')?.set(YjsDatabaseKey.hide_ungrouped_column, true);
+
+    const { result } = renderHook(() => useBoardLayoutSettings(), {
+      wrapper: createWrapper(databaseDoc, viewId),
+    });
+
+    await waitFor(() => {
+      expect(result.current.hideUnGroup).toBe(true);
+    });
+
+    expect(result.current.isCollapsed).toBe(true);
   });
 
   it('persists and observes the shared hide empty groups Board setting', async () => {

--- a/src/application/database-yjs/dispatch.ts
+++ b/src/application/database-yjs/dispatch.ts
@@ -48,6 +48,7 @@ import { createRollupField } from '@/application/database-yjs/fields/rollup/util
 import { createSelectOptionCell } from '@/application/database-yjs/fields/select-option/utils';
 import { createDateTimeField } from '@/application/database-yjs/fields/text/utils';
 import { getDefaultFilterCondition } from '@/application/database-yjs/filter';
+import { getGroupColumns } from '@/application/database-yjs/group';
 import { DEFAULT_FIELD_WRAP } from '@/application/database-yjs/const';
 import { waitForDatabaseRowHydration } from '@/application/database-yjs/row.hydration';
 import { getMetaIdMap } from '@/application/database-yjs/row_meta';
@@ -414,6 +415,7 @@ export function useDeleteGroupColumnDispatch(groupId: string, columnId: string, 
 
 export function useToggleHiddenGroupColumnDispatch(groupId: string, fieldId: string) {
   const view = useDatabaseView();
+  const fields = useDatabaseFields();
   const sharedRoot = useSharedRoot();
 
   return useCallback(
@@ -444,23 +446,56 @@ export function useToggleHiddenGroupColumnDispatch(groupId: string, fieldId: str
               throw new Error('Group columns not found');
             }
 
-            const index = columns.toArray().findIndex((column) => column.id === columnId);
-            const column = columns.toArray().find((column) => column.id === columnId);
+            const getColumnId = (column: unknown) => {
+              if (column instanceof Y.Map) {
+                return column.get(YjsDatabaseKey.id);
+              }
+
+              return (column as { id?: string } | undefined)?.id;
+            };
+
+            let index = columns.toArray().findIndex((column) => getColumnId(column) === columnId);
+
+            if (index === -1) {
+              const field = fields?.get(fieldId);
+              const fallbackColumns = field ? getGroupColumns(field) ?? [] : [];
+
+              if (!fallbackColumns.some((column) => column.id === columnId)) {
+                throw new Error(`Column with id ${columnId} not found in group ${groupId}`);
+              }
+
+              const existingColumnIds = new Set(columns.toArray().map(getColumnId));
+              const missingColumns = fallbackColumns
+                .filter((column) => !existingColumnIds.has(column.id))
+                .map((column) => ({ ...column, visible: true }));
+
+              if (missingColumns.length > 0) {
+                columns.insert(columns.length, missingColumns);
+              }
+
+              index = columns.toArray().findIndex((column) => getColumnId(column) === columnId);
+            }
+
+            const column = columns.get(index) as { id: string; visible: boolean } | Y.Map<unknown> | undefined;
 
             if (index === -1 || !column) {
               throw new Error(`Column with id ${columnId} not found in group ${groupId}`);
             }
 
-            const newColumn = {
-              ...column,
-              visible: !hidden,
-            };
+            if (column instanceof Y.Map) {
+              column.set(YjsDatabaseKey.visible, !hidden);
+            } else {
+              const newColumn = {
+                ...column,
+                visible: !hidden,
+              };
 
-            columns.delete(index);
+              columns.delete(index);
 
-            columns.insert(index, [newColumn]);
+              columns.insert(index, [newColumn]);
+            }
 
-            if (column.id === fieldId) {
+            if (columnId === fieldId) {
               getOrCreateBoardLayoutSetting(view).set(YjsDatabaseKey.hide_ungrouped_column, hidden);
             }
           },
@@ -468,7 +503,7 @@ export function useToggleHiddenGroupColumnDispatch(groupId: string, fieldId: str
         'hideGroupColumn'
       );
     },
-    [fieldId, groupId, sharedRoot, view]
+    [fieldId, fields, groupId, sharedRoot, view]
   );
 }
 

--- a/src/application/database-yjs/group.ts
+++ b/src/application/database-yjs/group.ts
@@ -1,4 +1,5 @@
 import { getCell } from '@/application/database-yjs/const';
+import { hasRowConditionData } from '@/application/database-yjs/condition-value-cache';
 import { FieldType } from '@/application/database-yjs/database.type';
 import { parseYDatabaseCellToCell } from '@/application/database-yjs/cell.parse';
 import {
@@ -8,8 +9,12 @@ import {
 } from '@/application/database-yjs/fields';
 import { parseCheckboxValue } from '@/application/database-yjs/fields/text/utils';
 import { checkboxFilterCheck, selectOptionFilterCheck } from '@/application/database-yjs/filter';
-import { Row } from '@/application/database-yjs/selector';
+import type { Row } from '@/application/database-yjs/selector';
 import { RowId, YDatabaseField, YDatabaseFilter, YDoc, YjsDatabaseKey } from '@/application/types';
+
+export function areGroupRowsHydrated(rows: Row[], rowMetas: Record<RowId, YDoc>) {
+  return rows.every((row) => hasRowConditionData(rowMetas[row.id]));
+}
 
 export function groupByField(
   rows: Row[],
@@ -79,20 +84,11 @@ export function groupByCheckbox(
   });
 
   rows.forEach((row) => {
-    // If row document isn't loaded yet, default to 'No' group
-    // The card component will trigger loading via ensureRow
-    if (!rowMetas[row.id]) {
-      const defaultGroupName = 'No';
-
-      if (result.has(defaultGroupName)) {
-        const group = result.get(defaultGroupName) ?? [];
-
-        group.push(row);
-        result.set(defaultGroupName, group);
-      }
-
-      return;
-    }
+    // Rendering an unloaded row in a guessed group lets hydration move its
+    // card between columns during a pointer gesture. The board hydrates group
+    // rows in the background, so only expose a row once its real value is
+    // available.
+    if (!hasRowConditionData(rowMetas[row.id])) return;
 
     const cell = getCell(row.id, fieldId, rowMetas);
     const cellData = cell ? parseYDatabaseCellToCell(cell, field).data : undefined;
@@ -157,18 +153,9 @@ export function groupBySelectOption(
   });
 
   rows.forEach((row) => {
-    // If row document isn't loaded yet, put in "No Status" group (fieldId)
-    // The card component will trigger loading via ensureRow
-    if (!rowMetas[row.id]) {
-      if (result.has(fieldId)) {
-        const group = result.get(fieldId) ?? [];
-
-        group.push(row);
-        result.set(fieldId, group);
-      }
-
-      return;
-    }
+    // Do not guess "No Status" for an unloaded row. Moving that row after
+    // hydration can unmount a card between pointer-down and click.
+    if (!hasRowConditionData(rowMetas[row.id])) return;
 
     const cell = getCell(row.id, fieldId, rowMetas);
     const cellData = cell ? parseYDatabaseCellToCell(cell, field).data : undefined;

--- a/src/application/database-yjs/hooks/__tests__/useBackgroundRowDocLoader.test.tsx
+++ b/src/application/database-yjs/hooks/__tests__/useBackgroundRowDocLoader.test.tsx
@@ -1,0 +1,76 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import type React from 'react';
+import * as Y from 'yjs';
+
+import { DatabaseContext, DatabaseContextState } from '@/application/database-yjs/context';
+import { useBackgroundRowDocLoader } from '@/application/database-yjs/hooks/useBackgroundRowDocLoader';
+import { YDatabaseRowOrders, YDoc, YjsDatabaseKey, YjsEditorKey } from '@/application/types';
+
+import { createRowDoc } from '../../__tests__/test-helpers';
+
+jest.mock('@/utils/runtime-config', () => ({
+  getConfigValue: (_key: string, fallback: string) => fallback,
+}));
+
+function createDatabaseFixture() {
+  const databaseId = 'database-id';
+  const viewId = 'board-view-id';
+  const databaseDoc = new Y.Doc({ guid: databaseId }) as YDoc;
+  const database = new Y.Map();
+  const views = new Y.Map();
+  const view = new Y.Map();
+  const rowOrders = new Y.Array<{ id: string; height: number }>() as YDatabaseRowOrders;
+
+  rowOrders.push([{ id: 'initial-row', height: 44 }]);
+  view.set(YjsDatabaseKey.row_orders, rowOrders);
+  views.set(viewId, view);
+  database.set(YjsDatabaseKey.id, databaseId);
+  database.set(YjsDatabaseKey.views, views);
+  databaseDoc.getMap(YjsEditorKey.data_section).set(YjsEditorKey.database, database);
+
+  return { databaseDoc, databaseId, rowOrders, viewId };
+}
+
+describe('useBackgroundRowDocLoader', () => {
+  it('hydrates a row inserted collaboratively after the initial loading pass', async () => {
+    const { databaseDoc, databaseId, rowOrders, viewId } = createDatabaseFixture();
+    const initialRowDoc = createRowDoc('initial-row', databaseId, {});
+    const insertedRowDoc = createRowDoc('inserted-row', databaseId, {});
+    const loadRowFromSeed = jest.fn(async () => undefined);
+    const ensureRow = jest.fn(async () => insertedRowDoc);
+    const contextValue: DatabaseContextState = {
+      activeViewId: viewId,
+      blobPrefetchComplete: true,
+      databaseDoc,
+      databasePageId: viewId,
+      ensureRow,
+      loadRowFromSeed,
+      readOnly: false,
+      rowMap: { 'initial-row': initialRowDoc },
+      seedsReady: false,
+      workspaceId: 'workspace-id',
+    };
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <DatabaseContext.Provider value={contextValue}>{children}</DatabaseContext.Provider>
+    );
+    const { unmount } = renderHook(() => useBackgroundRowDocLoader(true, 'board-grouping'), { wrapper });
+
+    await waitFor(() => {
+      expect(loadRowFromSeed).not.toHaveBeenCalled();
+    });
+
+    act(() => {
+      rowOrders.push([{ id: 'inserted-row', height: 44 }]);
+    });
+
+    await waitFor(() => {
+      expect(loadRowFromSeed).toHaveBeenCalledWith('inserted-row');
+      expect(ensureRow).toHaveBeenCalledWith('inserted-row');
+    });
+
+    unmount();
+    initialRowDoc.destroy();
+    insertedRowDoc.destroy();
+    databaseDoc.destroy();
+  });
+});

--- a/src/application/database-yjs/hooks/useBackgroundRowDocLoader.ts
+++ b/src/application/database-yjs/hooks/useBackgroundRowDocLoader.ts
@@ -1,4 +1,4 @@
-import { startTransition, useCallback, useEffect, useMemo, useSyncExternalStore } from 'react';
+import { startTransition, useCallback, useEffect, useMemo, useState, useSyncExternalStore } from 'react';
 import * as Y from 'yjs';
 
 import { useDatabaseContext, useDatabaseView, useDatabaseViewId, useRowMap } from '@/application/database-yjs/context';
@@ -250,9 +250,18 @@ export function useBackgroundRowDocLoader(active: boolean, scope = 'conditions')
   const rows = useRowMap();
   const view = useDatabaseView();
   const viewId = useDatabaseViewId();
-  const { databaseDoc, loadRowFromSeed, peekRowDocFromSeed, blobPrefetchComplete, seedsReady } = useDatabaseContext();
+  const rowOrders = view?.get(YjsDatabaseKey.row_orders);
+  const {
+    databaseDoc,
+    ensureRow,
+    loadRowFromSeed,
+    peekRowDocFromSeed,
+    blobPrefetchComplete,
+    seedsReady,
+  } = useDatabaseContext();
   const storeKey = `${databaseDoc.guid}:${viewId ?? 'unknown'}:${scope}`;
   const store = useMemo(() => getLoaderStore(storeKey), [storeKey]);
+  const [rowOrderRevision, setRowOrderRevision] = useState(0);
 
   store.rows = rows;
 
@@ -269,6 +278,22 @@ export function useBackgroundRowDocLoader(active: boolean, scope = 'conditions')
     useCallback(() => store.cachedRowDocs, [store]),
     useCallback(() => store.cachedRowDocs, [store])
   );
+
+  // Y.Array identity is stable when collaborative edits insert rows. Track a
+  // primitive revision so the loading effects also process rows added after
+  // the initial Board hydration pass.
+  useEffect(() => {
+    if (!active || !rowOrders) return;
+
+    const handleRowOrdersChange = () => {
+      setRowOrderRevision((revision) => revision + 1);
+    };
+
+    rowOrders.observeDeep(handleRowOrdersChange);
+    return () => {
+      rowOrders.unobserveDeep(handleRowOrdersChange);
+    };
+  }, [active, rowOrders]);
 
   const scheduleFlush = useCallback(() => {
     if (store.flushHandle !== null) return;
@@ -345,7 +370,7 @@ export function useBackgroundRowDocLoader(active: boolean, scope = 'conditions')
   useEffect(() => {
     if (!active || !seedsReady || !peekRowDocFromSeed || store.seedHydrateActive) return;
 
-    const rowOrdersData = (view?.get(YjsDatabaseKey.row_orders)?.toJSON() as { id: string; is_deleted?: boolean }[] | undefined)?.filter(
+    const rowOrdersData = (rowOrders?.toJSON() as { id: string; is_deleted?: boolean }[] | undefined)?.filter(
       (row) => !row.is_deleted
     );
 
@@ -430,7 +455,7 @@ export function useBackgroundRowDocLoader(active: boolean, scope = 'conditions')
         store.seedHydrateFrame = null;
       }
     };
-  }, [active, seedsReady, peekRowDocFromSeed, store, view, viewId]);
+  }, [active, seedsReady, peekRowDocFromSeed, store, rowOrders, rowOrderRevision]);
 
   useEffect(() => {
     if (active) return;
@@ -444,7 +469,7 @@ export function useBackgroundRowDocLoader(active: boolean, scope = 'conditions')
   useEffect(() => {
     if (!active || !blobPrefetchComplete) return;
 
-    const rowOrdersData = (view?.get(YjsDatabaseKey.row_orders)?.toJSON() as { id: string; is_deleted?: boolean }[] | undefined)?.filter(
+    const rowOrdersData = (rowOrders?.toJSON() as { id: string; is_deleted?: boolean }[] | undefined)?.filter(
       (row) => !row.is_deleted
     );
 
@@ -516,6 +541,22 @@ export function useBackgroundRowDocLoader(active: boolean, scope = 'conditions')
 
               if (!isRunActive()) return;
 
+              // A row inserted after the blob snapshot has no seed yet. Open
+              // its live row document so collaborative inserts can hydrate
+              // even though no card was mounted to call ensureRow itself.
+              if (ensureRow) {
+                try {
+                  const doc = await ensureRow(rowId);
+
+                  if (!isRunActive()) return;
+                  if (doc && hasRowConditionData(doc)) return;
+                } catch {
+                  // Fall through to the read-only IndexedDB path.
+                }
+              }
+
+              if (!isRunActive()) return;
+
               // Fallback: open from IndexedDB for rows without seeds. The
               // module-level pending map dedupes concurrent opens across views
               // without retaining the doc in the process-wide row cache.
@@ -570,7 +611,18 @@ export function useBackgroundRowDocLoader(active: boolean, scope = 'conditions')
         cancelBackgroundRun(store, runId);
       }
     };
-  }, [databaseDoc.guid, active, blobPrefetchComplete, rows, view, viewId, loadRowFromSeed, scheduleFlush, store]);
+  }, [
+    databaseDoc.guid,
+    active,
+    blobPrefetchComplete,
+    rows,
+    rowOrders,
+    rowOrderRevision,
+    loadRowFromSeed,
+    ensureRow,
+    scheduleFlush,
+    store,
+  ]);
 
   return {
     cachedRowDocs,

--- a/src/application/database-yjs/hooks/useBackgroundRowDocLoader.ts
+++ b/src/application/database-yjs/hooks/useBackgroundRowDocLoader.ts
@@ -236,22 +236,22 @@ function destroyStore(store: LoaderStore) {
 }
 
 /**
- * Hook that handles background loading of row documents for sorting/filtering.
- * When sorts or filters are active, row docs need to be loaded to apply conditions.
+ * Loads row documents for consumers that need values across the complete view,
+ * including sorting, filtering, and Board grouping.
  *
- * The loader state is shared per database view because useRowOrdersSelector is
- * consumed by several grid subcomponents. Without this store, each consumer
- * starts its own row hydration pass.
+ * Loader state is shared per database view and consumer scope. The scope keeps
+ * independently activated consumers from cancelling each other's hydration.
  *
- * @param hasConditions - Whether there are active sorts or filters
- * @returns Object containing cached row docs and merged row docs for conditions
+ * @param active - Whether this consumer needs complete row data
+ * @param scope - Isolates independently activated consumers sharing a view
+ * @returns Cached read-only row docs that are not already in the main row map
  */
-export function useBackgroundRowDocLoader(hasConditions: boolean) {
+export function useBackgroundRowDocLoader(active: boolean, scope = 'conditions') {
   const rows = useRowMap();
   const view = useDatabaseView();
   const viewId = useDatabaseViewId();
   const { databaseDoc, loadRowFromSeed, peekRowDocFromSeed, blobPrefetchComplete, seedsReady } = useDatabaseContext();
-  const storeKey = `${databaseDoc.guid}:${viewId ?? 'unknown'}`;
+  const storeKey = `${databaseDoc.guid}:${viewId ?? 'unknown'}:${scope}`;
   const store = useMemo(() => getLoaderStore(storeKey), [storeKey]);
 
   store.rows = rows;
@@ -340,10 +340,10 @@ export function useBackgroundRowDocLoader(hasConditions: boolean) {
   }, [rows, store]);
 
   // Fast path: as soon as seeds are cached in memory, read shared in-memory
-  // row docs without IndexedDB. Hydrate in frame-sized chunks so large filtered
+  // row docs without IndexedDB. Hydrate in frame-sized chunks so large
   // databases do not spend one long task resolving every row.
   useEffect(() => {
-    if (!hasConditions || !seedsReady || !peekRowDocFromSeed || store.seedHydrateActive) return;
+    if (!active || !seedsReady || !peekRowDocFromSeed || store.seedHydrateActive) return;
 
     const rowOrdersData = (view?.get(YjsDatabaseKey.row_orders)?.toJSON() as { id: string; is_deleted?: boolean }[] | undefined)?.filter(
       (row) => !row.is_deleted
@@ -430,19 +430,19 @@ export function useBackgroundRowDocLoader(hasConditions: boolean) {
         store.seedHydrateFrame = null;
       }
     };
-  }, [hasConditions, seedsReady, peekRowDocFromSeed, store, view, viewId]);
+  }, [active, seedsReady, peekRowDocFromSeed, store, view, viewId]);
 
   useEffect(() => {
-    if (hasConditions) return;
+    if (active) return;
     cancelBackgroundRun(store);
-  }, [hasConditions, store]);
+  }, [active, store]);
 
-  // Background loading of row docs for sorting/filtering.
+  // Background loading of complete-view row docs.
   // Waits for blob prefetch to complete so seeds are available, then uses
   // loadRowFromSeed (fast, in-memory seed application) for each row.
   // Falls back to IndexedDB for rows without seeds.
   useEffect(() => {
-    if (!hasConditions || !blobPrefetchComplete) return;
+    if (!active || !blobPrefetchComplete) return;
 
     const rowOrdersData = (view?.get(YjsDatabaseKey.row_orders)?.toJSON() as { id: string; is_deleted?: boolean }[] | undefined)?.filter(
       (row) => !row.is_deleted
@@ -570,7 +570,7 @@ export function useBackgroundRowDocLoader(hasConditions: boolean) {
         cancelBackgroundRun(store, runId);
       }
     };
-  }, [databaseDoc.guid, hasConditions, blobPrefetchComplete, rows, view, viewId, loadRowFromSeed, scheduleFlush, store]);
+  }, [databaseDoc.guid, active, blobPrefetchComplete, rows, view, viewId, loadRowFromSeed, scheduleFlush, store]);
 
   return {
     cachedRowDocs,

--- a/src/application/database-yjs/selector.ts
+++ b/src/application/database-yjs/selector.ts
@@ -33,7 +33,7 @@ import {
   hasEffectiveFilters,
   parseFilter,
 } from '@/application/database-yjs/filter';
-import { getGroupColumns, groupByField } from '@/application/database-yjs/group';
+import { areGroupRowsHydrated, getGroupColumns, groupByField } from '@/application/database-yjs/group';
 import { useBackgroundRowDocLoader, useRollupFieldObservers } from '@/application/database-yjs/hooks';
 import {
   invalidateRelationCell,
@@ -1070,8 +1070,9 @@ export function useBoardLayoutSettings() {
 
     const observerEvent = () => {
       const layoutSetting = view.get(YjsDatabaseKey.layout_settings)?.get('1');
+      const collapseHiddenGroups = layoutSetting?.get(YjsDatabaseKey.collapse_hidden_groups);
 
-      setIsCollapsed(Boolean(layoutSetting?.get(YjsDatabaseKey.collapse_hidden_groups)));
+      setIsCollapsed(collapseHiddenGroups === undefined ? true : Boolean(collapseHiddenGroups));
       setHideUnGroup(Boolean(layoutSetting?.get(YjsDatabaseKey.hide_ungrouped_column)));
       setHideEmptyGroups(Boolean(layoutSetting?.get(YjsDatabaseKey.hide_empty_groups)));
     };
@@ -1140,6 +1141,18 @@ export function useRowsByGroup(groupId: string, temporarilyShownColumnIds?: Read
   const { columns, fieldId } = useGroup(groupId);
   const rows = useRowMap();
   const rowOrders = useRowOrdersSelector();
+  const { cachedRowDocs } = useBackgroundRowDocLoader(Boolean(fieldId), 'board-grouping');
+  const groupingRows = useMemo(() => {
+    const next = { ...cachedRowDocs };
+
+    Object.entries(rows ?? {}).forEach(([rowId, rowDoc]) => {
+      if (hasRowConditionData(rowDoc) || !next[rowId]) {
+        next[rowId] = rowDoc;
+      }
+    });
+
+    return next;
+  }, [cachedRowDocs, rows]);
 
   const fields = useDatabaseFields();
   const [notFound, setNotFound] = useState(false);
@@ -1150,7 +1163,11 @@ export function useRowsByGroup(groupId: string, temporarilyShownColumnIds?: Read
   const { hideEmptyGroups, hideUnGroup } = useBoardLayoutSettings();
 
   useEffect(() => {
-    if (!fieldId || !rowOrders || !rows) return;
+    if (!fieldId || !rowOrders) {
+      setGroupResult(new Map());
+      setGroupRowsReady(false);
+      return;
+    }
 
     const onConditionsChange = () => {
       const newResult = new Map<string, Row[]>();
@@ -1164,6 +1181,8 @@ export function useRowsByGroup(groupId: string, temporarilyShownColumnIds?: Read
         return;
       }
 
+      setNotFound(false);
+
       const fieldType = Number(field.get(YjsDatabaseKey.type)) as FieldType;
 
       if (![FieldType.SingleSelect, FieldType.MultiSelect, FieldType.Checkbox].includes(fieldType)) {
@@ -1175,7 +1194,7 @@ export function useRowsByGroup(groupId: string, temporarilyShownColumnIds?: Read
 
       const filter = filters?.toArray().find((filter) => filter.get(YjsDatabaseKey.field_id) === fieldId);
 
-      const groupResult = groupByField(rowOrders, rows, field, filter);
+      const groupResult = groupByField(rowOrders, groupingRows, field, filter);
 
       if (!groupResult) {
         setGroupResult(newResult);
@@ -1184,7 +1203,7 @@ export function useRowsByGroup(groupId: string, temporarilyShownColumnIds?: Read
       }
 
       setGroupResult(groupResult);
-      setGroupRowsReady(true);
+      setGroupRowsReady(areGroupRowsHydrated(rowOrders, groupingRows));
     };
 
     onConditionsChange();
@@ -1198,7 +1217,7 @@ export function useRowsByGroup(groupId: string, temporarilyShownColumnIds?: Read
       debouncedConditionsChange();
     };
 
-    Object.values(rows).forEach((row) => {
+    Object.values(groupingRows).forEach((row) => {
       row.getMap(YjsEditorKey.data_section).observeDeep(observerRowsEvent);
     });
     return () => {
@@ -1206,11 +1225,11 @@ export function useRowsByGroup(groupId: string, temporarilyShownColumnIds?: Read
 
       fields.unobserveDeep(onConditionsChange);
       filters?.unobserveDeep(onConditionsChange);
-      Object.values(rows).forEach((row) => {
+      Object.values(groupingRows).forEach((row) => {
         row.getMap(YjsEditorKey.data_section).unobserveDeep(observerRowsEvent);
       });
     };
-  }, [fieldId, fields, rowOrders, rows, filters]);
+  }, [fieldId, fields, rowOrders, groupingRows, filters]);
 
   const visibleColumns = useMemo(
     () =>

--- a/src/components/database/Database.tsx
+++ b/src/components/database/Database.tsx
@@ -23,6 +23,7 @@ import {
   CreatePageResponse,
   CreateRow,
   DatabaseRelations,
+  DatabaseViewLayout,
   GenerateAISummaryRowPayload,
   GenerateAITranslateRowPayload,
   LoadRowDocument,
@@ -357,19 +358,23 @@ function Database(props: Database2Props) {
     return ids;
   }, [doc, activeViewId]);
 
-  const getActiveViewHasConditions = useCallback(() => {
+  const getActiveViewNeedsFullRowData = useCallback(() => {
     const sharedRoot = doc.getMap(YjsEditorKey.data_section);
     const database = sharedRoot?.get(YjsEditorKey.database) as YDatabase | undefined;
     const view = database?.get(YjsDatabaseKey.views)?.get(activeViewId);
     const fields = database?.get(YjsDatabaseKey.fields);
+    const isGroupedBoard =
+      Number(view?.get(YjsDatabaseKey.layout)) === DatabaseViewLayout.Board &&
+      (view?.get(YjsDatabaseKey.groups)?.length ?? 0) > 0;
 
     return (
+      isGroupedBoard ||
       hasEffectiveFilters(view?.get(YjsDatabaseKey.filters), fields) ||
       (view?.get(YjsDatabaseKey.sorts)?.length ?? 0) > 0
     );
   }, [doc, activeViewId]);
 
-  const activeViewHasConditions = useSyncExternalStore(
+  const activeViewNeedsFullRowData = useSyncExternalStore(
     useCallback(
       (onStoreChange) => {
         const sharedRoot = doc.getMap(YjsEditorKey.data_section);
@@ -394,8 +399,8 @@ function Database(props: Database2Props) {
       },
       [doc, activeViewId]
     ),
-    getActiveViewHasConditions,
-    getActiveViewHasConditions
+    getActiveViewNeedsFullRowData,
+    getActiveViewNeedsFullRowData
   );
 
   const registerRowSync = useCallback(
@@ -634,7 +639,7 @@ function Database(props: Database2Props) {
       return null;
     }
 
-    const forceFullSync = activeViewHasConditions;
+    const forceFullSync = activeViewNeedsFullRowData;
     const prefetchKey = `${databaseId}:${forceFullSync ? 'full' : 'delta'}`;
     const existingPromise = prefetchPromisesRef.current.get(prefetchKey);
 
@@ -680,7 +685,7 @@ function Database(props: Database2Props) {
     prefetchPromisesRef.current.set(prefetchKey, promise);
     blobPrefetchPromiseRef.current = promise;
     return promise;
-  }, [readOnly, workspaceId, getDatabaseId, getPriorityRowIds, activeViewHasConditions, runBatchPreload]);
+  }, [readOnly, workspaceId, getDatabaseId, getPriorityRowIds, activeViewNeedsFullRowData, runBatchPreload]);
 
   useEffect(() => {
     retainDatabaseRowDocSeedCache(currentDatabaseId);

--- a/src/components/database/__tests__/Database.prefetch-lifecycle.test.tsx
+++ b/src/components/database/__tests__/Database.prefetch-lifecycle.test.tsx
@@ -3,7 +3,7 @@ import * as Y from 'yjs';
 
 import { peekDatabaseRowDocSeed, prefetchDatabaseBlobDiff } from '@/application/database-blob';
 import { getCachedRowDoc, openRowDoc } from '@/application/services/js-services/cache';
-import { YDoc, YjsDatabaseKey, YjsEditorKey } from '@/application/types';
+import { DatabaseViewLayout, YDoc, YjsDatabaseKey, YjsEditorKey } from '@/application/types';
 import Database, { Database2Props } from '@/components/database/Database';
 
 const mockSeedLoadPromises: Array<Promise<YDoc | undefined>> = [];
@@ -177,6 +177,28 @@ describe('Database blob prefetch lifecycle', () => {
     mockedPrefetch.mockReset();
     mockedGetCachedRowDoc.mockReturnValue(undefined);
     mockedPrefetch.mockImplementation(() => new Promise(() => undefined));
+  });
+
+  it('requests a complete row seed set for a grouped Board view', async () => {
+    const doc = createDatabaseDoc('database-id');
+    const database = doc.getMap(YjsEditorKey.data_section).get(YjsEditorKey.database);
+    const view = database?.get(YjsDatabaseKey.views)?.get('view-id');
+    const groups = new Y.Array();
+
+    groups.push([new Y.Map()]);
+    view?.set(YjsDatabaseKey.layout, DatabaseViewLayout.Board);
+    view?.set(YjsDatabaseKey.groups, groups);
+
+    const { unmount } = render(<Database {...databaseProps(doc)} />);
+
+    await waitFor(() => {
+      expect(mockedPrefetch).toHaveBeenCalledTimes(1);
+    });
+
+    expect(mockedPrefetch.mock.calls[0][2]?.forceFullSync).toBe(true);
+
+    unmount();
+    doc.destroy();
   });
 
   it('starts a new prefetch when the Y.Doc instance changes but its guid stays the same', async () => {

--- a/src/components/database/components/board/card/CardPrimitive.tsx
+++ b/src/components/database/components/board/card/CardPrimitive.tsx
@@ -18,7 +18,13 @@ import { useAIEnabled } from '@/components/app/app.hooks';
 import { cn } from '@/lib/utils';
 import { renderColor } from '@/utils/color';
 import { coverOffsetToObjectPosition } from '@/utils/cover';
-import { Log } from '@/utils/log';
+
+const CARD_INTERACTIVE_TARGET_SELECTOR =
+  '.custom-icon, a, button, input, label, select, textarea, [contenteditable]:not([contenteditable="false"]), [role="button"]';
+
+export function isBoardCardInteractiveTarget(target: EventTarget | null) {
+  return target instanceof Element && Boolean(target.closest(CARD_INTERACTIVE_TARGET_SELECTOR));
+}
 
 export interface CardProps {
   groupFieldId: string;
@@ -131,33 +137,23 @@ export const CardPrimitive = forwardRef<HTMLDivElement, CardProps>(
     return (
       <div
         onClick={(e) => {
-          if (editing) return;
           const target = e.target as HTMLElement;
 
-          Log.debug('custom-icon', target);
           if (target.closest('.custom-icon')) {
             e.stopPropagation();
             return;
           }
 
+          if (isBoardCardInteractiveTarget(target)) return;
+
+          if (editing) setEditing(false);
           navigateToRow?.(rowId);
-        }}
-        onPointerMove={(e) => {
-          if (editing) {
-            e.preventDefault();
-            e.stopPropagation();
-          }
         }}
         onMouseEnter={() => {
           setHovered(true);
         }}
         onMouseLeave={() => {
           setHovered(false);
-        }}
-        onMouseDown={(e) => {
-          if (editing) {
-            e.preventDefault();
-          }
         }}
         ref={ref}
         data-card-id={dataCardId}

--- a/src/components/database/components/board/card/__tests__/CardPrimitive.test.tsx
+++ b/src/components/database/components/board/card/__tests__/CardPrimitive.test.tsx
@@ -1,0 +1,91 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import { useDatabaseContext, useFieldsSelector, useReadOnly, useRowMetaSelector } from '@/application/database-yjs';
+import { useBoardActions, useBoardSelection } from '@/components/database/board/BoardProvider';
+
+import { CardPrimitive } from '../CardPrimitive';
+
+jest.mock('@/application/database-yjs', () => ({
+  FieldVisibility: { AlwaysHidden: 2 },
+  isAIFieldType: () => false,
+  useDatabaseContext: jest.fn(),
+  useFieldsSelector: jest.fn(),
+  useReadOnly: jest.fn(),
+  useRowMetaSelector: jest.fn(),
+}));
+
+jest.mock('@/components/app/app.hooks', () => ({
+  useAIEnabled: () => false,
+}));
+
+jest.mock('@/components/database/board/BoardProvider', () => ({
+  useBoardActions: jest.fn(),
+  useBoardSelection: jest.fn(),
+}));
+
+jest.mock('@/components/database/components/field/CardField', () => ({
+  __esModule: true,
+  default: ({ editing }: { editing?: boolean }) =>
+    editing ? <textarea aria-label='card title' /> : <span>Card title</span>,
+}));
+
+jest.mock('@/components/database/components/board/card/CardToolbar', () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+const mockUseDatabaseContext = useDatabaseContext as jest.MockedFunction<typeof useDatabaseContext>;
+const mockUseFieldsSelector = useFieldsSelector as jest.MockedFunction<typeof useFieldsSelector>;
+const mockUseReadOnly = useReadOnly as jest.MockedFunction<typeof useReadOnly>;
+const mockUseRowMetaSelector = useRowMetaSelector as jest.MockedFunction<typeof useRowMetaSelector>;
+const mockUseBoardActions = useBoardActions as jest.MockedFunction<typeof useBoardActions>;
+const mockUseBoardSelection = useBoardSelection as jest.MockedFunction<typeof useBoardSelection>;
+
+describe('CardPrimitive', () => {
+  const navigateToRow = jest.fn();
+  const setEditingCardId = jest.fn();
+  const setSelectedCardIds = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseDatabaseContext.mockReturnValue({ navigateToRow } as ReturnType<typeof useDatabaseContext>);
+    mockUseFieldsSelector.mockReturnValue([
+      {
+        fieldId: 'title-field',
+        fieldType: 0,
+        visibility: 0,
+      },
+    ] as ReturnType<typeof useFieldsSelector>);
+    mockUseReadOnly.mockReturnValue(false);
+    mockUseRowMetaSelector.mockReturnValue(undefined);
+    mockUseBoardActions.mockReturnValue({
+      setEditingCardId,
+      setSelectedCardIds,
+    } as ReturnType<typeof useBoardActions>);
+    mockUseBoardSelection.mockReturnValue({
+      editingCardId: 'todo/row-1',
+      selectedCardIds: [],
+    } as ReturnType<typeof useBoardSelection>);
+  });
+
+  it('opens an editing card when its non-interactive surface is clicked', () => {
+    const { container } = render(<CardPrimitive columnId='todo' groupFieldId='status-field' rowId='row-1' />);
+    const card = container.querySelector('[data-card-id="todo/row-1"]');
+
+    expect(card).not.toBeNull();
+    fireEvent.click(card as Element);
+
+    expect(setEditingCardId).toHaveBeenCalledWith(null);
+    expect(setSelectedCardIds).toHaveBeenCalledWith(['todo/row-1']);
+    expect(navigateToRow).toHaveBeenCalledWith('row-1');
+  });
+
+  it('keeps clicks inside the title editor from opening the row', () => {
+    render(<CardPrimitive columnId='todo' groupFieldId='status-field' rowId='row-1' />);
+
+    fireEvent.click(screen.getByRole('textbox', { name: 'card title' }));
+
+    expect(setEditingCardId).not.toHaveBeenCalled();
+    expect(navigateToRow).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/database/components/board/column/CardList.tsx
+++ b/src/components/database/components/board/column/CardList.tsx
@@ -1,5 +1,5 @@
 import { useVirtualizer } from '@tanstack/react-virtual';
-import { memo, useCallback, useLayoutEffect, useMemo, useRef } from 'react';
+import { memo, useCallback, useMemo, useRef } from 'react';
 
 import { PADDING_END } from '@/application/database-yjs';
 import { useBoardActions, useBoardSelection } from '@/components/database/board/BoardProvider';
@@ -35,7 +35,6 @@ function CardList({
   setScrollElement?: (element: HTMLDivElement | null) => void;
 }) {
   const parentRef = useRef<HTMLDivElement>(null);
-  const parentOffsetRef = useRef(0);
   const { creatingColumnId } = useBoardSelection();
   const { setCreatingColumnId } = useBoardActions();
 
@@ -61,37 +60,21 @@ function CardList({
     return parentRef.current;
   }, []);
 
-  // Board columns have local scroll, so scrollMargin should always be 0
-  // No need for RAF measurement like Grid - layout is stable within the column
-  useLayoutEffect(() => {
-    parentOffsetRef.current = 0;
-  }, []);
-
   const virtualizer = useVirtualizer({
     count: data.length,
     scrollMargin: 0, // Always 0 for Board - items are positioned relative to column top
     overscan: 5,
     getScrollElement,
-    estimateSize: () => 36,
+    estimateSize: () => 72,
     paddingStart: 0,
     paddingEnd: PADDING_END,
     getItemKey: (index) => data[index].id || String(index),
   });
 
-  const virtualItems = virtualizer.getVirtualItems();
-  const viewportHeight = Math.min(
-    parentRef.current?.clientHeight || CARD_LIST_MAX_HEIGHT,
-    CARD_LIST_MAX_HEIGHT
-  );
-  const scrollTop = parentRef.current?.scrollTop ?? 0;
-  const renderStart = Math.max(0, scrollTop - 5 * 36);
-  const renderEnd = scrollTop + viewportHeight + 5 * 36;
-  const maxRenderedItems = Math.ceil(viewportHeight / 36) + 12;
-  const items = virtualItems.length > maxRenderedItems
-    ? virtualItems
-      .filter((item) => item.end >= renderStart && item.start <= renderEnd)
-      .slice(0, maxRenderedItems)
-    : virtualItems;
+  // TanStack Virtual already applies viewport bounds and overscan using the
+  // measured card heights. A second fixed-height cap could discard valid
+  // virtual items and remount a card during a pointer gesture.
+  const items = virtualizer.getVirtualItems();
 
   return (
     <div

--- a/src/components/database/components/board/column/__tests__/CardList.test.tsx
+++ b/src/components/database/components/board/column/__tests__/CardList.test.tsx
@@ -1,0 +1,52 @@
+import { render, screen } from '@testing-library/react';
+
+import { useVirtualizer } from '@tanstack/react-virtual';
+
+import CardList, { CardType, RenderCard } from '../CardList';
+
+jest.mock('@tanstack/react-virtual', () => ({
+  useVirtualizer: jest.fn(),
+}));
+
+jest.mock('@/application/database-yjs', () => ({
+  PADDING_END: 0,
+}));
+
+jest.mock('@/components/database/board/BoardProvider', () => ({
+  useBoardActions: () => ({ setCreatingColumnId: jest.fn() }),
+  useBoardSelection: () => ({ creatingColumnId: null }),
+}));
+
+jest.mock('@/components/database/components/board/card', () => ({
+  Card: ({ rowId }: { rowId: string }) => <div data-testid='virtual-card'>{rowId}</div>,
+}));
+
+const mockUseVirtualizer = useVirtualizer as jest.MockedFunction<typeof useVirtualizer>;
+
+describe('CardList', () => {
+  it('renders every item selected by the measured virtualizer', () => {
+    const data: RenderCard[] = Array.from({ length: 80 }, (_, index) => ({
+      id: `row-${index}`,
+      type: CardType.CARD,
+    }));
+
+    mockUseVirtualizer.mockReturnValue({
+      getTotalSize: () => 5760,
+      getVirtualItems: () =>
+        data.map((_, index) => ({
+          end: (index + 1) * 72,
+          index,
+          key: `row-${index}`,
+          lane: 0,
+          size: 72,
+          start: index * 72,
+        })),
+      measureElement: jest.fn(),
+      options: { scrollMargin: 0 },
+    } as unknown as ReturnType<typeof useVirtualizer>);
+
+    render(<CardList columnId='todo' data={data} fieldId='status-field' />);
+
+    expect(screen.getAllByTestId('virtual-card')).toHaveLength(data.length);
+  });
+});


### PR DESCRIPTION
### **Description**

Fixes intermittent board cards ignoring clicks. The issue was reproduced when grouping-row hydration moved and unmounted a card between pointerdown and click, so the browser never delivered navigation.

- Preload row data for grouped boards and wait for all grouping rows before treating group counts as exact or auto-hiding empty groups.
- Omit unloaded rows from derived groups instead of temporarily assigning them to No Status.
- Preserve the collapsed Hidden Groups default when the setting is absent.
- Materialize fallback group columns before persisting a visibility toggle.
- Allow card-surface clicks to exit inline editing and navigate while keeping interactive controls isolated.
- Trust the virtualizer item set so a second height cap cannot remount valid cards during interaction.

---

### **Checklist**

#### **General**
- [x] Relevant comments are included for non-obvious lifecycle behavior.
- [ ] Tested in multiple browser/OS environments.

#### **Testing**
- [x] Added or updated regression tests.
- [x] Full Jest suite: 212 suites, 2,208 tests.
- [x] TypeScript type-check.
- [x] ESLint on changed files.
- [x] Production build.

Live post-fix browser replay was unavailable in the test environment; the reproduced pointer lifecycle, grouping hydration, inline-edit click, and virtualizer paths are covered by regression tests.

#### **Feature-Specific**
- [x] Not a feature addition; no preview required.
- [x] Verified integration through the full test suite and production build.

## Summary by Sourcery

Stabilize grouped Board interactions by deferring group visibility to hydrated row data, preserving hidden-group layout defaults, and ensuring card clicks and virtualization do not remount or misroute cards during user interaction.

Bug Fixes:
- Ensure grouped Board rows are only rendered in their true groups once row condition data is hydrated, preventing cards from moving between columns mid-interaction.
- Keep Board card surface clicks exiting inline editing and navigating to the row while ignoring clicks on interactive child controls.
- Avoid discarding valid virtualized Board cards by trusting TanStack Virtual’s measured item set instead of applying a second fixed-height cap.
- Preserve the collapsed Hidden Groups state as the default when the layout collapse setting is missing.

Enhancements:
- Background row hydration is now shared per database view and consumer scope, and Board grouping consumers request their own complete row data without interfering with other conditions-based loaders.
- Grouped Board views now trigger full row-seed prefetch so grouping has complete data across the view.
- Hidden group column toggling now materializes fallback group columns before persisting visibility changes and supports both plain objects and Y.Map-backed group column entries.

Tests:
- Extend grouping tests to cover omission of unloaded rows, hydration tracking, and the distinction between missing cells and unloaded rows.
- Add Board hook tests for fallback group column materialization and Hidden Groups collapse defaults.
- Add Database prefetch lifecycle coverage for grouped Board views requesting full sync.
- Add unit tests for Board card click behavior and CardList virtualization to verify interaction isolation and use of the virtualizer’s item set.