### PR TITLE
fix(database): reconcile remote rows after id hydration

### DIFF
--- a/playwright/bdd/features/database/row-document.feature
+++ b/playwright/bdd/features/database/row-document.feature
@@ -27,6 +27,14 @@ Feature: Database row document
     And I close the card row page
     Then the other web client shows exactly one row document icon for the card
 
+  Scenario: Every newly ordered card reconciles its row document metadata without reload
+    Given a board database is open before three synchronized cards are created
+    And another web client opens the Board before the synchronized card is created
+    When I create three synchronized cards
+    Then the other web client shows no row document icons for the synchronized cards
+    When I add row page content to all three synchronized cards
+    Then the other web client shows exactly three synchronized cards with document icons without reload
+
   Scenario: Duplicating an inline grid block in a row page creates an independent database
     Given a grid database is open for row-page inline grid duplication
     When I open the first row as a full row page

--- a/playwright/bdd/steps/database-row-document.steps.ts
+++ b/playwright/bdd/steps/database-row-document.steps.ts
@@ -25,8 +25,9 @@ import { generateRandomEmail, setupPageErrorHandling } from '../../support/test-
 const { Given, When, Then, After } = createBdd();
 
 const cardNamesByPage = new WeakMap<Page, string>();
+const synchronizedCardNamesByPage = new WeakMap<Page, string[]>();
 const rowInlineGridStateByPage = new WeakMap<Page, RowInlineGridState>();
-const secondCardClientByPage = new WeakMap<Page, { context: BrowserContext; page: Page }>();
+const secondCardClientByPage = new WeakMap<Page, { context: BrowserContext; page: Page; loadsAfterOpen: number }>();
 
 After(async ({ page }) => {
   await secondCardClientByPage.get(page)?.context.close();
@@ -82,6 +83,23 @@ Given('a board database is open before the synchronized card is created', async 
   });
 });
 
