### PR TITLE
fix: cache eviction and database page request/sync fixes

### DIFF
--- a/src/application/__tests__/view-loader.test.ts
+++ b/src/application/__tests__/view-loader.test.ts
@@ -1,8 +1,9 @@
 import { expect } from '@jest/globals';
 import * as Y from 'yjs';
 
-import { openCollabDB, openCollabDBWithProvider } from '@/application/db';
+import { deleteCollabDB, openCollabDB, openCollabDBWithProvider } from '@/application/db';
 import { getOrCreateRowSubDoc } from '@/application/services/js-services/cache';
+import { invalidateViewCache } from '@/application/services/js-services/cached-api';
 import { fetchPageCollab } from '@/application/services/js-services/fetch';
 import { enqueueOutboxUpdate } from '@/application/sync-outbox';
 import { Types, ViewLayout, YDoc, YjsDatabaseKey, YjsEditorKey } from '@/application/types';
@@ -11,6 +12,11 @@ import { getDatabaseIdFromDoc, openRowSubDocument, openView } from '@/applicatio
 jest.mock('@/application/db', () => ({
   openCollabDB: jest.fn(),
   openCollabDBWithProvider: jest.fn(),
+  deleteCollabDB: jest.fn(),
+}));
+
+jest.mock('@/application/services/js-services/cached-api', () => ({
+  invalidateViewCache: jest.fn(),
 }));
 
 jest.mock('@/application/services/js-services/cache', () => ({
@@ -32,6 +38,8 @@ jest.mock('@/application/sync-outbox', () => ({
 
 const mockOpenCollabDB = openCollabDB as jest.MockedFunction<typeof openCollabDB>;
 const mockOpenCollabDBWithProvider = openCollabDBWithProvider as jest.MockedFunction<typeof openCollabDBWithProvider>;
+const mockDeleteCollabDB = deleteCollabDB as jest.MockedFunction<typeof deleteCollabDB>;
+const mockInvalidateViewCache = invalidateViewCache as jest.MockedFunction<typeof invalidateViewCache>;
 const mockGetOrCreateRowSubDoc = getOrCreateRowSubDoc as jest.MockedFunction<typeof getOrCreateRowSubDoc>;
 const mockFetchPageCollab = fetchPageCollab as jest.MockedFunction<typeof fetchPageCollab>;
 const mockEnqueueOutboxUpdate = enqueueOutboxUpdate as jest.MockedFunction<typeof enqueueOutboxUpdate>;
@@ -156,6 +164,59 @@ describe('view-loader database cache identity', () => {
     expect(result.doc).toBe(canonicalDoc);
     expect(result.fromCache).toBe(true);
     expect(getDatabaseIdFromDoc(canonicalDoc)).toBe(databaseId);
+  });
+});
+
+describe('view-loader permission error cache eviction', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockDeleteCollabDB.mockResolvedValue(undefined);
+  });
+
+  it('evicts the collab and view caches instead of retrying when the fetch is denied', async () => {
+    const viewId = '00000000-0000-4000-8000-000000000005';
+    const databaseId = '00000000-0000-4000-8000-000000000006';
+    const canonicalDoc = createEmptyDoc(databaseId);
+    const legacyDoc = createEmptyDoc(viewId);
+    const docs = new Map([
+      [databaseId, canonicalDoc],
+      [viewId, legacyDoc],
+    ]);
+
+    mockOpenCollabDBWithProvider.mockImplementation(async (name: string) => {
+      const doc = docs.get(name);
+
+      if (!doc) throw new Error(`Unexpected open ${name}`);
+      return createProvider(doc) as never;
+    });
+    mockOpenCollabDB.mockImplementation(async (name: string) => {
+      const doc = docs.get(name);
+
+      if (!doc) throw new Error(`Unexpected open ${name}`);
+      return doc;
+    });
+    mockFetchPageCollab.mockRejectedValue({ code: 1012, message: 'user is not allowed to access this view' });
+
+    await expect(openView('workspace-id', viewId, ViewLayout.Grid, { databaseId })).rejects.toMatchObject({
+      code: 1012,
+    });
+
+    expect(mockFetchPageCollab).toHaveBeenCalledTimes(1);
+    expect(mockDeleteCollabDB).toHaveBeenCalledWith(databaseId, { destroyDoc: true });
+    expect(mockInvalidateViewCache).toHaveBeenCalledWith('workspace-id', viewId);
+  });
+
+  it('does not evict caches for non-permission fetch failures', async () => {
+    const viewId = '00000000-0000-4000-8000-000000000007';
+    const doc = createEmptyDoc(viewId);
+
+    mockOpenCollabDB.mockResolvedValue(doc);
+    mockFetchPageCollab.mockRejectedValue({ code: -2, message: 'Record not found' });
+
+    await expect(openView('workspace-id', viewId, ViewLayout.Document)).rejects.toMatchObject({ code: -2 });
+
+    expect(mockDeleteCollabDB).not.toHaveBeenCalled();
+    expect(mockInvalidateViewCache).not.toHaveBeenCalled();
   });
 });
 

--- a/src/application/services/domains/view.ts
+++ b/src/application/services/domains/view.ts
@@ -14,5 +14,7 @@ export {
   getCachedAppViewFromDisk as getCachedFromDisk,
   invalidateViewCache as invalidateCache,
   refreshAppViewCache as refresh,
+  getAppTrashCached as getTrashCached,
+  refreshAppTrashCache as refreshTrash,
   getAppDatabaseViewRelationsFromCollab as getDatabaseRelations,
 } from '../js-services/cached-api';

--- a/src/application/services/js-services/__tests__/cached-api.app-trash-cache.test.ts
+++ b/src/application/services/js-services/__tests__/cached-api.app-trash-cache.test.ts
@@ -1,0 +1,214 @@
+import { getAppTrash } from '@/application/services/js-services/http';
+import { getTokenParsed } from '@/application/session/token';
+import { View, ViewLayout } from '@/application/types';
+
+import { getAppTrashCached, refreshAppTrashCache } from '../cached-api';
+
+jest.mock('@/application/db', () => ({
+  db: {
+    app_view_cache: {
+      delete: jest.fn(),
+      get: jest.fn(),
+      put: jest.fn(),
+    },
+  },
+  openCollabDB: jest.fn(),
+}));
+
+jest.mock('@/application/services/js-services/cache', () => ({
+  createRow: jest.fn(),
+  deleteRow: jest.fn(),
+  deleteView: jest.fn(),
+  getPageDoc: jest.fn(),
+  getPublishView: jest.fn(),
+  getPublishViewMeta: jest.fn(),
+  getUser: jest.fn(),
+  hasCollabCache: jest.fn(),
+  hasViewMetaCache: jest.fn(),
+}));
+
+jest.mock('@/application/services/js-services/device-id', () => ({
+  getOrCreateDeviceId: jest.fn(() => 'device-id'),
+}));
+
+jest.mock('@/application/services/js-services/fetch', () => ({
+  fetchPageCollab: jest.fn(),
+  fetchPublishView: jest.fn(),
+  fetchPublishViewMeta: jest.fn(),
+  fetchViewInfo: jest.fn(),
+}));
+
+jest.mock('@/application/services/js-services/http', () => ({
+  cancelImportTask: jest.fn(),
+  changePassword: jest.fn(),
+  createImportTask: jest.fn(),
+  duplicatePublishView: jest.fn(),
+  forgotPassword: jest.fn(),
+  getAppTrash: jest.fn(),
+  getCollab: jest.fn(),
+  getCurrentUser: jest.fn(),
+  getUserWorkspaceInfo: jest.fn(),
+  getView: jest.fn(),
+  publishView: jest.fn(),
+  signInApple: jest.fn(),
+  signInDiscord: jest.fn(),
+  signInGithub: jest.fn(),
+  signInGoogle: jest.fn(),
+  signInOTP: jest.fn(),
+  signInSaml: jest.fn(),
+  signInWithMagicLink: jest.fn(),
+  signInWithPassword: jest.fn(),
+  signInWithUrl: jest.fn(),
+  signUpWithPassword: jest.fn(),
+  unpublishView: jest.fn(),
+  updatePublishConfig: jest.fn(),
+  updatePublishNamespace: jest.fn(),
+  uploadFileMultipart: jest.fn(),
+  uploadImportFile: jest.fn(),
+  uploadImportFileMultipart: jest.fn(),
+}));
+
+jest.mock('@/application/session', () => ({
+  emit: jest.fn(),
+  EventType: {
+    SESSION_INVALID: 'SESSION_INVALID',
+    SESSION_VALID: 'SESSION_VALID',
+  },
+}));
+
+jest.mock('@/application/session/sign_in', () => ({
+  afterAuth: jest.fn(),
+  AUTH_CALLBACK_URL: 'http://localhost/auth/callback',
+  saveRedirectTo: jest.fn(),
+}));
+
+jest.mock('@/application/session/token', () => ({
+  getTokenParsed: jest.fn(),
+}));
+
+jest.mock('@/application/ydoc/apply', () => ({
+  applyYDoc: jest.fn(),
+}));
+
+jest.mock('@/utils/upload-tracker', () => ({
+  registerUpload: jest.fn(() => 'upload-id'),
+  unregisterUpload: jest.fn(),
+}));
+
+const getTokenParsedMock = getTokenParsed as jest.Mock;
+const getAppTrashMock = getAppTrash as jest.Mock;
+
+function setCurrentUser(userId: string | undefined) {
+  getTokenParsedMock.mockReturnValue(
+    userId
+      ? {
+          access_token: 'access-token',
+          expires_at: Date.now() + 60000,
+          refresh_token: 'refresh-token',
+          user: {
+            email: `${userId}@example.com`,
+            id: userId,
+          },
+        }
+      : null
+  );
+}
+
+function createTrashView(viewId: string): View {
+  return {
+    view_id: viewId,
+    name: `trash ${viewId}`,
+    icon: null,
+    layout: ViewLayout.Document,
+    extra: null,
+    children: [],
+    is_published: false,
+    is_private: false,
+  };
+}
+
+describe('cached app trash', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    setCurrentUser('user-a');
+  });
+
+  it('serves the TTL cache instead of refetching within the window', async () => {
+    const workspaceId = 'workspace-trash-ttl';
+    const trash = [createTrashView('trashed-1')];
+
+    getAppTrashMock.mockResolvedValue(trash);
+
+    await expect(getAppTrashCached(workspaceId)).resolves.toBe(trash);
+    await expect(getAppTrashCached(workspaceId)).resolves.toBe(trash);
+
+    expect(getAppTrashMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('dedups concurrent callers into a single request', async () => {
+    const workspaceId = 'workspace-trash-concurrent';
+    const trash = [createTrashView('trashed-2')];
+
+    getAppTrashMock.mockResolvedValue(trash);
+
+    const [first, second] = await Promise.all([
+      getAppTrashCached(workspaceId),
+      getAppTrashCached(workspaceId),
+    ]);
+
+    expect(first).toBe(trash);
+    expect(second).toBe(trash);
+    expect(getAppTrashMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('refresh bypasses the TTL cache but still shares in-flight requests', async () => {
+    const workspaceId = 'workspace-trash-refresh';
+    const initial = [createTrashView('trashed-3')];
+    const refreshed = [createTrashView('trashed-3'), createTrashView('trashed-4')];
+
+    getAppTrashMock.mockResolvedValueOnce(initial).mockResolvedValue(refreshed);
+
+    await expect(getAppTrashCached(workspaceId)).resolves.toBe(initial);
+
+    const [refreshA, refreshB] = await Promise.all([
+      refreshAppTrashCache(workspaceId),
+      refreshAppTrashCache(workspaceId),
+    ]);
+
+    expect(refreshA).toBe(refreshed);
+    expect(refreshB).toBe(refreshed);
+    expect(getAppTrashMock).toHaveBeenCalledTimes(2);
+
+    // The refreshed payload replaces the TTL cache entry
+    await expect(getAppTrashCached(workspaceId)).resolves.toBe(refreshed);
+    expect(getAppTrashMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not cache failures', async () => {
+    const workspaceId = 'workspace-trash-error';
+    const trash = [createTrashView('trashed-5')];
+
+    getAppTrashMock.mockRejectedValueOnce({ code: -1, message: 'Network error' }).mockResolvedValue(trash);
+
+    await expect(getAppTrashCached(workspaceId)).rejects.toEqual({ code: -1, message: 'Network error' });
+    await expect(getAppTrashCached(workspaceId)).resolves.toBe(trash);
+
+    expect(getAppTrashMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('keeps trash caches isolated across account switches', async () => {
+    const workspaceId = 'workspace-trash-users';
+    const userATrash = [createTrashView('user-a-trash')];
+    const userBTrash = [createTrashView('user-b-trash')];
+
+    getAppTrashMock.mockResolvedValueOnce(userATrash).mockResolvedValueOnce(userBTrash);
+
+    setCurrentUser('user-a');
+    await expect(getAppTrashCached(workspaceId)).resolves.toBe(userATrash);
+
+    setCurrentUser('user-b');
+    await expect(getAppTrashCached(workspaceId)).resolves.toBe(userBTrash);
+
+    expect(getAppTrashMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/application/services/js-services/cached-api.ts
+++ b/src/application/services/js-services/cached-api.ts
@@ -28,6 +28,7 @@ import {
   fetchViewInfo,
 } from '@/application/services/js-services/fetch';
 import {
+  getAppTrash,
   getView,
   signInWithUrl,
   uploadFileMultipart,
@@ -101,6 +102,10 @@ const _getAppViewInFlight = new Map<string, Promise<View>>();
 const _getAppViewCache = new Map<string, { data: View; expiresAt: number }>();
 const VIEW_CACHE_TTL_MS = 5000;
 const ANONYMOUS_VIEW_CACHE_SCOPE = 'anonymous';
+
+const _getAppTrashInFlight = new Map<string, Promise<View[]>>();
+const _getAppTrashCache = new Map<string, { data: View[]; expiresAt: number }>();
+const TRASH_CACHE_TTL_MS = 5000;
 
 // ============================================================================
 // Simple getters
@@ -228,6 +233,60 @@ export function invalidateViewCache(workspaceId: string, viewId: string) {
       error,
     });
   });
+}
+
+/**
+ * In-flight dedup + short-lived result cache for getAppTrash.
+ * Every embedded DatabaseBlock probes the trash list to detect deleted
+ * containers, so a page with several embedded databases would otherwise fire
+ * one trash request per block.
+ */
+function getAppTrashCacheKey(userId: string | undefined, workspaceId: string) {
+  return `${userId ?? ANONYMOUS_VIEW_CACHE_SCOPE}:${workspaceId}`;
+}
+
+function requestAppTrash(workspaceId: string, userId = getCurrentAppViewCacheUserId()) {
+  const key = getAppTrashCacheKey(userId, workspaceId);
+  const existing = _getAppTrashInFlight.get(key);
+
+  if (existing) {
+    return existing;
+  }
+
+  const request = getAppTrash(workspaceId)
+    .then((views) => {
+      _getAppTrashCache.set(key, {
+        data: views,
+        expiresAt: Date.now() + TRASH_CACHE_TTL_MS,
+      });
+      return views;
+    })
+    .finally(() => {
+      _getAppTrashInFlight.delete(key);
+    });
+
+  _getAppTrashInFlight.set(key, request);
+  return request;
+}
+
+export async function getAppTrashCached(workspaceId: string) {
+  const userId = getCurrentAppViewCacheUserId();
+  const cached = _getAppTrashCache.get(getAppTrashCacheKey(userId, workspaceId));
+
+  if (cached && Date.now() < cached.expiresAt) {
+    return cached.data;
+  }
+
+  return requestAppTrash(workspaceId, userId);
+}
+
+/**
+ * Bypasses the TTL cache but still shares any in-flight request, so
+ * concurrent refreshers (e.g. every embedded database re-checking on
+ * OUTLINE_LOADED) collapse into a single network call.
+ */
+export async function refreshAppTrashCache(workspaceId: string) {
+  return requestAppTrash(workspaceId);
 }
 
 export async function getPageDocCached(

--- a/src/application/view-loader/index.ts
+++ b/src/application/view-loader/index.ts
@@ -10,8 +10,9 @@
  * before the component finishes rendering.
  */
 
-import { openCollabDB, openCollabDBWithProvider } from '@/application/db';
+import { deleteCollabDB, openCollabDB, openCollabDBWithProvider } from '@/application/db';
 import { getOrCreateRowSubDoc, hasCollabCache } from '@/application/services/js-services/cache';
+import { invalidateViewCache } from '@/application/services/js-services/cached-api';
 import { fetchPageCollab } from '@/application/services/js-services/fetch';
 import { enqueueOutboxUpdate } from '@/application/sync-outbox';
 import {
@@ -323,9 +324,24 @@ export async function openView(
         await fetchAndApply(workspaceId, viewId, doc);
         break;
       } catch (e) {
-        // Permission denials are permanent — retrying cannot succeed.
+        // Permission denials are permanent for this attempt — retrying cannot
+        // succeed. Evict every local copy keyed to this load before rethrowing:
+        // a cached collab (or the positive view-meta cache) would otherwise pin
+        // the failure and suppress the refetch after the server grants access.
         // (404s must keep retrying: they cover the post-duplication race.)
-        if (attempt === MAX_RETRIES || determineErrorType(e).type === ErrorType.Forbidden) throw e;
+        if (determineErrorType(e).type === ErrorType.Forbidden) {
+          const docKey = options.databaseId ?? viewId;
+
+          Log.debug('[ViewLoader] permission denial — evicting local caches', {
+            viewId,
+            docKey,
+          });
+          invalidateViewCache(workspaceId, viewId);
+          await deleteCollabDB(docKey, { destroyDoc: true }).catch(() => undefined);
+          throw e;
+        }
+
+        if (attempt === MAX_RETRIES) throw e;
         Log.debug('[ViewLoader] openView fetch retry', {
           viewId,
           attempt,

--- a/src/components/app/layers/AppBusinessLayer.tsx
+++ b/src/components/app/layers/AppBusinessLayer.tsx
@@ -473,6 +473,17 @@ export const AppBusinessLayer: FC<AppBusinessLayerProps> = ({ children }) => {
       }
 
       void probe.then((result) => {
+        // A denied verdict is a permission error and must not be served from the
+        // probe cache for the rest of its TTL: the server can grant access at any
+        // moment, and a retained denial keeps suppressing the re-probe. Evict it
+        // as soon as it resolves (before any supersession guard), keyed on the
+        // promise identity so a newer probe is never dropped by an older one.
+        if (result.verdict === 'denied') {
+          const retained = permissionProbeCache.get(cacheKey);
+
+          if (retained && retained.promise === probe) permissionProbeCache.delete(cacheKey);
+        }
+
         // Ignore a result superseded by an auth transition or an explicit
         // revoke/restore notification. Route-only navigation does not change
         // the revision, so a confirmed revoke still purges an off-screen page.

--- a/src/components/database/Database.tsx
+++ b/src/components/database/Database.tsx
@@ -898,12 +898,12 @@ function Database(props: Database2Props) {
   const scheduleMissingRowRecovery = useCallback(() => {
     if (readOnly) return;
     if (missingRowRecoveryLifecycleRef.current === databaseLifecycleIdentity) return;
-    missingRowRecoveryLifecycleRef.current = databaseLifecycleIdentity;
 
     const databaseId = getDatabaseId();
     const recoveryGeneration = blobPrefetchGenerationRef.current;
 
     if (!workspaceId || !databaseId) return;
+    missingRowRecoveryLifecycleRef.current = databaseLifecycleIdentity;
 
     Log.warn('[Database] visible row has no local data after blob prefetch; forcing full blob resync', {
       workspaceId,

--- a/src/components/database/Database.tsx
+++ b/src/components/database/Database.tsx
@@ -48,6 +48,7 @@ import DatabaseViews from '@/components/database/DatabaseViews';
 import { CalendarViewType } from '@/components/database/fullcalendar/types';
 import { shouldUseFixedDatabaseViewport } from '@/components/database/layout';
 import { cn } from '@/lib/utils';
+import { Log } from '@/utils/log';
 
 import { DatabaseContextProvider } from './DatabaseContext';
 
@@ -885,6 +886,57 @@ function Database(props: Database2Props) {
     [createRow, databaseLifecycleIdentity, getDatabaseId, ensureBlobPrefetch]
   );
 
+  // Self-healing for a lying delta watermark: the RID cursor lives in
+  // localStorage while row data lives in IndexedDB, so the two can diverge
+  // (storage eviction, partial clears). The delta diff then reports "no
+  // changes", no seeds exist, and a visible row opens as an empty doc whose
+  // only remaining data path is per-row realtime sync — slow or never on
+  // rows without a live collab. When that happens, force one full blob
+  // resync per database lifecycle and re-seed the already-open row docs.
+  const missingRowRecoveryLifecycleRef = useRef<unknown>(null);
+
+  const scheduleMissingRowRecovery = useCallback(() => {
+    if (readOnly) return;
+    if (missingRowRecoveryLifecycleRef.current === databaseLifecycleIdentity) return;
+    missingRowRecoveryLifecycleRef.current = databaseLifecycleIdentity;
+
+    const databaseId = getDatabaseId();
+    const recoveryGeneration = blobPrefetchGenerationRef.current;
+
+    if (!workspaceId || !databaseId) return;
+
+    Log.warn('[Database] visible row has no local data after blob prefetch; forcing full blob resync', {
+      workspaceId,
+      databaseId,
+    });
+
+    void prefetchDatabaseBlobDiff(workspaceId, databaseId, {
+      forceFullSync: true,
+      priorityRowIds: getPriorityRowIds(),
+      onSeedsReady: () => {
+        if (blobPrefetchGenerationRef.current !== recoveryGeneration) return;
+        if (activeDatabaseLifecycleRef.current !== databaseLifecycleIdentity) return;
+
+        // openRowDoc reuses the cached doc entry, so applying the fresh seed
+        // mutates the same Y.Doc instances the UI already observes — spinners
+        // clear through the row observers without touching rowMap.
+        const currentDatabaseId = getDatabaseId();
+
+        for (const [rowId, rowDoc] of Object.entries(rowMapRef.current)) {
+          if (hasRowConditionData(rowDoc)) continue;
+
+          const rowKey = getRowKey(currentDatabaseId, rowId);
+          const seed = peekDatabaseRowDocSeed(rowKey);
+
+          if (!seed) continue;
+          void openRowDoc(rowKey, seed).catch(() => undefined);
+        }
+      },
+    }).catch((error) => {
+      Log.warn('[Database] full blob resync for missing rows failed', { workspaceId, databaseId, error });
+    });
+  }, [readOnly, workspaceId, databaseLifecycleIdentity, getDatabaseId, getPriorityRowIds]);
+
   const ensureRow = useCallback(
     async (rowId: string) => {
       if (!createRow || !rowId) return;
@@ -900,6 +952,13 @@ function Database(props: Database2Props) {
       const finishEnsure = (rowDoc: YDoc | undefined) => {
         if (rowDoc && isCurrentEnsure()) {
           scheduleRowSyncReconciliation(rowId);
+
+          // The local pipeline (seed cache + IndexedDB) produced no row data —
+          // the delta watermark is ahead of the local store. Trigger the
+          // one-shot full resync instead of leaving the row to realtime sync.
+          if (!hasRowConditionData(rowDoc)) {
+            scheduleMissingRowRecovery();
+          }
         }
 
         return rowDoc;
@@ -1036,6 +1095,7 @@ function Database(props: Database2Props) {
       readOnly,
       registerRowSync,
       scheduleRowSyncReconciliation,
+      scheduleMissingRowRecovery,
     ]
   );
 

--- a/src/components/database/components/header/DatabaseRowHeader.tsx
+++ b/src/components/database/components/header/DatabaseRowHeader.tsx
@@ -24,7 +24,6 @@ import {
 } from '@/application/types';
 import ImageRender from '@/components/_shared/image-render/ImageRender';
 import {
-  createRowDocumentViewNameBaseline,
   normalizeRowDocumentViewName,
   shouldSyncRowDocumentViewName,
 } from '@/components/database/components/header/rowDocumentViewName';
@@ -189,33 +188,37 @@ function DatabaseRowHeader({ rowId, appendBreadcrumb }: { rowId: string; appendB
   }, [isDatabaseRowPage, rowId, documentId, title, hasDocument, databaseId, databaseViewId]);
 
   // Keep the row-document view name in sync with the primary cell so
-  // favorites/trash entries show the row title. Baseline on first run:
-  // an existing title is already current (explicit actions like favorite/delete
-  // push it themselves), while an initially blank title must sync its first value.
-  const titleSyncBaselineRef = useRef(createRowDocumentViewNameBaseline(documentId, title));
+  // favorites/trash entries show the row title. Sync only from title edits
+  // made in this header: observing cell state cannot distinguish a user edit
+  // from the loading sequence (empty placeholder doc → loaded title), which
+  // used to push a spurious update-name on every row page open. Loads and
+  // remote renames never sync — the editing client pushes its own rename, and
+  // explicit actions (favorite/delete) push the current title themselves.
+  const titleSyncTimerRef = useRef<number | undefined>(undefined);
+  const lastSyncedTitleRef = useRef<string>('');
+
+  const onTitleEdited = useCallback(
+    (editedTitle: string) => {
+      if (readOnly || !hasDocument || !documentId || !workspaceId) return;
+
+      const name = normalizeRowDocumentViewName(editedTitle);
+
+      if (!shouldSyncRowDocumentViewName(lastSyncedTitleRef.current, name)) return;
+
+      window.clearTimeout(titleSyncTimerRef.current);
+      titleSyncTimerRef.current = window.setTimeout(() => {
+        lastSyncedTitleRef.current = name;
+        void syncRowDocumentViewName(workspaceId, documentId, name);
+      }, 500);
+    },
+    [readOnly, hasDocument, documentId, workspaceId]
+  );
 
   useEffect(() => {
-    const name = normalizeRowDocumentViewName(title);
-    const baseline = titleSyncBaselineRef.current;
-
-    if (baseline.documentId !== documentId) {
-      titleSyncBaselineRef.current = createRowDocumentViewNameBaseline(documentId, name);
-      return;
-    }
-
-    if (readOnly || !hasDocument || !documentId || !workspaceId) return;
-
-    if (!shouldSyncRowDocumentViewName(baseline.title, name)) return;
-
-    const timer = window.setTimeout(() => {
-      titleSyncBaselineRef.current = createRowDocumentViewNameBaseline(documentId, name);
-      void syncRowDocumentViewName(workspaceId, documentId, name);
-    }, 500);
-
     return () => {
-      window.clearTimeout(timer);
+      window.clearTimeout(titleSyncTimerRef.current);
     };
-  }, [readOnly, hasDocument, documentId, workspaceId, title]);
+  }, []);
 
   useEffect(() => {
     const el = ref.current;
@@ -266,7 +269,14 @@ function DatabaseRowHeader({ rowId, appendBreadcrumb }: { rowId: string; appendB
           </div>
         )}
       </div>
-      <Title rowId={rowId} fieldId={fieldId} icon={meta?.icon} name={cell?.data as string} hasCover={!!cover} />
+      <Title
+        rowId={rowId}
+        fieldId={fieldId}
+        icon={meta?.icon}
+        name={cell?.data as string}
+        hasCover={!!cover}
+        onEdited={onTitleEdited}
+      />
     </div>
   );
 }

--- a/src/components/database/components/header/Title.tsx
+++ b/src/components/database/components/header/Title.tsx
@@ -16,12 +16,14 @@ export function Title({
   rowId,
   fieldId,
   hasCover,
+  onEdited,
 }: {
   rowId: string;
   icon?: string;
   name?: string;
   hasCover: boolean;
   fieldId: string;
+  onEdited?: (value: string) => void;
 }) {
   const readOnly = useReadOnly();
   const [value, setValue] = useState(name || '');
@@ -129,6 +131,7 @@ export function Title({
                 updateCell(e.target.value);
 
                 setValue(e.target.value);
+                onEdited?.(e.target.value);
               }}
               onKeyDown={(e) => {
                 if (createHotkey(HOT_KEY_NAME.ESCAPE)(e.nativeEvent)) {

--- a/src/components/database/components/header/__tests__/rowDocumentViewName.test.ts
+++ b/src/components/database/components/header/__tests__/rowDocumentViewName.test.ts
@@ -1,35 +1,27 @@
 import { describe, expect, it } from '@jest/globals';
 
 import {
-  createRowDocumentViewNameBaseline,
   normalizeRowDocumentViewName,
   shouldSyncRowDocumentViewName,
 } from '../rowDocumentViewName';
 
 describe('row document view name sync', () => {
-  it('syncs the first non-empty title when the initial title was blank', () => {
-    const initialTitle = normalizeRowDocumentViewName('   ');
-
-    expect(shouldSyncRowDocumentViewName(initialTitle, 'First title')).toBe(true);
+  it('syncs the first non-empty edited title', () => {
+    expect(shouldSyncRowDocumentViewName('', 'First title')).toBe(true);
   });
 
-  it('treats an existing initial title as the baseline', () => {
-    const initialTitle = normalizeRowDocumentViewName('Existing title');
-
-    expect(shouldSyncRowDocumentViewName(initialTitle, 'Existing title')).toBe(false);
-    expect(shouldSyncRowDocumentViewName(initialTitle, 'Renamed title')).toBe(true);
+  it('does not re-sync an unchanged title', () => {
+    expect(shouldSyncRowDocumentViewName('Existing title', 'Existing title')).toBe(false);
+    expect(shouldSyncRowDocumentViewName('Existing title', '  Existing title  ')).toBe(false);
+    expect(shouldSyncRowDocumentViewName('Existing title', 'Renamed title')).toBe(true);
   });
 
   it('does not sync an empty title', () => {
     expect(shouldSyncRowDocumentViewName('Existing title', '   ')).toBe(false);
+    expect(shouldSyncRowDocumentViewName('', '')).toBe(false);
   });
 
-  it('creates an independent baseline when the document changes', () => {
-    const first = createRowDocumentViewNameBaseline('document-1', 'First row');
-    const second = createRowDocumentViewNameBaseline('document-2', '   ');
-
-    expect(first).toEqual({ documentId: 'document-1', title: 'First row' });
-    expect(second).toEqual({ documentId: 'document-2', title: '' });
-    expect(shouldSyncRowDocumentViewName(second.title, 'Second row')).toBe(true);
+  it('normalizes surrounding whitespace', () => {
+    expect(normalizeRowDocumentViewName('  padded  ')).toBe('padded');
   });
 });

--- a/src/components/database/components/header/rowDocumentViewName.ts
+++ b/src/components/database/components/header/rowDocumentViewName.ts
@@ -2,18 +2,6 @@ export function normalizeRowDocumentViewName(title: string) {
   return title.trim();
 }
 
-export interface RowDocumentViewNameBaseline {
-  documentId: string;
-  title: string;
-}
-
-export function createRowDocumentViewNameBaseline(documentId: string, title: string): RowDocumentViewNameBaseline {
-  return {
-    documentId,
-    title: normalizeRowDocumentViewName(title),
-  };
-}
-
 export function shouldSyncRowDocumentViewName(lastSyncedTitle: string, title: string) {
   const name = normalizeRowDocumentViewName(title);
 

--- a/src/components/editor/components/blocks/database/DatabaseBlock.tsx
+++ b/src/components/editor/components/blocks/database/DatabaseBlock.tsx
@@ -18,7 +18,13 @@ import { useDocumentLoader } from './hooks/useDocumentLoader';
 import { useResizePositioning } from './hooks/useResizePositioning';
 import { useViewMeta } from './hooks/useViewMeta';
 import { useViewSelection } from './hooks/useViewSelection';
-import { addViewId, getViewIds, isDatabaseDuplicatePlaceholder, removeViewId } from './utils/databaseBlockUtils';
+import {
+  addViewId,
+  getViewIds,
+  isDatabaseDuplicatePlaceholder,
+  isViewGoneError,
+  removeViewId,
+} from './utils/databaseBlockUtils';
 
 function DatabaseDuplicatePlaceholder() {
   const { t } = useTranslation();
@@ -113,22 +119,24 @@ function DatabaseBlockBody({ node, children, editor, forwardedRef, readOnly, ...
 
     let cancelled = false;
 
-    const checkView = async () => {
+    // On mount, go through the short-lived view/trash caches so the fetch
+    // coalesces with useViewMeta's request (and with other embedded blocks on
+    // the same page). When OUTLINE_LOADED fires the folder just changed, so
+    // force fresh fetches — refresh() bypasses the TTL but still shares any
+    // in-flight request, keeping N blocks at one request per resource.
+    const checkView = async (refresh: boolean) => {
       try {
-        // Invalidate the view cache to get an authoritative answer from the server.
-        // Without this, the 5-second cache could return stale data for a permanently
-        // deleted view, causing it to be misclassified as "restored".
-        ViewService.invalidateCache(workspaceId, viewId);
-
         // Fetch view metadata and trash list in parallel (async-parallel rule).
-        // Only treat 404-like failures (record not found) as permanent deletion.
         const [viewResult, trashResult] = await Promise.allSettled([
-          ViewService.get(workspaceId, viewId),
-          ViewService.getTrash(workspaceId),
+          refresh ? ViewService.refresh(workspaceId, viewId) : ViewService.get(workspaceId, viewId),
+          refresh ? ViewService.refreshTrash(workspaceId) : ViewService.getTrashCached(workspaceId),
         ]);
 
         const viewMeta = viewResult.status === 'fulfilled' ? viewResult.value : null;
-        const viewGone = viewResult.status === 'rejected';
+        // Only a confirmed record-not-found/deleted response means the view is
+        // gone; transient network/server errors must not flip the block into
+        // the "deleted" state (the trash list may still resolve from cache).
+        const viewGone = viewResult.status === 'rejected' && isViewGoneError(viewResult.reason);
         const trashItems = trashResult.status === 'fulfilled' ? trashResult.value : null;
 
         // If both requests failed, optimistically allow rendering rather than
@@ -199,12 +207,14 @@ function DatabaseBlockBody({ node, children, editor, forwardedRef, readOnly, ...
     };
 
     // Check immediately on mount (covers navigating back to a page after deletion)
-    void checkView();
+    void checkView(false);
 
-    eventEmitter.on(APP_EVENTS.OUTLINE_LOADED, checkView);
+    const handleOutlineLoaded = () => void checkView(true);
+
+    eventEmitter.on(APP_EVENTS.OUTLINE_LOADED, handleOutlineLoaded);
     return () => {
       cancelled = true;
-      eventEmitter.off(APP_EVENTS.OUTLINE_LOADED, checkView);
+      eventEmitter.off(APP_EVENTS.OUTLINE_LOADED, handleOutlineLoaded);
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps -- node.data excluded to avoid re-subscribing on every block edit
   }, [context.eventEmitter, viewId, workspaceId, hasDatabase, setNotFound]);

--- a/src/components/editor/components/blocks/database/hooks/__tests__/useDocumentLoader.test.ts
+++ b/src/components/editor/components/blocks/database/hooks/__tests__/useDocumentLoader.test.ts
@@ -4,9 +4,16 @@ import { act, renderHook, waitFor } from '@testing-library/react';
 import * as Y from 'yjs';
 
 import { APP_EVENTS } from '@/application/constants';
+import { deleteCollabDB } from '@/application/db';
 import { YDoc } from '@/application/types';
 
 import { useDocumentLoader } from '../useDocumentLoader';
+
+jest.mock('@/application/db', () => ({
+  deleteCollabDB: jest.fn().mockResolvedValue(undefined),
+}));
+
+const mockDeleteCollabDB = deleteCollabDB as jest.MockedFunction<typeof deleteCollabDB>;
 
 function createDoc(guid: string): YDoc {
   return new Y.Doc({ guid }) as YDoc;
@@ -53,6 +60,23 @@ describe('useDocumentLoader', () => {
 
     expect(result.current.notFound).toBe(true);
     expect(loadView).toHaveBeenCalledTimes(1);
+  });
+
+  it('evicts the cached collab when loadView fails with a permission error', async () => {
+    mockDeleteCollabDB.mockClear();
+    const loadView = jest.fn(async () => {
+      return Promise.reject({ code: 1012, message: 'user is not allowed to access this view' });
+    });
+
+    renderHook(() => useDocumentLoader({
+      viewId: 'view-id',
+      databaseId: 'database-id',
+      loadView,
+    }));
+
+    await waitFor(() => {
+      expect(mockDeleteCollabDB).toHaveBeenCalledWith('database-id', { destroyDoc: true });
+    });
   });
 
   it('reports notFound but not noAccess for non-permission errors', async () => {

--- a/src/components/editor/components/blocks/database/hooks/useDocumentLoader.ts
+++ b/src/components/editor/components/blocks/database/hooks/useDocumentLoader.ts
@@ -2,6 +2,7 @@ import EventEmitter from 'events';
 import { useCallback, useEffect, useState } from 'react';
 
 import { APP_EVENTS } from '@/application/constants';
+import { deleteCollabDB } from '@/application/db';
 import { LoadView, YDoc, YDocWithMeta } from '@/application/types';
 import { SyncContext } from '@/application/services/js-services/sync-protocol';
 import { determineErrorType, ErrorType } from '@/application/utils/error-utils';
@@ -145,7 +146,16 @@ export function useDocumentLoader({
           viewId,
           error: error instanceof Error ? error.message : String(error),
         });
-        setNoAccess(determineErrorType(error).type === ErrorType.Forbidden);
+        const isPermissionDenied = determineErrorType(error).type === ErrorType.Forbidden;
+
+        // A permission failure must never be pinned by a stale local copy: evict
+        // the collab keyed to this load so the next mount or reload refetches
+        // once the server grants access, instead of serving the denial forever.
+        if (isPermissionDenied) {
+          void deleteCollabDB(databaseId ?? viewId, { destroyDoc: true }).catch(() => undefined);
+        }
+
+        setNoAccess(isPermissionDenied);
         setNotFound(true);
       }
     };
@@ -155,7 +165,7 @@ export function useDocumentLoader({
     return () => {
       cancelled = true;
     };
-  }, [viewId, loadWithRetry]);
+  }, [viewId, databaseId, loadWithRetry]);
 
   useEffect(() => {
     if (!doc || !bindViewSync || syncBound) return;

--- a/src/components/editor/components/blocks/database/utils/__tests__/isViewGoneError.test.ts
+++ b/src/components/editor/components/blocks/database/utils/__tests__/isViewGoneError.test.ts
@@ -1,0 +1,22 @@
+import { isViewGoneError } from '../databaseBlockUtils';
+
+describe('isViewGoneError', () => {
+  it('recognizes server record-not-found responses', () => {
+    // RecordNotFound app error code with HTTP 404
+    expect(isViewGoneError({ code: -2, message: 'Record not exist in db.', httpStatus: 404 })).toBe(true);
+    // RecordDeleted app error code with HTTP 410
+    expect(isViewGoneError({ code: -4, message: 'Record deleted', httpStatus: 410 })).toBe(true);
+    // Raw HTTP status propagated as code (no app error body)
+    expect(isViewGoneError({ code: 404, message: 'Request failed' })).toBe(true);
+    // Message-only fallback
+    expect(isViewGoneError({ code: -1, message: 'View not found' })).toBe(true);
+  });
+
+  it('rejects transient and permission errors', () => {
+    expect(isViewGoneError({ code: -1, message: 'Network error' })).toBe(false);
+    expect(isViewGoneError({ code: 500, message: 'Internal server error', httpStatus: 500 })).toBe(false);
+    expect(isViewGoneError({ code: 1012, message: 'Not enough permissions', httpStatus: 403 })).toBe(false);
+    expect(isViewGoneError(undefined)).toBe(false);
+    expect(isViewGoneError('not found')).toBe(false);
+  });
+});

--- a/src/components/editor/components/blocks/database/utils/databaseBlockUtils.ts
+++ b/src/components/editor/components/blocks/database/utils/databaseBlockUtils.ts
@@ -118,6 +118,8 @@ export function serializeDatabaseNodeData(data: DatabaseNodeData): string {
   return JSON.stringify(data);
 }
 
+const VIEW_GONE_MESSAGE_PATTERN = /\b(not\s*found|not\s*exist)\b/i;
+
 /**
  * True when a view fetch failed because the record no longer exists on the
  * server (RecordNotFound = -2 / HTTP 404, RecordDeleted = -4 / HTTP 410),
@@ -135,5 +137,5 @@ export function isViewGoneError(error: unknown): boolean {
   if (httpStatus === 404 || httpStatus === 410) return true;
   if (code === 404 || code === -2 || code === -4) return true;
 
-  return typeof message === 'string' && /\b(not\s*found|not\s*exist)\b/i.test(message);
+  return typeof message === 'string' && VIEW_GONE_MESSAGE_PATTERN.test(message);
 }

--- a/src/components/editor/components/blocks/database/utils/databaseBlockUtils.ts
+++ b/src/components/editor/components/blocks/database/utils/databaseBlockUtils.ts
@@ -117,3 +117,23 @@ export function parseDatabaseNodeData(jsonString: string): DatabaseNodeData {
 export function serializeDatabaseNodeData(data: DatabaseNodeData): string {
   return JSON.stringify(data);
 }
+
+/**
+ * True when a view fetch failed because the record no longer exists on the
+ * server (RecordNotFound = -2 / HTTP 404, RecordDeleted = -4 / HTTP 410),
+ * as opposed to a transient network/server error.
+ */
+export function isViewGoneError(error: unknown): boolean {
+  if (!error || typeof error !== 'object') return false;
+
+  const { code, httpStatus, message } = error as {
+    code?: number;
+    httpStatus?: number;
+    message?: string;
+  };
+
+  if (httpStatus === 404 || httpStatus === 410) return true;
+  if (code === 404 || code === -2 || code === -4) return true;
+
+  return typeof message === 'string' && /\b(not\s*found|not\s*exist)\b/i.test(message);
+}


### PR DESCRIPTION
## Summary

Four related fixes around local caches and database page loading:

### 1. Never retain caches across a permission error (`14c248e5`)
A permission denial (1012 / 403) could be pinned by local caches long after the server granted access. Evict the collab cache and view-meta cache on a Forbidden fetch, mirror the eviction in `useDocumentLoader`, and drop denied verdicts from the permission-probe cache so restored access is observed.

### 2. Coalesce embedded database view and trash checks (`d43b3283`)
Opening a page with an embedded database fired the folder view request 3× and the trash request 2×:
- The deletion-detection check invalidated the view cache on every run, defeating the in-flight dedup shared with `useViewMeta`, and re-fetched on every `OUTLINE_LOADED`.
- Mount checks now go through the short-lived caches; `OUTLINE_LOADED` re-checks use refresh variants that bypass the TTL but still share one in-flight request per resource.
- The trash list gets the same TTL cache + in-flight dedup as views, so N embedded blocks share one fetch.
- Only confirmed `RecordNotFound`/`RecordDeleted` responses count as a deleted view; transient errors no longer flip a block into the "deleted" state.

### 3. Sync row-document name only from actual title edits (`930913cf`)
Opening a database row page pushed a spurious `update-name` for the row document: the title-sync effect baselined the primary cell on first render, but on a cold open the row doc loads after mount, so the loaded title was misread as a rename. The sync is now driven by the Title input's edit path — loads and remote renames never sync, local edits debounce into a single `update-name`.

### 4. Force a full blob resync when a visible row has no local data (`b8c0b1d3`)
The delta-sync watermark lives in localStorage while row data lives in IndexedDB, so the two can diverge (storage eviction, partial clears). The delta diff then reports "no changes" and visible rows hang on per-row realtime sync with loading spinners. When `ensureRow` completes and the row doc still has no content, trigger one forced full blob resync per database lifecycle and re-apply the fresh seeds to the already-open row docs. The resync also repopulates IndexedDB and corrects the watermark.

## Test plan

- [x] `pnpm type-check`, eslint clean
- [x] Full jest suite: 223 suites / 2279 tests pass (includes new tests for the trash cache, `isViewGoneError`, and updated title-sync tests)
- [x] Verified live against the local stack:
  - Row page with embedded database: `view/{id}?depth=1` requests 3 → 1, trash fetches shared, no `update-name` on open, one debounced `update-name` on a real title edit
  - Watermark divergence repro (IndexedDB wiped, localStorage kept): recovery warning logged, forced full diff issued per database, rows render; subsequent reloads clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Improve robustness of database views and row pages by fixing cache behavior on permission errors, optimizing embedded database view/trash checks, and hardening row title and blob sync flows.

Bug Fixes:
- Evict collab and view caches on permission-denied view loads so restored access is not blocked by stale local data.
- Ensure permission-probe cache does not retain denied verdicts beyond the initial check, allowing access changes to be detected promptly.
- Prevent embedded database blocks from misclassifying transient errors as deleted views by distinguishing permanent gone errors from other failures.
- Fix row-document name sync so opening a row page or remote title changes no longer trigger spurious update-name operations.
- Recover from diverged delta watermarks by forcing a one-time full blob resync when visible rows have no local data, avoiding stuck loading states.

Enhancements:
- Add short-lived in-flight dedup and TTL caching for workspace trash lists so multiple embedded databases share a single fetch.
- Align embedded database view and trash checks with shared cached/refresh APIs to coalesce mount and outline reload traffic.
- Refine row title sync to be driven by explicit edits in the header with debounced updates, avoiding unnecessary renames.
- Introduce helper utilities to detect when a view is permanently gone and to schedule missing-row recovery within the database lifecycle.

Tests:
- Add unit tests covering view-loader permission-error cache eviction and document-loader permission handling.
- Add tests for row document view name normalization and sync conditions based on edited titles.
- Add a dedicated test suite for cached app trash behavior, including TTL usage, in-flight deduplication, error handling, and user isolation.
- Add tests for the isViewGoneError helper to validate classification of not-found vs transient/permission errors.