### PR TITLE
fix(publish): include visible database child metadata

### DIFF
--- a/playwright/bdd/features/database/published-template-multiple-views.feature
+++ b/playwright/bdd/features/database/published-template-multiple-views.feature
@@ -1,0 +1,11 @@
+Feature: Published database templates
+  A published database container can be reused without losing its sibling
+  database views or row data.
+
+  Scenario: Another account duplicates a database container with multiple views
+    Given a publisher has a database container with Grid and Board views
+    And the publisher adds identifiable row data
+    When the publisher publishes the database container as a template
+    And another account starts with the published template
+    Then the duplicated database container has views "Grid, Board"
+    And the duplicated database contains the publisher row data

--- a/playwright/bdd/steps/published-template-multiple-views.steps.ts
+++ b/playwright/bdd/steps/published-template-multiple-views.steps.ts
@@ -1,0 +1,237 @@
+import { BrowserContext, expect, Page } from '@playwright/test';
+import { createBdd } from 'playwright-bdd';
+
+import { signInAndWaitForApp } from '../../support/auth-flow-helpers';
+import { signInAndCreateDatabaseView, waitForGridReady } from '../../support/database-ui-helpers';
+import { DatabaseGridSelectors, DatabaseViewSelectors, ShareSelectors } from '../../support/selectors';
+import { generateRandomEmail, setupPageErrorHandling } from '../../support/test-config';
+
+const { Given, When, Then, After } = createBdd();
+
+type PublishedTemplateState = {
+  marker: string;
+  publisherEmail: string;
+  publishedUrl?: string;
+  consumerContext?: BrowserContext;
+  consumerPage?: Page;
+};
+
+const stateByPage = new WeakMap<Page, PublishedTemplateState>();
+
+After(async ({ page }) => {
+  const state = stateByPage.get(page);
+
+  await state?.consumerContext?.close();
+  stateByPage.delete(page);
+});
+
+Given('a publisher has a database container with Grid and Board views', async ({ page, request }) => {
+  setupPageErrorHandling(page);
+  await page.setViewportSize({ width: 1440, height: 900 });
+
+  const publisherEmail = generateRandomEmail();
+
+  await signInAndCreateDatabaseView(page, request, publisherEmail, 'Grid', {
+    verify: async (databasePage) => {
+      await expect(DatabaseViewSelectors.viewTab(databasePage).first()).toBeVisible({ timeout: 15000 });
+    },
+  });
+  await waitForGridReady(page);
+  await addDatabaseView(page, 'Board');
+
+  const gridTab = DatabaseViewSelectors.viewTab(page).filter({ hasText: 'Grid' }).first();
+
+  await gridTab.click({ force: true });
+  await waitForGridReady(page);
+
+  stateByPage.set(page, {
+    marker: `Published template row ${Date.now()}`,
+    publisherEmail,
+  });
+});
+
+Given('the publisher adds identifiable row data', async ({ page }) => {
+  const state = requireState(page);
+
+  await DatabaseGridSelectors.firstCell(page).click({ force: true });
+  await page.keyboard.type(state.marker);
+  await page.keyboard.press('Escape');
+  await expect(DatabaseGridSelectors.grid(page)).toContainText(state.marker, { timeout: 15000 });
+
+  // Reload before publishing so the scenario proves the row reached the server,
+  // rather than duplicating unsaved browser state.
+  await page.reload({ waitUntil: 'domcontentloaded' });
+  await waitForGridReady(page);
+  await expect(DatabaseGridSelectors.grid(page)).toContainText(state.marker, { timeout: 30000 });
+});
+
+When('the publisher publishes the database container as a template', async ({ page }) => {
+  const state = requireState(page);
+
+  state.publishedUrl = await publishCurrentDatabase(page);
+});
+
+When('another account starts with the published template', async ({ page, request, browser }) => {
+  const state = requireState(page);
+  const publishedUrl = requirePublishedUrl(state);
+  const origin = new URL(publishedUrl).origin;
+  const consumerEmail = generateRandomEmail();
+
+  expect(consumerEmail).not.toBe(state.publisherEmail);
+
+  const consumerContext = await browser.newContext({
+    baseURL: origin,
+    viewport: { width: 1440, height: 900 },
+  });
+  const consumerPage = await consumerContext.newPage();
+
+  state.consumerContext = consumerContext;
+  state.consumerPage = consumerPage;
+  setupPageErrorHandling(consumerPage);
+
+  await signInAndWaitForApp(consumerPage, request, consumerEmail);
+  await consumerPage.goto(publishedUrl, { waitUntil: 'domcontentloaded' });
+
+  const startWithTemplate = consumerPage.getByRole('button', {
+    name: 'Start with this template',
+  });
+
+  await expect(startWithTemplate).toBeVisible({ timeout: 30000 });
+  await startWithTemplate.click();
+
+  const destinationDialog = consumerPage.getByRole('dialog').filter({ hasText: 'Where would you like to add' }).last();
+
+  await expect(destinationDialog).toBeVisible({ timeout: 15000 });
+
+  const generalSpace = destinationDialog.getByTestId('space-item').filter({ hasText: 'General' }).first();
+
+  await expect(generalSpace).toBeVisible({ timeout: 30000 });
+  await generalSpace.click();
+
+  const addButton = destinationDialog.getByRole('button', { name: 'Add', exact: true });
+
+  await expect(addButton).toBeEnabled();
+
+  const duplicateResponsePromise = consumerPage.waitForResponse(
+    (response) => {
+      const pathname = new URL(response.url()).pathname;
+
+      return response.request().method() === 'POST' && pathname.endsWith('/published-duplicate');
+    },
+    { timeout: 60000 }
+  );
+
+  await addButton.click();
+
+  const duplicateResponse = await duplicateResponsePromise;
+
+  expect(
+    duplicateResponse.ok(),
+    `Published template duplication failed with HTTP ${duplicateResponse.status()}`
+  ).toBeTruthy();
+
+  const openInBrowser = consumerPage.getByRole('button', { name: 'Open in browser' });
+
+  await expect(openInBrowser).toBeVisible({ timeout: 30000 });
+  await openInBrowser.click();
+  await expect(consumerPage).toHaveURL(/\/app\//, { timeout: 30000 });
+  await expect(consumerPage.locator('.appflowy-database')).toBeVisible({ timeout: 60000 });
+});
+
+Then('the duplicated database container has views {string}', async ({ page }, expectedViewLabels: string) => {
+  const consumerPage = requireConsumerPage(requireState(page));
+  const expected = expectedViewLabels.split(',').map((label) => label.trim());
+
+  await expect
+    .poll(() => databaseViewLabels(consumerPage), {
+      timeout: 60000,
+      message: `Expected duplicated database views: ${expected.join(', ')}`,
+    })
+    .toEqual(expected);
+});
+
+Then('the duplicated database contains the publisher row data', async ({ page }) => {
+  const state = requireState(page);
+  const consumerPage = requireConsumerPage(state);
+  const gridTab = DatabaseViewSelectors.viewTab(consumerPage).filter({ hasText: 'Grid' }).first();
+
+  await gridTab.click({ force: true });
+  await waitForGridReady(consumerPage);
+  await expect(DatabaseGridSelectors.grid(consumerPage)).toContainText(state.marker, { timeout: 60000 });
+});
+
+async function addDatabaseView(page: Page, viewType: 'Board'): Promise<void> {
+  const previousCount = await DatabaseViewSelectors.viewTab(page).count();
+  const addButton = DatabaseViewSelectors.addViewButton(page);
+
+  await expect(addButton).toBeVisible({ timeout: 10000 });
+  await addButton.click();
+
+  const menuItem = DatabaseViewSelectors.viewTypeOption(page, viewType);
+
+  await expect(menuItem).toBeVisible({ timeout: 10000 });
+  await menuItem.click();
+  await expect(DatabaseViewSelectors.viewTab(page)).toHaveCount(previousCount + 1, { timeout: 30000 });
+  await expect(DatabaseViewSelectors.viewTab(page).filter({ hasText: viewType })).toBeVisible({
+    timeout: 15000,
+  });
+}
+
+async function publishCurrentDatabase(page: Page): Promise<string> {
+  await expect(ShareSelectors.shareButton(page)).toBeVisible({ timeout: 15000 });
+  await ShareSelectors.shareButton(page).click({ force: true });
+
+  const sharePopover = ShareSelectors.sharePopover(page);
+
+  await expect(sharePopover).toBeVisible({ timeout: 10000 });
+  await sharePopover.getByText('Publish', { exact: true }).click({ force: true });
+
+  const publishButton = ShareSelectors.publishConfirmButton(page);
+
+  await expect(publishButton).toBeEnabled({ timeout: 15000 });
+  await publishButton.click({ force: true });
+  await expect(ShareSelectors.publishNamespace(page)).toBeVisible({ timeout: 30000 });
+
+  const namespace = ((await ShareSelectors.publishNamespace(page).textContent()) ?? '').trim();
+  const publishName = (await ShareSelectors.publishNameInput(page).inputValue()).trim();
+
+  expect(namespace, 'Expected a publish namespace').not.toBe('');
+  expect(publishName, 'Expected a publish name').not.toBe('');
+
+  const publishedUrl = `${new URL(page.url()).origin}/${namespace}/${publishName}`;
+
+  await page.keyboard.press('Escape');
+  return publishedUrl;
+}
+
+async function databaseViewLabels(page: Page): Promise<string[]> {
+  const labels = await DatabaseViewSelectors.viewTab(page).allInnerTexts();
+
+  return labels.map((label) => label.trim());
+}
+
+function requireState(page: Page): PublishedTemplateState {
+  const state = stateByPage.get(page);
+
+  if (!state) {
+    throw new Error('Published database template scenario state is missing');
+  }
+
+  return state;
+}
+
+function requirePublishedUrl(state: PublishedTemplateState): string {
+  if (!state.publishedUrl) {
+    throw new Error('The database has not been published');
+  }
+
+  return state.publishedUrl;
+}
+
+function requireConsumerPage(state: PublishedTemplateState): Page {
+  if (!state.consumerPage) {
+    throw new Error('The consumer account has not duplicated the template');
+  }
+
+  return state.consumerPage;
+}

--- a/src/components/app/hooks/__tests__/usePageOperations.publish.test.tsx
+++ b/src/components/app/hooks/__tests__/usePageOperations.publish.test.tsx
@@ -136,6 +136,52 @@ describe('usePageOperations publish', () => {
     expect(getDatabaseIdForViewId).not.toHaveBeenCalled();
     expect(gatherDatabasePublishData).toHaveBeenCalledWith(viewId, undefined, databaseId);
   });
+
+  it('publishes metadata for visible database views under a database container', async () => {
+    const containerViewId = 'database-container-id';
+    const gridViewId = 'grid-view-id';
+    const databaseId = 'database-id';
+    const gridView = createView({
+      view_id: gridViewId,
+      name: 'Grid',
+      layout: ViewLayout.Grid,
+      extra: { is_space: false, database_id: databaseId },
+    });
+    const containerView = createView({
+      view_id: containerViewId,
+      name: 'Publish database',
+      layout: ViewLayout.Grid,
+      extra: { is_space: false, database_id: databaseId, is_database_container: true },
+      children: [gridView],
+    });
+    const { result, workspaceId } = renderUsePageOperations();
+
+    await act(async () => {
+      await result.current.publish(containerView, undefined, [containerViewId, gridViewId]);
+    });
+
+    expect(gatherDatabasePublishData).toHaveBeenCalledWith(
+      containerViewId,
+      [containerViewId, gridViewId],
+      databaseId
+    );
+    expect(publishCollabs).toHaveBeenCalledWith(workspaceId, [
+      expect.objectContaining({
+        meta: expect.objectContaining({
+          view_id: containerViewId,
+          metadata: expect.objectContaining({
+            child_views: [
+              expect.objectContaining({
+                view_id: gridViewId,
+                name: 'Grid',
+                layout: ViewLayout.Grid,
+              }),
+            ],
+          }),
+        }),
+      }),
+    ]);
+  });
 });
 
 describe('usePageOperations addPage', () => {

--- a/src/components/app/hooks/usePageOperations.ts
+++ b/src/components/app/hooks/usePageOperations.ts
@@ -430,23 +430,32 @@ export function usePageOperations({
           return isNaN(t) ? 0 : Math.floor(t / 1000);
         };
 
+        const toPublishViewInfo = (publishView: View): PublishCollabMetadata['metadata']['view'] => ({
+          view_id: publishView.view_id,
+          name: publishView.name,
+          icon: publishView.icon,
+          layout: publishView.layout,
+          extra: publishView.extra
+            ? typeof publishView.extra === 'string'
+              ? publishView.extra
+              : JSON.stringify(publishView.extra)
+            : null,
+          created_by: null,
+          last_edited_by: null,
+          last_edited_time: toTimestamp(publishView.last_edited_time),
+          created_at: toTimestamp(publishView.created_at),
+          child_views: null,
+        });
+        const visibleViewIdSet = new Set(resolvedVisibleViewIds ?? []);
+
         const meta: PublishCollabMetadata = {
           view_id: viewId,
           publish_name: name,
           metadata: {
-            view: {
-              view_id: viewId,
-              name: view.name,
-              icon: view.icon,
-              layout: view.layout,
-              extra: view.extra ? (typeof view.extra === 'string' ? view.extra : JSON.stringify(view.extra)) : null,
-              created_by: null,
-              last_edited_by: null,
-              last_edited_time: toTimestamp(view.last_edited_time),
-              created_at: toTimestamp(view.created_at),
-              child_views: null,
-            },
-            child_views: [],
+            view: toPublishViewInfo(view),
+            child_views: view.children
+              .filter((child) => visibleViewIdSet.has(child.view_id))
+              .map(toPublishViewInfo),
             ancestor_views: [],
           },
         };


### PR DESCRIPTION
## Summary

- include PublishViewInfo for visible database children when publishing a database container
- use the same metadata serialization for the root and child database views
- add a Playwright-BDD regression scenario that publishes Grid + Board, signs in as a different account, starts with the template, and verifies both views and row data

Without child metadata, the duplication API receives visible view IDs that it cannot resolve and returns metadata not found for the Grid view.

## Verification

- pnpm exec jest src/components/app/hooks/__tests__/usePageOperations.publish.test.tsx --runInBand --no-coverage (4 passed)
- pnpm exec bddgen test -c playwright.bdd.config.ts
- Playwright-BDD scenario: Another account duplicates a database container with multiple views (1 passed)
- git diff --check

Companion server compatibility fix: AppFlowy-IO/AppFlowy-Cloud-Premium#965