### PR TITLE
fix(database): render published pages when visible ids include the container

### DIFF
--- a/playwright/e2e/database/publish-database-views.spec.ts
+++ b/playwright/e2e/database/publish-database-views.spec.ts
@@ -144,7 +144,8 @@ test.describe('Publish Database with Multiple Views', () => {
 
     // When: publishing the database page
     testLog.info('Publishing database page');
-    const publishedUrl = withPublishedDatabaseView(await publishCurrentPage(page), activeDatabaseViewId);
+    const barePublishedUrl = await publishCurrentPage(page);
+    const publishedUrl = withPublishedDatabaseView(barePublishedUrl, activeDatabaseViewId);
 
     testLog.info(`Published URL: ${publishedUrl}`);
 
@@ -155,11 +156,24 @@ test.describe('Publish Database with Multiple Views', () => {
 
     suppressBenignErrors(freshPage);
     await freshPage.setViewportSize({ width: 1280, height: 720 });
-    await freshPage.goto(publishedUrl, { waitUntil: 'load' });
+
+    // Then: the BARE published URL (no ?v= tab param) renders the database.
+    // Publishing a database container records the container's own id inside
+    // visible_database_view_ids; the published page must fall back to a view
+    // that actually exists in the database collab instead of rendering blank.
+    testLog.info('Checking bare published URL renders without ?v= param');
+    await freshPage.goto(barePublishedUrl, { waitUntil: 'load' });
     await freshPage.waitForTimeout(8000);
 
-    // Then: the published page renders the database
     const dbContainer = freshPage.locator('.appflowy-database');
+
+    await expect(dbContainer).toBeVisible({ timeout: 15000 });
+    await expect(dbContainer).toContainText(testText, { timeout: 10000 });
+    testLog.info('Bare published URL renders the database');
+
+    // And: the deep-linked URL with an explicit ?v= view id also renders
+    await freshPage.goto(publishedUrl, { waitUntil: 'load' });
+    await freshPage.waitForTimeout(8000);
 
     await expect(dbContainer).toBeVisible({ timeout: 15000 });
     testLog.info('Database visible on published page');

--- a/src/application/__tests__/view-utils.test.ts
+++ b/src/application/__tests__/view-utils.test.ts
@@ -635,6 +635,63 @@ describe('view-utils', () => {
           })
         ).toBe('board-view');
       });
+
+      it('falls back to a real database view when visible ids include the container id', () => {
+        // Published pages can carry the folder container id inside
+        // visibleViewIds; the container is not a view in the database collab.
+        expect(
+          resolveActiveDatabaseViewId({
+            databasePageId: 'container',
+            tabViewId: null,
+            visibleViewIds: ['container', 'grid-view'],
+            existingViewIds: ['inline-view', 'grid-view'],
+          })
+        ).toBe('grid-view');
+      });
+
+      it('keeps the resolved id when it exists in the database', () => {
+        expect(
+          resolveActiveDatabaseViewId({
+            databasePageId: 'grid-view',
+            tabViewId: null,
+            visibleViewIds: ['grid-view', 'board-view'],
+            existingViewIds: ['grid-view', 'board-view'],
+          })
+        ).toBe('grid-view');
+      });
+
+      it('falls back from a tab query pointing at a non-database view', () => {
+        expect(
+          resolveActiveDatabaseViewId({
+            databasePageId: 'container',
+            tabViewId: 'container',
+            visibleViewIds: ['container', 'grid-view'],
+            existingViewIds: ['grid-view'],
+          })
+        ).toBe('grid-view');
+      });
+
+      it('keeps the resolved id when no visible id exists in the database', () => {
+        expect(
+          resolveActiveDatabaseViewId({
+            databasePageId: 'container',
+            tabViewId: null,
+            visibleViewIds: ['container'],
+            existingViewIds: ['grid-view'],
+          })
+        ).toBe('container');
+      });
+
+      it('ignores an empty existing view list', () => {
+        expect(
+          resolveActiveDatabaseViewId({
+            databasePageId: 'container',
+            tabViewId: null,
+            visibleViewIds: ['container', 'grid-view'],
+            existingViewIds: [],
+          })
+        ).toBe('container');
+      });
     });
 
     /**

--- a/src/application/view-utils.ts
+++ b/src/application/view-utils.ts
@@ -256,26 +256,37 @@ export function resolveActiveDatabaseViewId({
   databasePageId,
   tabViewId,
   visibleViewIds,
+  existingViewIds,
 }: {
   databasePageId?: string;
   tabViewId?: string | null;
   visibleViewIds?: string[];
+  /**
+   * View ids that actually exist in the database collab. Published pages can
+   * carry a `visibleViewIds` list that includes the folder container id, which
+   * is not a database view; when this list is provided, a resolved id that is
+   * not a real database view falls back to the first visible id that is.
+   */
+  existingViewIds?: string[];
 }): string | undefined {
   const hasAuthoritativeVisibleViews = Boolean(visibleViewIds && visibleViewIds.length > 0);
 
+  let resolved: string | undefined;
+
   if (tabViewId && (!hasAuthoritativeVisibleViews || visibleViewIds?.includes(tabViewId))) {
-    return tabViewId;
+    resolved = tabViewId;
+  } else if (!databasePageId) {
+    resolved = visibleViewIds?.[0];
+  } else if (hasAuthoritativeVisibleViews && !visibleViewIds?.includes(databasePageId)) {
+    resolved = visibleViewIds?.[0] ?? databasePageId;
+  } else {
+    resolved = databasePageId;
   }
 
-  if (!databasePageId) {
-    return visibleViewIds?.[0];
-  }
+  if (!existingViewIds || existingViewIds.length === 0) return resolved;
+  if (resolved && existingViewIds.includes(resolved)) return resolved;
 
-  if (hasAuthoritativeVisibleViews && !visibleViewIds?.includes(databasePageId)) {
-    return visibleViewIds?.[0] ?? databasePageId;
-  }
-
-  return databasePageId;
+  return visibleViewIds?.find((id) => existingViewIds.includes(id)) ?? resolved;
 }
 
 /**

--- a/src/components/publish/DatabaseView.tsx
+++ b/src/components/publish/DatabaseView.tsx
@@ -2,7 +2,7 @@ import { Suspense, useCallback, useMemo } from 'react';
 import { useSearchParams } from 'react-router-dom';
 
 import { usePublishContext } from '@/application/publish';
-import { UIVariant, ViewLayout, YjsEditorKey } from '@/application/types';
+import { UIVariant, ViewLayout, YjsDatabaseKey, YjsEditorKey } from '@/application/types';
 import { resolveActiveDatabaseViewId } from '@/application/view-utils';
 import type {
   AppendBreadcrumb,
@@ -86,6 +86,18 @@ function DatabaseView({ viewMeta, navigateToView, ...props }: DatabaseProps) {
    */
   const databasePageId = viewMeta.viewId;
 
