### PR TITLE
fix: use server flag for page history visibility

### DIFF
--- a/src/components/app/ViewModal.tsx
+++ b/src/components/app/ViewModal.tsx
@@ -358,7 +358,6 @@ function ViewModal({ viewId, open, onClose }: { viewId?: string; open: boolean; 
               }}
               onDeleted={handleClose}
               viewId={effectiveViewId}
-              enableVersionHistory={false}
             />
           )}
 

--- a/src/components/app/header/MoreActions.tsx
+++ b/src/components/app/header/MoreActions.tsx
@@ -87,12 +87,10 @@ function MoreActions({
   viewId,
   onDeleted,
   menuContentProps,
-  enableVersionHistory = true,
 }: {
   viewId: string;
   onDeleted?: () => void;
   menuContentProps?: ComponentProps<typeof DropdownMenuContent>;
-  enableVersionHistory?: boolean;
 } & ComponentProps<typeof DropdownMenu>) {
   const workspaceId = useCurrentWorkspaceId();
   const aiEnabled = useAIEnabled();
@@ -162,7 +160,7 @@ function MoreActions({
   }, [viewId]);
 
   const pageHistoryEnabled = usePageHistoryEnabled();
-  const showHistory = enableVersionHistory && pageHistoryEnabled && view?.layout === ViewLayout.Document;
+  const showHistory = pageHistoryEnabled && view?.layout === ViewLayout.Document;
 
   const eventEmitter = useEventEmitter();
   const isDocument = view?.layout === ViewLayout.Document;


### PR DESCRIPTION
### **Description**

Use the backend enable_page_history setting as the single feature flag for document version-history visibility.

- Remove the component-local enableVersionHistory prop from the header MoreActions component.
- Remove the ViewModal-specific history override.
- Continue gating history by document layout and effective user permission.
- Keep sidebar page actions unchanged; they do not provide a history action.

### **Testing**

- [x] pnpm type-check
- [x] pnpm exec jest src/components/app/view-actions/useViewActionPermissions.test.ts --runInBand --no-coverage
- [x] Targeted ESLint completed with zero errors
- [x] git diff --check

## Summary by Sourcery

Use the server-controlled page history flag as the single source of truth for showing document version history in the header actions.

Bug Fixes:
- Ensure document version history visibility in the header is consistently controlled by the backend page history setting instead of a component-level override.

Enhancements:
- Remove the local version history prop and ViewModal-specific override so history behavior is uniformly gated by layout and user permissions.