### PR TITLE
fix: never retain caches across a permission error

### DIFF
--- a/src/application/__tests__/view-loader.test.ts
+++ b/src/application/__tests__/view-loader.test.ts
@@ -1,8 +1,9 @@
 import { expect } from '@jest/globals';
 import * as Y from 'yjs';
 
-import { openCollabDB, openCollabDBWithProvider } from '@/application/db';
+import { deleteCollabDB, openCollabDB, openCollabDBWithProvider } from '@/application/db';
 import { getOrCreateRowSubDoc } from '@/application/services/js-services/cache';
+import { invalidateViewCache } from '@/application/services/js-services/cached-api';
 import { fetchPageCollab } from '@/application/services/js-services/fetch';
 import { enqueueOutboxUpdate } from '@/application/sync-outbox';
 import { Types, ViewLayout, YDoc, YjsDatabaseKey, YjsEditorKey } from '@/application/types';
@@ -11,6 +12,11 @@ import { getDatabaseIdFromDoc, openRowSubDocument, openView } from '@/applicatio
 jest.mock('@/application/db', () => ({
   openCollabDB: jest.fn(),
   openCollabDBWithProvider: jest.fn(),
+  deleteCollabDB: jest.fn(),
+}));
+
+jest.mock('@/application/services/js-services/cached-api', () => ({
+  invalidateViewCache: jest.fn(),
 }));
 
 jest.mock('@/application/services/js-services/cache', () => ({
@@ -32,6 +38,8 @@ jest.mock('@/application/sync-outbox', () => ({
 
 const mockOpenCollabDB = openCollabDB as jest.MockedFunction<typeof openCollabDB>;
 const mockOpenCollabDBWithProvider = openCollabDBWithProvider as jest.MockedFunction<typeof openCollabDBWithProvider>;
+const mockDeleteCollabDB = deleteCollabDB as jest.MockedFunction<typeof deleteCollabDB>;
+const mockInvalidateViewCache = invalidateViewCache as jest.MockedFunction<typeof invalidateViewCache>;
 const mockGetOrCreateRowSubDoc = getOrCreateRowSubDoc as jest.MockedFunction<typeof getOrCreateRowSubDoc>;
 const mockFetchPageCollab = fetchPageCollab as jest.MockedFunction<typeof fetchPageCollab>;
 const mockEnqueueOutboxUpdate = enqueueOutboxUpdate as jest.MockedFunction<typeof enqueueOutboxUpdate>;
@@ -156,6 +164,59 @@ describe('view-loader database cache identity', () => {
     expect(result.doc).toBe(canonicalDoc);
     expect(result.fromCache).toBe(true);
     expect(getDatabaseIdFromDoc(canonicalDoc)).toBe(databaseId);
+  });
+});
+
+describe('view-loader permission error cache eviction', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockDeleteCollabDB.mockResolvedValue(undefined);
+  });
+
+  it('evicts the collab and view caches instead of retrying when the fetch is denied', async () => {
+    const viewId = '00000000-0000-4000-8000-000000000005';
+    const databaseId = '00000000-0000-4000-8000-000000000006';
+    const canonicalDoc = createEmptyDoc(databaseId);
+    const legacyDoc = createEmptyDoc(viewId);
+    const docs = new Map([
+      [databaseId, canonicalDoc],
+      [viewId, legacyDoc],
+    ]);
+
+    mockOpenCollabDBWithProvider.mockImplementation(async (name: string) => {
+      const doc = docs.get(name);
+
+      if (!doc) throw new Error(`Unexpected open ${name}`);
+      return createProvider(doc) as never;
+    });
+    mockOpenCollabDB.mockImplementation(async (name: string) => {
+      const doc = docs.get(name);
+
+      if (!doc) throw new Error(`Unexpected open ${name}`);
+      return doc;
+    });
+    mockFetchPageCollab.mockRejectedValue({ code: 1012, message: 'user is not allowed to access this view' });
+
+    await expect(openView('workspace-id', viewId, ViewLayout.Grid, { databaseId })).rejects.toMatchObject({
+      code: 1012,
+    });
+
+    expect(mockFetchPageCollab).toHaveBeenCalledTimes(1);
+    expect(mockDeleteCollabDB).toHaveBeenCalledWith(databaseId, { destroyDoc: true });
+    expect(mockInvalidateViewCache).toHaveBeenCalledWith('workspace-id', viewId);
+  });
+
+  it('does not evict caches for non-permission fetch failures', async () => {
+    const viewId = '00000000-0000-4000-8000-000000000007';
+    const doc = createEmptyDoc(viewId);
+
+    mockOpenCollabDB.mockResolvedValue(doc);
+    mockFetchPageCollab.mockRejectedValue({ code: -2, message: 'Record not found' });
+
+    await expect(openView('workspace-id', viewId, ViewLayout.Document)).rejects.toMatchObject({ code: -2 });
+
+    expect(mockDeleteCollabDB).not.toHaveBeenCalled();
+    expect(mockInvalidateViewCache).not.toHaveBeenCalled();
   });
 });
 

--- a/src/application/view-loader/index.ts
+++ b/src/application/view-loader/index.ts
@@ -10,8 +10,9 @@
  * before the component finishes rendering.
  */
 
-import { openCollabDB, openCollabDBWithProvider } from '@/application/db';
+import { deleteCollabDB, openCollabDB, openCollabDBWithProvider } from '@/application/db';
 import { getOrCreateRowSubDoc, hasCollabCache } from '@/application/services/js-services/cache';
+import { invalidateViewCache } from '@/application/services/js-services/cached-api';
 import { fetchPageCollab } from '@/application/services/js-services/fetch';
 import { enqueueOutboxUpdate } from '@/application/sync-outbox';
 import {
@@ -323,9 +324,24 @@ export async function openView(
         await fetchAndApply(workspaceId, viewId, doc);
         break;
       } catch (e) {
-        // Permission denials are permanent — retrying cannot succeed.
+        // Permission denials are permanent for this attempt — retrying cannot
+        // succeed. Evict every local copy keyed to this load before rethrowing:
+        // a cached collab (or the positive view-meta cache) would otherwise pin
+        // the failure and suppress the refetch after the server grants access.
         // (404s must keep retrying: they cover the post-duplication race.)
-        if (attempt === MAX_RETRIES || determineErrorType(e).type === ErrorType.Forbidden) throw e;
+        if (determineErrorType(e).type === ErrorType.Forbidden) {
+          const docKey = options.databaseId ?? viewId;
+
+          Log.debug('[ViewLoader] permission denial — evicting local caches', {
+            viewId,
+            docKey,
+          });
+          invalidateViewCache(workspaceId, viewId);
+          await deleteCollabDB(docKey, { destroyDoc: true }).catch(() => undefined);
+          throw e;
+        }
+
+        if (attempt === MAX_RETRIES) throw e;
         Log.debug('[ViewLoader] openView fetch retry', {
           viewId,
           attempt,

--- a/src/components/app/layers/AppBusinessLayer.tsx
+++ b/src/components/app/layers/AppBusinessLayer.tsx
@@ -473,6 +473,17 @@ export const AppBusinessLayer: FC<AppBusinessLayerProps> = ({ children }) => {
       }
 
       void probe.then((result) => {
+        // A denied verdict is a permission error and must not be served from the
+        // probe cache for the rest of its TTL: the server can grant access at any
+        // moment, and a retained denial keeps suppressing the re-probe. Evict it
+        // as soon as it resolves (before any supersession guard), keyed on the
+        // promise identity so a newer probe is never dropped by an older one.
+        if (result.verdict === 'denied') {
+          const retained = permissionProbeCache.get(cacheKey);
+
+          if (retained && retained.promise === probe) permissionProbeCache.delete(cacheKey);
+        }
+
         // Ignore a result superseded by an auth transition or an explicit
         // revoke/restore notification. Route-only navigation does not change
         // the revision, so a confirmed revoke still purges an off-screen page.

--- a/src/components/editor/components/blocks/database/hooks/__tests__/useDocumentLoader.test.ts
+++ b/src/components/editor/components/blocks/database/hooks/__tests__/useDocumentLoader.test.ts
@@ -4,9 +4,16 @@ import { act, renderHook, waitFor } from '@testing-library/react';
 import * as Y from 'yjs';
 
 import { APP_EVENTS } from '@/application/constants';
+import { deleteCollabDB } from '@/application/db';
 import { YDoc } from '@/application/types';
 
 import { useDocumentLoader } from '../useDocumentLoader';
+
+jest.mock('@/application/db', () => ({
+  deleteCollabDB: jest.fn().mockResolvedValue(undefined),
+}));
+
+const mockDeleteCollabDB = deleteCollabDB as jest.MockedFunction<typeof deleteCollabDB>;
 
 function createDoc(guid: string): YDoc {
   return new Y.Doc({ guid }) as YDoc;
@@ -53,6 +60,23 @@ describe('useDocumentLoader', () => {
 
     expect(result.current.notFound).toBe(true);
     expect(loadView).toHaveBeenCalledTimes(1);
+  });
+
+  it('evicts the cached collab when loadView fails with a permission error', async () => {
+    mockDeleteCollabDB.mockClear();
+    const loadView = jest.fn(async () => {
+      return Promise.reject({ code: 1012, message: 'user is not allowed to access this view' });
+    });
+
+    renderHook(() => useDocumentLoader({
+      viewId: 'view-id',
+      databaseId: 'database-id',
+      loadView,
+    }));
+
+    await waitFor(() => {
+      expect(mockDeleteCollabDB).toHaveBeenCalledWith('database-id', { destroyDoc: true });
+    });
   });
 
   it('reports notFound but not noAccess for non-permission errors', async () => {

--- a/src/components/editor/components/blocks/database/hooks/useDocumentLoader.ts
+++ b/src/components/editor/components/blocks/database/hooks/useDocumentLoader.ts
@@ -2,6 +2,7 @@ import EventEmitter from 'events';
 import { useCallback, useEffect, useState } from 'react';
 
 import { APP_EVENTS } from '@/application/constants';
+import { deleteCollabDB } from '@/application/db';
 import { LoadView, YDoc, YDocWithMeta } from '@/application/types';
 import { SyncContext } from '@/application/services/js-services/sync-protocol';
 import { determineErrorType, ErrorType } from '@/application/utils/error-utils';
@@ -145,7 +146,16 @@ export function useDocumentLoader({
           viewId,
           error: error instanceof Error ? error.message : String(error),
         });
-        setNoAccess(determineErrorType(error).type === ErrorType.Forbidden);
+        const isPermissionDenied = determineErrorType(error).type === ErrorType.Forbidden;
+
+        // A permission failure must never be pinned by a stale local copy: evict
+        // the collab keyed to this load so the next mount or reload refetches
+        // once the server grants access, instead of serving the denial forever.
+        if (isPermissionDenied) {
+          void deleteCollabDB(databaseId ?? viewId, { destroyDoc: true }).catch(() => undefined);
+        }
+
+        setNoAccess(isPermissionDenied);
         setNotFound(true);
       }
     };
@@ -155,7 +165,7 @@ export function useDocumentLoader({
     return () => {
       cancelled = true;
     };
-  }, [viewId, loadWithRetry]);
+  }, [viewId, databaseId, loadWithRetry]);
 
   useEffect(() => {
     if (!doc || !bindViewSync || syncBound) return;


### PR DESCRIPTION
## Problem

When the server returns a permission error (`{"code":1012}` / 403) for an embedded database view, the web app can pin that failure in local caches — and keep showing **"You don't have permission to view this database"** even after the server grants access, sometimes issuing **zero network requests** on reload.

Observed live while debugging AppFlowy-Cloud-Premium#951 (embedded databases from desktop row templates): after the server-side fix deployed, the web kept serving the denial from local state.

## Pinning sites and fixes

```mermaid
flowchart TD
    A["embedded database block"] --> B["openView(viewId, {databaseId})"]
    B --> C{"hasCollabCache(doc)?<br/>doc keyed by databaseId"}
    C -- "yes → fetch skipped forever" --> D["stale collab pins the denial"]
    C -- no --> E["GET /page-view/{viewId}"]
    E -- "1012 / 403" --> F["FIX 1: evict collab (databaseId key)<br/>+ invalidate view-meta cache,<br/>then rethrow"]
    G["loadView fails before fetch"] -- "1012 / 403" --> H["FIX 2: useDocumentLoader<br/>evicts the same collab"]
    I["permission probe"] -- "denied verdict" --> J["FIX 3: evict probe cache entry<br/>immediately (was retained full TTL)"]

    style D fill:#7f1d1d,color:#fff
    style F fill:#14532d,color:#fff
    style H fill:#14532d,color:#fff
    style J fill:#14532d,color:#fff
```

1. **`view-loader/index.ts`** — the collab cache is keyed by `databaseId` while the fetch is keyed by `viewId`; any cached copy suppresses the `page-view` request entirely, with no eviction on failure. On a Forbidden fetch result, evict the opened doc's collab cache (`deleteCollabDB(databaseId ?? viewId, { destroyDoc: true })`) and `invalidateViewCache(workspaceId, viewId)` before rethrowing. Non-permission errors (e.g. the post-duplication 404 race) keep their existing retry behavior and caches.
2. **`useDocumentLoader.ts`** — same eviction when `loadView` rejects with a permission error, covering failures upstream of the fetch.
3. **`AppBusinessLayer.tsx`** — a `denied` probe verdict resolved into `permissionProbeCache` and was served for the remaining TTL, suppressing the re-probe that would observe restored access. Evict the entry as soon as the denied verdict resolves (promise-identity keyed, before any supersession guard).

Not-found results are deliberately left cached (`routeViewExistsCacheRef` semantics unchanged) — this PR only stops **permission** errors from being retained.

## Tests

- `view-loader.test.ts`: denied fetch evicts collab + view caches and does not retry; non-permission failure evicts nothing.
- `useDocumentLoader.test.ts`: permission rejection evicts the `databaseId`-keyed collab.
- Suites: 13/13; eslint clean on touched files (warnings identical to baseline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Ensure permission errors never persist in local caches so access can be restored correctly after server-side changes.

Bug Fixes:
- Stop embedded database views from retaining Forbidden responses in collab and view caches, allowing refetch after permissions are updated.
- Prevent permission probe results from being cached for their full TTL so that restored access is re-detected promptly.

Enhancements:
- Add targeted eviction of collab and view metadata caches on permission failures in the view loader and document loader hooks to avoid stale denials.

Tests:
- Extend view-loader and useDocumentLoader test suites to cover cache eviction behavior for permission vs non-permission failures.