+Given('a board database is open before three synchronized cards are created', async ({ page, request }) => {
+  const cardNamePrefix = `NewRemoteCards-${uuidv4().slice(0, 6)}`;
+
+  synchronizedCardNamesByPage.set(
+    page,
+    Array.from({ length: 3 }, (_, index) => `${cardNamePrefix}-${index + 1}`)
+  );
+
+  await signInAndCreateDatabaseView(page, request, generateRandomEmail(), 'Board', {
+    createWaitMs: 7000,
+    verify: async (p) => {
+      await expect(BoardSelectors.boardContainer(p)).toHaveCount(1, { timeout: 15000 });
+      await expect(BoardSelectors.boardContainer(p)).toBeVisible({ timeout: 15000 });
+    },
+  });
+});
+
 Given('another web client opens the same card Board', async ({ page, browser }) => {
   const currentCardName = getCurrentCardName(page);
   const context = await browser.newContext({
@@ -90,14 +108,19 @@ Given('another web client opens the same card Board', async ({ page, browser }) 
     viewport: { width: 1440, height: 900 },
   });
   const secondPage = await context.newPage();
+  const secondClient = { context, page: secondPage, loadsAfterOpen: 0 };
 
-  secondCardClientByPage.set(page, { context, page: secondPage });
+  secondCardClientByPage.set(page, secondClient);
   setupPageErrorHandling(secondPage);
 
   await secondPage.goto(page.url(), { waitUntil: 'domcontentloaded' });
   await expect(BoardSelectors.boardContainer(secondPage)).toHaveCount(1, { timeout: 30000 });
   await expect(cardsByName(secondPage, currentCardName)).toHaveCount(1, { timeout: 30000 });
   await expect(cardByName(secondPage, currentCardName)).toBeVisible({ timeout: 30000 });
+  await secondPage.waitForLoadState('load');
+  secondPage.on('load', () => {
+    secondClient.loadsAfterOpen += 1;
+  });
 });
 
 Given('another web client opens the Board before the synchronized card is created', async ({ page, browser }) => {
@@ -107,13 +130,18 @@ Given('another web client opens the Board before the synchronized card is create
     viewport: { width: 1440, height: 900 },
   });
   const secondPage = await context.newPage();
+  const secondClient = { context, page: secondPage, loadsAfterOpen: 0 };
 
-  secondCardClientByPage.set(page, { context, page: secondPage });
+  secondCardClientByPage.set(page, secondClient);
   setupPageErrorHandling(secondPage);
 
   await secondPage.goto(page.url(), { waitUntil: 'domcontentloaded' });
   await expect(BoardSelectors.boardContainer(secondPage)).toHaveCount(1, { timeout: 30000 });
   await expect(BoardSelectors.boardContainer(secondPage)).toBeVisible({ timeout: 30000 });
+  await secondPage.waitForLoadState('load');
+  secondPage.on('load', () => {
+    secondClient.loadsAfterOpen += 1;
+  });
 });
 
 When('I create the synchronized card', async ({ page }) => {
@@ -124,36 +152,29 @@ When('I create the synchronized card', async ({ page }) => {
   await expect(cardByName(page, currentCardName)).toBeVisible({ timeout: 15000 });
 });
 
+When('I create three synchronized cards', async ({ page }) => {
+  for (const cardName of getSynchronizedCardNames(page)) {
+    await addNewCard(page, cardName);
+    await expect(cardsByName(page, cardName)).toHaveCount(1, { timeout: 15000 });
+    await expect(cardByName(page, cardName)).toBeVisible({ timeout: 15000 });
+  }
+});
+
 When('I add image link {string} to the card row page', async ({ page }, imageUrl: string) => {
-  const currentCardName = getCurrentCardName(page);
-
-  await cardByName(page, currentCardName).click({ force: true });
-  await expect(RowDetailSelectors.modal(page)).toBeVisible({ timeout: 15000 });
-
-  await focusRowDocumentEditor(page);
-  await page.keyboard.type('/image', { delay: 30 });
-
-  const imageCommand = page.getByTestId('slash-menu-image');
-
-  await expect(imageCommand).toBeVisible({ timeout: 10000 });
-  await imageCommand.click({ force: true });
-
-  const popover = page.locator('.MuiPopover-root:visible').last();
-
-  await expect(popover).toBeVisible({ timeout: 10000 });
-  await popover.getByText('Embed link', { exact: true }).click({ force: true });
-
-  const input = popover.getByPlaceholder('Paste or type an image link');
-
-  await expect(input).toBeVisible({ timeout: 10000 });
-  await input.fill(imageUrl);
-  await input.press('Enter');
-  await expect(popover).toBeHidden({ timeout: 10000 });
+  await addImageLinkToCardRowPage(page, getCurrentCardName(page), imageUrl);
 });
 
 When('I close the card row page', async ({ page }) => {
-  await closeRowDetailWithEscape(page);
-  await page.waitForTimeout(2000);
+  await closeCardRowPage(page);
+});
+
+When('I add row page content to all three synchronized cards', async ({ page }) => {
+  const cardNames = getSynchronizedCardNames(page);
+
+  for (const [index, cardName] of cardNames.entries()) {
+    await addImageLinkToCardRowPage(page, cardName, `https://example.com/newly-ordered-row-page-image-${index + 1}.png`);
+    await closeCardRowPage(page);
+  }
 });
 
 When('I switch the database to a new Grid view', async ({ page }) => {
@@ -213,6 +234,38 @@ Then('the other web client shows exactly one row document icon for the card', as
   await expect(documentIcon).toHaveCount(1, { timeout: 30000 });
   await expect(documentIcon).toBeVisible({ timeout: 30000 });
 });
+
+Then('the other web client shows no row document icons for the synchronized cards', async ({ page }) => {
+  const secondPage = getSecondCardClient(page).page;
+
+  for (const cardName of getSynchronizedCardNames(page)) {
+    const cards = cardsByName(secondPage, cardName);
+
+    await expect(cards).toHaveCount(1, { timeout: 30000 });
+    await expect(cards.first()).toBeVisible({ timeout: 30000 });
+    await expect(cards.first().locator('[data-testid^="row-document-icon-"]')).toHaveCount(0);
+  }
+});
+
+Then(
+  'the other web client shows exactly three synchronized cards with document icons without reload',
+  async ({ page }) => {
+    const secondClient = getSecondCardClient(page);
+    const board = BoardSelectors.boardContainer(secondClient.page);
+
+    for (const cardName of getSynchronizedCardNames(page)) {
+      const cards = cardsByName(secondClient.page, cardName);
+      const documentIcon = cards.first().locator('[data-testid^="row-document-icon-"]');
+
+      await expect(cards).toHaveCount(1, { timeout: 30000 });
+      await expect(documentIcon).toHaveCount(1, { timeout: 30000 });
+      await expect(documentIcon).toBeVisible({ timeout: 30000 });
+    }
+
+    await expect(board.locator('[data-testid^="row-document-icon-"]')).toHaveCount(3, { timeout: 30000 });
+    expect(secondClient.loadsAfterOpen).toBe(0);
+  }
+);
 
 Given('a grid database is open for row-page inline grid duplication', async ({ page, request }) => {
   setupPageErrorHandling(page);
@@ -394,6 +447,36 @@ async function addNewCard(page: Page, cardName: string) {
   await page.waitForTimeout(2000);
 }
 
+async function addImageLinkToCardRowPage(page: Page, cardName: string, imageUrl: string) {
+  await cardByName(page, cardName).click({ force: true });
+  await expect(RowDetailSelectors.modal(page)).toBeVisible({ timeout: 15000 });
+
+  await focusRowDocumentEditor(page);
+  await page.keyboard.type('/image', { delay: 30 });
+
+  const imageCommand = page.getByTestId('slash-menu-image');
+
+  await expect(imageCommand).toBeVisible({ timeout: 10000 });
+  await imageCommand.click({ force: true });
+
+  const popover = page.locator('.MuiPopover-root:visible').last();
+
+  await expect(popover).toBeVisible({ timeout: 10000 });
+  await popover.getByText('Embed link', { exact: true }).click({ force: true });
+
+  const input = popover.getByPlaceholder('Paste or type an image link');
+
+  await expect(input).toBeVisible({ timeout: 10000 });
+  await input.fill(imageUrl);
+  await input.press('Enter');
+  await expect(popover).toBeHidden({ timeout: 10000 });
+}
+
+async function closeCardRowPage(page: Page) {
+  await closeRowDetailWithEscape(page);
+  await page.waitForTimeout(2000);
+}
+
 async function focusRowDocumentEditor(page: Page) {
   const dialog = page.locator('[role="dialog"]');
   const scrollContainer = dialog.locator('.appflowy-scroll-container');
@@ -425,6 +508,26 @@ function getCurrentCardName(page: Page) {
   }
 
   return cardName;
+}
+
+function getSynchronizedCardNames(page: Page) {
+  const cardNames = synchronizedCardNamesByPage.get(page);
+
+  if (!cardNames) {
+    throw new Error('No synchronized card names are available for this scenario');
+  }
+
+  return cardNames;
+}
+
+function getSecondCardClient(page: Page) {
+  const secondClient = secondCardClientByPage.get(page);
+
+  if (!secondClient) {
+    throw new Error('Expected another web client to have opened the Board');
+  }
+
+  return secondClient;
 }
 
 function initializeRowInlineGridState(page: Page): RowInlineGridState {

--- a/src/components/database/Database.tsx
+++ b/src/components/database/Database.tsx
@@ -344,6 +344,7 @@ function Database(props: Database2Props) {
     [workspaceId, doc, currentDatabaseId, props.initialRowMap]
   );
   const activeDatabaseLifecycleRef = useRef<typeof databaseLifecycleIdentity | null>(databaseLifecycleIdentity);
+  const previousDatabaseLifecycleRef = useRef(databaseLifecycleIdentity);
 
   const getPriorityRowIds = useCallback(() => {
     const sharedRoot = doc.getMap(YjsEditorKey.data_section);
@@ -1048,7 +1049,6 @@ function Database(props: Database2Props) {
     const database = sharedRoot.get(YjsEditorKey.database) as YDatabase | undefined;
     const view = database?.get(YjsDatabaseKey.views)?.get(activeViewId);
     const rowOrders = view?.get(YjsDatabaseKey.row_orders);
-    const lifecycleReconciliationRows = remoteRowsNeedingReconciliationRef.current;
 
     if (!rowOrders) return;
 
@@ -1064,6 +1064,7 @@ function Database(props: Database2Props) {
           .filter((row) => !row.is_deleted)
           .map((row) => row.id)
       );
+      const lifecycleReconciliationRows = remoteRowsNeedingReconciliationRef.current;
 
       if (!transaction.local) {
         nextOrderedRowIds.forEach((rowId) => {
@@ -1088,6 +1089,14 @@ function Database(props: Database2Props) {
   }, [activeViewId, createRow, doc, readOnly]);
 
   useLayoutEffect(() => {
+    const previousLifecycleIdentity = previousDatabaseLifecycleRef.current;
+    const nextRemoteRowsNeedingReconciliation =
+      previousLifecycleIdentity?.doc === databaseLifecycleIdentity.doc &&
+      previousLifecycleIdentity.databaseId !== databaseLifecycleIdentity.databaseId
+        ? new Set(remoteRowsNeedingReconciliationRef.current)
+        : new Set<RowId>();
+
+    previousDatabaseLifecycleRef.current = databaseLifecycleIdentity;
     activeDatabaseLifecycleRef.current = databaseLifecycleIdentity;
     const lifecycleRowSyncRegistrations = new Map<string, RowSyncRegistration>();
     const prefetchGeneration = blobPrefetchGenerationRef.current + 1;
@@ -1100,7 +1109,10 @@ function Database(props: Database2Props) {
     rowMapRef.current = {};
     pendingRowDocsRef.current.clear();
     prefetchPromisesRef.current.clear();
-    remoteRowsNeedingReconciliationRef.current = new Set();
+    // A remote update can hydrate the database id and append row orders in the
+    // same Yjs transaction. Carry those markers into the real-id lifecycle;
+    // unrelated document/workspace lifecycle changes still start empty.
+    remoteRowsNeedingReconciliationRef.current = nextRemoteRowsNeedingReconciliation;
     blobPrefetchPromiseRef.current = null;
     localCachePrimedRef.current = false;
     rowSyncRegistrationsRef.current = lifecycleRowSyncRegistrations;

--- a/src/components/database/__tests__/Database.prefetch-lifecycle.test.tsx
+++ b/src/components/database/__tests__/Database.prefetch-lifecycle.test.tsx
@@ -132,6 +132,20 @@ jest.mock('@/components/database/DatabaseViews', () => {
           type: 'button',
         },
         'Ensure remote row'
+      ),
+      ...['remote-row-a', 'remote-row-b', 'remote-row-c'].map((rowId) =>
+        React.createElement(
+          'button',
+          {
+            key: rowId,
+            onClick: () => {
+              if (!ensureRow) throw new Error('ensureRow is not available');
+              mockEnsureRowPromises.push(ensureRow(rowId));
+            },
+            type: 'button',
+          },
+          `Ensure ${rowId}`
+        )
       )
     );
   };
@@ -184,6 +198,23 @@ function insertRemoteRowOrder(doc: YDoc, rowId: string) {
 
   rowOrders?.push([{ id: rowId }]);
   Y.applyUpdate(doc, Y.encodeStateAsUpdate(remoteDoc, beforeInsert));
+  remoteDoc.destroy();
+}
+
+function hydrateDatabaseIdWithRemoteRowOrders(doc: YDoc, databaseId: string, rowIds: string[]) {
+  const remoteDoc = new Y.Doc();
+
+  Y.applyUpdate(remoteDoc, Y.encodeStateAsUpdate(doc));
+  const beforeHydration = Y.encodeStateVector(remoteDoc);
+  const database = remoteDoc.getMap(YjsEditorKey.data_section).get(YjsEditorKey.database);
+  const view = database?.get(YjsDatabaseKey.views)?.get('view-id');
+  const rowOrders = view?.get(YjsDatabaseKey.row_orders);
+
+  remoteDoc.transact(() => {
+    database?.set(YjsDatabaseKey.id, databaseId);
+    rowOrders?.push(rowIds.map((id) => ({ id })));
+  });
+  Y.applyUpdate(doc, Y.encodeStateAsUpdate(remoteDoc, beforeHydration));
   remoteDoc.destroy();
 }
 
@@ -246,6 +277,16 @@ function requestRemoteRowEnsure() {
   const request = mockEnsureRowPromises[requestIndex];
 
   if (!request) throw new Error('DatabaseViews did not request the remote row');
+  return request;
+}
+
+function requestNamedRemoteRowEnsure(rowId: string) {
+  const requestIndex = mockEnsureRowPromises.length;
+
+  fireEvent.click(screen.getByRole('button', { name: `Ensure ${rowId}` }));
+  const request = mockEnsureRowPromises[requestIndex];
+
+  if (!request) throw new Error(`DatabaseViews did not request remote row ${rowId}`);
   return request;
 }
 
@@ -490,6 +531,93 @@ describe('Database blob prefetch lifecycle', () => {
       firstDoc.destroy();
       secondDoc.destroy();
       rowDoc.destroy();
+      jest.useRealTimers();
+    }
+  });
+
+  it('reconciles every remote row after the database id hydrates on the same document', async () => {
+    jest.useFakeTimers();
+    const doc = createDatabaseDoc('database-doc-id', 'temporary-database-id');
+    const rowIds = ['remote-row-a', 'remote-row-b', 'remote-row-c'];
+    const rowDocs = Object.fromEntries(rowIds.map((rowId) => [rowId, createHydratedRowDoc(rowId)]));
+    const createRow = jest.fn(async (rowKey: string) => {
+      const rowId = rowKey.split('_rows_')[1];
+
+      return rowDocs[rowId];
+    });
+    const { unmount } = render(<Database {...databaseProps(doc)} createRow={createRow} initialRowMap={rowDocs} />);
+    const database = doc.getMap(YjsEditorKey.data_section).get(YjsEditorKey.database);
+
+    try {
+      await act(async () => {
+        database?.set(YjsDatabaseKey.id, 'hydrated-database-id');
+        await Promise.resolve();
+      });
+
+      await act(async () => {
+        rowIds.forEach((rowId) => insertRemoteRowOrder(doc, rowId));
+        await Promise.resolve();
+      });
+
+      await act(async () => {
+        await Promise.all(rowIds.map(requestNamedRemoteRowEnsure));
+      });
+      expect(createRow).toHaveBeenCalledTimes(3);
+      expect(createRow.mock.calls.map(([rowKey]) => rowKey)).toEqual(
+        rowIds.map((rowId) => `hydrated-database-id_rows_${rowId}`)
+      );
+
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(1_000);
+      });
+
+      expect(createRow).toHaveBeenCalledTimes(6);
+      rowIds.forEach((rowId) => {
+        expect(createRow).toHaveBeenCalledWith(`hydrated-database-id_rows_${rowId}`, { forceSync: true });
+      });
+    } finally {
+      unmount();
+      doc.destroy();
+      Object.values(rowDocs).forEach((rowDoc) => rowDoc.destroy());
+      jest.useRealTimers();
+    }
+  });
+
+  it('reconciles remote rows when the database id and row orders hydrate together', async () => {
+    jest.useFakeTimers();
+    const doc = createDatabaseDoc('database-doc-id', 'temporary-database-id');
+    const rowIds = ['remote-row-a', 'remote-row-b', 'remote-row-c'];
+    const rowDocs = Object.fromEntries(rowIds.map((rowId) => [rowId, createHydratedRowDoc(rowId)]));
+    const createRow = jest.fn(async (rowKey: string) => {
+      const rowId = rowKey.split('_rows_')[1];
+
+      return rowDocs[rowId];
+    });
+    const { unmount } = render(<Database {...databaseProps(doc)} createRow={createRow} initialRowMap={rowDocs} />);
+
+    try {
+      await act(async () => {
+        hydrateDatabaseIdWithRemoteRowOrders(doc, 'hydrated-database-id', rowIds);
+        await Promise.resolve();
+      });
+
+      await act(async () => {
+        await Promise.all(rowIds.map(requestNamedRemoteRowEnsure));
+      });
+      expect(createRow).toHaveBeenCalledTimes(3);
+
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(1_000);
+      });
+
+      expect(createRow).toHaveBeenCalledTimes(6);
+      rowIds.forEach((rowId) => {
+        expect(createRow).toHaveBeenCalledWith(`hydrated-database-id_rows_${rowId}`, { forceSync: true });
+      });
+    } finally {
+      unmount();
+      doc.destroy();
+      Object.values(rowDocs).forEach((rowDoc) => rowDoc.destroy());
       jest.useRealTimers();
     }
   });


### PR DESCRIPTION
### Description

Fixes Board clients missing row-document indicators for remotely inserted cards after a temporary database ID hydrates to the server ID.

The row-order observer captured the reconciliation `Set` before the database lifecycle reset. When hydration replaced the ref, later remote rows were written to the stale set and visible rows skipped their forced sync. The observer now reads the current lifecycle set for each transaction, and pending markers are carried across an ID-only lifecycle transition on the same Y.Doc. Markers remain isolated across true document or workspace changes.

This also adds:

- lifecycle regression coverage for several rows when ID hydration happens before row insertion
- coverage for ID hydration and row insertion in the same Yjs update
- a two-client Board scenario that verifies all three indicators appear without a reload

### Impact

Remote Board clients reconcile every newly ordered row's document metadata, so row-page indicators appear consistently without refreshing the page.

### Testing

- [x] `pnpm lint`
- [x] `pnpm exec jest src/components/database/__tests__/Database.prefetch-lifecycle.test.tsx --runInBand --no-coverage` (19 tests)
- [x] `pnpm exec bddgen test -c playwright.bdd.config.ts`
- [x] Generated Playwright scenario listing
- [ ] Live BDD run: blocked during test setup because the local auth service returned HTTP 403 while generating an action link

### Checklist

- [x] Added comments for the lifecycle edge case
- [x] Added and updated regression tests
- [ ] Tested in multiple browsers/environments

## Summary by Sourcery

Ensure remote Board database rows reconcile their document metadata after database ID hydration so row-page indicators appear reliably for newly ordered rows across clients.

New Features:
- Add a multi-client Board scenario validating row document icons appear for three newly ordered synchronized cards without page reload.

Enhancements:
- Preserve pending remote row reconciliation markers across database ID-only lifecycle transitions on the same Y.Doc while resetting them for true document or workspace changes.
- Refine Playwright step definitions by sharing helpers for adding row page content and tracking secondary client reloads.

Tests:
- Add regression tests covering database ID hydration before remote row insertion, joint hydration of IDs and row orders, and reconciliation of multiple remote rows.