### PR TITLE
fix: open published database row pages without AppProvider

### DIFF
--- a/playwright/bdd/features/database/board-hidden-empty-groups.feature
+++ b/playwright/bdd/features/database/board-hidden-empty-groups.feature
@@ -43,6 +43,7 @@ Feature: Board hidden empty groups
     And I expand the Board Hidden Groups section
     Then the other web client has no visible column named "BDD Shared Empty Group"
     And the other web client's Hidden Groups has exactly one "BDD Shared Empty Group" row with only a show action
+
     When I click the show action for hidden Board group "BDD Shared Empty Group"
     Then the Board has exactly one visible empty column named "BDD Shared Empty Group"
     And Hidden Groups has exactly one "BDD Shared Empty Group" row with only a hide action
@@ -53,3 +54,13 @@ Feature: Board hidden empty groups
     And Hidden Groups has exactly one "BDD Shared Empty Group" row with only a show action
     And the other web client has no visible column named "BDD Shared Empty Group"
     And the other web client's Hidden Groups has exactly one "BDD Shared Empty Group" row with only a show action
+
+  Scenario: A remotely created card appears without revealing empty groups
+    Given a Board database is open for group behavior testing
+    And an empty Board group named "BDD Remote Empty Group" exists
+    And another web client opens the same Board database
+    When I enable Hide empty groups for the Board
+    And I add a Board card named "BDD Remote Card" to the "To Do" column
+    Then the other web client has exactly one "BDD Remote Card" card in the "To Do" column
+    And the other web client has no visible column named "BDD Remote Empty Group"
+    And the other web client's Hidden Groups has exactly one "BDD Remote Empty Group" row with only a show action

--- a/playwright/bdd/features/database/board-hidden-empty-groups.feature
+++ b/playwright/bdd/features/database/board-hidden-empty-groups.feature
@@ -60,7 +60,10 @@ Feature: Board hidden empty groups
     And an empty Board group named "BDD Remote Empty Group" exists
     And another web client opens the same Board database
     When I enable Hide empty groups for the Board
+    Then the other web client has no visible column named "BDD Remote Empty Group"
+    When the other web client starts watching Board group "BDD Remote Empty Group" for visibility flicker
     And I add a Board card named "BDD Remote Card" to the "To Do" column
     Then the other web client has exactly one "BDD Remote Card" card in the "To Do" column
+    And Board group "BDD Remote Empty Group" never became visible on the other web client
     And the other web client has no visible column named "BDD Remote Empty Group"
     And the other web client's Hidden Groups has exactly one "BDD Remote Empty Group" row with only a show action

--- a/playwright/bdd/features/database/published-row-document.feature
+++ b/playwright/bdd/features/database/published-row-document.feature
@@ -1,0 +1,11 @@
+@issue-1645
+Feature: Published database row document
+  A database row containing page content must open from a public published link.
+  Published routes do not mount the authenticated AppProvider, so editor features
+  used by the row document must tolerate the missing app-only event emitter.
+
+  Scenario: Opening a published row document does not require AppProvider
+    Given a public database snapshot contains a row document
+    When I open the public database snapshot
+    And I open the published database row
+    Then the published row document opens without an AppProvider error

--- a/playwright/bdd/features/database/row-document.feature
+++ b/playwright/bdd/features/database/row-document.feature
@@ -18,6 +18,15 @@ Feature: Database row document
     And I close the card row page
     Then the other web client shows exactly one row document icon for the card
 
+  Scenario: A newly ordered card reconciles its row document metadata without reload
+    Given a board database is open before the synchronized card is created
+    And another web client opens the Board before the synchronized card is created
+    When I create the synchronized card
+    Then the other web client shows no row document icon for the card
+    When I add image link "https://example.com/newly-ordered-row-page-image.png" to the card row page
+    And I close the card row page
+    Then the other web client shows exactly one row document icon for the card
+
   Scenario: Duplicating an inline grid block in a row page creates an independent database
     Given a grid database is open for row-page inline grid duplication
     When I open the first row as a full row page

--- a/playwright/bdd/features/database/row-document.feature
+++ b/playwright/bdd/features/database/row-document.feature
@@ -10,6 +10,14 @@ Feature: Database row document
     When I switch the database to a new Grid view
     Then the grid primary cell shows a row document icon
 
+  Scenario: Row document indicator synchronizes to another Board client
+    Given a board database with a card is open
+    And another web client opens the same card Board
+    Then the other web client shows no row document icon for the card
+    When I add image link "https://example.com/synced-row-page-image.png" to the card row page
+    And I close the card row page
+    Then the other web client shows exactly one row document icon for the card
+
   Scenario: Duplicating an inline grid block in a row page creates an independent database
     Given a grid database is open for row-page inline grid duplication
     When I open the first row as a full row page

--- a/playwright/bdd/steps/board-hidden-empty-groups.steps.ts
+++ b/playwright/bdd/steps/board-hidden-empty-groups.steps.ts
@@ -246,6 +246,31 @@ When('I add another Board view from the database tab bar', async ({ page }) => {
   await expect(BoardSelectors.mainColumns(page)).toBeVisible();
 });
 
+When(
+  'I add a Board card named {string} to the {string} column',
+  async ({ page }, cardName: string, groupName: string) => {
+    const column = BoardSelectors.columnByName(page, groupName);
+
+    await expect(column).toHaveCount(1);
+    await expect(column).toBeVisible();
+    await column.getByText('New', { exact: true }).click();
+    await page.keyboard.type(cardName);
+    await page.keyboard.press('Enter');
+    await expect(column.locator('.board-card').filter({ hasText: cardName })).toHaveCount(1, { timeout: 15_000 });
+  }
+);
+
+Then(
+  'the other web client has exactly one {string} card in the {string} column',
+  async ({ page }, cardName: string, groupName: string) => {
+    const column = BoardSelectors.columnByName(requireSecondPage(page), groupName);
+
+    await expect(column).toHaveCount(1, { timeout: 30_000 });
+    await expect(column).toBeVisible({ timeout: 30_000 });
+    await expect(column.locator('.board-card').filter({ hasText: cardName })).toHaveCount(1, { timeout: 30_000 });
+  }
+);
+
 async function expectExactEmptyBoardColumn(page: Page, groupName: string, timeout = 5000) {
   const column = BoardSelectors.columnByName(page, groupName);
 

--- a/playwright/bdd/steps/board-hidden-empty-groups.steps.ts
+++ b/playwright/bdd/steps/board-hidden-empty-groups.steps.ts
@@ -17,6 +17,16 @@ const stateByPage = new WeakMap<Page, BoardHiddenGroupsState>();
 After(async ({ page }) => {
   const state = stateByPage.get(page);
 
+  if (state?.secondPage && !state.secondPage.isClosed()) {
+    await state.secondPage.evaluate(() => {
+      const watchedWindow = window as typeof window & {
+        __boardVisibilityWatches?: Record<string, { observer: MutationObserver }>;
+      };
+
+      Object.values(watchedWindow.__boardVisibilityWatches ?? {}).forEach(({ observer }) => observer.disconnect());
+      delete watchedWindow.__boardVisibilityWatches;
+    });
+  }
   await state?.secondContext?.close();
   stateByPage.delete(page);
 });
@@ -270,6 +280,69 @@ Then(
     await expect(column.locator('.board-card').filter({ hasText: cardName })).toHaveCount(1, { timeout: 30_000 });
   }
 );
