### PR TITLE
fix(board): sync No Status column visibility with desktop

### DIFF
--- a/src/application/database-yjs/__tests__/board-visibility.test.ts
+++ b/src/application/database-yjs/__tests__/board-visibility.test.ts
@@ -13,16 +13,18 @@ const rowCounts = new Map([
 ]);
 
 function resolveVisibility({
+  columns: overrideColumns = columns,
   hideEmptyGroups = true,
   hideUngroupedColumn = false,
   shownEmptyGroupIds,
 }: {
+  columns?: { id: string; visible: boolean; visibleExplicit?: boolean }[];
   hideEmptyGroups?: boolean;
   hideUngroupedColumn?: boolean;
   shownEmptyGroupIds?: ReadonlySet<string>;
 } = {}) {
   return resolveBoardColumnVisibility({
-    columns,
+    columns: overrideColumns,
     fieldId: 'status-field',
     getRowCount: (columnId) => rowCounts.get(columnId) ?? 0,
     groupRowsReady: true,
@@ -68,5 +70,47 @@ describe('resolveBoardColumnVisibility', () => {
 
     expect(result.visibleColumns.map((column) => column.id)).toEqual(['status-field', 'todo']);
     expect(result.hiddenColumns.map((column) => column.id)).toEqual(['done']);
+  });
+
+  it('hides the ungrouped column when its persisted visible flag is false (desktop hide)', () => {
+    const result = resolveVisibility({
+      columns: [
+        { id: 'status-field', visible: false, visibleExplicit: true },
+        { id: 'todo', visible: true },
+      ],
+      hideEmptyGroups: false,
+      hideUngroupedColumn: false,
+    });
+
+    expect(result.visibleColumns.map((column) => column.id)).toEqual(['todo']);
+    expect(result.hiddenColumns.map((column) => column.id)).toEqual(['status-field']);
+  });
+
+  it('shows an explicitly visible ungrouped column despite a stale legacy hide flag (desktop show)', () => {
+    const result = resolveVisibility({
+      columns: [
+        { id: 'status-field', visible: true, visibleExplicit: true },
+        { id: 'todo', visible: true },
+      ],
+      hideEmptyGroups: false,
+      hideUngroupedColumn: true,
+    });
+
+    expect(result.visibleColumns.map((column) => column.id)).toEqual(['status-field', 'todo']);
+    expect(result.hiddenColumns.map((column) => column.id)).toEqual([]);
+  });
+
+  it('falls back to the legacy hide flag when the ungrouped column has no explicit visibility', () => {
+    const result = resolveVisibility({
+      columns: [
+        { id: 'status-field', visible: true },
+        { id: 'todo', visible: true },
+      ],
+      hideEmptyGroups: false,
+      hideUngroupedColumn: true,
+    });
+
+    expect(result.visibleColumns.map((column) => column.id)).toEqual(['todo']);
+    expect(result.hiddenColumns.map((column) => column.id)).toEqual(['status-field']);
   });
 });

--- a/src/application/database-yjs/__tests__/useGroup.test.tsx
+++ b/src/application/database-yjs/__tests__/useGroup.test.tsx
@@ -13,6 +13,7 @@ import {
   useSetBoardColumnRenderedDispatch,
   useToggleHiddenGroupColumnDispatch,
   useToggleHideEmptyGroups,
+  useToggleHideUnGrouped,
 } from '@/application/database-yjs/dispatch';
 import { YDoc, YjsDatabaseKey, YjsEditorKey } from '@/application/types';
 
@@ -110,7 +111,7 @@ describe('useGroup', () => {
       expect(result.current.fieldId).toBe(fieldId);
     });
 
-    expect(result.current.columns).toEqual([{ id: fieldId, visible: true }]);
+    expect(result.current.columns).toEqual([{ id: fieldId, visible: true, visibleExplicit: false }]);
   });
 
   it('materializes fallback columns before persisting their visibility', async () => {
@@ -140,9 +141,13 @@ describe('useGroup', () => {
       })
     );
 
-    const expectedColumns = [
-      { id: fieldId, visible: true },
-      { id: optionId, visible: true },
+    const fallbackColumns = [
+      { id: fieldId, visible: true, visibleExplicit: false },
+      { id: optionId, visible: true, visibleExplicit: false },
+    ];
+    const materializedColumns = [
+      { id: fieldId, visible: true, visibleExplicit: true },
+      { id: optionId, visible: true, visibleExplicit: true },
     ];
     const { result } = renderHook(
       () => ({
@@ -155,7 +160,7 @@ describe('useGroup', () => {
     );
 
     await waitFor(() => {
-      expect(result.current.group.columns).toEqual(expectedColumns);
+      expect(result.current.group.columns).toEqual(fallbackColumns);
     });
 
     expect(() => {
@@ -165,7 +170,7 @@ describe('useGroup', () => {
     }).not.toThrow();
 
     await waitFor(() => {
-      expect(result.current.group.columns).toEqual(expectedColumns);
+      expect(result.current.group.columns).toEqual(materializedColumns);
     });
 
     const views = database.get(YjsDatabaseKey.views) as Y.Map<Y.Map<unknown>>;
@@ -173,7 +178,10 @@ describe('useGroup', () => {
     const groups = view?.get(YjsDatabaseKey.groups) as Y.Array<Y.Map<unknown>>;
     const persistedColumns = groups.get(0).get(YjsDatabaseKey.groups) as Y.Array<unknown>;
 
-    expect(persistedColumns.toJSON()).toEqual(expectedColumns);
+    expect(persistedColumns.toJSON()).toEqual([
+      { id: fieldId, visible: true },
+      { id: optionId, visible: true },
+    ]);
   });
 
   it('normalizes Y.Map group columns from persisted collab data', async () => {
@@ -201,7 +209,97 @@ describe('useGroup', () => {
       expect(result.current.fieldId).toBe(fieldId);
     });
 
-    expect(result.current.columns).toEqual([{ id: optionId, visible: false }]);
+    expect(result.current.columns).toEqual([{ id: optionId, visible: false, visibleExplicit: true }]);
+  });
+
+  it('derives the ungrouped hidden state from the persisted visible flag written by desktop', async () => {
+    const fieldId = 'field-id';
+    const groupId = 'group-id';
+    const viewId = 'board-view-id';
+    const databaseDoc = createDatabaseDoc({
+      fieldId,
+      groupId,
+      groupColumns: [{ id: fieldId, visible: false }],
+      viewId,
+    });
+
+    const { result } = renderHook(() => useBoardLayoutSettings(), {
+      wrapper: createWrapper(databaseDoc, viewId),
+    });
+
+    await waitFor(() => {
+      expect(result.current.ungroupedColumnHidden).toBe(true);
+    });
+
+    expect(result.current.hideUnGroup).toBe(false);
+  });
+
+  it('lets an explicit visible flag override a stale legacy hide_ungrouped_column key', async () => {
+    const fieldId = 'field-id';
+    const groupId = 'group-id';
+    const viewId = 'board-view-id';
+    const databaseDoc = createDatabaseDoc({
+      fieldId,
+      groupId,
+      groupColumns: [{ id: fieldId, visible: true }],
+      viewId,
+    });
+    const view = databaseDoc
+      .getMap(YjsEditorKey.data_section)
+      .get(YjsEditorKey.database)
+      ?.get(YjsDatabaseKey.views)
+      ?.get(viewId);
+
+    view?.get(YjsDatabaseKey.layout_settings)?.get('1')?.set(YjsDatabaseKey.hide_ungrouped_column, true);
+
+    const { result } = renderHook(() => useBoardLayoutSettings(), {
+      wrapper: createWrapper(databaseDoc, viewId),
+    });
+
+    await waitFor(() => {
+      expect(result.current.hideUnGroup).toBe(true);
+    });
+
+    expect(result.current.ungroupedColumnHidden).toBe(false);
+  });
+
+  it('writes the canonical visible flag and mirrors the legacy key when toggling Show ungrouped', async () => {
+    const fieldId = 'field-id';
+    const groupId = 'group-id';
+    const viewId = 'board-view-id';
+    const databaseDoc = createDatabaseDoc({
+      fieldId,
+      groupId,
+      groupColumns: [{ id: fieldId, visible: true }],
+      viewId,
+    });
+
+    const { result } = renderHook(
+      () => ({
+        layoutSettings: useBoardLayoutSettings(),
+        toggleHideUnGrouped: useToggleHideUnGrouped(),
+      }),
+      {
+        wrapper: createWrapper(databaseDoc, viewId),
+      }
+    );
+
+    act(() => {
+      result.current.toggleHideUnGrouped(true);
+    });
+
+    await waitFor(() => {
+      expect(result.current.layoutSettings.ungroupedColumnHidden).toBe(true);
+    });
+
+    expect(result.current.layoutSettings.hideUnGroup).toBe(true);
+
+    const database = databaseDoc.getMap(YjsEditorKey.data_section).get(YjsEditorKey.database) as Y.Map<unknown>;
+    const views = database.get(YjsDatabaseKey.views) as Y.Map<Y.Map<unknown>>;
+    const groups = views.get(viewId)?.get(YjsDatabaseKey.groups) as Y.Array<Y.Map<unknown>>;
+    const persistedColumns = groups.get(0).get(YjsDatabaseKey.groups) as Y.Array<unknown>;
+
+    expect(persistedColumns.toJSON()).toEqual([{ id: fieldId, visible: false }]);
   });
 
   it('keeps Hidden Groups collapsed when the collapse setting is absent', async () => {

--- a/src/application/database-yjs/board-visibility.ts
+++ b/src/application/database-yjs/board-visibility.ts
@@ -1,6 +1,8 @@
 type BoardColumn = {
   id: string;
   visible: boolean;
+  /** Whether `visible` was explicitly persisted rather than defaulted to true. */
+  visibleExplicit?: boolean;
 };
 
 type ResolveBoardColumnVisibilityOptions<T extends BoardColumn> = {
@@ -12,6 +14,27 @@ type ResolveBoardColumnVisibilityOptions<T extends BoardColumn> = {
   getRowCount: (columnId: string) => number;
   shownEmptyGroupIds?: ReadonlySet<string>;
 };
+
+/**
+ * Desktop persists the No Status column's visibility only as that column's own
+ * `visible` flag inside the group setting and treats `hide_ungrouped_column`
+ * as legacy, so an explicitly persisted flag must win here. The layout key
+ * survives purely as a fallback for data written before any client persisted
+ * the ungrouped column entry, and as a mirror for old web clients.
+ */
+export function isUngroupedColumnHidden({
+  column,
+  hideUngroupedColumn,
+}: {
+  column: Pick<BoardColumn, 'visible' | 'visibleExplicit'> | null | undefined;
+  hideUngroupedColumn: boolean;
+}): boolean {
+  if (column?.visibleExplicit === true) {
+    return !column.visible;
+  }
+
+  return hideUngroupedColumn;
+}
 
 /**
  * Resolves the two Board column partitions from persisted settings and exact
@@ -32,7 +55,8 @@ export function resolveBoardColumnVisibility<T extends BoardColumn>({
   const hiddenColumns: T[] = [];
 
   columns.forEach((column) => {
-    const explicitlyHidden = column.id === fieldId ? hideUngroupedColumn : !column.visible;
+    const explicitlyHidden =
+      column.id === fieldId ? isUngroupedColumnHidden({ column, hideUngroupedColumn }) : !column.visible;
     const automaticallyHidden = groupRowsReady && hideEmptyGroups && getRowCount(column.id) === 0;
 
     if (explicitlyHidden || automaticallyHidden) {

--- a/src/application/database-yjs/dispatch.ts
+++ b/src/application/database-yjs/dispatch.ts
@@ -614,6 +614,7 @@ export function useToggleCollapsedHiddenGroupColumnDispatch() {
 
 export function useToggleHideUnGrouped() {
   const view = useDatabaseView();
+  const fields = useDatabaseFields();
   const sharedRoot = useSharedRoot();
 
   return useCallback(
@@ -626,13 +627,31 @@ export function useToggleHideUnGrouped() {
               throw new Error(`Unable to toggle hide ungrouped column`);
             }
 
+            const group = view.get(YjsDatabaseKey.groups)?.toArray()?.[0];
+            const fieldId = group?.get(YjsDatabaseKey.field_id);
+
+            // Desktop only reads the ungrouped column's `visible` flag, so the
+            // canonical write must go through it; setGroupColumnHidden also
+            // mirrors hide_ungrouped_column for older web clients.
+            if (group && fieldId) {
+              setGroupColumnHidden({
+                columnId: fieldId,
+                fieldId,
+                fields,
+                groupId: group.get(YjsDatabaseKey.id),
+                hidden: hide,
+                view,
+              });
+              return;
+            }
+
             getOrCreateBoardLayoutSetting(view).set(YjsDatabaseKey.hide_ungrouped_column, hide);
           },
         ],
         'toggleHideUnGrouped'
       );
     },
-    [sharedRoot, view]
+    [fields, sharedRoot, view]
   );
 }
 

--- a/src/application/database-yjs/selector.ts
+++ b/src/application/database-yjs/selector.ts
@@ -2,7 +2,7 @@ import dayjs from 'dayjs';
 import { debounce } from 'lodash-es';
 import { useCallback, useDeferredValue, useEffect, useMemo, useRef, useState } from 'react';
 
-import { resolveBoardColumnVisibility } from '@/application/database-yjs/board-visibility';
+import { isUngroupedColumnHidden, resolveBoardColumnVisibility } from '@/application/database-yjs/board-visibility';
 import { parseYDatabaseCellToCell } from '@/application/database-yjs/cell.parse';
 import { DateTimeCell, RollupCell } from '@/application/database-yjs/cell.type';
 import { hasRowConditionData, invalidateRowConditionCache } from '@/application/database-yjs/condition-value-cache';
@@ -977,10 +977,13 @@ export function useGroupsSelector() {
 export interface GroupColumn {
   id: string;
   visible: boolean;
+  /** Whether `visible` was explicitly persisted rather than defaulted to true. */
+  visibleExplicit?: boolean;
 }
 
 function normalizeGroupColumn(column: unknown): GroupColumn | null {
   const parseVisible = (value: unknown) => value !== false && value !== 'false';
+  const isExplicitVisible = (value: unknown) => value !== undefined && value !== null;
 
   if (!column || typeof column !== 'object') return null;
 
@@ -990,9 +993,12 @@ function normalizeGroupColumn(column: unknown): GroupColumn | null {
 
     if (typeof id !== 'string' || !id) return null;
 
+    const rawVisible = mapColumn.get(YjsDatabaseKey.visible);
+
     return {
       id,
-      visible: parseVisible(mapColumn.get(YjsDatabaseKey.visible)),
+      visible: parseVisible(rawVisible),
+      visibleExplicit: isExplicitVisible(rawVisible),
     };
   }
 
@@ -1003,6 +1009,7 @@ function normalizeGroupColumn(column: unknown): GroupColumn | null {
   return {
     id: plainColumn.id,
     visible: parseVisible(plainColumn.visible),
+    visibleExplicit: isExplicitVisible(plainColumn.visible),
   };
 }
 
@@ -1012,6 +1019,7 @@ function getFallbackGroupColumns(field?: YDatabaseField): GroupColumn[] {
   return (getGroupColumns(field) ?? []).map((column) => ({
     id: column.id,
     visible: true,
+    visibleExplicit: false,
   }));
 }
 
@@ -1066,6 +1074,7 @@ export function useBoardLayoutSettings() {
   const [shownEmptyGroupIds, setShownEmptyGroupIds] = useState<ReadonlySet<string>>(() => new Set());
   const groups = view?.get(YjsDatabaseKey.groups);
   const [fieldId, setFieldId] = useState<string | null>(null);
+  const [ungroupedColumn, setUngroupedColumn] = useState<GroupColumn | null>(null);
 
   useEffect(() => {
     if (!view) return;
@@ -1112,6 +1121,19 @@ export function useBoardLayoutSettings() {
       const groupFieldId = group.get(YjsDatabaseKey.field_id);
 
       setFieldId(groupFieldId);
+
+      const next =
+        (group.get(YjsDatabaseKey.groups)?.toArray() ?? [])
+          .map(normalizeGroupColumn)
+          .find((column): column is GroupColumn => column?.id === groupFieldId) ?? null;
+
+      setUngroupedColumn((current) =>
+        current?.id === next?.id &&
+        current?.visible === next?.visible &&
+        current?.visibleExplicit === next?.visibleExplicit
+          ? current
+          : next
+      );
     };
 
     observerEvent();
@@ -1122,12 +1144,18 @@ export function useBoardLayoutSettings() {
     };
   }, [groups]);
 
+  const ungroupedColumnHidden = isUngroupedColumnHidden({
+    column: ungroupedColumn,
+    hideUngroupedColumn: hideUnGroup,
+  });
+
   return {
     isCollapsed,
     hideUnGroup,
     hideEmptyGroups,
     shownEmptyGroupIds,
     fieldId,
+    ungroupedColumnHidden,
   };
 }
 

--- a/src/application/database-yjs/selector.ts
+++ b/src/application/database-yjs/selector.ts
@@ -1122,10 +1122,17 @@ export function useBoardLayoutSettings() {
 
       setFieldId(groupFieldId);
 
-      const next =
-        (group.get(YjsDatabaseKey.groups)?.toArray() ?? [])
-          .map(normalizeGroupColumn)
-          .find((column): column is GroupColumn => column?.id === groupFieldId) ?? null;
+      const rawColumns = group.get(YjsDatabaseKey.groups)?.toArray() ?? [];
+      let next: GroupColumn | null = null;
+
+      for (const rawColumn of rawColumns) {
+        const column = normalizeGroupColumn(rawColumn);
+
+        if (column?.id === groupFieldId) {
+          next = column;
+          break;
+        }
+      }
 
       setUngroupedColumn((current) =>
         current?.id === next?.id &&

--- a/src/components/database/components/settings/BoardSettingGroup.tsx
+++ b/src/components/database/components/settings/BoardSettingGroup.tsx
@@ -22,7 +22,7 @@ function BoardSettingGroup () {
   const { t } = useTranslation();
   const {
     hideEmptyGroups,
-    hideUnGroup,
+    ungroupedColumnHidden,
     fieldId,
   } = useBoardLayoutSettings();
   const fieldType = useFieldType(fieldId || '');
@@ -79,13 +79,13 @@ function BoardSettingGroup () {
                 className={'w-full'}
                 onSelect={(e) => {
                   e.preventDefault();
-                  toggle(!hideUnGroup);
+                  toggle(!ungroupedColumnHidden);
                 }}
               >
                 {t('board.showUngrouped')}
                 <Switch
                   className={'ml-auto'}
-                  checked={!hideUnGroup}
+                  checked={!ungroupedColumnHidden}
                 />
 
               </DropdownMenuItem>


### PR DESCRIPTION
## Problem

Hiding the Board's **No Status** (ungrouped) column on desktop does not sync to web — web keeps showing it expanded (reported by annie: "No status is hidden in the desktop but expand on web").

Desktop persists this state only as the ungrouped column's own `visible` flag inside the view's group setting, and explicitly treats the `hide_ungrouped_column` board layout key as legacy (it never writes it). Web decided the No Status column solely from that legacy key, so desktop's write was invisible to web. Web→desktop worked only because web dual-writes both keys.

## Fix

- `board-visibility.ts`: columns carry a `visibleExplicit` flag; new `isUngroupedColumnHidden` helper — an explicitly persisted `visible` flag wins, the legacy `hide_ungrouped_column` key is only a fallback when no explicit flag exists (pre-migration data). A plain OR was deliberately avoided: desktop never clears the legacy key, so OR-ing would leave the column stuck hidden on web after a desktop *show*.
- `selector.ts`: `normalizeGroupColumn` records whether `visible` was actually present in the collab data; `useBoardLayoutSettings` exposes the derived `ungroupedColumnHidden`.
- `dispatch.ts`: the "Show ungrouped" settings toggle now writes the canonical `visible` flag via `setGroupColumnHidden` (still mirroring the legacy key for older web clients) instead of only the legacy key desktop ignores.
- `BoardSettingGroup.tsx`: the switch reflects the effective visibility, so it tracks changes made on desktop.

## Behavior after the fix

- Desktop hide → web hides (the reported bug)
- Desktop show → web shows, even with a stale legacy `hide_ungrouped_column: true` from an old web write
- Legacy boards where only the old key was ever written still render hidden
- Web → desktop unchanged (dual write kept)

## Tests

New resolver cases for the three scenarios above in `board-visibility.test.ts`, plus hook-level tests in `useGroup.test.tsx` for the derived hidden state and the toggle's dual write. Full runs: 585/585 database-yjs tests, 81/81 database component tests, `pnpm type-check` and eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Synchronize the Board “No Status” column visibility between desktop and web by treating the column’s persisted visible flag as the canonical source and using the legacy layout key only as a fallback.

Enhancements:
- Track whether board group column visibility was explicitly persisted via a new visibleExplicit flag and derive the effective hidden state for the ungrouped column.
- Update board layout settings and UI to use the derived ungrouped column visibility so the “Show ungrouped” toggle reflects cross‑platform state.
- Route the “Show ungrouped” toggle through canonical group column visibility updates while still mirroring the legacy hide_ungrouped_column key for older clients.

Tests:
- Add resolver tests covering desktop hide/show interactions with the legacy hide_ungrouped_column key and explicit visibility.
- Add hook-level tests for deriving the ungrouped hidden state and verifying the toggle writes both canonical and legacy visibility settings.