+  const doc = props.doc;
+  const database = doc?.getMap(YjsEditorKey.data_section)?.get(YjsEditorKey.database) as YDatabase;
+
+  // View ids that actually exist in the database collab. Published pages may
+  // list the folder container id among visibleViewIds even though it is not a
+  // database view; resolution below must never land on such an id.
+  const existingViewIds = useMemo(() => {
+    const views = database?.get(YjsDatabaseKey.views);
+
+    return views ? Array.from(views.keys()) : [];
+  }, [database]);
+
   /**
    * The currently active/selected view tab ID (Grid, Board, or Calendar).
    * Comes from URL param 'v', defaults to the route id for direct child-view
@@ -97,8 +109,9 @@ function DatabaseView({ viewMeta, navigateToView, ...props }: DatabaseProps) {
       databasePageId,
       tabViewId: search.get('v'),
       visibleViewIds,
+      existingViewIds,
     });
-  }, [search, databasePageId, visibleViewIds]);
+  }, [search, databasePageId, visibleViewIds, existingViewIds]);
 
   const handleChangeView = useCallback(
     (viewId: string) => {
@@ -145,8 +158,6 @@ function DatabaseView({ viewMeta, navigateToView, ...props }: DatabaseProps) {
   );
 
   const rowId = search.get('r') || undefined;
-  const doc = props.doc;
-  const database = doc?.getMap(YjsEditorKey.data_section)?.get(YjsEditorKey.database) as YDatabase;
   const isPublishVariant = props.variant === UIVariant.Publish;
 
   const skeleton = useMemo(() => {

--- a/src/components/publish/__tests__/DatabaseView.databaseContainer.test.tsx
+++ b/src/components/publish/__tests__/DatabaseView.databaseContainer.test.tsx
@@ -31,11 +31,17 @@ jest.mock('@/components/database', () => ({
 
 jest.mock('src/components/view-meta/ViewMetaPreview', () => () => null);
 
-function createDatabaseDoc(): YDoc {
+function createDatabaseDoc(databaseViewIds: string[] = []): YDoc {
   const doc = new Y.Doc() as unknown as YDoc;
   const sharedRoot = doc.getMap(YjsEditorKey.data_section);
   const database = new Y.Map();
+  const views = new Y.Map();
 
+  for (const viewId of databaseViewIds) {
+    views.set(viewId, new Y.Map());
+  }
+
+  database.set('views', views);
   sharedRoot.set(YjsEditorKey.database, database);
   return doc;
 }
@@ -69,5 +75,37 @@ describe('published DatabaseView database container', () => {
     expect(databaseProps?.databasePageId).toBe('container-id');
     expect(databaseProps?.activeViewId).toBe('grid-view-id');
     expect(databaseProps?.visibleViewIds).toEqual(['grid-view-id', 'board-view-id']);
+  });
+
+  it('falls back to a real database view when visibleViewIds include the container id', () => {
+    // Pages published from a database container carry the container's own id
+    // inside visibleViewIds. The container is not a view in the database
+    // collab, so resolution must land on a view that actually exists there.
+    const viewMeta: ViewMetaProps = {
+      viewId: 'container-id',
+      name: 'Published Database',
+      layout: ViewLayout.Grid,
+      icon: undefined,
+      extra: { is_database_container: true },
+      workspaceId: 'workspace-id',
+      visibleViewIds: ['container-id', 'grid-view-id'],
+    };
+
+    render(
+      <MemoryRouter initialEntries={['/published/database']}>
+        <DatabaseView
+          doc={createDatabaseDoc(['inline-view-id', 'grid-view-id'])}
+          workspaceId='workspace-id'
+          viewMeta={viewMeta}
+        />
+      </MemoryRouter>
+    );
+
+    const databaseProps = global.__publishDatabaseViewTestState?.capturedDatabaseProps as
+      | { databasePageId?: string; activeViewId?: string }
+      | undefined;
+
+    expect(databaseProps?.databasePageId).toBe('container-id');
+    expect(databaseProps?.activeViewId).toBe('grid-view-id');
   });
 });


### PR DESCRIPTION
## Problem

Publishing a database **container** view produces a blank published page — only the title and tab bar render, the grid body is empty.

Pages published from a database container record the container's own view id inside `visible_database_view_ids` (`PublishPanel` prepends `view.view_id` to the list). On the published page, `resolveActiveDatabaseViewId` sees the route's page id listed in `visibleViewIds`, treats it as a legit tab, and selects it as the active view. But the container is a folder-level view — it does not exist in the database collab's `views` map — so `DatabaseViews` never resolves an active view or layout and renders `null`.

## Fix (render-time fallback)

- `resolveActiveDatabaseViewId` accepts an optional `existingViewIds` list (view ids actually present in the database collab). When the resolved id is not a real database view, it falls back to the first `visibleViewIds` entry that is. Absent/empty `existingViewIds` keeps the previous behavior exactly.
- The published `DatabaseView` derives `existingViewIds` from the database doc and passes it in. This also covers the v2 snapshot path (`PublishedDatabaseRenderer` renders through the same component).
- The app-side `DatabaseView` is intentionally left unwired: a just-created view can be briefly missing from the views map, and the fallback could bounce the user off the new tab.

Because the fallback is applied at render time, **already-published pages are repaired without republishing**.

## Tests

- **Unit** (`view-utils.test.ts`): 5 new cases — container id inside `visibleViewIds`, container id as the `?v=` tab param, no visible id existing in the database, empty `existingViewIds`, and unchanged happy path.
- **Component** (`DatabaseView.databaseContainer.test.tsx`): new case replicating the bug — `visibleViewIds = [container, grid]` with a collab containing only the inline + grid views resolves the grid as active.
- **E2E** (`publish-database-views.spec.ts`): the spec previously opened published pages via `withPublishedDatabaseView()`, which appends `?v=<view id>` and masked this exact bug. It now asserts the **bare** published URL renders the database (with row data) before exercising the `?v=` deep link and tab switching. Passed against the local stack (1 passed, 1.1m).

`pnpm type-check` clean; affected jest suites 91/91 passing.

## Follow-up (not in this PR)

`PublishPanel` still includes the container's own id in `visible_database_view_ids` at publish time. The fallback makes the stored data harmless, but the publish-time list could be cleaned up separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Ensure published database container pages resolve to a real database view instead of rendering blank when the container id appears in visible view ids.

Bug Fixes:
- Fix published database container pages rendering with an empty grid body by falling back to an existing database view when resolution picks a non-database container id.

Enhancements:
- Extend database view resolution to accept existing database view ids and prefer them when the initially resolved id does not exist in the collab.

Tests:
- Add unit tests for active database view resolution with container ids, tab params, nonexistent visible ids, and empty existing-view lists.
- Add a published DatabaseView component test verifying fallback to a real database view when visibleViewIds include the container id.
- Strengthen e2e coverage for published database views by asserting bare published URLs render database content before exercising ?v= deep links.