### PR TITLE
test(board): cover hidden empty group parity with desktop

### DIFF
--- a/playwright/bdd/features/database/board-grouping-default.feature
+++ b/playwright/bdd/features/database/board-grouping-default.feature
@@ -1,0 +1,14 @@
+Feature: Board grouping defaults
+  Board views must always remain grouped, including a newly added view of an
+  existing database.
+
+  Scenario: Board hides ungrouping actions and a new Board view defaults to Status grouping
+    Given a Board database is open for group behavior testing
+    When I open Board Group settings
+    Then Board Group settings expose no ungrouping action
+    And Board Group settings show exactly one selected field named "Status"
+    When I close Board Group settings
+    And I add another Board view from the database tab bar
+    And I open Board Group settings
+    Then Board Group settings expose no ungrouping action
+    And Board Group settings show exactly one selected field named "Status"

--- a/playwright/bdd/features/database/board-hidden-empty-groups.feature
+++ b/playwright/bdd/features/database/board-hidden-empty-groups.feature
@@ -14,6 +14,9 @@ Feature: Board hidden empty groups
     When I click the show action for hidden Board group "BDD Reopened Empty Group"
     Then the Board has exactly one visible empty column named "BDD Reopened Empty Group"
     And Hidden Groups has exactly one "BDD Reopened Empty Group" row with only a hide action
+    When I navigate to another page and reopen the database
+    Then the Board has exactly one visible empty column named "BDD Reopened Empty Group"
+    And Hidden Groups has exactly one "BDD Reopened Empty Group" row with only a hide action
     When I click the hide action for shown Board group "BDD Reopened Empty Group"
     Then the Board has no visible column named "BDD Reopened Empty Group"
     And Hidden Groups has exactly one "BDD Reopened Empty Group" row with only a show action
@@ -31,3 +34,22 @@ Feature: Board hidden empty groups
     When I click the hide action for shown Board group "BDD Empty Group"
     Then the Board has no visible column named "BDD Empty Group"
     And Hidden Groups has exactly one "BDD Empty Group" row with only a show action
+
+  Scenario: Explicit empty Board group visibility synchronizes between web clients
+    Given a Board database is open for group behavior testing
+    And an empty Board group named "BDD Shared Empty Group" exists
+    And another web client opens the same Board database
+    When I enable Hide empty groups for the Board
+    And I expand the Board Hidden Groups section
+    Then the other web client has no visible column named "BDD Shared Empty Group"
+    And the other web client's Hidden Groups has exactly one "BDD Shared Empty Group" row with only a show action
+    When I click the show action for hidden Board group "BDD Shared Empty Group"
+    Then the Board has exactly one visible empty column named "BDD Shared Empty Group"
+    And Hidden Groups has exactly one "BDD Shared Empty Group" row with only a hide action
+    And the other web client has exactly one visible empty column named "BDD Shared Empty Group"
+    And the other web client's Hidden Groups has exactly one "BDD Shared Empty Group" row with only a hide action
+    When I click the hide action for shown Board group "BDD Shared Empty Group"
+    Then the Board has no visible column named "BDD Shared Empty Group"
+    And Hidden Groups has exactly one "BDD Shared Empty Group" row with only a show action
+    And the other web client has no visible column named "BDD Shared Empty Group"
+    And the other web client's Hidden Groups has exactly one "BDD Shared Empty Group" row with only a show action

--- a/playwright/bdd/features/database/board-hidden-empty-groups.feature
+++ b/playwright/bdd/features/database/board-hidden-empty-groups.feature
@@ -2,8 +2,24 @@ Feature: Board hidden empty groups
   Empty Board groups should be hidden by the shared view setting while remaining
   available in Hidden Groups for an explicit temporary show or hide action.
 
-  Scenario: Show and hide an empty Board group from Hidden Groups
-    Given a Board database is open for hide-empty-group testing
+  Scenario: Hidden empty Board groups remain available after reopening
+    Given a Board database is open for group behavior testing
+    And an empty Board group named "BDD Reopened Empty Group" exists
+    When I enable Hide empty groups for the Board
+    And I navigate to another page and reopen the database
+    Then Hide empty groups remains enabled for the Board
+    And the Board has no visible column named "BDD Reopened Empty Group"
+    When I expand the Board Hidden Groups section
+    Then Hidden Groups has exactly one "BDD Reopened Empty Group" row with only a show action
+    When I click the show action for hidden Board group "BDD Reopened Empty Group"
+    Then the Board has exactly one visible empty column named "BDD Reopened Empty Group"
+    And Hidden Groups has exactly one "BDD Reopened Empty Group" row with only a hide action
+    When I click the hide action for shown Board group "BDD Reopened Empty Group"
+    Then the Board has no visible column named "BDD Reopened Empty Group"
+    And Hidden Groups has exactly one "BDD Reopened Empty Group" row with only a show action
+
+  Scenario: Hidden Groups eye reflects rendered empty column visibility
+    Given a Board database is open for group behavior testing
     And an empty Board group named "BDD Empty Group" exists
     When I enable Hide empty groups for the Board
     And I expand the Board Hidden Groups section

--- a/playwright/bdd/steps/board-hidden-empty-groups.steps.ts
+++ b/playwright/bdd/steps/board-hidden-empty-groups.steps.ts
@@ -1,14 +1,29 @@
-import { expect, Locator, Page } from '@playwright/test';
+import { BrowserContext, expect, Locator, Page } from '@playwright/test';
 import { createBdd } from 'playwright-bdd';
 
 import { signInAndCreateDatabaseView } from '../../support/database-ui-helpers';
 import { BoardSelectors, DatabaseViewSelectors } from '../../support/selectors';
 import { generateRandomEmail, setupPageErrorHandling } from '../../support/test-config';
 
