### PR TITLE
Render source names for inline AI citations

### DIFF
--- a/src/components/chat/components/chat-messages/__tests__/answer-md.test.tsx
+++ b/src/components/chat/components/chat-messages/__tests__/answer-md.test.tsx
@@ -1,0 +1,36 @@
+import { render, waitFor } from '@testing-library/react';
+
+import { AnswerMd } from '@/components/chat/components/chat-messages/answer-md';
+import type { ResolvedMessageSource } from '@/components/chat/components/chat-messages/message-sources';
+
+const mockApplyMarkdown = jest.fn();
+
+jest.mock('@appflowyinc/editor', () => ({
+  Editor: () => <div data-testid='answer-editor' />,
+  useEditor: () => ({ applyMarkdown: mockApplyMarkdown }),
+}));
+
+describe('AnswerMd', () => {
+  beforeEach(() => {
+    mockApplyMarkdown.mockClear();
+  });
+
+  it('applies citation-resolved markdown to the editor', async () => {
+    const sources: ResolvedMessageSource[] = [
+      {
+        metadata: {
+          citation_id: 'W2',
+          id: 'https://example.com/kanban',
+          name: 'https://example.com/kanban',
+          source: 'web',
+          title: 'Kanban Guide',
+        },
+        label: 'Kanban Guide',
+      },
+    ];
+
+    render(<AnswerMd mdContent='Use a pull system [W2].' sources={sources} />);
+
+    await waitFor(() => expect(mockApplyMarkdown).toHaveBeenCalledWith('Use a pull system 【Kanban Guide】.'));
+  });
+});

--- a/src/components/chat/components/chat-messages/__tests__/citation-markdown.test.ts
+++ b/src/components/chat/components/chat-messages/__tests__/citation-markdown.test.ts
@@ -1,0 +1,53 @@
+import { resolveCitationMarkdown } from '@/components/chat/components/chat-messages/citation-markdown';
+import type { ResolvedMessageSource } from '@/components/chat/components/chat-messages/message-sources';
+
+function source(citationId: string | undefined, label: string): ResolvedMessageSource {
+  return {
+    metadata: {
+      citation_id: citationId,
+      id: citationId || label,
+      name: label,
+      source: 'appflowy',
+    },
+    label,
+  };
+}
+
+describe('citation markdown', () => {
+  it('replaces single, adjacent, and doubled citation markers with source names', () => {
+    const markdown = 'First claim [W1][A2].\n\n[[W1]]';
+
+    expect(resolveCitationMarkdown(markdown, [source('W1', 'Kanban Guide'), source('A2', 'Workflow Policies')])).toBe(
+      'First claim 【Kanban Guide】【Workflow Policies】.\n\n【Kanban Guide】'
+    );
+  });
+
+  it('matches complete citation IDs and leaves unknown markers unchanged', () => {
+    const markdown = '[W1] [W10] [W2]';
+
+    expect(resolveCitationMarkdown(markdown, [source('W1', 'First source'), source('W10', 'Tenth source')])).toBe(
+      '【First source】 【Tenth source】 [W2]'
+    );
+  });
+
+  it('does not replace citation examples inside inline or block code', () => {
+    const markdown = ['Use [A1].', '', '`[A1]` and ``[A1]``', '', '```text', '[A1]', '```', '', '    [A1]'].join('\n');
+
+    expect(resolveCitationMarkdown(markdown, [source('A1', 'Getting Started')])).toBe(
+      ['Use 【Getting Started】.', '', '`[A1]` and ``[A1]``', '', '```text', '[A1]', '```', '', '    [A1]'].join('\n')
+    );
+  });
+
+  it('neutralizes markdown control characters in untrusted source titles', () => {
+    const label = 'Guide [draft](url) *one* _two_ `code` {x}|y\\z';
+
+    expect(resolveCitationMarkdown('[W1]', [source('W1', label)])).toBe(
+      '【Guide ［draft］（url） ∗one∗ ＿two＿ ˋcodeˋ ｛x｝｜y＼z】'
+    );
+  });
+
+  it('returns the original markdown when no citation metadata is available', () => {
+    expect(resolveCitationMarkdown('Keep [W1].', [source(undefined, 'No citation')])).toBe('Keep [W1].');
+    expect(resolveCitationMarkdown('Keep [W1].', [])).toBe('Keep [W1].');
+  });
+});

