### PR TITLE
fix(database): show a no-access message for embedded databases

### DIFF
--- a/src/@types/translations/en.json
+++ b/src/@types/translations/en.json
@@ -2022,7 +2022,8 @@
   "document": {
     "inlineDatabase": {
       "viewInTrash": "This referenced database is in Trash",
-      "viewDeleted": "This referenced database was permanently deleted"
+      "viewDeleted": "This referenced database was permanently deleted",
+      "noAccess": "You don't have permission to view this database"
     },
     "callout": {
       "changeIcon": "Icon",

--- a/src/application/view-loader/index.ts
+++ b/src/application/view-loader/index.ts
@@ -23,6 +23,7 @@ import {
   YjsEditorKey,
   YSharedRoot,
 } from '@/application/types';
+import { determineErrorType, ErrorType } from '@/application/utils/error-utils';
 import { applyYDoc } from '@/application/ydoc/apply';
 import { Log } from '@/utils/log';
 import * as Y from 'yjs';
@@ -322,7 +323,9 @@ export async function openView(
         await fetchAndApply(workspaceId, viewId, doc);
         break;
       } catch (e) {
-        if (attempt === MAX_RETRIES) throw e;
+        // Permission denials are permanent — retrying cannot succeed.
+        // (404s must keep retrying: they cover the post-duplication race.)
+        if (attempt === MAX_RETRIES || determineErrorType(e).type === ErrorType.Forbidden) throw e;
         Log.debug('[ViewLoader] openView fetch retry', {
           viewId,
           attempt,

--- a/src/components/editor/components/blocks/database/DatabaseBlock.tsx
+++ b/src/components/editor/components/blocks/database/DatabaseBlock.tsx
@@ -61,7 +61,7 @@ function DatabaseBlockBody({ node, children, editor, forwardedRef, readOnly, ...
 
   // Compose focused hooks instead of one monolithic hook
   // 1. Document loading
-  const { doc, notFound, setNotFound } = useDocumentLoader({
+  const { doc, notFound, noAccess, setNotFound } = useDocumentLoader({
     viewId,
     databaseId,
     loadView,
@@ -386,6 +386,7 @@ function DatabaseBlockBody({ node, children, editor, forwardedRef, readOnly, ...
           selectedViewId={selectedViewId}
           hasDatabase={hasDatabase}
           notFound={notFound}
+          noAccess={noAccess}
           deletionStatus={effectiveDeletionStatus}
           paddingStart={paddingStart}
           paddingEnd={paddingEnd}

--- a/src/components/editor/components/blocks/database/components/DatabaseContent.tsx
+++ b/src/components/editor/components/blocks/database/components/DatabaseContent.tsx
@@ -21,6 +21,7 @@ interface DatabaseContentProps {
   selectedViewId: string | null;
   hasDatabase: boolean;
   notFound: boolean;
+  noAccess?: boolean;
   deletionStatus?: 'none' | 'inTrash' | 'deleted' | null;
   paddingStart: number;
   paddingEnd: number;
@@ -47,6 +48,7 @@ export const DatabaseContent = ({
   selectedViewId,
   hasDatabase,
   notFound,
+  noAccess,
   deletionStatus,
   paddingStart,
   paddingEnd,
@@ -117,11 +119,15 @@ export const DatabaseContent = ({
       case 'deleted':
         return t('document.inlineDatabase.viewDeleted', 'This referenced database was permanently deleted');
       default:
+        if (noAccess) {
+          return t('document.inlineDatabase.noAccess', "You don't have permission to view this database");
+        }
+
         return t('error.generalError');
     }
   };
 
-  const showError = notFound || deletionStatus === 'inTrash' || deletionStatus === 'deleted';
+  const showError = notFound || noAccess || deletionStatus === 'inTrash' || deletionStatus === 'deleted';
 
   return (
     <div className="flex h-full w-full flex-col items-center justify-center gap-2 rounded bg-background-primary px-16 py-10 text-text-secondary max-md:px-4">

--- a/src/components/editor/components/blocks/database/components/__tests__/DatabaseContent.test.tsx
+++ b/src/components/editor/components/blocks/database/components/__tests__/DatabaseContent.test.tsx
@@ -73,4 +73,37 @@ describe('DatabaseContent', () => {
       })
     );
   });
+
+  it('shows a no-access message instead of the generic error for permission failures', () => {
+    const context = {
+      readOnly: true,
+      workspaceId: 'workspace-id',
+      variant: UIVariant.App,
+    } as DatabaseContextState;
+
+    const { getByText } = render(
+      <DatabaseContent
+        baseViewId="view-id"
+        selectedViewId={null}
+        hasDatabase={false}
+        notFound={true}
+        noAccess={true}
+        deletionStatus={null}
+        paddingStart={0}
+        paddingEnd={0}
+        width={800}
+        doc={null}
+        workspaceId="workspace-id"
+        onOpenRowPage={jest.fn()}
+        loadViewMeta={jest.fn()}
+        databaseName=""
+        visibleViewIds={[]}
+        onChangeView={jest.fn()}
+        context={context}
+      />
+    );
+
+    expect(getByText("You don't have permission to view this database")).toBeTruthy();
+    expect(Database).not.toHaveBeenCalled();
+  });
 });

--- a/src/components/editor/components/blocks/database/hooks/__tests__/useDocumentLoader.test.ts
+++ b/src/components/editor/components/blocks/database/hooks/__tests__/useDocumentLoader.test.ts
@@ -37,6 +37,42 @@ describe('useDocumentLoader', () => {
     });
   });
 
+  it('reports noAccess without retrying when loadView fails with a permission error', async () => {
+    const loadView = jest.fn(async () => {
+      return Promise.reject({ code: 1012, message: 'user is not allowed to access this view' });
+    });
+
+    const { result } = renderHook(() => useDocumentLoader({
+      viewId: 'view-id',
+      loadView,
+    }));
+
+    await waitFor(() => {
+      expect(result.current.noAccess).toBe(true);
+    });
+
+    expect(result.current.notFound).toBe(true);
+    expect(loadView).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports notFound but not noAccess for non-permission errors', async () => {
+    const loadView = jest.fn(async () => {
+      return Promise.reject(new Error('network down'));
+    });
+
+    const { result } = renderHook(() => useDocumentLoader({
+      viewId: 'view-id',
+      loadView,
+    }));
+
+    await waitFor(() => {
+      expect(result.current.notFound).toBe(true);
+    });
+
+    expect(result.current.noAccess).toBe(false);
+    expect(loadView).toHaveBeenCalledTimes(3);
+  });
+
   it('shares one reset event listener across loader instances for the same emitter', async () => {
     const eventEmitter = new EventEmitter();
     const loadView = jest.fn(async (viewId: string) => createDoc(viewId));

--- a/src/components/editor/components/blocks/database/hooks/useDocumentLoader.ts
+++ b/src/components/editor/components/blocks/database/hooks/useDocumentLoader.ts
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useState } from 'react';
 import { APP_EVENTS } from '@/application/constants';
 import { LoadView, YDoc, YDocWithMeta } from '@/application/types';
 import { SyncContext } from '@/application/services/js-services/sync-protocol';
+import { determineErrorType, ErrorType } from '@/application/utils/error-utils';
 import { CollabDocResetPayload } from '@/components/ws/sync/types';
 import { Log } from '@/utils/log';
 
@@ -56,6 +57,7 @@ interface UseDocumentLoaderProps {
 interface UseDocumentLoaderResult {
   doc: YDoc | null;
   notFound: boolean;
+  noAccess: boolean;
   setNotFound: (notFound: boolean) => void;
 }
 
@@ -65,7 +67,7 @@ interface UseDocumentLoaderResult {
  * Handles:
  * - Loading the YDoc for the given viewId
  * - Retry logic on failure
- * - NotFound state management
+ * - NotFound / NoAccess state management
  */
 export function useDocumentLoader({
   viewId,
@@ -76,6 +78,7 @@ export function useDocumentLoader({
 }: UseDocumentLoaderProps): UseDocumentLoaderResult {
   const [doc, setDoc] = useState<YDoc | null>(null);
   const [notFound, setNotFound] = useState(false);
+  const [noAccess, setNoAccess] = useState(false);
   const [syncBound, setSyncBound] = useState(false);
 
   const loadWithRetry = useCallback(
@@ -102,7 +105,9 @@ export function useDocumentLoader({
             attempt,
             error: error instanceof Error ? error.message : String(error),
           });
-          if (attempt === retries) {
+          // Permission denials are permanent — retrying just hammers the server
+          // with requests that will fail the same way.
+          if (attempt === retries || determineErrorType(error).type === ErrorType.Forbidden) {
             throw error;
           }
 
@@ -131,6 +136,7 @@ export function useDocumentLoader({
         Log.debug('[useDocumentLoader] loaded doc', { viewId, hasDoc: !!loadedDoc });
         setDoc(loadedDoc);
         setNotFound(false);
+        setNoAccess(false);
         setSyncBound(false);
       } catch (error) {
         if (cancelled) return;
@@ -139,6 +145,7 @@ export function useDocumentLoader({
           viewId,
           error: error instanceof Error ? error.message : String(error),
         });
+        setNoAccess(determineErrorType(error).type === ErrorType.Forbidden);
         setNotFound(true);
       }
     };
@@ -203,5 +210,5 @@ export function useDocumentLoader({
     return subscribeCollabDocReset(eventEmitter, handleCollabDocReset);
   }, [eventEmitter, viewId]);
 
-  return { doc, notFound, setNotFound };
+  return { doc, notFound, noAccess, setNotFound };
 }


### PR DESCRIPTION
## Problem

When a page contains an embedded (referenced) database the current user is not allowed to access, the server responds with `403 {"code":1012,"message":"user is not allowed to access this view"}`, but the embedded block renders the generic **"Something went wrong. Please try again later"** — implying a transient failure the user should retry.

On top of the wrong message, two retry layers (3 load attempts in `useDocumentLoader` × 3 fetch attempts in `openView`) kept re-requesting a view that can never load, flooding the network panel with identical failing requests.

## Changes

- `useDocumentLoader` classifies the load error via the existing `determineErrorType` utility (code 1012 / HTTP 403 → `ErrorType.Forbidden`), exposes a `noAccess` flag, and stops retrying immediately on permission denials.
- `openView` (view-loader) also bails out of its fetch retry loop on permission errors. 404s still retry, since that path covers the post-duplication persistence race.
- `DatabaseBlock` / `DatabaseContent` render a dedicated message — **"You don't have permission to view this database"** — using a new `document.inlineDatabase.noAccess` translation key, following the existing `viewInTrash` / `viewDeleted` pattern.

## Tests

- `useDocumentLoader`: a `{code: 1012}` rejection sets `noAccess` and calls `loadView` exactly once (no retries); non-permission errors keep the existing behavior (`notFound` after 3 attempts, `noAccess` stays false).
- `DatabaseContent`: renders the no-access message instead of the generic error when `noAccess` is set.
- Verified live against a dev stack by intercepting the embedded view's requests with the exact server response — the block shows the new message with a single request instead of a retry storm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Handle permission-denied errors for embedded databases by stopping unnecessary retries and showing a clear no-access message to the user.

Bug Fixes:
- Stop repeated load and fetch retries when embedded database views return permission-denied errors.

Enhancements:
- Expose a noAccess state from useDocumentLoader and propagate it into DatabaseContent to render a dedicated no-access message for forbidden views.

Tests:
- Add tests covering useDocumentLoader behavior for permission vs non-permission errors and DatabaseContent rendering of the no-access message.