-const { Given, When, Then } = createBdd();
+const { Given, When, Then, After } = createBdd();
+
+type BoardHiddenGroupsState = {
+  secondContext?: BrowserContext;
+  secondPage?: Page;
+};
+
+const stateByPage = new WeakMap<Page, BoardHiddenGroupsState>();
+
+After(async ({ page }) => {
+  const state = stateByPage.get(page);
+
+  await state?.secondContext?.close();
+  stateByPage.delete(page);
+});
 
 Given('a Board database is open for group behavior testing', async ({ page, request }) => {
   setupPageErrorHandling(page);
+  stateByPage.set(page, {});
 
   await signInAndCreateDatabaseView(page, request, generateRandomEmail(), 'Board', {
     createWaitMs: 7000,
@@ -20,6 +35,36 @@ Given('a Board database is open for group behavior testing', async ({ page, requ
       await expect.poll(() => BoardSelectors.cards(currentPage).count(), { timeout: 15000 }).toBeGreaterThan(0);
     },
   });
+});
+
+Given('another web client opens the same Board database', async ({ page, browser }) => {
+  const state = stateByPage.get(page) ?? {};
+  const secondContext = await browser.newContext({
+    baseURL: new URL(page.url()).origin,
+    storageState: await page.context().storageState({ indexedDB: true }),
+    viewport: { width: 1440, height: 900 },
+  });
+  const secondPage = await secondContext.newPage();
+
+  state.secondContext = secondContext;
+  state.secondPage = secondPage;
+  stateByPage.set(page, state);
+  setupPageErrorHandling(secondPage);
+
+  await secondPage.goto(page.url(), { waitUntil: 'domcontentloaded' });
+  await expect(BoardSelectors.boardContainer(secondPage)).toHaveCount(1, { timeout: 30000 });
+  await expect(BoardSelectors.boardContainer(secondPage)).toBeVisible({ timeout: 30000 });
+  await expect(BoardSelectors.mainColumns(secondPage)).toHaveCount(1, { timeout: 30000 });
+  await expect(BoardSelectors.mainColumns(secondPage)).toBeVisible({ timeout: 30000 });
+
+  const toggle = BoardSelectors.hiddenGroupsToggle(secondPage);
+
+  await expect(toggle).toHaveCount(1, { timeout: 30000 });
+  await expect(toggle).toBeVisible({ timeout: 30000 });
+  if ((await toggle.getAttribute('aria-expanded')) === 'false') {
+    await toggle.click();
+  }
+  await expect(toggle).toHaveAttribute('aria-expanded', 'true');
 });
 
 Given('an empty Board group named {string} exists', async ({ page }, groupName: string) => {
@@ -85,8 +130,9 @@ When('I expand the Board Hidden Groups section', async ({ page }) => {
 
   await expect(toggle).toHaveCount(1);
   await expect(toggle).toBeVisible();
-  await expect(toggle).toHaveAttribute('aria-expanded', 'false');
-  await toggle.click();
+  if ((await toggle.getAttribute('aria-expanded')) === 'false') {
+    await toggle.click();
+  }
   await expect(toggle).toHaveAttribute('aria-expanded', 'true');
 });
 
@@ -94,12 +140,9 @@ Then('the Board has no visible column named {string}', async ({ page }, groupNam
   await expect(BoardSelectors.columnByName(page, groupName)).toHaveCount(0);
 });
 
-Then(
-  'Hidden Groups has exactly one {string} row with only a show action',
-  async ({ page }, groupName: string) => {
-    await expectExactHiddenGroupAction(page, groupName, 'show');
-  }
-);
+Then('Hidden Groups has exactly one {string} row with only a show action', async ({ page }, groupName: string) => {
+  await expectExactHiddenGroupAction(page, groupName, 'show');
+});
 
 When('I click the show action for hidden Board group {string}', async ({ page }, groupName: string) => {
   await clickExactHiddenGroupAction(page, groupName, 'show');
@@ -109,16 +152,35 @@ Then('the Board has exactly one visible empty column named {string}', async ({ p
   await expectExactEmptyBoardColumn(page, groupName);
 });
 
-Then(
-  'Hidden Groups has exactly one {string} row with only a hide action',
-  async ({ page }, groupName: string) => {
-    await expectExactHiddenGroupAction(page, groupName, 'hide');
-  }
-);
+Then('Hidden Groups has exactly one {string} row with only a hide action', async ({ page }, groupName: string) => {
+  await expectExactHiddenGroupAction(page, groupName, 'hide');
+});
 
 When('I click the hide action for shown Board group {string}', async ({ page }, groupName: string) => {
   await clickExactHiddenGroupAction(page, groupName, 'hide');
 });
+
+Then('the other web client has no visible column named {string}', async ({ page }, groupName: string) => {
+  await expect(BoardSelectors.columnByName(requireSecondPage(page), groupName)).toHaveCount(0, { timeout: 30000 });
+});
+
+Then('the other web client has exactly one visible empty column named {string}', async ({ page }, groupName: string) => {
+  await expectExactEmptyBoardColumn(requireSecondPage(page), groupName, 30000);
+});
+
+Then(
+  "the other web client's Hidden Groups has exactly one {string} row with only a show action",
+  async ({ page }, groupName: string) => {
+    await expectExactHiddenGroupAction(requireSecondPage(page), groupName, 'show', 30000);
+  }
+);
+
+Then(
+  "the other web client's Hidden Groups has exactly one {string} row with only a hide action",
+  async ({ page }, groupName: string) => {
+    await expectExactHiddenGroupAction(requireSecondPage(page), groupName, 'hide', 30000);
+  }
+);
 
 When('I open Board Group settings', async ({ page }) => {
   const { menu } = await openBoardGroupSettings(page);
@@ -177,37 +239,38 @@ When('I add another Board view from the database tab bar', async ({ page }) => {
   await expect(viewTabs).toHaveCount(previousTabCount + 1);
   await expect(DatabaseViewSelectors.activeViewTab(page)).toHaveCount(1);
   await expect(DatabaseViewSelectors.activeViewTab(page)).toContainText('Board');
-  await expect(DatabaseViewSelectors.activeViewTab(page)).not.toHaveAttribute(
-    'data-testid',
-    previousActiveTabId ?? ''
-  );
+  await expect(DatabaseViewSelectors.activeViewTab(page)).not.toHaveAttribute('data-testid', previousActiveTabId ?? '');
   await expect(BoardSelectors.boardContainer(page)).toHaveCount(1);
   await expect(BoardSelectors.boardContainer(page)).toBeVisible();
   await expect(BoardSelectors.mainColumns(page)).toHaveCount(1);
   await expect(BoardSelectors.mainColumns(page)).toBeVisible();
 });
 
-async function expectExactEmptyBoardColumn(page: Page, groupName: string) {
+async function expectExactEmptyBoardColumn(page: Page, groupName: string, timeout = 5000) {
   const column = BoardSelectors.columnByName(page, groupName);
 
-  await expect(column).toHaveCount(1);
-  await expect(column).toBeVisible();
-  await expect(column.getByTestId('board-column-name').getByText(groupName, { exact: true })).toHaveCount(1);
-  await expect(column.locator('.board-card')).toHaveCount(0);
+  await expect(column).toHaveCount(1, { timeout });
+  await expect(column).toBeVisible({ timeout });
+  await expect(column.getByTestId('board-column-name').getByText(groupName, { exact: true })).toHaveCount(1, {
+    timeout,
+  });
+  await expect(column.locator('.board-card')).toHaveCount(0, { timeout });
 }
 
-async function expectExactHiddenGroupAction(page: Page, groupName: string, action: 'show' | 'hide') {
+async function expectExactHiddenGroupAction(page: Page, groupName: string, action: 'show' | 'hide', timeout = 5000) {
   const row = BoardSelectors.hiddenGroupByName(page, groupName);
   const expectedAction = hiddenGroupAction(row, action);
   const oppositeAction = hiddenGroupAction(row, action === 'show' ? 'hide' : 'show');
 
-  await expect(row).toHaveCount(1);
-  await expect(row).toBeVisible();
-  await expect(row.getByTestId('board-hidden-group-name').getByText(groupName, { exact: true })).toHaveCount(1);
+  await expect(row).toHaveCount(1, { timeout });
+  await expect(row).toBeVisible({ timeout });
+  await expect(row.getByTestId('board-hidden-group-name').getByText(groupName, { exact: true })).toHaveCount(1, {
+    timeout,
+  });
   await row.hover();
-  await expect(expectedAction).toHaveCount(1);
-  await expect(expectedAction).toBeVisible();
-  await expect(oppositeAction).toHaveCount(0);
+  await expect(expectedAction).toHaveCount(1, { timeout });
+  await expect(expectedAction).toBeVisible({ timeout });
+  await expect(oppositeAction).toHaveCount(0, { timeout });
 }
 
 async function clickExactHiddenGroupAction(page: Page, groupName: string, action: 'show' | 'hide') {
@@ -219,6 +282,16 @@ async function clickExactHiddenGroupAction(page: Page, groupName: string, action
 
 function hiddenGroupAction(row: Locator, action: 'show' | 'hide') {
   return row.getByTestId(`board-hidden-group-${action}`);
+}
+
+function requireSecondPage(page: Page) {
+  const secondPage = stateByPage.get(page)?.secondPage;
+
+  if (!secondPage) {
+    throw new Error('Expected another web client to have opened the Board database');
+  }
+
+  return secondPage;
 }
 
 async function openBoardGroupSettings(page: Page) {

--- a/playwright/bdd/steps/board-hidden-empty-groups.steps.ts
+++ b/playwright/bdd/steps/board-hidden-empty-groups.steps.ts
@@ -2,12 +2,12 @@ import { expect, Locator, Page } from '@playwright/test';
 import { createBdd } from 'playwright-bdd';
 
 import { signInAndCreateDatabaseView } from '../../support/database-ui-helpers';
-import { BoardSelectors } from '../../support/selectors';
+import { BoardSelectors, DatabaseViewSelectors } from '../../support/selectors';
 import { generateRandomEmail, setupPageErrorHandling } from '../../support/test-config';
 
 const { Given, When, Then } = createBdd();
 
-Given('a Board database is open for hide-empty-group testing', async ({ page, request }) => {
+Given('a Board database is open for group behavior testing', async ({ page, request }) => {
   setupPageErrorHandling(page);
 
   await signInAndCreateDatabaseView(page, request, generateRandomEmail(), 'Board', {
@@ -66,6 +66,20 @@ When('I enable Hide empty groups for the Board', async ({ page }) => {
   await page.keyboard.press('Escape');
 });
 
+Then('Hide empty groups remains enabled for the Board', async ({ page }) => {
+  const { menu, toggleRow, toggleSwitch } = await openBoardGroupSettings(page);
+
+  await expect(menu).toHaveCount(1);
+  await expect(menu).toBeVisible();
+  await expect(toggleRow).toHaveCount(1);
+  await expect(toggleRow).toBeVisible();
+  await expect(toggleSwitch).toHaveCount(1);
+  await expect(toggleSwitch).toBeVisible();
+  await expect(toggleSwitch).toBeChecked();
+
+  await closeBoardGroupSettings(page);
+});
+
 When('I expand the Board Hidden Groups section', async ({ page }) => {
   const toggle = BoardSelectors.hiddenGroupsToggle(page);
 
@@ -104,6 +118,73 @@ Then(
 
 When('I click the hide action for shown Board group {string}', async ({ page }, groupName: string) => {
   await clickExactHiddenGroupAction(page, groupName, 'hide');
+});
+
+When('I open Board Group settings', async ({ page }) => {
+  const { menu } = await openBoardGroupSettings(page);
+
+  await expect(menu).toHaveCount(1);
+  await expect(menu).toBeVisible();
+});
+
+Then('Board Group settings expose no ungrouping action', async ({ page }) => {
+  const menu = boardGroupSettingsMenu(page);
+
+  await expect(menu).toHaveCount(1);
+  await expect(menu).toBeVisible();
+  await expect(menu.getByRole('menuitem', { name: 'None', exact: true })).toHaveCount(0);
+  await expect(menu.getByRole('menuitem', { name: 'Delete grouping', exact: true })).toHaveCount(0);
+});
+
+Then('Board Group settings show exactly one selected field named {string}', async ({ page }, fieldName: string) => {
+  const menu = boardGroupSettingsMenu(page);
+  const fieldRows = menu.getByTestId('board-group-by-field');
+  const selectedField = fieldRows.filter({
+    has: page.getByTestId('board-group-by-field-name').getByText(fieldName, { exact: true }),
+  });
+
+  await expect(menu).toHaveCount(1);
+  await expect(menu).toBeVisible();
+  await expect(selectedField).toHaveCount(1);
+  await expect(selectedField).toBeVisible();
+  await expect(selectedField.getByTestId('board-group-by-field-selected')).toHaveCount(1);
+  await expect(menu.getByTestId('board-group-by-field-selected')).toHaveCount(1);
+});
+
+When('I close Board Group settings', async ({ page }) => {
+  await closeBoardGroupSettings(page);
+});
+
+When('I add another Board view from the database tab bar', async ({ page }) => {
+  const viewTabs = DatabaseViewSelectors.viewTab(page);
+  const previousTabCount = await viewTabs.count();
+  const previousActiveTabId = await DatabaseViewSelectors.activeViewTab(page).getAttribute('data-testid');
+  const addViewButton = DatabaseViewSelectors.addViewButton(page);
+
+  await expect(addViewButton).toHaveCount(1);
+  await expect(addViewButton).toBeVisible();
+  await addViewButton.click();
+
+  const menu = page.locator('[data-slot="dropdown-menu-content"]:visible');
+  const boardOption = menu.getByRole('menuitem', { name: 'Board', exact: true });
+
+  await expect(menu).toHaveCount(1);
+  await expect(menu).toBeVisible();
+  await expect(boardOption).toHaveCount(1);
+  await expect(boardOption).toBeVisible();
+  await boardOption.click();
+
+  await expect(viewTabs).toHaveCount(previousTabCount + 1);
+  await expect(DatabaseViewSelectors.activeViewTab(page)).toHaveCount(1);
+  await expect(DatabaseViewSelectors.activeViewTab(page)).toContainText('Board');
+  await expect(DatabaseViewSelectors.activeViewTab(page)).not.toHaveAttribute(
+    'data-testid',
+    previousActiveTabId ?? ''
+  );
+  await expect(BoardSelectors.boardContainer(page)).toHaveCount(1);
+  await expect(BoardSelectors.boardContainer(page)).toBeVisible();
+  await expect(BoardSelectors.mainColumns(page)).toHaveCount(1);
+  await expect(BoardSelectors.mainColumns(page)).toBeVisible();
 });
 
 async function expectExactEmptyBoardColumn(page: Page, groupName: string) {
@@ -154,7 +235,18 @@ async function openBoardGroupSettings(page: Page) {
   await groupSettingsTrigger.click();
 
   return {
+    menu: boardGroupSettingsMenu(page),
     toggleRow: page.getByTestId('board-hide-empty-groups-toggle'),
     toggleSwitch: page.getByTestId('board-hide-empty-groups-switch'),
   };
+}
+
+async function closeBoardGroupSettings(page: Page) {
+  await page.keyboard.press('Escape');
+  await page.keyboard.press('Escape');
+  await expect(boardGroupSettingsMenu(page)).toHaveCount(0);
+}
+
+function boardGroupSettingsMenu(page: Page) {
+  return page.getByTestId('board-group-settings-menu');
 }

--- a/src/application/database-yjs/__tests__/board-visibility.test.ts
+++ b/src/application/database-yjs/__tests__/board-visibility.test.ts
@@ -15,11 +15,11 @@ const rowCounts = new Map([
 function resolveVisibility({
   hideEmptyGroups = true,
   hideUngroupedColumn = false,
-  temporarilyShownColumnIds,
+  shownEmptyGroupIds,
 }: {
   hideEmptyGroups?: boolean;
   hideUngroupedColumn?: boolean;
-  temporarilyShownColumnIds?: ReadonlySet<string>;
+  shownEmptyGroupIds?: ReadonlySet<string>;
 } = {}) {
   return resolveBoardColumnVisibility({
     columns,
@@ -28,7 +28,7 @@ function resolveVisibility({
     groupRowsReady: true,
     hideEmptyGroups,
     hideUngroupedColumn,
-    temporarilyShownColumnIds,
+    shownEmptyGroupIds,
   });
 }
 
@@ -40,9 +40,9 @@ describe('resolveBoardColumnVisibility', () => {
     expect(result.hiddenColumns.map((column) => column.id)).toEqual(['status-field', 'done']);
   });
 
-  it('keeps a temporarily shown empty column in both Board and Hidden Groups', () => {
+  it('keeps a shared explicitly shown empty column in both Board and Hidden Groups', () => {
     const result = resolveVisibility({
-      temporarilyShownColumnIds: new Set(['status-field']),
+      shownEmptyGroupIds: new Set(['status-field']),
     });
 
     expect(result.visibleColumns.map((column) => column.id)).toEqual(['status-field', 'todo']);

--- a/src/application/database-yjs/__tests__/useGroup.test.tsx
+++ b/src/application/database-yjs/__tests__/useGroup.test.tsx
@@ -9,7 +9,11 @@ import {
   useBoardLayoutSettings,
   useGroup,
 } from '@/application/database-yjs';
-import { useToggleHiddenGroupColumnDispatch, useToggleHideEmptyGroups } from '@/application/database-yjs/dispatch';
+import {
+  useSetBoardColumnRenderedDispatch,
+  useToggleHiddenGroupColumnDispatch,
+  useToggleHideEmptyGroups,
+} from '@/application/database-yjs/dispatch';
 import { YDoc, YjsDatabaseKey, YjsEditorKey } from '@/application/types';
 
 jest.mock('@/utils/runtime-config', () => ({
@@ -260,5 +264,53 @@ describe('useGroup', () => {
     await waitFor(() => {
       expect(result.current.layoutSettings.hideEmptyGroups).toBe(true);
     });
+  });
+
+  it('persists and observes explicitly shown empty Board groups', async () => {
+    const fieldId = 'field-id';
+    const groupId = 'group-id';
+    const emptyGroupId = 'empty-group-id';
+    const viewId = 'board-view-id';
+    const databaseDoc = createDatabaseDoc({
+      fieldId,
+      groupId,
+      groupColumns: [{ id: emptyGroupId, visible: true }],
+      viewId,
+    });
+
+    const { result } = renderHook(
+      () => ({
+        layoutSettings: useBoardLayoutSettings(),
+        setColumnRendered: useSetBoardColumnRenderedDispatch(groupId, fieldId),
+        toggleHideEmptyGroups: useToggleHideEmptyGroups(),
+      }),
+      {
+        wrapper: createWrapper(databaseDoc, viewId),
+      }
+    );
+
+    act(() => {
+      result.current.toggleHideEmptyGroups(true);
+      result.current.setColumnRendered(emptyGroupId, true, true);
+    });
+
+    await waitFor(() => {
+      expect(result.current.layoutSettings.shownEmptyGroupIds).toEqual(new Set([emptyGroupId]));
+    });
+
+    act(() => {
+      result.current.setColumnRendered(emptyGroupId, false, true);
+    });
+
+    await waitFor(() => {
+      expect(result.current.layoutSettings.shownEmptyGroupIds).toEqual(new Set());
+    });
+
+    const database = databaseDoc.getMap(YjsEditorKey.data_section).get(YjsEditorKey.database);
+    const view = database?.get(YjsDatabaseKey.views)?.get(viewId);
+    const groups = view?.get(YjsDatabaseKey.groups) as Y.Array<Y.Map<unknown>>;
+    const columns = groups.get(0).get(YjsDatabaseKey.groups) as Y.Array<{ id: string; visible: boolean }>;
+
+    expect(columns.toJSON()).toEqual([{ id: emptyGroupId, visible: false }]);
   });
 });

--- a/src/application/database-yjs/board-visibility.ts
+++ b/src/application/database-yjs/board-visibility.ts
@@ -10,13 +10,14 @@ type ResolveBoardColumnVisibilityOptions<T extends BoardColumn> = {
   hideEmptyGroups: boolean;
   groupRowsReady: boolean;
   getRowCount: (columnId: string) => number;
-  temporarilyShownColumnIds?: ReadonlySet<string>;
+  shownEmptyGroupIds?: ReadonlySet<string>;
 };
 
 /**
  * Resolves the two Board column partitions from persisted settings and exact
- * row counts. Temporarily shown empty columns deliberately stay in the hidden
- * partition so their eye action can hide them again, matching desktop.
+ * row counts. Explicitly shown empty columns deliberately stay in the hidden
+ * partition so their eye action can hide them again. The explicit-show set is
+ * shared view state, so Web and desktop resolve the same rendered columns.
  */
 export function resolveBoardColumnVisibility<T extends BoardColumn>({
   columns,
@@ -25,7 +26,7 @@ export function resolveBoardColumnVisibility<T extends BoardColumn>({
   hideEmptyGroups,
   groupRowsReady,
   getRowCount,
-  temporarilyShownColumnIds,
+  shownEmptyGroupIds,
 }: ResolveBoardColumnVisibilityOptions<T>) {
   const visibleColumns: T[] = [];
   const hiddenColumns: T[] = [];
@@ -38,7 +39,7 @@ export function resolveBoardColumnVisibility<T extends BoardColumn>({
       hiddenColumns.push(column);
     }
 
-    if (!explicitlyHidden && (!automaticallyHidden || temporarilyShownColumnIds?.has(column.id) === true)) {
+    if (!explicitlyHidden && (!automaticallyHidden || shownEmptyGroupIds?.has(column.id) === true)) {
       visibleColumns.push(column);
     }
   });

--- a/src/application/database-yjs/dispatch.ts
+++ b/src/application/database-yjs/dispatch.ts
@@ -74,6 +74,7 @@ import {
   YDatabaseChartLayoutSetting,
   YDatabaseField,
   YDatabaseFieldOrders,
+  YDatabaseFields,
   YDatabaseFieldSetting,
   YDatabaseFieldSettings,
   YDatabaseFieldTypeOption,
@@ -413,6 +414,108 @@ export function useDeleteGroupColumnDispatch(groupId: string, columnId: string, 
   );
 }
 
+function setGroupColumnHidden({
+  columnId,
+  fieldId,
+  fields,
+  groupId,
+  hidden,
+  view,
+}: {
+  columnId: string;
+  fieldId: string;
+  fields: YDatabaseFields | undefined;
+  groupId: string;
+  hidden: boolean;
+  view: YDatabaseView;
+}) {
+  const groups = view.get(YjsDatabaseKey.groups);
+
+  if (!groups) {
+    throw new Error('Groups not found');
+  }
+
+  const group = groups.toArray().find((group) => group.get(YjsDatabaseKey.id) === groupId);
+
+  if (!group) {
+    throw new Error(`Group with id ${groupId} not found`);
+  }
+
+  const columns = group.get(YjsDatabaseKey.groups);
+
+  if (!columns) {
+    throw new Error('Group columns not found');
+  }
+
+  const getColumnId = (column: unknown) => {
+    if (column instanceof Y.Map) {
+      return column.get(YjsDatabaseKey.id);
+    }
+
+    return (column as { id?: string } | undefined)?.id;
+  };
+
+  let index = columns.toArray().findIndex((column) => getColumnId(column) === columnId);
+
+  if (index === -1) {
+    const field = fields?.get(fieldId);
+    const fallbackColumns = field ? getGroupColumns(field) ?? [] : [];
+
+    if (!fallbackColumns.some((column) => column.id === columnId)) {
+      throw new Error(`Column with id ${columnId} not found in group ${groupId}`);
+    }
+
+    const existingColumnIds = new Set(columns.toArray().map(getColumnId));
+    const missingColumns = fallbackColumns
+      .filter((column) => !existingColumnIds.has(column.id))
+      .map((column) => ({ ...column, visible: true }));
+
+    if (missingColumns.length > 0) {
+      columns.insert(columns.length, missingColumns);
+    }
+
+    index = columns.toArray().findIndex((column) => getColumnId(column) === columnId);
+  }
+
+  const column = columns.get(index) as { id: string; visible: boolean } | Y.Map<unknown> | undefined;
+
+  if (index === -1 || !column) {
+    throw new Error(`Column with id ${columnId} not found in group ${groupId}`);
+  }
+
+  if (column instanceof Y.Map) {
+    column.set(YjsDatabaseKey.visible, !hidden);
+  } else {
+    columns.delete(index);
+    columns.insert(index, [{ ...column, visible: !hidden }]);
+  }
+
+  if (columnId === fieldId) {
+    getOrCreateBoardLayoutSetting(view).set(YjsDatabaseKey.hide_ungrouped_column, hidden);
+  }
+}
+
+function readShownEmptyGroupIds(layoutSetting: YDatabaseBoardLayoutSetting) {
+  const storedIds = layoutSetting.get(YjsDatabaseKey.shown_empty_group_ids) as unknown;
+  const ids = storedIds instanceof Y.Array ? storedIds.toArray() : Array.isArray(storedIds) ? storedIds : [];
+
+  return new Set(ids.filter((id): id is string => typeof id === 'string'));
+}
+
+function setEmptyGroupOverride(layoutSetting: YDatabaseBoardLayoutSetting, columnId: string, shown: boolean) {
+  const shownIds = readShownEmptyGroupIds(layoutSetting);
+
+  if (shownIds.has(columnId) === shown) return;
+
+  if (shown) {
+    shownIds.add(columnId);
+  } else {
+    shownIds.delete(columnId);
+  }
+
+  layoutSetting.set(YjsDatabaseKey.shown_empty_group_ids, [...shownIds].sort());
+}
+
 export function useToggleHiddenGroupColumnDispatch(groupId: string, fieldId: string) {
   const view = useDatabaseView();
   const fields = useDatabaseFields();
@@ -428,79 +531,39 @@ export function useToggleHiddenGroupColumnDispatch(groupId: string, fieldId: str
               throw new Error('View not found');
             }
 
-            const groups = view?.get(YjsDatabaseKey.groups);
-
-            if (!groups) {
-              throw new Error('Groups not found');
-            }
-
-            const group = groups.toArray().find((group) => group.get(YjsDatabaseKey.id) === groupId);
-
-            if (!group) {
-              throw new Error(`Group with id ${groupId} not found`);
-            }
-
-            const columns = group.get(YjsDatabaseKey.groups);
-
-            if (!columns) {
-              throw new Error('Group columns not found');
-            }
-
-            const getColumnId = (column: unknown) => {
-              if (column instanceof Y.Map) {
-                return column.get(YjsDatabaseKey.id);
-              }
-
-              return (column as { id?: string } | undefined)?.id;
-            };
-
-            let index = columns.toArray().findIndex((column) => getColumnId(column) === columnId);
-
-            if (index === -1) {
-              const field = fields?.get(fieldId);
-              const fallbackColumns = field ? getGroupColumns(field) ?? [] : [];
-
-              if (!fallbackColumns.some((column) => column.id === columnId)) {
-                throw new Error(`Column with id ${columnId} not found in group ${groupId}`);
-              }
-
-              const existingColumnIds = new Set(columns.toArray().map(getColumnId));
-              const missingColumns = fallbackColumns
-                .filter((column) => !existingColumnIds.has(column.id))
-                .map((column) => ({ ...column, visible: true }));
-
-              if (missingColumns.length > 0) {
-                columns.insert(columns.length, missingColumns);
-              }
-
-              index = columns.toArray().findIndex((column) => getColumnId(column) === columnId);
-            }
-
-            const column = columns.get(index) as { id: string; visible: boolean } | Y.Map<unknown> | undefined;
-
-            if (index === -1 || !column) {
-              throw new Error(`Column with id ${columnId} not found in group ${groupId}`);
-            }
-
-            if (column instanceof Y.Map) {
-              column.set(YjsDatabaseKey.visible, !hidden);
-            } else {
-              const newColumn = {
-                ...column,
-                visible: !hidden,
-              };
-
-              columns.delete(index);
-
-              columns.insert(index, [newColumn]);
-            }
-
-            if (columnId === fieldId) {
-              getOrCreateBoardLayoutSetting(view).set(YjsDatabaseKey.hide_ungrouped_column, hidden);
+            setGroupColumnHidden({ columnId, fieldId, fields, groupId, hidden, view });
+            if (hidden) {
+              setEmptyGroupOverride(getOrCreateBoardLayoutSetting(view), columnId, false);
             }
           },
         ],
         'hideGroupColumn'
+      );
+    },
+    [fieldId, fields, groupId, sharedRoot, view]
+  );
+}
+
+export function useSetBoardColumnRenderedDispatch(groupId: string, fieldId: string) {
+  const view = useDatabaseView();
+  const fields = useDatabaseFields();
+  const sharedRoot = useSharedRoot();
+
+  return useCallback(
+    (columnId: string, shown: boolean, automaticallyHidden: boolean) => {
+      executeOperations(
+        sharedRoot,
+        [
+          () => {
+            if (!view) {
+              throw new Error('View not found');
+            }
+
+            setGroupColumnHidden({ columnId, fieldId, fields, groupId, hidden: !shown, view });
+            setEmptyGroupOverride(getOrCreateBoardLayoutSetting(view), columnId, shown && automaticallyHidden);
+          },
+        ],
+        'setBoardColumnRendered'
       );
     },
     [fieldId, fields, groupId, sharedRoot, view]
@@ -587,7 +650,12 @@ export function useToggleHideEmptyGroups() {
               throw new Error('Unable to toggle hide empty groups');
             }
 
-            getOrCreateBoardLayoutSetting(view).set(YjsDatabaseKey.hide_empty_groups, hide);
+            const layoutSetting = getOrCreateBoardLayoutSetting(view);
+
+            layoutSetting.set(YjsDatabaseKey.hide_empty_groups, hide);
+            if (!hide) {
+              layoutSetting.set(YjsDatabaseKey.shown_empty_group_ids, []);
+            }
           },
         ],
         'toggleHideEmptyGroups'
@@ -2673,12 +2741,12 @@ export function useSwitchPropertyType() {
       };
 
       return loadRowsAndSwitch().catch((error: unknown) => {
-          Log.warn('[useSwitchPropertyType] Field type was not changed', {
-            fieldId,
-            fieldType,
-            error,
-          });
-          throw error;
+        Log.warn('[useSwitchPropertyType] Field type was not changed', {
+          fieldId,
+          fieldType,
+          error,
+        });
+        throw error;
       });
     },
     [bindViewSync, database, databaseDoc, ensureRow, getViewIdFromDatabaseId, loadView, sharedRoot, rowMap]

--- a/src/application/database-yjs/selector.ts
+++ b/src/application/database-yjs/selector.ts
@@ -1062,6 +1062,7 @@ export function useBoardLayoutSettings() {
   const [isCollapsed, setIsCollapsed] = useState(true);
   const [hideUnGroup, setHideUnGroup] = useState(false);
   const [hideEmptyGroups, setHideEmptyGroups] = useState(false);
+  const [shownEmptyGroupIds, setShownEmptyGroupIds] = useState<ReadonlySet<string>>(() => new Set());
   const groups = view?.get(YjsDatabaseKey.groups);
   const [fieldId, setFieldId] = useState<string | null>(null);
 
@@ -1075,6 +1076,22 @@ export function useBoardLayoutSettings() {
       setIsCollapsed(collapseHiddenGroups === undefined ? true : Boolean(collapseHiddenGroups));
       setHideUnGroup(Boolean(layoutSetting?.get(YjsDatabaseKey.hide_ungrouped_column)));
       setHideEmptyGroups(Boolean(layoutSetting?.get(YjsDatabaseKey.hide_empty_groups)));
+      const rawShownEmptyGroupIds = layoutSetting?.get(YjsDatabaseKey.shown_empty_group_ids) as unknown;
+      const shownIds: unknown[] = Array.isArray(rawShownEmptyGroupIds)
+        ? rawShownEmptyGroupIds
+        : rawShownEmptyGroupIds &&
+          typeof rawShownEmptyGroupIds === 'object' &&
+          'toArray' in rawShownEmptyGroupIds &&
+          typeof rawShownEmptyGroupIds.toArray === 'function'
+        ? (rawShownEmptyGroupIds.toArray() as unknown[])
+        : [];
+      const nextShownEmptyGroupIds = new Set<string>(shownIds.filter((id): id is string => typeof id === 'string'));
+
+      setShownEmptyGroupIds((currentIds) =>
+        currentIds.size === nextShownEmptyGroupIds.size && [...currentIds].every((id) => nextShownEmptyGroupIds.has(id))
+          ? currentIds
+          : nextShownEmptyGroupIds
+      );
     };
 
     observerEvent();
@@ -1108,6 +1125,7 @@ export function useBoardLayoutSettings() {
     isCollapsed,
     hideUnGroup,
     hideEmptyGroups,
+    shownEmptyGroupIds,
     fieldId,
   };
 }
@@ -1137,7 +1155,7 @@ export function useGetBoardHiddenGroup(
   };
 }
 
-export function useRowsByGroup(groupId: string, temporarilyShownColumnIds?: ReadonlySet<string>) {
+export function useRowsByGroup(groupId: string) {
   const { columns, fieldId } = useGroup(groupId);
   const rows = useRowMap();
   const rowOrders = useRowOrdersSelector();
@@ -1160,7 +1178,7 @@ export function useRowsByGroup(groupId: string, temporarilyShownColumnIds?: Read
   const [groupRowsReady, setGroupRowsReady] = useState(false);
   const view = useDatabaseView();
   const filters = view?.get(YjsDatabaseKey.filters);
-  const { hideEmptyGroups, hideUnGroup } = useBoardLayoutSettings();
+  const { hideEmptyGroups, hideUnGroup, shownEmptyGroupIds } = useBoardLayoutSettings();
 
   useEffect(() => {
     if (!fieldId || !rowOrders) {
@@ -1240,9 +1258,9 @@ export function useRowsByGroup(groupId: string, temporarilyShownColumnIds?: Read
         groupRowsReady,
         hideEmptyGroups,
         hideUngroupedColumn: hideUnGroup,
-        temporarilyShownColumnIds,
+        shownEmptyGroupIds,
       }).visibleColumns,
-    [columns, fieldId, groupResult, groupRowsReady, hideEmptyGroups, hideUnGroup, temporarilyShownColumnIds]
+    [columns, fieldId, groupResult, groupRowsReady, hideEmptyGroups, hideUnGroup, shownEmptyGroupIds]
   );
 
   return {

--- a/src/application/types.ts
+++ b/src/application/types.ts
@@ -610,6 +610,7 @@ export enum YjsDatabaseKey {
   collapsed_group_ids = 'collapsed_group_ids',
   hide_ungrouped_column = 'hide_ungrouped_column',
   hide_empty_groups = 'hide_empty_groups',
+  shown_empty_group_ids = 'shown_empty_group_ids',
   collapse_hidden_groups = 'collapse_hidden_groups',
   first_day_of_week = 'first_day_of_week',
   show_week_numbers = 'show_week_numbers',
@@ -907,6 +908,7 @@ export interface YDatabaseBoardLayoutSetting extends Y.Map<unknown> {
   get(
     key: YjsDatabaseKey.hide_ungrouped_column | YjsDatabaseKey.hide_empty_groups | YjsDatabaseKey.collapse_hidden_groups
   ): boolean;
+  get(key: YjsDatabaseKey.shown_empty_group_ids): string[];
 }
 
 export interface YDatabaseCalendarLayoutSetting extends Y.Map<unknown> {

--- a/src/components/database/components/board/column/HiddenColumnItem.tsx
+++ b/src/components/database/components/board/column/HiddenColumnItem.tsx
@@ -2,7 +2,7 @@ import { useCallback, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { Row } from '@/application/database-yjs';
-import { useToggleHiddenGroupColumnDispatch } from '@/application/database-yjs/dispatch';
+import { useSetBoardColumnRenderedDispatch } from '@/application/database-yjs/dispatch';
 import { ReactComponent as HideIcon } from '@/assets/icons/hide.svg';
 import { ReactComponent as ShowIcon } from '@/assets/icons/show.svg';
 import { useRenderColumn } from '@/components/database/components/board/column/useRenderColumn';
@@ -19,14 +19,14 @@ function HiddenColumnItem({
   getRows: getRowsProp,
   groupId,
   isShownOnBoard,
-  onColumnTemporarilyShownChange,
+  automaticallyHidden,
 }: {
   id: string;
   fieldId: string;
   getRows: (id: string) => Row[];
   groupId: string;
   isShownOnBoard: boolean;
-  onColumnTemporarilyShownChange: (columnId: string, shown: boolean) => void;
+  automaticallyHidden: boolean;
 }) {
   const { t } = useTranslation();
   const { header } = useRenderColumn(id, fieldId);
@@ -38,7 +38,7 @@ function HiddenColumnItem({
   }, [getRows]);
 
   const [hover, setHover] = useState(false);
-  const toggleHidden = useToggleHiddenGroupColumnDispatch(groupId, fieldId);
+  const setColumnRendered = useSetBoardColumnRenderedDispatch(groupId, fieldId);
 
   return (
     <div
@@ -55,7 +55,9 @@ function HiddenColumnItem({
       <DragItem id={id}>
         <HiddenItemMenu getRows={getRows}>
           <div className={'flex w-full items-center gap-1.5'}>
-            <div data-testid={'board-hidden-group-name'} className={'w-auto max-w-[150px] overflow-hidden'}>{header}</div>
+            <div data-testid={'board-hidden-group-name'} className={'w-auto max-w-[150px] overflow-hidden'}>
+              {header}
+            </div>
             <span className={'text-xs text-text-secondary'}>{count}</span>
 
             <Button
@@ -68,8 +70,7 @@ function HiddenColumnItem({
                 e.stopPropagation();
                 const shouldShow = !isShownOnBoard;
 
-                onColumnTemporarilyShownChange(id, shouldShow);
-                toggleHidden(id, !shouldShow);
+                setColumnRendered(id, shouldShow, automaticallyHidden);
               }}
             >
               {isShownOnBoard ? <HideIcon className={'h-5 w-5'} /> : <ShowIcon className={'h-5 w-5'} />}

--- a/src/components/database/components/board/column/HiddenGroupColumn.tsx
+++ b/src/components/database/components/board/column/HiddenGroupColumn.tsx
@@ -12,18 +12,16 @@ function HiddenGroupColumn({
   getRows,
   groupRowsReady,
   shownColumnIds,
-  onColumnTemporarilyShownChange,
 }: {
   groupId: string;
   fieldId: string;
   getRows: (id: string) => Row[];
   groupRowsReady: boolean;
   shownColumnIds: ReadonlySet<string>;
-  onColumnTemporarilyShownChange: (columnId: string, shown: boolean) => void;
 }) {
   const getRowCount = useCallback((columnId: string) => getRows(columnId).length, [getRows]);
   const { hiddenColumns } = useGetBoardHiddenGroup(groupId, getRowCount, groupRowsReady);
-  const { isCollapsed } = useBoardLayoutSettings();
+  const { hideEmptyGroups, isCollapsed } = useBoardLayoutSettings();
   const reorderColumn = useReorderGroupColumnDispatch(groupId);
   const onReorder = useCallback(
     ({
@@ -79,7 +77,7 @@ function HiddenGroupColumn({
                 getRows={getRows}
                 groupId={groupId}
                 isShownOnBoard={shownColumnIds.has(column.id)}
-                onColumnTemporarilyShownChange={onColumnTemporarilyShownChange}
+                automaticallyHidden={groupRowsReady && hideEmptyGroups && getRows(column.id).length === 0}
               />
             ))}
           </div>

--- a/src/components/database/components/board/column/__tests__/HiddenColumnItem.test.tsx
+++ b/src/components/database/components/board/column/__tests__/HiddenColumnItem.test.tsx
@@ -1,7 +1,7 @@
 import { fireEvent, render, screen } from '@testing-library/react';
 import type React from 'react';
 
-import { useToggleHiddenGroupColumnDispatch } from '@/application/database-yjs/dispatch';
+import { useSetBoardColumnRenderedDispatch } from '@/application/database-yjs/dispatch';
 
 import HiddenColumnItem from '../HiddenColumnItem';
 
@@ -12,7 +12,7 @@ jest.mock('react-i18next', () => ({
 }));
 
 jest.mock('@/application/database-yjs/dispatch', () => ({
-  useToggleHiddenGroupColumnDispatch: jest.fn(),
+  useSetBoardColumnRenderedDispatch: jest.fn(),
 }));
 
 jest.mock('@/components/database/components/board/column/useRenderColumn', () => ({
@@ -28,35 +28,32 @@ jest.mock('@/components/database/components/board/column/HiddenItemMenu', () => 
   HiddenItemMenu: ({ children }: { children: React.ReactNode }) => <>{children}</>,
 }));
 
-const mockUseToggleHiddenGroupColumnDispatch = useToggleHiddenGroupColumnDispatch as jest.MockedFunction<
-  typeof useToggleHiddenGroupColumnDispatch
+const mockUseSetBoardColumnRenderedDispatch = useSetBoardColumnRenderedDispatch as jest.MockedFunction<
+  typeof useSetBoardColumnRenderedDispatch
 >;
 
 describe('HiddenColumnItem', () => {
   it('shows an auto-hidden group on the first eye click and hides it on the second', () => {
-    const toggleHidden = jest.fn();
-    const onColumnTemporarilyShownChange = jest.fn();
+    const setColumnRendered = jest.fn();
     const baseProps = {
       fieldId: 'status-field',
       getRows: () => [],
       groupId: 'board-group',
       id: 'empty-group',
-      onColumnTemporarilyShownChange,
+      automaticallyHidden: true,
     };
 
-    mockUseToggleHiddenGroupColumnDispatch.mockReturnValue(toggleHidden);
+    mockUseSetBoardColumnRenderedDispatch.mockReturnValue(setColumnRendered);
 
     const { rerender } = render(<HiddenColumnItem {...baseProps} isShownOnBoard={false} />);
 
     fireEvent.click(screen.getByRole('button', { name: 'board.mobile.showGroup' }));
 
-    expect(onColumnTemporarilyShownChange).toHaveBeenLastCalledWith('empty-group', true);
-    expect(toggleHidden).toHaveBeenLastCalledWith('empty-group', false);
+    expect(setColumnRendered).toHaveBeenLastCalledWith('empty-group', true, true);
 
     rerender(<HiddenColumnItem {...baseProps} isShownOnBoard />);
     fireEvent.click(screen.getByRole('button', { name: 'board.column.hideColumn' }));
 
-    expect(onColumnTemporarilyShownChange).toHaveBeenLastCalledWith('empty-group', false);
-    expect(toggleHidden).toHaveBeenLastCalledWith('empty-group', true);
+    expect(setColumnRendered).toHaveBeenLastCalledWith('empty-group', false, true);
   });
 });

--- a/src/components/database/components/board/group/Columns.tsx
+++ b/src/components/database/components/board/group/Columns.tsx
@@ -14,9 +14,8 @@ const Columns = forwardRef<
     addCardBefore: (id: string) => void;
     groupId: string;
     groupRowsReady: boolean;
-    onColumnTemporarilyShownChange: (columnId: string, shown: boolean) => void;
   }
->(({ columns, groupResult, fieldId, groupRowsReady, onColumnTemporarilyShownChange, ...props }, ref) => {
+>(({ columns, groupResult, fieldId, groupRowsReady, ...props }, ref) => {
   const fieldType = useFieldType(fieldId);
   const isSelectField = useMemo(() => {
     return [FieldType.SingleSelect, FieldType.MultiSelect].includes(fieldType);
@@ -58,7 +57,6 @@ const Columns = forwardRef<
           getRows={getRows}
           groupRowsReady={groupRowsReady}
           shownColumnIds={shownColumnIds}
-          onColumnTemporarilyShownChange={onColumnTemporarilyShownChange}
         />
       )}
 

--- a/src/components/database/components/board/group/Group.tsx
+++ b/src/components/database/components/board/group/Group.tsx
@@ -22,11 +22,7 @@ export interface GroupProps {
 }
 
 export const Group = ({ groupId }: GroupProps) => {
-  const [temporarilyShownColumnIds, setTemporarilyShownColumnIds] = useState<ReadonlySet<string>>(() => new Set());
-  const { columns, groupResult, fieldId, groupRowsReady, hideEmptyGroups, notFound } = useRowsByGroup(
-    groupId,
-    temporarilyShownColumnIds
-  );
+  const { columns, groupResult, fieldId, groupRowsReady, notFound } = useRowsByGroup(groupId);
   const { t } = useTranslation();
   const context = useDatabaseContext();
   const { paddingStart, paddingEnd, navigateToRow } = context;
@@ -43,31 +39,6 @@ export const Group = ({ groupId }: GroupProps) => {
   const [element, setElement] = useState<HTMLElement | null>(null);
   const [deleteConfirm, setDeleteConfirm] = useState(false);
   const deleteRowIdsRef = useRef<string[]>([]);
-  const previousHideEmptyGroupsRef = useRef(hideEmptyGroups);
-
-  const setColumnTemporarilyShown = useCallback((columnId: string, shown: boolean) => {
-    setTemporarilyShownColumnIds((currentIds) => {
-      if (currentIds.has(columnId) === shown) return currentIds;
-
-      const nextIds = new Set(currentIds);
-
-      if (shown) {
-        nextIds.add(columnId);
-      } else {
-        nextIds.delete(columnId);
-      }
-
-      return nextIds;
-    });
-  }, []);
-
-  useEffect(() => {
-    if (previousHideEmptyGroupsRef.current === hideEmptyGroups) return;
-
-    previousHideEmptyGroupsRef.current = hideEmptyGroups;
-    setTemporarilyShownColumnIds(new Set());
-  }, [hideEmptyGroups]);
-
   const onDeleteCards = useCallback((ids: string[]) => {
     const rowIds = ids.map((id) => id.split('/')[1]);
 
@@ -120,15 +91,18 @@ export const Group = ({ groupId }: GroupProps) => {
   const innerRef = useRef<HTMLDivElement | null>(null);
   const stickyHeaderRef = useRef<HTMLDivElement>(null);
 
-  const handleRefCallback = useCallback((el: HTMLDivElement | null) => {
-    ref.current = el;
-    if (!el) return;
-    const container = getVerticalScrollContainer(el);
+  const handleRefCallback = useCallback(
+    (el: HTMLDivElement | null) => {
+      ref.current = el;
+      if (!el) return;
+      const container = getVerticalScrollContainer(el);
 
-    if (!container) return;
-    setVerticalScrollContainer(container);
-    setElement(el);
-  }, [getVerticalScrollContainer, ref]);
+      if (!container) return;
+      setVerticalScrollContainer(container);
+      setElement(el);
+    },
+    [getVerticalScrollContainer, ref]
+  );
 
   const handleScroll = useCallback((e: React.UIEvent<HTMLDivElement>) => {
     const scrollLeft = e.currentTarget.scrollLeft;
@@ -149,12 +123,15 @@ export const Group = ({ groupId }: GroupProps) => {
     });
   }, []);
 
-  const handleScrollLeft = useCallback((scrollLeft: number) => {
-    ref.current?.scrollTo({
-      left: scrollLeft,
-      behavior: 'auto',
-    });
-  }, [ref]);
+  const handleScrollLeft = useCallback(
+    (scrollLeft: number) => {
+      ref.current?.scrollTo({
+        left: scrollLeft,
+        behavior: 'auto',
+      });
+    },
+    [ref]
+  );
 
   const handleCloseDeleteConfirm = useCallback(() => {
     setDeleteConfirm(false);
@@ -273,7 +250,6 @@ export const Group = ({ groupId }: GroupProps) => {
             columns={columns}
             ref={innerRef}
             addCardBefore={addCardBefore}
-            onColumnTemporarilyShownChange={setColumnTemporarilyShown}
           />
         </div>
         <DatabaseStickyTopOverlay>

--- a/src/components/database/components/settings/BoardSettingGroup.tsx
+++ b/src/components/database/components/settings/BoardSettingGroup.tsx
@@ -54,6 +54,7 @@ function BoardSettingGroup () {
       </DropdownMenuSubTrigger>
       <DropdownMenuPortal>
         <DropdownMenuSubContent
+          data-testid={'board-group-settings-menu'}
           className={'max-w-[240px] appflowy-scroller overflow-y-auto'}
         >
           {fieldType !== FieldType.Checkbox && (
@@ -95,6 +96,7 @@ function BoardSettingGroup () {
           <DropdownMenuLabel>{t('board.groupBy')}</DropdownMenuLabel>
           {properties.map(property => (
             <DropdownMenuItem
+              data-testid={'board-group-by-field'}
               key={property.id}
               className={'w-full'}
               onSelect={(e) => {
@@ -102,8 +104,8 @@ function BoardSettingGroup () {
                 groupBy(property.id);
               }}
             >
-              <FieldDisplay fieldId={property.id} />
-              {fieldId === property.id && <DropdownMenuItemTick />}
+              <FieldDisplay data-testid={'board-group-by-field-name'} fieldId={property.id} />
+              {fieldId === property.id && <DropdownMenuItemTick data-testid={'board-group-by-field-selected'} />}
 
             </DropdownMenuItem>
           ))}


### PR DESCRIPTION
## Summary
- align Board hidden-empty-group Playwright coverage with the Flutter regressions
- verify the setting and hidden group remain available after reopening the database
- strictly assert show/hide eye state from the rendered Board column
- verify initial and newly added Board views cannot be ungrouped and select Status
- add stable Board Group settings selectors for strict UI assertions

## Validation
- focused Playwright BDD suite: 3 passed
- focused Jest suites: 10 passed
- pnpm lint
- pnpm type-check
- Playwright BDD generation

## Summary by Sourcery

Strengthen Board view grouping and hidden empty group behavior validation in Playwright BDD and UI.

New Features:
- Introduce Board grouping defaults feature coverage to enforce always-grouped Board views with Status as default.

Enhancements:
- Expose stable test IDs for Board group settings menu, group-by field rows, names, and selection state to support strict UI assertions.

Tests:
- Add BDD scenarios ensuring hidden empty Board groups persist and remain controllable after reopening the database.
- Add BDD coverage to verify Board Hidden Groups eye state matches rendered empty column visibility.
- Add BDD coverage to ensure Board views cannot be ungrouped and that initial and new views default to Status grouping.