### PR TITLE
fix: stabilize collaborator avatar order

### DIFF
--- a/src/application/awareness/__tests__/selector.test.tsx
+++ b/src/application/awareness/__tests__/selector.test.tsx
@@ -1,0 +1,114 @@
+import { act, renderHook } from '@testing-library/react';
+import { Awareness } from 'y-protocols/awareness';
+
+import { useUsersSelector } from '@/application/awareness/selector';
+import { AwarenessState } from '@/application/awareness/types';
+
+jest.mock('@/application/services/domains', () => ({
+  CollabService: {
+    getDeviceId: () => 'local-device',
+  },
+}));
+
+const createState = ({
+  deviceId,
+  name,
+  timestamp,
+  uid,
+  uuid,
+}: {
+  deviceId: string;
+  name: string;
+  timestamp: number;
+  uid: number;
+  uuid?: string;
+}): AwarenessState => ({
+  version: 1,
+  timestamp,
+  user: {
+    uid,
+    device_id: deviceId,
+  },
+  metadata: JSON.stringify({
+    user_name: name,
+    cursor_color: '',
+    selection_color: '',
+    user_avatar: '',
+    user_uuid: uuid,
+  }),
+});
+
+const createAwarenessHarness = (initialStates: Array<[number, AwarenessState]>) => {
+  const states = new Map(initialStates);
+  const changeListeners = new Set<() => void>();
+  const awareness = {
+    getStates: () => states,
+    on: (event: string, listener: () => void) => {
+      if (event === 'change') changeListeners.add(listener);
+    },
+    off: (event: string, listener: () => void) => {
+      if (event === 'change') changeListeners.delete(listener);
+    },
+  } as unknown as Awareness;
+
+  return {
+    awareness,
+    emitChange: () => changeListeners.forEach((listener) => listener()),
+    states,
+  };
+};
+
+describe('useUsersSelector', () => {
+  it('keeps avatar order stable when awareness timestamps change', () => {
+    const alpha = createState({
+      deviceId: 'device-alpha',
+      name: 'Alpha',
+      timestamp: 10,
+      uid: 1,
+      uuid: 'user-a',
+    });
+    const bravo = createState({
+      deviceId: 'device-bravo',
+      name: 'Bravo',
+      timestamp: 30,
+      uid: 2,
+      uuid: 'user-b',
+    });
+    const charlie = createState({
+      deviceId: 'device-charlie',
+      name: 'Charlie',
+      timestamp: 20,
+      uid: 3,
+      uuid: 'user-c',
+    });
+    const harness = createAwarenessHarness([
+      [101, charlie],
+      [102, alpha],
+      [103, bravo],
+    ]);
+    const { result } = renderHook(() => useUsersSelector(harness.awareness));
+
+    expect(result.current.map((user) => user.name)).toEqual(['Alpha', 'Bravo', 'Charlie']);
+
+    harness.states.set(101, { ...charlie, timestamp: 40 });
+    harness.states.set(102, { ...alpha, timestamp: 50 });
+    act(harness.emitChange);
+
+    expect(result.current.map((user) => user.name)).toEqual(['Alpha', 'Bravo', 'Charlie']);
+  });
+
+  it('uses the newest state when the same user has multiple devices', () => {
+    const harness = createAwarenessHarness([
+      [101, createState({ deviceId: 'old-device', name: 'Old profile', timestamp: 10, uid: 1, uuid: 'user-a' })],
+      [102, createState({ deviceId: 'new-device', name: 'New profile', timestamp: 20, uid: 1, uuid: 'user-a' })],
+    ]);
+    const { result } = renderHook(() => useUsersSelector(harness.awareness));
+
+    expect(result.current).toHaveLength(1);
+    expect(result.current[0]).toMatchObject({
+      device_id: 'new-device',
+      name: 'New profile',
+      timestamp: 20,
+    });
+  });
+});

--- a/src/application/awareness/selector.ts
+++ b/src/application/awareness/selector.ts
@@ -24,6 +24,38 @@ const getAwarenessIdentityKey = (uuid: string | undefined, uid: number, deviceId
   return `device:${deviceId}`;
 };
 
+const compareAwarenessIdentities = (aIdentity: string, bIdentity: string) => {
+  if (aIdentity === bIdentity) {
+    return 0;
+  }
+
+  return aIdentity < bIdentity ? -1 : 1;
+};
+
+const getUniqueUsersInStableOrder = (users: AwarenessUser[]) => {
+  const latestUsersByIdentity = new Map<string, AwarenessUser>();
+
+  for (const user of users) {
+    const identity = getAwarenessIdentityKey(user.uuid, user.uid, user.device_id);
+    const latestUser = latestUsersByIdentity.get(identity);
+
+    if (!latestUser || user.timestamp > latestUser.timestamp) {
+      latestUsersByIdentity.set(identity, user);
+    }
+  }
+
+  const namedUsers: Array<[string, AwarenessUser]> = [];
+
+  for (const userEntry of latestUsersByIdentity.entries()) {
+    if (userEntry[1].name) namedUsers.push(userEntry);
+  }
+
+  // Activity timestamps select the newest duplicate, but must not influence avatar positions.
+  return namedUsers
+    .sort(([aIdentity], [bIdentity]) => compareAwarenessIdentities(aIdentity, bIdentity))
+    .map(([, user]) => user);
+};
+
 const getNormalizedMetadata = (rawMetadata?: string): AwarenessMetadata | null => {
   if (!rawMetadata) {
     return null;
@@ -81,12 +113,7 @@ export function useUsersSelector(awareness?: Awareness) {
         });
       });
 
-      setUsers(
-        uniqBy(
-          users.sort((a, b) => b.timestamp - a.timestamp),
-          (user) => getAwarenessIdentityKey(user.uuid, user.uid, user.device_id)
-        ).filter((user) => !!user.name)
-      );
+      setUsers(getUniqueUsersInStableOrder(users));
     };
 
     renderUsers();


### PR DESCRIPTION
## Summary

- keep collaborator avatars in a deterministic order when awareness timestamps update
- continue selecting the newest awareness state when one user has multiple devices
- add regression coverage for stable ordering and multi-device deduplication

## Root cause

`useUsersSelector` sorted the full collaborator list by descending activity timestamp. Cursor and selection updates refresh that timestamp, so whichever collaborator moved most recently was continuously promoted to the front of the avatar stack.

## Impact

Active editing no longer reshuffles the visible avatar stack or changes which collaborators appear behind the overflow counter.

## Validation

- `pnpm type-check`
- `pnpm exec jest src/application/awareness/__tests__/selector.test.tsx --runInBand --coverage=false`
- ESLint and Prettier checks on the changed files
- live browser reproduction with five synthetic awareness clients; the avatar order remained unchanged after multiple timestamp updates

## Summary by Sourcery

Stabilize collaborator avatar ordering while still preferring the newest awareness state per user and add regression tests for these behaviors.

New Features:
- Ensure collaborator avatars are derived from the latest awareness state per identity while maintaining a deterministic display order.

Bug Fixes:
- Prevent collaborator avatar positions from reshuffling when awareness activity timestamps change.

Tests:
- Add unit tests covering stable avatar ordering across timestamp updates and selection of the newest state for multi-device users.