### PR TITLE
fix: render embedded databases in short history previews

### DIFF
--- a/playwright/e2e/editor/version-history-database.spec.ts
+++ b/playwright/e2e/editor/version-history-database.spec.ts
@@ -5,6 +5,7 @@ import {
   HeaderSelectors,
   VersionHistorySelectors,
   DatabaseGridSelectors,
+  RevertedDialogSelectors,
 } from '../../support/selectors';
 import { testLog } from '../../support/test-helpers';
 
@@ -29,8 +30,7 @@ import { testLog } from '../../support/test-helpers';
 // Seeded account + page. Overridable via env so CI can point at its own fixture.
 const SEEDED_USER_EMAIL = process.env.SEEDED_USER_EMAIL || 'nathan@appflowy.io';
 const SEEDED_USER_PASSWORD = process.env.SEEDED_USER_PASSWORD || 'AppFlowy!@123';
-const SEEDED_WORKSPACE_ID =
-  process.env.SEEDED_WORKSPACE_ID || '997c87ed-1667-4a62-8c0a-a74ee1aadb4b';
+const SEEDED_WORKSPACE_ID = process.env.SEEDED_WORKSPACE_ID || '997c87ed-1667-4a62-8c0a-a74ee1aadb4b';
 const SEEDED_VIEW_ID = process.env.SEEDED_VIEW_ID || 'da539c35-a852-434c-88a9-52fc086c1551';
 
 test.describe('Version History — embedded database', () => {
@@ -45,9 +45,7 @@ test.describe('Version History — embedded database', () => {
     await signInWithPasswordViaUi(page, SEEDED_USER_EMAIL, SEEDED_USER_PASSWORD);
   });
 
-  test('renders the embedded database in the version-history preview (no infinite spinner)', async ({
-    page,
-  }) => {
+  test('renders the embedded database in the version-history preview (no infinite spinner)', async ({ page }) => {
     testLog.step(2, 'Open the seeded page that embeds a database');
     await page.goto(`/app/${SEEDED_WORKSPACE_ID}/${SEEDED_VIEW_ID}`, {
       waitUntil: 'domcontentloaded',
@@ -55,6 +53,20 @@ test.describe('Version History — embedded database', () => {
     await expect(page).toHaveURL(new RegExp(`/app/${SEEDED_WORKSPACE_ID}/${SEEDED_VIEW_ID}`), {
       timeout: 30000,
     });
+
+    // This shared fixture may have a pending restore notification from another
+    // test client. Dismiss it and reload so this scenario starts from the
+    // restored document instead of a pre-restore local cache.
+    const revertedDialog = RevertedDialogSelectors.dialog(page);
+    const hasRevertedDialog = await revertedDialog
+      .waitFor({ state: 'visible', timeout: 5000 })
+      .then(() => true)
+      .catch(() => false);
+
+    if (hasRevertedDialog) {
+      await RevertedDialogSelectors.confirmButton(page).click();
+      await page.reload({ waitUntil: 'domcontentloaded' });
+    }
 
     // Confirm the page itself loaded with its embedded database (baseline).
     await expect(DatabaseGridSelectors.grid(page).first()).toBeVisible({ timeout: 30000 });
@@ -71,6 +83,19 @@ test.describe('Version History — embedded database', () => {
     await expect(modal).toBeVisible({ timeout: 15000 });
     // At least one version must exist for a preview to render.
     await expect(VersionHistorySelectors.items(page).first()).toBeVisible({ timeout: 15000 });
+
+    // The shortest seeded snapshot used to leave the embedded database at
+    // width: 0 because the preview had not overflowed when sizing first ran.
+    const shortestVersionItem = VersionHistorySelectors.items(page).last();
+    const shortestVersionTestId = await shortestVersionItem.getAttribute('data-testid');
+    const shortestVersionId = shortestVersionTestId?.replace('version-history-item-', '');
+
+    expect(shortestVersionId).toBeTruthy();
+    await shortestVersionItem.click();
+    await page.waitForFunction(
+      (versionId) => (window as Window & { __TEST_DOC__?: { version?: string } }).__TEST_DOC__?.version === versionId,
+      shortestVersionId
+    );
 
     testLog.step(5, 'Assert the embedded database renders inside the preview');
     // The core regression assertion: the grid appears inside the modal.

--- a/src/components/editor/components/blocks/database/hooks/__tests__/useResizePositioning.test.tsx
+++ b/src/components/editor/components/blocks/database/hooks/__tests__/useResizePositioning.test.tsx
@@ -1,0 +1,74 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { Editor, Element } from 'slate';
+import { ReactEditor } from 'slate-react';
+
+import { useResizePositioning } from '../useResizePositioning';
+
+function createRect({ left, width }: { left: number; width: number }): DOMRect {
+  return {
+    x: left,
+    y: 0,
+    left,
+    right: left + width,
+    top: 0,
+    bottom: 600,
+    width,
+    height: 600,
+    toJSON: () => ({}),
+  } as DOMRect;
+}
+
+describe('useResizePositioning', () => {
+  const observe = jest.fn();
+  const disconnect = jest.fn();
+
+  beforeAll(() => {
+    Object.defineProperty(window, 'ResizeObserver', {
+      configurable: true,
+      value: class ResizeObserverMock {
+        observe = observe;
+        disconnect = disconnect;
+      },
+    });
+  });
+
+  beforeEach(() => {
+    observe.mockClear();
+    disconnect.mockClear();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    document.body.replaceChildren();
+  });
+
+  it('measures the version-history scroller before its content overflows', async () => {
+    const scroller = document.createElement('div');
+    const block = document.createElement('div');
+
+    scroller.className = 'appflowy-scroller';
+    scroller.append(block);
+    document.body.append(scroller);
+
+    scroller.getBoundingClientRect = () => createRect({ left: 100, width: 800 });
+    block.getBoundingClientRect = () => createRect({ left: 200, width: 500 });
+
+    jest.spyOn(ReactEditor, 'toDOMNode').mockReturnValue(block);
+
+    const { result, unmount } = renderHook(() =>
+      useResizePositioning({
+        editor: {} as Editor,
+        node: {} as Element,
+      })
+    );
+
+    await waitFor(() => expect(result.current.width).toBe(800));
+
+    expect(result.current.paddingStart).toBe(100);
+    expect(result.current.paddingEnd).toBe(200);
+    expect(observe).toHaveBeenCalledWith(scroller);
+
+    unmount();
+    expect(disconnect).toHaveBeenCalled();
+  });
+});

--- a/src/components/editor/components/blocks/database/hooks/useResizePositioning.ts
+++ b/src/components/editor/components/blocks/database/hooks/useResizePositioning.ts
@@ -16,7 +16,10 @@ export const useResizePositioning = ({ editor, node }: UseResizePositioningProps
 
   useEffect(() => {
     const dom = ReactEditor.toDOMNode(editor, node);
-    const scrollContainer = dom.closest('.appflowy-scroll-container') || (getScrollParent(dom) as HTMLElement);
+    // History previews use `.appflowy-scroller` and may not overflow before the
+    // database finishes rendering, so prefer the stable container classes.
+    const scrollContainer =
+      dom.closest('.appflowy-scroll-container, .appflowy-scroller') || (getScrollParent(dom) as HTMLElement);
 
     if (!dom || !scrollContainer) return;
 
@@ -37,7 +40,7 @@ export const useResizePositioning = ({ editor, node }: UseResizePositioningProps
     const resizeObserver = new ResizeObserver(onResize);
 
     resizeObserver.observe(scrollContainer);
-    
+
     return () => {
       resizeObserver.disconnect();
     };


### PR DESCRIPTION
### **Description**

Fix embedded databases rendering at zero width in short document history snapshots.

The sizing hook only recognized appflowy-scroll-container and otherwise inferred a scroll parent from current overflow. Version history uses appflowy-scroller, and short snapshots may not overflow before the database finishes rendering, leaving the measured width at its initial zero value.

- Recognize both stable editor scroller classes before falling back to overflow detection.
- Keep ResizeObserver handling for subsequent modal resizing.
- Add a unit regression test for a non-overflowing history scroller.
- Strengthen the seeded browser test to select the shortest snapshot and wait for that exact version before checking the grid.
- Dismiss a pending shared-fixture restore notice so the browser test starts from restored state.

### **Testing**

- [x] pnpm type-check
- [x] pnpm exec jest src/components/editor/components/blocks/database/hooks/__tests__/useResizePositioning.test.tsx src/components/document/history/__tests__/DocumentHistoryModal.test.tsx --runInBand --no-coverage
- [x] pnpm exec playwright test playwright/e2e/editor/version-history-database.spec.ts --project=chromium --workers=1
- [x] Targeted ESLint
- [x] Prettier check
- [x] git diff --check

## Summary by Sourcery

Fix embedded database sizing in version history previews and strengthen related automated tests.

Bug Fixes:
- Ensure embedded databases in version history previews measure against the correct scroll container even when the preview has not yet overflowed.

Enhancements:
- Prefer stable editor scroll container classes when computing database resize positioning while retaining ResizeObserver-based updates.

Tests:
- Add a unit test covering resize positioning within the non-overflowing version history scroller.
- Tighten the version history embedded-database Playwright test to use the shortest snapshot, wait for the selected version, and start from a restored shared fixture state.