+
+When(
+  'the other web client starts watching Board group {string} for visibility flicker',
+  async ({ page }, groupName: string) => {
+    const secondPage = requireSecondPage(page);
+
+    await expect(BoardSelectors.columnByName(secondPage, groupName)).toHaveCount(0);
+    await secondPage.evaluate((watchedGroupName) => {
+      const watchedWindow = window as typeof window & {
+        __boardVisibilityWatches?: Record<string, { everVisible: boolean; observer: MutationObserver }>;
+      };
+      const isVisible = () =>
+        [...document.querySelectorAll<HTMLElement>('[data-testid="board-column"]')].some((column) => {
+          const name = column.querySelector<HTMLElement>('[data-testid="board-column-name"]');
+
+          return name?.textContent?.trim() === watchedGroupName && column.getClientRects().length > 0;
+        });
+      const containsWatchedColumn = (node: Node) => {
+        if (!(node instanceof Element)) return false;
+        const columns = [
+          ...(node.matches('[data-testid="board-column"]') ? [node] : []),
+          ...node.querySelectorAll('[data-testid="board-column"]'),
+        ];
+
+        return columns.some(
+          (column) =>
+            column.querySelector<HTMLElement>('[data-testid="board-column-name"]')?.textContent?.trim() ===
+            watchedGroupName
+        );
+      };
+      const watch = {
+        everVisible: false,
+        observer: new MutationObserver((records) => {
+          const added = records.some((record) => [...record.addedNodes].some(containsWatchedColumn));
+
+          watch.everVisible ||= added || isVisible();
+        }),
+      };
+
+      watch.everVisible = isVisible();
+      watch.observer.observe(document.body, {
+        attributes: true,
+        attributeFilter: ['class', 'style', 'hidden', 'aria-hidden'],
+        childList: true,
+        subtree: true,
+      });
+      watchedWindow.__boardVisibilityWatches ??= {};
+      watchedWindow.__boardVisibilityWatches[watchedGroupName] = watch;
+    }, groupName);
+  }
+);
+
+Then('Board group {string} never became visible on the other web client', async ({ page }, groupName: string) => {
+  const everVisible = await requireSecondPage(page).evaluate((watchedGroupName) => {
+    const watchedWindow = window as typeof window & {
+      __boardVisibilityWatches?: Record<string, { everVisible: boolean }>;
+    };
+
+    return watchedWindow.__boardVisibilityWatches?.[watchedGroupName]?.everVisible;
+  }, groupName);
+
+  expect(everVisible, `Board group "${groupName}" became visible during remote row hydration`).toBe(false);
+});
 
 async function expectExactEmptyBoardColumn(page: Page, groupName: string, timeout = 5000) {
   const column = BoardSelectors.columnByName(page, groupName);

--- a/playwright/bdd/steps/database-row-document.steps.ts
+++ b/playwright/bdd/steps/database-row-document.steps.ts
@@ -1,4 +1,4 @@
-import { expect, Locator, Page, Route } from '@playwright/test';
+import { BrowserContext, expect, Locator, Page, Route } from '@playwright/test';
 import { createBdd } from 'playwright-bdd';
 import { v4 as uuidv4 } from 'uuid';
 
@@ -22,10 +22,16 @@ import {
 } from '../../support/selectors';
 import { generateRandomEmail, setupPageErrorHandling } from '../../support/test-config';
 
-const { Given, When, Then } = createBdd();
+const { Given, When, Then, After } = createBdd();
 
 const cardNamesByPage = new WeakMap<Page, string>();
 const rowInlineGridStateByPage = new WeakMap<Page, RowInlineGridState>();
+const secondCardClientByPage = new WeakMap<Page, { context: BrowserContext; page: Page }>();
+
+After(async ({ page }) => {
+  await secondCardClientByPage.get(page)?.context.close();
+  secondCardClientByPage.delete(page);
+});
 
 interface DatabaseBlockState {
   blockId?: string;
@@ -60,6 +66,24 @@ Given('a board database with a card is open', async ({ page, request }) => {
 
   await addNewCard(page, currentCardName);
   await expect(cardByName(page, currentCardName)).toBeVisible({ timeout: 15000 });
+});
+
+Given('another web client opens the same card Board', async ({ page, browser }) => {
+  const currentCardName = getCurrentCardName(page);
+  const context = await browser.newContext({
+    baseURL: new URL(page.url()).origin,
+    storageState: await page.context().storageState({ indexedDB: true }),
+    viewport: { width: 1440, height: 900 },
+  });
+  const secondPage = await context.newPage();
+
+  secondCardClientByPage.set(page, { context, page: secondPage });
+  setupPageErrorHandling(secondPage);
+
+  await secondPage.goto(page.url(), { waitUntil: 'domcontentloaded' });
+  await expect(BoardSelectors.boardContainer(secondPage)).toHaveCount(1, { timeout: 30000 });
+  await expect(cardByName(secondPage, currentCardName)).toHaveCount(1, { timeout: 30000 });
+  await expect(cardByName(secondPage, currentCardName)).toBeVisible({ timeout: 30000 });
 });
 
 When('I add image link {string} to the card row page', async ({ page }, imageUrl: string) => {
@@ -116,6 +140,38 @@ Then('the grid primary cell shows a row document icon', async ({ page }) => {
 
   await expect(row).toBeVisible({ timeout: 15000 });
   await expect(row.locator('.custom-icon')).toBeVisible({ timeout: 15000 });
+});
+
+Then('the other web client shows no row document icon for the card', async ({ page }) => {
+  const currentCardName = getCurrentCardName(page);
+  const secondPage = secondCardClientByPage.get(page)?.page;
+
+  if (!secondPage) {
+    throw new Error('Expected another web client to have opened the Board');
+  }
+
+  const card = cardByName(secondPage, currentCardName);
+
+  await expect(card).toHaveCount(1, { timeout: 30000 });
+  await expect(card).toBeVisible({ timeout: 30000 });
+  await expect(card.locator('[data-testid^="row-document-icon-"]')).toHaveCount(0);
+});
+
+Then('the other web client shows exactly one row document icon for the card', async ({ page }) => {
+  const currentCardName = getCurrentCardName(page);
+  const secondPage = secondCardClientByPage.get(page)?.page;
+
+  if (!secondPage) {
+    throw new Error('Expected another web client to have opened the Board');
+  }
+
+  const card = cardByName(secondPage, currentCardName);
+  const documentIcon = card.locator('[data-testid^="row-document-icon-"]');
+
+  await expect(card).toHaveCount(1, { timeout: 30000 });
+  await expect(card).toBeVisible({ timeout: 30000 });
+  await expect(documentIcon).toHaveCount(1, { timeout: 30000 });
+  await expect(documentIcon).toBeVisible({ timeout: 30000 });
 });
 
 Given('a grid database is open for row-page inline grid duplication', async ({ page, request }) => {

--- a/playwright/bdd/steps/database-row-document.steps.ts
+++ b/playwright/bdd/steps/database-row-document.steps.ts
@@ -68,6 +68,20 @@ Given('a board database with a card is open', async ({ page, request }) => {
   await expect(cardByName(page, currentCardName)).toBeVisible({ timeout: 15000 });
 });
 
+Given('a board database is open before the synchronized card is created', async ({ page, request }) => {
+  const currentCardName = `NewRemoteCard-${uuidv4().slice(0, 6)}`;
+
+  cardNamesByPage.set(page, currentCardName);
+
+  await signInAndCreateDatabaseView(page, request, generateRandomEmail(), 'Board', {
+    createWaitMs: 7000,
+    verify: async (p) => {
+      await expect(BoardSelectors.boardContainer(p)).toHaveCount(1, { timeout: 15000 });
+      await expect(BoardSelectors.boardContainer(p)).toBeVisible({ timeout: 15000 });
+    },
+  });
+});
+
 Given('another web client opens the same card Board', async ({ page, browser }) => {
   const currentCardName = getCurrentCardName(page);
   const context = await browser.newContext({
@@ -82,8 +96,32 @@ Given('another web client opens the same card Board', async ({ page, browser }) 
 
   await secondPage.goto(page.url(), { waitUntil: 'domcontentloaded' });
   await expect(BoardSelectors.boardContainer(secondPage)).toHaveCount(1, { timeout: 30000 });
-  await expect(cardByName(secondPage, currentCardName)).toHaveCount(1, { timeout: 30000 });
+  await expect(cardsByName(secondPage, currentCardName)).toHaveCount(1, { timeout: 30000 });
   await expect(cardByName(secondPage, currentCardName)).toBeVisible({ timeout: 30000 });
+});
+
+Given('another web client opens the Board before the synchronized card is created', async ({ page, browser }) => {
+  const context = await browser.newContext({
+    baseURL: new URL(page.url()).origin,
+    storageState: await page.context().storageState({ indexedDB: true }),
+    viewport: { width: 1440, height: 900 },
+  });
+  const secondPage = await context.newPage();
+
+  secondCardClientByPage.set(page, { context, page: secondPage });
+  setupPageErrorHandling(secondPage);
+
+  await secondPage.goto(page.url(), { waitUntil: 'domcontentloaded' });
+  await expect(BoardSelectors.boardContainer(secondPage)).toHaveCount(1, { timeout: 30000 });
+  await expect(BoardSelectors.boardContainer(secondPage)).toBeVisible({ timeout: 30000 });
+});
+
+When('I create the synchronized card', async ({ page }) => {
+  const currentCardName = getCurrentCardName(page);
+
+  await addNewCard(page, currentCardName);
+  await expect(cardsByName(page, currentCardName)).toHaveCount(1, { timeout: 15000 });
+  await expect(cardByName(page, currentCardName)).toBeVisible({ timeout: 15000 });
 });
 
 When('I add image link {string} to the card row page', async ({ page }, imageUrl: string) => {
@@ -150,9 +188,10 @@ Then('the other web client shows no row document icon for the card', async ({ pa
     throw new Error('Expected another web client to have opened the Board');
   }
 
-  const card = cardByName(secondPage, currentCardName);
+  const cards = cardsByName(secondPage, currentCardName);
+  const card = cards.first();
 
-  await expect(card).toHaveCount(1, { timeout: 30000 });
+  await expect(cards).toHaveCount(1, { timeout: 30000 });
   await expect(card).toBeVisible({ timeout: 30000 });
   await expect(card.locator('[data-testid^="row-document-icon-"]')).toHaveCount(0);
 });
@@ -165,10 +204,11 @@ Then('the other web client shows exactly one row document icon for the card', as
     throw new Error('Expected another web client to have opened the Board');
   }
 
-  const card = cardByName(secondPage, currentCardName);
+  const cards = cardsByName(secondPage, currentCardName);
+  const card = cards.first();
   const documentIcon = card.locator('[data-testid^="row-document-icon-"]');
 
-  await expect(card).toHaveCount(1, { timeout: 30000 });
+  await expect(cards).toHaveCount(1, { timeout: 30000 });
   await expect(card).toBeVisible({ timeout: 30000 });
   await expect(documentIcon).toHaveCount(1, { timeout: 30000 });
   await expect(documentIcon).toBeVisible({ timeout: 30000 });
@@ -370,7 +410,11 @@ async function focusRowDocumentEditor(page: Page) {
 }
 
 function cardByName(page: Page, cardName: string) {
-  return BoardSelectors.boardContainer(page).locator('.board-card').filter({ hasText: cardName }).first();
+  return cardsByName(page, cardName).first();
+}
+
+function cardsByName(page: Page, cardName: string) {
+  return BoardSelectors.boardContainer(page).locator('.board-card').filter({ hasText: cardName });
 }
 
 function getCurrentCardName(page: Page) {

--- a/playwright/bdd/steps/published-row-document.steps.ts
+++ b/playwright/bdd/steps/published-row-document.steps.ts
@@ -1,0 +1,186 @@
+import { expect, Page } from '@playwright/test';
+import { createBdd } from 'playwright-bdd';
+import { v5 as uuidv5 } from 'uuid';
+
+import { RowMetaKey } from '../../../src/application/database-yjs/database.type';
+import {
+  publishedDatabasePayload,
+  publishedRowDocumentId,
+} from '../../../src/application/publish-snapshot/__fixtures__/published-page-snapshots';
+import type {
+  PublishedDatabaseSnapshotPayload,
+  PublishedJsonObject,
+} from '../../../src/application/publish-snapshot/types';
+import { YjsDatabaseKey, YjsEditorKey } from '../../../src/application/types';
+import { DatabaseGridSelectors } from '../../support/selectors';
+
+const { Given, When, Then } = createBdd();
+
+const ISSUE_NAMESPACE = 'issue-1645';
+const ISSUE_PUBLISH_NAME = 'published-row-document';
+const ISSUE_ROW_ID = '16450000-0000-4000-8000-000000000001';
+const ISSUE_ROW_DOCUMENT_ID = uuidv5(RowMetaKey.DocumentId, ISSUE_ROW_ID);
+const ISSUE_ROW_DOCUMENT_CONTENT = 'Published row document body';
+const APP_PROVIDER_ERROR = 'useEventEmitter must be used within an AppProvider';
+
+interface Issue1645State {
+  browserErrors: string[];
+}
+
+const issueStateByPage = new WeakMap<Page, Issue1645State>();
+
+Given('a public database snapshot contains a row document', async ({ page }) => {
+  const state: Issue1645State = { browserErrors: [] };
+
+  issueStateByPage.set(page, state);
+  page.on('pageerror', (error) => state.browserErrors.push(error.message));
+  page.on('console', (message) => {
+    if (message.type() === 'error') {
+      state.browserErrors.push(message.text());
+    }
+  });
+
+  const snapshot = createIssue1645Snapshot();
+  const corsHeaders = {
+    'access-control-allow-origin': '*',
+    'content-type': 'application/json',
+  };
+
+  await page.route(`**/api/workspace/v2/published/${ISSUE_NAMESPACE}/${ISSUE_PUBLISH_NAME}/snapshot`, async (route) => {
+    await route.fulfill({
+      status: 200,
+      headers: corsHeaders,
+      body: JSON.stringify({ code: 0, data: snapshot, message: '' }),
+    });
+  });
+
+  await page.route('**/api/workspace/v1/published-info/*', async (route) => {
+    await route.fulfill({
+      status: 200,
+      headers: corsHeaders,
+      body: JSON.stringify({
+        code: 0,
+        data: {
+          namespace: ISSUE_NAMESPACE,
+          publish_name: ISSUE_PUBLISH_NAME,
+          publisher_email: 'publisher@example.com',
+          view_id: snapshot.view.viewId,
+          publish_timestamp: new Date(0).toISOString(),
+          comments_enabled: false,
+          duplicate_enabled: false,
+        },
+        message: '',
+      }),
+    });
+  });
+
+  await page.route(`**/api/workspace/published-outline/${ISSUE_NAMESPACE}`, async (route) => {
+    await route.fulfill({
+      status: 200,
+      headers: corsHeaders,
+      body: JSON.stringify({ code: 0, data: { children: [] }, message: '' }),
+    });
+  });
+});
+
+When('I open the public database snapshot', async ({ page }) => {
+  await page.goto(`/${ISSUE_NAMESPACE}/${ISSUE_PUBLISH_NAME}`, { waitUntil: 'domcontentloaded' });
+
+  await expect(DatabaseGridSelectors.grid(page)).toBeVisible({ timeout: 15000 });
+  await expect(DatabaseGridSelectors.rowById(page, ISSUE_ROW_ID)).toContainText('First published row', {
+    timeout: 15000,
+  });
+});
+
+When('I open the published database row', async ({ page }) => {
+  const state = getIssueState(page);
+  const row = DatabaseGridSelectors.rowById(page, ISSUE_ROW_ID);
+
+  await row.hover();
+  const openRowButton = row.getByTestId('row-expand-button');
+
+  await expect(openRowButton).toBeVisible({ timeout: 10000 });
+  await openRowButton.click();
+  await expect
+    .poll(() => new URL(page.url()).searchParams.get('r'), {
+      timeout: 10000,
+      message: 'Expected the published database to navigate to the row page',
+    })
+    .toBe(ISSUE_ROW_ID);
+
+  // Settle on either outcome so the Then step reports the regression directly:
+  // the row content renders, or React reports the missing AppProvider context.
+  await expect
+    .poll(
+      async () => {
+        const rowDocumentVisible = await page
+          .getByText(ISSUE_ROW_DOCUMENT_CONTENT, { exact: true })
+          .isVisible()
+          .catch(() => false);
+        const providerErrorReported = state.browserErrors.some((message) => message.includes(APP_PROVIDER_ERROR));
+
+        return rowDocumentVisible || providerErrorReported;
+      },
+      {
+        timeout: 15000,
+        message: 'Expected the published row document to render or report the AppProvider regression',
+      }
+    )
+    .toBe(true);
+});
+
+Then('the published row document opens without an AppProvider error', async ({ page }) => {
+  const state = getIssueState(page);
+  const bodyText = await page.locator('body').innerText();
+  const providerErrors = [...state.browserErrors, bodyText].filter((message) => message.includes(APP_PROVIDER_ERROR));
+
+  expect(providerErrors, `Published row editor crashed: ${APP_PROVIDER_ERROR}`).toEqual([]);
+  await expect(page.getByText(ISSUE_ROW_DOCUMENT_CONTENT, { exact: true })).toBeVisible({ timeout: 15000 });
+});
+
+function getIssueState(page: Page): Issue1645State {
+  const state = issueStateByPage.get(page);
+
+  if (!state) {
+    throw new Error('Issue #1645 test state has not been initialized');
+  }
+
+  return state;
+}
+
+function createIssue1645Snapshot(): PublishedDatabaseSnapshotPayload {
+  const snapshot = structuredClone(publishedDatabasePayload);
+  const sourceRowId = snapshot.database.rows?.[0]?.rowId;
+  const raw = snapshot.database.raw;
+  const sourceRawRow = sourceRowId ? raw?.rows?.[sourceRowId] : undefined;
+  const sourceRowDocument = raw?.row_documents?.[publishedRowDocumentId];
+
+  if (!sourceRowId || !raw || !sourceRawRow || !sourceRowDocument) {
+    throw new Error('Published database fixture is missing its row document data');
+  }
+
+  snapshot.namespace = ISSUE_NAMESPACE;
+  snapshot.publishName = ISSUE_PUBLISH_NAME;
+  snapshot.database.rows = snapshot.database.rows?.map((row) => ({ ...row, rowId: ISSUE_ROW_ID }));
+  snapshot.database.views = snapshot.database.views?.map((view) => ({ ...view, rowIds: [ISSUE_ROW_ID] }));
+
+  const rawDatabaseRow = sourceRawRow[YjsEditorKey.database_row] as PublishedJsonObject | undefined;
+
+  if (!rawDatabaseRow) {
+    throw new Error('Published database fixture is missing the raw database row');
+  }
+
+  rawDatabaseRow[YjsDatabaseKey.id] = ISSUE_ROW_ID;
+  raw.rows = { [ISSUE_ROW_ID]: sourceRawRow };
+  raw.row_documents = { [ISSUE_ROW_DOCUMENT_ID]: sourceRowDocument };
+
+  const rawViews = raw.database?.[YjsDatabaseKey.views] as PublishedJsonObject | undefined;
+  const rawActiveView = rawViews?.[snapshot.database.activeViewId] as PublishedJsonObject | undefined;
+
+  if (!rawActiveView) {
+    throw new Error('Published database fixture is missing its active raw view');
+  }
+
+  rawActiveView[YjsDatabaseKey.row_orders] = [{ id: ISSUE_ROW_ID, height: 36 }];
+  return snapshot;
+}

--- a/src/application/database-blob/__tests__/prefetch-dedup.test.ts
+++ b/src/application/database-blob/__tests__/prefetch-dedup.test.ts
@@ -1,14 +1,17 @@
 import {
   prefetchDatabaseBlobDiff,
   clearDatabaseRowDocSeedCache,
+  invalidateDatabaseRowDocSeed,
   takeDatabaseRowDocSeed,
 } from '@/application/database-blob';
 import * as pageStageModule from '@/application/database-blob/page-stage';
 import type { DatabaseBlobDiffPageStage } from '@/application/database-blob/page-stage';
+import { isDatabaseRowDocSeedCurrent } from '@/application/database-blob/row-seed-fence';
 import { deleteCollabDB, openRowCollabDBWithProvider } from '@/application/db';
 import { deleteRow } from '@/application/services/js-services/cache';
 import { databaseBlobDiff } from '@/application/services/js-services/http/http_api';
 import { deleteOutboxByObjectId, getCurrentOutboxSession } from '@/application/sync-outbox';
+import { applyYDoc } from '@/application/ydoc/apply';
 import { database_blob } from '@/proto/database_blob';
 
 jest.mock('@/application/db', () => ({
@@ -51,6 +54,7 @@ const mockedOpenRowCollabDB = openRowCollabDBWithProvider as jest.MockedFunction
 const mockedDeleteRow = deleteRow as jest.MockedFunction<typeof deleteRow>;
 const mockedDeleteOutbox = deleteOutboxByObjectId as jest.MockedFunction<typeof deleteOutboxByObjectId>;
 const mockedGetCurrentOutboxSession = getCurrentOutboxSession as jest.MockedFunction<typeof getCurrentOutboxSession>;
+const mockedApplyYDoc = applyYDoc as jest.MockedFunction<typeof applyYDoc>;
 const databaseIds = new Set<string>();
 
 /** Drains the promise chain the page walk runs on, without advancing timers. */
@@ -569,6 +573,68 @@ describe('database blob prefetch deduplication', () => {
     expect(Array.from(seed?.bytes ?? [])).toEqual([1, 2, 3]);
     expect(seed?.bytes.byteLength).toBe(3);
     expect(seed?.bytes.buffer.byteLength).toBe(3);
+  });
+
+  it('fences a reset row out of a blob request that is still in flight', async () => {
+    const databaseId = 'database-reset-fence';
+    const deferred = createDeferred<database_blob.DatabaseBlobDiffResponse>();
+
+    databaseIds.add(databaseId);
+    mockedDatabaseBlobDiff.mockReturnValueOnce(deferred.promise);
+
+    const prefetch = prefetchDatabaseBlobDiff('workspace-reset-fence', databaseId);
+
+    invalidateDatabaseRowDocSeed(VALID_ROW_ID);
+    deferred.resolve(persistablePage({ timestamp: 16, seqNo: 1 }));
+    await prefetch;
+
+    expect(takeDatabaseRowDocSeed(`${databaseId}_rows_${VALID_ROW_ID}`)).toBeNull();
+    expect(mockedOpenRowCollabDB).not.toHaveBeenCalled();
+  });
+
+  it('invalidates a seed reference that a row loader already captured', async () => {
+    const databaseId = 'database-captured-reset-seed';
+
+    databaseIds.add(databaseId);
+    mockedDatabaseBlobDiff.mockResolvedValueOnce(persistablePage({ timestamp: 16, seqNo: 2 }));
+
+    await prefetchDatabaseBlobDiff('workspace-captured-reset-seed', databaseId);
+
+    const capturedSeed = takeDatabaseRowDocSeed(`${databaseId}_rows_${VALID_ROW_ID}`);
+
+    if (!capturedSeed) throw new Error('expected the row loader to capture a seed');
+    expect(isDatabaseRowDocSeedCurrent(capturedSeed)).toBe(true);
+
+    invalidateDatabaseRowDocSeed(VALID_ROW_ID);
+
+    expect(isDatabaseRowDocSeedCurrent(capturedSeed)).toBe(false);
+  });
+
+  it('rechecks the reset fence after an asynchronous row storage open', async () => {
+    const databaseId = 'database-reset-open-fence';
+    const deferredOpen = createDeferred<Awaited<ReturnType<typeof openRowCollabDBWithProvider>>>();
+    const doc = { destroy: jest.fn() };
+    const provider = { destroy: jest.fn().mockResolvedValue(undefined) };
+
+    databaseIds.add(databaseId);
+    mockedDatabaseBlobDiff.mockResolvedValueOnce(persistablePage({ timestamp: 17, seqNo: 1 }));
+    mockedOpenRowCollabDB.mockReturnValueOnce(deferredOpen.promise);
+
+    const prefetch = prefetchDatabaseBlobDiff('workspace-reset-open-fence', databaseId);
+
+    for (let attempt = 0; attempt < 5 && mockedOpenRowCollabDB.mock.calls.length === 0; attempt += 1) {
+      await flushPendingWork();
+    }
+
+    expect(mockedOpenRowCollabDB).toHaveBeenCalledTimes(1);
+    invalidateDatabaseRowDocSeed(VALID_ROW_ID);
+    deferredOpen.resolve({ doc, provider } as unknown as Awaited<ReturnType<typeof openRowCollabDBWithProvider>>);
+    await prefetch;
+
+    expect(mockedApplyYDoc).not.toHaveBeenCalled();
+    expect(provider.destroy).toHaveBeenCalledTimes(1);
+    expect(doc.destroy).toHaveBeenCalledTimes(1);
+    expect(takeDatabaseRowDocSeed(`${databaseId}_rows_${VALID_ROW_ID}`)).toBeNull();
   });
 
   it('falls back to row sync when provisional page staging fails', async () => {

--- a/src/application/database-blob/index.ts
+++ b/src/application/database-blob/index.ts
@@ -18,15 +18,15 @@ import { database_blob } from '@/proto/database_blob';
 import { Log } from '@/utils/log';
 
 import { createDatabaseBlobDiffPageStage, type DatabaseBlobDiffPageStage } from './page-stage';
+import {
+  createDatabaseRowDocSeed,
+  invalidateDatabaseRowDocSeedGeneration,
+  type DatabaseRowDocSeed,
+} from './row-seed-fence';
 
 type DatabaseBlobRowRid = {
   timestamp: number;
   seqNo: number;
-};
-
-type RowDocSeed = {
-  bytes: Uint8Array;
-  encoderVersion: number;
 };
 
 type PrefetchOptions = {
@@ -44,6 +44,8 @@ type PrefetchOptions = {
 
 type SharedPrefetchEntry = {
   priorityRowIds: Set<string>;
+  /** Rows reset after this prefetch started must not consume its stale snapshot. */
+  invalidatedRowIds: Set<string>;
   onSeedsReadyCallbacks: Set<() => void>;
   seedsReady: boolean;
   hasCompleteSeedSet: boolean;
@@ -226,10 +228,11 @@ function cursorKey(cursor: Uint8Array) {
   return cursor.join(',');
 }
 
-const rowDocSeedCache = new Map<string, RowDocSeed>();
-const rowDocSeedLookup = new Map<string, RowDocSeed>();
+const rowDocSeedCache = new Map<string, DatabaseRowDocSeed>();
+const rowDocSeedLookup = new Map<string, DatabaseRowDocSeed>();
 const rowDocSeedDocCache = new Map<string, YDoc>();
 const rowDocSeedCacheRetainCounts = new Map<string, number>();
+const ROW_KEY_SEPARATOR = '_rows_';
 
 function clearRowDocSeeds(databaseId: string, rowId: string) {
   const rowKey = getRowKey(databaseId, rowId);
@@ -244,7 +247,42 @@ function clearRowDocSeeds(databaseId: string, rowId: string) {
   }
 }
 
-function applySeedToSharedRowDoc(rowKey: string, seed: RowDocSeed) {
+/**
+ * Remove every cached seed for a row and fence it out of blob requests that
+ * started before a version reset. Row object IDs are globally unique, while
+ * the database ID is not available to the row sync reset handler.
+ */
+export function invalidateDatabaseRowDocSeed(rowId: string) {
+  if (!rowId) return;
+
+  invalidateDatabaseRowDocSeedGeneration(rowId);
+  const rowKeySuffix = `${ROW_KEY_SEPARATOR}${rowId}`;
+
+  for (const key of rowDocSeedCache.keys()) {
+    if (key.endsWith(rowKeySuffix)) {
+      rowDocSeedCache.delete(key);
+    }
+  }
+
+  for (const key of rowDocSeedLookup.keys()) {
+    if (key.endsWith(rowKeySuffix)) {
+      rowDocSeedLookup.delete(key);
+    }
+  }
+
+  for (const [key, doc] of rowDocSeedDocCache.entries()) {
+    if (key.endsWith(rowKeySuffix)) {
+      doc.destroy();
+      rowDocSeedDocCache.delete(key);
+    }
+  }
+
+  sharedPrefetchEntries.forEach((entry) => {
+    entry.invalidatedRowIds.add(rowId);
+  });
+}
+
+function applySeedToSharedRowDoc(rowKey: string, seed: DatabaseRowDocSeed) {
   const doc = rowDocSeedDocCache.get(rowKey);
 
   if (!doc) return;
@@ -267,14 +305,16 @@ function trimRowDocSeedLookup() {
   }
 }
 
-function cacheRowDocSeed(rowKey: string, docState?: database_blob.ICollabDocState | null) {
+function cacheRowDocSeed(rowKey: string, rowId: string, docState?: database_blob.ICollabDocState | null) {
   const cachedDoc = getCachedRowDoc(rowKey);
 
   if (hasRowConditionData(cachedDoc)) return;
 
-  const seed = getDocState(docState);
+  const state = getDocState(docState);
 
-  if (!seed) return;
+  if (!state) return;
+
+  const seed = createDatabaseRowDocSeed(rowId, state);
 
   applySeedToSharedRowDoc(rowKey, seed);
   rowDocSeedCache.set(rowKey, seed);
@@ -287,7 +327,7 @@ function cacheRowDocSeed(rowKey: string, docState?: database_blob.ICollabDocStat
   }
 }
 
-export function takeDatabaseRowDocSeed(rowKey: string): RowDocSeed | null {
+export function takeDatabaseRowDocSeed(rowKey: string): DatabaseRowDocSeed | null {
   const cachedSeed = rowDocSeedCache.get(rowKey);
 
   if (cachedSeed) {
@@ -328,7 +368,7 @@ export function takeDatabaseRowDocSeed(rowKey: string): RowDocSeed | null {
  * the same row seed at the same time: one to build an in-memory doc for
  * filter/sort, another to open the IndexedDB-backed row doc for rendering.
  */
-export function peekDatabaseRowDocSeed(rowKey: string): RowDocSeed | null {
+export function peekDatabaseRowDocSeed(rowKey: string): DatabaseRowDocSeed | null {
   return rowDocSeedCache.get(rowKey) ?? rowDocSeedLookup.get(rowKey) ?? null;
 }
 
@@ -503,7 +543,7 @@ function decodeRowId(rowIdBytes?: Uint8Array | null) {
   return uuidStringify(rowIdBytes);
 }
 
-function applySeedToCachedDoc(rowKey: string, seed: RowDocSeed) {
+function applySeedToCachedDoc(rowKey: string, seed: DatabaseRowDocSeed) {
   const cachedDoc = getCachedRowDoc(rowKey);
 
   if (!cachedDoc) return false;
@@ -516,7 +556,7 @@ function applySeedToCachedDoc(rowKey: string, seed: RowDocSeed) {
 function seedRowDocCacheFromDiff(
   databaseId: string,
   diff: database_blob.DatabaseBlobDiffResponse,
-  options?: PrefetchOptions
+  options?: Pick<PrefetchOptions, 'priorityRowIds'> & { invalidatedRowIds?: ReadonlySet<string> }
 ) {
   const updates = [...diff.creates, ...diff.updates];
 
@@ -527,17 +567,24 @@ function seedRowDocCacheFromDiff(
   let prioritized = 0;
   let appliedToCached = 0;
   let deleted = 0;
+  let invalidated = 0;
 
   updates.forEach((update) => {
     const rowId = decodeRowId(update.rowId);
 
     if (!rowId) return;
+    if (options?.invalidatedRowIds?.has(rowId)) {
+      invalidated += 1;
+      return;
+    }
 
     const rowKey = getRowKey(databaseId, rowId);
 
-    const seed = getDocState(update.docState);
+    const state = getDocState(update.docState);
 
-    if (!seed) return;
+    if (!state) return;
+
+    const seed = createDatabaseRowDocSeed(rowId, state);
 
     applySeedToSharedRowDoc(rowKey, seed);
     rowDocSeedLookup.set(rowKey, seed);
@@ -576,9 +623,11 @@ function seedRowDocCacheFromDiff(
 
     const rowKey = getRowKey(databaseId, rowId);
 
-    const seed = getDocState(update.docState);
+    const state = getDocState(update.docState);
 
-    if (!seed) return;
+    if (!state) return;
+
+    const seed = createDatabaseRowDocSeed(rowId, state);
 
     applySeedToSharedRowDoc(rowKey, seed);
     rowDocSeedLookup.set(rowKey, seed);
@@ -607,6 +656,11 @@ function seedRowDocCacheFromDiff(
     const rowId = decodeRowId(del.rowId);
 
     if (!rowId) return;
+    if (options?.invalidatedRowIds?.has(rowId)) {
+      invalidated += 1;
+      return;
+    }
+
     clearRowDocSeeds(databaseId, rowId);
     deleted += 1;
   });
@@ -617,6 +671,7 @@ function seedRowDocCacheFromDiff(
     priorityRequested: priorityRowIds.length,
     appliedToCached,
     deleted,
+    invalidated,
   };
 }
 
@@ -658,7 +713,7 @@ function inspectDocRowData(
 async function applyCollabUpdate(
   objectId: string,
   docState: database_blob.ICollabDocState,
-  options?: { useSharedRowStorage?: boolean }
+  options?: { useSharedRowStorage?: boolean; shouldApply?: () => boolean }
 ) {
   const state = getDocState(docState);
 
@@ -666,6 +721,8 @@ async function applyCollabUpdate(
     Log.debug('[Database] applyCollabUpdate skipped - no doc state', { objectId });
     return;
   }
+
+  if (options?.shouldApply?.() === false) return;
 
   const cachedDoc = getCachedRowDoc(objectId) || getCachedProviderDoc(objectId);
 
@@ -702,15 +759,18 @@ async function applyCollabUpdate(
     ? await openRowCollabDBWithProvider(objectId, { skipCache: true })
     : await openCollabDBWithProvider(objectId, { skipCache: true });
 
-  const beforeState = inspectDocRowData(doc, objectId);
-
   Log.debug('[Database] applyCollabUpdate IndexedDB opened', {
     objectId,
     openDurationMs: Date.now() - openStartedAt,
-    beforeApply: beforeState,
   });
 
   try {
+    // The storage open above yields. A row version reset may have invalidated
+    // this prefetch while it was pending, so check the fence again before
+    // merging any structs into the newly opened canonical document.
+    if (options?.shouldApply?.() === false) return;
+
+    const beforeState = inspectDocRowData(doc, objectId);
     const applyStartedAt = Date.now();
 
     applyYDoc(doc, state.bytes, state.encoderVersion);
@@ -721,6 +781,7 @@ async function applyCollabUpdate(
       objectId,
       bytes: state.bytes.length,
       applyDurationMs: Date.now() - applyStartedAt,
+      beforeApply: beforeState,
       afterApply: afterState,
     });
   } finally {
@@ -738,7 +799,7 @@ async function applyCollabUpdate(
 async function applyRowUpdate(
   databaseId: string,
   update: database_blob.IDatabaseBlobRowUpdate,
-  options?: { seedCache?: boolean }
+  options?: { seedCache?: boolean; invalidatedRowIds?: ReadonlySet<string> }
 ) {
   const rowId = decodeRowId(update.rowId);
 
@@ -746,6 +807,10 @@ async function applyRowUpdate(
     Log.debug('[Database] applyRowUpdate skipped - invalid rowId bytes');
     return;
   }
+
+  const isInvalidated = () => options?.invalidatedRowIds?.has(rowId) ?? false;
+
+  if (isInvalidated()) return;
 
   const rowDocState = update.docState;
   const hasRowDocState = Boolean(rowDocState?.docState?.length);
@@ -766,10 +831,15 @@ async function applyRowUpdate(
     const rowKey = getRowKey(databaseId, rowId);
 
     if (options?.seedCache !== false) {
-      cacheRowDocSeed(rowKey, rowDocState);
+      cacheRowDocSeed(rowKey, rowId, rowDocState);
     }
 
-    await applyCollabUpdate(rowId, rowDocState, { useSharedRowStorage: true });
+    await applyCollabUpdate(rowId, rowDocState, {
+      useSharedRowStorage: true,
+      shouldApply: () => !isInvalidated(),
+    });
+
+    if (isInvalidated()) return;
   }
 
   const doc = update.document;
@@ -825,13 +895,18 @@ async function applyRowUpdate(
 async function applyRowDelete(
   databaseId: string,
   deletion: database_blob.IDatabaseBlobRowDelete,
-  outboxSession: SyncOutboxSession | null
+  outboxSession: SyncOutboxSession | null,
+  invalidatedRowIds?: ReadonlySet<string>
 ) {
   const rowId = decodeRowId(deletion.rowId);
 
   if (!rowId) {
     throw new Error('database blob diff contained a delete with an invalid row ID');
   }
+
+  const isInvalidated = () => invalidatedRowIds?.has(rowId) ?? false;
+
+  if (isInvalidated()) return;
 
   const rowKey = getRowKey(databaseId, rowId);
 
@@ -843,6 +918,9 @@ async function applyRowDelete(
     }
 
     await deleteOutboxByObjectId(rowId, { session: outboxSession });
+
+    if (isInvalidated()) return;
+
     const storageDeletes = await Promise.allSettled([
       deleteCollabDB(rowId, { destroyDoc: false }),
       // Older Web clients persisted rows under the composite row key. Leaving
@@ -864,7 +942,9 @@ async function applyRowDelete(
     // deleteCollabDB must dispose its provider before deleteCachedRow evicts
     // that provider entry. The cached Y.Doc is removed even when storage
     // deletion fails, and the unchanged RID makes the next diff retry it.
-    deleteCachedRow(rowKey);
+    if (!isInvalidated()) {
+      deleteCachedRow(rowKey);
+    }
   }
 }
 
@@ -880,7 +960,11 @@ async function awaitBatch(operations: Promise<void>[]) {
 async function applyDiff(
   databaseId: string,
   diff: database_blob.DatabaseBlobDiffResponse,
-  options?: { seedCache?: boolean; outboxSession?: SyncOutboxSession | null }
+  options?: {
+    seedCache?: boolean;
+    outboxSession?: SyncOutboxSession | null;
+    invalidatedRowIds?: ReadonlySet<string>;
+  }
 ) {
   const updates = [...diff.creates, ...diff.updates];
   const totalUpdates = updates.length;
@@ -926,7 +1010,11 @@ async function applyDiff(
   for (let i = 0; i < deletes.length; i += APPLY_CONCURRENCY) {
     const batch = deletes.slice(i, i + APPLY_CONCURRENCY);
 
-    await awaitBatch(batch.map((deletion) => applyRowDelete(databaseId, deletion, options?.outboxSession ?? null)));
+    await awaitBatch(
+      batch.map((deletion) =>
+        applyRowDelete(databaseId, deletion, options?.outboxSession ?? null, options?.invalidatedRowIds)
+      )
+    );
   }
 
   Log.debug('[Database] applyDiff completed', {
@@ -942,12 +1030,13 @@ async function persistDiffToIndexedDB(
   databaseId: string,
   diff: database_blob.DatabaseBlobDiffResponse,
   source: string,
-  outboxSession: SyncOutboxSession | null
+  outboxSession: SyncOutboxSession | null,
+  invalidatedRowIds?: ReadonlySet<string>
 ): Promise<boolean> {
   const applyStartedAt = Date.now();
 
   try {
-    await applyDiff(databaseId, diff, { seedCache: false, outboxSession });
+    await applyDiff(databaseId, diff, { seedCache: false, outboxSession, invalidatedRowIds });
     Log.debug('[Database] blob diff persisted to IndexedDB', {
       databaseId,
       source,
@@ -1179,6 +1268,7 @@ export async function prefetchDatabaseBlobDiff(workspaceId: string, databaseId: 
   const cachedRid = options?.forceFullSync ? null : readCachedRid(databaseId);
   const entry: SharedPrefetchEntry = {
     priorityRowIds: new Set(),
+    invalidatedRowIds: new Set(),
     onSeedsReadyCallbacks: new Set(),
     seedsReady: false,
     hasCompleteSeedSet: false,
@@ -1190,6 +1280,7 @@ export async function prefetchDatabaseBlobDiff(workspaceId: string, databaseId: 
   const seedDiff = (diff: database_blob.DatabaseBlobDiffResponse, source: string) => {
     const seedSummary = seedRowDocCacheFromDiff(databaseId, diff, {
       priorityRowIds: Array.from(entry.priorityRowIds),
+      invalidatedRowIds: entry.invalidatedRowIds,
     });
 
     Log.debug('[Database] blob seed cache prepared', {
@@ -1248,7 +1339,8 @@ export async function prefetchDatabaseBlobDiff(workspaceId: string, databaseId: 
           databaseId,
           page,
           `${sourceLabel} page ${index + 1}/${pageCount}`,
-          outboxSession
+          outboxSession,
+          entry.invalidatedRowIds
         );
 
         allPagesPersisted = persisted && allPagesPersisted;

--- a/src/application/database-blob/row-seed-fence.ts
+++ b/src/application/database-blob/row-seed-fence.ts
@@ -1,0 +1,29 @@
+export type DatabaseRowDocSeed = {
+  bytes: Uint8Array;
+  encoderVersion: number;
+  rowId?: string;
+  generation?: number;
+};
+
+const rowSeedGenerations = new Map<string, number>();
+
+export function createDatabaseRowDocSeed(
+  rowId: string,
+  state: Pick<DatabaseRowDocSeed, 'bytes' | 'encoderVersion'>
+): DatabaseRowDocSeed {
+  return {
+    ...state,
+    rowId,
+    generation: rowSeedGenerations.get(rowId) ?? 0,
+  };
+}
+
+export function invalidateDatabaseRowDocSeedGeneration(rowId: string) {
+  rowSeedGenerations.set(rowId, (rowSeedGenerations.get(rowId) ?? 0) + 1);
+}
+
+/** Unfenced seeds remain valid for callers outside the blob prefetch path. */
+export function isDatabaseRowDocSeedCurrent(seed: DatabaseRowDocSeed) {
+  if (!seed.rowId || seed.generation === undefined) return true;
+  return seed.generation === (rowSeedGenerations.get(seed.rowId) ?? 0);
+}

--- a/src/application/database-yjs/__tests__/useRowMetaSelector.test.tsx
+++ b/src/application/database-yjs/__tests__/useRowMetaSelector.test.tsx
@@ -84,4 +84,72 @@ describe('useRowMetaSelector', () => {
       expect(result.current?.isEmptyDocument).toBe(false);
     });
   });
+
+  it('clears metadata when the canonical row doc is replaced by an empty doc', async () => {
+    const initialRowDoc = new Y.Doc() as YDoc;
+    const initialRoot = initialRowDoc.getMap(YjsEditorKey.data_section);
+    const initialMeta = new Y.Map<unknown>();
+    const replacementRowDoc = new Y.Doc() as YDoc;
+    const databaseDoc = new Y.Doc() as YDoc;
+    const isDocumentEmptyKey = getMetaIdMap(rowId).get(RowMetaKey.IsDocumentEmpty);
+
+    expect(isDocumentEmptyKey).toBeDefined();
+    initialMeta.set(isDocumentEmptyKey as string, false);
+    initialRoot.set(YjsEditorKey.meta, initialMeta);
+
+    let contextValue: DatabaseContextState = {
+      readOnly: false,
+      databaseDoc,
+      databasePageId: 'database-page-id',
+      activeViewId: 'board-view-id',
+      rowMap: { [rowId]: initialRowDoc },
+      workspaceId: 'workspace-id',
+    };
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <DatabaseContext.Provider value={contextValue}>{children}</DatabaseContext.Provider>
+    );
+    const { result, rerender, unmount } = renderHook(() => useRowMetaSelector(rowId), { wrapper });
+
+    expect(result.current?.isEmptyDocument).toBe(false);
+
+    contextValue = { ...contextValue, rowMap: { [rowId]: replacementRowDoc } };
+    rerender();
+
+    await waitFor(() => {
+      expect(result.current).toBeNull();
+    });
+
+    unmount();
+    initialRowDoc.destroy();
+    replacementRowDoc.destroy();
+    databaseDoc.destroy();
+  });
+
+  it('clears metadata when the active row doc removes its metadata map', async () => {
+    const rowDoc = new Y.Doc() as YDoc;
+    const rowRoot = rowDoc.getMap(YjsEditorKey.data_section);
+    const rowMeta = new Y.Map<unknown>();
+    const isDocumentEmptyKey = getMetaIdMap(rowId).get(RowMetaKey.IsDocumentEmpty);
+
+    expect(isDocumentEmptyKey).toBeDefined();
+    rowMeta.set(isDocumentEmptyKey as string, false);
+    rowRoot.set(YjsEditorKey.meta, rowMeta);
+
+    const { result, unmount } = renderHook(() => useRowMetaSelector(rowId), {
+      wrapper: createWrapper(rowDoc),
+    });
+
+    expect(result.current?.isEmptyDocument).toBe(false);
+
+    act(() => {
+      rowRoot.delete(YjsEditorKey.meta);
+    });
+
+    await waitFor(() => {
+      expect(result.current).toBeNull();
+    });
+
+    unmount();
+    rowDoc.destroy();
+  });
 });

--- a/src/application/database-yjs/__tests__/useRowMetaSelector.test.tsx
+++ b/src/application/database-yjs/__tests__/useRowMetaSelector.test.tsx
@@ -1,0 +1,53 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { type ReactNode } from 'react';
+import * as Y from 'yjs';
+
+import { DatabaseContext, DatabaseContextState, RowMetaKey, useRowMetaSelector } from '@/application/database-yjs';
+import { getMetaIdMap } from '@/application/database-yjs/row_meta';
+import { YDoc, YjsEditorKey } from '@/application/types';
+
+const rowId = 'c570d6fd-4ec2-4ce9-9c2f-2bca48174007';
+
+function createWrapper(rowDoc: YDoc) {
+  const databaseDoc = new Y.Doc() as YDoc;
+  const contextValue: DatabaseContextState = {
+    readOnly: false,
+    databaseDoc,
+    databasePageId: 'database-page-id',
+    activeViewId: 'board-view-id',
+    rowMap: { [rowId]: rowDoc },
+    workspaceId: 'workspace-id',
+  };
+
+  return ({ children }: { children: ReactNode }) => (
+    <DatabaseContext.Provider value={contextValue}>{children}</DatabaseContext.Provider>
+  );
+}
+
+describe('useRowMetaSelector', () => {
+  it('observes metadata that arrives after an initially empty row doc', async () => {
+    const localRowDoc = new Y.Doc() as YDoc;
+    const remoteRowDoc = new Y.Doc();
+    const remoteRoot = remoteRowDoc.getMap(YjsEditorKey.data_section);
+    const remoteMeta = new Y.Map<unknown>();
+    const isDocumentEmptyKey = getMetaIdMap(rowId).get(RowMetaKey.IsDocumentEmpty);
+
+    expect(isDocumentEmptyKey).toBeDefined();
+    remoteMeta.set(isDocumentEmptyKey as string, false);
+    remoteRoot.set(YjsEditorKey.meta, remoteMeta);
+
+    const { result } = renderHook(() => useRowMetaSelector(rowId), {
+      wrapper: createWrapper(localRowDoc),
+    });
+
+    expect(result.current?.isEmptyDocument).not.toBe(false);
+
+    act(() => {
+      Y.applyUpdate(localRowDoc, Y.encodeStateAsUpdate(remoteRowDoc));
+    });
+
+    await waitFor(() => {
+      expect(result.current?.isEmptyDocument).toBe(false);
+    });
+  });
+});

--- a/src/application/database-yjs/__tests__/useRowMetaSelector.test.tsx
+++ b/src/application/database-yjs/__tests__/useRowMetaSelector.test.tsx
@@ -8,7 +8,7 @@ import { YDoc, YjsEditorKey } from '@/application/types';
 
 const rowId = 'c570d6fd-4ec2-4ce9-9c2f-2bca48174007';
 
-function createWrapper(rowDoc: YDoc) {
+function createWrapper(rowDoc: YDoc, ensureRow?: DatabaseContextState['ensureRow']) {
   const databaseDoc = new Y.Doc() as YDoc;
   const contextValue: DatabaseContextState = {
     readOnly: false,
@@ -17,6 +17,7 @@ function createWrapper(rowDoc: YDoc) {
     activeViewId: 'board-view-id',
     rowMap: { [rowId]: rowDoc },
     workspaceId: 'workspace-id',
+    ensureRow,
   };
 
   return ({ children }: { children: ReactNode }) => (
@@ -44,6 +45,39 @@ describe('useRowMetaSelector', () => {
 
     act(() => {
       Y.applyUpdate(localRowDoc, Y.encodeStateAsUpdate(remoteRowDoc));
+    });
+
+    await waitFor(() => {
+      expect(result.current?.isEmptyDocument).toBe(false);
+    });
+  });
+
+  it('observes row-page metadata from the canonical doc when a seed shell is already present', async () => {
+    const shellRowDoc = new Y.Doc() as YDoc;
+    const shellRoot = shellRowDoc.getMap(YjsEditorKey.data_section);
+    const shellMeta = new Y.Map<unknown>();
+    const canonicalRowDoc = new Y.Doc() as YDoc;
+    const canonicalRoot = canonicalRowDoc.getMap(YjsEditorKey.data_section);
+    const canonicalMeta = new Y.Map<unknown>();
+    const isDocumentEmptyKey = getMetaIdMap(rowId).get(RowMetaKey.IsDocumentEmpty);
+
+    expect(isDocumentEmptyKey).toBeDefined();
+    shellMeta.set(isDocumentEmptyKey as string, true);
+    shellRoot.set(YjsEditorKey.meta, shellMeta);
+    canonicalMeta.set(isDocumentEmptyKey as string, true);
+    canonicalRoot.set(YjsEditorKey.meta, canonicalMeta);
+
+    const ensureRow = jest.fn(async () => canonicalRowDoc);
+    const { result } = renderHook(() => useRowMetaSelector(rowId), {
+      wrapper: createWrapper(shellRowDoc, ensureRow),
+    });
+
+    await waitFor(() => {
+      expect(result.current?.isEmptyDocument).toBe(true);
+    });
+
+    act(() => {
+      canonicalMeta.set(isDocumentEmptyKey as string, false);
     });
 
     await waitFor(() => {

--- a/src/application/database-yjs/__tests__/useRowsByGroup.test.tsx
+++ b/src/application/database-yjs/__tests__/useRowsByGroup.test.tsx
@@ -223,4 +223,58 @@ describe('useRowsByGroup', () => {
     fixture.existingTodoRowDoc.destroy();
     fixture.databaseDoc.destroy();
   });
+
+  it('does not reuse grouping readiness after the database document is replaced with the same ids', async () => {
+    const fixture = createBoardFixture();
+    const replacement = createBoardFixture();
+    const coldTodoRowDoc = new Y.Doc({ guid: existingTodoRowId }) as YDoc;
+    const coldDoingRowDoc = new Y.Doc({ guid: existingDoingRowId }) as YDoc;
+    const readinessHistory: boolean[] = [];
+    const { result, rerender, unmount } = renderHook(
+      () => {
+        const groupedRows = useRowsByGroup(groupId);
+
+        readinessHistory.push(groupedRows.groupRowsReady);
+        return groupedRows;
+      },
+      { wrapper: fixture.wrapper }
+    );
+
+    await waitFor(() => expect(result.current.groupRowsReady).toBe(true));
+    const transitionStart = readinessHistory.length;
+
+    Object.assign(fixture.contextValue, replacement.contextValue, {
+      rowMap: {
+        [existingTodoRowId]: coldTodoRowDoc,
+        [existingDoingRowId]: coldDoingRowDoc,
+      },
+    });
+    rerender();
+
+    await waitFor(() => expect(result.current.groupRowsReady).toBe(false));
+    expect(readinessHistory.slice(transitionStart)).not.toContain(true);
+    expect(result.current.columns.map(({ id }) => id)).toEqual([statusFieldId, todoId, doingId, doneId]);
+
+    act(() => {
+      Y.applyUpdate(coldTodoRowDoc, Y.encodeStateAsUpdate(replacement.existingTodoRowDoc));
+      Y.applyUpdate(coldDoingRowDoc, Y.encodeStateAsUpdate(replacement.existingDoingRowDoc));
+    });
+
+    await waitFor(() => {
+      expect(result.current.groupRowsReady).toBe(true);
+      expect(result.current.columns.map(({ id }) => id)).toEqual([todoId, doingId]);
+    });
+
+    unmount();
+    coldTodoRowDoc.destroy();
+    coldDoingRowDoc.destroy();
+    replacement.remoteDoingRowDoc.destroy();
+    replacement.existingDoingRowDoc.destroy();
+    replacement.existingTodoRowDoc.destroy();
+    replacement.databaseDoc.destroy();
+    fixture.remoteDoingRowDoc.destroy();
+    fixture.existingDoingRowDoc.destroy();
+    fixture.existingTodoRowDoc.destroy();
+    fixture.databaseDoc.destroy();
+  });
 });

--- a/src/application/database-yjs/__tests__/useRowsByGroup.test.tsx
+++ b/src/application/database-yjs/__tests__/useRowsByGroup.test.tsx
@@ -1,0 +1,226 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import type React from 'react';
+import * as Y from 'yjs';
+
+import { DatabaseContext, DatabaseContextState, FieldType, useRowsByGroup } from '@/application/database-yjs';
+import {
+  YDatabase,
+  YDatabaseField,
+  YDatabaseFields,
+  YDatabaseRowOrders,
+  YDatabaseView,
+  YDatabaseViews,
+  YDoc,
+  YjsDatabaseKey,
+  YjsEditorKey,
+} from '@/application/types';
+
+import { createCell, createRowDoc } from './test-helpers';
+
+jest.mock('@/utils/runtime-config', () => ({
+  getConfigValue: (_key: string, fallback: string) => fallback,
+}));
+
+const databaseId = 'database-id';
+const viewId = 'board-view-id';
+const groupId = 'status-group-id';
+const statusFieldId = 'status-field-id';
+const todoId = 'todo-id';
+const doingId = 'doing-id';
+const doneId = 'done-id';
+const existingTodoRowId = 'existing-todo-row';
+const existingDoingRowId = 'existing-doing-row';
+const remoteDoingRowId = 'remote-doing-row';
+
+function createBoardFixture() {
+  const databaseDoc = new Y.Doc({ guid: databaseId }) as YDoc;
+  const database = new Y.Map() as YDatabase;
+  const fields = new Y.Map<YDatabaseField>() as YDatabaseFields;
+  const statusField = new Y.Map() as YDatabaseField;
+  const typeOptions = new Y.Map();
+  const selectOptions = new Y.Map();
+  const views = new Y.Map<YDatabaseView>() as YDatabaseViews;
+  const view = new Y.Map() as YDatabaseView;
+  const rowOrders = new Y.Array<{ id: string; height: number }>() as YDatabaseRowOrders;
+  const groups = new Y.Array<Y.Map<unknown>>();
+  const group = new Y.Map<unknown>();
+  const columns = new Y.Array<{ id: string; visible: boolean }>();
+  const layoutSettings = new Y.Map<Y.Map<unknown>>();
+  const boardLayoutSettings = new Y.Map<unknown>();
+
+  selectOptions.set(
+    YjsDatabaseKey.content,
+    JSON.stringify({
+      disable_color: false,
+      options: [
+        { id: todoId, name: 'To Do', color: 'Purple' },
+        { id: doingId, name: 'Doing', color: 'Blue' },
+        { id: doneId, name: 'Done', color: 'Green' },
+      ],
+    })
+  );
+  typeOptions.set(String(FieldType.SingleSelect), selectOptions);
+  statusField.set(YjsDatabaseKey.id, statusFieldId);
+  statusField.set(YjsDatabaseKey.name, 'Status');
+  statusField.set(YjsDatabaseKey.type, FieldType.SingleSelect);
+  statusField.set(YjsDatabaseKey.type_option, typeOptions);
+  fields.set(statusFieldId, statusField);
+
+  columns.push([
+    { id: statusFieldId, visible: true },
+    { id: todoId, visible: true },
+    { id: doingId, visible: true },
+    { id: doneId, visible: true },
+  ]);
+  group.set(YjsDatabaseKey.id, groupId);
+  group.set(YjsDatabaseKey.field_id, statusFieldId);
+  group.set(YjsDatabaseKey.type, FieldType.SingleSelect);
+  group.set(YjsDatabaseKey.groups, columns);
+  groups.push([group]);
+
+  rowOrders.push([
+    { id: existingTodoRowId, height: 44 },
+    { id: existingDoingRowId, height: 44 },
+  ]);
+  boardLayoutSettings.set(YjsDatabaseKey.hide_empty_groups, true);
+  layoutSettings.set('1', boardLayoutSettings);
+  view.set(YjsDatabaseKey.row_orders, rowOrders);
+  view.set(YjsDatabaseKey.groups, groups);
+  view.set(YjsDatabaseKey.layout_settings, layoutSettings);
+  views.set(viewId, view);
+
+  database.set(YjsDatabaseKey.id, databaseId);
+  database.set(YjsDatabaseKey.fields, fields);
+  database.set(YjsDatabaseKey.views, views);
+  databaseDoc.getMap(YjsEditorKey.data_section).set(YjsEditorKey.database, database);
+
+  const existingTodoRowDoc = createRowDoc(existingTodoRowId, databaseId, {
+    [statusFieldId]: createCell(FieldType.SingleSelect, todoId),
+  });
+  const existingDoingRowDoc = createRowDoc(existingDoingRowId, databaseId, {
+    [statusFieldId]: createCell(FieldType.SingleSelect, doingId),
+  });
+  // The database row order can arrive before the independent DatabaseRow
+  // collab. Keep this canonical document empty until the test hydrates it.
+  const remoteDoingRowDoc = new Y.Doc({ guid: remoteDoingRowId }) as YDoc;
+  const rowMap = {
+    [existingTodoRowId]: existingTodoRowDoc,
+    [existingDoingRowId]: existingDoingRowDoc,
+    [remoteDoingRowId]: remoteDoingRowDoc,
+  };
+  const contextValue: DatabaseContextState = {
+    activeViewId: viewId,
+    blobPrefetchComplete: false,
+    databaseDoc,
+    databasePageId: viewId,
+    readOnly: false,
+    rowMap,
+    seedsReady: false,
+    workspaceId: 'workspace-id',
+  };
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <DatabaseContext.Provider value={contextValue}>{children}</DatabaseContext.Provider>
+  );
+
+  return {
+    contextValue,
+    databaseDoc,
+    existingDoingRowDoc,
+    existingTodoRowDoc,
+    remoteDoingRowDoc,
+    rowOrders,
+    wrapper,
+  };
+}
+
+describe('useRowsByGroup', () => {
+  it('never reveals empty columns while a remotely ordered row is still hydrating', async () => {
+    const fixture = createBoardFixture();
+    const visibleColumnHistory: string[][] = [];
+    const { result, unmount } = renderHook(
+      () => {
+        const groupedRows = useRowsByGroup(groupId);
+
+        visibleColumnHistory.push(groupedRows.columns.map(({ id }) => id));
+        return groupedRows;
+      },
+      { wrapper: fixture.wrapper }
+    );
+
+    await waitFor(() => {
+      expect(result.current.groupRowsReady).toBe(true);
+      expect(result.current.columns.map(({ id }) => id)).toEqual([todoId, doingId]);
+    });
+
+    const transitionStart = visibleColumnHistory.length;
+
+    await act(async () => {
+      fixture.rowOrders.push([{ id: remoteDoingRowId, height: 44 }]);
+      await Promise.resolve();
+    });
+
+    const assertOnlyPopulatedColumnsRendered = () => {
+      const transitionSnapshots = visibleColumnHistory.slice(transitionStart);
+
+      expect(transitionSnapshots).not.toHaveLength(0);
+      transitionSnapshots.forEach((visibleColumnIds) => {
+        expect(visibleColumnIds).toEqual([todoId, doingId]);
+      });
+    };
+
+    assertOnlyPopulatedColumnsRendered();
+    expect(result.current.groupResult.get(doingId)?.map(({ id }) => id)).toEqual([existingDoingRowId]);
+
+    const hydratedRemoteRow = createRowDoc(remoteDoingRowId, databaseId, {
+      [statusFieldId]: createCell(FieldType.SingleSelect, doingId),
+    });
+
+    act(() => {
+      Y.applyUpdate(fixture.remoteDoingRowDoc, Y.encodeStateAsUpdate(hydratedRemoteRow));
+    });
+
+    await waitFor(() => {
+      expect(result.current.groupResult.get(doingId)?.map(({ id }) => id)).toEqual([
+        existingDoingRowId,
+        remoteDoingRowId,
+      ]);
+    });
+    assertOnlyPopulatedColumnsRendered();
+
+    unmount();
+    hydratedRemoteRow.destroy();
+    fixture.remoteDoingRowDoc.destroy();
+    fixture.existingDoingRowDoc.destroy();
+    fixture.existingTodoRowDoc.destroy();
+    fixture.databaseDoc.destroy();
+  });
+
+  it('does not reuse grouping readiness after the active view changes', async () => {
+    const fixture = createBoardFixture();
+    const readinessHistory: boolean[] = [];
+    const { result, rerender, unmount } = renderHook(
+      () => {
+        const groupedRows = useRowsByGroup(groupId);
+
+        readinessHistory.push(groupedRows.groupRowsReady);
+        return groupedRows;
+      },
+      { wrapper: fixture.wrapper }
+    );
+
+    await waitFor(() => expect(result.current.groupRowsReady).toBe(true));
+    const transitionStart = readinessHistory.length;
+
+    fixture.contextValue.activeViewId = 'cold-board-view-id';
+    rerender();
+
+    await waitFor(() => expect(result.current.groupRowsReady).toBe(false));
+    expect(readinessHistory.slice(transitionStart)).not.toContain(true);
+
+    unmount();
+    fixture.remoteDoingRowDoc.destroy();
+    fixture.existingDoingRowDoc.destroy();
+    fixture.existingTodoRowDoc.destroy();
+    fixture.databaseDoc.destroy();
+  });
+});

--- a/src/application/database-yjs/hooks/__tests__/useBackgroundRowDocLoader.test.tsx
+++ b/src/application/database-yjs/hooks/__tests__/useBackgroundRowDocLoader.test.tsx
@@ -1,4 +1,4 @@
-import { act, renderHook, waitFor } from '@testing-library/react';
+import { act, render, renderHook, waitFor } from '@testing-library/react';
 import type React from 'react';
 import * as Y from 'yjs';
 
@@ -10,6 +10,12 @@ import { createRowDoc } from '../../__tests__/test-helpers';
 
 jest.mock('@/utils/runtime-config', () => ({
   getConfigValue: (_key: string, fallback: string) => fallback,
+}));
+
+jest.mock('@/application/db', () => ({
+  openRowCollabDBWithProvider: jest.fn(async () => {
+    throw new Error('record not found');
+  }),
 }));
 
 function createDatabaseFixture() {
@@ -29,6 +35,19 @@ function createDatabaseFixture() {
   databaseDoc.getMap(YjsEditorKey.data_section).set(YjsEditorKey.database, database);
 
   return { databaseDoc, databaseId, rowOrders, viewId };
+}
+
+function BackgroundLoaderHarness({ contextValue, scope }: { contextValue: DatabaseContextState; scope: string }) {
+  return (
+    <DatabaseContext.Provider value={contextValue}>
+      <BackgroundLoader scope={scope} />
+    </DatabaseContext.Provider>
+  );
+}
+
+function BackgroundLoader({ scope }: { scope: string }) {
+  useBackgroundRowDocLoader(true, scope);
+  return null;
 }
 
 describe('useBackgroundRowDocLoader', () => {
@@ -71,6 +90,124 @@ describe('useBackgroundRowDocLoader', () => {
     unmount();
     initialRowDoc.destroy();
     insertedRowDoc.destroy();
+    databaseDoc.destroy();
+  });
+
+  it('retries when row_orders arrives before the remote row collab', async () => {
+    const { databaseDoc, databaseId, rowOrders, viewId } = createDatabaseFixture();
+    const initialRowDoc = createRowDoc('initial-row', databaseId, {});
+    const remoteRowDoc = createRowDoc('inserted-row', databaseId, {});
+    const unresolvedRowDoc = new Y.Doc({ guid: 'inserted-row' }) as YDoc;
+    const remoteRowUpdate = Y.encodeStateAsUpdate(remoteRowDoc);
+    const loadRowFromSeed = jest.fn(async () => undefined);
+    let ensureAttempts = 0;
+    const ensureRow = jest.fn<Promise<YDoc | undefined>, [string]>(async () => {
+      ensureAttempts += 1;
+      if (ensureAttempts === 2) {
+        // The retry's manifest request receives the DatabaseRow collab that
+        // was not yet present when row_orders first arrived.
+        Y.applyUpdate(unresolvedRowDoc, remoteRowUpdate);
+      }
+
+      return unresolvedRowDoc;
+    });
+    const contextValue: DatabaseContextState = {
+      activeViewId: viewId,
+      blobPrefetchComplete: true,
+      databaseDoc,
+      databasePageId: viewId,
+      ensureRow,
+      loadRowFromSeed,
+      readOnly: false,
+      rowMap: { 'initial-row': initialRowDoc },
+      seedsReady: false,
+      workspaceId: 'workspace-id',
+    };
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <DatabaseContext.Provider value={contextValue}>{children}</DatabaseContext.Provider>
+    );
+    const { unmount } = renderHook(() => useBackgroundRowDocLoader(true, 'board-grouping-retry'), { wrapper });
+
+    act(() => {
+      rowOrders.push([{ id: 'inserted-row', height: 44 }]);
+    });
+
+    await waitFor(
+      () => {
+        expect(ensureRow).toHaveBeenCalledTimes(2);
+        expect(ensureRow).toHaveBeenNthCalledWith(1, 'inserted-row');
+        expect(ensureRow).toHaveBeenNthCalledWith(2, 'inserted-row');
+      },
+      { timeout: 5_000 }
+    );
+    expect(unresolvedRowDoc.getMap(YjsEditorKey.data_section).has(YjsEditorKey.database_row)).toBe(true);
+
+    await new Promise((resolve) => setTimeout(resolve, 500));
+    expect(ensureRow).toHaveBeenCalledTimes(2);
+
+    unmount();
+    initialRowDoc.destroy();
+    remoteRowDoc.destroy();
+    unresolvedRowDoc.destroy();
+    databaseDoc.destroy();
+  });
+
+  it('uses the latest row loader callback while a retry is pending', async () => {
+    const { databaseDoc, databaseId, rowOrders, viewId } = createDatabaseFixture();
+    const initialRowDoc = createRowDoc('initial-row', databaseId, {});
+    const remoteRowDoc = createRowDoc('inserted-row', databaseId, {});
+    const unresolvedRowDoc = new Y.Doc({ guid: 'inserted-row' }) as YDoc;
+    const remoteRowUpdate = Y.encodeStateAsUpdate(remoteRowDoc);
+    const loadRowFromSeed = jest.fn(async () => undefined);
+    const firstEnsureRow = jest.fn(async () => unresolvedRowDoc);
+    const nextEnsureRow = jest.fn(async () => {
+      Y.applyUpdate(unresolvedRowDoc, remoteRowUpdate);
+      return unresolvedRowDoc;
+    });
+    const baseContextValue: DatabaseContextState = {
+      activeViewId: viewId,
+      blobPrefetchComplete: true,
+      databaseDoc,
+      databasePageId: viewId,
+      ensureRow: firstEnsureRow,
+      loadRowFromSeed,
+      readOnly: false,
+      rowMap: { 'initial-row': initialRowDoc },
+      seedsReady: false,
+      workspaceId: 'workspace-id',
+    };
+    const { rerender, unmount } = render(
+      <BackgroundLoaderHarness contextValue={baseContextValue} scope='board-grouping-latest-callback' />
+    );
+
+    act(() => {
+      rowOrders.push([{ id: 'inserted-row', height: 44 }]);
+    });
+
+    await waitFor(() => {
+      expect(firstEnsureRow).toHaveBeenCalledTimes(1);
+    });
+
+    rerender(
+      <BackgroundLoaderHarness
+        contextValue={{ ...baseContextValue, ensureRow: nextEnsureRow }}
+        scope='board-grouping-latest-callback'
+      />
+    );
+
+    await waitFor(
+      () => {
+        expect(firstEnsureRow).toHaveBeenCalledTimes(1);
+        expect(nextEnsureRow).toHaveBeenCalledTimes(1);
+      },
+      { timeout: 5_000 }
+    );
+    expect(unresolvedRowDoc.getMap(YjsEditorKey.data_section).has(YjsEditorKey.database_row)).toBe(true);
+
+    unmount();
+    initialRowDoc.destroy();
+    remoteRowDoc.destroy();
+    unresolvedRowDoc.destroy();
     databaseDoc.destroy();
   });
 });

--- a/src/application/database-yjs/hooks/__tests__/useBackgroundRowDocLoader.test.tsx
+++ b/src/application/database-yjs/hooks/__tests__/useBackgroundRowDocLoader.test.tsx
@@ -1,5 +1,5 @@
 import { act, render, renderHook, waitFor } from '@testing-library/react';
-import type React from 'react';
+import { startTransition, Suspense, type ReactNode } from 'react';
 import * as Y from 'yjs';
 
 import { DatabaseContext, DatabaseContextState } from '@/application/database-yjs/context';
@@ -37,16 +37,28 @@ function createDatabaseFixture() {
   return { databaseDoc, databaseId, rowOrders, viewId };
 }
 
-function BackgroundLoaderHarness({ contextValue, scope }: { contextValue: DatabaseContextState; scope: string }) {
+const neverResolvingPromise = new Promise<never>(() => undefined);
+
+function BackgroundLoaderHarness({
+  contextValue,
+  scope,
+  suspend = false,
+}: {
+  contextValue: DatabaseContextState;
+  scope: string;
+  suspend?: boolean;
+}) {
   return (
     <DatabaseContext.Provider value={contextValue}>
-      <BackgroundLoader scope={scope} />
+      <BackgroundLoader scope={scope} suspend={suspend} />
     </DatabaseContext.Provider>
   );
 }
 
-function BackgroundLoader({ scope }: { scope: string }) {
+function BackgroundLoader({ scope, suspend = false }: { scope: string; suspend?: boolean }) {
   useBackgroundRowDocLoader(true, scope);
+
+  if (suspend) throw neverResolvingPromise;
   return null;
 }
 
@@ -69,7 +81,7 @@ describe('useBackgroundRowDocLoader', () => {
       seedsReady: false,
       workspaceId: 'workspace-id',
     };
-    const wrapper = ({ children }: { children: React.ReactNode }) => (
+    const wrapper = ({ children }: { children: ReactNode }) => (
       <DatabaseContext.Provider value={contextValue}>{children}</DatabaseContext.Provider>
     );
     const { unmount } = renderHook(() => useBackgroundRowDocLoader(true, 'board-grouping'), { wrapper });
@@ -123,7 +135,7 @@ describe('useBackgroundRowDocLoader', () => {
       seedsReady: false,
       workspaceId: 'workspace-id',
     };
-    const wrapper = ({ children }: { children: React.ReactNode }) => (
+    const wrapper = ({ children }: { children: ReactNode }) => (
       <DatabaseContext.Provider value={contextValue}>{children}</DatabaseContext.Provider>
     );
     const { unmount } = renderHook(() => useBackgroundRowDocLoader(true, 'board-grouping-retry'), { wrapper });
@@ -207,6 +219,67 @@ describe('useBackgroundRowDocLoader', () => {
     unmount();
     initialRowDoc.destroy();
     remoteRowDoc.destroy();
+    unresolvedRowDoc.destroy();
+    databaseDoc.destroy();
+  });
+
+  it('keeps the committed row loader callback when a replacement render suspends', async () => {
+    const { databaseDoc, databaseId, rowOrders, viewId } = createDatabaseFixture();
+    const initialRowDoc = createRowDoc('initial-row', databaseId, {});
+    const unresolvedRowDoc = new Y.Doc({ guid: 'inserted-row' }) as YDoc;
+    const loadRowFromSeed = jest.fn(async () => undefined);
+    const committedEnsureRow = jest.fn(async () => unresolvedRowDoc);
+    const uncommittedEnsureRow = jest.fn(async () => unresolvedRowDoc);
+    const baseContextValue: DatabaseContextState = {
+      activeViewId: viewId,
+      blobPrefetchComplete: true,
+      databaseDoc,
+      databasePageId: viewId,
+      ensureRow: committedEnsureRow,
+      loadRowFromSeed,
+      readOnly: false,
+      rowMap: { 'initial-row': initialRowDoc },
+      seedsReady: false,
+      workspaceId: 'workspace-id',
+    };
+    const { rerender, unmount } = render(
+      <Suspense fallback={null}>
+        <BackgroundLoaderHarness contextValue={baseContextValue} scope='board-grouping-suspended-callback' />
+      </Suspense>
+    );
+
+    act(() => {
+      rowOrders.push([{ id: 'inserted-row', height: 44 }]);
+    });
+
+    await waitFor(() => {
+      expect(committedEnsureRow).toHaveBeenCalledTimes(1);
+    });
+
+    act(() => {
+      startTransition(() => {
+        rerender(
+          <Suspense fallback={null}>
+            <BackgroundLoaderHarness
+              contextValue={{ ...baseContextValue, ensureRow: uncommittedEnsureRow }}
+              scope='board-grouping-suspended-callback'
+              suspend
+            />
+          </Suspense>
+        );
+      });
+    });
+
+    await waitFor(
+      () => {
+        expect(committedEnsureRow).toHaveBeenCalledTimes(2);
+      },
+      { timeout: 5_000 }
+    );
+    expect(uncommittedEnsureRow).not.toHaveBeenCalled();
+
+    unmount();
+    initialRowDoc.destroy();
     unresolvedRowDoc.destroy();
     databaseDoc.destroy();
   });

--- a/src/application/database-yjs/hooks/useBackgroundRowDocLoader.ts
+++ b/src/application/database-yjs/hooks/useBackgroundRowDocLoader.ts
@@ -11,13 +11,13 @@ import * as Y from 'yjs';
 
 import { hasRowConditionData } from '@/application/database-yjs/condition-value-cache';
 import { useDatabaseContext, useDatabaseView, useDatabaseViewId, useRowMap } from '@/application/database-yjs/context';
+import { ROW_SYNC_RETRY_DELAYS_MS } from '@/application/database-yjs/row-sync';
 import { getRowKey } from '@/application/database-yjs/row_meta';
 import { openRowCollabDBWithProvider } from '@/application/db';
 import { YDatabaseRowOrders, YDoc, YjsDatabaseKey } from '@/application/types';
 
 const BACKGROUND_BATCH_SIZE = 24;
 const BACKGROUND_CONCURRENCY = 12;
-const BACKGROUND_RETRY_DELAYS_MS = [1_000, 3_000, 5_000] as const;
 const SEED_HYDRATE_BATCH_SIZE = 128;
 
 type RowDocMap = Record<string, YDoc>;
@@ -72,11 +72,16 @@ async function openLegacyReadOnlyRowDoc(rowKey: string) {
     const updates = await getAllStoreValues<Uint8Array>(db, 'updates');
     const doc = new Y.Doc({ guid: rowKey }) as YDoc;
 
-    Y.transact(doc, () => {
-      updates.forEach((update) => {
-        Y.applyUpdate(doc, update);
-      });
-    }, null, false);
+    Y.transact(
+      doc,
+      () => {
+        updates.forEach((update) => {
+          Y.applyUpdate(doc, update);
+        });
+      },
+      null,
+      false
+    );
 
     return doc;
   } finally {
@@ -106,11 +111,13 @@ function openEphemeralRowDoc(rowKey: string, rowId: string) {
   const promise = openReadOnlyRowDoc(rowKey, rowId);
 
   pendingEphemeralRowDocs.set(pendingKey, promise);
-  promise.finally(() => {
-    if (pendingEphemeralRowDocs.get(pendingKey) === promise) {
-      pendingEphemeralRowDocs.delete(pendingKey);
-    }
-  }).catch(() => undefined);
+  promise
+    .finally(() => {
+      if (pendingEphemeralRowDocs.get(pendingKey) === promise) {
+        pendingEphemeralRowDocs.delete(pendingKey);
+      }
+    })
+    .catch(() => undefined);
 
   return promise;
 }
@@ -268,14 +275,8 @@ export function useBackgroundRowDocLoader(active: boolean, scope = 'conditions')
   const view = useDatabaseView();
   const viewId = useDatabaseViewId();
   const rowOrders = view?.get(YjsDatabaseKey.row_orders);
-  const {
-    databaseDoc,
-    ensureRow,
-    loadRowFromSeed,
-    peekRowDocFromSeed,
-    blobPrefetchComplete,
-    seedsReady,
-  } = useDatabaseContext();
+  const { databaseDoc, ensureRow, loadRowFromSeed, peekRowDocFromSeed, blobPrefetchComplete, seedsReady } =
+    useDatabaseContext();
   const storeKey = `${databaseDoc.guid}:${viewId ?? 'unknown'}:${scope}`;
   const store = useMemo(() => getLoaderStore(storeKey), [storeKey]);
   const [rowOrderRevision, setRowOrderRevision] = useState(0);
@@ -525,12 +526,12 @@ export function useBackgroundRowDocLoader(active: boolean, scope = 'conditions')
 
       const attempt = retryAttempts.get(rowId) ?? 0;
 
-      if (attempt >= BACKGROUND_RETRY_DELAYS_MS.length) {
+      if (attempt >= ROW_SYNC_RETRY_DELAYS_MS.length) {
         retryAttempts.delete(rowId);
         return;
       }
 
-      const delayMs = BACKGROUND_RETRY_DELAYS_MS[attempt];
+      const delayMs = ROW_SYNC_RETRY_DELAYS_MS[attempt];
 
       retryAttempts.set(rowId, attempt + 1);
       await new Promise((resolve) => setTimeout(resolve, delayMs));

--- a/src/application/database-yjs/hooks/useBackgroundRowDocLoader.ts
+++ b/src/application/database-yjs/hooks/useBackgroundRowDocLoader.ts
@@ -1,10 +1,18 @@
-import { startTransition, useCallback, useEffect, useMemo, useState, useSyncExternalStore } from 'react';
+import {
+  startTransition,
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useState,
+  useSyncExternalStore,
+} from 'react';
 import * as Y from 'yjs';
 
-import { useDatabaseContext, useDatabaseView, useDatabaseViewId, useRowMap } from '@/application/database-yjs/context';
 import { hasRowConditionData } from '@/application/database-yjs/condition-value-cache';
-import { openRowCollabDBWithProvider } from '@/application/db';
+import { useDatabaseContext, useDatabaseView, useDatabaseViewId, useRowMap } from '@/application/database-yjs/context';
 import { getRowKey } from '@/application/database-yjs/row_meta';
+import { openRowCollabDBWithProvider } from '@/application/db';
 import { YDatabaseRowOrders, YDoc, YjsDatabaseKey } from '@/application/types';
 
 const BACKGROUND_BATCH_SIZE = 24;
@@ -272,13 +280,16 @@ export function useBackgroundRowDocLoader(active: boolean, scope = 'conditions')
   const store = useMemo(() => getLoaderStore(storeKey), [storeKey]);
   const [rowOrderRevision, setRowOrderRevision] = useState(0);
 
-  store.rows = rows;
   // A background run is shared by consumers and can outlive the render that
-  // started it. Always read transport-sensitive operations from the store so
-  // a WebSocket transition cannot leave the run using a stale callback.
-  store.rowOrders = rowOrders;
-  store.ensureRow = ensureRow;
-  store.loadRowFromSeed = loadRowFromSeed;
+  // started it. Publish transport-sensitive operations only after commit so an
+  // interrupted render cannot replace an active run's callbacks with values
+  // from a database lifecycle that never became active.
+  useLayoutEffect(() => {
+    store.rows = rows;
+    store.rowOrders = rowOrders;
+    store.ensureRow = ensureRow;
+    store.loadRowFromSeed = loadRowFromSeed;
+  }, [ensureRow, loadRowFromSeed, rowOrders, rows, store]);
 
   const cachedRowDocs = useSyncExternalStore(
     useCallback(

--- a/src/application/database-yjs/hooks/useBackgroundRowDocLoader.ts
+++ b/src/application/database-yjs/hooks/useBackgroundRowDocLoader.ts
@@ -5,13 +5,16 @@ import { useDatabaseContext, useDatabaseView, useDatabaseViewId, useRowMap } fro
 import { hasRowConditionData } from '@/application/database-yjs/condition-value-cache';
 import { openRowCollabDBWithProvider } from '@/application/db';
 import { getRowKey } from '@/application/database-yjs/row_meta';
-import { YDoc, YjsDatabaseKey } from '@/application/types';
+import { YDatabaseRowOrders, YDoc, YjsDatabaseKey } from '@/application/types';
 
 const BACKGROUND_BATCH_SIZE = 24;
 const BACKGROUND_CONCURRENCY = 12;
+const BACKGROUND_RETRY_DELAYS_MS = [1_000, 3_000, 5_000] as const;
 const SEED_HYDRATE_BATCH_SIZE = 128;
 
 type RowDocMap = Record<string, YDoc>;
+type EnsureRow = (rowId: string) => Promise<YDoc | undefined> | void;
+type LoadRowFromSeed = (rowId: string) => Promise<YDoc | undefined>;
 
 const pendingEphemeralRowDocs = new Map<string, Promise<YDoc>>();
 const retainedEphemeralRowDocs = new WeakMap<YDoc, number>();
@@ -140,6 +143,9 @@ type LoaderStore = {
   seedHydrateRun: number;
   seedHydrateActive: boolean;
   rows: RowDocMap | null | undefined;
+  rowOrders: YDatabaseRowOrders | undefined;
+  ensureRow: EnsureRow | undefined;
+  loadRowFromSeed: LoadRowFromSeed | undefined;
 };
 
 const loaderStores = new Map<string, LoaderStore>();
@@ -162,6 +168,9 @@ function createLoaderStore(key: string): LoaderStore {
     seedHydrateRun: 0,
     seedHydrateActive: false,
     rows: undefined,
+    rowOrders: undefined,
+    ensureRow: undefined,
+    loadRowFromSeed: undefined,
   };
 }
 
@@ -264,6 +273,12 @@ export function useBackgroundRowDocLoader(active: boolean, scope = 'conditions')
   const [rowOrderRevision, setRowOrderRevision] = useState(0);
 
   store.rows = rows;
+  // A background run is shared by consumers and can outlive the render that
+  // started it. Always read transport-sensitive operations from the store so
+  // a WebSocket transition cannot leave the run using a stale callback.
+  store.rowOrders = rowOrders;
+  store.ensureRow = ensureRow;
+  store.loadRowFromSeed = loadRowFromSeed;
 
   const cachedRowDocs = useSyncExternalStore(
     useCallback(
@@ -489,122 +504,178 @@ export function useBackgroundRowDocLoader(active: boolean, scope = 'conditions')
 
     const runId = store.backgroundRun + 1;
     const isRunActive = () => store.backgroundRun === runId && !store.backgroundCancelled;
+    const retryAttempts = new Map<string, number>();
+    const isRowStillOrdered = (rowId: string) =>
+      (store.rowOrders?.toJSON() as { id: string; is_deleted?: boolean }[] | undefined)?.some(
+        (row) => row.id === rowId && !row.is_deleted
+      ) ?? false;
+    const retryMissingRow = async (rowId: string) => {
+      if (!store.ensureRow) return;
+
+      const attempt = retryAttempts.get(rowId) ?? 0;
+
+      if (attempt >= BACKGROUND_RETRY_DELAYS_MS.length) {
+        retryAttempts.delete(rowId);
+        return;
+      }
+
+      const delayMs = BACKGROUND_RETRY_DELAYS_MS[attempt];
+
+      retryAttempts.set(rowId, attempt + 1);
+      await new Promise((resolve) => setTimeout(resolve, delayMs));
+
+      if (!isRunActive() || hasReadyRowDoc(rowId) || !isRowStillOrdered(rowId)) {
+        retryAttempts.delete(rowId);
+        return;
+      }
+
+      store.backgroundQueue.add(rowId);
+    };
 
     store.backgroundRun = runId;
     store.backgroundLoading = true;
     store.backgroundCancelled = false;
 
+    const loadMissingRow = async (rowId: string) => {
+      if (!isRunActive() || hasReadyRowDoc(rowId)) {
+        retryAttempts.delete(rowId);
+        return;
+      }
+
+      const retryAttempt = retryAttempts.get(rowId) ?? 0;
+
+      if (store.cachedRowDocPending.has(rowId)) {
+        try {
+          await store.cachedRowDocPending.get(rowId);
+        } catch {
+          // Treat another consumer's missing-row result as transient.
+        }
+
+        if (!hasReadyRowDoc(rowId)) await retryMissingRow(rowId);
+        return;
+      }
+
+      // Try fast path: use blob diff seeds via loadRowFromSeed.
+      // This adds the doc directly to the main rowMap (no separate cache needed).
+      const currentLoadRowFromSeed = store.loadRowFromSeed;
+
+      if (retryAttempt === 0 && currentLoadRowFromSeed) {
+        const pending = currentLoadRowFromSeed(rowId);
+
+        store.cachedRowDocPending.set(rowId, pending);
+
+        try {
+          const doc = await pending;
+
+          if (!isRunActive()) return;
+          if (hasRowConditionData(doc)) {
+            retryAttempts.delete(rowId);
+            return;
+          }
+        } catch {
+          // A new row may not be present in the database blob yet.
+        } finally {
+          store.cachedRowDocPending.delete(rowId);
+        }
+      }
+
+      if (!isRunActive()) return;
+
+      // A row inserted after the blob snapshot has no seed yet. Open its live
+      // row document so collaborative inserts hydrate before a card mounts.
+      const currentEnsureRow = store.ensureRow;
+
+      if (currentEnsureRow) {
+        try {
+          const doc = await currentEnsureRow(rowId);
+
+          if (!isRunActive()) return;
+          if (doc && hasRowConditionData(doc)) {
+            retryAttempts.delete(rowId);
+            return;
+          }
+        } catch {
+          // Fall through to the read-only IndexedDB path.
+        }
+      }
+
+      if (!isRunActive()) return;
+
+      // The first pass checks every local cache. Later passes only re-request
+      // the live collab; repeating skip-cache opens cannot make remote data appear.
+      if (retryAttempt > 0) {
+        await retryMissingRow(rowId);
+        return;
+      }
+
+      // Fallback: open from IndexedDB for rows without seeds. The module-level
+      // pending map dedupes concurrent opens without retaining the doc globally.
+      const rowKey = getRowKey(databaseDoc.guid, rowId);
+      const pending = openEphemeralRowDoc(rowKey, rowId);
+
+      store.cachedRowDocPending.set(rowId, pending);
+
+      try {
+        const doc = await pending;
+
+        retainEphemeralRowDoc(doc);
+
+        if (!isRunActive()) {
+          releaseOwnedRowDoc(doc);
+          return;
+        }
+
+        if (!hasRowConditionData(doc)) {
+          releaseOwnedRowDoc(doc);
+          await retryMissingRow(rowId);
+          return;
+        }
+
+        if (hasReadyRowDoc(rowId) || hasRowConditionData(store.pendingDocs[rowId])) {
+          releaseOwnedRowDoc(doc);
+          return;
+        }
+
+        store.pendingDocs[rowId] = doc;
+        retryAttempts.delete(rowId);
+        scheduleFlush();
+      } catch {
+        // row_orders and DatabaseRow collabs are independent. A transient
+        // record-not-found must remain retryable.
+        await retryMissingRow(rowId);
+      } finally {
+        store.cachedRowDocPending.delete(rowId);
+      }
+    };
+
     const drainQueue = async () => {
       while (isRunActive()) {
         if (store.backgroundQueue.size === 0) {
           await new Promise((resolve) => setTimeout(resolve, 0));
-          if (store.backgroundQueue.size === 0 || !isRunActive()) {
-            break;
-          }
+          if (store.backgroundQueue.size === 0 || !isRunActive()) break;
         }
 
         const batch = Array.from(store.backgroundQueue).slice(0, BACKGROUND_BATCH_SIZE);
 
-        batch.forEach((rowId) => {
-          store.backgroundQueue.delete(rowId);
-        });
+        batch.forEach((rowId) => store.backgroundQueue.delete(rowId));
 
         for (let i = 0; i < batch.length; i += BACKGROUND_CONCURRENCY) {
           if (!isRunActive()) break;
-          const slice = batch.slice(i, i + BACKGROUND_CONCURRENCY);
-
-          await Promise.all(
-            slice.map(async (rowId) => {
-              if (!isRunActive() || hasReadyRowDoc(rowId)) return;
-
-              if (store.cachedRowDocPending.has(rowId)) {
-                await store.cachedRowDocPending.get(rowId);
-                return;
-              }
-
-              // Try fast path: use blob diff seeds via loadRowFromSeed.
-              // This adds the doc directly to the main rowMap (no separate cache needed).
-              if (loadRowFromSeed) {
-                const pending = loadRowFromSeed(rowId);
-
-                store.cachedRowDocPending.set(rowId, pending);
-
-                try {
-                  const doc = await pending;
-
-                  if (!isRunActive()) return;
-                  if (hasRowConditionData(doc)) return;
-                } finally {
-                  store.cachedRowDocPending.delete(rowId);
-                }
-              }
-
-              if (!isRunActive()) return;
-
-              // A row inserted after the blob snapshot has no seed yet. Open
-              // its live row document so collaborative inserts can hydrate
-              // even though no card was mounted to call ensureRow itself.
-              if (ensureRow) {
-                try {
-                  const doc = await ensureRow(rowId);
-
-                  if (!isRunActive()) return;
-                  if (doc && hasRowConditionData(doc)) return;
-                } catch {
-                  // Fall through to the read-only IndexedDB path.
-                }
-              }
-
-              if (!isRunActive()) return;
-
-              // Fallback: open from IndexedDB for rows without seeds. The
-              // module-level pending map dedupes concurrent opens across views
-              // without retaining the doc in the process-wide row cache.
-              const rowKey = getRowKey(databaseDoc.guid, rowId);
-              const pending = openEphemeralRowDoc(rowKey, rowId);
-
-              store.cachedRowDocPending.set(rowId, pending);
-
-              try {
-                const doc = await pending;
-
-                retainEphemeralRowDoc(doc);
-
-                if (!isRunActive()) {
-                  releaseOwnedRowDoc(doc);
-                  return;
-                }
-
-                if (!hasRowConditionData(doc)) {
-                  releaseOwnedRowDoc(doc);
-                  return;
-                }
-
-                if (hasReadyRowDoc(rowId) || hasRowConditionData(store.pendingDocs[rowId])) {
-                  releaseOwnedRowDoc(doc);
-                  return;
-                }
-
-                store.pendingDocs[rowId] = doc;
-                scheduleFlush();
-              } finally {
-                store.cachedRowDocPending.delete(rowId);
-              }
-            })
-          );
+          await Promise.all(batch.slice(i, i + BACKGROUND_CONCURRENCY).map(loadMissingRow));
         }
 
         if (!isRunActive()) break;
-
         await new Promise((resolve) => setTimeout(resolve, 0));
-      }
-
-      if (store.backgroundRun === runId) {
-        store.backgroundLoading = false;
       }
     };
 
-    void drainQueue();
+    void drainQueue()
+      .catch(() => undefined)
+      .finally(() => {
+        if (store.backgroundRun === runId) {
+          store.backgroundLoading = false;
+        }
+      });
 
     return () => {
       if (store.refCount <= 0) {

--- a/src/application/database-yjs/row-sync.ts
+++ b/src/application/database-yjs/row-sync.ts
@@ -1,0 +1,1 @@
+export const ROW_SYNC_RETRY_DELAYS_MS = [1_000, 3_000, 5_000] as const;

--- a/src/application/database-yjs/selector.ts
+++ b/src/application/database-yjs/selector.ts
@@ -1159,6 +1159,7 @@ export function useRowsByGroup(groupId: string) {
   const { columns, fieldId } = useGroup(groupId);
   const rows = useRowMap();
   const rowOrders = useRowOrdersSelector();
+  const viewId = useDatabaseViewId();
   const { cachedRowDocs } = useBackgroundRowDocLoader(Boolean(fieldId), 'board-grouping');
   const groupingRows = useMemo(() => {
     const next = { ...cachedRowDocs };
@@ -1175,15 +1176,15 @@ export function useRowsByGroup(groupId: string) {
   const fields = useDatabaseFields();
   const [notFound, setNotFound] = useState(false);
   const [groupResult, setGroupResult] = useState<Map<string, Row[]>>(new Map());
-  const [groupRowsReady, setGroupRowsReady] = useState(false);
+  const [hydratedGroupingIdentity, setHydratedGroupingIdentity] = useState<string | null>(null);
   const view = useDatabaseView();
   const filters = view?.get(YjsDatabaseKey.filters);
   const { hideEmptyGroups, hideUnGroup, shownEmptyGroupIds } = useBoardLayoutSettings();
+  const groupingIdentity = fieldId ? `${viewId ?? ''}:${groupId}:${fieldId}` : null;
 
   useEffect(() => {
     if (!fieldId || !rowOrders) {
       setGroupResult(new Map());
-      setGroupRowsReady(false);
       return;
     }
 
@@ -1195,7 +1196,6 @@ export function useRowsByGroup(groupId: string) {
       if (!field) {
         setNotFound(true);
         setGroupResult(newResult);
-        setGroupRowsReady(true);
         return;
       }
 
@@ -1206,7 +1206,6 @@ export function useRowsByGroup(groupId: string) {
       if (![FieldType.SingleSelect, FieldType.MultiSelect, FieldType.Checkbox].includes(fieldType)) {
         setNotFound(true);
         setGroupResult(newResult);
-        setGroupRowsReady(true);
         return;
       }
 
@@ -1216,12 +1215,15 @@ export function useRowsByGroup(groupId: string) {
 
       if (!groupResult) {
         setGroupResult(newResult);
-        setGroupRowsReady(true);
         return;
       }
 
       setGroupResult(groupResult);
-      setGroupRowsReady(areGroupRowsHydrated(rowOrders, groupingRows));
+      const rowsHydrated = areGroupRowsHydrated(rowOrders, groupingRows);
+
+      if (rowsHydrated && groupingIdentity) {
+        setHydratedGroupingIdentity(groupingIdentity);
+      }
     };
 
     onConditionsChange();
@@ -1247,7 +1249,13 @@ export function useRowsByGroup(groupId: string) {
         row.getMap(YjsEditorKey.data_section).unobserveDeep(observerRowsEvent);
       });
     };
-  }, [fieldId, fields, rowOrders, groupingRows, filters]);
+  }, [fieldId, fields, rowOrders, groupingRows, filters, groupingIdentity]);
+
+  // Cold Boards must wait for their first complete grouping before empty
+  // columns can be classified safely. Once that baseline exists, a later
+  // row_order arriving before its separate DatabaseRow collab must not
+  // temporarily disable Hide empty groups for every column.
+  const groupVisibilityReady = groupingIdentity !== null && hydratedGroupingIdentity === groupingIdentity;
 
   const visibleColumns = useMemo(
     () =>
@@ -1255,19 +1263,19 @@ export function useRowsByGroup(groupId: string) {
         columns,
         fieldId,
         getRowCount: (columnId) => groupResult.get(columnId)?.length ?? 0,
-        groupRowsReady,
+        groupRowsReady: groupVisibilityReady,
         hideEmptyGroups,
         hideUngroupedColumn: hideUnGroup,
         shownEmptyGroupIds,
       }).visibleColumns,
-    [columns, fieldId, groupResult, groupRowsReady, hideEmptyGroups, hideUnGroup, shownEmptyGroupIds]
+    [columns, fieldId, groupResult, groupVisibilityReady, hideEmptyGroups, hideUnGroup, shownEmptyGroupIds]
   );
 
   return {
     fieldId,
     groupResult,
     columns: visibleColumns,
-    groupRowsReady,
+    groupRowsReady: groupVisibilityReady,
     hideEmptyGroups,
     notFound,
   };

--- a/src/application/database-yjs/selector.ts
+++ b/src/application/database-yjs/selector.ts
@@ -2239,17 +2239,18 @@ export const useRowMetaSelector = (rowId: string) => {
   const { rowMap, ensureRow } = useDatabaseContext();
   const [rowDoc, setRowDoc] = useState<YDoc | null>(null);
 
-  // Ensure the row document is loaded and track it directly
+  const mappedRowDoc = rowMap?.[rowId] ?? null;
+
+  // Keep the selector attached to the document owned by Database. A version
+  // reset can replace a prefetched row doc without changing the row id.
+  useEffect(() => {
+    setRowDoc(mappedRowDoc);
+  }, [mappedRowDoc]);
+
+  // A seeded row is sufficient for the first paint but is not necessarily the
+  // canonical realtime document. Resolve it even when rowMap already has data.
   useEffect(() => {
     let cancelled = false;
-
-    // Check if already available in rowMap
-    const existing = rowMap?.[rowId];
-
-    if (existing) {
-      setRowDoc(existing);
-      return;
-    }
 
     if (ensureRow && rowId) {
       const promise = ensureRow(rowId);
@@ -2272,7 +2273,7 @@ export const useRowMetaSelector = (rowId: string) => {
     return () => {
       cancelled = true;
     };
-  }, [ensureRow, rowId, rowMap]);
+  }, [ensureRow, rowId]);
 
   // Read meta and observe changes on the row doc.
   // The meta key may not exist initially (empty Y.Map before sync completes),

--- a/src/application/database-yjs/selector.ts
+++ b/src/application/database-yjs/selector.ts
@@ -2270,8 +2270,11 @@ export const useRowMetaSelector = (rowId: string) => {
   // The meta key may not exist initially (empty Y.Map before sync completes),
   // so we observe the shared root to detect when the meta key is added.
   useEffect(() => {
-    if (!rowDoc || !rowDoc.share.has(YjsEditorKey.data_section)) return;
+    if (!rowDoc) return;
 
+    // Create the named root before realtime hydration. A remote update mutates
+    // this same Y.Map without replacing rowDoc, so waiting for share.has here
+    // leaves the hook with no observer and no React state change to retry it.
     const rowSharedRoot = rowDoc.getMap(YjsEditorKey.data_section);
     let metaObserverCleanup: (() => void) | null = null;
 

--- a/src/application/database-yjs/selector.ts
+++ b/src/application/database-yjs/selector.ts
@@ -2,9 +2,9 @@ import dayjs from 'dayjs';
 import { debounce } from 'lodash-es';
 import { useCallback, useDeferredValue, useEffect, useMemo, useRef, useState } from 'react';
 
+import { resolveBoardColumnVisibility } from '@/application/database-yjs/board-visibility';
 import { parseYDatabaseCellToCell } from '@/application/database-yjs/cell.parse';
 import { DateTimeCell, RollupCell } from '@/application/database-yjs/cell.type';
-import { resolveBoardColumnVisibility } from '@/application/database-yjs/board-visibility';
 import { hasRowConditionData, invalidateRowConditionCache } from '@/application/database-yjs/condition-value-cache';
 import { DEFAULT_FIELD_WRAP, getCell, MIN_COLUMN_WIDTH } from '@/application/database-yjs/const';
 import {
@@ -2234,18 +2234,34 @@ export function usePrimaryFieldId() {
   return primaryFieldId;
 }
 
+function readRowMeta(rowId: string, rowDoc: YDoc | null): RowMeta | null {
+  if (!rowDoc || !rowDoc.share.has(YjsEditorKey.data_section)) return null;
+
+  const rowSharedRoot = rowDoc.getMap(YjsEditorKey.data_section);
+  const yMeta = rowSharedRoot.get(YjsEditorKey.meta) as YDatabaseMetas | undefined;
+
+  return yMeta ? getMetaJSON(rowId, yMeta) : null;
+}
+
 export const useRowMetaSelector = (rowId: string) => {
-  const [meta, setMeta] = useState<RowMeta | null>();
   const { rowMap, ensureRow } = useDatabaseContext();
-  const [rowDoc, setRowDoc] = useState<YDoc | null>(null);
-
   const mappedRowDoc = rowMap?.[rowId] ?? null;
-
-  // Keep the selector attached to the document owned by Database. A version
-  // reset can replace a prefetched row doc without changing the row id.
-  useEffect(() => {
-    setRowDoc(mappedRowDoc);
-  }, [mappedRowDoc]);
+  const [resolvedRowDoc, setResolvedRowDoc] = useState<{
+    rowId: string;
+    mappedRowDoc: YDoc | null;
+    rowDoc: YDoc;
+  } | null>(null);
+  const rowDoc =
+    resolvedRowDoc?.rowId === rowId && resolvedRowDoc.mappedRowDoc === mappedRowDoc
+      ? resolvedRowDoc.rowDoc
+      : mappedRowDoc;
+  const [observedMeta, setObservedMeta] = useState<{
+    rowId: string;
+    rowDoc: YDoc;
+    value: RowMeta | null;
+  } | null>(null);
+  const meta =
+    observedMeta?.rowId === rowId && observedMeta.rowDoc === rowDoc ? observedMeta.value : readRowMeta(rowId, rowDoc);
 
   // A seeded row is sufficient for the first paint but is not necessarily the
   // canonical realtime document. Resolve it even when rowMap already has data.
@@ -2259,7 +2275,7 @@ export const useRowMetaSelector = (rowId: string) => {
         promise
           .then((doc) => {
             if (!cancelled && doc) {
-              setRowDoc(doc);
+              setResolvedRowDoc({ rowId, mappedRowDoc, rowDoc: doc });
             }
           })
           .catch((error: unknown) => {
@@ -2273,7 +2289,7 @@ export const useRowMetaSelector = (rowId: string) => {
     return () => {
       cancelled = true;
     };
-  }, [ensureRow, rowId]);
+  }, [ensureRow, mappedRowDoc, rowId]);
 
   // Read meta and observe changes on the row doc.
   // The meta key may not exist initially (empty Y.Map before sync completes),
@@ -2296,12 +2312,13 @@ export const useRowMetaSelector = (rowId: string) => {
 
       const yMeta = rowSharedRoot.get(YjsEditorKey.meta) as YDatabaseMetas | undefined;
 
-      if (!yMeta) return;
+      if (!yMeta) {
+        setObservedMeta({ rowId, rowDoc, value: null });
+        return;
+      }
 
       const updateMeta = () => {
-        const meta = getMetaJSON(rowId, yMeta);
-
-        setMeta(meta);
+        setObservedMeta({ rowId, rowDoc, value: getMetaJSON(rowId, yMeta) });
       };
 
       updateMeta();
@@ -2315,9 +2332,9 @@ export const useRowMetaSelector = (rowId: string) => {
       };
     };
 
-    // Watch for the meta key being added to the shared root (arrives via sync)
-    const handleRootChange = () => {
-      if (rowSharedRoot.has(YjsEditorKey.meta)) {
+    // Watch for the meta key being added, replaced, or removed.
+    const handleRootChange = (event: { keysChanged?: Set<string> }) => {
+      if (event.keysChanged?.has(YjsEditorKey.meta)) {
         attachMetaObserver();
       }
     };

--- a/src/application/database-yjs/selector.ts
+++ b/src/application/database-yjs/selector.ts
@@ -1160,6 +1160,7 @@ export function useRowsByGroup(groupId: string) {
   const rows = useRowMap();
   const rowOrders = useRowOrdersSelector();
   const viewId = useDatabaseViewId();
+  const { databaseDoc } = useDatabaseContext();
   const { cachedRowDocs } = useBackgroundRowDocLoader(Boolean(fieldId), 'board-grouping');
   const groupingRows = useMemo(() => {
     const next = { ...cachedRowDocs };
@@ -1176,11 +1177,14 @@ export function useRowsByGroup(groupId: string) {
   const fields = useDatabaseFields();
   const [notFound, setNotFound] = useState(false);
   const [groupResult, setGroupResult] = useState<Map<string, Row[]>>(new Map());
-  const [hydratedGroupingIdentity, setHydratedGroupingIdentity] = useState<string | null>(null);
+  const [hydratedGroupingIdentity, setHydratedGroupingIdentity] = useState<{
+    databaseDoc: YDoc;
+    groupingKey: string;
+  } | null>(null);
   const view = useDatabaseView();
   const filters = view?.get(YjsDatabaseKey.filters);
   const { hideEmptyGroups, hideUnGroup, shownEmptyGroupIds } = useBoardLayoutSettings();
-  const groupingIdentity = fieldId ? `${viewId ?? ''}:${groupId}:${fieldId}` : null;
+  const groupingKey = fieldId ? `${viewId ?? ''}:${groupId}:${fieldId}` : null;
 
   useEffect(() => {
     if (!fieldId || !rowOrders) {
@@ -1221,8 +1225,12 @@ export function useRowsByGroup(groupId: string) {
       setGroupResult(groupResult);
       const rowsHydrated = areGroupRowsHydrated(rowOrders, groupingRows);
 
-      if (rowsHydrated && groupingIdentity) {
-        setHydratedGroupingIdentity(groupingIdentity);
+      if (rowsHydrated && groupingKey) {
+        setHydratedGroupingIdentity((current) =>
+          current?.databaseDoc === databaseDoc && current.groupingKey === groupingKey
+            ? current
+            : { databaseDoc, groupingKey }
+        );
       }
     };
 
@@ -1249,13 +1257,16 @@ export function useRowsByGroup(groupId: string) {
         row.getMap(YjsEditorKey.data_section).unobserveDeep(observerRowsEvent);
       });
     };
-  }, [fieldId, fields, rowOrders, groupingRows, filters, groupingIdentity]);
+  }, [databaseDoc, fieldId, fields, rowOrders, groupingRows, filters, groupingKey]);
 
   // Cold Boards must wait for their first complete grouping before empty
   // columns can be classified safely. Once that baseline exists, a later
   // row_order arriving before its separate DatabaseRow collab must not
   // temporarily disable Hide empty groups for every column.
-  const groupVisibilityReady = groupingIdentity !== null && hydratedGroupingIdentity === groupingIdentity;
+  const groupVisibilityReady =
+    groupingKey !== null &&
+    hydratedGroupingIdentity?.databaseDoc === databaseDoc &&
+    hydratedGroupingIdentity.groupingKey === groupingKey;
 
   const visibleColumns = useMemo(
     () =>

--- a/src/application/services/js-services/cache/__tests__/cache.test.ts
+++ b/src/application/services/js-services/cache/__tests__/cache.test.ts
@@ -1,4 +1,9 @@
 import * as Y from 'yjs';
+import {
+  createDatabaseRowDocSeed,
+  invalidateDatabaseRowDocSeedGeneration,
+} from '@/application/database-blob/row-seed-fence';
+import { FieldType } from '@/application/database-yjs/database.type';
 import { Types, YDoc, YjsDatabaseKey, YjsEditorKey } from '@/application/types';
 import { withTestingYDoc } from '@/application/slate-yjs/__tests__/withTestingYjsEditor';
 import { expect } from '@jest/globals';
@@ -10,6 +15,7 @@ import {
   getPublishView,
   getPublishViewMeta,
   mergeLegacyRowDocIfExists,
+  openRowDoc,
 } from '@/application/services/js-services/cache';
 import { applyYDoc } from '@/application/ydoc/apply';
 import {
@@ -328,6 +334,36 @@ describe('database row document cache', () => {
     secondDoc.destroy();
   });
 
+  it('does not apply a row seed invalidated while its canonical doc is opening', async () => {
+    const rowId = 'row-cache-reset-seed';
+    const rowKey = `database-cache-reset-seed_rows_${rowId}`;
+    const canonicalDoc = createRowDoc(rowId, 'database-cache-reset-seed', {});
+    const provider = {
+      synced: true,
+      destroy: jest.fn().mockResolvedValue(undefined),
+    };
+    const seed = createDatabaseRowDocSeed(rowId, {
+      bytes: new Uint8Array([1, 2, 3]),
+      encoderVersion: 1,
+    });
+    let resolveOpen!: (value: Awaited<ReturnType<typeof openRowCollabDBWithProvider>>) => void;
+    const pendingOpen = new Promise<Awaited<ReturnType<typeof openRowCollabDBWithProvider>>>((resolve) => {
+      resolveOpen = resolve;
+    });
+
+    mockedOpenRowCollabDBWithProvider.mockReturnValueOnce(pendingOpen);
+
+    const opening = openRowDoc(rowKey, seed);
+
+    invalidateDatabaseRowDocSeedGeneration(rowId);
+    resolveOpen({ doc: canonicalDoc, provider } as never);
+
+    await expect(opening).resolves.toBe(canonicalDoc);
+    expect(mockedApplyYDoc).not.toHaveBeenCalled();
+
+    canonicalDoc.destroy();
+  });
+
   it('adopts the canonical row document selected by version reset', () => {
     const rowId = 'row-cache-reset';
     const rowKey = `database-cache-reset_rows_${rowId}`;
@@ -339,6 +375,26 @@ describe('database row document cache', () => {
 
     canonicalDoc.destroy();
     expect(getCachedRowDoc(rowKey)).toBeUndefined();
+  });
+
+  it('normalizes legacy cell field types on a canonical reset document', () => {
+    const rowId = 'row-cache-reset-normalizer';
+    const rowKey = `database-cache-reset-normalizer_rows_${rowId}`;
+    const canonicalDoc = createRowDoc(rowId, 'database-cache-reset-normalizer', { 'field-id': '42' });
+    const row = canonicalDoc.getMap(YjsEditorKey.data_section).get(YjsEditorKey.database_row) as Y.Map<unknown>;
+    const cells = row.get(YjsDatabaseKey.cells) as Y.Map<Y.Map<unknown>>;
+    const cell = cells.get('field-id');
+
+    cell?.set(YjsDatabaseKey.field_type, String(FieldType.RichText));
+    cell?.set(YjsDatabaseKey.source_field_type, FieldType.Number);
+
+    cacheCanonicalRowDoc(rowId, canonicalDoc);
+
+    expect(getCachedRowDoc(rowKey)).toBe(canonicalDoc);
+    expect(cell?.get(YjsDatabaseKey.field_type)).toBe(FieldType.Number);
+    expect(cell?.has(YjsDatabaseKey.source_field_type)).toBe(false);
+
+    canonicalDoc.destroy();
   });
 });
 

--- a/src/application/services/js-services/cache/__tests__/cache.test.ts
+++ b/src/application/services/js-services/cache/__tests__/cache.test.ts
@@ -4,12 +4,21 @@ import { withTestingYDoc } from '@/application/slate-yjs/__tests__/withTestingYj
 import { expect } from '@jest/globals';
 import {
   collabTypeToDBType,
+  createRow,
+  getCachedRowDoc,
   getPublishView,
   getPublishViewMeta,
   mergeLegacyRowDocIfExists,
 } from '@/application/services/js-services/cache';
 import { applyYDoc } from '@/application/ydoc/apply';
-import { openCollabDB, openCollabDBWithProvider, collabIndexedDBExists, db, deleteCollabDB } from '@/application/db';
+import {
+  openCollabDB,
+  openCollabDBWithProvider,
+  openRowCollabDBWithProvider,
+  collabIndexedDBExists,
+  db,
+  deleteCollabDB,
+} from '@/application/db';
 import { StrategyType } from '@/application/services/js-services/cache/types';
 
 jest.mock('@/application/ydoc/apply', () => ({
@@ -40,6 +49,9 @@ const normalDoc = withTestingYDoc('1');
 const mockFetcher = jest.fn();
 const mockedApplyYDoc = applyYDoc as jest.MockedFunction<typeof applyYDoc>;
 const mockedOpenCollabDBWithProvider = openCollabDBWithProvider as jest.MockedFunction<typeof openCollabDBWithProvider>;
+const mockedOpenRowCollabDBWithProvider = openRowCollabDBWithProvider as jest.MockedFunction<
+  typeof openRowCollabDBWithProvider
+>;
 const mockedCollabIndexedDBExists = collabIndexedDBExists as jest.MockedFunction<typeof collabIndexedDBExists>;
 const mockedDeleteCollabDB = deleteCollabDB as jest.MockedFunction<typeof deleteCollabDB>;
 
@@ -279,6 +291,40 @@ describe('database row legacy cache migration', () => {
     expect(db.collab_custom.put).not.toHaveBeenCalled();
     expect(mockedDeleteCollabDB).not.toHaveBeenCalled();
     expect(getCellData(sharedDoc, 'same-field')).toBe('current-value');
+  });
+});
+
+describe('database row document cache', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedCollabIndexedDBExists.mockResolvedValue(false);
+    (db.collab_custom.get as jest.Mock).mockResolvedValue(undefined);
+  });
+
+  it('evicts a destroyed row document before the next open', async () => {
+    const rowId = 'row-cache-destroyed';
+    const rowKey = `database-cache-destroyed_rows_${rowId}`;
+    const firstDoc = createRowDoc(rowId, 'database-cache-destroyed', {});
+    const secondDoc = createRowDoc(rowId, 'database-cache-destroyed', {});
+    const provider = {
+      synced: true,
+      destroy: jest.fn().mockResolvedValue(undefined),
+    };
+
+    mockedOpenRowCollabDBWithProvider
+      .mockResolvedValueOnce({ doc: firstDoc, provider } as never)
+      .mockResolvedValueOnce({ doc: secondDoc, provider } as never);
+
+    await expect(createRow(rowKey)).resolves.toBe(firstDoc);
+    expect(getCachedRowDoc(rowKey)).toBe(firstDoc);
+
+    firstDoc.destroy();
+
+    expect(getCachedRowDoc(rowKey)).toBeUndefined();
+    await expect(createRow(rowKey)).resolves.toBe(secondDoc);
+    expect(mockedOpenRowCollabDBWithProvider).toHaveBeenCalledTimes(2);
+
+    secondDoc.destroy();
   });
 });
 

--- a/src/application/services/js-services/cache/__tests__/cache.test.ts
+++ b/src/application/services/js-services/cache/__tests__/cache.test.ts
@@ -3,6 +3,7 @@ import { Types, YDoc, YjsDatabaseKey, YjsEditorKey } from '@/application/types';
 import { withTestingYDoc } from '@/application/slate-yjs/__tests__/withTestingYjsEditor';
 import { expect } from '@jest/globals';
 import {
+  cacheCanonicalRowDoc,
   collabTypeToDBType,
   createRow,
   getCachedRowDoc,
@@ -325,6 +326,19 @@ describe('database row document cache', () => {
     expect(mockedOpenRowCollabDBWithProvider).toHaveBeenCalledTimes(2);
 
     secondDoc.destroy();
+  });
+
+  it('adopts the canonical row document selected by version reset', () => {
+    const rowId = 'row-cache-reset';
+    const rowKey = `database-cache-reset_rows_${rowId}`;
+    const canonicalDoc = createRowDoc(rowId, 'database-cache-reset', {});
+
+    cacheCanonicalRowDoc(rowId, canonicalDoc);
+
+    expect(getCachedRowDoc(rowKey)).toBe(canonicalDoc);
+
+    canonicalDoc.destroy();
+    expect(getCachedRowDoc(rowKey)).toBeUndefined();
   });
 });
 

--- a/src/application/services/js-services/cache/index.ts
+++ b/src/application/services/js-services/cache/index.ts
@@ -488,6 +488,28 @@ function getRowObjectId(rowKey: string) {
   return rowObjectId || rowKey;
 }
 
+function storeRowDocEntry(rowObjectId: string, entry: RowDocEntry) {
+  const existing = rowDocs.get(rowObjectId);
+
+  if (existing?.doc === entry.doc) return existing;
+
+  rowDocs.set(rowObjectId, entry);
+  entry.doc.on('destroy', () => {
+    if (rowDocs.get(rowObjectId) === entry) {
+      rowDocs.delete(rowObjectId);
+    }
+  });
+  return entry;
+}
+
+/** Keep RowService consumers on the document selected by sync version reset. */
+export function cacheCanonicalRowDoc(rowId: string, doc: YDoc) {
+  storeRowDocEntry(getRowObjectId(rowId), {
+    doc,
+    whenSynced: Promise.resolve(),
+  });
+}
+
 function hasDatabaseRow(doc: YDoc) {
   return doc.getMap(YjsEditorKey.data_section).has(YjsEditorKey.database_row);
 }
@@ -766,13 +788,7 @@ async function getOrCreateRowDocEntry(rowKey: string): Promise<RowDocEntry> {
       return raceWinner;
     }
 
-    rowDocs.set(rowObjectId, entry);
-    entry.doc.on('destroy', () => {
-      if (rowDocs.get(rowObjectId) === entry) {
-        rowDocs.delete(rowObjectId);
-      }
-    });
-    return entry;
+    return storeRowDocEntry(rowObjectId, entry);
   })();
 
   pendingRowDocEntries.set(rowObjectId, promise);

--- a/src/application/services/js-services/cache/index.ts
+++ b/src/application/services/js-services/cache/index.ts
@@ -767,6 +767,11 @@ async function getOrCreateRowDocEntry(rowKey: string): Promise<RowDocEntry> {
     }
 
     rowDocs.set(rowObjectId, entry);
+    entry.doc.on('destroy', () => {
+      if (rowDocs.get(rowObjectId) === entry) {
+        rowDocs.delete(rowObjectId);
+      }
+    });
     return entry;
   })();
 

--- a/src/application/services/js-services/cache/index.ts
+++ b/src/application/services/js-services/cache/index.ts
@@ -1,5 +1,9 @@
 import * as Y from 'yjs';
 
+import {
+  type DatabaseRowDocSeed,
+  isDatabaseRowDocSeedCurrent,
+} from '@/application/database-blob/row-seed-fence';
 import { installLegacyCellFieldTypeNormalizer } from '@/application/database-yjs/cell.field-type';
 import { invalidateRowConditionCache } from '@/application/database-yjs/condition-value-cache';
 import { migrateDatabaseFieldTypes } from '@/application/database-yjs/migrations/rollup_fieldtype';
@@ -504,6 +508,7 @@ function storeRowDocEntry(rowObjectId: string, entry: RowDocEntry) {
 
 /** Keep RowService consumers on the document selected by sync version reset. */
 export function cacheCanonicalRowDoc(rowId: string, doc: YDoc) {
+  installLegacyCellFieldTypeNormalizer(doc);
   storeRowDocEntry(getRowObjectId(rowId), {
     doc,
     whenSynced: Promise.resolve(),
@@ -860,7 +865,7 @@ export async function createRow(rowKey: string) {
   return entry.doc;
 }
 
-export async function openRowDoc(rowKey: string, seed?: { bytes: Uint8Array; encoderVersion: number }) {
+export async function openRowDoc(rowKey: string, seed?: DatabaseRowDocSeed) {
   Log.debug('[Database] createRowDocFast start', {
     rowKey,
     hasSeed: Boolean(seed),
@@ -873,7 +878,7 @@ export async function openRowDoc(rowKey: string, seed?: { bytes: Uint8Array; enc
   const rowSharedRootBefore = entry.doc.getMap(YjsEditorKey.data_section);
   const hasRowDataBefore = rowSharedRootBefore.has(YjsEditorKey.database_row);
 
-  if (seed && !hasAppliedSeed(entry.doc, seed.bytes)) {
+  if (seed && isDatabaseRowDocSeedCurrent(seed) && !hasAppliedSeed(entry.doc, seed.bytes)) {
     Log.debug('[Database] createRowDocFast applying seed', {
       rowKey,
       seedBytes: seed.bytes.length,

--- a/src/application/types.ts
+++ b/src/application/types.ts
@@ -1148,7 +1148,7 @@ export interface PublishViewMetaData {
 
 export type AppendBreadcrumb = (view?: View) => void;
 
-export type CreateRow = (rowKey: string) => Promise<YDoc>;
+export type CreateRow = (rowKey: string, options?: { forceSync?: boolean }) => Promise<YDoc>;
 export interface LoadViewOptions {
   databaseId?: string | null;
   forceFetch?: boolean;

--- a/src/components/app/__tests__/app.hooks.eventEmitter.test.tsx
+++ b/src/components/app/__tests__/app.hooks.eventEmitter.test.tsx
@@ -1,0 +1,39 @@
+import EventEmitter from 'events';
+
+import { renderHook } from '@testing-library/react';
+import type { ReactNode } from 'react';
+
+import { useEventEmitter, useEventEmitterOptional } from '@/components/app/app.hooks';
+import { AppEventEmitterContext } from '@/components/app/contexts/AppEventEmitterContext';
+
+jest.mock('@/components/app/layers/AppAuthLayer', () => ({ AppAuthLayer: () => null }));
+jest.mock('@/components/app/layers/AppBusinessLayer', () => ({ AppBusinessLayer: () => null }));
+jest.mock('@/components/app/layers/AppSyncLayer', () => ({ AppSyncLayer: () => null }));
+
+describe('app event emitter hooks', () => {
+  it('keeps the required hook strict outside AppProvider', () => {
+    const consoleError = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    try {
+      expect(() => renderHook(() => useEventEmitter())).toThrow('useEventEmitter must be used within an AppProvider');
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+
+  it('allows publish-page consumers to render without AppProvider', () => {
+    const { result } = renderHook(() => useEventEmitterOptional());
+
+    expect(result.current).toBeUndefined();
+  });
+
+  it('returns the app event emitter when the context is available', () => {
+    const eventEmitter = new EventEmitter();
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <AppEventEmitterContext.Provider value={eventEmitter}>{children}</AppEventEmitterContext.Provider>
+    );
+    const { result } = renderHook(() => useEventEmitterOptional(), { wrapper });
+
+    expect(result.current).toBe(eventEmitter);
+  });
+});

--- a/src/components/app/app.hooks.tsx
+++ b/src/components/app/app.hooks.tsx
@@ -570,6 +570,13 @@ export function useEventEmitter() {
   return context;
 }
 
+/** The app-wide event bus, or undefined when rendered outside AppProvider. Safe for publish pages. */
+export function useEventEmitterOptional() {
+  const context = useContext(AppEventEmitterContext);
+
+  return context ?? undefined;
+}
+
 /** Schedule deferred cleanup of a sync object (e.g. Yjs doc) after a delay. */
 export function useScheduleDeferredCleanup() {
   const context = useContext(AppSyncContext);

--- a/src/components/app/contexts/SyncInternalContext.ts
+++ b/src/components/app/contexts/SyncInternalContext.ts
@@ -2,6 +2,7 @@ import { createContext, useContext } from 'react';
 import { Awareness } from 'y-protocols/awareness';
 
 import { SyncContext } from '@/application/services/js-services/sync-protocol';
+import { YDoc } from '@/application/types';
 import type { AppEventEmitter } from '@/components/app/contexts/AppEventEmitterContext';
 import { RegisterSyncContext } from '@/components/ws/useSync';
 
@@ -13,6 +14,7 @@ import { RegisterSyncContext } from '@/components/ws/useSync';
 // which receives the transports directly in AppSyncLayer.
 export interface SyncInternalContextType {
   registerSyncContext: (params: RegisterSyncContext) => SyncContext;
+  rebindSyncContext: (objectId: string) => YDoc | undefined;
   revertCollabVersion: (viewId: string, version: string) => Promise<void>;
   eventEmitter: AppEventEmitter;
   awarenessMap: Record<string, Awareness>;

--- a/src/components/app/header/RightMenu.tsx
+++ b/src/components/app/header/RightMenu.tsx
@@ -61,7 +61,7 @@ function RightMenu() {
   return (
     <div className={'flex items-center gap-2'}>
       <Users viewId={routeViewId} />
-      {actionViewId ? <ShareButton viewId={actionViewId} disablePublish={hasRowPageRoute} /> : null}
+      {actionViewId ? <ShareButton viewId={actionViewId} hidePublish={hasRowPageRoute} /> : null}
       {favoriteViewId && (
         <FavoriteButton viewId={favoriteViewId} beforeToggle={rowPage ? prepareRowDocumentForFavorite : undefined} />
       )}

--- a/src/components/app/header/RightMenu.tsx
+++ b/src/components/app/header/RightMenu.tsx
@@ -61,7 +61,7 @@ function RightMenu() {
   return (
     <div className={'flex items-center gap-2'}>
       <Users viewId={routeViewId} />
-      {actionViewId && <ShareButton viewId={actionViewId} />}
+      {actionViewId && !hasRowPageRoute ? <ShareButton viewId={actionViewId} /> : null}
       {favoriteViewId && (
         <FavoriteButton viewId={favoriteViewId} beforeToggle={rowPage ? prepareRowDocumentForFavorite : undefined} />
       )}

--- a/src/components/app/header/RightMenu.tsx
+++ b/src/components/app/header/RightMenu.tsx
@@ -61,7 +61,7 @@ function RightMenu() {
   return (
     <div className={'flex items-center gap-2'}>
       <Users viewId={routeViewId} />
-      {actionViewId && !hasRowPageRoute ? <ShareButton viewId={actionViewId} /> : null}
+      {actionViewId ? <ShareButton viewId={actionViewId} disablePublish={hasRowPageRoute} /> : null}
       {favoriteViewId && (
         <FavoriteButton viewId={favoriteViewId} beforeToggle={rowPage ? prepareRowDocumentForFavorite : undefined} />
       )}

--- a/src/components/app/header/__tests__/RightMenu.rowFavorite.test.tsx
+++ b/src/components/app/header/__tests__/RightMenu.rowFavorite.test.tsx
@@ -28,8 +28,8 @@ jest.mock('@/components/app/app.hooks', () => ({
 
 jest.mock('src/components/app/share/ShareButton', () => ({
   __esModule: true,
-  default: ({ disablePublish = false }: { disablePublish?: boolean }) => (
-    <div data-testid='share-button' data-publish-disabled={String(disablePublish)} />
+  default: ({ hidePublish = false }: { hidePublish?: boolean }) => (
+    <div data-testid='share-button' data-publish-hidden={String(hidePublish)} />
   ),
 }));
 
@@ -99,7 +99,7 @@ describe('RightMenu row-page actions', () => {
     expect(screen.getByTestId('favorite-button').getAttribute('data-view-id')).toBe('row-document');
   });
 
-  it('keeps sharing available but disables publishing on a row-page route', () => {
+  it('keeps sharing available but hides publishing on a row-page route', () => {
     mockActiveRowPage = {
       rowId: 'requested-row',
       documentId: 'row-document',
@@ -117,7 +117,7 @@ describe('RightMenu row-page actions', () => {
       </MemoryRouter>
     );
 
-    expect(screen.getByTestId('share-button').getAttribute('data-publish-disabled')).toBe('true');
+    expect(screen.getByTestId('share-button').getAttribute('data-publish-hidden')).toBe('true');
   });
 
   it('continues targeting the route view outside row-page routes', () => {
@@ -131,6 +131,6 @@ describe('RightMenu row-page actions', () => {
     );
 
     expect(screen.getByTestId('favorite-button').getAttribute('data-view-id')).toBe('database-container');
-    expect(screen.getByTestId('share-button').getAttribute('data-publish-disabled')).toBe('false');
+    expect(screen.getByTestId('share-button').getAttribute('data-publish-hidden')).toBe('false');
   });
 });

--- a/src/components/app/header/__tests__/RightMenu.rowFavorite.test.tsx
+++ b/src/components/app/header/__tests__/RightMenu.rowFavorite.test.tsx
@@ -28,7 +28,9 @@ jest.mock('@/components/app/app.hooks', () => ({
 
 jest.mock('src/components/app/share/ShareButton', () => ({
   __esModule: true,
-  default: () => <div data-testid='share-button' />,
+  default: ({ disablePublish = false }: { disablePublish?: boolean }) => (
+    <div data-testid='share-button' data-publish-disabled={String(disablePublish)} />
+  ),
 }));
 
 jest.mock('@/components/app/header/FavoriteButton', () => ({
@@ -97,7 +99,7 @@ describe('RightMenu row-page actions', () => {
     expect(screen.getByTestId('favorite-button').getAttribute('data-view-id')).toBe('row-document');
   });
 
-  it('hides the share and publish action on a row-page route', () => {
+  it('keeps sharing available but disables publishing on a row-page route', () => {
     mockActiveRowPage = {
       rowId: 'requested-row',
       documentId: 'row-document',
@@ -115,7 +117,7 @@ describe('RightMenu row-page actions', () => {
       </MemoryRouter>
     );
 
-    expect(screen.queryByTestId('share-button')).toBeNull();
+    expect(screen.getByTestId('share-button').getAttribute('data-publish-disabled')).toBe('true');
   });
 
   it('continues targeting the route view outside row-page routes', () => {
@@ -129,6 +131,6 @@ describe('RightMenu row-page actions', () => {
     );
 
     expect(screen.getByTestId('favorite-button').getAttribute('data-view-id')).toBe('database-container');
-    expect(screen.getByTestId('share-button')).toBeTruthy();
+    expect(screen.getByTestId('share-button').getAttribute('data-publish-disabled')).toBe('false');
   });
 });

--- a/src/components/app/header/__tests__/RightMenu.rowFavorite.test.tsx
+++ b/src/components/app/header/__tests__/RightMenu.rowFavorite.test.tsx
@@ -45,7 +45,7 @@ jest.mock('@/components/app/header/Users', () => ({
   Users: () => <div data-testid='users' />,
 }));
 
-describe('RightMenu row favorite action', () => {
+describe('RightMenu row-page actions', () => {
   beforeEach(() => {
     mockActiveRowPage = null;
   });
@@ -97,6 +97,27 @@ describe('RightMenu row favorite action', () => {
     expect(screen.getByTestId('favorite-button').getAttribute('data-view-id')).toBe('row-document');
   });
 
+  it('hides the share and publish action on a row-page route', () => {
+    mockActiveRowPage = {
+      rowId: 'requested-row',
+      documentId: 'row-document',
+      title: 'Requested row',
+      source: null,
+      hasDocument: false,
+    };
+
+    render(
+      <MemoryRouter
+        initialEntries={['/app/workspace-1/database-container?r=requested-row']}
+        future={{ v7_relativeSplatPath: true, v7_startTransition: true }}
+      >
+        <RightMenu />
+      </MemoryRouter>
+    );
+
+    expect(screen.queryByTestId('share-button')).toBeNull();
+  });
+
   it('continues targeting the route view outside row-page routes', () => {
     render(
       <MemoryRouter
@@ -108,5 +129,6 @@ describe('RightMenu row favorite action', () => {
     );
 
     expect(screen.getByTestId('favorite-button').getAttribute('data-view-id')).toBe('database-container');
+    expect(screen.getByTestId('share-button')).toBeTruthy();
   });
 });

--- a/src/components/app/hooks/__tests__/useRowOperations.test.tsx
+++ b/src/components/app/hooks/__tests__/useRowOperations.test.tsx
@@ -1,0 +1,55 @@
+import { renderHook } from '@testing-library/react';
+import * as Y from 'yjs';
+
+import { RowService } from '@/application/services/domains';
+import { YDoc } from '@/application/types';
+import { useAuthInternal } from '@/components/app/contexts/AuthInternalContext';
+import { useSyncInternal } from '@/components/app/contexts/SyncInternalContext';
+import { useRowOperations } from '@/components/app/hooks/useRowOperations';
+
+jest.mock('@/application/services/domains', () => ({
+  RowService: {
+    create: jest.fn(),
+    remove: jest.fn(),
+  },
+}));
+
+jest.mock('@/components/app/contexts/AuthInternalContext', () => ({
+  useAuthInternal: jest.fn(),
+}));
+
+jest.mock('@/components/app/contexts/SyncInternalContext', () => ({
+  useSyncInternal: jest.fn(),
+}));
+
+describe('useRowOperations', () => {
+  it('returns the canonical live row doc when retrying synchronization', async () => {
+    const databaseId = '11111111-1111-4111-8111-111111111111';
+    const rowId = '22222222-2222-4222-8222-222222222222';
+    const rowKey = `${databaseId}_rows_${rowId}`;
+    const canonicalDoc = new Y.Doc({ guid: rowId }) as YDoc;
+    const staleCachedDoc = new Y.Doc({ guid: rowId }) as YDoc;
+    const rebindSyncContext = jest.fn(() => canonicalDoc);
+    const registerSyncContext = jest.fn();
+
+    jest
+      .mocked(useAuthInternal)
+      .mockReturnValue({ currentWorkspaceId: 'workspace-id' } as ReturnType<typeof useAuthInternal>);
+    jest
+      .mocked(useSyncInternal)
+      .mockReturnValue({ rebindSyncContext, registerSyncContext } as ReturnType<typeof useSyncInternal>);
+    jest.mocked(RowService.create).mockResolvedValue(staleCachedDoc);
+
+    const { result, unmount } = renderHook(() => useRowOperations());
+
+    await expect(result.current.createRow(rowKey, { forceSync: true })).resolves.toBe(canonicalDoc);
+    expect(rebindSyncContext).toHaveBeenCalledTimes(1);
+    expect(rebindSyncContext).toHaveBeenCalledWith(rowId);
+    expect(RowService.create).not.toHaveBeenCalled();
+    expect(registerSyncContext).not.toHaveBeenCalled();
+
+    unmount();
+    canonicalDoc.destroy();
+    staleCachedDoc.destroy();
+  });
+});

--- a/src/components/app/hooks/__tests__/useRowOperations.test.tsx
+++ b/src/components/app/hooks/__tests__/useRowOperations.test.tsx
@@ -52,4 +52,33 @@ describe('useRowOperations', () => {
     canonicalDoc.destroy();
     staleCachedDoc.destroy();
   });
+
+  it('does not acquire a new row owner when a force rebind misses', async () => {
+    const databaseId = '33333333-3333-4333-8333-333333333333';
+    const rowId = '44444444-4444-4444-8444-444444444444';
+    const rowKey = `${databaseId}_rows_${rowId}`;
+    const staleCachedDoc = new Y.Doc({ guid: rowId }) as YDoc;
+    const rebindSyncContext = jest.fn(() => undefined);
+    const registerSyncContext = jest.fn();
+
+    jest
+      .mocked(useAuthInternal)
+      .mockReturnValue({ currentWorkspaceId: 'workspace-id' } as ReturnType<typeof useAuthInternal>);
+    jest
+      .mocked(useSyncInternal)
+      .mockReturnValue({ rebindSyncContext, registerSyncContext } as ReturnType<typeof useSyncInternal>);
+    jest.mocked(RowService.create).mockResolvedValue(staleCachedDoc);
+
+    const { result, unmount } = renderHook(() => useRowOperations());
+
+    await expect(result.current.createRow(rowKey, { forceSync: true })).rejects.toThrow(
+      'Cannot rebind row sync while its context is unavailable'
+    );
+    expect(rebindSyncContext).toHaveBeenCalledWith(rowId);
+    expect(RowService.create).not.toHaveBeenCalled();
+    expect(registerSyncContext).not.toHaveBeenCalled();
+
+    unmount();
+    staleCachedDoc.destroy();
+  });
 });

--- a/src/components/app/hooks/useRowOperations.ts
+++ b/src/components/app/hooks/useRowOperations.ts
@@ -9,25 +9,34 @@ import { useSyncInternal } from '../contexts/SyncInternalContext';
 // Hook for managing database row operations (create + cleanup)
 export function useRowOperations() {
   const { currentWorkspaceId } = useAuthInternal();
-  const { registerSyncContext } = useSyncInternal();
+  const { registerSyncContext, rebindSyncContext } = useSyncInternal();
 
   const createdRowKeys = useRef<string[]>([]);
 
   // Create row document
   const createRow = useCallback(
-    async (rowKey: string): Promise<YDoc> => {
+    async (rowKey: string, options?: { forceSync?: boolean }): Promise<YDoc> => {
       if (!currentWorkspaceId) {
         throw new Error('Failed to create row doc');
       }
 
       try {
+        // A remote database update can advertise a row before its separate
+        // DatabaseRow collab is queryable. Retrying must resend the manifest
+        // on the canonical context; registering it again would leak a ref count.
+        const rowId = rowKey.split('_rows_')[1];
+
+        if (options?.forceSync && rowId) {
+          const canonicalDoc = rebindSyncContext(rowId);
+
+          if (canonicalDoc) return canonicalDoc;
+        }
+
         const doc = await RowService.create(rowKey);
 
         if (!doc) {
           throw new Error('Failed to create row doc');
         }
-
-        const rowId = rowKey.split('_rows_')[1];
 
         if (!rowId) {
           throw new Error('Failed to create row doc');
@@ -47,7 +56,7 @@ export function useRowOperations() {
         return Promise.reject(e);
       }
     },
-    [currentWorkspaceId, registerSyncContext]
+    [currentWorkspaceId, rebindSyncContext, registerSyncContext]
   );
 
   // Clean up created row documents when view changes

--- a/src/components/app/hooks/useRowOperations.ts
+++ b/src/components/app/hooks/useRowOperations.ts
@@ -26,10 +26,20 @@ export function useRowOperations() {
         // on the canonical context; registering it again would leak a ref count.
         const rowId = rowKey.split('_rows_')[1];
 
-        if (options?.forceSync && rowId) {
+        if (options?.forceSync) {
+          if (!rowId) {
+            throw new Error('Failed to create row doc');
+          }
+
           const canonicalDoc = rebindSyncContext(rowId);
 
           if (canonicalDoc) return canonicalDoc;
+
+          // Force sync is a rebind of an existing owner, never an acquisition.
+          // During a version reset the old context has already been destroyed
+          // and its replacement may still be opening; falling through here
+          // would register a second owner that this Database never releases.
+          throw new Error('Cannot rebind row sync while its context is unavailable');
         }
 
         const doc = await RowService.create(rowKey);

--- a/src/components/app/layers/AppSyncLayer.tsx
+++ b/src/components/app/layers/AppSyncLayer.tsx
@@ -120,6 +120,7 @@ export const AppSyncLayer: FC<AppSyncLayerProps> = ({ children }) => {
   // Initialize sync context for collaborative editing
   const {
     registerSyncContext,
+    rebindSyncContext,
     flushAllSync,
     syncAllToServer,
     applyHttpFullSyncResult,
@@ -610,6 +611,7 @@ export const AppSyncLayer: FC<AppSyncLayerProps> = ({ children }) => {
   const syncContextValue: SyncInternalContextType = useMemo(
     () => ({
       registerSyncContext,
+      rebindSyncContext,
       revertCollabVersion,
       eventEmitter,
       awarenessMap,
@@ -620,6 +622,7 @@ export const AppSyncLayer: FC<AppSyncLayerProps> = ({ children }) => {
     [
       eventEmitter,
       registerSyncContext,
+      rebindSyncContext,
       revertCollabVersion,
       awarenessMap,
       flushAllSync,

--- a/src/components/app/share/ShareButton.tsx
+++ b/src/components/app/share/ShareButton.tsx
@@ -9,7 +9,7 @@ import ShareTabs from '@/components/app/share/ShareTabs';
 import { Button } from '@/components/ui/button';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 
-export function ShareButton({ viewId }: { viewId: string }) {
+export function ShareButton({ viewId, disablePublish = false }: { viewId: string; disablePublish?: boolean }) {
   const { t } = useTranslation();
 
   const view = useAppView(viewId);
@@ -38,6 +38,7 @@ export function ShareButton({ viewId }: { viewId: string }) {
           <ShareTabs
             opened={opened}
             viewId={viewId}
+            disablePublish={disablePublish}
             onClose={() => setOpened(false)}
             onOpenPublishManage={() => {
               setOpened(false);

--- a/src/components/app/share/ShareButton.tsx
+++ b/src/components/app/share/ShareButton.tsx
@@ -16,6 +16,7 @@ export function ShareButton({ viewId, hidePublish = false }: { viewId: string; h
   const layout = view?.layout;
   const [opened, setOpened] = React.useState(false);
   const [publishManageOpen, setPublishManageOpen] = React.useState(false);
+  const publishManageVisible = publishManageOpen && !hidePublish;
 
   if (layout === ViewLayout.AIChat) return null;
 
@@ -49,7 +50,7 @@ export function ShareButton({ viewId, hidePublish = false }: { viewId: string; h
       </Popover>
       <NormalModal
         data-testid='publish-manage-modal'
-        open={publishManageOpen}
+        open={publishManageVisible}
         onClose={() => setPublishManageOpen(false)}
         scroll='paper'
         overflowHidden

--- a/src/components/app/share/ShareButton.tsx
+++ b/src/components/app/share/ShareButton.tsx
@@ -9,7 +9,7 @@ import ShareTabs from '@/components/app/share/ShareTabs';
 import { Button } from '@/components/ui/button';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 
-export function ShareButton({ viewId, disablePublish = false }: { viewId: string; disablePublish?: boolean }) {
+export function ShareButton({ viewId, hidePublish = false }: { viewId: string; hidePublish?: boolean }) {
   const { t } = useTranslation();
 
   const view = useAppView(viewId);
@@ -38,7 +38,7 @@ export function ShareButton({ viewId, disablePublish = false }: { viewId: string
           <ShareTabs
             opened={opened}
             viewId={viewId}
-            disablePublish={disablePublish}
+            hidePublish={hidePublish}
             onClose={() => setOpened(false)}
             onOpenPublishManage={() => {
               setOpened(false);

--- a/src/components/app/share/ShareTabs.tsx
+++ b/src/components/app/share/ShareTabs.tsx
@@ -38,6 +38,7 @@ function ShareTabs({
   const { t } = useTranslation();
   const view = useAppView(viewId);
   const [value, setValue] = React.useState<TabKey>(TabKey.SHARE);
+  const activeValue = hidePublish && value === TabKey.PUBLISH ? TabKey.SHARE : value;
   const currentUser = useCurrentUser();
   const {
     people,
@@ -96,7 +97,7 @@ function ShareTabs({
   }, [opened]);
 
   return (
-    <Tabs value={value} className='gap-0' onValueChange={(newValue) => setValue(newValue as TabKey)}>
+    <Tabs value={activeValue} className='gap-0' onValueChange={(newValue) => setValue(newValue as TabKey)}>
       <TabsList className={'flex w-full items-center justify-start px-3 pt-3'}>
         {opened &&
           options.map((option) => (

--- a/src/components/app/share/ShareTabs.tsx
+++ b/src/components/app/share/ShareTabs.tsx
@@ -25,11 +25,13 @@ enum TabKey {
 function ShareTabs({
   opened,
   viewId,
+  disablePublish = false,
   onClose,
   onOpenPublishManage,
 }: {
   opened: boolean;
   viewId: string;
+  disablePublish?: boolean;
   onClose: () => void;
   onOpenPublishManage?: () => void;
 }) {
@@ -100,6 +102,7 @@ function ShareTabs({
               className={'flex flex-row items-center justify-center gap-3 px-1.5 pb-1.5'}
               key={option.value}
               value={option.value}
+              disabled={disablePublish && option.value === TabKey.PUBLISH}
               data-testid={option.value === TabKey.PUBLISH ? 'publish-tab' : undefined}
             >
               {option.icon}

--- a/src/components/app/share/ShareTabs.tsx
+++ b/src/components/app/share/ShareTabs.tsx
@@ -25,13 +25,13 @@ enum TabKey {
 function ShareTabs({
   opened,
   viewId,
-  disablePublish = false,
+  hidePublish = false,
   onClose,
   onOpenPublishManage,
 }: {
   opened: boolean;
   viewId: string;
-  disablePublish?: boolean;
+  hidePublish?: boolean;
   onClose: () => void;
   onOpenPublishManage?: () => void;
 }) {
@@ -56,12 +56,14 @@ function ShareTabs({
         label: t('shareAction.shareTab'),
         Panel: SharePanel,
       },
-      {
-        value: TabKey.PUBLISH,
-        label: t('shareAction.publish'),
-        icon: view?.is_published ? <SuccessIcon className={'mb-0 h-5 w-5 text-text-action'} /> : undefined,
-        Panel: PublishPanel,
-      },
+      hidePublish
+        ? false
+        : {
+            value: TabKey.PUBLISH,
+            label: t('shareAction.publish'),
+            icon: view?.is_published ? <SuccessIcon className={'mb-0 h-5 w-5 text-text-action'} /> : undefined,
+            Panel: PublishPanel,
+          },
       {
         value: TabKey.EXPORT_AS,
         label: t('shareAction.exportAsTab'),
@@ -85,7 +87,7 @@ function ShareTabs({
         onOpenPublishManage?: () => void;
       }>;
     }>;
-  }, [currentUser?.email, t, view?.is_published]);
+  }, [currentUser?.email, hidePublish, t, view?.is_published]);
 
   useEffect(() => {
     if (opened) {
@@ -102,7 +104,6 @@ function ShareTabs({
               className={'flex flex-row items-center justify-center gap-3 px-1.5 pb-1.5'}
               key={option.value}
               value={option.value}
-              disabled={disablePublish && option.value === TabKey.PUBLISH}
               data-testid={option.value === TabKey.PUBLISH ? 'publish-tab' : undefined}
             >
               {option.icon}

--- a/src/components/app/share/__tests__/ShareButton.test.tsx
+++ b/src/components/app/share/__tests__/ShareButton.test.tsx
@@ -1,0 +1,48 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import type { ReactNode } from 'react';
+
+import ShareButton from '@/components/app/share/ShareButton';
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+jest.mock('@/components/app/app.hooks', () => ({
+  useAppView: () => ({}),
+}));
+
+jest.mock('@/components/_shared/modal', () => ({
+  NormalModal: ({ open }: { open: boolean }) => (open ? <div data-testid='publish-manage-modal' /> : null),
+}));
+
+jest.mock('@/components/app/publish-manage', () => ({
+  PublishManage: () => null,
+}));
+
+jest.mock('@/components/app/share/ShareTabs', () => ({
+  __esModule: true,
+  default: ({ onOpenPublishManage }: { onOpenPublishManage?: () => void }) => (
+    <button data-testid='open-publish-manage' onClick={onOpenPublishManage}>
+      Open publish management
+    </button>
+  ),
+}));
+
+jest.mock('@/components/ui/popover', () => ({
+  Popover: ({ children }: { children: ReactNode }) => <>{children}</>,
+  PopoverContent: ({ children }: { children: ReactNode }) => <>{children}</>,
+  PopoverTrigger: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+
+describe('ShareButton publish availability', () => {
+  it('hides open publish management when navigating to a row page', () => {
+    const { rerender } = render(<ShareButton viewId='database-view' />);
+
+    fireEvent.click(screen.getByTestId('open-publish-manage'));
+    expect(screen.getByTestId('publish-manage-modal')).toBeTruthy();
+
+    rerender(<ShareButton viewId='database-view' hidePublish />);
+
+    expect(screen.queryByTestId('publish-manage-modal')).toBeNull();
+  });
+});

--- a/src/components/app/share/__tests__/ShareTabs.test.tsx
+++ b/src/components/app/share/__tests__/ShareTabs.test.tsx
@@ -1,0 +1,67 @@
+import { render, screen } from '@testing-library/react';
+
+import ShareTabs from '@/components/app/share/ShareTabs';
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+jest.mock('@/components/app/app.hooks', () => ({
+  useAppView: () => ({ is_published: false }),
+}));
+
+jest.mock('@/components/main/app.hooks', () => ({
+  useCurrentUser: () => ({ email: 'owner@example.com' }),
+}));
+
+jest.mock('@/components/app/share/useShareAccessDetails', () => ({
+  useShareAccessDetails: () => ({
+    people: [],
+    isLoadingPeople: false,
+    loadPeople: jest.fn(),
+    removePersonFromAccessList: jest.fn(),
+    currentUserAccessLevel: undefined,
+    hasFullAccess: true,
+    sectionType: undefined,
+  }),
+}));
+
+jest.mock('@/components/app/share/SharePanel', () => ({
+  __esModule: true,
+  default: () => <div data-testid='share-panel' />,
+}));
+
+jest.mock('@/components/app/share/PublishPanel', () => ({
+  __esModule: true,
+  default: () => <div data-testid='publish-panel' />,
+}));
+
+jest.mock('@/components/app/share/TemplatePanel', () => ({
+  __esModule: true,
+  default: () => <div data-testid='template-panel' />,
+}));
+
+jest.mock('@/components/app/share/ExportPanel', () => ({
+  __esModule: true,
+  default: () => <div data-testid='export-panel' />,
+}));
+
+function renderShareTabs(disablePublish: boolean) {
+  return render(<ShareTabs opened viewId='database-view' disablePublish={disablePublish} onClose={() => undefined} />);
+}
+
+describe('ShareTabs publish availability', () => {
+  it('keeps Share enabled while disabling Publish when requested', () => {
+    renderShareTabs(true);
+
+    expect(screen.getByRole('tab', { name: 'shareAction.shareTab' }).disabled).toBe(false);
+    expect(screen.getByTestId('publish-tab').disabled).toBe(true);
+    expect(screen.getByTestId('share-panel')).toBeTruthy();
+  });
+
+  it('keeps Publish enabled by default', () => {
+    renderShareTabs(false);
+
+    expect(screen.getByTestId('publish-tab').disabled).toBe(false);
+  });
+});

--- a/src/components/app/share/__tests__/ShareTabs.test.tsx
+++ b/src/components/app/share/__tests__/ShareTabs.test.tsx
@@ -46,22 +46,22 @@ jest.mock('@/components/app/share/ExportPanel', () => ({
   default: () => <div data-testid='export-panel' />,
 }));
 
-function renderShareTabs(disablePublish: boolean) {
-  return render(<ShareTabs opened viewId='database-view' disablePublish={disablePublish} onClose={() => undefined} />);
+function renderShareTabs(hidePublish: boolean) {
+  return render(<ShareTabs opened viewId='database-view' hidePublish={hidePublish} onClose={() => undefined} />);
 }
 
 describe('ShareTabs publish availability', () => {
-  it('keeps Share enabled while disabling Publish when requested', () => {
+  it('keeps Share available while removing Publish when requested', () => {
     renderShareTabs(true);
 
-    expect(screen.getByRole('tab', { name: 'shareAction.shareTab' }).disabled).toBe(false);
-    expect(screen.getByTestId('publish-tab').disabled).toBe(true);
+    expect(screen.getByRole('tab', { name: 'shareAction.shareTab' })).toBeTruthy();
+    expect(screen.queryByTestId('publish-tab')).toBeNull();
     expect(screen.getByTestId('share-panel')).toBeTruthy();
   });
 
-  it('keeps Publish enabled by default', () => {
+  it('keeps Publish available by default', () => {
     renderShareTabs(false);
 
-    expect(screen.getByTestId('publish-tab').disabled).toBe(false);
+    expect(screen.getByTestId('publish-tab')).toBeTruthy();
   });
 });

--- a/src/components/app/share/__tests__/ShareTabs.test.tsx
+++ b/src/components/app/share/__tests__/ShareTabs.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 
 import ShareTabs from '@/components/app/share/ShareTabs';
 
@@ -63,5 +63,17 @@ describe('ShareTabs publish availability', () => {
     renderShareTabs(false);
 
     expect(screen.getByTestId('publish-tab')).toBeTruthy();
+  });
+
+  it('falls back to Share when Publish is removed after being selected', () => {
+    const { rerender } = renderShareTabs(false);
+
+    fireEvent.mouseDown(screen.getByTestId('publish-tab'), { button: 0, ctrlKey: false });
+    expect(screen.getByTestId('publish-panel')).toBeTruthy();
+
+    rerender(<ShareTabs opened viewId='database-view' hidePublish onClose={() => undefined} />);
+
+    expect(screen.queryByTestId('publish-tab')).toBeNull();
+    expect(screen.getByTestId('share-panel')).toBeTruthy();
   });
 });

--- a/src/components/database/Database.tsx
+++ b/src/components/database/Database.tsx
@@ -66,6 +66,7 @@ type RowSyncRegistration = {
   status: 'pending' | 'registered' | 'release-pending' | 'released';
   cleanup?: (objectId: string, delayMs?: number) => void;
   promise?: Promise<YDoc | undefined>;
+  forceSyncPromise?: Promise<YDoc | undefined>;
 };
 
 function cleanupRegisteredRowSync(registration: RowSyncRegistration) {
@@ -420,10 +421,22 @@ function Database(props: Database2Props) {
 
       if (existingRegistration) {
         if (forceSync && existingRegistration.status === 'registered') {
-          return createRow(rowKey, { forceSync: true }).catch((error) => {
-            console.error('[Database] row sync retry failed', rowKey, error);
-            return undefined;
-          });
+          if (!existingRegistration.forceSyncPromise) {
+            existingRegistration.forceSyncPromise = createRow(rowKey, { forceSync: true })
+              .then((doc) => {
+                if (lifecycleRegistrations.get(rowKey) === existingRegistration) {
+                  existingRegistration.promise = Promise.resolve(doc);
+                }
+
+                return doc;
+              })
+              .catch((error) => {
+                console.error('[Database] row sync retry failed', rowKey, error);
+                return undefined;
+              });
+          }
+
+          return existingRegistration.forceSyncPromise;
         }
 
         return existingRegistration.promise;
@@ -482,6 +495,7 @@ function Database(props: Database2Props) {
 
       if (registration?.status === 'registered') {
         registration.promise = Promise.resolve(canonicalDoc);
+        registration.forceSyncPromise = registration.promise;
       }
     };
 

--- a/src/components/database/Database.tsx
+++ b/src/components/database/Database.tsx
@@ -9,6 +9,7 @@ import {
   releaseDatabaseRowDocSeedCache,
   retainDatabaseRowDocSeedCache,
 } from '@/application/database-blob';
+import { APP_EVENTS } from '@/application/constants';
 import { hasRowConditionData } from '@/application/database-yjs/condition-value-cache';
 import { hasEffectiveFilters } from '@/application/database-yjs/filter';
 import { getRowKey } from '@/application/database-yjs/row_meta';
@@ -459,6 +460,37 @@ function Database(props: Database2Props) {
     [createRow, databaseLifecycleIdentity, props.scheduleDeferredCleanup]
   );
 
+  useEffect(() => {
+    const eventEmitter = props.eventEmitter;
+
+    if (!eventEmitter) return;
+
+    const handleCollabDocReset = (payload: { objectId?: string; doc?: YDoc }) => {
+      const { objectId, doc: canonicalDoc } = payload;
+
+      if (!objectId || !canonicalDoc) return;
+
+      setRowMap((prev) => {
+        // This Database owns only the row ids already present in its map. The
+        // same app-wide event also carries resets for pages and databases.
+        if (!prev[objectId] || prev[objectId] === canonicalDoc) return prev;
+        return { ...prev, [objectId]: canonicalDoc };
+      });
+
+      const rowKey = getRowKey(getDatabaseId(), objectId);
+      const registration = rowSyncRegistrationsRef.current.get(rowKey);
+
+      if (registration?.status === 'registered') {
+        registration.promise = Promise.resolve(canonicalDoc);
+      }
+    };
+
+    eventEmitter.on(APP_EVENTS.COLLAB_DOC_RESET, handleCollabDocReset);
+    return () => {
+      eventEmitter.off(APP_EVENTS.COLLAB_DOC_RESET, handleCollabDocReset);
+    };
+  }, [getDatabaseId, props.eventEmitter]);
+
   const bindRowSync = useCallback(
     (rowId: string) => {
       if (!createRow || !rowId) return;
@@ -773,9 +805,16 @@ function Database(props: Database2Props) {
       if (hasRowConditionData(existing)) {
         const databaseId = getDatabaseId();
         const rowKey = getRowKey(databaseId, rowId);
+        const syncedRowDoc = await registerRowSync(rowKey, true);
 
-        void registerRowSync(rowKey);
-        return existing;
+        if (!isCurrentEnsure()) return;
+        const canonicalRowDoc = syncedRowDoc ?? existing;
+
+        if (canonicalRowDoc !== existing) {
+          setRowMap((prev) => (prev[rowId] === canonicalRowDoc ? prev : { ...prev, [rowId]: canonicalRowDoc }));
+        }
+
+        return canonicalRowDoc;
       }
 
       // Wait for batch preload to finish — it loads visible rows from seeds
@@ -789,9 +828,16 @@ function Database(props: Database2Props) {
       if (hasRowConditionData(existingAfterGate)) {
         const databaseId = getDatabaseId();
         const rowKey = getRowKey(databaseId, rowId);
+        const syncedRowDoc = await registerRowSync(rowKey, true);
 
-        void registerRowSync(rowKey);
-        return existingAfterGate;
+        if (!isCurrentEnsure()) return;
+        const canonicalRowDoc = syncedRowDoc ?? existingAfterGate;
+
+        if (canonicalRowDoc !== existingAfterGate) {
+          setRowMap((prev) => (prev[rowId] === canonicalRowDoc ? prev : { ...prev, [rowId]: canonicalRowDoc }));
+        }
+
+        return canonicalRowDoc;
       }
 
       const pending = pendingRowDocsRef.current.get(rowId);
@@ -809,8 +855,9 @@ function Database(props: Database2Props) {
         const seed = peekDatabaseRowDocSeed(rowKey);
 
         if (hasRowConditionData(cachedRowDoc)) {
-          void registerRowSync(rowKey);
-          return cachedRowDoc;
+          const syncedRowDoc = await registerRowSync(rowKey, true);
+
+          return syncedRowDoc ?? cachedRowDoc;
         }
 
         try {

--- a/src/components/database/Database.tsx
+++ b/src/components/database/Database.tsx
@@ -803,6 +803,11 @@ function Database(props: Database2Props) {
       const existing = rowMapRef.current[rowId];
 
       if (hasRowConditionData(existing)) {
+        // Published JSON snapshots already contain the authoritative static
+        // row docs. Opening a local transport doc would replace them with an
+        // empty Y.Doc because publish pages do not establish realtime sync.
+        if (readOnly && ensureLifecycleIdentity.hasInitialRowMap) return existing;
+
         const databaseId = getDatabaseId();
         const rowKey = getRowKey(databaseId, rowId);
         const syncedRowDoc = await registerRowSync(rowKey, true);
@@ -826,6 +831,8 @@ function Database(props: Database2Props) {
       const existingAfterGate = rowMapRef.current[rowId];
 
       if (hasRowConditionData(existingAfterGate)) {
+        if (readOnly && ensureLifecycleIdentity.hasInitialRowMap) return existingAfterGate;
+
         const databaseId = getDatabaseId();
         const rowKey = getRowKey(databaseId, rowId);
         const syncedRowDoc = await registerRowSync(rowKey, true);
@@ -912,7 +919,7 @@ function Database(props: Database2Props) {
     // Omitted deps are stable: setRowMap (useState setter), refs (rowMapRef, pendingRowDocsRef,
     // localCachePrimedRef), and module-level imports (openRowDoc, getCachedRowDoc, peekDatabaseRowDocSeed, getRowKey).
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [createRow, databaseLifecycleIdentity, getDatabaseId, ensureBlobPrefetch, registerRowSync]
+    [createRow, databaseLifecycleIdentity, getDatabaseId, ensureBlobPrefetch, readOnly, registerRowSync]
   );
 
   useLayoutEffect(() => {

--- a/src/components/database/Database.tsx
+++ b/src/components/database/Database.tsx
@@ -422,18 +422,32 @@ function Database(props: Database2Props) {
       if (existingRegistration) {
         if (forceSync && existingRegistration.status === 'registered') {
           if (!existingRegistration.forceSyncPromise) {
-            existingRegistration.forceSyncPromise = createRow(rowKey, { forceSync: true })
-              .then((doc) => {
-                if (lifecycleRegistrations.get(rowKey) === existingRegistration) {
-                  existingRegistration.promise = Promise.resolve(doc);
-                }
-
-                return doc;
-              })
+            const forceSyncPromise = createRow(rowKey, { forceSync: true })
               .catch((error) => {
                 console.error('[Database] row sync retry failed', rowKey, error);
                 return undefined;
               });
+
+            existingRegistration.forceSyncPromise = forceSyncPromise;
+            void forceSyncPromise.then((doc) => {
+              if (
+                lifecycleRegistrations.get(rowKey) !== existingRegistration ||
+                existingRegistration.forceSyncPromise !== forceSyncPromise
+              ) {
+                return;
+              }
+
+              if (doc) {
+                existingRegistration.promise = Promise.resolve(doc);
+              }
+
+              // Keep a hydrated canonical result cached so mounted cells do not
+              // emit duplicate manifests. Empty/failed results must remain
+              // retryable: row_orders can arrive before its DatabaseRow collab.
+              if (!hasRowConditionData(doc)) {
+                existingRegistration.forceSyncPromise = undefined;
+              }
+            });
           }
 
           return existingRegistration.forceSyncPromise;
@@ -495,7 +509,7 @@ function Database(props: Database2Props) {
 
       if (registration?.status === 'registered') {
         registration.promise = Promise.resolve(canonicalDoc);
-        registration.forceSyncPromise = registration.promise;
+        registration.forceSyncPromise = hasRowConditionData(canonicalDoc) ? registration.promise : undefined;
       }
     };
 

--- a/src/components/database/Database.tsx
+++ b/src/components/database/Database.tsx
@@ -2,6 +2,7 @@ import EventEmitter from 'events';
 
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState, useSyncExternalStore } from 'react';
 
+import { APP_EVENTS } from '@/application/constants';
 import {
   getDatabaseRowDocFromSeed,
   peekDatabaseRowDocSeed,
@@ -9,9 +10,9 @@ import {
   releaseDatabaseRowDocSeedCache,
   retainDatabaseRowDocSeedCache,
 } from '@/application/database-blob';
-import { APP_EVENTS } from '@/application/constants';
 import { hasRowConditionData } from '@/application/database-yjs/condition-value-cache';
 import { hasEffectiveFilters } from '@/application/database-yjs/filter';
+import { ROW_SYNC_RETRY_DELAYS_MS } from '@/application/database-yjs/row-sync';
 import { getRowKey } from '@/application/database-yjs/row_meta';
 import { getCachedRowDoc, openRowDoc } from '@/application/services/js-services/cache';
 import { SyncContext } from '@/application/services/js-services/sync-protocol';
@@ -64,9 +65,12 @@ function createDeferredGate() {
 type RowSyncRegistration = {
   rowKey: string;
   status: 'pending' | 'registered' | 'release-pending' | 'released';
+  revision: number;
   cleanup?: (objectId: string, delayMs?: number) => void;
   promise?: Promise<YDoc | undefined>;
   forceSyncPromise?: Promise<YDoc | undefined>;
+  forceSyncedDoc?: YDoc;
+  reconciliationPromise?: Promise<void>;
 };
 
 function cleanupRegisteredRowSync(registration: RowSyncRegistration) {
@@ -82,6 +86,8 @@ function cleanupRegisteredRowSync(registration: RowSyncRegistration) {
 }
 
 function releaseRowSyncRegistration(registration: RowSyncRegistration) {
+  registration.revision += 1;
+
   if (registration.status === 'pending') {
     // createRow registers the sync context before resolving. Defer the matching
     // release until that async registration has actually completed.
@@ -258,6 +264,7 @@ function Database(props: Database2Props) {
   const blobPrefetchPromiseRef = useRef<Promise<void> | null>(null);
   const localCachePrimedRef = useRef(false);
   const rowSyncRegistrationsRef = useRef<Map<string, RowSyncRegistration>>(new Map());
+  const remoteRowsNeedingReconciliationRef = useRef<Set<RowId>>(new Set());
   const batchPreloadDoneRef = useRef(false);
   // Async blob work is scoped to one workspace/database lifecycle. A later
   // generation makes completions from the previous lifecycle inert.
@@ -407,7 +414,7 @@ function Database(props: Database2Props) {
   );
 
   const registerRowSync = useCallback(
-    (rowKey: string, forceSync = false) => {
+    (rowKey: string, forceSync = false, refreshForceSync = false) => {
       if (!createRow) {
         return;
       }
@@ -421,32 +428,33 @@ function Database(props: Database2Props) {
 
       if (existingRegistration) {
         if (forceSync && existingRegistration.status === 'registered') {
+          if (!refreshForceSync && existingRegistration.forceSyncedDoc) {
+            return Promise.resolve(existingRegistration.forceSyncedDoc);
+          }
+
           if (!existingRegistration.forceSyncPromise) {
-            const forceSyncPromise = createRow(rowKey, { forceSync: true })
-              .catch((error) => {
-                console.error('[Database] row sync retry failed', rowKey, error);
-                return undefined;
-              });
+            const registrationRevision = existingRegistration.revision;
+            const forceSyncPromise = createRow(rowKey, { forceSync: true }).catch((error) => {
+              console.error('[Database] row sync retry failed', rowKey, error);
+              return undefined;
+            });
 
             existingRegistration.forceSyncPromise = forceSyncPromise;
             void forceSyncPromise.then((doc) => {
               if (
                 lifecycleRegistrations.get(rowKey) !== existingRegistration ||
-                existingRegistration.forceSyncPromise !== forceSyncPromise
+                existingRegistration.forceSyncPromise !== forceSyncPromise ||
+                existingRegistration.revision !== registrationRevision
               ) {
                 return;
               }
 
               if (doc) {
                 existingRegistration.promise = Promise.resolve(doc);
+                existingRegistration.forceSyncedDoc = hasRowConditionData(doc) ? doc : undefined;
               }
 
-              // Keep a hydrated canonical result cached so mounted cells do not
-              // emit duplicate manifests. Empty/failed results must remain
-              // retryable: row_orders can arrive before its DatabaseRow collab.
-              if (!hasRowConditionData(doc)) {
-                existingRegistration.forceSyncPromise = undefined;
-              }
+              existingRegistration.forceSyncPromise = undefined;
             });
           }
 
@@ -459,6 +467,7 @@ function Database(props: Database2Props) {
       const registration: RowSyncRegistration = {
         rowKey,
         status: 'pending',
+        revision: 0,
         cleanup: props.scheduleDeferredCleanup,
       };
 
@@ -487,6 +496,64 @@ function Database(props: Database2Props) {
     [createRow, databaseLifecycleIdentity, props.scheduleDeferredCleanup]
   );
 
+  const scheduleRowSyncReconciliation = useCallback(
+    (rowId: string) => {
+      const lifecycleReconciliationRows = remoteRowsNeedingReconciliationRef.current;
+
+      if (!lifecycleReconciliationRows.has(rowId)) return;
+      if (activeDatabaseLifecycleRef.current !== databaseLifecycleIdentity) return;
+
+      const rowKey = getRowKey(getDatabaseId(), rowId);
+      const registrations = rowSyncRegistrationsRef.current;
+      const registration = registrations.get(rowKey);
+
+      // Reconciliation is started by ensureRow after the visible row has
+      // acquired its one sync owner. Off-screen rows remain seed-only.
+      if (!registration || registration.status !== 'registered' || registration.reconciliationPromise) return;
+
+      const registrationRevision = registration.revision;
+      const reconciliationPromise = (async () => {
+        for (const delayMs of ROW_SYNC_RETRY_DELAYS_MS) {
+          await new Promise((resolve) => setTimeout(resolve, delayMs));
+
+          if (
+            !lifecycleReconciliationRows.has(rowId) ||
+            activeDatabaseLifecycleRef.current !== databaseLifecycleIdentity ||
+            registrations.get(rowKey) !== registration ||
+            registration.status !== 'registered' ||
+            registration.revision !== registrationRevision
+          ) {
+            return;
+          }
+
+          const canonicalDoc = await registerRowSync(rowKey, true, true);
+
+          if (
+            !canonicalDoc ||
+            activeDatabaseLifecycleRef.current !== databaseLifecycleIdentity ||
+            registrations.get(rowKey) !== registration ||
+            registration.revision !== registrationRevision
+          ) {
+            continue;
+          }
+
+          setRowMap((prev) => (prev[rowId] === canonicalDoc ? prev : { ...prev, [rowId]: canonicalDoc }));
+        }
+      })();
+
+      registration.reconciliationPromise = reconciliationPromise;
+      const clearReconciliationPromise = () => {
+        if (registration.reconciliationPromise === reconciliationPromise) {
+          registration.reconciliationPromise = undefined;
+          lifecycleReconciliationRows.delete(rowId);
+        }
+      };
+
+      void reconciliationPromise.then(clearReconciliationPromise, clearReconciliationPromise);
+    },
+    [databaseLifecycleIdentity, getDatabaseId, registerRowSync]
+  );
+
   useEffect(() => {
     const eventEmitter = props.eventEmitter;
 
@@ -508,8 +575,11 @@ function Database(props: Database2Props) {
       const registration = rowSyncRegistrationsRef.current.get(rowKey);
 
       if (registration?.status === 'registered') {
+        registration.revision += 1;
         registration.promise = Promise.resolve(canonicalDoc);
-        registration.forceSyncPromise = hasRowConditionData(canonicalDoc) ? registration.promise : undefined;
+        registration.forceSyncPromise = undefined;
+        registration.forceSyncedDoc = hasRowConditionData(canonicalDoc) ? canonicalDoc : undefined;
+        registration.reconciliationPromise = undefined;
       }
     };
 
@@ -612,87 +682,90 @@ function Database(props: Database2Props) {
     [getDatabaseId]
   );
 
-  const runBatchPreload = useCallback((prefetchGeneration: number) => {
-    if (blobPrefetchGenerationRef.current !== prefetchGeneration) return;
-    if (batchPreloadDoneRef.current) return;
-    batchPreloadDoneRef.current = true;
-    const gate = seedsGateRef.current;
-    const isCurrentPreload = () =>
-      blobPrefetchGenerationRef.current === prefetchGeneration && seedsGateRef.current === gate;
-    const databaseId = getDatabaseId();
-    const priorityRowIds = getPriorityRowIds();
+  const runBatchPreload = useCallback(
+    (prefetchGeneration: number) => {
+      if (blobPrefetchGenerationRef.current !== prefetchGeneration) return;
+      if (batchPreloadDoneRef.current) return;
+      batchPreloadDoneRef.current = true;
+      const gate = seedsGateRef.current;
+      const isCurrentPreload = () =>
+        blobPrefetchGenerationRef.current === prefetchGeneration && seedsGateRef.current === gate;
+      const databaseId = getDatabaseId();
+      const priorityRowIds = getPriorityRowIds();
 
-    if (priorityRowIds.length === 0) {
-      gate.resolve();
-      return;
-    }
-
-    // Collect seeds for the first N priority rows (visible + overscan) in a single pass
-    const BATCH_SIZE = 30;
-    const rowsWithSeeds: {
-      rowId: string;
-      rowKey: string;
-      seed: NonNullable<ReturnType<typeof peekDatabaseRowDocSeed>>;
-    }[] = [];
-
-    for (const rowId of priorityRowIds) {
-      if (rowsWithSeeds.length >= BATCH_SIZE) break;
-      if (hasRowConditionData(rowMapRef.current[rowId])) continue;
-
-      const rowKey = getRowKey(databaseId, rowId);
-      const seed = peekDatabaseRowDocSeed(rowKey);
-
-      if (seed) {
-        rowsWithSeeds.push({ rowId, rowKey, seed });
+      if (priorityRowIds.length === 0) {
+        gate.resolve();
+        return;
       }
-    }
 
-    if (rowsWithSeeds.length === 0) {
-      gate.resolve();
-      return;
-    }
+      // Collect seeds for the first N priority rows (visible + overscan) in a single pass
+      const BATCH_SIZE = 30;
+      const rowsWithSeeds: {
+        rowId: string;
+        rowKey: string;
+        seed: NonNullable<ReturnType<typeof peekDatabaseRowDocSeed>>;
+      }[] = [];
 
-    Promise.all(
-      rowsWithSeeds.map(async ({ rowId, rowKey, seed }) => {
-        try {
-          const rowDoc = await openRowDoc(rowKey, seed ?? undefined);
+      for (const rowId of priorityRowIds) {
+        if (rowsWithSeeds.length >= BATCH_SIZE) break;
+        if (hasRowConditionData(rowMapRef.current[rowId])) continue;
 
-          return { rowId, rowDoc };
-        } catch {
-          return null;
+        const rowKey = getRowKey(databaseId, rowId);
+        const seed = peekDatabaseRowDocSeed(rowKey);
+
+        if (seed) {
+          rowsWithSeeds.push({ rowId, rowKey, seed });
         }
-      })
-    )
-      .then((results) => {
-        if (!isCurrentPreload()) return;
+      }
 
-        const newEntries: Record<string, YDoc> = {};
+      if (rowsWithSeeds.length === 0) {
+        gate.resolve();
+        return;
+      }
 
-        for (const result of results) {
-          if (result?.rowDoc && !rowMapRef.current[result.rowId]) {
-            newEntries[result.rowId] = result.rowDoc;
+      Promise.all(
+        rowsWithSeeds.map(async ({ rowId, rowKey, seed }) => {
+          try {
+            const rowDoc = await openRowDoc(rowKey, seed ?? undefined);
+
+            return { rowId, rowDoc };
+          } catch {
+            return null;
           }
-        }
+        })
+      )
+        .then((results) => {
+          if (!isCurrentPreload()) return;
 
-        const count = Object.keys(newEntries).length;
+          const newEntries: Record<string, YDoc> = {};
 
-        if (count > 0) {
-          // Keep seed-only rows local. ensureRow attaches realtime only when a
-          // row is actually rendered, preserving the viewport boundary.
-          setRowMap((prev) => ({ ...prev, ...newEntries }));
-        }
+          for (const result of results) {
+            if (result?.rowDoc && !rowMapRef.current[result.rowId]) {
+              newEntries[result.rowId] = result.rowDoc;
+            }
+          }
 
-        // Open the gate — ensureRow calls can now proceed
-        gate.resolve();
-      })
-      .catch(() => {
-        if (!isCurrentPreload()) return;
+          const count = Object.keys(newEntries).length;
 
-        // Ensure the gate always resolves even on unexpected errors,
-        // otherwise ensureRow calls would be permanently blocked.
-        gate.resolve();
-      });
-  }, [getDatabaseId, getPriorityRowIds]);
+          if (count > 0) {
+            // Keep seed-only rows local. ensureRow attaches realtime only when a
+            // row is actually rendered, preserving the viewport boundary.
+            setRowMap((prev) => ({ ...prev, ...newEntries }));
+          }
+
+          // Open the gate — ensureRow calls can now proceed
+          gate.resolve();
+        })
+        .catch(() => {
+          if (!isCurrentPreload()) return;
+
+          // Ensure the gate always resolves even on unexpected errors,
+          // otherwise ensureRow calls would be permanently blocked.
+          gate.resolve();
+        });
+    },
+    [getDatabaseId, getPriorityRowIds]
+  );
 
   const ensureBlobPrefetch = useCallback(() => {
     const prefetchGeneration = blobPrefetchGenerationRef.current;
@@ -823,6 +896,13 @@ function Database(props: Database2Props) {
         getDatabaseId() === ensureLifecycleIdentity.databaseId &&
         blobPrefetchGenerationRef.current === ensureGeneration &&
         seedsGateRef.current === gate;
+      const finishEnsure = (rowDoc: YDoc | undefined) => {
+        if (rowDoc && isCurrentEnsure()) {
+          scheduleRowSyncReconciliation(rowId);
+        }
+
+        return rowDoc;
+      };
 
       if (!isCurrentEnsure()) return;
 
@@ -847,7 +927,7 @@ function Database(props: Database2Props) {
           setRowMap((prev) => (prev[rowId] === canonicalRowDoc ? prev : { ...prev, [rowId]: canonicalRowDoc }));
         }
 
-        return canonicalRowDoc;
+        return finishEnsure(canonicalRowDoc);
       }
 
       // Wait for batch preload to finish — it loads visible rows from seeds
@@ -872,7 +952,7 @@ function Database(props: Database2Props) {
           setRowMap((prev) => (prev[rowId] === canonicalRowDoc ? prev : { ...prev, [rowId]: canonicalRowDoc }));
         }
 
-        return canonicalRowDoc;
+        return finishEnsure(canonicalRowDoc);
       }
 
       const pending = pendingRowDocsRef.current.get(rowId);
@@ -880,7 +960,7 @@ function Database(props: Database2Props) {
       if (pending) {
         const rowDoc = await pending;
 
-        return isCurrentEnsure() ? rowDoc : undefined;
+        return finishEnsure(isCurrentEnsure() ? rowDoc : undefined);
       }
 
       const promise = (async () => {
@@ -937,7 +1017,7 @@ function Database(props: Database2Props) {
           });
         }
 
-        return isCurrentEnsure() ? rowDoc : undefined;
+        return finishEnsure(isCurrentEnsure() ? rowDoc : undefined);
       } finally {
         if (pendingRowDocsRef.current.get(rowId) === promise) {
           pendingRowDocsRef.current.delete(rowId);
@@ -947,8 +1027,65 @@ function Database(props: Database2Props) {
     // Omitted deps are stable: setRowMap (useState setter), refs (rowMapRef, pendingRowDocsRef,
     // localCachePrimedRef), and module-level imports (openRowDoc, getCachedRowDoc, peekDatabaseRowDocSeed, getRowKey).
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [createRow, databaseLifecycleIdentity, getDatabaseId, ensureBlobPrefetch, readOnly, registerRowSync]
+    [
+      createRow,
+      databaseLifecycleIdentity,
+      getDatabaseId,
+      ensureBlobPrefetch,
+      readOnly,
+      registerRowSync,
+      scheduleRowSyncReconciliation,
+    ]
   );
+
+  // Row orders and DatabaseRow collabs are independent objects. Remember
+  // remote additions here, but defer all transport work to ensureRow so an
+  // off-screen bulk import does not acquire thousands of sync owners.
+  useEffect(() => {
+    if (!createRow || readOnly) return;
+
+    const sharedRoot = doc.getMap(YjsEditorKey.data_section);
+    const database = sharedRoot.get(YjsEditorKey.database) as YDatabase | undefined;
+    const view = database?.get(YjsDatabaseKey.views)?.get(activeViewId);
+    const rowOrders = view?.get(YjsDatabaseKey.row_orders);
+    const lifecycleReconciliationRows = remoteRowsNeedingReconciliationRef.current;
+
+    if (!rowOrders) return;
+
+    let knownOrderedRowIds = new Set(
+      (rowOrders.toJSON() as { id: string; is_deleted?: boolean }[])
+        .filter((row) => !row.is_deleted)
+        .map((row) => row.id)
+    );
+
+    const handleRowOrdersChange: Parameters<typeof rowOrders.observeDeep>[0] = (_events, transaction) => {
+      const nextOrderedRowIds = new Set(
+        (rowOrders.toJSON() as { id: string; is_deleted?: boolean }[])
+          .filter((row) => !row.is_deleted)
+          .map((row) => row.id)
+      );
+
+      if (!transaction.local) {
+        nextOrderedRowIds.forEach((rowId) => {
+          if (!knownOrderedRowIds.has(rowId)) {
+            lifecycleReconciliationRows.add(rowId);
+          }
+        });
+      }
+
+      knownOrderedRowIds.forEach((rowId) => {
+        if (!nextOrderedRowIds.has(rowId)) {
+          lifecycleReconciliationRows.delete(rowId);
+        }
+      });
+      knownOrderedRowIds = nextOrderedRowIds;
+    };
+
+    rowOrders.observeDeep(handleRowOrdersChange);
+    return () => {
+      rowOrders.unobserveDeep(handleRowOrdersChange);
+    };
+  }, [activeViewId, createRow, doc, readOnly]);
 
   useLayoutEffect(() => {
     activeDatabaseLifecycleRef.current = databaseLifecycleIdentity;
@@ -963,6 +1100,7 @@ function Database(props: Database2Props) {
     rowMapRef.current = {};
     pendingRowDocsRef.current.clear();
     prefetchPromisesRef.current.clear();
+    remoteRowsNeedingReconciliationRef.current = new Set();
     blobPrefetchPromiseRef.current = null;
     localCachePrimedRef.current = false;
     rowSyncRegistrationsRef.current = lifecycleRowSyncRegistrations;

--- a/src/components/database/Database.tsx
+++ b/src/components/database/Database.tsx
@@ -64,6 +64,7 @@ type RowSyncRegistration = {
   rowKey: string;
   status: 'pending' | 'registered' | 'release-pending' | 'released';
   cleanup?: (objectId: string, delayMs?: number) => void;
+  promise?: Promise<YDoc | undefined>;
 };
 
 function cleanupRegisteredRowSync(registration: RowSyncRegistration) {
@@ -404,7 +405,7 @@ function Database(props: Database2Props) {
   );
 
   const registerRowSync = useCallback(
-    (rowKey: string) => {
+    (rowKey: string, forceSync = false) => {
       if (!createRow) {
         return;
       }
@@ -414,8 +415,18 @@ function Database(props: Database2Props) {
       }
 
       const lifecycleRegistrations = rowSyncRegistrationsRef.current;
+      const existingRegistration = lifecycleRegistrations.get(rowKey);
 
-      if (lifecycleRegistrations.has(rowKey)) return;
+      if (existingRegistration) {
+        if (forceSync && existingRegistration.status === 'registered') {
+          return createRow(rowKey, { forceSync: true }).catch((error) => {
+            console.error('[Database] row sync retry failed', rowKey, error);
+            return undefined;
+          });
+        }
+
+        return existingRegistration.promise;
+      }
 
       const registration: RowSyncRegistration = {
         rowKey,
@@ -424,9 +435,10 @@ function Database(props: Database2Props) {
       };
 
       lifecycleRegistrations.set(rowKey, registration);
-      void createRow(rowKey)
-        .then(() => {
+      const promise = createRow(rowKey)
+        .then((doc) => {
           completeRowSyncRegistration(registration);
+          return doc;
         })
         .catch((e) => {
           registration.status = 'released';
@@ -437,7 +449,12 @@ function Database(props: Database2Props) {
           if (lifecycleRegistrations.get(rowKey) === registration) {
             lifecycleRegistrations.delete(rowKey);
           }
+
+          return undefined;
         });
+
+      registration.promise = promise;
+      return promise;
     },
     [createRow, databaseLifecycleIdentity, props.scheduleDeferredCleanup]
   );
@@ -448,7 +465,7 @@ function Database(props: Database2Props) {
       const databaseId = getDatabaseId();
       const rowKey = getRowKey(databaseId, rowId);
 
-      registerRowSync(rowKey);
+      void registerRowSync(rowKey);
     },
     [createRow, getDatabaseId, registerRowSync]
   );
@@ -757,7 +774,7 @@ function Database(props: Database2Props) {
         const databaseId = getDatabaseId();
         const rowKey = getRowKey(databaseId, rowId);
 
-        registerRowSync(rowKey);
+        void registerRowSync(rowKey);
         return existing;
       }
 
@@ -773,7 +790,7 @@ function Database(props: Database2Props) {
         const databaseId = getDatabaseId();
         const rowKey = getRowKey(databaseId, rowId);
 
-        registerRowSync(rowKey);
+        void registerRowSync(rowKey);
         return existingAfterGate;
       }
 
@@ -792,7 +809,7 @@ function Database(props: Database2Props) {
         const seed = peekDatabaseRowDocSeed(rowKey);
 
         if (hasRowConditionData(cachedRowDoc)) {
-          registerRowSync(rowKey);
+          void registerRowSync(rowKey);
           return cachedRowDoc;
         }
 
@@ -803,14 +820,14 @@ function Database(props: Database2Props) {
 
           // Bind sync for this row - only visible rows call ensureRow
           // Non-visible rows rely on blob diff cached data
-          registerRowSync(rowKey);
+          const syncedRowDoc = await registerRowSync(rowKey, true);
 
           if (!localCachePrimedRef.current) {
             localCachePrimedRef.current = true;
             void ensureBlobPrefetch();
           }
 
-          return rowDoc;
+          return syncedRowDoc ?? rowDoc;
         } catch {
           if (!isCurrentEnsure()) return undefined;
 
@@ -830,7 +847,10 @@ function Database(props: Database2Props) {
 
         if (rowDoc && isCurrentEnsure()) {
           setRowMap((prev) => {
-            if (prev[rowId]) return prev;
+            // A version reset may replace the sync context's Y.Doc while the
+            // row map still points at the old instance. The canonical doc must
+            // win so future remote updates reach selectors and Board cards.
+            if (prev[rowId] === rowDoc) return prev;
             return { ...prev, [rowId]: rowDoc };
           });
         }

--- a/src/components/database/__tests__/Database.prefetch-lifecycle.test.tsx
+++ b/src/components/database/__tests__/Database.prefetch-lifecycle.test.tsx
@@ -482,6 +482,52 @@ describe('Database blob prefetch lifecycle', () => {
     canonicalRowDoc.destroy();
   });
 
+  it('deduplicates concurrent force sync requests for a registered row', async () => {
+    const doc = createDatabaseDoc('database-id');
+    const seedShell = createHydratedRowDoc('seed-shell');
+    const canonicalRowDoc = createHydratedRowDoc('canonical-row');
+    const forceSync = createDeferred<YDoc>();
+    const createRow = jest.fn((_rowKey: string, options?: { forceSync?: boolean }) =>
+      options?.forceSync ? forceSync.promise : Promise.resolve(seedShell)
+    );
+    const { unmount } = render(
+      <Database {...databaseProps(doc)} createRow={createRow} initialRowMap={{ 'row-id': seedShell }} />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Bind row sync' }));
+    await waitFor(() => expect(createRow).toHaveBeenCalledTimes(1));
+
+    const firstEnsure = requestEnsureRow();
+    const secondEnsure = requestEnsureRow();
+
+    await waitFor(() => expect(createRow).toHaveBeenCalledTimes(2));
+    expect(createRow).toHaveBeenLastCalledWith('database-id_rows_row-id', { forceSync: true });
+
+    let ensuredRows: Array<YDoc | undefined> = [];
+
+    await act(async () => {
+      forceSync.resolve(canonicalRowDoc);
+      ensuredRows = await Promise.all([firstEnsure, secondEnsure]);
+    });
+
+    expect(ensuredRows).toEqual([canonicalRowDoc, canonicalRowDoc]);
+    expect(createRow).toHaveBeenCalledTimes(2);
+
+    let cachedEnsure: YDoc | undefined;
+
+    await act(async () => {
+      cachedEnsure = await requestEnsureRow();
+    });
+
+    expect(cachedEnsure).toBe(canonicalRowDoc);
+    expect(createRow).toHaveBeenCalledTimes(2);
+
+    unmount();
+    doc.destroy();
+    seedShell.destroy();
+    canonicalRowDoc.destroy();
+  });
+
   it('keeps hydrated snapshot rows local in a read-only database', async () => {
     const doc = createDatabaseDoc('database-id');
     const snapshotRowDoc = createHydratedRowDoc('snapshot-row');

--- a/src/components/database/__tests__/Database.prefetch-lifecycle.test.tsx
+++ b/src/components/database/__tests__/Database.prefetch-lifecycle.test.tsx
@@ -3,8 +3,8 @@ import EventEmitter from 'events';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import * as Y from 'yjs';
 
-import { peekDatabaseRowDocSeed, prefetchDatabaseBlobDiff } from '@/application/database-blob';
 import { APP_EVENTS } from '@/application/constants';
+import { peekDatabaseRowDocSeed, prefetchDatabaseBlobDiff } from '@/application/database-blob';
 import { getCachedRowDoc, openRowDoc } from '@/application/services/js-services/cache';
 import { DatabaseViewLayout, YDoc, YjsDatabaseKey, YjsEditorKey } from '@/application/types';
 import Database, { Database2Props } from '@/components/database/Database';
@@ -33,8 +33,9 @@ jest.mock('@/components/database/DatabaseRow', () => ({
 jest.mock('@/components/database/DatabaseRowModal', () => () => null);
 jest.mock('@/components/database/DatabaseContext', () => {
   const React = jest.requireActual<typeof import('react')>('react');
-  const { DatabaseContext } =
-    jest.requireActual<typeof import('@/application/database-yjs/context')>('@/application/database-yjs/context');
+  const { DatabaseContext } = jest.requireActual<typeof import('@/application/database-yjs/context')>(
+    '@/application/database-yjs/context'
+  );
 
   return {
     DatabaseContextProvider: ({
@@ -48,8 +49,9 @@ jest.mock('@/components/database/DatabaseContext', () => {
 });
 jest.mock('@/components/database/DatabaseViews', () => {
   const React = jest.requireActual<typeof import('react')>('react');
-  const { useDatabaseContext } =
-    jest.requireActual<typeof import('@/application/database-yjs/context')>('@/application/database-yjs/context');
+  const { useDatabaseContext } = jest.requireActual<typeof import('@/application/database-yjs/context')>(
+    '@/application/database-yjs/context'
+  );
 
   return function MockDatabaseViews() {
     const { bindRowSync, ensureRow, loadRowFromSeed, rowMap } = useDatabaseContext();
@@ -83,6 +85,17 @@ jest.mock('@/components/database/DatabaseViews', () => {
         'button',
         {
           onClick: () => {
+            if (!loadRowFromSeed) throw new Error('loadRowFromSeed is not available');
+            mockSeedLoadPromises.push(loadRowFromSeed('remote-row-id'));
+          },
+          type: 'button',
+        },
+        'Load remote seeded row'
+      ),
+      React.createElement(
+        'button',
+        {
+          onClick: () => {
             if (!initialLoadRowFromSeed) throw new Error('initial loadRowFromSeed is not available');
             mockSeedLoadPromises.push(initialLoadRowFromSeed('row-id'));
           },
@@ -108,6 +121,17 @@ jest.mock('@/components/database/DatabaseViews', () => {
           type: 'button',
         },
         'Ensure row'
+      ),
+      React.createElement(
+        'button',
+        {
+          onClick: () => {
+            if (!ensureRow) throw new Error('ensureRow is not available');
+            mockEnsureRowPromises.push(ensureRow('remote-row-id'));
+          },
+          type: 'button',
+        },
+        'Ensure remote row'
       )
     );
   };
@@ -149,6 +173,20 @@ function createDatabaseDoc(guid: string, databaseId = 'database-id') {
   return doc;
 }
 
+function insertRemoteRowOrder(doc: YDoc, rowId: string) {
+  const remoteDoc = new Y.Doc();
+
+  Y.applyUpdate(remoteDoc, Y.encodeStateAsUpdate(doc));
+  const beforeInsert = Y.encodeStateVector(remoteDoc);
+  const database = remoteDoc.getMap(YjsEditorKey.data_section).get(YjsEditorKey.database);
+  const view = database?.get(YjsDatabaseKey.views)?.get('view-id');
+  const rowOrders = view?.get(YjsDatabaseKey.row_orders);
+
+  rowOrders?.push([{ id: rowId }]);
+  Y.applyUpdate(doc, Y.encodeStateAsUpdate(remoteDoc, beforeInsert));
+  remoteDoc.destroy();
+}
+
 function databaseProps(doc: YDoc): Database2Props {
   return {
     workspaceId: 'workspace-id',
@@ -171,6 +209,16 @@ function requestSeedLoad() {
   return request;
 }
 
+function requestRemoteSeedLoad() {
+  const requestIndex = mockSeedLoadPromises.length;
+
+  fireEvent.click(screen.getByRole('button', { name: 'Load remote seeded row' }));
+  const request = mockSeedLoadPromises[requestIndex];
+
+  if (!request) throw new Error('DatabaseViews did not request the remote seeded row');
+  return request;
+}
+
 function requestSeedLoadFromInitialLifecycle() {
   const requestIndex = mockSeedLoadPromises.length;
 
@@ -188,6 +236,16 @@ function requestEnsureRow() {
   const request = mockEnsureRowPromises[requestIndex];
 
   if (!request) throw new Error('DatabaseViews did not request an ensured row');
+  return request;
+}
+
+function requestRemoteRowEnsure() {
+  const requestIndex = mockEnsureRowPromises.length;
+
+  fireEvent.click(screen.getByRole('button', { name: 'Ensure remote row' }));
+  const request = mockEnsureRowPromises[requestIndex];
+
+  if (!request) throw new Error('DatabaseViews did not request the remote row');
   return request;
 }
 
@@ -233,6 +291,241 @@ describe('Database blob prefetch lifecycle', () => {
 
     unmount();
     doc.destroy();
+  });
+
+  it('sequentially rebinds a visible remote row after its initial registration settles', async () => {
+    jest.useFakeTimers();
+    const doc = createDatabaseDoc('database-id');
+    const seededRowDoc = createHydratedRowDoc('remote-row-id');
+    const initialRegistration = createDeferred<YDoc>();
+    const createRow = jest.fn((_rowKey: string, options?: { forceSync?: boolean }) =>
+      options?.forceSync ? Promise.resolve(seededRowDoc) : initialRegistration.promise
+    );
+    const { unmount } = render(
+      <Database {...databaseProps(doc)} createRow={createRow} initialRowMap={{ 'remote-row-id': seededRowDoc }} />
+    );
+
+    try {
+      await act(async () => {
+        insertRemoteRowOrder(doc, 'remote-row-id');
+        await Promise.resolve();
+      });
+
+      const ensuredRow = requestRemoteRowEnsure();
+
+      expect(createRow).toHaveBeenCalledTimes(1);
+      expect(createRow).toHaveBeenLastCalledWith('database-id_rows_remote-row-id');
+
+      // Retry deadlines must not be consumed while IndexedDB/sync-context
+      // registration is still pending.
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(9_000);
+      });
+      expect(createRow).toHaveBeenCalledTimes(1);
+
+      await act(async () => {
+        initialRegistration.resolve(seededRowDoc);
+        await ensuredRow;
+      });
+
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(1_000);
+      });
+      expect(createRow).toHaveBeenCalledTimes(2);
+      expect(createRow).toHaveBeenLastCalledWith('database-id_rows_remote-row-id', { forceSync: true });
+
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(3_000);
+      });
+      expect(createRow).toHaveBeenCalledTimes(3);
+      expect(createRow).toHaveBeenLastCalledWith('database-id_rows_remote-row-id', { forceSync: true });
+
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(5_000);
+      });
+      expect(createRow).toHaveBeenCalledTimes(4);
+      expect(createRow).toHaveBeenLastCalledWith('database-id_rows_remote-row-id', { forceSync: true });
+    } finally {
+      unmount();
+      doc.destroy();
+      seededRowDoc.destroy();
+      jest.useRealTimers();
+    }
+  });
+
+  it('retains remote reconciliation when a visible ensure joins a seed-only load', async () => {
+    jest.useFakeTimers();
+    const doc = createDatabaseDoc('database-id');
+    const seededRowDoc = createHydratedRowDoc('remote-row-id');
+    const seedLoad = createDeferred<YDoc>();
+    const seed = { bytes: new Uint8Array([1, 2, 3]), encoderVersion: 1 };
+    const createRow = jest.fn(async () => seededRowDoc);
+
+    mockedPeekSeed.mockImplementation((rowKey) => (rowKey === 'database-id_rows_remote-row-id' ? seed : undefined));
+    mockedOpenRowDoc.mockImplementation((rowKey) => {
+      if (rowKey === 'database-id_rows_remote-row-id') return seedLoad.promise;
+      throw new Error(`unexpected row key: ${rowKey}`);
+    });
+
+    const { unmount } = render(<Database {...databaseProps(doc)} createRow={createRow} />);
+
+    try {
+      await waitFor(() => expect(mockedPrefetch).toHaveBeenCalledTimes(1));
+      act(() => {
+        mockedPrefetch.mock.calls[0][2]?.onSeedsReady?.();
+      });
+      await act(async () => {
+        insertRemoteRowOrder(doc, 'remote-row-id');
+        await Promise.resolve();
+      });
+
+      const seedRequest = requestRemoteSeedLoad();
+      const firstEnsure = requestRemoteRowEnsure();
+
+      await act(async () => {
+        seedLoad.resolve(seededRowDoc);
+        await Promise.all([seedRequest, firstEnsure]);
+      });
+      expect(createRow).not.toHaveBeenCalled();
+
+      await act(async () => {
+        await requestRemoteRowEnsure();
+      });
+      expect(createRow).toHaveBeenCalledTimes(1);
+      expect(createRow).toHaveBeenLastCalledWith('database-id_rows_remote-row-id');
+
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(1_000);
+      });
+      expect(createRow).toHaveBeenCalledTimes(2);
+      expect(createRow).toHaveBeenLastCalledWith('database-id_rows_remote-row-id', { forceSync: true });
+    } finally {
+      unmount();
+      doc.destroy();
+      seededRowDoc.destroy();
+      jest.useRealTimers();
+    }
+  });
+
+  it('cancels remote reconciliation when the row order is removed', async () => {
+    jest.useFakeTimers();
+    const doc = createDatabaseDoc('database-id');
+    const rowDoc = createHydratedRowDoc('remote-row-id');
+    const createRow = jest.fn(async () => rowDoc);
+    const { unmount } = render(
+      <Database {...databaseProps(doc)} createRow={createRow} initialRowMap={{ 'remote-row-id': rowDoc }} />
+    );
+    const database = doc.getMap(YjsEditorKey.data_section).get(YjsEditorKey.database);
+    const view = database?.get(YjsDatabaseKey.views)?.get('view-id');
+    const rowOrders = view?.get(YjsDatabaseKey.row_orders);
+
+    try {
+      await act(async () => {
+        insertRemoteRowOrder(doc, 'remote-row-id');
+        await Promise.resolve();
+      });
+      await act(async () => {
+        await requestRemoteRowEnsure();
+      });
+      expect(createRow).toHaveBeenCalledTimes(1);
+
+      act(() => {
+        const index = rowOrders?.toArray().findIndex((row) => row.id === 'remote-row-id') ?? -1;
+
+        if (index >= 0) rowOrders?.delete(index, 1);
+      });
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(10_000);
+      });
+
+      expect(createRow).toHaveBeenCalledTimes(1);
+    } finally {
+      unmount();
+      doc.destroy();
+      rowDoc.destroy();
+      jest.useRealTimers();
+    }
+  });
+
+  it('keeps reconciliation markers isolated across database document lifecycles', async () => {
+    jest.useFakeTimers();
+    const firstDoc = createDatabaseDoc('database-id');
+    const secondDoc = createDatabaseDoc('database-id');
+    const rowDoc = createHydratedRowDoc('remote-row-id');
+    const createRow = jest.fn(async () => rowDoc);
+    const initialRowMap = { 'remote-row-id': rowDoc };
+    const { rerender, unmount } = render(
+      <Database {...databaseProps(firstDoc)} createRow={createRow} initialRowMap={initialRowMap} />
+    );
+
+    try {
+      await act(async () => {
+        insertRemoteRowOrder(firstDoc, 'remote-row-id');
+        await Promise.resolve();
+      });
+      await act(async () => {
+        await requestRemoteRowEnsure();
+      });
+      expect(createRow).toHaveBeenCalledTimes(1);
+
+      rerender(<Database {...databaseProps(secondDoc)} createRow={createRow} initialRowMap={initialRowMap} />);
+      await act(async () => {
+        insertRemoteRowOrder(secondDoc, 'remote-row-id');
+        await Promise.resolve();
+      });
+      await act(async () => {
+        await requestRemoteRowEnsure();
+      });
+      expect(createRow).toHaveBeenCalledTimes(2);
+
+      // The first lifecycle's timer resolves first. Its cleanup must not
+      // remove the replacement lifecycle's marker for the same row id.
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(1_000);
+      });
+      expect(createRow).toHaveBeenCalledTimes(3);
+      expect(createRow).toHaveBeenLastCalledWith('database-id_rows_remote-row-id', { forceSync: true });
+    } finally {
+      unmount();
+      firstDoc.destroy();
+      secondDoc.destroy();
+      rowDoc.destroy();
+      jest.useRealTimers();
+    }
+  });
+
+  it('does not schedule reconciliation for a locally inserted row', async () => {
+    jest.useFakeTimers();
+    const doc = createDatabaseDoc('database-id');
+    const rowDoc = createHydratedRowDoc('remote-row-id');
+    const createRow = jest.fn(async () => rowDoc);
+    const { unmount } = render(
+      <Database {...databaseProps(doc)} createRow={createRow} initialRowMap={{ 'remote-row-id': rowDoc }} />
+    );
+    const database = doc.getMap(YjsEditorKey.data_section).get(YjsEditorKey.database);
+    const view = database?.get(YjsDatabaseKey.views)?.get('view-id');
+    const rowOrders = view?.get(YjsDatabaseKey.row_orders);
+
+    try {
+      await act(async () => {
+        rowOrders?.push([{ id: 'remote-row-id' }]);
+        await Promise.resolve();
+      });
+      await act(async () => {
+        await requestRemoteRowEnsure();
+      });
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(10_000);
+      });
+
+      expect(createRow).toHaveBeenCalledTimes(1);
+      expect(createRow).toHaveBeenLastCalledWith('database-id_rows_remote-row-id');
+    } finally {
+      unmount();
+      doc.destroy();
+      rowDoc.destroy();
+      jest.useRealTimers();
+    }
   });
 
   it('starts a new prefetch when the Y.Doc instance changes but its guid stays the same', async () => {
@@ -419,11 +712,7 @@ describe('Database blob prefetch lifecycle', () => {
     await waitFor(() => expect(createRow).toHaveBeenCalledTimes(1));
 
     rerender(
-      <Database
-        {...databaseProps(secondDoc)}
-        createRow={createRow}
-        scheduleDeferredCleanup={scheduleDeferredCleanup}
-      />
+      <Database {...databaseProps(secondDoc)} createRow={createRow} scheduleDeferredCleanup={scheduleDeferredCleanup} />
     );
 
     await waitFor(() => expect(scheduleDeferredCleanup).toHaveBeenCalledTimes(1));
@@ -640,22 +929,14 @@ describe('Database blob prefetch lifecycle', () => {
     const createRow = jest.fn().mockReturnValue(pendingRowSync.promise);
     const scheduleDeferredCleanup = jest.fn();
     const { rerender, unmount } = render(
-      <Database
-        {...databaseProps(firstDoc)}
-        createRow={createRow}
-        scheduleDeferredCleanup={scheduleDeferredCleanup}
-      />
+      <Database {...databaseProps(firstDoc)} createRow={createRow} scheduleDeferredCleanup={scheduleDeferredCleanup} />
     );
 
     fireEvent.click(screen.getByRole('button', { name: 'Bind row sync' }));
     expect(createRow).toHaveBeenCalledTimes(1);
 
     rerender(
-      <Database
-        {...databaseProps(secondDoc)}
-        createRow={createRow}
-        scheduleDeferredCleanup={scheduleDeferredCleanup}
-      />
+      <Database {...databaseProps(secondDoc)} createRow={createRow} scheduleDeferredCleanup={scheduleDeferredCleanup} />
     );
 
     expect(scheduleDeferredCleanup).not.toHaveBeenCalled();

--- a/src/components/database/__tests__/Database.prefetch-lifecycle.test.tsx
+++ b/src/components/database/__tests__/Database.prefetch-lifecycle.test.tsx
@@ -528,6 +528,56 @@ describe('Database blob prefetch lifecycle', () => {
     canonicalRowDoc.destroy();
   });
 
+  it('retries force sync after a settled request returns an unhydrated row', async () => {
+    const doc = createDatabaseDoc('database-id');
+    const seedShell = createHydratedRowDoc('seed-shell');
+    const unhydratedCanonicalRowDoc = new Y.Doc({ guid: 'row-id' }) as YDoc;
+    const hydratedCanonicalRowDoc = createHydratedRowDoc('row-id');
+    let forceSyncAttempts = 0;
+    const createRow = jest.fn(async (_rowKey: string, options?: { forceSync?: boolean }) => {
+      if (!options?.forceSync) return unhydratedCanonicalRowDoc;
+
+      forceSyncAttempts += 1;
+      return forceSyncAttempts === 1 ? unhydratedCanonicalRowDoc : hydratedCanonicalRowDoc;
+    });
+    const { unmount } = render(
+      <Database {...databaseProps(doc)} createRow={createRow} initialRowMap={{ 'row-id': seedShell }} />
+    );
+
+    await waitFor(() => expect(mockedPrefetch).toHaveBeenCalledTimes(1));
+    act(() => {
+      mockedPrefetch.mock.calls[0][2]?.onSeedsReady?.();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Bind row sync' }));
+    await waitFor(() => expect(createRow).toHaveBeenCalledTimes(1));
+
+    let firstEnsure: YDoc | undefined;
+
+    await act(async () => {
+      firstEnsure = await requestEnsureRow();
+    });
+
+    expect(firstEnsure).toBe(unhydratedCanonicalRowDoc);
+    expect(createRow).toHaveBeenCalledTimes(2);
+
+    let secondEnsure: YDoc | undefined;
+
+    await act(async () => {
+      secondEnsure = await requestEnsureRow();
+    });
+
+    expect(secondEnsure).toBe(hydratedCanonicalRowDoc);
+    expect(createRow).toHaveBeenCalledTimes(3);
+    expect(createRow).toHaveBeenLastCalledWith('database-id_rows_row-id', { forceSync: true });
+
+    unmount();
+    doc.destroy();
+    seedShell.destroy();
+    unhydratedCanonicalRowDoc.destroy();
+    hydratedCanonicalRowDoc.destroy();
+  });
+
   it('keeps hydrated snapshot rows local in a read-only database', async () => {
     const doc = createDatabaseDoc('database-id');
     const snapshotRowDoc = createHydratedRowDoc('snapshot-row');

--- a/src/components/database/__tests__/Database.prefetch-lifecycle.test.tsx
+++ b/src/components/database/__tests__/Database.prefetch-lifecycle.test.tsx
@@ -1,12 +1,16 @@
+import EventEmitter from 'events';
+
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import * as Y from 'yjs';
 
 import { peekDatabaseRowDocSeed, prefetchDatabaseBlobDiff } from '@/application/database-blob';
+import { APP_EVENTS } from '@/application/constants';
 import { getCachedRowDoc, openRowDoc } from '@/application/services/js-services/cache';
 import { DatabaseViewLayout, YDoc, YjsDatabaseKey, YjsEditorKey } from '@/application/types';
 import Database, { Database2Props } from '@/components/database/Database';
 
 const mockSeedLoadPromises: Array<Promise<YDoc | undefined>> = [];
+const mockEnsureRowPromises: Array<Promise<YDoc | undefined> | void> = [];
 let mockLoadSeedOnLifecycleChange = false;
 
 jest.mock('@/application/database-blob', () => ({
@@ -48,7 +52,7 @@ jest.mock('@/components/database/DatabaseViews', () => {
     jest.requireActual<typeof import('@/application/database-yjs/context')>('@/application/database-yjs/context');
 
   return function MockDatabaseViews() {
-    const { bindRowSync, loadRowFromSeed, rowMap } = useDatabaseContext();
+    const { bindRowSync, ensureRow, loadRowFromSeed, rowMap } = useDatabaseContext();
     const initialLoadRowFromSeed = React.useRef(loadRowFromSeed).current;
     const previousLoadRowFromSeed = React.useRef(loadRowFromSeed);
 
@@ -93,6 +97,17 @@ jest.mock('@/components/database/DatabaseViews', () => {
           type: 'button',
         },
         'Bind row sync'
+      ),
+      React.createElement(
+        'button',
+        {
+          onClick: () => {
+            if (!ensureRow) throw new Error('ensureRow is not available');
+            mockEnsureRowPromises.push(ensureRow('row-id'));
+          },
+          type: 'button',
+        },
+        'Ensure row'
       )
     );
   };
@@ -166,10 +181,29 @@ function requestSeedLoadFromInitialLifecycle() {
   return request;
 }
 
+function requestEnsureRow() {
+  const requestIndex = mockEnsureRowPromises.length;
+
+  fireEvent.click(screen.getByRole('button', { name: 'Ensure row' }));
+  const request = mockEnsureRowPromises[requestIndex];
+
+  if (!request) throw new Error('DatabaseViews did not request an ensured row');
+  return request;
+}
+
+function createHydratedRowDoc(guid: string) {
+  const doc = new Y.Doc({ guid }) as YDoc;
+  const sharedRoot = doc.getMap(YjsEditorKey.data_section);
+
+  sharedRoot.set(YjsEditorKey.database_row, new Y.Map());
+  return doc;
+}
+
 describe('Database blob prefetch lifecycle', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockSeedLoadPromises.length = 0;
+    mockEnsureRowPromises.length = 0;
     mockLoadSeedOnLifecycleChange = false;
     mockedPeekSeed.mockReset();
     mockedGetCachedRowDoc.mockReset();
@@ -406,6 +440,72 @@ describe('Database blob prefetch lifecycle', () => {
     firstDoc.destroy();
     secondDoc.destroy();
     rowDoc.destroy();
+  });
+
+  it('replaces a hydrated seed shell with the canonical force-synced row doc', async () => {
+    const doc = createDatabaseDoc('database-id');
+    const seedShell = createHydratedRowDoc('seed-shell');
+    const canonicalRowDoc = createHydratedRowDoc('canonical-row');
+    const createRow = jest.fn(async (_rowKey: string, options?: { forceSync?: boolean }) =>
+      options?.forceSync ? canonicalRowDoc : seedShell
+    );
+    const props = {
+      ...databaseProps(doc),
+      createRow,
+      initialRowMap: { 'row-id': seedShell },
+    };
+    const { unmount } = render(<Database {...props} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Bind row sync' }));
+    await waitFor(() => {
+      expect(createRow).toHaveBeenCalledWith('database-id_rows_row-id');
+    });
+    expect(screen.getByRole('button', { name: 'Load seeded row' }).getAttribute('data-row-guid')).toBe('seed-shell');
+
+    let ensuredRow: YDoc | undefined;
+
+    await act(async () => {
+      ensuredRow = await requestEnsureRow();
+    });
+
+    expect(createRow).toHaveBeenLastCalledWith('database-id_rows_row-id', { forceSync: true });
+    expect(ensuredRow).toBe(canonicalRowDoc);
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Load seeded row' }).getAttribute('data-row-guid')).toBe(
+        'canonical-row'
+      );
+    });
+
+    unmount();
+    doc.destroy();
+    seedShell.destroy();
+    canonicalRowDoc.destroy();
+  });
+
+  it('adopts a replacement DatabaseRow doc emitted by a version reset', async () => {
+    const doc = createDatabaseDoc('database-id');
+    const seedShell = createHydratedRowDoc('seed-shell');
+    const canonicalRowDoc = createHydratedRowDoc('canonical-row');
+    const eventEmitter = new EventEmitter();
+    const { unmount } = render(
+      <Database {...databaseProps(doc)} eventEmitter={eventEmitter} initialRowMap={{ 'row-id': seedShell }} />
+    );
+
+    expect(screen.getByRole('button', { name: 'Load seeded row' }).getAttribute('data-row-guid')).toBe('seed-shell');
+
+    act(() => {
+      eventEmitter.emit(APP_EVENTS.COLLAB_DOC_RESET, {
+        objectId: 'row-id',
+        doc: canonicalRowDoc,
+      });
+    });
+
+    expect(screen.getByRole('button', { name: 'Load seeded row' }).getAttribute('data-row-guid')).toBe('canonical-row');
+
+    unmount();
+    doc.destroy();
+    seedShell.destroy();
+    canonicalRowDoc.destroy();
   });
 
   it('releases a row sync that finishes registering after its lifecycle ended', async () => {

--- a/src/components/database/__tests__/Database.prefetch-lifecycle.test.tsx
+++ b/src/components/database/__tests__/Database.prefetch-lifecycle.test.tsx
@@ -482,6 +482,34 @@ describe('Database blob prefetch lifecycle', () => {
     canonicalRowDoc.destroy();
   });
 
+  it('keeps hydrated snapshot rows local in a read-only database', async () => {
+    const doc = createDatabaseDoc('database-id');
+    const snapshotRowDoc = createHydratedRowDoc('snapshot-row');
+    const transportRowDoc = new Y.Doc({ guid: 'empty-transport-row' }) as YDoc;
+    const createRow = jest.fn().mockResolvedValue(transportRowDoc);
+    const props = {
+      ...databaseProps(doc),
+      readOnly: true,
+      createRow,
+      initialRowMap: { 'row-id': snapshotRowDoc },
+    };
+    const { unmount } = render(<Database {...props} />);
+    let ensuredRow: YDoc | undefined;
+
+    await act(async () => {
+      ensuredRow = await requestEnsureRow();
+    });
+
+    expect(ensuredRow).toBe(snapshotRowDoc);
+    expect(createRow).not.toHaveBeenCalled();
+    expect(screen.getByRole('button', { name: 'Load seeded row' }).getAttribute('data-row-guid')).toBe('snapshot-row');
+
+    unmount();
+    doc.destroy();
+    snapshotRowDoc.destroy();
+    transportRowDoc.destroy();
+  });
+
   it('adopts a replacement DatabaseRow doc emitted by a version reset', async () => {
     const doc = createDatabaseDoc('database-id');
     const seedShell = createHydratedRowDoc('seed-shell');

--- a/src/components/database/components/cell/primary/PrimaryCell.tsx
+++ b/src/components/database/components/cell/primary/PrimaryCell.tsx
@@ -65,7 +65,7 @@ export function PrimaryCell(props: CellProps<CellType>) {
             {icon ? (
               <div className={cn('flex h-5 w-5 items-center justify-center', isFlag && 'icon')}>{icon}</div>
             ) : (
-              <DocumentSvg className={'h-5 w-5'} />
+              <DocumentSvg className={'h-5 w-5'} data-testid={`row-document-icon-${rowId}`} />
             )}
           </Button>
         ) : null}
@@ -75,11 +75,7 @@ export function PrimaryCell(props: CellProps<CellType>) {
         {isRowLoaded ? (
           <DatabaseCell {...props} />
         ) : (
-          <CircularProgress
-            size={14}
-            className={'text-icon-secondary'}
-            data-testid={`primary-cell-loading-${rowId}`}
-          />
+          <CircularProgress size={14} className={'text-icon-secondary'} data-testid={`primary-cell-loading-${rowId}`} />
         )}
       </div>
     </div>

--- a/src/components/database/components/cell/primary/__tests__/PrimaryCell.test.tsx
+++ b/src/components/database/components/cell/primary/__tests__/PrimaryCell.test.tsx
@@ -53,17 +53,20 @@ function renderPrimaryCell(rowDoc: YDoc, ensureRow?: DatabaseContextState['ensur
 describe('PrimaryCell', () => {
   it('shows the row document icon when non-empty metadata arrives remotely', async () => {
     const localRowDoc = new Y.Doc() as YDoc;
+    const localRoot = localRowDoc.getMap(YjsEditorKey.data_section);
     const remoteRowDoc = new Y.Doc();
     const remoteRoot = remoteRowDoc.getMap(YjsEditorKey.data_section);
     const remoteMeta = new Y.Map<unknown>();
     const isDocumentEmptyKey = getMetaIdMap(rowId).get(RowMetaKey.IsDocumentEmpty);
 
     expect(isDocumentEmptyKey).toBeDefined();
+    localRoot.set(YjsEditorKey.database_row, new Y.Map());
     remoteMeta.set(isDocumentEmptyKey as string, false);
     remoteRoot.set(YjsEditorKey.meta, remoteMeta);
 
     renderPrimaryCell(localRowDoc);
 
+    expect(screen.getByText('Row title')).toBeTruthy();
     expect(screen.queryByTestId(`row-document-icon-${rowId}`)).toBeNull();
 
     act(() => {

--- a/src/components/database/components/cell/primary/__tests__/PrimaryCell.test.tsx
+++ b/src/components/database/components/cell/primary/__tests__/PrimaryCell.test.tsx
@@ -1,0 +1,76 @@
+import { act, render, screen, waitFor } from '@testing-library/react';
+import { type ReactNode } from 'react';
+import * as Y from 'yjs';
+
+import { DatabaseContext, DatabaseContextState, FieldType, RowMetaKey } from '@/application/database-yjs';
+import { getMetaIdMap } from '@/application/database-yjs/row_meta';
+import { YDoc, YjsEditorKey } from '@/application/types';
+import { PrimaryCell } from '@/components/database/components/cell/primary/PrimaryCell';
+
+jest.mock('@/components/_shared/cutsom-icon', () => ({
+  CustomIconPopover: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+
+jest.mock('@/components/database/components/cell', () => ({
+  Cell: () => <span>Row title</span>,
+}));
+
+jest.mock('@/utils/platform', () => ({
+  getPlatform: () => ({ isMobile: false }),
+}));
+
+const rowId = '43ed1aeb-a8bd-4039-be1d-92f33f3c1c03';
+
+function renderPrimaryCell(rowDoc: YDoc) {
+  const contextValue: DatabaseContextState = {
+    readOnly: false,
+    databaseDoc: new Y.Doc() as YDoc,
+    databasePageId: 'database-page-id',
+    activeViewId: 'board-view-id',
+    rowMap: { [rowId]: rowDoc },
+    workspaceId: 'workspace-id',
+  };
+
+  return render(
+    <DatabaseContext.Provider value={contextValue}>
+      <PrimaryCell
+        cell={{
+          createdAt: 0,
+          lastModified: 0,
+          fieldType: FieldType.RichText,
+          data: 'Synced row',
+        }}
+        rowId={rowId}
+        fieldId='primary-field-id'
+        readOnly={false}
+        wrap
+      />
+    </DatabaseContext.Provider>
+  );
+}
+
+describe('PrimaryCell', () => {
+  it('shows the row document icon when non-empty metadata arrives remotely', async () => {
+    const localRowDoc = new Y.Doc() as YDoc;
+    const remoteRowDoc = new Y.Doc();
+    const remoteRoot = remoteRowDoc.getMap(YjsEditorKey.data_section);
+    const remoteMeta = new Y.Map<unknown>();
+    const isDocumentEmptyKey = getMetaIdMap(rowId).get(RowMetaKey.IsDocumentEmpty);
+
+    expect(isDocumentEmptyKey).toBeDefined();
+    remoteMeta.set(isDocumentEmptyKey as string, false);
+    remoteRoot.set(YjsEditorKey.meta, remoteMeta);
+
+    renderPrimaryCell(localRowDoc);
+
+    expect(screen.queryByTestId(`row-document-icon-${rowId}`)).toBeNull();
+
+    act(() => {
+      Y.applyUpdate(localRowDoc, Y.encodeStateAsUpdate(remoteRowDoc));
+    });
+
+    await waitFor(() => {
+      expect(screen.getAllByTestId(`row-document-icon-${rowId}`)).toHaveLength(1);
+    });
+  });
+});

--- a/src/components/database/components/cell/primary/__tests__/PrimaryCell.test.tsx
+++ b/src/components/database/components/cell/primary/__tests__/PrimaryCell.test.tsx
@@ -21,7 +21,7 @@ jest.mock('@/utils/platform', () => ({
 
 const rowId = '43ed1aeb-a8bd-4039-be1d-92f33f3c1c03';
 
-function renderPrimaryCell(rowDoc: YDoc) {
+function renderPrimaryCell(rowDoc: YDoc, ensureRow?: DatabaseContextState['ensureRow']) {
   const contextValue: DatabaseContextState = {
     readOnly: false,
     databaseDoc: new Y.Doc() as YDoc,
@@ -29,6 +29,7 @@ function renderPrimaryCell(rowDoc: YDoc) {
     activeViewId: 'board-view-id',
     rowMap: { [rowId]: rowDoc },
     workspaceId: 'workspace-id',
+    ensureRow,
   };
 
   return render(
@@ -67,6 +68,34 @@ describe('PrimaryCell', () => {
 
     act(() => {
       Y.applyUpdate(localRowDoc, Y.encodeStateAsUpdate(remoteRowDoc));
+    });
+
+    await waitFor(() => {
+      expect(screen.getAllByTestId(`row-document-icon-${rowId}`)).toHaveLength(1);
+    });
+  });
+
+  it('shows the row document icon when realtime replaces an existing seed shell', async () => {
+    const shellRowDoc = new Y.Doc() as YDoc;
+    const shellRoot = shellRowDoc.getMap(YjsEditorKey.data_section);
+    const shellMeta = new Y.Map<unknown>();
+    const canonicalRowDoc = new Y.Doc() as YDoc;
+    const canonicalRoot = canonicalRowDoc.getMap(YjsEditorKey.data_section);
+    const canonicalMeta = new Y.Map<unknown>();
+    const isDocumentEmptyKey = getMetaIdMap(rowId).get(RowMetaKey.IsDocumentEmpty);
+
+    expect(isDocumentEmptyKey).toBeDefined();
+    shellMeta.set(isDocumentEmptyKey as string, true);
+    shellRoot.set(YjsEditorKey.meta, shellMeta);
+    canonicalMeta.set(isDocumentEmptyKey as string, true);
+    canonicalRoot.set(YjsEditorKey.meta, canonicalMeta);
+
+    renderPrimaryCell(shellRowDoc, async () => canonicalRowDoc);
+
+    expect(screen.queryByTestId(`row-document-icon-${rowId}`)).toBeNull();
+
+    act(() => {
+      canonicalMeta.set(isDocumentEmptyKey as string, false);
     });
 
     await waitFor(() => {

--- a/src/components/editor/components/find-replace/FindReplaceContext.tsx
+++ b/src/components/editor/components/find-replace/FindReplaceContext.tsx
@@ -19,7 +19,7 @@ import { APP_EVENTS } from '@/application/constants';
 import { YjsEditor } from '@/application/slate-yjs';
 import { CustomEditor } from '@/application/slate-yjs/command';
 import { notify } from '@/components/_shared/notify';
-import { useEventEmitter } from '@/components/app/app.hooks';
+import { useEventEmitterOptional } from '@/components/app/app.hooks';
 import { useEditorContext } from '@/components/editor/EditorContext';
 import { createHotkey, HOT_KEY_NAME } from '@/utils/hotkeys';
 
@@ -125,7 +125,7 @@ export function useFindReplaceDecorations() {
 export function FindReplaceProvider({ children }: { children: ReactNode }) {
   const editor = useSlate() as YjsEditor;
   const { viewId, readOnly } = useEditorContext();
-  const eventEmitter = useEventEmitter();
+  const eventEmitter = useEventEmitterOptional();
   const { t } = useTranslation();
 
   const [open, setOpen] = useState(false);

--- a/src/components/ws/__tests__/useSync.test.ts
+++ b/src/components/ws/__tests__/useSync.test.ts
@@ -929,6 +929,56 @@ describe('useSync version-gated message handling', () => {
     nextDoc.destroy();
   });
 
+  it('reopens a DatabaseRow version reset through shared row storage', async () => {
+    const ws = createWs();
+    const bc = createBroadcastChannel();
+    const eventEmitter = new EventEmitter();
+    const emitSpy = jest.spyOn(eventEmitter, 'emit');
+    const objectId = '56565656-5656-4656-8656-565656565656';
+    const incomingVersion = '018f2f9e-3f04-7c8d-8a2e-8df6dff4b013';
+    const doc = createDoc(objectId) as Y.Doc & { version?: string };
+    const nextDoc = createDoc(objectId) as Y.Doc & { version?: string };
+    const provider = { destroy: jest.fn().mockResolvedValue(undefined) };
+
+    nextDoc.version = incomingVersion;
+    mockedOpenRowCollabDBWithProvider.mockResolvedValueOnce({ doc: nextDoc, provider } as never);
+
+    const { result, rerender, unmount } = renderHook(() => useSync(ws, bc, eventEmitter, defaultWorkspaceId));
+
+    act(() => {
+      result.current.registerSyncContext({ doc, collabType: Types.DatabaseRow });
+    });
+
+    act(() => {
+      ws.lastMessage = {
+        collabMessage: {
+          objectId,
+          collabType: Types.DatabaseRow,
+          update: { version: incomingVersion },
+        },
+      } as AppflowyWebSocketType['lastMessage'];
+      rerender();
+    });
+
+    await waitFor(() => {
+      expect(mockedOpenRowCollabDBWithProvider).toHaveBeenCalledWith(objectId, {
+        expectedVersion: incomingVersion,
+        currentUser: undefined,
+      });
+    });
+    expect(mockedOpenCollabDB).not.toHaveBeenCalled();
+    await waitFor(() => {
+      expect(emitSpy).toHaveBeenCalledWith(
+        APP_EVENTS.COLLAB_DOC_RESET,
+        expect.objectContaining({ objectId, doc: nextDoc })
+      );
+    });
+
+    unmount();
+    doc.destroy();
+    nextDoc.destroy();
+  });
+
   it('processes versioned updates sequentially during reset handling', async () => {
     const ws = createWs();
     const bc = createBroadcastChannel();

--- a/src/components/ws/__tests__/useSync.test.ts
+++ b/src/components/ws/__tests__/useSync.test.ts
@@ -490,12 +490,15 @@ describe('useSync deferred cleanup', () => {
       })
     );
 
+    const openRebindSyncContext = result.current.rebindSyncContext;
+
     rerender({
       transport: {
         ...ws,
         readyState: WebSocket.CLOSED,
       },
     });
+    expect(result.current.rebindSyncContext).toBe(openRebindSyncContext);
     sendMessage.mockClear();
 
     expect(result.current.rebindSyncContext(rowId)).toBe(doc);

--- a/src/components/ws/__tests__/useSync.test.ts
+++ b/src/components/ws/__tests__/useSync.test.ts
@@ -3,6 +3,7 @@ import EventEmitter from 'events';
 import { act, renderHook, waitFor } from '@testing-library/react';
 import * as Y from 'yjs';
 
+import { invalidateDatabaseRowDocSeed } from '@/application/database-blob';
 import { APP_EVENTS } from '@/application/constants';
 import {
   openCollabDB,
@@ -21,6 +22,10 @@ import { useCurrentUserOptional } from '@/components/main/app.hooks';
 import { BroadcastChannelType } from '../useBroadcastChannel';
 import { AppflowyWebSocketType } from '../useAppflowyWebSocket';
 import { useSync } from '../useSync';
+
+jest.mock('@/application/database-blob', () => ({
+  invalidateDatabaseRowDocSeed: jest.fn(),
+}));
 
 jest.mock('@/application/db', () => {
   return {
@@ -237,6 +242,9 @@ const mockedHandleMessage = handleMessage as jest.MockedFunction<typeof handleMe
 const mockedCollabFullSyncBatch = httpApi.collabFullSyncBatch as jest.MockedFunction<typeof httpApi.collabFullSyncBatch>;
 const mockedRevertCollabVersion = httpApi.revertCollabVersion as jest.MockedFunction<typeof httpApi.revertCollabVersion>;
 const mockedUseCurrentUserOptional = useCurrentUserOptional as jest.MockedFunction<typeof useCurrentUserOptional>;
+const mockedInvalidateDatabaseRowDocSeed = invalidateDatabaseRowDocSeed as jest.MockedFunction<
+  typeof invalidateDatabaseRowDocSeed
+>;
 
 const createUser = (workspaceId = 'workspace-from-user'): User => ({
   uid: 'user-1',
@@ -262,6 +270,7 @@ const resetCommonMocks = () => {
   mockedHandleMessage.mockReset();
   mockedCollabFullSyncBatch.mockReset();
   mockedRevertCollabVersion.mockReset();
+  mockedInvalidateDatabaseRowDocSeed.mockReset();
 };
 
 describe('useSync reconnect binding', () => {
@@ -972,6 +981,10 @@ describe('useSync version-gated message handling', () => {
       });
     });
     expect(mockedOpenCollabDB).not.toHaveBeenCalled();
+    expect(mockedInvalidateDatabaseRowDocSeed).toHaveBeenCalledWith(objectId);
+    expect(mockedInvalidateDatabaseRowDocSeed.mock.invocationCallOrder[0]).toBeLessThan(
+      mockedOpenRowCollabDBWithProvider.mock.invocationCallOrder[0]
+    );
     await waitFor(() => {
       expect(emitSpy).toHaveBeenCalledWith(
         APP_EVENTS.COLLAB_DOC_RESET,

--- a/src/components/ws/__tests__/useSync.test.ts
+++ b/src/components/ws/__tests__/useSync.test.ts
@@ -457,6 +457,60 @@ describe('useSync deferred cleanup', () => {
     doc.destroy();
   });
 
+  it('rebinds a row sync context without acquiring another owner', () => {
+    const ws = {
+      ...createWs(),
+      readyState: WebSocket.OPEN,
+    };
+    const bc = createBroadcastChannel();
+    const rowId = '23232323-2323-4232-8232-232323232323';
+    const doc = createDoc(rowId);
+    const { result, rerender, unmount } = renderHook(
+      ({ transport }) => useSync(transport, bc, defaultEventEmitter, defaultWorkspaceId),
+      { initialProps: { transport: ws } }
+    );
+    const sendMessage = ws.sendMessage as jest.Mock;
+
+    act(() => {
+      result.current.registerSyncContext({ doc, collabType: Types.DatabaseRow });
+    });
+    sendMessage.mockClear();
+
+    expect(result.current.rebindSyncContext('24242424-2424-4242-8242-242424242424')).toBeUndefined();
+    expect(result.current.rebindSyncContext(rowId)).toBe(doc);
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+    expect(sendMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        collabMessage: expect.objectContaining({
+          objectId: rowId,
+          collabType: Types.DatabaseRow,
+          syncRequest: expect.any(Object),
+        }),
+      })
+    );
+
+    rerender({
+      transport: {
+        ...ws,
+        readyState: WebSocket.CLOSED,
+      },
+    });
+    sendMessage.mockClear();
+
+    expect(result.current.rebindSyncContext(rowId)).toBe(doc);
+    expect(sendMessage).not.toHaveBeenCalled();
+
+    act(() => {
+      result.current.scheduleDeferredCleanup(rowId, 0);
+      jest.runOnlyPendingTimers();
+    });
+
+    expect(result.current.rebindSyncContext(rowId)).toBeUndefined();
+
+    unmount();
+    doc.destroy();
+  });
+
   it('enqueues local updates to the outbox and drains to sendMessage', () => {
     const outboxMock = jest.requireMock('@/application/sync-outbox');
 

--- a/src/components/ws/__tests__/useSync.test.ts
+++ b/src/components/ws/__tests__/useSync.test.ts
@@ -12,6 +12,7 @@ import {
   collabIndexedDBExists,
 } from '@/application/db';
 import * as httpApi from '@/application/services/js-services/http/http_api';
+import { getCachedRowDoc } from '@/application/services/js-services/cache';
 import { handleMessage, type SyncContext } from '@/application/services/js-services/sync-protocol';
 import { Types, User, YDoc, YjsDatabaseKey, YjsEditorKey } from '@/application/types';
 import { Log } from '@/utils/log';
@@ -947,6 +948,7 @@ describe('useSync version-gated message handling', () => {
 
     act(() => {
       result.current.registerSyncContext({ doc, collabType: Types.DatabaseRow });
+      result.current.registerSyncContext({ doc, collabType: Types.DatabaseRow });
     });
 
     act(() => {
@@ -973,6 +975,15 @@ describe('useSync version-gated message handling', () => {
         expect.objectContaining({ objectId, doc: nextDoc })
       );
     });
+    expect(getCachedRowDoc(`database-id_rows_${objectId}`)).toBe(nextDoc);
+
+    act(() => {
+      result.current.scheduleDeferredCleanup(objectId, 0);
+    });
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    });
+    expect(result.current.rebindSyncContext(objectId)).toBe(nextDoc);
 
     unmount();
     doc.destroy();

--- a/src/components/ws/sync/rebuildCollabDoc.ts
+++ b/src/components/ws/sync/rebuildCollabDoc.ts
@@ -22,6 +22,8 @@ export type RebuildCollabDocParams = {
   openDoc: () => Promise<YDoc & SyncDocMeta>;
   /** If true, the COLLAB_DOC_RESET event includes `isExternalRevert: true`. */
   isExternalRevert?: boolean;
+  /** Number of active owners that must survive replacing the Y.Doc instance. */
+  ownerCount?: number;
   /**
    * Whether the previous doc had a pending deferred cleanup timer.
    * Must be captured by the caller BEFORE destroying the previous doc,
@@ -46,6 +48,7 @@ export async function rebuildCollabDoc(params: RebuildCollabDocParams): Promise<
     openDoc,
     isExternalRevert,
     hadPendingDeferredCleanup,
+    ownerCount = 1,
   } = params;
 
   const nextDoc = await openDoc();
@@ -63,6 +66,17 @@ export async function rebuildCollabDoc(params: RebuildCollabDocParams): Promise<
     awareness: nextAwareness,
     collabType: context.collabType,
   });
+
+  // Destroying the previous doc unregisters the whole context and its owner
+  // count. Re-register the additional owners so one mounted consumer cannot
+  // tear down sync while another still renders the replacement document.
+  for (let ownerIndex = 1; ownerIndex < ownerCount; ownerIndex += 1) {
+    registerSyncContext({
+      doc: newContext.doc,
+      awareness: nextAwareness,
+      collabType: context.collabType,
+    });
+  }
 
   if (hadPendingDeferredCleanup) {
     scheduleDeferredCleanup(previousDoc.guid);

--- a/src/components/ws/sync/types.ts
+++ b/src/components/ws/sync/types.ts
@@ -76,6 +76,11 @@ export interface QueuedCollabMessage {
 export type SyncContextType = {
   registerSyncContext: (context: RegisterSyncContext) => SyncContext;
   /**
+   * Return the canonical live document and, while online, re-send its
+   * state-vector exchange without changing context ownership.
+   */
+  rebindSyncContext: (objectId: string) => YDoc | undefined;
+  /**
    * Wait until all pending updates for every registered sync context have
    * been drained to the WebSocket from the persistent sync_outbox. Resolves
    * `true` when fully drained, `false` on timeout (e.g. WS remained closed).

--- a/src/components/ws/sync/useCollabMessageHandler.ts
+++ b/src/components/ws/sync/useCollabMessageHandler.ts
@@ -3,9 +3,9 @@ import EventEmitter from 'events';
 import { useCallback, useEffect, useRef } from 'react';
 import * as Y from 'yjs';
 
-import { deleteCollabDB, openCollabDB } from '@/application/db';
+import { deleteCollabDB, openCollabDB, openRowCollabDBWithProvider } from '@/application/db';
 import { handleMessage, SyncContext } from '@/application/services/js-services/sync-protocol';
-import { YDoc } from '@/application/types';
+import { Types, YDoc } from '@/application/types';
 import { collab } from '@/proto/messages';
 import { Log } from '@/utils/log';
 
@@ -250,9 +250,16 @@ export function useCollabMessageHandler(
                       previousDoc.version,
                       newVersion
                     );
-                    nextDoc = (await openCollabDB(previousDoc.guid, {
-                      ...openOptions,
-                    })) as YDoc & SyncDocMeta;
+                    if (localContext.collabType === Types.DatabaseRow) {
+                      const rowEntry = await openRowCollabDBWithProvider(previousDoc.guid, openOptions);
+
+                      nextDoc = rowEntry.doc as YDoc & SyncDocMeta;
+                    } else {
+                      nextDoc = (await openCollabDB(previousDoc.guid, {
+                        ...openOptions,
+                      })) as YDoc & SyncDocMeta;
+                    }
+
                     Log.debug('[Version] opened new doc: objectId=%s, nextDocVersion=%s', objectId, nextDoc.version);
                     if (!isCollabVersionId(newVersion)) {
                       // Align with desktop Option<version> semantics after mismatch reset:

--- a/src/components/ws/sync/useCollabMessageHandler.ts
+++ b/src/components/ws/sync/useCollabMessageHandler.ts
@@ -3,6 +3,7 @@ import EventEmitter from 'events';
 import { useCallback, useEffect, useRef } from 'react';
 import * as Y from 'yjs';
 
+import { invalidateDatabaseRowDocSeed } from '@/application/database-blob';
 import { deleteCollabDB, openCollabDB, openRowCollabDBWithProvider } from '@/application/db';
 import { cacheCanonicalRowDoc } from '@/application/services/js-services/cache';
 import { handleMessage, SyncContext } from '@/application/services/js-services/sync-protocol';
@@ -202,6 +203,13 @@ export function useCollabMessageHandler(
             refs.resettingObjectIds.current.add(objectId);
 
             try {
+              if (context.collabType === Types.DatabaseRow) {
+                // Blob snapshots and seed-derived docs predate this reset. Fence
+                // the row before awaiting teardown so mounted cell loaders cannot
+                // observe or merge that stale state into the replacement doc.
+                invalidateDatabaseRowDocSeed(objectId);
+              }
+
               // Discard and destroy live inside the try so a rejection
               // (e.g. IDB blocked/closing) still runs the finally that
               // clears `resettingObjectIds`. Without this, a failed discard

--- a/src/components/ws/sync/useCollabMessageHandler.ts
+++ b/src/components/ws/sync/useCollabMessageHandler.ts
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useRef } from 'react';
 import * as Y from 'yjs';
 
 import { deleteCollabDB, openCollabDB, openRowCollabDBWithProvider } from '@/application/db';
+import { cacheCanonicalRowDoc } from '@/application/services/js-services/cache';
 import { handleMessage, SyncContext } from '@/application/services/js-services/sync-protocol';
 import { Types, YDoc } from '@/application/types';
 import { collab } from '@/proto/messages';
@@ -189,6 +190,7 @@ export function useCollabMessageHandler(
             messageHandled = handleOnActiveContext();
           } else {
             const hadPendingDeferredCleanup = refs.pendingCleanups.current.has(previousDoc.guid);
+            const ownerCount = Math.max(1, refs.contextRefCounts.current.get(objectId) ?? 0);
             const previousDocSnapshot = Y.encodeStateAsUpdate(previousDoc);
 
             // Tear down the currently active doc first to stop stale edits from being
@@ -221,6 +223,7 @@ export function useCollabMessageHandler(
                 registerSyncContext,
                 scheduleDeferredCleanup,
                 hadPendingDeferredCleanup,
+                ownerCount,
                 isExternalRevert: true,
                 openDoc: async () => {
                   let nextDoc: YDoc & SyncDocMeta;
@@ -290,6 +293,10 @@ export function useCollabMessageHandler(
                   return nextDoc;
                 },
               });
+
+              if (localContext.collabType === Types.DatabaseRow) {
+                cacheCanonicalRowDoc(objectId, context.doc);
+              }
             } finally {
               // If discard threw before destroy fired, the doc.on('destroy')
               // handler never consumed this flag — clean it up defensively so

--- a/src/components/ws/sync/useCollabVersionRevert.ts
+++ b/src/components/ws/sync/useCollabVersionRevert.ts
@@ -52,6 +52,7 @@ export function useCollabVersionRevert(deps: CollabVersionRevertDeps) {
     if (currentUser && context) {
       const previousDoc = context.doc as YDoc & SyncDocMeta;
       const objectId = previousDoc.guid;
+      const ownerCount = Math.max(1, refs.contextRefCounts.current.get(objectId) ?? 0);
 
       // Drop stale pending edits and pause active sync before restore/open.
       // Mark the objectId as "resetting" *before* awaiting so that any
@@ -87,6 +88,7 @@ export function useCollabVersionRevert(deps: CollabVersionRevertDeps) {
             registerSyncContext,
             scheduleDeferredCleanup,
             hadPendingDeferredCleanup: false,
+            ownerCount,
             openDoc: async () => {
               let doc: (YDoc & SyncDocMeta) | null = null;
 
@@ -106,11 +108,14 @@ export function useCollabVersionRevert(deps: CollabVersionRevertDeps) {
           });
         } catch (error) {
           // Restore previous context if version restore fails.
-          registerSyncContext({
-            doc: previousDoc,
-            awareness: context.awareness,
-            collabType: context.collabType,
-          });
+          for (let ownerIndex = 0; ownerIndex < ownerCount; ownerIndex += 1) {
+            registerSyncContext({
+              doc: previousDoc,
+              awareness: context.awareness,
+              collabType: context.collabType,
+            });
+          }
+
           throw error;
         }
       } finally {

--- a/src/components/ws/useSync.ts
+++ b/src/components/ws/useSync.ts
@@ -246,6 +246,23 @@ export const useSync = (
     refs.registeredContexts.current.forEach((context) => bindSyncContext(context));
   }, [readyState, refs]);
 
+  const rebindSyncContext = useCallback(
+    (objectId: string) => {
+      const context = refs.registeredContexts.current.get(objectId);
+
+      if (!context) return undefined;
+
+      // Reconnect already rebinds every registered context. Avoid filling the
+      // transport's offline queue with repeated retry manifests.
+      if (readyState === WS_READY_STATE_OPEN) {
+        bindSyncContext(context);
+      }
+
+      return context.doc;
+    },
+    [readyState, refs]
+  );
+
   // ── Incoming collab messages ─────────────────────────────────────────
   // Watches wsCollabMessage / bcCollabMessage and routes them through a per-objectId
   // sequential queue.  Handles version mismatch detection and triggers doc rebuild
@@ -329,6 +346,7 @@ export const useSync = (
   return useMemo(
     () => ({
       registerSyncContext,
+      rebindSyncContext,
       revertCollabVersion,
       flushAllSync,
       syncAllToServer,
@@ -337,6 +355,7 @@ export const useSync = (
     }),
     [
       registerSyncContext,
+      rebindSyncContext,
       revertCollabVersion,
       flushAllSync,
       syncAllToServer,

--- a/src/components/ws/useSync.ts
+++ b/src/components/ws/useSync.ts
@@ -1,6 +1,6 @@
 import EventEmitter from 'events';
 
-import { useCallback, useEffect, useMemo, useRef } from 'react';
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef } from 'react';
 
 import { bindSyncContext, UpdateFlags } from '@/application/services/js-services/sync-protocol';
 import { useCurrentUserOptional } from '@/components/main/app.hooks';
@@ -229,6 +229,13 @@ export const useSync = (
   // a full registration: existing observers and owner ref-counts stay intact.
   const previousReadyStateRef = useRef(readyState);
   const hasOpenedRef = useRef(readyState === WS_READY_STATE_OPEN);
+  const readyStateRef = useRef(readyState);
+
+  // Keep the public rebind callback stable so a transport state change does
+  // not invalidate SyncInternalContext and every downstream database callback.
+  useLayoutEffect(() => {
+    readyStateRef.current = readyState;
+  }, [readyState]);
 
   useEffect(() => {
     const previousReadyState = previousReadyStateRef.current;
@@ -254,13 +261,13 @@ export const useSync = (
 
       // Reconnect already rebinds every registered context. Avoid filling the
       // transport's offline queue with repeated retry manifests.
-      if (readyState === WS_READY_STATE_OPEN) {
+      if (readyStateRef.current === WS_READY_STATE_OPEN) {
         bindSyncContext(context);
       }
 
       return context.doc;
     },
-    [readyState, refs]
+    [refs]
   );
 
   // ── Incoming collab messages ─────────────────────────────────────────


### PR DESCRIPTION
## Summary
- allow published database row editors to render outside the authenticated AppProvider by using an optional app event emitter
- preserve header-driven find and replace when the authenticated event emitter is available
- keep Share available on database row routes while removing the Publish tab entirely, preventing publication changes to the parent database
- handle route transitions by falling back to Share and hiding any open publish-management modal
- add deterministic Playwright BDD and focused unit regression coverage

## Test plan
- [x] 12 focused Jest tests across event-emitter, row-header, Share-tab, and route-transition behavior
- [x] pnpm type-check
- [x] ESLint and Prettier checks for the changed application files
- [x] pnpm exec bddgen test -c playwright.bdd.config.ts and headed Chromium run filtered by @issue-1645

## User-reported issue
Closes AppFlowy-IO/AppFlowy-Cloud#1645