### PR TITLE
fix(database): keep advanced filter conditions in sync

### DIFF
--- a/src/application/database-yjs/__tests__/filter-default-and-rollup.test.ts
+++ b/src/application/database-yjs/__tests__/filter-default-and-rollup.test.ts
@@ -17,7 +17,7 @@ jest.mock('@/utils/runtime-config', () => ({
 import { CalculationType, FieldType, RollupDisplayMode } from '@/application/database-yjs/database.type';
 import { NumberFilterCondition, TextFilterCondition } from '@/application/database-yjs/fields';
 import { createRollupField } from '@/application/database-yjs/fields/rollup/utils';
-import { getDefaultFilterCondition } from '@/application/database-yjs/filter';
+import { getDefaultFilterCondition, resolveRollupFilterTargetFieldType } from '@/application/database-yjs/filter';
 import { isNumericRollupField } from '@/application/database-yjs/rollup/utils';
 import { YDatabaseField, YDatabaseFields, YjsDatabaseKey } from '@/application/types';
 
@@ -207,5 +207,28 @@ describe('isNumericRollupField', () => {
     const field = fields.get('rollup-defaults') as YDatabaseField;
 
     expect(isNumericRollupField(field)).toBe(true);
+  });
+});
+
+describe('resolveRollupFilterTargetFieldType', () => {
+  it('persists Number for calculated numeric Rollups', () => {
+    const field = makeRollupField({ calculationType: CalculationType.Sum });
+
+    expect(resolveRollupFilterTargetFieldType(FieldType.Rollup, field)).toBe(FieldType.Number);
+  });
+
+  it('persists RichText for list-style Rollups', () => {
+    const field = makeRollupField({
+      calculationType: CalculationType.Sum,
+      showAs: RollupDisplayMode.OriginalList,
+    });
+
+    expect(resolveRollupFilterTargetFieldType(FieldType.Rollup, field)).toBe(FieldType.RichText);
+  });
+
+  it('does not add Rollup metadata to ordinary fields', () => {
+    const field = createField('number', FieldType.Number);
+
+    expect(resolveRollupFilterTargetFieldType(FieldType.Number, field)).toBeUndefined();
   });
 });

--- a/src/application/database-yjs/__tests__/useRowOrdersSelector.test.tsx
+++ b/src/application/database-yjs/__tests__/useRowOrdersSelector.test.tsx
@@ -7,12 +7,18 @@ import {
   DatabaseContextState,
   FieldType,
   FilterType,
+  NumberFilterCondition,
   TextFilterCondition,
   useFieldCellsByRowsSelector,
   useRowOrdersSelector,
 } from '@/application/database-yjs';
 import { CalculationType } from '@/application/database-yjs/database.type';
-import { useCalculateFieldDispatch, useUpdateAdvancedFilter } from '@/application/database-yjs/dispatch';
+import {
+  useAddAdvancedFilterAndRebuild,
+  useCalculateFieldDispatch,
+  useUpdateAdvancedFilter,
+} from '@/application/database-yjs/dispatch';
+import { createRollupField } from '@/application/database-yjs/fields/rollup/utils';
 import * as databaseFilter from '@/application/database-yjs/filter';
 import {
   RowId,
@@ -37,6 +43,7 @@ jest.mock('@/utils/runtime-config', () => ({
 
 type DatabaseFixture = {
   databaseDoc: YDoc;
+  fields: Y.Map<YDatabaseField>;
   filters: YDatabaseFilters;
   rowMap: Record<RowId, YDoc>;
   rowOrders: YDatabaseRowOrders;
@@ -57,10 +64,10 @@ function createTextField() {
   return field;
 }
 
-function createTextFilter(content: string) {
+function createTextFilter(content: string, id = 'filter-id') {
   const filter = new Y.Map() as YDatabaseFilter;
 
-  filter.set(YjsDatabaseKey.id, 'filter-id');
+  filter.set(YjsDatabaseKey.id, id);
   filter.set(YjsDatabaseKey.field_id, fieldId);
   filter.set(YjsDatabaseKey.filter_type, FilterType.Data);
   filter.set(YjsDatabaseKey.condition, TextFilterCondition.TextContains);
@@ -74,7 +81,7 @@ function createDatabaseFixture(): DatabaseFixture {
   const databaseDoc = new Y.Doc() as unknown as YDoc;
   const sharedRoot = databaseDoc.getMap(YjsEditorKey.data_section);
   const database = new Y.Map();
-  const fields = new Y.Map();
+  const fields = new Y.Map<YDatabaseField>();
   const views = new Y.Map();
   const view = new Y.Map() as YDatabaseView;
   const rowOrders = new Y.Array<{ id: RowId; height: number }>();
@@ -100,6 +107,7 @@ function createDatabaseFixture(): DatabaseFixture {
 
   return {
     databaseDoc,
+    fields,
     filters,
     rowMap: {
       'row-a': createRowDoc('row-a', databaseId, {
@@ -526,6 +534,94 @@ describe('useRowOrdersSelector', () => {
 });
 
 describe('useUpdateAdvancedFilter', () => {
+  it('updates a nested condition without replacing the filter tree', () => {
+    const fixture = createDatabaseFixture();
+    const root = new Y.Map() as YDatabaseFilter;
+    const children = new Y.Array<YDatabaseFilter>() as YDatabaseFilters;
+    const target = createTextFilter('match', 'filter-id');
+    const sibling = createTextFilter('other', 'sibling-filter');
+
+    root.set(YjsDatabaseKey.id, 'root-filter');
+    root.set(YjsDatabaseKey.filter_type, FilterType.And);
+    children.push([target, sibling]);
+    root.set(YjsDatabaseKey.children, children);
+    fixture.filters.push([root]);
+
+    const { result } = renderHook(() => useUpdateAdvancedFilter(), {
+      wrapper: createWrapper(fixture),
+    });
+
+    act(() => {
+      result.current({
+        filterId: 'filter-id',
+        fieldId,
+        condition: TextFilterCondition.TextDoesNotContain,
+      });
+    });
+
+    expect(fixture.filters.get(0)).toBe(root);
+    expect(root.get(YjsDatabaseKey.children)).toBe(children);
+    expect(target.get(YjsDatabaseKey.condition)).toBe(TextFilterCondition.TextDoesNotContain);
+    expect(sibling.get(YjsDatabaseKey.condition)).toBe(TextFilterCondition.TextContains);
+  });
+
+  it('preserves a numeric Rollup variant when a Desktop tree must be rebuilt', () => {
+    const fixture = createDatabaseFixture();
+    const rollupFieldId = 'rollup-field';
+    const rollupField = new Y.Map() as YDatabaseField;
+
+    rollupField.set(YjsDatabaseKey.id, rollupFieldId);
+    rollupField.set(YjsDatabaseKey.name, 'Total');
+    rollupField.set(YjsDatabaseKey.type, FieldType.Rollup);
+    fixture.fields.set(rollupFieldId, rollupField);
+
+    fixture.filters.push([
+      {
+        id: 'desktop-root',
+        filter_type: FilterType.And,
+        children: [
+          {
+            id: 'filter-id',
+            field_id: fieldId,
+            filter_type: FilterType.Data,
+            ty: FieldType.RichText,
+            condition: TextFilterCondition.TextContains,
+            content: 'match',
+          },
+          {
+            id: 'rollup-filter',
+            field_id: rollupFieldId,
+            filter_type: FilterType.Data,
+            ty: FieldType.Rollup,
+            condition: NumberFilterCondition.Equal,
+            content: '10',
+            rollup_target_ty: FieldType.Number,
+          },
+        ],
+      } as unknown as YDatabaseFilter,
+    ]);
+
+    const { result } = renderHook(() => useUpdateAdvancedFilter(), {
+      wrapper: createWrapper(fixture),
+    });
+
+    act(() => {
+      result.current({
+        filterId: 'filter-id',
+        fieldId,
+        condition: TextFilterCondition.TextIs,
+      });
+    });
+
+    const rebuiltRoot = fixture.filters.get(0);
+    const rebuiltChildren = rebuiltRoot.get(YjsDatabaseKey.children) as YDatabaseFilters;
+    const rebuiltTextFilter = rebuiltChildren.get(0);
+    const rebuiltRollupFilter = rebuiltChildren.get(1);
+
+    expect(rebuiltTextFilter.get(YjsDatabaseKey.condition)).toBe(TextFilterCondition.TextIs);
+    expect(rebuiltRollupFilter.get(YjsDatabaseKey.rollup_target_type)).toBe(FieldType.Number);
+  });
+
   it('ignores a delayed update targeting a previous field', () => {
     const fixture = createDatabaseFixture();
     const filter = createTextFilter('');
@@ -547,5 +643,29 @@ describe('useUpdateAdvancedFilter', () => {
 
     expect(filter.get(YjsDatabaseKey.field_id)).toBe('replacement-field');
     expect(filter.get(YjsDatabaseKey.content)).toBe('');
+  });
+});
+
+describe('useAddAdvancedFilterAndRebuild', () => {
+  it('persists the numeric Rollup variant and Number default condition', () => {
+    const fixture = createDatabaseFixture();
+    const rollupFieldId = 'numeric-rollup-field';
+
+    fixture.fields.set(rollupFieldId, createRollupField(rollupFieldId));
+
+    const { result } = renderHook(() => useAddAdvancedFilterAndRebuild(), {
+      wrapper: createWrapper(fixture),
+    });
+
+    act(() => {
+      result.current(rollupFieldId);
+    });
+
+    const root = fixture.filters.get(0);
+    const children = root.get(YjsDatabaseKey.children) as YDatabaseFilters;
+    const rollupFilter = children.get(0);
+
+    expect(rollupFilter.get(YjsDatabaseKey.condition)).toBe(NumberFilterCondition.Equal);
+    expect(rollupFilter.get(YjsDatabaseKey.rollup_target_type)).toBe(FieldType.Number);
   });
 });

--- a/src/application/database-yjs/database.type.ts
+++ b/src/application/database-yjs/database.type.ts
@@ -83,6 +83,8 @@ export interface Filter {
   operator?: FilterType.And | FilterType.Or | null;
   /** The actual field column type (RichText, Number, etc.) */
   fieldType?: FieldType;
+  /** Persisted Rollup filter variant used by Desktop to distinguish Number from Text filters. */
+  rollupTargetFieldType?: FieldType;
 }
 
 export enum CalendarLayout {

--- a/src/application/database-yjs/dispatch.ts
+++ b/src/application/database-yjs/dispatch.ts
@@ -47,7 +47,7 @@ import { createRelationField } from '@/application/database-yjs/fields/relation/
 import { createRollupField } from '@/application/database-yjs/fields/rollup/utils';
 import { createSelectOptionCell } from '@/application/database-yjs/fields/select-option/utils';
 import { createDateTimeField } from '@/application/database-yjs/fields/text/utils';
-import { getDefaultFilterCondition } from '@/application/database-yjs/filter';
+import { getDefaultFilterCondition, resolveRollupFilterTargetFieldType } from '@/application/database-yjs/filter';
 import { getGroupColumns } from '@/application/database-yjs/group';
 import { DEFAULT_FIELD_WRAP } from '@/application/database-yjs/const';
 import { waitForDatabaseRowHydration } from '@/application/database-yjs/row.hydration';
@@ -3658,6 +3658,11 @@ export function useAddFilter() {
 
             filter.set(YjsDatabaseKey.type, fieldType);
             filter.set(YjsDatabaseKey.filter_type, FilterType.Data);
+            const rollupTargetFieldType = resolveRollupFilterTargetFieldType(fieldType, field);
+
+            if (rollupTargetFieldType !== undefined) {
+              filter.set(YjsDatabaseKey.rollup_target_type, rollupTargetFieldType);
+            }
 
             filters.push([filter]);
 

--- a/src/application/database-yjs/dispatch/sort-filter.ts
+++ b/src/application/database-yjs/dispatch/sort-filter.ts
@@ -18,7 +18,13 @@ import * as Y from 'yjs';
 
 import { useDatabaseFields, useDatabaseView, useSharedRoot } from '@/application/database-yjs/context';
 import { FilterType, SortCondition } from '@/application/database-yjs/database.type';
-import { FilterDraft, flattenFilterTree, getDefaultFilterCondition, groupByConsecutiveOperator } from '@/application/database-yjs/filter';
+import {
+  FilterDraft,
+  flattenFilterTree,
+  getDefaultFilterCondition,
+  groupByConsecutiveOperator,
+  resolveRollupFilterTargetFieldType,
+} from '@/application/database-yjs/filter';
 import { executeOperations } from '@/application/slate-yjs/utils/yjs';
 import { YDatabaseFilter, YDatabaseFilters, YDatabaseSort, YDatabaseSorts, YjsDatabaseKey } from '@/application/types';
 import { Log } from '@/utils/log';
@@ -274,7 +280,7 @@ export function useAddFilter() {
 
             filter.set(YjsDatabaseKey.id, id);
             filter.set(YjsDatabaseKey.field_id, fieldId);
-            const conditionData = getDefaultFilterCondition(fieldType);
+            const conditionData = getDefaultFilterCondition(fieldType, field);
 
             if (!conditionData) {
               Log.warn('[useAddFilter] No default condition for fieldType:', fieldType);
@@ -296,6 +302,11 @@ export function useAddFilter() {
 
             filter.set(YjsDatabaseKey.type, fieldType);
             filter.set(YjsDatabaseKey.filter_type, FilterType.Data);
+            const rollupTargetFieldType = resolveRollupFilterTargetFieldType(fieldType, field);
+
+            if (rollupTargetFieldType !== undefined) {
+              filter.set(YjsDatabaseKey.rollup_target_type, rollupTargetFieldType);
+            }
 
             filters.push([filter]);
 
@@ -634,13 +645,19 @@ export function useAddAdvancedFilter() {
             filter.set(YjsDatabaseKey.filter_type, FilterType.Data);
             filter.set(YjsDatabaseKey.type, fieldType);
 
-            const conditionData = getDefaultFilterCondition(fieldType);
+            const conditionData = getDefaultFilterCondition(fieldType, field);
 
             if (conditionData) {
               filter.set(YjsDatabaseKey.condition, conditionData.condition);
               if (conditionData.content !== undefined) {
                 filter.set(YjsDatabaseKey.content, conditionData.content);
               }
+            }
+
+            const rollupTargetFieldType = resolveRollupFilterTargetFieldType(fieldType, field);
+
+            if (rollupTargetFieldType !== undefined) {
+              filter.set(YjsDatabaseKey.rollup_target_type, rollupTargetFieldType);
             }
 
             children.push([filter]);
@@ -982,6 +999,10 @@ function createDataFilterNode(draft: FilterDraft): YDatabaseFilter {
   node.set(YjsDatabaseKey.type, draft.fieldType);
   node.set(YjsDatabaseKey.condition, draft.condition);
 
+  if (draft.rollupTargetFieldType !== undefined) {
+    node.set(YjsDatabaseKey.rollup_target_type, draft.rollupTargetFieldType);
+  }
+
   if (draft.content !== undefined) {
     node.set(YjsDatabaseKey.content, draft.content);
   }
@@ -1121,7 +1142,7 @@ export function useAddAdvancedFilterAndRebuild() {
             if (!field) return;
 
             const fieldType = Number(field.get(YjsDatabaseKey.type));
-            const conditionData = getDefaultFilterCondition(fieldType);
+            const conditionData = getDefaultFilterCondition(fieldType, field);
 
             if (!conditionData) return;
 
@@ -1160,6 +1181,7 @@ export function useAddAdvancedFilterAndRebuild() {
               id,
               fieldId,
               fieldType,
+              rollupTargetFieldType: resolveRollupFilterTargetFieldType(fieldType, field),
               condition: conditionData.condition,
               content: conditionData.content ?? '',
               operator: defaultOperator,
@@ -1273,6 +1295,7 @@ export function useUpdateAdvancedFilterAndRebuild() {
 
               if (field) {
                 draft.fieldType = Number(field.get(YjsDatabaseKey.type));
+                draft.rollupTargetFieldType = resolveRollupFilterTargetFieldType(draft.fieldType, field);
               }
             }
 

--- a/src/application/database-yjs/filter.ts
+++ b/src/application/database-yjs/filter.ts
@@ -418,9 +418,18 @@ export interface FilterDraft {
   id: string;
   fieldId: string;
   fieldType: number;
+  rollupTargetFieldType?: FieldType;
   condition: number;
   content: string;
   operator: FilterType.And | FilterType.Or | null;
+}
+
+export function resolveRollupFilterTargetFieldType(fieldType: FieldType, field?: YDatabaseField): FieldType | undefined {
+  if (fieldType !== FieldType.Rollup) return undefined;
+
+  // Desktop persists the evaluated filter variant, not the Rollup's raw target
+  // field type. Every non-numeric Rollup is evaluated as text.
+  return isNumericRollupField(field) ? FieldType.Number : FieldType.RichText;
 }
 
 /**
@@ -527,10 +536,21 @@ function collectFiltersRecursive(
     fieldTypeNum = tyValue !== undefined ? Number(tyValue) : FieldType.RichText;
   }
 
+  const persistedRollupTargetFieldType = node.get(YjsDatabaseKey.rollup_target_type);
+  let rollupTargetFieldType: FieldType | undefined;
+
+  if (fieldTypeNum === FieldType.Rollup) {
+    rollupTargetFieldType =
+      persistedRollupTargetFieldType !== undefined
+        ? (Number(persistedRollupTargetFieldType) as FieldType)
+        : resolveRollupFilterTargetFieldType(FieldType.Rollup, field);
+  }
+
   result.push({
     id: String(node.get(YjsDatabaseKey.id) ?? ''),
     fieldId,
     fieldType: fieldTypeNum,
+    rollupTargetFieldType,
     condition: Number(node.get(YjsDatabaseKey.condition)),
     content: String(node.get(YjsDatabaseKey.content) ?? ''),
     operator: inheritedOperator,

--- a/src/application/database-yjs/selector.ts
+++ b/src/application/database-yjs/selector.ts
@@ -672,6 +672,7 @@ export function useAdvancedFiltersSelector() {
           ...parsed,
           operator: draft.operator,
           fieldType: ft,
+          rollupTargetFieldType: draft.rollupTargetFieldType,
         } as Filter;
       });
 

--- a/src/application/types.ts
+++ b/src/application/types.ts
@@ -603,6 +603,7 @@ export enum YjsDatabaseKey {
   cv = 'cv',
   source_field_type = 'source_field_type', // Added this
   condition = 'condition',
+  rollup_target_type = 'rollup_target_ty',
   schema_version = 'schema_version',
   format = 'format',
   filter_type = 'filter_type',
@@ -963,6 +964,8 @@ export interface YDatabaseFilter extends Y.Map<unknown> {
   get(key: YjsDatabaseKey.field_id): FieldId;
 
   get(key: YjsDatabaseKey.type | YjsDatabaseKey.condition | YjsDatabaseKey.content | YjsDatabaseKey.filter_type): string;
+
+  get(key: YjsDatabaseKey.rollup_target_type): number | string | undefined;
 
   get(key: YjsDatabaseKey.children): YDatabaseFilters | YDatabaseFilter[] | undefined;
 }

--- a/src/components/database/components/filters/advanced/AdvancedFilterPanel.tsx
+++ b/src/components/database/components/filters/advanced/AdvancedFilterPanel.tsx
@@ -50,6 +50,7 @@ export function AdvancedFilterPanel() {
         id: f.id,
         fieldId: f.fieldId,
         fieldType: f.fieldType ?? 0,
+        rollupTargetFieldType: f.rollupTargetFieldType,
         condition: f.condition,
         content: f.content,
         operator: f.id === filterId ? newOperator : (index === 0 ? null : f.operator ?? FilterType.And),

--- a/src/components/database/components/filters/advanced/FilterPanelRow.tsx
+++ b/src/components/database/components/filters/advanced/FilterPanelRow.tsx
@@ -67,7 +67,8 @@ export function FilterPanelRow({ filter, isFirst, onOperatorChange }: FilterPane
   const { t } = useTranslation();
   const readOnly = useReadOnly();
   const removeFilter = useRemoveAdvancedFilterAndRebuild();
-  const updateFilter = useUpdateAdvancedFilterAndRebuild();
+  const updateFilterValue = useUpdateAdvancedFilter();
+  const updateFilterAndRebuild = useUpdateAdvancedFilterAndRebuild();
   const { field } = useFieldSelector(filter.fieldId);
 
   const [fieldSelectorOpen, setFieldSelectorOpen] = useState(false);
@@ -83,24 +84,26 @@ export function FilterPanelRow({ filter, isFirst, onOperatorChange }: FilterPane
 
   const handleFieldChange = useCallback(
     (newFieldId: string) => {
-      updateFilter({
+      updateFilterAndRebuild({
         filterId: filter.id,
         fieldId: newFieldId,
       });
       setFieldSelectorOpen(false);
     },
-    [filter.id, updateFilter]
+    [filter.id, updateFilterAndRebuild]
   );
 
   const handleConditionChange = useCallback(
     (condition: number) => {
-      updateFilter({
+      // Condition changes are scalar CRDT updates. Rebuilding the tree here
+      // would let this edit overwrite unrelated filters from another client.
+      updateFilterValue({
         filterId: filter.id,
         fieldId: filter.fieldId,
         condition,
       });
     },
-    [filter.id, filter.fieldId, updateFilter]
+    [filter.id, filter.fieldId, updateFilterValue]
   );
 
   if (!field) return null;


### PR DESCRIPTION
### **Description**

Improve cross-client consistency for advanced database filters shared by Web and Desktop.

- Update condition changes in place as scalar Yjs mutations instead of rebuilding the entire advanced-filter tree. This preserves CRDT identity and avoids overwriting unrelated concurrent filter edits.
- Persist and round-trip `rollup_target_ty` when filter trees must be rebuilt, so Desktop keeps the correct numeric or text Rollup filter semantics.
- Select the default Rollup condition from the actual field definition.
- Add regressions for nested condition updates, Desktop-origin fallback rebuilds, and numeric Rollup creation.

This addresses the code-level consistency risks found while investigating a Web/Desktop condition mismatch. A live reproduction of the original incident was not available, so the PR does not claim a confirmed end-to-end root cause.

---

### **Testing**

- `pnpm exec jest src/application/database-yjs/__tests__/useRowOrdersSelector.test.tsx src/application/database-yjs/__tests__/filter-default-and-rollup.test.ts src/application/database-yjs/__tests__/filter.test.ts src/application/database-yjs/__tests__/useConditionSelectors.test.tsx --runInBand --no-coverage` — 258 tests passed
- `pnpm lint` — TypeScript and ESLint passed
- `git diff --check` — passed

---

### **Checklist**

#### **General**
- [x] I have included relevant comments for the non-obvious cross-client CRDT constraint.
- [ ] I have tested the changes in multiple browsers or operating systems.

#### **Testing**
- [x] I have added or updated tests to validate the changes.

#### **Feature-Specific**
- [ ] Not applicable; this PR does not add a feature.
- [ ] Live Web/Desktop verification is still pending a reproducible target page.

## Summary by Sourcery

Keep advanced database filter conditions in sync across Web and Desktop, including nested updates and Rollup variants.

New Features:
- Expose persisted Rollup filter variant metadata on filters so clients can distinguish numeric from text Rollup conditions.

Bug Fixes:
- Update advanced filter conditions in place instead of rebuilding filter trees, preventing concurrent edits from being overwritten.
- Persist and round-trip the Rollup target field type on filters so numeric and text Rollup conditions remain consistent with Desktop.
- Select default filter conditions for Rollup fields based on the actual field definition, ensuring numeric Rollups use number conditions by default.

Enhancements:
- Propagate Rollup target field type through filter drafts and selectors to keep UI and CRDT state aligned.

Tests:
- Add regression tests for nested advanced filter condition updates without tree replacement.
- Add tests covering Desktop-origin filter tree rebuilds preserving numeric Rollup variants.
- Add tests verifying Rollup target type resolution and default numeric Rollup filter creation.