--- a/src/components/chat/components/chat-messages/ai-answer.tsx
+++ b/src/components/chat/components/chat-messages/ai-answer.tsx
@@ -4,7 +4,7 @@ import { ChatMessageMetadata } from '@/components/chat/types';
 
 import { AnswerMd } from '../chat-messages/answer-md';
 import { MessageActions } from '../chat-messages/message-actions';
-import MessageSources from '../chat-messages/message-sources';
+import { ResolvedMessageSources, useResolvedMessageSources } from '../chat-messages/message-sources';
 
 import MessageCheckbox from './message-checkbox';
 
@@ -19,17 +19,17 @@ export function AIAnswer({
   sources?: ChatMessageMetadata[];
   isHovered: boolean;
 }) {
+  const resolvedSources = useResolvedMessageSources(sources);
+
   return (
     <div className={`chat-message flex flex-col w-full pl-0.5 relative`}>
       <div className={'flex gap-2 w-full overflow-hidden py-1'}>
         <MessageCheckbox id={id} />
         <EditorProvider>
-          <AnswerMd id={id} mdContent={content} />
+          <AnswerMd id={id} mdContent={content} sources={resolvedSources} />
         </EditorProvider>
       </div>
-      {sources && sources.length > 0 ? (
-        <MessageSources sources={sources} />
-      ) : null}
+      {resolvedSources.length > 0 ? <ResolvedMessageSources sources={resolvedSources} /> : null}
       <MessageActions id={id} isHovered={isHovered} />
     </div>
   );

--- a/src/components/chat/components/chat-messages/answer-md.tsx
+++ b/src/components/chat/components/chat-messages/answer-md.tsx
@@ -1,9 +1,14 @@
 import { AppFlowyEditor, Editor, useEditor } from '@appflowyinc/editor';
-import { useEffect } from 'react';
+import { useEffect, useMemo } from 'react';
 import { ErrorBoundary } from 'react-error-boundary';
 
 import { Alert, AlertDescription } from '@/components/chat/components/ui/alert';
 import { useEditorContext } from '@/components/chat/provider/editor-provider';
+
+import { resolveCitationMarkdown } from './citation-markdown';
+import type { ResolvedMessageSource } from './message-sources';
+
+const EMPTY_RESOLVED_SOURCES: ResolvedMessageSource[] = [];
 
 function RegisterMessageEditor({ editor, id }: { editor: AppFlowyEditor; id: number }) {
   const { setEditor: setMessageEditor } = useEditorContext();
@@ -15,18 +20,27 @@ function RegisterMessageEditor({ editor, id }: { editor: AppFlowyEditor; id: num
   return null;
 }
 
-export function AnswerMd({ mdContent, id }: { mdContent: string; id?: number }) {
+export function AnswerMd({
+  mdContent,
+  id,
+  sources = EMPTY_RESOLVED_SOURCES,
+}: {
+  mdContent: string;
+  id?: number;
+  sources?: ResolvedMessageSource[];
+}) {
   const editor = useEditor();
+  const renderedContent = useMemo(() => resolveCitationMarkdown(mdContent, sources), [mdContent, sources]);
 
   useEffect(() => {
-    if (!mdContent) return;
+    if (!renderedContent) return;
 
     try {
-      editor.applyMarkdown(mdContent);
+      editor.applyMarkdown(renderedContent);
     } catch (error) {
       console.error('Failed to apply markdown', error);
     }
-  }, [editor, mdContent]);
+  }, [editor, renderedContent]);
 
   return (
     <>

--- a/src/components/chat/components/chat-messages/assistant-message.tsx
+++ b/src/components/chat/components/chat-messages/assistant-message.tsx
@@ -13,7 +13,7 @@ import { ChatInputMode } from '@/components/chat/types';
 
 import { AnswerMd } from '../chat-messages/answer-md';
 import { MessageActions } from '../chat-messages/message-actions';
-import MessageSources from '../chat-messages/message-sources';
+import { ResolvedMessageSources, useResolvedMessageSources } from '../chat-messages/message-sources';
 import { MessageSuggestions } from '../chat-messages/message-suggestions';
 
 import MessageCheckbox from './message-checkbox';
@@ -32,6 +32,7 @@ export function AssistantMessage({ id, isHovered }: { id: number; isHovered: boo
 
   const questionId = id - 1;
   const sources = message?.meta_data;
+  const resolvedSources = useResolvedMessageSources(sources);
 
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<boolean>(false);
@@ -129,12 +130,12 @@ export function AssistantMessage({ id, isHovered }: { id: number; isHovered: boo
           <div className={'flex w-full gap-2 overflow-hidden py-1 pl-0.5'}>
             <MessageCheckbox id={id} />
             <EditorProvider>
-              <AnswerMd id={id} mdContent={content} />
+              <AnswerMd id={id} mdContent={content} sources={resolvedSources} />
             </EditorProvider>
           </div>
         )
       )}
-      {sources && sources.length > 0 ? <MessageSources sources={sources} /> : null}
+      {resolvedSources.length > 0 ? <ResolvedMessageSources sources={resolvedSources} /> : null}
       {done && <MessageActions id={id} isHovered={isHovered} />}
       {suggestions && suggestions.items.length > 0 ? <MessageSuggestions suggestions={suggestions} /> : null}
     </div>

--- a/src/components/chat/components/chat-messages/citation-markdown.ts
+++ b/src/components/chat/components/chat-messages/citation-markdown.ts
@@ -1,0 +1,140 @@
+import type { ResolvedMessageSource } from './message-sources';
+
+const MARKDOWN_CONTROL_CHARACTERS: Record<string, string> = {
+  '\\': '＼',
+  '`': 'ˋ',
+  '*': '∗',
+  _: '＿',
+  '[': '［',
+  ']': '］',
+  '(': '（',
+  ')': '）',
+  '{': '｛',
+  '}': '｝',
+  '|': '｜',
+};
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function formatCitationLabel(label: string): string {
+  const normalized = label
+    .trim()
+    .replace(/\s+/g, ' ')
+    .replace(/[\\`*_(){}|[\]]/g, (character) => MARKDOWN_CONTROL_CHARACTERS[character] || character);
+
+  return `【${normalized}】`;
+}
+
+function isEscaped(value: string, index: number): boolean {
+  let slashCount = 0;
+
+  for (let cursor = index - 1; cursor >= 0 && value[cursor] === '\\'; cursor -= 1) {
+    slashCount += 1;
+  }
+
+  return slashCount % 2 === 1;
+}
+
+function replaceOutsideInlineCode(value: string, replaceText: (text: string) => string): string {
+  let output = '';
+  let segmentStart = 0;
+  let delimiterLength = 0;
+  let cursor = 0;
+
+  while (cursor < value.length) {
+    if (value[cursor] !== '`' || isEscaped(value, cursor)) {
+      cursor += 1;
+      continue;
+    }
+
+    let runEnd = cursor + 1;
+
+    while (runEnd < value.length && value[runEnd] === '`') {
+      runEnd += 1;
+    }
+
+    const runLength = runEnd - cursor;
+
+    if (delimiterLength === 0) {
+      output += replaceText(value.slice(segmentStart, cursor));
+      output += value.slice(cursor, runEnd);
+      delimiterLength = runLength;
+      segmentStart = runEnd;
+    } else if (runLength === delimiterLength) {
+      output += value.slice(segmentStart, runEnd);
+      delimiterLength = 0;
+      segmentStart = runEnd;
+    }
+
+    cursor = runEnd;
+  }
+
+  output += delimiterLength === 0 ? replaceText(value.slice(segmentStart)) : value.slice(segmentStart);
+
+  return output;
+}
+
+function replaceOutsideCodeBlocks(markdown: string, replaceText: (text: string) => string): string {
+  const lines = markdown.match(/[^\n]*(?:\n|$)/g) || [];
+  let fenceCharacter = '';
+  let fenceLength = 0;
+
+  return lines
+    .filter((line, index) => line.length > 0 || index < lines.length - 1)
+    .map((lineWithEnding) => {
+      const hasLineEnding = lineWithEnding.endsWith('\n');
+      const line = hasLineEnding ? lineWithEnding.slice(0, -1) : lineWithEnding;
+      const fenceMatch = line.match(/^[ \t]{0,3}(`{3,}|~{3,})/);
+
+      if (fenceCharacter) {
+        const closingFence = line.match(/^[ \t]{0,3}(`{3,}|~{3,})[ \t]*$/);
+
+        if (closingFence && closingFence[1][0] === fenceCharacter && closingFence[1].length >= fenceLength) {
+          fenceCharacter = '';
+          fenceLength = 0;
+        }
+
+        return lineWithEnding;
+      }
+
+      if (fenceMatch) {
+        fenceCharacter = fenceMatch[1][0];
+        fenceLength = fenceMatch[1].length;
+        return lineWithEnding;
+      }
+
+      if (/^(?: {4}|\t)/.test(line)) {
+        return lineWithEnding;
+      }
+
+      const replacedLine = replaceOutsideInlineCode(line, replaceText);
+
+      return hasLineEnding ? `${replacedLine}\n` : replacedLine;
+    })
+    .join('');
+}
+
+export function resolveCitationMarkdown(markdown: string, sources: ResolvedMessageSource[]): string {
+  if (!markdown || sources.length === 0) return markdown;
+
+  const labelByCitationId = new Map<string, string>();
+
+  sources.forEach(({ metadata, label }) => {
+    const citationId = metadata.citation_id?.trim();
+
+    if (citationId && !labelByCitationId.has(citationId)) {
+      labelByCitationId.set(citationId, formatCitationLabel(label || citationId));
+    }
+  });
+
+  if (labelByCitationId.size === 0) return markdown;
+
+  const citationIds = Array.from(labelByCitationId.keys()).sort((left, right) => right.length - left.length);
+  const citationPattern = new RegExp(`\\[\\[?(${citationIds.map(escapeRegExp).join('|')})\\]\\]?`, 'g');
+
+  return replaceOutsideCodeBlocks(markdown, (text) =>
+    text.replace(citationPattern, (marker, citationId: string) => labelByCitationId.get(citationId) || marker)
+  );
+}

--- a/src/components/chat/components/chat-messages/message-sources.tsx
+++ b/src/components/chat/components/chat-messages/message-sources.tsx
@@ -9,6 +9,13 @@ import { ChatMessageMetadata } from '@/components/chat/types';
 import { Button } from '@/components/ui/button';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 
+const EMPTY_MESSAGE_SOURCES: ChatMessageMetadata[] = [];
+
+export interface ResolvedMessageSource {
+  metadata: ChatMessageMetadata;
+  label: string;
+}
+
 export function getMessageSourceLabel(source: ChatMessageMetadata): string {
   return source.title?.trim() || source.name.trim() || source.id;
 }
@@ -37,23 +44,21 @@ export function getAppFlowySourceTarget(source: ChatMessageMetadata): { viewId: 
   };
 }
 
-function MessageSources({ sources }: { sources: ChatMessageMetadata[] }) {
+export function useResolvedMessageSources(sources?: ChatMessageMetadata[]): ResolvedMessageSource[] {
   const { getView } = useViewLoader();
-  const { onOpenView } = useChatContext();
-  const { t } = useTranslation();
-  const [expanded, setExpanded] = useState(true);
+  const sourceList = sources ?? EMPTY_MESSAGE_SOURCES;
   const [viewNames, setViewNames] = useState<Record<string, string>>({});
 
   const appflowySourceIds = useMemo(
     () =>
       Array.from(
         new Set(
-          sources
+          sourceList
             .filter((source) => isAppFlowySource(source) && !source.title?.trim())
             .map((source) => getAppFlowySourceTarget(source).viewId)
         )
       ),
-    [sources]
+    [sourceList]
   );
 
   useEffect(() => {
@@ -81,6 +86,25 @@ function MessageSources({ sources }: { sources: ChatMessageMetadata[] }) {
     };
   }, [appflowySourceIds, getView]);
 
+  return useMemo(
+    () =>
+      sourceList.map((metadata) => {
+        const appflowyTarget = isAppFlowySource(metadata) ? getAppFlowySourceTarget(metadata) : undefined;
+        const sourceLabel = getMessageSourceLabel(metadata);
+        const label =
+          (metadata.title?.trim() ? sourceLabel : appflowyTarget && viewNames[appflowyTarget.viewId]) || sourceLabel;
+
+        return { metadata, label };
+      }),
+    [sourceList, viewNames]
+  );
+}
+
+export function ResolvedMessageSources({ sources }: { sources: ResolvedMessageSource[] }) {
+  const { onOpenView } = useChatContext();
+  const { t } = useTranslation();
+  const [expanded, setExpanded] = useState(true);
+
   return (
     <div className={'flex flex-col pb-2 max-sm:hidden'}>
       <Button
@@ -98,19 +122,15 @@ function MessageSources({ sources }: { sources: ChatMessageMetadata[] }) {
       </Button>
       {expanded ? (
         <div className={'flex flex-wrap items-start gap-2'}>
-          {sources.map((source) => {
+          {sources.map(({ metadata: source, label }) => {
             const webUrl = getSafeWebSourceUrl(source);
             const appflowyTarget = isAppFlowySource(source) ? getAppFlowySourceTarget(source) : undefined;
-            const sourceLabel = getMessageSourceLabel(source);
-            const label =
-              (source.title?.trim() ? sourceLabel : appflowyTarget && viewNames[appflowyTarget.viewId]) ||
-              sourceLabel ||
-              t('chat.view.placeholder');
+            const displayLabel = label || t('chat.view.placeholder');
             const key = `${source.source}:${source.id}:${source.database_row_id || ''}`;
             const content = (
               <>
                 {source.source === 'web' ? <ExternalLink className={'h-4 w-4'} /> : <DocumentIcon />}
-                <span className={'truncate text-foreground'}>{label}</span>
+                <span className={'truncate text-foreground'}>{displayLabel}</span>
               </>
             );
 
@@ -144,7 +164,7 @@ function MessageSources({ sources }: { sources: ChatMessageMetadata[] }) {
                     </Button>
                   )}
                 </TooltipTrigger>
-                <TooltipContent>{label}</TooltipContent>
+                <TooltipContent>{displayLabel}</TooltipContent>
               </Tooltip>
             );
           })}
@@ -152,6 +172,12 @@ function MessageSources({ sources }: { sources: ChatMessageMetadata[] }) {
       ) : null}
     </div>
   );
+}
+
+function MessageSources({ sources }: { sources: ChatMessageMetadata[] }) {
+  const resolvedSources = useResolvedMessageSources(sources);
+
+  return <ResolvedMessageSources sources={resolvedSources} />;
 }
 
 export default MessageSources;


### PR DESCRIPTION
## Summary

- resolve inline citation markers such as `[W2]` and `[A1]` to their human-readable source names before rendering AI answers
- share resolved source labels between the answer body and the source cards
- preserve unknown citations and citation examples inside inline or fenced code
- sanitize source labels before inserting them into Markdown

## Root cause

AI answer Markdown was passed directly to the editor with request-scoped citation IDs intact. Source metadata was rendered separately in the source-card list, but it was never correlated with the inline markers.

## User impact

AI answers now display citations such as `【Kanban Guide】` instead of internal identifiers such as `[W2]`, while existing source-card navigation remains unchanged.

## Validation

- `pnpm exec jest src/components/chat --runInBand --no-coverage` — 17 suites, 208 tests passed
- `pnpm type-check`
- targeted ESLint for the changed chat-message files
- `pnpm build`

## Summary by Sourcery

Resolve inline AI citation markers to human-readable source labels and ensure consistent citation rendering between answer content and source cards while preserving code examples.

New Features:
- Derive and share resolved source labels from message metadata for use in both inline citations and source cards.
- Introduce citation-aware markdown processing that replaces internal citation IDs with sanitized, human-readable labels outside of code regions.

Enhancements:
- Refactor message source handling to compute resolved sources via a reusable hook and pass them through rendering components.

Tests:
- Add unit tests for citation markdown resolution, including handling of unknown markers, code blocks, and markdown control characters.
- Add a unit test for the answer markdown component to verify that citation-resolved markdown is applied to the editor.