### PR TITLE
fix(publish): preserve related database templates

### DIFF
--- a/playwright/bdd/features/database/published-relation-template.feature
+++ b/playwright/bdd/features/database/published-relation-template.feature
@@ -19,6 +19,7 @@ Feature: Published database templates preserve relations
     When that account starts with the relation template in "General"
     Then the destination space request uses depth 2
     And the relation template duplication contains 2 database mappings
+    And the duplicated relation database is named "Related DB"
     And the duplicated relation cell shows "Related DB content"
     And the duplicated relation cell does not show "No access"
     When I clear the duplication mappings and reload the duplicated relation template

--- a/playwright/bdd/features/database/published-relation-template.feature
+++ b/playwright/bdd/features/database/published-relation-template.feature
@@ -1,0 +1,23 @@
+@published-relation-template @mode:serial
+Feature: Published database templates preserve relations
+  This scenario reuses the `pdf_db_relation@appflowy.io` fixture documented in
+  `AppFlowy-Cloud-Premium/backup/README.md`. Its `New Database` Grid has a
+  Relation field that points to `Related DB`, whose row title is
+  `Related DB content`. The matching server regression fixture is documented in
+  `tests/workspace/publish/duplication_test.rs` by
+  `publishing_only_database_with_relation_includes_related_database_in_template`.
+
+  Background:
+    Given the seeded relation template fixture exists
+
+  Scenario: Another account starts with a published database that has a relation
+    Given I sign in as the relation template fixture publisher
+    And the seeded relation cell resolves before publishing
+    When I publish only the seeded source database as a template
+    And another account opens the published relation template
+    Then the published relation cell shows "Related DB content"
+    When that account starts with the relation template in "General"
+    Then the destination space request uses depth 2
+    And the relation template duplication contains 2 database mappings
+    And the duplicated relation cell shows "Related DB content"
+    And the duplicated relation cell does not show "No access"

--- a/playwright/bdd/features/database/published-relation-template.feature
+++ b/playwright/bdd/features/database/published-relation-template.feature
@@ -21,3 +21,6 @@ Feature: Published database templates preserve relations
     And the relation template duplication contains 2 database mappings
     And the duplicated relation cell shows "Related DB content"
     And the duplicated relation cell does not show "No access"
+    When I reload the duplicated relation template without its mapping query
+    Then the duplicated relation cell shows "Related DB content"
+    And the duplicated relation cell does not show "No access"

--- a/playwright/bdd/features/database/published-relation-template.feature
+++ b/playwright/bdd/features/database/published-relation-template.feature
@@ -21,6 +21,6 @@ Feature: Published database templates preserve relations
     And the relation template duplication contains 2 database mappings
     And the duplicated relation cell shows "Related DB content"
     And the duplicated relation cell does not show "No access"
-    When I reload the duplicated relation template without its mapping query
+    When I clear the duplication mappings and reload the duplicated relation template
     Then the duplicated relation cell shows "Related DB content"
     And the duplicated relation cell does not show "No access"

--- a/playwright/bdd/features/page/published-document-template-dependencies.feature
+++ b/playwright/bdd/features/page/published-document-template-dependencies.feature
@@ -1,0 +1,54 @@
+@published-document-template-dependencies @mode:serial
+Feature: Published document templates preserve referenced content
+  These scenarios reuse the `duplicate@appflowy.io` fixture documented by
+  `AppFlowy-Cloud-Premium/tests/workspace/page_view/duplication_test.rs`.
+  Its `DB 1` database contains `db 1 row 1`, while `DB 2` contains the rows
+  `Row with linked database` and `Row with inline database`; each DB 2 row page
+  contains the corresponding nested database kind. Temporary source documents
+  are created in that fixture workspace and removed during teardown.
+
+  Every scenario publishes only the temporary root document. A newly registered,
+  different account then opens the public page, clicks "Start with this template",
+  adds it to General, and validates the resulting private workspace copy.
+
+  Background:
+    Given I sign in as the seeded document dependency publisher
+
+  Scenario: A document template deep-copies a referenced database view
+    Given a temporary document template contains a referenced view of database "DB 1"
+    And the source referenced database shows "db 1 row 1"
+    When I publish only the temporary document template
+    And a different account starts with the published document template in "General"
+    Then the duplicated referenced database shows "db 1 row 1"
+    And the duplicated referenced database remains available after reload
+
+  Scenario: A document template deep-copies an inline database view
+    Given a temporary document template contains an inline database with identifiable row data
+    When I publish only the temporary document template
+    And a different account starts with the published document template in "General"
+    Then the duplicated inline database has an independent database identity
+    And the duplicated inline database row remains available after reload
+
+  Scenario: A document template deep-copies a referenced page
+    Given a temporary document template contains a reference to another temporary page
+    When I publish only the temporary document template
+    And a different account starts with the published document template in "General"
+    Then the duplicated page reference points to a new accessible page copy
+
+  Scenario: A referenced database preserves a nested referenced database in a row page
+    Given a temporary document template contains a referenced view of nested fixture database "DB 2"
+    And the source referenced database contains nested rows "Row with linked database" and "Row with inline database"
+    When I publish only the temporary document template
+    And a different account starts with the published document template in "General"
+    Then the duplicated referenced database contains nested rows "Row with linked database" and "Row with inline database"
+    And row "Row with linked database" has an available nested referenced database
+    And the nested database in row "Row with linked database" remains available after reload
+
+  Scenario: A referenced database preserves a nested inline database in a row page
+    Given a temporary document template contains a referenced view of nested fixture database "DB 2"
+    And the source referenced database contains nested rows "Row with linked database" and "Row with inline database"
+    When I publish only the temporary document template
+    And a different account starts with the published document template in "General"
+    Then the duplicated referenced database contains nested rows "Row with linked database" and "Row with inline database"
+    And row "Row with inline database" has an available nested inline database
+    And the nested database in row "Row with inline database" remains available after reload

--- a/playwright/bdd/steps/published-document-template-dependencies.steps.ts
+++ b/playwright/bdd/steps/published-document-template-dependencies.steps.ts
@@ -1,0 +1,941 @@
+import { APIRequestContext, BrowserContext, expect, Locator, Page } from '@playwright/test';
+import { createBdd } from 'playwright-bdd';
+
+import { signInAndWaitForApp, signInWithPasswordViaUi } from '../../support/auth-flow-helpers';
+import {
+  databaseBlocks,
+  editFirstGridCell,
+  editorForView,
+  firstGridCellText,
+  insertInlineGridViaSlash,
+  insertLinkedGridViaSlash,
+} from '../../support/duplicate-test-helpers';
+import { closeRowDetailWithEscape } from '../../support/row-detail-helpers';
+import { ShareSelectors, SidebarSelectors } from '../../support/selectors';
+import { generateRandomEmail, setupPageErrorHandling, TestConfig } from '../../support/test-config';
+
+const { Given, When, Then, Before, After } = createBdd();
+
+const FIXTURE_EMAIL = 'duplicate@appflowy.io';
+const FIXTURE_PASSWORD = 'AppFlowy!@123';
+const PERMANENTLY_DELETED_TEXT = 'This referenced database was permanently deleted';
+const NO_ACCESS_TEXT = 'No access';
+const NO_PERMISSION_TEXT = "You don't have permission to view this database";
+
+const ViewLayout = {
+  Document: 0,
+} as const;
+
+type ApiResponse<T> = {
+  code?: number;
+  data?: T;
+  message?: string;
+};
+
+type WorkspaceView = {
+  view_id: string;
+  name: string;
+  layout?: number;
+  extra?: {
+    database_id?: string;
+    is_database_container?: boolean;
+  };
+  children?: WorkspaceView[];
+};
+
+type CreatePageResponse = {
+  view_id: string;
+  database_id?: string;
+};
+
+type DuplicateResult = {
+  view_id: string;
+  database_mappings: Record<string, string[]>;
+};
+
+type DatabaseBlockIdentity = {
+  databaseId: string;
+  viewId: string;
+  parentId: string;
+};
+
+type PublishedDocumentTemplateState = {
+  publisherToken?: string;
+  publisherWorkspaceId?: string;
+  publisherGeneralSpaceId?: string;
+  sourceDocumentId?: string;
+  sourceDocumentName?: string;
+  sourceDatabaseIdentity?: DatabaseBlockIdentity;
+  inlineRowMarker?: string;
+  duplicatedInlineRowMarker?: string;
+  referencedPageId?: string;
+  referencedPageName?: string;
+  referencedPageMarker?: string;
+  publishedUrl?: string;
+  consumerContext?: BrowserContext;
+  consumerPage?: Page;
+  consumerToken?: string;
+  consumerWorkspaceId?: string;
+  duplicateResult?: DuplicateResult;
+  publisherRoots: string[];
+  consumerRoots: string[];
+};
+
+const stateByPage = new WeakMap<Page, PublishedDocumentTemplateState>();
+
+Before({ tags: '@published-document-template-dependencies' }, async ({ page }) => {
+  setupPageErrorHandling(page);
+  await page.setViewportSize({ width: 1440, height: 900 });
+  stateByPage.set(page, {
+    publisherRoots: [],
+    consumerRoots: [],
+  });
+});
+
+After({ tags: '@published-document-template-dependencies' }, async ({ page, request }) => {
+  const state = stateByPage.get(page);
+
+  if (!state) return;
+
+  const cleanupErrors: string[] = [];
+
+  await cleanupConsumerCopies(request, state).catch((error) => {
+    cleanupErrors.push(`consumer cleanup: ${errorMessage(error)}`);
+  });
+  await cleanupPublisherPages(request, state).catch((error) => {
+    cleanupErrors.push(`publisher cleanup: ${errorMessage(error)}`);
+  });
+  await state.consumerContext?.close().catch((error) => {
+    cleanupErrors.push(`consumer context cleanup: ${errorMessage(error)}`);
+  });
+
+  stateByPage.delete(page);
+
+  if (cleanupErrors.length > 0) {
+    throw new Error(`Published document template teardown failed:\n${cleanupErrors.join('\n')}`);
+  }
+});
+
+Given('I sign in as the seeded document dependency publisher', async ({ page, request }) => {
+  const state = getState(page);
+
+  // Fixture source:
+  // AppFlowy-Cloud-Premium/tests/workspace/page_view/duplication_test.rs
+  // - duplicate_preconfigured_document_with_linked_and_inline_databases
+  // - duplicate_preconfigured_database_row_docs_preserve_linked_and_inline_semantics
+  await signInWithPasswordViaUi(page, FIXTURE_EMAIL, FIXTURE_PASSWORD, 3000);
+  await expect(page).toHaveURL(/\/app\//, { timeout: 30000 });
+  await expect(SidebarSelectors.pageHeader(page)).toBeVisible({ timeout: 30000 });
+
+  state.publisherToken = await requireAuthToken(page);
+  state.publisherWorkspaceId = workspaceIdFromAppUrl(page.url());
+
+  const workspaceRoot = await getWorkspaceView(
+    request,
+    state.publisherToken,
+    state.publisherWorkspaceId,
+    state.publisherWorkspaceId,
+    2
+  );
+  const generalSpace = workspaceRoot.children?.find((view) => view.name === 'General');
+
+  if (!generalSpace) {
+    throw new Error('The seeded document dependency fixture has no General space');
+  }
+
+  state.publisherGeneralSpaceId = generalSpace.view_id;
+});
+
+Given(
+  'a temporary document template contains a referenced view of database {string}',
+  async ({ page, request }, databaseName: string) => {
+    const state = getState(page);
+    const source = await createTemporaryDocument(page, request, state, 'referenced database');
+
+    await insertLinkedGridViaSlash(page, source.view_id, databaseName);
+
+    const sourceBlock = firstDatabaseBlock(page, source.view_id);
+
+    await expect(sourceBlock).toBeVisible({ timeout: 30000 });
+    state.sourceDatabaseIdentity = await requireDatabaseBlockIdentity(page, source.view_id);
+  }
+);
+
+Given('the source referenced database shows {string}', async ({ page }, expectedRow: string) => {
+  const state = getState(page);
+  const sourceDocumentId = requireValue(state.sourceDocumentId, 'source document id');
+
+  await expect(firstDatabaseBlock(page, sourceDocumentId)).toContainText(expectedRow, { timeout: 60000 });
+});
+
+Given(
+  'a temporary document template contains an inline database with identifiable row data',
+  async ({ page, request }) => {
+    const state = getState(page);
+    const source = await createTemporaryDocument(page, request, state, 'inline database');
+    const marker = `BDD inline template row ${Date.now()}`;
+
+    await insertInlineGridViaSlash(page, source.view_id);
+
+    const sourceBlock = firstDatabaseBlock(page, source.view_id);
+
+    await expect(sourceBlock).toBeVisible({ timeout: 30000 });
+    await editFirstGridCell(page, sourceBlock, marker);
+
+    state.inlineRowMarker = marker;
+    state.sourceDatabaseIdentity = await requireDatabaseBlockIdentity(page, source.view_id);
+
+    // Reload before publishing so this scenario proves the block and row reached
+    // the server rather than duplicating unsaved browser state.
+    await page.reload({ waitUntil: 'domcontentloaded' });
+    await expect(firstDatabaseBlock(page, source.view_id)).toContainText(marker, { timeout: 60000 });
+  }
+);
+
+Given('a temporary document template contains a reference to another temporary page', async ({ page, request }) => {
+  const state = getState(page);
+  const targetName = `BDD referenced page ${Date.now()}`;
+  const targetMarker = `Referenced page body ${Date.now()}`;
+  const target = await createDocumentViaApi(request, state, targetName, targetMarker);
+  const source = await createTemporaryDocument(page, request, state, 'page reference');
+
+  state.referencedPageId = target.view_id;
+  state.referencedPageName = targetName;
+  state.referencedPageMarker = targetMarker;
+  registerPublisherRoot(state, target.view_id);
+
+  const slateEditor = page.locator('[data-slate-editor="true"]').first();
+  const targetUrl = `${new URL(page.url()).origin}/app/${requireValue(
+    state.publisherWorkspaceId,
+    'publisher workspace id'
+  )}/${target.view_id}`;
+
+  await expect(slateEditor).toBeVisible({ timeout: 30000 });
+  await slateEditor.click({ force: true });
+  await page.keyboard.press('End');
+  await page.keyboard.press('Enter');
+  await page.context().grantPermissions(['clipboard-read', 'clipboard-write']);
+  await page.evaluate(async (url) => navigator.clipboard.writeText(url), targetUrl);
+  await page.keyboard.press(`${modifierKey()}+V`);
+
+  const mention = page.locator(`.mention-inline[data-mention-id="${target.view_id}"]`);
+
+  await expect(mention).toBeVisible({ timeout: 30000 });
+  await expect(mention.locator('.mention-content')).toContainText(targetName, { timeout: 30000 });
+
+  // A reload is the persistence boundary used by the template publish below.
+  await page.waitForTimeout(1500);
+  await page.reload({ waitUntil: 'domcontentloaded' });
+  await expect(page.locator(`.mention-inline[data-mention-id="${target.view_id}"]`)).toBeVisible({
+    timeout: 30000,
+  });
+});
+
+Given(
+  'a temporary document template contains a referenced view of nested fixture database {string}',
+  async ({ page, request }, databaseName: string) => {
+    const state = getState(page);
+    const source = await createTemporaryDocument(page, request, state, 'nested referenced database');
+
+    await insertLinkedGridViaSlash(page, source.view_id, databaseName);
+
+    const sourceBlock = firstDatabaseBlock(page, source.view_id);
+
+    await expect(sourceBlock).toBeVisible({ timeout: 30000 });
+    state.sourceDatabaseIdentity = await requireDatabaseBlockIdentity(page, source.view_id);
+  }
+);
+
+Given(
+  'the source referenced database contains nested rows {string} and {string}',
+  async ({ page }, linkedRow: string, inlineRow: string) => {
+    const state = getState(page);
+    const sourceDocumentId = requireValue(state.sourceDocumentId, 'source document id');
+    const sourceBlock = firstDatabaseBlock(page, sourceDocumentId);
+
+    await expect(sourceBlock).toContainText(linkedRow, { timeout: 60000 });
+    await expect(sourceBlock).toContainText(inlineRow, { timeout: 60000 });
+
+    // Validate the seeded precondition so a later failure cannot be attributed
+    // to stale or incomplete fixture data.
+    await expectNestedRowDatabaseAvailable(page, sourceBlock, linkedRow);
+    await closeRowDetailWithEscape(page);
+    await expectNestedRowDatabaseAvailable(page, sourceBlock, inlineRow);
+    await closeRowDetailWithEscape(page);
+  }
+);
+
+When('I publish only the temporary document template', async ({ page }) => {
+  const state = getState(page);
+  const sourceDocumentId = requireValue(state.sourceDocumentId, 'source document id');
+
+  state.publishedUrl = await publishCurrentDocument(
+    page,
+    requireValue(state.publisherWorkspaceId, 'publisher workspace id'),
+    sourceDocumentId
+  );
+});
+
+When(
+  'a different account starts with the published document template in {string}',
+  async ({ page, request, browser }, destinationSpaceName: string) => {
+    const state = getState(page);
+    const publishedUrl = requireValue(state.publishedUrl, 'published URL');
+    const consumerEmail = generateRandomEmail();
+
+    expect(consumerEmail).not.toBe(FIXTURE_EMAIL);
+
+    const consumerContext = await browser.newContext({
+      baseURL: new URL(publishedUrl).origin,
+      viewport: { width: 1440, height: 900 },
+    });
+    const consumerPage = await consumerContext.newPage();
+
+    state.consumerContext = consumerContext;
+    state.consumerPage = consumerPage;
+    setupPageErrorHandling(consumerPage);
+
+    await signInAndWaitForApp(consumerPage, request, consumerEmail);
+
+    state.consumerToken = await requireAuthToken(consumerPage);
+    state.consumerWorkspaceId = workspaceIdFromAppUrl(consumerPage.url());
+
+    const consumerWorkspaceRoot = await getWorkspaceView(
+      request,
+      state.consumerToken,
+      state.consumerWorkspaceId,
+      state.consumerWorkspaceId,
+      2
+    );
+    const destinationSpace = consumerWorkspaceRoot.children?.find((view) => view.name === destinationSpaceName);
+
+    if (!destinationSpace) {
+      throw new Error(`The consumer workspace has no ${destinationSpaceName} space`);
+    }
+
+    await consumerPage.goto(publishedUrl, { waitUntil: 'domcontentloaded' });
+
+    const startWithTemplate = consumerPage.getByRole('button', { name: 'Start with this template' });
+
+    await expect(startWithTemplate).toBeVisible({ timeout: 60000 });
+    await startWithTemplate.click();
+
+    const destinationDialog = consumerPage.getByRole('dialog').filter({ hasText: 'Where would you like to add' }).last();
+
+    await expect(destinationDialog).toBeVisible({ timeout: 30000 });
+
+    const destinationSpaceItem = destinationDialog
+      .getByTestId('space-item')
+      .filter({ hasText: destinationSpaceName })
+      .first();
+
+    await expect(destinationSpaceItem).toBeVisible({ timeout: 30000 });
+    await destinationSpaceItem.click();
+
+    const addButton = destinationDialog.getByRole('button', { name: 'Add', exact: true });
+
+    await expect(addButton).toBeEnabled({ timeout: 15000 });
+
+    const duplicateResponsePromise = consumerPage.waitForResponse(
+      (response) => {
+        const url = new URL(response.url());
+
+        return (
+          response.request().method() === 'POST' &&
+          url.pathname === `/api/workspace/${state.consumerWorkspaceId}/published-duplicate`
+        );
+      },
+      { timeout: 90000 }
+    );
+
+    await addButton.click();
+
+    const duplicateResponse = await duplicateResponsePromise;
+    const responseBody = (await duplicateResponse.json().catch(() => null)) as ApiResponse<DuplicateResult> | null;
+
+    expect(
+      duplicateResponse.ok() && responseBody?.code === 0 && responseBody.data,
+      `Published document template duplication failed with HTTP ${duplicateResponse.status()}: ${JSON.stringify(
+        responseBody
+      )}`
+    ).toBeTruthy();
+
+    state.duplicateResult = responseBody!.data!;
+    state.consumerRoots.push(responseBody!.data!.view_id);
+
+    const openInBrowser = consumerPage.getByRole('button', { name: /Open in browser/i });
+
+    await expect(openInBrowser).toBeVisible({ timeout: 30000 });
+    await openInBrowser.click();
+    await expect(consumerPage).toHaveURL(/\/app\//, { timeout: 30000 });
+    await expect(editorForView(consumerPage, responseBody!.data!.view_id)).toBeVisible({ timeout: 60000 });
+  }
+);
+
+Then('the duplicated referenced database shows {string}', async ({ page }, expectedRow: string) => {
+  const state = getState(page);
+  const consumerPage = requireConsumerPage(state);
+  const duplicateResult = requireDuplicateResult(state);
+  const duplicatedBlock = firstDatabaseBlock(consumerPage, duplicateResult.view_id);
+
+  await expectDatabaseBlockAvailable(consumerPage, duplicatedBlock, expectedRow);
+
+  const duplicatedIdentity = await requireDatabaseBlockIdentity(consumerPage, duplicateResult.view_id);
+  const sourceIdentity = requireValue(state.sourceDatabaseIdentity, 'source database identity');
+
+  expect(duplicatedIdentity.databaseId).not.toBe(sourceIdentity.databaseId);
+  expect(Object.keys(duplicateResult.database_mappings)).toContain(duplicatedIdentity.databaseId);
+});
+
+Then('the duplicated referenced database remains available after reload', async ({ page }) => {
+  const state = getState(page);
+  const consumerPage = requireConsumerPage(state);
+  const duplicateResult = requireDuplicateResult(state);
+
+  await reloadDuplicatedDocument(consumerPage, state);
+  await expectDatabaseBlockAvailable(consumerPage, firstDatabaseBlock(consumerPage, duplicateResult.view_id));
+});
+
+Then('the duplicated inline database has an independent database identity', async ({ page }) => {
+  const state = getState(page);
+  const consumerPage = requireConsumerPage(state);
+  const duplicateResult = requireDuplicateResult(state);
+  const sourceDocumentId = requireValue(state.sourceDocumentId, 'source document id');
+  const sourceIdentity = requireValue(state.sourceDatabaseIdentity, 'source database identity');
+  const sourceMarker = requireValue(state.inlineRowMarker, 'inline row marker');
+  const duplicatedBlock = firstDatabaseBlock(consumerPage, duplicateResult.view_id);
+
+  await expectDatabaseBlockAvailable(consumerPage, duplicatedBlock, sourceMarker);
+
+  const duplicatedIdentity = await requireDatabaseBlockIdentity(consumerPage, duplicateResult.view_id);
+
+  expect(duplicatedIdentity.databaseId).not.toBe(sourceIdentity.databaseId);
+  expect(Object.keys(duplicateResult.database_mappings)).toContain(duplicatedIdentity.databaseId);
+
+  const duplicatedMarker = `Edited only in consumer ${Date.now()}`;
+
+  await editFirstGridCell(consumerPage, duplicatedBlock, duplicatedMarker);
+  state.duplicatedInlineRowMarker = duplicatedMarker;
+
+  // Prove this is a deep copy, not merely a working reference to the source DB.
+  await page.goto(`/app/${requireValue(state.publisherWorkspaceId, 'publisher workspace id')}/${sourceDocumentId}`, {
+    waitUntil: 'domcontentloaded',
+  });
+  await expect(firstDatabaseBlock(page, sourceDocumentId)).toContainText(sourceMarker, { timeout: 60000 });
+  expect(await firstGridCellText(firstDatabaseBlock(page, sourceDocumentId))).not.toContain(duplicatedMarker);
+});
+
+Then('the duplicated inline database row remains available after reload', async ({ page }) => {
+  const state = getState(page);
+  const consumerPage = requireConsumerPage(state);
+  const duplicateResult = requireDuplicateResult(state);
+  const expectedMarker = requireValue(state.duplicatedInlineRowMarker, 'duplicated inline row marker');
+
+  await reloadDuplicatedDocument(consumerPage, state);
+  await expectDatabaseBlockAvailable(
+    consumerPage,
+    firstDatabaseBlock(consumerPage, duplicateResult.view_id),
+    expectedMarker
+  );
+});
+
+Then('the duplicated page reference points to a new accessible page copy', async ({ page, request }) => {
+  const state = getState(page);
+  const consumerPage = requireConsumerPage(state);
+  const duplicateResult = requireDuplicateResult(state);
+  const sourceReferenceId = requireValue(state.referencedPageId, 'source referenced page id');
+  const referenceName = requireValue(state.referencedPageName, 'referenced page name');
+  const referenceMarker = requireValue(state.referencedPageMarker, 'referenced page marker');
+  const mention = editorForView(consumerPage, duplicateResult.view_id).locator('.mention-inline').first();
+
+  await expect(mention).toBeVisible({ timeout: 60000 });
+
+  const duplicatedReferenceId = await mention.getAttribute('data-mention-id');
+
+  expect(duplicatedReferenceId, 'The duplicated mention must have a page id').toBeTruthy();
+  expect(
+    duplicatedReferenceId,
+    'The duplicated mention must point to a new destination page instead of the publisher page'
+  ).not.toBe(sourceReferenceId);
+  await expect(mention).toContainText(referenceName, { timeout: 30000 });
+
+  const duplicatedSubtree = await getWorkspaceView(
+    request,
+    requireValue(state.consumerToken, 'consumer token'),
+    requireValue(state.consumerWorkspaceId, 'consumer workspace id'),
+    duplicateResult.view_id,
+    2
+  );
+  const duplicatedReference = findView(duplicatedSubtree, duplicatedReferenceId!);
+
+  expect(duplicatedReference?.name).toBe(referenceName);
+
+  await mention.click({ force: true });
+  await expect(consumerPage.getByText(referenceMarker, { exact: true })).toBeVisible({ timeout: 60000 });
+});
+
+Then(
+  'the duplicated referenced database contains nested rows {string} and {string}',
+  async ({ page }, linkedRow: string, inlineRow: string) => {
+    const state = getState(page);
+    const consumerPage = requireConsumerPage(state);
+    const duplicateResult = requireDuplicateResult(state);
+    const duplicatedBlock = firstDatabaseBlock(consumerPage, duplicateResult.view_id);
+
+    await expectDatabaseBlockAvailable(consumerPage, duplicatedBlock, linkedRow);
+    await expect(duplicatedBlock).toContainText(inlineRow, { timeout: 60000 });
+
+    const duplicatedIdentity = await requireDatabaseBlockIdentity(consumerPage, duplicateResult.view_id);
+    const sourceIdentity = requireValue(state.sourceDatabaseIdentity, 'source database identity');
+
+    expect(duplicatedIdentity.databaseId).not.toBe(sourceIdentity.databaseId);
+    expect(Object.keys(duplicateResult.database_mappings)).toContain(duplicatedIdentity.databaseId);
+  }
+);
+
+Then('row {string} has an available nested referenced database', async ({ page }, rowName: string) => {
+  const state = getState(page);
+  const consumerPage = requireConsumerPage(state);
+  const duplicateResult = requireDuplicateResult(state);
+
+  await expectNestedRowDatabaseAvailable(
+    consumerPage,
+    firstDatabaseBlock(consumerPage, duplicateResult.view_id),
+    rowName
+  );
+  await closeRowDetailWithEscape(consumerPage);
+});
+
+Then('row {string} has an available nested inline database', async ({ page }, rowName: string) => {
+  const state = getState(page);
+  const consumerPage = requireConsumerPage(state);
+  const duplicateResult = requireDuplicateResult(state);
+
+  await expectNestedRowDatabaseAvailable(
+    consumerPage,
+    firstDatabaseBlock(consumerPage, duplicateResult.view_id),
+    rowName
+  );
+  await closeRowDetailWithEscape(consumerPage);
+});
+
+Then('the nested database in row {string} remains available after reload', async ({ page }, rowName: string) => {
+  const state = getState(page);
+  const consumerPage = requireConsumerPage(state);
+  const duplicateResult = requireDuplicateResult(state);
+
+  await reloadDuplicatedDocument(consumerPage, state);
+
+  const duplicatedBlock = firstDatabaseBlock(consumerPage, duplicateResult.view_id);
+
+  await expectNestedRowDatabaseAvailable(consumerPage, duplicatedBlock, rowName);
+  await closeRowDetailWithEscape(consumerPage);
+});
+
+async function createTemporaryDocument(
+  page: Page,
+  request: APIRequestContext,
+  state: PublishedDocumentTemplateState,
+  label: string
+): Promise<CreatePageResponse> {
+  const sourceName = `BDD published ${label} ${Date.now()}`;
+  const sourceMarker = `${sourceName} body`;
+  const source = await createDocumentViaApi(request, state, sourceName, sourceMarker);
+
+  state.sourceDocumentId = source.view_id;
+  state.sourceDocumentName = sourceName;
+  registerPublisherRoot(state, source.view_id);
+
+  await page.goto(`/app/${requireValue(state.publisherWorkspaceId, 'publisher workspace id')}/${source.view_id}`, {
+    waitUntil: 'domcontentloaded',
+  });
+  await expect(editorForView(page, source.view_id)).toBeVisible({ timeout: 60000 });
+  await expect(page.getByText(sourceMarker, { exact: true })).toBeVisible({ timeout: 30000 });
+
+  return source;
+}
+
+async function createDocumentViaApi(
+  request: APIRequestContext,
+  state: PublishedDocumentTemplateState,
+  name: string,
+  marker: string
+): Promise<CreatePageResponse> {
+  return postApi<CreatePageResponse>(
+    request,
+    requireValue(state.publisherToken, 'publisher token'),
+    `/api/workspace/${requireValue(state.publisherWorkspaceId, 'publisher workspace id')}/page-view`,
+    {
+      parent_view_id: requireValue(state.publisherGeneralSpaceId, 'publisher General space id'),
+      layout: ViewLayout.Document,
+      name,
+      page_data: {
+        type: 'page',
+        children: [
+          {
+            type: 'paragraph',
+            data: {
+              delta: [{ insert: marker }],
+            },
+          },
+        ],
+      },
+    }
+  );
+}
+
+async function publishCurrentDocument(page: Page, workspaceId: string, documentViewId: string): Promise<string> {
+  await expect(ShareSelectors.shareButton(page)).toBeVisible({ timeout: 30000 });
+  await ShareSelectors.shareButton(page).click({ force: true });
+
+  const sharePopover = ShareSelectors.sharePopover(page);
+
+  await expect(sharePopover).toBeVisible({ timeout: 15000 });
+  await sharePopover.getByText('Publish', { exact: true }).click({ force: true });
+
+  const publishButton = ShareSelectors.publishConfirmButton(page);
+
+  await expect(publishButton).toBeEnabled({ timeout: 30000 });
+
+  const publishResponsePromise = page.waitForResponse(
+    (response) => {
+      const url = new URL(response.url());
+
+      return (
+        response.request().method() === 'POST' &&
+        url.pathname === `/api/workspace/${workspaceId}/page-view/${documentViewId}/publish`
+      );
+    },
+    { timeout: 90000 }
+  );
+
+  await publishButton.click({ force: true });
+
+  const publishResponse = await publishResponsePromise;
+
+  expect(
+    publishResponse.ok(),
+    `Publishing document ${documentViewId} failed with HTTP ${publishResponse.status()}`
+  ).toBeTruthy();
+  await expect(ShareSelectors.publishNamespace(page)).toBeVisible({ timeout: 60000 });
+
+  const namespace = ((await ShareSelectors.publishNamespace(page).textContent()) ?? '').trim();
+  const publishName = (await ShareSelectors.publishNameInput(page).inputValue()).trim();
+
+  expect(namespace, 'Expected the publisher to have a publish namespace').not.toBe('');
+  expect(publishName, 'Expected the document to have a publish name').not.toBe('');
+
+  const publishedUrl = `${new URL(page.url()).origin}/${namespace}/${publishName}`;
+
+  await page.keyboard.press('Escape');
+  return publishedUrl;
+}
+
+async function reloadDuplicatedDocument(page: Page, state: PublishedDocumentTemplateState): Promise<void> {
+  const duplicateResult = requireDuplicateResult(state);
+  const workspaceId = requireValue(state.consumerWorkspaceId, 'consumer workspace id');
+
+  await page.goto(`/app/${workspaceId}/${duplicateResult.view_id}`, { waitUntil: 'domcontentloaded' });
+  await expect(editorForView(page, duplicateResult.view_id)).toBeVisible({ timeout: 60000 });
+}
+
+function firstDatabaseBlock(page: Page, documentViewId: string): Locator {
+  return databaseBlocks(editorForView(page, documentViewId)).first();
+}
+
+async function expectDatabaseBlockAvailable(page: Page, block: Locator, expectedText?: string): Promise<void> {
+  await expect(block).toBeVisible({ timeout: 60000 });
+  await expect(block.locator('[data-testid="database-grid"]')).toBeVisible({ timeout: 60000 });
+
+  if (expectedText) {
+    await expect(block).toContainText(expectedText, { timeout: 60000 });
+  }
+
+  await expect(block.getByText(PERMANENTLY_DELETED_TEXT, { exact: true })).toHaveCount(0);
+  await expect(block.getByText(NO_ACCESS_TEXT, { exact: true })).toHaveCount(0);
+  await expect(block.getByText(NO_PERMISSION_TEXT, { exact: true })).toHaveCount(0);
+
+  // `page` is deliberately part of this helper's signature so failures report
+  // the active URL, which is useful when the copied document unexpectedly
+  // navigates to a stale source view.
+  expect(page.url()).toContain('/app/');
+}
+
+async function expectNestedRowDatabaseAvailable(page: Page, outerDatabase: Locator, rowName: string): Promise<void> {
+  await expectDatabaseBlockAvailable(page, outerDatabase, rowName);
+
+  const row = outerDatabase.locator('[data-testid^="grid-row-"]').filter({ hasText: rowName }).first();
+
+  await expect(row).toBeVisible({ timeout: 60000 });
+  await row.scrollIntoViewIfNeeded();
+  await row.hover({ force: true });
+
+  const scopedExpandButton = row.getByTestId('row-expand-button');
+  const expandButton =
+    (await scopedExpandButton.count()) > 0 ? scopedExpandButton.first() : page.getByTestId('row-expand-button').first();
+
+  await expect(expandButton).toBeVisible({ timeout: 15000 });
+  await expandButton.click({ force: true });
+
+  const dialog = page.getByRole('dialog').last();
+
+  await expect(dialog).toBeVisible({ timeout: 30000 });
+
+  const scrollContainer = dialog.locator('.appflowy-scroll-container').last();
+
+  if ((await scrollContainer.count()) > 0) {
+    await scrollContainer.evaluate((element) => element.scrollTo(0, element.scrollHeight));
+  }
+
+  const nestedDatabase = dialog.locator('.appflowy-database').last();
+
+  await expect(nestedDatabase).toBeVisible({ timeout: 60000 });
+  await expect(nestedDatabase.locator('[data-testid="database-grid"]')).toBeVisible({ timeout: 60000 });
+  await expect(dialog.getByText(PERMANENTLY_DELETED_TEXT, { exact: true })).toHaveCount(0);
+  await expect(dialog.getByText(NO_ACCESS_TEXT, { exact: true })).toHaveCount(0);
+  await expect(dialog.getByText(NO_PERMISSION_TEXT, { exact: true })).toHaveCount(0);
+}
+
+async function requireDatabaseBlockIdentity(page: Page, documentViewId: string): Promise<DatabaseBlockIdentity> {
+  await expect
+    .poll(() => databaseBlockIdentity(page, documentViewId), {
+      timeout: 30000,
+      message: `Expected document ${documentViewId} to expose a database block identity`,
+    })
+    .not.toBeNull();
+
+  const identity = await databaseBlockIdentity(page, documentViewId);
+
+  if (!identity) {
+    throw new Error(`Document ${documentViewId} has no database block identity`);
+  }
+
+  return identity;
+}
+
+async function databaseBlockIdentity(page: Page, documentViewId: string): Promise<DatabaseBlockIdentity | null> {
+  return page.evaluate((viewId) => {
+    type EditorNode = {
+      type?: string;
+      data?: {
+        database_id?: unknown;
+        view_id?: unknown;
+        view_ids?: unknown;
+        parent_id?: unknown;
+      };
+      children?: EditorNode[];
+    };
+
+    const testWindow = window as Window & {
+      __TEST_EDITORS__?: Record<string, { children?: EditorNode[] }>;
+    };
+    const editor = testWindow.__TEST_EDITORS__?.[viewId];
+    const queue = [...(editor?.children ?? [])];
+
+    while (queue.length > 0) {
+      const node = queue.shift()!;
+
+      if (node.type === 'grid') {
+        const data = node.data;
+        const databaseId = typeof data?.database_id === 'string' ? data.database_id : '';
+        const scalarViewId = typeof data?.view_id === 'string' ? data.view_id : '';
+        const arrayViewId = Array.isArray(data?.view_ids)
+          ? data.view_ids.find((value): value is string => typeof value === 'string') ?? ''
+          : '';
+        const parentId = typeof data?.parent_id === 'string' ? data.parent_id : '';
+
+        if (databaseId && (scalarViewId || arrayViewId) && parentId) {
+          return {
+            databaseId,
+            viewId: scalarViewId || arrayViewId,
+            parentId,
+          };
+        }
+      }
+
+      queue.push(...(node.children ?? []));
+    }
+
+    return null;
+  }, documentViewId);
+}
+
+async function getWorkspaceView(
+  request: APIRequestContext,
+  token: string,
+  workspaceId: string,
+  viewId: string,
+  depth: number
+): Promise<WorkspaceView> {
+  return getApi<WorkspaceView>(request, token, `/api/workspace/${workspaceId}/view/${viewId}?depth=${depth}`);
+}
+
+async function getApi<T>(request: APIRequestContext, token: string, path: string): Promise<T> {
+  const response = await request.get(`${TestConfig.apiUrl}${path}`, {
+    headers: { Authorization: `Bearer ${token}` },
+    failOnStatusCode: false,
+  });
+  const body = (await response.json().catch(() => null)) as ApiResponse<T> | null;
+
+  if (!response.ok() || body?.code !== 0 || body.data === undefined) {
+    throw new Error(`GET ${path} failed with HTTP ${response.status()}: ${JSON.stringify(body)}`);
+  }
+
+  return body.data;
+}
+
+async function postApi<T>(
+  request: APIRequestContext,
+  token: string,
+  path: string,
+  data?: Record<string, unknown>
+): Promise<T> {
+  const response = await request.post(`${TestConfig.apiUrl}${path}`, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    },
+    data,
+    failOnStatusCode: false,
+  });
+  const body = (await response.json().catch(() => null)) as ApiResponse<T> | null;
+
+  if (!response.ok() || body?.code !== 0 || body.data === undefined) {
+    throw new Error(`POST ${path} failed with HTTP ${response.status()}: ${JSON.stringify(body)}`);
+  }
+
+  return body.data;
+}
+
+async function cleanupConsumerCopies(request: APIRequestContext, state: PublishedDocumentTemplateState): Promise<void> {
+  if (!state.consumerToken || !state.consumerWorkspaceId) return;
+
+  for (const viewId of unique(state.consumerRoots)) {
+    await deleteWorkspaceView(request, state.consumerToken, state.consumerWorkspaceId, viewId);
+  }
+}
+
+async function cleanupPublisherPages(request: APIRequestContext, state: PublishedDocumentTemplateState): Promise<void> {
+  if (!state.publisherToken || !state.publisherWorkspaceId) return;
+
+  const roots = unique([...(state.sourceDocumentId ? [state.sourceDocumentId] : []), ...state.publisherRoots]);
+
+  for (const viewId of roots) {
+    await deleteWorkspaceView(request, state.publisherToken, state.publisherWorkspaceId, viewId);
+  }
+}
+
+async function deleteWorkspaceView(
+  request: APIRequestContext,
+  token: string,
+  workspaceId: string,
+  viewId: string
+): Promise<void> {
+  const moveResponse = await request.post(
+    `${TestConfig.apiUrl}/api/workspace/${workspaceId}/page-view/${viewId}/move-to-trash`,
+    {
+      headers: { Authorization: `Bearer ${token}` },
+      failOnStatusCode: false,
+    }
+  );
+
+  if (moveResponse.status() === 404) return;
+
+  const moveBody = (await moveResponse.json().catch(() => null)) as ApiResponse<unknown> | null;
+
+  if (!moveResponse.ok() || moveBody?.code !== 0) {
+    throw new Error(`Moving ${viewId} to trash failed with HTTP ${moveResponse.status()}: ${JSON.stringify(moveBody)}`);
+  }
+
+  const deleteResponse = await request.delete(`${TestConfig.apiUrl}/api/workspace/${workspaceId}/trash/${viewId}`, {
+    headers: { Authorization: `Bearer ${token}` },
+    failOnStatusCode: false,
+  });
+  const deleteBody = (await deleteResponse.json().catch(() => null)) as ApiResponse<unknown> | null;
+
+  if (deleteResponse.status() !== 404 && (!deleteResponse.ok() || deleteBody?.code !== 0)) {
+    throw new Error(
+      `Deleting ${viewId} from trash failed with HTTP ${deleteResponse.status()}: ${JSON.stringify(deleteBody)}`
+    );
+  }
+}
+
+async function requireAuthToken(page: Page): Promise<string> {
+  const token = await page.evaluate(() => {
+    const rawToken = localStorage.getItem('token');
+
+    if (rawToken) {
+      try {
+        const parsed = JSON.parse(rawToken) as { access_token?: string };
+
+        if (parsed.access_token) return parsed.access_token;
+      } catch {
+        // Fall back to the test-only token mirror below.
+      }
+    }
+
+    return localStorage.getItem('af_auth_token') ?? '';
+  });
+
+  if (!token) throw new Error('The signed-in browser has no access token');
+  return token;
+}
+
+function registerPublisherRoot(state: PublishedDocumentTemplateState, viewId: string): void {
+  if (!state.publisherRoots.includes(viewId)) {
+    state.publisherRoots.push(viewId);
+  }
+}
+
+function workspaceIdFromAppUrl(urlValue: string): string {
+  const segments = new URL(urlValue).pathname.split('/').filter(Boolean);
+  const appIndex = segments.indexOf('app');
+  const workspaceId = appIndex >= 0 ? segments[appIndex + 1] : undefined;
+
+  if (!workspaceId) throw new Error(`Could not read a workspace id from ${urlValue}`);
+  return workspaceId;
+}
+
+function findView(root: WorkspaceView, viewId: string): WorkspaceView | undefined {
+  if (root.view_id === viewId) return root;
+
+  for (const child of root.children ?? []) {
+    const found = findView(child, viewId);
+
+    if (found) return found;
+  }
+
+  return undefined;
+}
+
+function modifierKey(): 'Meta' | 'Control' {
+  return process.platform === 'darwin' ? 'Meta' : 'Control';
+}
+
+function unique(values: string[]): string[] {
+  return [...new Set(values)];
+}
+
+function getState(page: Page): PublishedDocumentTemplateState {
+  const state = stateByPage.get(page);
+
+  if (!state) throw new Error('Published document template dependency scenario state is missing');
+  return state;
+}
+
+function requireConsumerPage(state: PublishedDocumentTemplateState): Page {
+  return requireValue(state.consumerPage, 'consumer page');
+}
+
+function requireDuplicateResult(state: PublishedDocumentTemplateState): DuplicateResult {
+  return requireValue(state.duplicateResult, 'published document duplicate result');
+}
+
+function requireValue<T>(value: T | undefined, label: string): T {
+  if (value === undefined) throw new Error(`Missing ${label}`);
+  return value;
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/playwright/bdd/steps/published-relation-template.steps.ts
+++ b/playwright/bdd/steps/published-relation-template.steps.ts
@@ -316,6 +316,21 @@ Then('the duplicated relation cell does not show {string}', async ({ page }, ina
   await expect(consumerPage.getByText(inaccessibleText, { exact: true })).toHaveCount(0);
 });
 
+When('I reload the duplicated relation template without its mapping query', async ({ page }) => {
+  const consumerPage = requireConsumerPage(getState(page));
+
+  // The duplication URL seeds the mapping once. Removing that query before
+  // reload verifies the app can restore related databases from local storage.
+  await consumerPage.evaluate(() => {
+    const url = new URL(window.location.href);
+
+    url.searchParams.delete('db_mappings');
+    window.history.replaceState(null, '', url);
+  });
+  await consumerPage.reload({ waitUntil: 'domcontentloaded' });
+  await expect(DatabaseGridSelectors.grid(consumerPage)).toBeVisible({ timeout: 60000 });
+});
+
 async function openFixtureView(page: Page, viewId: string): Promise<void> {
   await page.goto(`/app/${FIXTURE_WORKSPACE_ID}/${viewId}`, { waitUntil: 'domcontentloaded' });
   await expect(DatabaseGridSelectors.grid(page)).toBeVisible({ timeout: 60000 });

--- a/playwright/bdd/steps/published-relation-template.steps.ts
+++ b/playwright/bdd/steps/published-relation-template.steps.ts
@@ -300,6 +300,30 @@ Then('the relation template duplication contains {int} database mappings', async
   expect(Object.keys(result.database_mappings)).toHaveLength(count);
 });
 
+Then('the duplicated relation database is named {string}', async ({ page, request }, expectedName: string) => {
+  const state = getState(page);
+  const result = requireDuplicateResult(state);
+  const token = requireValue(state.consumerToken, 'consumer token');
+  const workspaceId = requireValue(state.consumerWorkspaceId, 'consumer workspace id');
+  const duplicatedDatabaseViewIds = new Set(Object.values(result.database_mappings).flat());
+
+  await expect
+    .poll(
+      async () => {
+        const folder = await getWorkspaceFolder(request, token, workspaceId);
+
+        return [...duplicatedDatabaseViewIds]
+          .map((viewId) => findView(folder, viewId)?.name)
+          .filter((name): name is string => name !== undefined);
+      },
+      {
+        timeout: 30000,
+        message: `Expected a duplicated relation database view named ${expectedName}`,
+      }
+    )
+    .toContain(expectedName);
+});
+
 Then('the duplicated relation cell shows {string}', async ({ page }, expectedContent: string) => {
   const consumerPage = requireConsumerPage(getState(page));
 

--- a/playwright/bdd/steps/published-relation-template.steps.ts
+++ b/playwright/bdd/steps/published-relation-template.steps.ts
@@ -316,17 +316,20 @@ Then('the duplicated relation cell does not show {string}', async ({ page }, ina
   await expect(consumerPage.getByText(inaccessibleText, { exact: true })).toHaveCount(0);
 });
 
-When('I reload the duplicated relation template without its mapping query', async ({ page }) => {
-  const consumerPage = requireConsumerPage(getState(page));
+When('I clear the duplication mappings and reload the duplicated relation template', async ({ page }) => {
+  const state = getState(page);
+  const consumerPage = requireConsumerPage(state);
+  const workspaceId = requireValue(state.consumerWorkspaceId, 'consumer workspace id');
 
-  // The duplication URL seeds the mapping once. Removing that query before
-  // reload verifies the app can restore related databases from local storage.
-  await consumerPage.evaluate(() => {
+  // Remove both client-side mapping sources to reproduce a later direct visit.
+  // The relation must still resolve from refreshed workspace metadata.
+  await consumerPage.evaluate((workspaceId) => {
     const url = new URL(window.location.href);
 
     url.searchParams.delete('db_mappings');
+    localStorage.removeItem(`db_mappings_${workspaceId}`);
     window.history.replaceState(null, '', url);
-  });
+  }, workspaceId);
   await consumerPage.reload({ waitUntil: 'domcontentloaded' });
   await expect(DatabaseGridSelectors.grid(consumerPage)).toBeVisible({ timeout: 60000 });
 });

--- a/playwright/bdd/steps/published-relation-template.steps.ts
+++ b/playwright/bdd/steps/published-relation-template.steps.ts
@@ -1,0 +1,542 @@
+import { APIRequestContext, BrowserContext, expect, Page } from '@playwright/test';
+import { createBdd } from 'playwright-bdd';
+
+import { signInAndWaitForApp, signInWithPasswordViaUi } from '../../support/auth-flow-helpers';
+import { DatabaseGridSelectors, ShareSelectors, SidebarSelectors } from '../../support/selectors';
+import { generateRandomEmail, setupPageErrorHandling, TestConfig } from '../../support/test-config';
+
+const { Given, When, Then, Before, After } = createBdd();
+
+const FIXTURE_EMAIL = 'pdf_db_relation@appflowy.io';
+const FIXTURE_PASSWORD = 'AppFlowy!@123';
+const FIXTURE_WORKSPACE_ID = 'd767a65f-8d86-4f34-8498-07d2e7eed114';
+const SOURCE_DATABASE_VIEW_ID = 'b92c86f7-e385-43c2-a480-cca651beba35';
+const SOURCE_GRID_VIEW_ID = 'c21f0728-18ef-404b-8b4f-909bcf4d1fdd';
+const RELATED_DATABASE_VIEW_ID = 'e20165e8-0e95-40a4-927c-8e0ee3475d47';
+const RELATED_GRID_VIEW_ID = 'acb652f6-61c2-442b-a526-1d3ecc5c96f7';
+const RELATION_CONTENT = 'Related DB content';
+const FIXTURE_PUBLISH_VIEW_IDS = [
+  SOURCE_DATABASE_VIEW_ID,
+  SOURCE_GRID_VIEW_ID,
+  RELATED_DATABASE_VIEW_ID,
+  RELATED_GRID_VIEW_ID,
+] as const;
+
+type ApiResponse<T> = {
+  code?: number;
+  data?: T;
+  message?: string;
+};
+
+type FolderView = {
+  view_id: string;
+  name: string;
+  children?: FolderView[];
+};
+
+type DuplicateResult = {
+  view_id: string;
+  database_mappings: Record<string, string[]>;
+};
+
+type PublishState = Record<(typeof FIXTURE_PUBLISH_VIEW_IDS)[number], boolean>;
+
+type RelationTemplateState = {
+  publisherToken?: string;
+  initialPublishState?: PublishState;
+  publishedUrl?: string;
+  consumerContext?: BrowserContext;
+  consumerPage?: Page;
+  consumerToken?: string;
+  consumerWorkspaceId?: string;
+  destinationSpaceId?: string;
+  destinationChildrenBefore?: Set<string>;
+  createdDestinationRoots: Set<string>;
+  destinationDepth?: string | null;
+  duplicateResult?: DuplicateResult;
+};
+
+const stateByPage = new WeakMap<Page, RelationTemplateState>();
+
+Before({ tags: '@published-relation-template' }, async ({ page }) => {
+  setupPageErrorHandling(page);
+  await page.setViewportSize({ width: 1440, height: 900 });
+  stateByPage.set(page, { createdDestinationRoots: new Set() });
+});
+
+After({ tags: '@published-relation-template' }, async ({ page, request }) => {
+  const state = stateByPage.get(page);
+
+  if (!state) return;
+
+  const cleanupErrors: string[] = [];
+
+  await cleanupDestinationCopies(request, state).catch((error) => {
+    cleanupErrors.push(`destination cleanup: ${errorMessage(error)}`);
+  });
+  await state.consumerContext?.close().catch((error) => {
+    cleanupErrors.push(`consumer context cleanup: ${errorMessage(error)}`);
+  });
+  await restoreFixturePublishState(request, state).catch((error) => {
+    cleanupErrors.push(`fixture publish-state restore: ${errorMessage(error)}`);
+  });
+
+  stateByPage.delete(page);
+
+  if (cleanupErrors.length > 0) {
+    throw new Error(`Relation template teardown failed:\n${cleanupErrors.join('\n')}`);
+  }
+});
+
+Given('the seeded relation template fixture exists', async () => {
+  // Fixture source:
+  // AppFlowy-Cloud-Premium/backup/README.md (`pdf_db_relation@appflowy.io`)
+  // Server regression:
+  // tests/workspace/publish/duplication_test.rs::
+  // publishing_only_database_with_relation_includes_related_database_in_template
+});
+
+Given('I sign in as the relation template fixture publisher', async ({ page, request }) => {
+  const state = getState(page);
+
+  await signInWithPasswordViaUi(page, FIXTURE_EMAIL, FIXTURE_PASSWORD, 2000);
+  await expect(page).toHaveURL(/\/app\//, { timeout: 30000 });
+  await expect(SidebarSelectors.pageHeader(page)).toBeVisible({ timeout: 30000 });
+
+  state.publisherToken = await requireAuthToken(page);
+  state.initialPublishState = Object.fromEntries(
+    await Promise.all(FIXTURE_PUBLISH_VIEW_IDS.map(async (viewId) => [viewId, await isPublished(request, viewId)]))
+  ) as PublishState;
+
+  // Both databases must begin unpublished. Otherwise an old server can reuse an
+  // already-published relation target and conceal the auto-publish regression.
+  for (const viewId of FIXTURE_PUBLISH_VIEW_IDS) {
+    await setPublished(request, state.publisherToken, viewId, false);
+  }
+});
+
+Given('the seeded relation cell resolves before publishing', async ({ page }) => {
+  await openFixtureView(page, RELATED_GRID_VIEW_ID);
+  await expect(DatabaseGridSelectors.grid(page)).toContainText(RELATION_CONTENT, { timeout: 30000 });
+
+  // Opening the related database first primes a fresh browser's local collab
+  // cache, matching the fixture's existing relation-cell integration test.
+  await openFixtureView(page, SOURCE_GRID_VIEW_ID);
+  await expect(page.locator('.relation-cell').first()).toContainText(RELATION_CONTENT, {
+    timeout: 30000,
+  });
+});
+
+When('I publish only the seeded source database as a template', async ({ page, request }) => {
+  const state = getState(page);
+
+  await expect(ShareSelectors.shareButton(page)).toBeVisible({ timeout: 30000 });
+  await ShareSelectors.shareButton(page).click({ force: true });
+
+  const sharePopover = ShareSelectors.sharePopover(page);
+
+  await expect(sharePopover).toBeVisible({ timeout: 15000 });
+  await sharePopover.getByText('Publish', { exact: true }).click({ force: true });
+
+  const publishButton = ShareSelectors.publishConfirmButton(page);
+
+  await expect(publishButton).toBeEnabled({ timeout: 30000 });
+
+  const publishResponsePromise = page.waitForResponse(
+    (response) => {
+      const url = new URL(response.url());
+
+      return response.request().method() === 'POST' && url.pathname === `/api/workspace/${FIXTURE_WORKSPACE_ID}/publish`;
+    },
+    { timeout: 60000 }
+  );
+
+  await publishButton.click({ force: true });
+
+  const publishResponse = await publishResponsePromise;
+
+  expect(
+    publishResponse.ok(),
+    `Publishing the relation fixture failed with HTTP ${publishResponse.status()}`
+  ).toBeTruthy();
+  await expect(ShareSelectors.publishNamespace(page)).toBeVisible({ timeout: 60000 });
+
+  const namespace = ((await ShareSelectors.publishNamespace(page).textContent()) ?? '').trim();
+  const publishName = (await ShareSelectors.publishNameInput(page).inputValue()).trim();
+
+  expect(namespace, 'Expected the fixture publisher to have a publish namespace').not.toBe('');
+  expect(publishName, 'Expected the source database to have a publish name').not.toBe('');
+
+  state.publishedUrl = `${new URL(page.url()).origin}/${namespace}/${publishName}`;
+
+  await expect
+    .poll(() => isPublished(request, SOURCE_DATABASE_VIEW_ID), {
+      timeout: 30000,
+      message: 'Expected the source database to be published',
+    })
+    .toBe(true);
+});
+
+When('another account opens the published relation template', async ({ page, request, browser }) => {
+  const state = getState(page);
+  const publishedUrl = requirePublishedUrl(state);
+  const consumerContext = await browser.newContext({
+    baseURL: new URL(publishedUrl).origin,
+    viewport: { width: 1440, height: 900 },
+  });
+  const consumerPage = await consumerContext.newPage();
+
+  state.consumerContext = consumerContext;
+  state.consumerPage = consumerPage;
+  setupPageErrorHandling(consumerPage);
+
+  await signInAndWaitForApp(consumerPage, request, generateRandomEmail());
+
+  state.consumerToken = await requireAuthToken(consumerPage);
+  state.consumerWorkspaceId = workspaceIdFromAppUrl(consumerPage.url());
+
+  const destinationFolder = await getWorkspaceFolder(request, state.consumerToken, state.consumerWorkspaceId);
+  const generalSpace = destinationFolder.children?.find((view) => view.name === 'General');
+
+  if (!generalSpace) {
+    throw new Error('The consumer workspace does not contain the General space');
+  }
+
+  state.destinationSpaceId = generalSpace.view_id;
+  state.destinationChildrenBefore = new Set((generalSpace.children ?? []).map((view) => view.view_id));
+
+  await consumerPage.goto(publishedUrl, { waitUntil: 'domcontentloaded' });
+  await expect(consumerPage.getByRole('button', { name: 'Start with this template' })).toBeVisible({
+    timeout: 60000,
+  });
+  await expect(DatabaseGridSelectors.grid(consumerPage)).toBeVisible({ timeout: 60000 });
+});
+
+Then('the published relation cell shows {string}', async ({ page }, expectedContent: string) => {
+  const consumerPage = requireConsumerPage(getState(page));
+
+  await expect(consumerPage.locator('.relation-cell').first()).toContainText(expectedContent, {
+    timeout: 60000,
+  });
+});
+
+When('that account starts with the relation template in {string}', async ({ page, request }, spaceName: string) => {
+  const state = getState(page);
+  const consumerPage = requireConsumerPage(state);
+  const consumerWorkspaceId = requireValue(state.consumerWorkspaceId, 'consumer workspace id');
+
+  const spaceResponsePromise = consumerPage.waitForResponse(
+    (response) => {
+      const url = new URL(response.url());
+
+      return (
+        response.request().method() === 'GET' &&
+        url.pathname === `/api/workspace/${consumerWorkspaceId}/view/${consumerWorkspaceId}`
+      );
+    },
+    { timeout: 60000 }
+  );
+
+  await consumerPage.getByRole('button', { name: 'Start with this template' }).click();
+
+  const spaceResponse = await spaceResponsePromise;
+
+  expect(spaceResponse.ok(), `Loading destination spaces failed with HTTP ${spaceResponse.status()}`).toBeTruthy();
+  state.destinationDepth = new URL(spaceResponse.url()).searchParams.get('depth');
+
+  const destinationDialog = consumerPage.getByRole('dialog').filter({ hasText: 'Where would you like to add' }).last();
+
+  await expect(destinationDialog).toBeVisible({ timeout: 30000 });
+
+  const destinationSpace = destinationDialog.getByTestId('space-item').filter({ hasText: spaceName }).first();
+
+  await expect(destinationSpace).toBeVisible({ timeout: 30000 });
+  await destinationSpace.click();
+
+  const addButton = destinationDialog.getByRole('button', { name: 'Add', exact: true });
+
+  await expect(addButton).toBeEnabled({ timeout: 15000 });
+
+  const duplicateResponsePromise = consumerPage.waitForResponse(
+    (response) => {
+      const url = new URL(response.url());
+
+      return (
+        response.request().method() === 'POST' &&
+        url.pathname === `/api/workspace/${consumerWorkspaceId}/published-duplicate`
+      );
+    },
+    { timeout: 60000 }
+  );
+
+  await addButton.click();
+
+  const duplicateResponse = await duplicateResponsePromise;
+  const responseBody = (await duplicateResponse.json().catch(() => null)) as ApiResponse<DuplicateResult> | null;
+
+  expect(
+    duplicateResponse.ok() && responseBody?.code === 0 && responseBody.data,
+    `Relation template duplication failed with HTTP ${duplicateResponse.status()}: ${JSON.stringify(responseBody)}`
+  ).toBeTruthy();
+
+  state.duplicateResult = responseBody!.data!;
+  await recordCreatedDestinationRoots(request, state);
+
+  const openInBrowser = consumerPage.getByRole('button', { name: /Open in browser/i });
+
+  await expect(openInBrowser).toBeVisible({ timeout: 30000 });
+  await openInBrowser.click();
+  await expect(consumerPage).toHaveURL(/\/app\//, { timeout: 30000 });
+  await expect(DatabaseGridSelectors.grid(consumerPage)).toBeVisible({ timeout: 60000 });
+});
+
+Then('the destination space request uses depth 2', async ({ page }) => {
+  expect(getState(page).destinationDepth).toBe('2');
+});
+
+Then('the relation template duplication contains {int} database mappings', async ({ page }, count: number) => {
+  const result = requireDuplicateResult(getState(page));
+
+  expect(Object.keys(result.database_mappings)).toHaveLength(count);
+});
+
+Then('the duplicated relation cell shows {string}', async ({ page }, expectedContent: string) => {
+  const consumerPage = requireConsumerPage(getState(page));
+
+  await expect(consumerPage.locator('.relation-cell').first()).toContainText(expectedContent, {
+    timeout: 60000,
+  });
+});
+
+Then('the duplicated relation cell does not show {string}', async ({ page }, inaccessibleText: string) => {
+  const consumerPage = requireConsumerPage(getState(page));
+  const relationCell = consumerPage.locator('.relation-cell').first();
+
+  await expect(relationCell).not.toContainText(inaccessibleText);
+  await expect(consumerPage.getByText(inaccessibleText, { exact: true })).toHaveCount(0);
+});
+
+async function openFixtureView(page: Page, viewId: string): Promise<void> {
+  await page.goto(`/app/${FIXTURE_WORKSPACE_ID}/${viewId}`, { waitUntil: 'domcontentloaded' });
+  await expect(DatabaseGridSelectors.grid(page)).toBeVisible({ timeout: 60000 });
+  await expect(DatabaseGridSelectors.cells(page).first()).toBeVisible({ timeout: 60000 });
+}
+
+async function getWorkspaceFolder(request: APIRequestContext, token: string, workspaceId: string): Promise<FolderView> {
+  // A destination selector only needs the workspace, its spaces, and each
+  // space's immediate children, so this intentionally mirrors the web request.
+  return getApi<FolderView>(request, token, `/api/workspace/${workspaceId}/view/${workspaceId}?depth=2`);
+}
+
+async function recordCreatedDestinationRoots(request: APIRequestContext, state: RelationTemplateState): Promise<void> {
+  const token = requireValue(state.consumerToken, 'consumer token');
+  const workspaceId = requireValue(state.consumerWorkspaceId, 'consumer workspace id');
+  const destinationSpaceId = requireValue(state.destinationSpaceId, 'destination space id');
+  const before = state.destinationChildrenBefore;
+
+  if (!before) throw new Error('Destination child baseline is missing');
+
+  await expect
+    .poll(
+      async () => {
+        const folder = await getWorkspaceFolder(request, token, workspaceId);
+        const destination = findView(folder, destinationSpaceId);
+        const created = (destination?.children ?? []).filter((view) => !before.has(view.view_id));
+
+        state.createdDestinationRoots = new Set(created.map((view) => view.view_id));
+        return created.length;
+      },
+      {
+        timeout: 30000,
+        message: 'Expected the duplicated template to create destination pages',
+      }
+    )
+    .toBeGreaterThan(0);
+}
+
+async function cleanupDestinationCopies(request: APIRequestContext, state: RelationTemplateState): Promise<void> {
+  if (
+    !state.consumerToken ||
+    !state.consumerWorkspaceId ||
+    !state.destinationSpaceId ||
+    !state.destinationChildrenBefore
+  ) {
+    return;
+  }
+
+  const folder = await getWorkspaceFolder(request, state.consumerToken, state.consumerWorkspaceId);
+  const destination = findView(folder, state.destinationSpaceId);
+
+  for (const child of destination?.children ?? []) {
+    if (!state.destinationChildrenBefore.has(child.view_id)) {
+      state.createdDestinationRoots.add(child.view_id);
+    }
+  }
+
+  for (const viewId of state.createdDestinationRoots) {
+    await postVoid(
+      request,
+      state.consumerToken,
+      `/api/workspace/${state.consumerWorkspaceId}/page-view/${viewId}/move-to-trash`
+    );
+    await deleteVoid(request, state.consumerToken, `/api/workspace/${state.consumerWorkspaceId}/trash/${viewId}`);
+  }
+}
+
+async function restoreFixturePublishState(request: APIRequestContext, state: RelationTemplateState): Promise<void> {
+  if (!state.publisherToken || !state.initialPublishState) return;
+
+  // Reconcile the source first and relation target last because publishing A
+  // can auto-publish B. A second pass handles parent/child side effects.
+  for (let pass = 0; pass < 2; pass += 1) {
+    for (const viewId of FIXTURE_PUBLISH_VIEW_IDS) {
+      await setPublished(request, state.publisherToken, viewId, state.initialPublishState[viewId]);
+    }
+  }
+}
+
+async function setPublished(
+  request: APIRequestContext,
+  token: string,
+  viewId: string,
+  expected: boolean
+): Promise<void> {
+  if ((await isPublished(request, viewId)) === expected) return;
+
+  const action = expected ? 'publish' : 'unpublish';
+  const data = expected ? { comments_enabled: true, duplicate_enabled: true } : undefined;
+
+  await postVoid(request, token, `/api/workspace/${FIXTURE_WORKSPACE_ID}/page-view/${viewId}/${action}`, data);
+  await expect
+    .poll(() => isPublished(request, viewId), {
+      timeout: 30000,
+      message: `Expected fixture view ${viewId} published=${expected}`,
+    })
+    .toBe(expected);
+}
+
+async function isPublished(request: APIRequestContext, viewId: string): Promise<boolean> {
+  const response = await request.get(`${TestConfig.apiUrl}/api/workspace/v1/published-info/${viewId}`, {
+    failOnStatusCode: false,
+  });
+  const body = (await response.json().catch(() => null)) as ApiResponse<unknown> | null;
+
+  return response.ok() && body?.code === 0 && body.data !== undefined;
+}
+
+async function getApi<T>(request: APIRequestContext, token: string, path: string): Promise<T> {
+  const response = await request.get(`${TestConfig.apiUrl}${path}`, {
+    headers: { Authorization: `Bearer ${token}` },
+    failOnStatusCode: false,
+  });
+  const body = (await response.json().catch(() => null)) as ApiResponse<T> | null;
+
+  if (!response.ok() || body?.code !== 0 || body.data === undefined) {
+    throw new Error(`GET ${path} failed with HTTP ${response.status()}: ${JSON.stringify(body)}`);
+  }
+
+  return body.data;
+}
+
+async function postVoid(
+  request: APIRequestContext,
+  token: string,
+  path: string,
+  data?: Record<string, unknown>
+): Promise<void> {
+  const response = await request.post(`${TestConfig.apiUrl}${path}`, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    },
+    data,
+    failOnStatusCode: false,
+  });
+  const body = (await response.json().catch(() => null)) as ApiResponse<unknown> | null;
+
+  if (!response.ok() || body?.code !== 0) {
+    throw new Error(`POST ${path} failed with HTTP ${response.status()}: ${JSON.stringify(body)}`);
+  }
+}
+
+async function deleteVoid(request: APIRequestContext, token: string, path: string): Promise<void> {
+  const response = await request.delete(`${TestConfig.apiUrl}${path}`, {
+    headers: { Authorization: `Bearer ${token}` },
+    failOnStatusCode: false,
+  });
+  const body = (await response.json().catch(() => null)) as ApiResponse<unknown> | null;
+
+  if (!response.ok() || body?.code !== 0) {
+    throw new Error(`DELETE ${path} failed with HTTP ${response.status()}: ${JSON.stringify(body)}`);
+  }
+}
+
+async function requireAuthToken(page: Page): Promise<string> {
+  const token = await page.evaluate(() => {
+    const rawToken = localStorage.getItem('token');
+
+    if (rawToken) {
+      try {
+        const parsed = JSON.parse(rawToken) as { access_token?: string };
+
+        if (parsed.access_token) return parsed.access_token;
+      } catch {
+        // Fall back to the test-only token mirror below.
+      }
+    }
+
+    return localStorage.getItem('af_auth_token') ?? '';
+  });
+
+  if (!token) throw new Error('The signed-in browser has no access token');
+  return token;
+}
+
+function workspaceIdFromAppUrl(urlValue: string): string {
+  const segments = new URL(urlValue).pathname.split('/').filter(Boolean);
+  const appIndex = segments.indexOf('app');
+  const workspaceId = appIndex >= 0 ? segments[appIndex + 1] : undefined;
+
+  if (!workspaceId) throw new Error(`Could not read a workspace id from ${urlValue}`);
+  return workspaceId;
+}
+
+function findView(root: FolderView, viewId: string): FolderView | undefined {
+  if (root.view_id === viewId) return root;
+
+  for (const child of root.children ?? []) {
+    const found = findView(child, viewId);
+
+    if (found) return found;
+  }
+
+  return undefined;
+}
+
+function getState(page: Page): RelationTemplateState {
+  const state = stateByPage.get(page);
+
+  if (!state) throw new Error('Published relation template scenario state is missing');
+  return state;
+}
+
+function requirePublishedUrl(state: RelationTemplateState): string {
+  return requireValue(state.publishedUrl, 'published relation template URL');
+}
+
+function requireConsumerPage(state: RelationTemplateState): Page {
+  return requireValue(state.consumerPage, 'consumer page');
+}
+
+function requireDuplicateResult(state: RelationTemplateState): DuplicateResult {
+  return requireValue(state.duplicateResult, 'relation template duplicate result');
+}
+
+function requireValue<T>(value: T | undefined, label: string): T {
+  if (value === undefined) throw new Error(`Missing ${label}`);
+  return value;
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/src/@types/translations/en.json
+++ b/src/@types/translations/en.json
@@ -3220,6 +3220,8 @@
     "duplicateTitle": "Where would you like to add",
     "selectWorkspace": "Select a workspace",
     "addTo": "Add to",
+    "loadSpacesFailed": "Couldn't load spaces.",
+    "noSpacesAvailable": "No spaces available.",
     "duplicateSuccessfully": "Added to your workspace",
     "duplicateSuccessfullyDescription": "Don't have AppFlowy installed? The download will start automatically after you click 'Download'.",
     "downloadIt": "Download",

--- a/src/application/publish/__tests__/context.test.tsx
+++ b/src/application/publish/__tests__/context.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import { useEffect } from 'react';
 
+import { getRowKey } from '@/application/database-yjs/row_meta';
 import { normalizePublishedPageSnapshot } from '@/application/publish-snapshot/normalize';
 import { getPublishedDatabaseRenderRowMap } from '@/application/publish-snapshot/database-yjs-render-bridge';
 import {
@@ -9,6 +10,7 @@ import {
   publishedRowDocumentId,
 } from '@/application/publish-snapshot/__fixtures__/published-page-snapshots';
 import { PublishContextType, PublishProvider, usePublishContext } from '@/application/publish';
+import { RowService } from '@/application/services/domains';
 import { YjsEditorKey } from '@/application/types';
 import { yDocToSlateContent } from '@/application/slate-yjs/utils/convert';
 
@@ -180,12 +182,18 @@ describe('PublishProvider', () => {
 
     const doc = await latestContext?.loadView(relatedSnapshot.view.viewId);
     const database = doc?.getMap(YjsEditorKey.data_section).get(YjsEditorKey.database);
+    const publishedRows = getPublishedDatabaseRenderRowMap(doc) ?? {};
+    const publishedRow = await latestContext?.createRow?.(
+      getRowKey(relatedSnapshot.database.databaseId, 'published-row-id')
+    );
 
     expect(mockGetPage).toHaveBeenCalledWith(relatedSnapshot.namespace, relatedSnapshot.publishName);
     expect(mockGetView).not.toHaveBeenCalled();
     expect(doc?.guid).toBe(relatedSnapshot.database.databaseId);
     expect(database).toBeDefined();
-    expect(Object.keys(getPublishedDatabaseRenderRowMap(doc) ?? {})).toEqual(['published-row-id']);
+    expect(Object.keys(publishedRows)).toEqual(['published-row-id']);
+    expect(publishedRow).toBe(publishedRows['published-row-id']);
+    expect(RowService.create).not.toHaveBeenCalled();
   });
 
   it('loads published row documents from the related database JSON snapshot', async () => {

--- a/src/application/publish/context.tsx
+++ b/src/application/publish/context.tsx
@@ -88,14 +88,6 @@ function findViewInfoById(views: ViewInfo[] | null | undefined, viewId: string):
   }
 }
 
-function snapshotToRenderDoc(snapshot: PublishedPageSnapshot) {
-  if (snapshot.kind === 'database') {
-    return createDatabaseYjsRenderDocsFromSnapshot(snapshot).doc;
-  }
-
-  return createDocumentYjsRenderDocFromSnapshot(snapshot);
-}
-
 function rowDocumentsFromSnapshot(snapshot: PublishedPageSnapshot): Record<string, PublishedDocumentRaw> {
   if (snapshot.kind !== 'database') return {};
 
@@ -146,10 +138,22 @@ export const PublishProvider = ({
   const [snapshotDataSource] = useState(() => createPublishSnapshotDataSource());
   const rowDocumentSnapshotsRef = useRef<Record<string, PublishedDocumentRaw>>({});
   const rowDocumentDocsRef = useRef<Map<string, YDoc>>(new Map());
+  const databaseRowDocsRef = useRef<Map<string, YDoc>>(new Map());
   const viewMetaSubscribersRef = useRef<Map<string, (meta: ViewMeta) => void>>(new Map());
 
   const registerSnapshotRowDocuments = useCallback((snapshot: PublishedPageSnapshot) => {
     Object.assign(rowDocumentSnapshotsRef.current, rowDocumentsFromSnapshot(snapshot));
+  }, []);
+
+  const createSnapshotRenderDoc = useCallback((snapshot: PublishedPageSnapshot) => {
+    if (snapshot.kind === 'database') {
+      const { doc, rowMap } = createDatabaseYjsRenderDocsFromSnapshot(snapshot);
+
+      Object.values(rowMap).forEach((rowDoc) => databaseRowDocsRef.current.set(rowDoc.guid, rowDoc));
+      return doc;
+    }
+
+    return createDocumentYjsRenderDocFromSnapshot(snapshot);
   }, []);
 
   const snapshotViewMeta = useMemo(() => {
@@ -218,6 +222,7 @@ export const PublishProvider = ({
   useEffect(() => {
     rowDocumentSnapshotsRef.current = {};
     rowDocumentDocsRef.current.clear();
+    databaseRowDocsRef.current.clear();
 
     if (snapshot) {
       registerSnapshotRowDocuments(snapshot);
@@ -429,6 +434,10 @@ export const PublishProvider = ({
   const createRow = useCallback(
     async (rowKey: string) => {
       try {
+        const snapshotRow = databaseRowDocsRef.current.get(rowKey);
+
+        if (snapshotRow) return snapshotRow;
+
         const doc = await RowService.create(rowKey);
 
         if (!doc) {
@@ -473,7 +482,7 @@ export const PublishProvider = ({
 
       try {
         if (snapshot?.view.viewId === viewId) {
-          return snapshotToRenderDoc(snapshot);
+          return createSnapshotRenderDoc(snapshot);
         }
 
         const res = await PublishService.getViewInfo(viewId);
@@ -492,12 +501,12 @@ export const PublishProvider = ({
 
         registerSnapshotRowDocuments(data);
 
-        return snapshotToRenderDoc(data);
+        return createSnapshotRenderDoc(data);
       } catch (e) {
         return Promise.reject(e);
       }
     },
-    [loadRowDocument, registerSnapshotRowDocuments, snapshot, snapshotDataSource]
+    [createSnapshotRenderDoc, loadRowDocument, registerSnapshotRowDocuments, snapshot, snapshotDataSource]
   );
 
   const onRendered = useCallback(() => {

--- a/src/application/services/js-services/http/workspace-api.ts
+++ b/src/application/services/js-services/http/workspace-api.ts
@@ -120,8 +120,8 @@ function iterateFolder(folder: WorkspaceFolder): FolderView {
   };
 }
 
-export async function getWorkspaceFolder(workspaceId: string): Promise<FolderView> {
-  const url = `/api/workspace/${workspaceId}/view/${workspaceId}?depth=50`;
+export async function getWorkspaceFolder(workspaceId: string, depth = 50): Promise<FolderView> {
+  const url = `/api/workspace/${workspaceId}/view/${workspaceId}?depth=${depth}`;
   const payload = await executeAPIRequest<WorkspaceFolder>(() =>
     getAxios()?.get<APIResponse<WorkspaceFolder>>(url)
   );

--- a/src/components/app/hooks/__tests__/useDatabaseIdentity.test.ts
+++ b/src/components/app/hooks/__tests__/useDatabaseIdentity.test.ts
@@ -44,6 +44,10 @@ describe('useDatabaseIdentity', () => {
     window.history.replaceState({}, '', `/app/${WORKSPACE_ID}/page`);
   });
 
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
   it('resolves a database view from template duplication URL mappings', async () => {
     const encodedMappings = encodeURIComponent(JSON.stringify(DATABASE_MAPPINGS));
 
@@ -53,6 +57,23 @@ describe('useDatabaseIdentity', () => {
 
     await expect(result.current.getViewIdFromDatabaseId(DATABASE_ID)).resolves.toBe(PRIMARY_VIEW_ID);
     expect(JSON.parse(localStorage.getItem(STORAGE_KEY) ?? '{}')).toEqual(DATABASE_MAPPINGS);
+  });
+
+  it('uses URL mappings when localStorage persistence is unavailable', async () => {
+    const storageError = new DOMException('Storage is disabled', 'SecurityError');
+
+    jest.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw storageError;
+    });
+    jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+    const encodedMappings = encodeURIComponent(JSON.stringify(DATABASE_MAPPINGS));
+
+    window.history.replaceState({}, '', `/app/${WORKSPACE_ID}/page?db_mappings=${encodedMappings}`);
+
+    const { result } = renderDatabaseIdentity();
+
+    await expect(result.current.getViewIdFromDatabaseId(DATABASE_ID)).resolves.toBe(PRIMARY_VIEW_ID);
   });
 
   it('resolves a database view from persisted template mappings after reload', async () => {

--- a/src/components/app/hooks/__tests__/useDatabaseIdentity.test.ts
+++ b/src/components/app/hooks/__tests__/useDatabaseIdentity.test.ts
@@ -23,12 +23,17 @@ const DATABASE_MAPPINGS = {
 
 const registerSyncContext = jest.fn() as unknown as SyncContextType['registerSyncContext'];
 
-function renderDatabaseIdentity() {
+type LoadDatabaseRelations = (options?: { refresh?: boolean }) => Promise<Record<string, string> | undefined>;
+
+function renderDatabaseIdentity(loadDatabaseRelations?: LoadDatabaseRelations) {
+  const params: Parameters<typeof useDatabaseIdentity>[0] = {
+    currentWorkspaceId: WORKSPACE_ID,
+    registerSyncContext,
+    loadDatabaseRelations,
+  };
+
   return renderHook(() =>
-    useDatabaseIdentity({
-      currentWorkspaceId: WORKSPACE_ID,
-      registerSyncContext,
-    })
+    useDatabaseIdentity(params)
   );
 }
 
@@ -56,5 +61,17 @@ describe('useDatabaseIdentity', () => {
     const { result } = renderDatabaseIdentity();
 
     await expect(result.current.getViewIdFromDatabaseId(DATABASE_ID)).resolves.toBe(PRIMARY_VIEW_ID);
+  });
+
+  it('refreshes workspace relation metadata when the synced mapping is unavailable', async () => {
+    const loadDatabaseRelations = jest
+      .fn<ReturnType<LoadDatabaseRelations>, Parameters<LoadDatabaseRelations>>()
+      .mockResolvedValueOnce({})
+      .mockResolvedValueOnce({ [DATABASE_ID]: PRIMARY_VIEW_ID });
+    const { result } = renderDatabaseIdentity(loadDatabaseRelations);
+
+    await expect(result.current.getViewIdFromDatabaseId(DATABASE_ID)).resolves.toBe(PRIMARY_VIEW_ID);
+    expect(loadDatabaseRelations).toHaveBeenNthCalledWith(1);
+    expect(loadDatabaseRelations).toHaveBeenNthCalledWith(2, { refresh: true });
   });
 });

--- a/src/components/app/hooks/__tests__/useDatabaseIdentity.test.ts
+++ b/src/components/app/hooks/__tests__/useDatabaseIdentity.test.ts
@@ -1,0 +1,60 @@
+import { renderHook } from '@testing-library/react';
+
+import type { SyncContextType } from '@/components/ws/useSync';
+
+import { useDatabaseIdentity } from '../useDatabaseIdentity';
+
+jest.mock('@/application/db', () => ({
+  openCollabDB: jest.fn(),
+}));
+
+jest.mock('@/application/view-loader', () => ({
+  getDatabaseIdFromDoc: jest.fn(),
+}));
+
+const WORKSPACE_ID = 'workspace-1';
+const DATABASE_ID = 'database-1';
+const PRIMARY_VIEW_ID = 'view-1';
+const SECONDARY_VIEW_ID = 'view-2';
+const STORAGE_KEY = `db_mappings_${WORKSPACE_ID}`;
+const DATABASE_MAPPINGS = {
+  [DATABASE_ID]: [PRIMARY_VIEW_ID, SECONDARY_VIEW_ID],
+};
+
+const registerSyncContext = jest.fn() as unknown as SyncContextType['registerSyncContext'];
+
+function renderDatabaseIdentity() {
+  return renderHook(() =>
+    useDatabaseIdentity({
+      currentWorkspaceId: WORKSPACE_ID,
+      registerSyncContext,
+    })
+  );
+}
+
+describe('useDatabaseIdentity', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    localStorage.clear();
+    window.history.replaceState({}, '', `/app/${WORKSPACE_ID}/page`);
+  });
+
+  it('resolves a database view from template duplication URL mappings', async () => {
+    const encodedMappings = encodeURIComponent(JSON.stringify(DATABASE_MAPPINGS));
+
+    window.history.replaceState({}, '', `/app/${WORKSPACE_ID}/page?db_mappings=${encodedMappings}`);
+
+    const { result } = renderDatabaseIdentity();
+
+    await expect(result.current.getViewIdFromDatabaseId(DATABASE_ID)).resolves.toBe(PRIMARY_VIEW_ID);
+    expect(JSON.parse(localStorage.getItem(STORAGE_KEY) ?? '{}')).toEqual(DATABASE_MAPPINGS);
+  });
+
+  it('resolves a database view from persisted template mappings after reload', async () => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(DATABASE_MAPPINGS));
+
+    const { result } = renderDatabaseIdentity();
+
+    await expect(result.current.getViewIdFromDatabaseId(DATABASE_ID)).resolves.toBe(PRIMARY_VIEW_ID);
+  });
+});

--- a/src/components/app/hooks/useDatabaseIdentity.ts
+++ b/src/components/app/hooks/useDatabaseIdentity.ts
@@ -12,6 +12,56 @@ type UseDatabaseIdentityParams = {
   registerSyncContext: SyncContextType['registerSyncContext'];
 };
 
+type DatabaseMappings = Record<DatabaseId, ViewId[]>;
+
+function parseDatabaseMappings(value: string): DatabaseMappings {
+  const parsed = JSON.parse(value) as unknown;
+
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    return {};
+  }
+
+  return Object.fromEntries(
+    Object.entries(parsed).filter(
+      (entry): entry is [DatabaseId, ViewId[]] =>
+        Array.isArray(entry[1]) && entry[1].every((viewId) => typeof viewId === 'string')
+    )
+  );
+}
+
+function getTemplateDatabaseMappings(workspaceId: string): DatabaseMappings {
+  const storageKey = `db_mappings_${workspaceId}`;
+  let storedMappings: DatabaseMappings = {};
+
+  try {
+    const cachedMappings = localStorage.getItem(storageKey);
+
+    if (cachedMappings) {
+      storedMappings = parseDatabaseMappings(cachedMappings);
+    }
+  } catch (e) {
+    console.warn('[useDatabaseIdentity] failed to read db_mappings from localStorage', e);
+  }
+
+  try {
+    const dbMappingsParam = new URLSearchParams(window.location.search).get('db_mappings');
+
+    if (!dbMappingsParam) {
+      return storedMappings;
+    }
+
+    const urlMappings = parseDatabaseMappings(dbMappingsParam);
+    const mergedMappings = { ...storedMappings, ...urlMappings };
+
+    localStorage.setItem(storageKey, JSON.stringify(mergedMappings));
+    Log.debug('[useDatabaseIdentity] stored db_mappings to localStorage', mergedMappings);
+    return mergedMappings;
+  } catch (e) {
+    console.warn('[useDatabaseIdentity] failed to parse db_mappings from URL', e);
+    return storedMappings;
+  }
+}
+
 /**
  * Encapsulates database-specific collab identity mapping.
  *
@@ -53,51 +103,15 @@ export function useDatabaseIdentity({
     async (viewId: string) => {
       if (!currentWorkspaceId) return;
 
-      // First check URL params for database mappings (passed from template duplication)
-      // This allows immediate lookup without waiting for workspace database sync
-      try {
-        const urlParams = new URLSearchParams(window.location.search);
-        const dbMappingsParam = urlParams.get('db_mappings');
+      // Template duplication mappings are available immediately and persist
+      // across reloads, so prefer them over waiting for workspace sync.
+      const databaseMappings = getTemplateDatabaseMappings(currentWorkspaceId);
 
-        if (dbMappingsParam) {
-          const dbMappings: Record<string, string[]> = JSON.parse(decodeURIComponent(dbMappingsParam));
-          // Store in localStorage for persistence across page refreshes
-          const storageKey = `db_mappings_${currentWorkspaceId}`;
-          const existingMappings = JSON.parse(localStorage.getItem(storageKey) || '{}');
-          const mergedMappings = { ...existingMappings, ...dbMappings };
-
-          localStorage.setItem(storageKey, JSON.stringify(mergedMappings));
-          Log.debug('[useDatabaseIdentity] stored db_mappings to localStorage', mergedMappings);
-
-          // Find the database ID that contains this view
-          for (const [databaseId, viewIds] of Object.entries(dbMappings)) {
-            if (viewIds.includes(viewId)) {
-              Log.debug('[useDatabaseIdentity] found databaseId from URL params', { viewId, databaseId });
-              return databaseId;
-            }
-          }
+      for (const [databaseId, viewIds] of Object.entries(databaseMappings)) {
+        if (viewIds.includes(viewId)) {
+          Log.debug('[useDatabaseIdentity] found databaseId from template mappings', { viewId, databaseId });
+          return databaseId;
         }
-      } catch (e) {
-        console.warn('[useDatabaseIdentity] failed to parse db_mappings from URL', e);
-      }
-
-      // Check localStorage for cached database mappings (persists across page refreshes)
-      try {
-        const storageKey = `db_mappings_${currentWorkspaceId}`;
-        const cachedMappings = localStorage.getItem(storageKey);
-
-        if (cachedMappings) {
-          const dbMappings: Record<string, string[]> = JSON.parse(cachedMappings);
-
-          for (const [databaseId, viewIds] of Object.entries(dbMappings)) {
-            if (viewIds.includes(viewId)) {
-              Log.debug('[useDatabaseIdentity] found databaseId from localStorage', { viewId, databaseId });
-              return databaseId;
-            }
-          }
-        }
-      } catch (e) {
-        console.warn('[useDatabaseIdentity] failed to read db_mappings from localStorage', e);
       }
 
       if (databaseStorageId && !workspaceDatabaseDocMapRef.current.has(currentWorkspaceId)) {
@@ -180,6 +194,14 @@ export function useDatabaseIdentity({
 
       if (databaseIdViewIdMapRef.current.has(databaseId)) {
         return databaseIdViewIdMapRef.current.get(databaseId) || null;
+      }
+
+      const mappedViewId = getTemplateDatabaseMappings(currentWorkspaceId)[databaseId]?.[0];
+
+      if (mappedViewId) {
+        databaseIdViewIdMapRef.current.set(databaseId, mappedViewId);
+        Log.debug('[useDatabaseIdentity] found viewId from template mappings', { databaseId, viewId: mappedViewId });
+        return mappedViewId;
       }
 
       // Lazy-load workspace database doc if not yet registered (e.g. after page refresh).

--- a/src/components/app/hooks/useDatabaseIdentity.ts
+++ b/src/components/app/hooks/useDatabaseIdentity.ts
@@ -1,7 +1,7 @@
 import { useCallback, useRef } from 'react';
 
 import { openCollabDB } from '@/application/db';
-import { DatabaseId, Types, ViewId, YDoc, YjsEditorKey } from '@/application/types';
+import { DatabaseId, DatabaseRelations, Types, ViewId, YDoc, YjsEditorKey } from '@/application/types';
 import { getDatabaseIdFromDoc } from '@/application/view-loader';
 import type { SyncContextType } from '@/components/ws/useSync';
 import { Log } from '@/utils/log';
@@ -10,6 +10,7 @@ type UseDatabaseIdentityParams = {
   currentWorkspaceId?: string;
   databaseStorageId?: string;
   registerSyncContext: SyncContextType['registerSyncContext'];
+  loadDatabaseRelations?: (options?: { refresh?: boolean }) => Promise<DatabaseRelations | undefined>;
 };
 
 type DatabaseMappings = Record<DatabaseId, ViewId[]>;
@@ -77,6 +78,7 @@ export function useDatabaseIdentity({
   currentWorkspaceId,
   databaseStorageId,
   registerSyncContext,
+  loadDatabaseRelations,
 }: UseDatabaseIdentityParams) {
   const workspaceDatabaseDocMapRef = useRef<Map<string, YDoc>>(new Map());
   const databaseIdViewIdMapRef = useRef<Map<DatabaseId, ViewId>>(new Map());
@@ -204,6 +206,31 @@ export function useDatabaseIdentity({
         return mappedViewId;
       }
 
+      if (loadDatabaseRelations) {
+        try {
+          let databaseRelations = await loadDatabaseRelations();
+          let relatedViewId = databaseRelations?.[databaseId];
+
+          // The workspace cache can predate a template duplication. Refresh
+          // once before falling back to the eventually-consistent sync doc.
+          if (!relatedViewId && databaseRelations) {
+            databaseRelations = await loadDatabaseRelations({ refresh: true });
+            relatedViewId = databaseRelations?.[databaseId];
+          }
+
+          if (relatedViewId) {
+            databaseIdViewIdMapRef.current.set(databaseId, relatedViewId);
+            Log.debug('[useDatabaseIdentity] found viewId from workspace relation metadata', {
+              databaseId,
+              viewId: relatedViewId,
+            });
+            return relatedViewId;
+          }
+        } catch (e) {
+          Log.warn('[useDatabaseIdentity] failed to load workspace relation metadata', e);
+        }
+      }
+
       // Lazy-load workspace database doc if not yet registered (e.g. after page refresh).
       // This mirrors the logic in getDatabaseIdForViewId.
       if (databaseStorageId && !workspaceDatabaseDocMapRef.current.has(currentWorkspaceId)) {
@@ -289,7 +316,7 @@ export function useDatabaseIdentity({
         }, 10000);
       });
     },
-    [currentWorkspaceId, databaseStorageId, registerWorkspaceDatabaseDoc]
+    [currentWorkspaceId, databaseStorageId, loadDatabaseRelations, registerWorkspaceDatabaseDoc]
   );
 
   const resolveCollabObjectId = useCallback(

--- a/src/components/app/hooks/useDatabaseIdentity.ts
+++ b/src/components/app/hooks/useDatabaseIdentity.ts
@@ -44,6 +44,8 @@ function getTemplateDatabaseMappings(workspaceId: string): DatabaseMappings {
     console.warn('[useDatabaseIdentity] failed to read db_mappings from localStorage', e);
   }
 
+  let urlMappings: DatabaseMappings;
+
   try {
     const dbMappingsParam = new URLSearchParams(window.location.search).get('db_mappings');
 
@@ -51,16 +53,25 @@ function getTemplateDatabaseMappings(workspaceId: string): DatabaseMappings {
       return storedMappings;
     }
 
-    const urlMappings = parseDatabaseMappings(dbMappingsParam);
-    const mergedMappings = { ...storedMappings, ...urlMappings };
-
-    localStorage.setItem(storageKey, JSON.stringify(mergedMappings));
-    Log.debug('[useDatabaseIdentity] stored db_mappings to localStorage', mergedMappings);
-    return mergedMappings;
+    urlMappings = parseDatabaseMappings(dbMappingsParam);
   } catch (e) {
     console.warn('[useDatabaseIdentity] failed to parse db_mappings from URL', e);
     return storedMappings;
   }
+
+  const mergedMappings = { ...storedMappings, ...urlMappings };
+
+  try {
+    localStorage.setItem(storageKey, JSON.stringify(mergedMappings));
+    Log.debug('[useDatabaseIdentity] stored db_mappings to localStorage', mergedMappings);
+  } catch (e) {
+    // URL mappings are the authoritative source for this navigation. Storage
+    // persistence is best-effort and must not break relation rendering when
+    // localStorage is unavailable or full.
+    console.warn('[useDatabaseIdentity] failed to persist db_mappings to localStorage', e);
+  }
+
+  return mergedMappings;
 }
 
 /**

--- a/src/components/app/hooks/useViewOperations.ts
+++ b/src/components/app/hooks/useViewOperations.ts
@@ -7,6 +7,7 @@ import { APP_EVENTS } from '@/application/constants';
 import { CollabService, ViewService, WorkspaceService } from '@/application/services/domains';
 import {
   AccessLevel,
+  DatabaseRelations,
   LoadViewOptions,
   Types,
   View,
@@ -69,7 +70,11 @@ export function getViewReadOnlyStatus(viewId: string, outline?: View[], fallback
 }
 
 // Hook for managing view-related operations
-export function useViewOperations() {
+export function useViewOperations({
+  loadDatabaseRelations,
+}: {
+  loadDatabaseRelations?: (options?: { refresh?: boolean }) => Promise<DatabaseRelations | undefined>;
+} = {}) {
   const { currentWorkspaceId, userWorkspaceInfo } = useAuthInternal();
   const { registerSyncContext, eventEmitter } = useSyncInternal();
   const navigate = useNavigate();
@@ -109,6 +114,7 @@ export function useViewOperations() {
     currentWorkspaceId,
     databaseStorageId,
     registerSyncContext,
+    loadDatabaseRelations,
   });
 
   // Check if view should be readonly based on access permissions

--- a/src/components/app/layers/AppBusinessLayer.tsx
+++ b/src/components/app/layers/AppBusinessLayer.tsx
@@ -192,7 +192,7 @@ export const AppBusinessLayer: FC<AppBusinessLayerProps> = ({ children }) => {
     bindViewSync,
     getCollabHistory,
     previewCollabVersion,
-  } = useViewOperations();
+  } = useViewOperations({ loadDatabaseRelations });
 
   // Initialize row operations
   const { createRow } = useRowOperations();

--- a/src/components/database/components/property/relation/RelationCreationDialog.test.tsx
+++ b/src/components/database/components/property/relation/RelationCreationDialog.test.tsx
@@ -1,12 +1,18 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
-import type { ReactNode } from 'react';
 
 import { useDatabaseContext } from '@/application/database-yjs';
+import { getMultiple as getViews } from '@/application/services/domains/view';
 import { View, ViewLayout } from '@/application/types';
 import { RelationCreationDialog } from '@/components/database/components/property/relation/RelationCreationDialog';
 
+import type { ReactNode } from 'react';
+
 jest.mock('@/application/database-yjs', () => ({
   useDatabaseContext: jest.fn(),
+}));
+
+jest.mock('@/application/services/domains/view', () => ({
+  getMultiple: jest.fn(),
 }));
 
 jest.mock('react-i18next', () => ({
@@ -54,6 +60,10 @@ function makeView({
 }
 
 describe('RelationCreationDialog', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   it('renders and searches relation targets by database container name', async () => {
     const currentGrid = makeView({
       viewId: 'current-grid',
@@ -87,7 +97,13 @@ describe('RelationCreationDialog', () => {
     };
     const loadViewMeta = jest.fn(async (viewId: string) => viewsById[viewId] ?? null);
 
+    (getViews as jest.MockedFunction<typeof getViews>).mockImplementation(async (_workspaceId, viewIds) => {
+      return viewIds.map((viewId) => viewsById[viewId]).filter((view): view is View => Boolean(view));
+    });
+
     (useDatabaseContext as jest.Mock).mockReturnValue({
+      workspaceId: 'workspace-1',
+      databaseDoc: { guid: 'current-database' },
       databasePageId: currentGrid.view_id,
       loadDatabaseRelations: jest.fn().mockResolvedValue({
         'current-database': currentGrid.view_id,
@@ -120,7 +136,146 @@ describe('RelationCreationDialog', () => {
       expect(screen.queryByTestId('relation-candidate-related-database')).not.toBeNull();
     });
 
-    expect(loadViewMeta).toHaveBeenCalledWith(currentContainer.view_id);
-    expect(loadViewMeta).toHaveBeenCalledWith(relatedContainer.view_id);
+    expect(getViews).toHaveBeenNthCalledWith(
+      1,
+      'workspace-1',
+      [currentGrid.view_id, relatedGrid.view_id],
+      0
+    );
+    expect(getViews).toHaveBeenNthCalledWith(
+      2,
+      'workspace-1',
+      [currentContainer.view_id, relatedContainer.view_id],
+      0
+    );
+    expect(loadViewMeta).not.toHaveBeenCalled();
+  });
+
+  it('uses the database container name when opened from a secondary view', async () => {
+    const currentGrid = makeView({
+      viewId: 'current-grid',
+      name: 'Grid',
+      databaseId: 'current-database',
+      parentViewId: 'current-container',
+    });
+    const currentBoard = makeView({
+      viewId: 'current-board',
+      name: 'Board',
+      databaseId: 'current-database',
+      parentViewId: 'current-container',
+    });
+    const currentContainer = makeView({
+      viewId: 'current-container',
+      name: 'To-dos',
+      databaseId: 'current-database',
+      isContainer: true,
+    });
+    const relatedGrid = makeView({
+      viewId: 'related-grid',
+      name: 'Grid',
+      databaseId: 'related-database',
+      parentViewId: 'related-container',
+    });
+    const relatedContainer = makeView({
+      viewId: 'related-container',
+      name: 'Product roadmap',
+      databaseId: 'related-database',
+      isContainer: true,
+    });
+    const viewsById: Record<string, View> = {
+      [currentGrid.view_id]: currentGrid,
+      [currentBoard.view_id]: currentBoard,
+      [currentContainer.view_id]: currentContainer,
+      [relatedGrid.view_id]: relatedGrid,
+      [relatedContainer.view_id]: relatedContainer,
+    };
+
+    (getViews as jest.MockedFunction<typeof getViews>).mockImplementation(async (_workspaceId, viewIds) => {
+      return viewIds.map((viewId) => viewsById[viewId]).filter((view): view is View => Boolean(view));
+    });
+
+    (useDatabaseContext as jest.Mock).mockReturnValue({
+      workspaceId: 'workspace-1',
+      databaseDoc: { guid: 'current-database' },
+      databasePageId: currentBoard.view_id,
+      loadDatabaseRelations: jest.fn().mockResolvedValue({
+        'current-database': currentGrid.view_id,
+        'related-database': relatedGrid.view_id,
+      }),
+      loadViewMeta: jest.fn(async (viewId: string) => viewsById[viewId] ?? null),
+    });
+
+    render(
+      <RelationCreationDialog
+        open
+        initialFieldName='Relation'
+        onOpenChange={jest.fn()}
+        onCreate={jest.fn()}
+      />
+    );
+
+    await screen.findByTestId('relation-candidate-related-database');
+
+    expect(screen.queryByText('This database')).toBeNull();
+    expect(screen.getAllByText('To-dos')).toHaveLength(2);
+  });
+
+  it('falls back to individual view metadata when batch loading is unavailable', async () => {
+    const currentGrid = makeView({
+      viewId: 'current-grid',
+      name: 'Grid',
+      databaseId: 'current-database',
+      parentViewId: 'current-container',
+    });
+    const currentContainer = makeView({
+      viewId: 'current-container',
+      name: 'To-dos',
+      databaseId: 'current-database',
+      isContainer: true,
+    });
+    const relatedGrid = makeView({
+      viewId: 'related-grid',
+      name: 'Grid',
+      databaseId: 'related-database',
+      parentViewId: 'related-container',
+    });
+    const relatedContainer = makeView({
+      viewId: 'related-container',
+      name: 'Product roadmap',
+      databaseId: 'related-database',
+      isContainer: true,
+    });
+    const viewsById: Record<string, View> = {
+      [currentGrid.view_id]: currentGrid,
+      [currentContainer.view_id]: currentContainer,
+      [relatedGrid.view_id]: relatedGrid,
+      [relatedContainer.view_id]: relatedContainer,
+    };
+    const loadViewMeta = jest.fn(async (viewId: string) => viewsById[viewId] ?? null);
+
+    (getViews as jest.MockedFunction<typeof getViews>).mockRejectedValue(new Error('Batch endpoint unavailable'));
+    (useDatabaseContext as jest.Mock).mockReturnValue({
+      workspaceId: 'workspace-1',
+      databaseDoc: { guid: 'current-database' },
+      databasePageId: currentGrid.view_id,
+      loadDatabaseRelations: jest.fn().mockResolvedValue({
+        'current-database': currentGrid.view_id,
+        'related-database': relatedGrid.view_id,
+      }),
+      loadViewMeta,
+    });
+
+    render(
+      <RelationCreationDialog
+        open
+        initialFieldName='Relation'
+        onOpenChange={jest.fn()}
+        onCreate={jest.fn()}
+      />
+    );
+
+    expect((await screen.findByTestId('relation-candidate-current-database')).textContent).toContain('To-dos');
+    expect(screen.getByTestId('relation-candidate-related-database').textContent).toContain('Product roadmap');
+    expect(loadViewMeta).toHaveBeenCalledTimes(4);
   });
 });

--- a/src/components/database/components/property/relation/RelationCreationDialog.test.tsx
+++ b/src/components/database/components/property/relation/RelationCreationDialog.test.tsx
@@ -1,0 +1,126 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+
+import { useDatabaseContext } from '@/application/database-yjs';
+import { View, ViewLayout } from '@/application/types';
+import { RelationCreationDialog } from '@/components/database/components/property/relation/RelationCreationDialog';
+
+jest.mock('@/application/database-yjs', () => ({
+  useDatabaseContext: jest.fn(),
+}));
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: { defaultValue?: string }) => options?.defaultValue ?? key,
+  }),
+}));
+
+jest.mock('@/components/_shared/modal', () => ({
+  NormalModal: ({ children, open }: { children: ReactNode; open: boolean }) =>
+    open ? <div data-testid='relation-modal'>{children}</div> : null,
+}));
+
+jest.mock('@/components/database/components/property/relation/RelationView', () => ({
+  RelationView: ({ view }: { view: View }) => <span>{view.name}</span>,
+}));
+
+function makeView({
+  viewId,
+  name,
+  databaseId,
+  parentViewId,
+  isContainer = false,
+}: {
+  viewId: string;
+  name: string;
+  databaseId: string;
+  parentViewId?: string;
+  isContainer?: boolean;
+}): View {
+  return {
+    view_id: viewId,
+    parent_view_id: parentViewId,
+    name,
+    layout: ViewLayout.Grid,
+    children: [],
+    icon: null,
+    extra: {
+      database_id: databaseId,
+      is_database_container: isContainer,
+    },
+    is_published: false,
+    is_private: false,
+  };
+}
+
+describe('RelationCreationDialog', () => {
+  it('renders and searches relation targets by database container name', async () => {
+    const currentGrid = makeView({
+      viewId: 'current-grid',
+      name: 'Grid',
+      databaseId: 'current-database',
+      parentViewId: 'current-container',
+    });
+    const currentContainer = makeView({
+      viewId: 'current-container',
+      name: 'To-dos',
+      databaseId: 'current-database',
+      isContainer: true,
+    });
+    const relatedGrid = makeView({
+      viewId: 'related-grid',
+      name: 'Grid',
+      databaseId: 'related-database',
+      parentViewId: 'related-container',
+    });
+    const relatedContainer = makeView({
+      viewId: 'related-container',
+      name: 'Product roadmap',
+      databaseId: 'related-database',
+      isContainer: true,
+    });
+    const viewsById: Record<string, View> = {
+      [currentGrid.view_id]: currentGrid,
+      [currentContainer.view_id]: currentContainer,
+      [relatedGrid.view_id]: relatedGrid,
+      [relatedContainer.view_id]: relatedContainer,
+    };
+    const loadViewMeta = jest.fn(async (viewId: string) => viewsById[viewId] ?? null);
+
+    (useDatabaseContext as jest.Mock).mockReturnValue({
+      databasePageId: currentGrid.view_id,
+      loadDatabaseRelations: jest.fn().mockResolvedValue({
+        'current-database': currentGrid.view_id,
+        'related-database': relatedGrid.view_id,
+      }),
+      loadViewMeta,
+    });
+
+    render(
+      <RelationCreationDialog
+        open
+        initialFieldName='Relation'
+        onOpenChange={jest.fn()}
+        onCreate={jest.fn()}
+      />
+    );
+
+    const currentCandidate = await screen.findByTestId('relation-candidate-current-database');
+    const relatedCandidate = await screen.findByTestId('relation-candidate-related-database');
+
+    expect(currentCandidate.textContent).toContain('To-dos');
+    expect(relatedCandidate.textContent).toContain('Product roadmap');
+    expect(currentCandidate.textContent).not.toContain('Grid');
+    expect(relatedCandidate.textContent).not.toContain('Grid');
+
+    fireEvent.change(screen.getByPlaceholderText('Search'), { target: { value: 'roadmap' } });
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('relation-candidate-current-database')).toBeNull();
+      expect(screen.queryByTestId('relation-candidate-related-database')).not.toBeNull();
+    });
+
+    expect(loadViewMeta).toHaveBeenCalledWith(currentContainer.view_id);
+    expect(loadViewMeta).toHaveBeenCalledWith(relatedContainer.view_id);
+  });
+});

--- a/src/components/database/components/property/relation/RelationCreationDialog.tsx
+++ b/src/components/database/components/property/relation/RelationCreationDialog.tsx
@@ -13,7 +13,8 @@ const MODAL_PAPER_PROPS = {
 
 import { useDatabaseContext } from '@/application/database-yjs';
 import { RelationLimit } from '@/application/database-yjs/fields/relation/relation.type';
-import { View } from '@/application/types';
+import { getMultiple as getViews } from '@/application/services/domains/view';
+import { LoadViewMeta, View } from '@/application/types';
 import { isDatabaseContainer } from '@/application/view-utils';
 import { NormalModal } from '@/components/_shared/modal';
 import { Button } from '@/components/ui/button';
@@ -37,6 +38,53 @@ type RelationCandidate = {
   databaseViewId: string;
   displayView: View;
 };
+
+function indexViews(views: View[]): Map<string, View> {
+  const indexedViews = new Map<string, View>();
+  const pending = [...views];
+  let index = 0;
+
+  while (index < pending.length) {
+    const view = pending[index];
+
+    index += 1;
+
+    if (!view || indexedViews.has(view.view_id)) continue;
+    indexedViews.set(view.view_id, view);
+    pending.push(...view.children);
+  }
+
+  return indexedViews;
+}
+
+async function loadViewsById(
+  workspaceId: string,
+  viewIds: string[],
+  loadViewMeta: LoadViewMeta
+): Promise<Map<string, View>> {
+  const uniqueViewIds = Array.from(new Set(viewIds.filter(Boolean)));
+
+  if (uniqueViewIds.length === 0) return new Map();
+
+  try {
+    // The API chunks large lists internally, replacing one request per view
+    // with one batch per 50 IDs.
+    return indexViews(await getViews(workspaceId, uniqueViewIds, 0));
+  } catch {
+    // Keep compatibility with servers that do not expose the batch endpoint.
+    const views = await Promise.all(
+      uniqueViewIds.map(async (viewId) => {
+        try {
+          return await loadViewMeta(viewId);
+        } catch {
+          return null;
+        }
+      })
+    );
+
+    return indexViews(views.filter((view): view is View => Boolean(view)));
+  }
+}
 
 function relationLimitLabel(t: TFunction, limit: RelationLimit) {
   return limit === RelationLimit.OneOnly
@@ -62,7 +110,7 @@ export function RelationCreationDialog({
   onCreate: (result: RelationCreationResult) => void;
 }) {
   const { t } = useTranslation();
-  const { databasePageId, loadDatabaseRelations, loadViewMeta } = useDatabaseContext();
+  const { databaseDoc, databasePageId, loadDatabaseRelations, loadViewMeta, workspaceId } = useDatabaseContext();
   const [fieldName, setFieldName] = useState(initialFieldName);
   const [reciprocalFieldName, setReciprocalFieldName] = useState('');
   const [selectedDatabaseId, setSelectedDatabaseId] = useState('');
@@ -130,38 +178,32 @@ export function RelationCreationDialog({
         // up — the workspace cache is otherwise only invalidated on workspace
         // switch.
         const databaseRelations = (await loadDatabaseRelationsFn({ refresh: true })) ?? {};
-        const entries = Object.entries(databaseRelations);
-
-        const fetched = await Promise.all(
-          entries.map(async ([databaseId, viewId]) => {
-            if (!viewId) return null;
-
-            try {
-              const databaseView = await loadViewMetaFn(viewId);
-
-              if (!databaseView) return null;
-
-              let displayView = databaseView;
-
-              if (!isDatabaseContainer(databaseView) && databaseView.parent_view_id) {
-                try {
-                  const parentView = await loadViewMetaFn(databaseView.parent_view_id);
-
-                  if (isDatabaseContainer(parentView)) {
-                    displayView = parentView;
-                  }
-                } catch {
-                  // Fall back to the registered database view for legacy or
-                  // inaccessible folder structures.
-                }
-              }
-
-              return { databaseId, databaseViewId: databaseView.view_id, displayView };
-            } catch {
-              return null;
-            }
-          })
+        const entries = Object.entries(databaseRelations).filter((entry): entry is [string, string] => Boolean(entry[1]));
+        const databaseViews = await loadViewsById(
+          workspaceId,
+          entries.map(([, viewId]) => viewId),
+          loadViewMetaFn
         );
+        const parentViews = await loadViewsById(
+          workspaceId,
+          Array.from(databaseViews.values())
+            .filter((view) => !isDatabaseContainer(view))
+            .map((view) => view.parent_view_id)
+            .filter((viewId): viewId is string => Boolean(viewId)),
+          loadViewMetaFn
+        );
+        const fetched = entries.map(([databaseId, viewId]) => {
+          const databaseView = databaseViews.get(viewId);
+
+          if (!databaseView) return null;
+
+          const parentView = databaseView.parent_view_id
+            ? parentViews.get(databaseView.parent_view_id)
+            : undefined;
+          const displayView = isDatabaseContainer(parentView) ? parentView : databaseView;
+
+          return { databaseId, databaseViewId: databaseView.view_id, displayView };
+        });
 
         if (cancelled) return;
 
@@ -189,7 +231,7 @@ export function RelationCreationDialog({
     return () => {
       cancelled = true;
     };
-  }, [open]);
+  }, [open, workspaceId]);
 
   const filteredCandidates = useMemo(() => {
     if (!query.trim()) return candidates;
@@ -206,9 +248,12 @@ export function RelationCreationDialog({
   const currentCandidate = useMemo(
     () =>
       candidates.find(
-        (entry) => entry.databaseViewId === databasePageId || entry.displayView.view_id === databasePageId
+        (entry) =>
+          entry.databaseId === databaseDoc.guid ||
+          entry.databaseViewId === databasePageId ||
+          entry.displayView.view_id === databasePageId
       ),
-    [candidates, databasePageId]
+    [candidates, databaseDoc.guid, databasePageId]
   );
 
   const relatedDatabaseName =

--- a/src/components/database/components/property/relation/RelationCreationDialog.tsx
+++ b/src/components/database/components/property/relation/RelationCreationDialog.tsx
@@ -14,6 +14,7 @@ const MODAL_PAPER_PROPS = {
 import { useDatabaseContext } from '@/application/database-yjs';
 import { RelationLimit } from '@/application/database-yjs/fields/relation/relation.type';
 import { View } from '@/application/types';
+import { isDatabaseContainer } from '@/application/view-utils';
 import { NormalModal } from '@/components/_shared/modal';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -29,6 +30,12 @@ export type RelationCreationResult = {
   isTwoWay: boolean;
   sourceLimit: RelationLimit;
   reciprocalFieldName?: string;
+};
+
+type RelationCandidate = {
+  databaseId: string;
+  databaseViewId: string;
+  displayView: View;
 };
 
 function relationLimitLabel(t: TFunction, limit: RelationLimit) {
@@ -63,9 +70,9 @@ export function RelationCreationDialog({
   const [isTwoWay, setIsTwoWay] = useState(false);
   const [query, setQuery] = useState('');
   const [loading, setLoading] = useState(false);
-  // Each candidate carries both view metadata (for display) and the database_id
-  // that needs to be persisted on the relation property.
-  const [candidates, setCandidates] = useState<Array<{ databaseId: string; view: View }>>([]);
+  // Keep the registered database view ID for identity, while rendering the
+  // database container so users see the database name instead of "Grid".
+  const [candidates, setCandidates] = useState<RelationCandidate[]>([]);
 
   // RelationCreationDialog itself stays mounted under PropertyMenu — only the
   // MUI Dialog subtree unmounts via `keepMounted={false}`. The useState above
@@ -114,9 +121,10 @@ export function RelationCreationDialog({
         // Mirror the desktop flow (RelationDatabaseListCubit):
         //   1. Ask the workspace for every registered database via
         //      DatabaseEventGetDatabases (here: `loadDatabaseRelations`).
-        //   2. For each `(databaseId, viewId)`, fetch the view metadata so we
-        //      get the database name. Desktop calls ViewBackendService.getView
-        //      per id; we call `loadViewMeta` per id.
+        //   2. For each `(databaseId, viewId)`, fetch the registered database
+        //      view and its container. The workspace map points to the first
+        //      internal view (usually named "Grid"), while the container owns
+        //      the user-facing database name.
         //   3. Drop entries whose view fetch failed.
         // Force a refresh so a database created earlier in this session shows
         // up — the workspace cache is otherwise only invalidated on workspace
@@ -129,9 +137,26 @@ export function RelationCreationDialog({
             if (!viewId) return null;
 
             try {
-              const view = await loadViewMetaFn(viewId);
+              const databaseView = await loadViewMetaFn(viewId);
 
-              return view ? { databaseId, view } : null;
+              if (!databaseView) return null;
+
+              let displayView = databaseView;
+
+              if (!isDatabaseContainer(databaseView) && databaseView.parent_view_id) {
+                try {
+                  const parentView = await loadViewMetaFn(databaseView.parent_view_id);
+
+                  if (isDatabaseContainer(parentView)) {
+                    displayView = parentView;
+                  }
+                } catch {
+                  // Fall back to the registered database view for legacy or
+                  // inaccessible folder structures.
+                }
+              }
+
+              return { databaseId, databaseViewId: databaseView.view_id, displayView };
             } catch {
               return null;
             }
@@ -141,7 +166,7 @@ export function RelationCreationDialog({
         if (cancelled) return;
 
         const seen = new Set<string>();
-        const resolved: Array<{ databaseId: string; view: View }> = [];
+        const resolved: RelationCandidate[] = [];
 
         for (const entry of fetched) {
           if (!entry || seen.has(entry.databaseId)) continue;
@@ -170,7 +195,7 @@ export function RelationCreationDialog({
     if (!query.trim()) return candidates;
     const lowered = query.trim().toLowerCase();
 
-    return candidates.filter(({ view }) => (view.name || '').toLowerCase().includes(lowered));
+    return candidates.filter(({ displayView }) => (displayView.name || '').toLowerCase().includes(lowered));
   }, [candidates, query]);
 
   const selectedCandidate = useMemo(
@@ -179,13 +204,17 @@ export function RelationCreationDialog({
   );
 
   const currentCandidate = useMemo(
-    () => candidates.find((entry) => entry.view.view_id === databasePageId),
+    () =>
+      candidates.find(
+        (entry) => entry.databaseViewId === databasePageId || entry.displayView.view_id === databasePageId
+      ),
     [candidates, databasePageId]
   );
 
-  const relatedDatabaseName = selectedCandidate?.view.name || t('grid.relation.relatedDatabasePlaceholder');
+  const relatedDatabaseName =
+    selectedCandidate?.displayView.name || t('grid.relation.relatedDatabasePlaceholder');
   const sourceDatabaseName =
-    currentCandidate?.view.name || t('grid.relation.thisDatabase', { defaultValue: 'This database' });
+    currentCandidate?.displayView.name || t('grid.relation.thisDatabase', { defaultValue: 'This database' });
 
   // Memoize the disabled flag so MUI's Button can bail out when only
   // unrelated state (search query, two-way toggle, …) changes.
@@ -242,7 +271,7 @@ export function RelationCreationDialog({
                 {t('grid.relation.emptySearchResult')}
               </div>
             ) : (
-              filteredCandidates.map(({ databaseId, view }) => {
+              filteredCandidates.map(({ databaseId, displayView }) => {
                 const selected = databaseId === selectedDatabaseId;
 
                 return (
@@ -256,7 +285,7 @@ export function RelationCreationDialog({
                     )}
                     onClick={() => setSelectedDatabaseId(databaseId)}
                   >
-                    <RelationView view={view} />
+                    <RelationView view={displayView} />
                   </button>
                 );
               })

--- a/src/components/publish/header/duplicate/DuplicateModal.tsx
+++ b/src/components/publish/header/duplicate/DuplicateModal.tsx
@@ -42,6 +42,7 @@ function DuplicateModal({ open, onClose }: { open: boolean; onClose: () => void 
     selectedSpaceId,
     workspaceLoading,
     spaceLoading,
+    spaceError,
     loadWorkspaces,
     loadSpaces,
   } = useLoadWorkspaces();
@@ -110,9 +111,15 @@ function DuplicateModal({ open, onClose }: { open: boolean; onClose: () => void 
           />
           <SpaceList
             loading={spaceLoading}
+            error={spaceError}
             spaceList={spaceList}
             value={selectedSpaceId}
             onChange={setSelectedSpaceId}
+            onRetry={() => {
+              if (selectedWorkspaceId) {
+                void loadSpaces(selectedWorkspaceId);
+              }
+            }}
           />
         </div>
       </NormalModal>

--- a/src/components/publish/header/duplicate/SelectWorkspace.tsx
+++ b/src/components/publish/header/duplicate/SelectWorkspace.tsx
@@ -9,6 +9,8 @@ import { Popover } from '@/components/_shared/popover';
 import { useCurrentUserOptional } from '@/components/main/app.hooks';
 import { stringToColor } from '@/utils/color';
 
+import { saveDuplicateSelectedWorkspaceId } from './storage';
+
 export interface SelectWorkspaceProps {
   value: string;
   onChange?: (value: string) => void;
@@ -121,7 +123,7 @@ function SelectWorkspace({ loading, value, onChange, workspaceList }: SelectWork
                     onClick={() => {
                       onChange?.(workspace.id);
                       setSelectOpen(false);
-                      localStorage.setItem('duplicate_selected_workspace', workspace.id);
+                      saveDuplicateSelectedWorkspaceId(workspace.id);
                     }}
                     className={'w-full px-3 py-2'}
                     variant={'text'}

--- a/src/components/publish/header/duplicate/SpaceList.test.tsx
+++ b/src/components/publish/header/duplicate/SpaceList.test.tsx
@@ -1,0 +1,37 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import SpaceList from '@/components/publish/header/duplicate/SpaceList';
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => {
+      const translations: Record<string, string> = {
+        'publish.addTo': 'Add to',
+        'publish.loadSpacesFailed': "Couldn't load spaces.",
+        'publish.noSpacesAvailable': 'No spaces available.',
+        'button.retry': 'Retry',
+      };
+
+      return translations[key] || key;
+    },
+  }),
+}));
+
+describe('SpaceList', () => {
+  it('shows a retry action when loading spaces fails', () => {
+    const onRetry = jest.fn();
+
+    render(<SpaceList error value={''} spaceList={[]} onRetry={onRetry} />);
+
+    expect(screen.getByRole('alert').textContent).toContain("Couldn't load spaces.");
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }));
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+
+  it('distinguishes an empty workspace from a loading failure', () => {
+    render(<SpaceList value={''} spaceList={[]} />);
+
+    expect(screen.getByText('No spaces available.')).toBeTruthy();
+    expect(screen.queryByRole('alert')).toBeNull();
+  });
+});

--- a/src/components/publish/header/duplicate/SpaceList.tsx
+++ b/src/components/publish/header/duplicate/SpaceList.tsx
@@ -12,10 +12,12 @@ export interface SpaceListProps {
   onChange?: (value: string) => void;
   spaceList: SpaceView[];
   loading?: boolean;
+  error?: boolean;
+  onRetry?: () => void;
   title?: React.ReactNode;
 }
 
-function SpaceList({ loading, spaceList, value, onChange, title }: SpaceListProps) {
+function SpaceList({ loading, error, spaceList, value, onChange, onRetry, title }: SpaceListProps) {
   const { t } = useTranslation();
 
   const getExtraObj = useCallback((extra: string) => {
@@ -61,6 +63,17 @@ function SpaceList({ loading, spaceList, value, onChange, title }: SpaceListProp
         <div className={'flex w-full items-center justify-center'}>
           <CircularProgress size={24} />
         </div>
+      ) : error ? (
+        <div className={'flex min-h-12 w-full items-center justify-between gap-3 text-sm'} role={'alert'}>
+          <span className={'text-text-secondary'}>{t('publish.loadSpacesFailed')}</span>
+          <Button color={'primary'} size={'small'} variant={'text'} onClick={onRetry}>
+            {t('button.retry')}
+          </Button>
+        </div>
+      ) : spaceList.length === 0 ? (
+        <div className={'flex min-h-12 w-full items-center text-sm text-text-secondary'}>
+          {t('publish.noSpacesAvailable')}
+        </div>
       ) : (
         <div className={'appflowy-scroller flex w-full flex-1 flex-col gap-1 overflow-y-auto overflow-x-hidden'}>
           {spaceList.map((space) => {
@@ -69,7 +82,7 @@ function SpaceList({ loading, spaceList, value, onChange, title }: SpaceListProp
             return (
               <Tooltip title={space.name} key={space.id} placement={'bottom'} enterDelay={1000} enterNextDelay={1000}>
                 <Button
-                  data-testid="space-item"
+                  data-testid='space-item'
                   variant={'text'}
                   color={'inherit'}
                   className={'flex items-center p-1 font-normal'}

--- a/src/components/publish/header/duplicate/storage.ts
+++ b/src/components/publish/header/duplicate/storage.ts
@@ -1,0 +1,17 @@
+const SELECTED_WORKSPACE_STORAGE_KEY = 'duplicate_selected_workspace';
+
+export function loadDuplicateSelectedWorkspaceId(): string {
+  try {
+    return localStorage.getItem(SELECTED_WORKSPACE_STORAGE_KEY) || '';
+  } catch {
+    return '';
+  }
+}
+
+export function saveDuplicateSelectedWorkspaceId(workspaceId: string): void {
+  try {
+    localStorage.setItem(SELECTED_WORKSPACE_STORAGE_KEY, workspaceId);
+  } catch {
+    // Selecting a workspace must still work when storage is disabled or full.
+  }
+}

--- a/src/components/publish/header/duplicate/useDuplicate.test.ts
+++ b/src/components/publish/header/duplicate/useDuplicate.test.ts
@@ -2,6 +2,7 @@ import { act, renderHook } from '@testing-library/react';
 
 import { WorkspaceService } from '@/application/services/domains';
 import { FolderView } from '@/application/types';
+import { saveDuplicateSelectedWorkspaceId } from '@/components/publish/header/duplicate/storage';
 import { useLoadWorkspaces } from '@/components/publish/header/duplicate/useDuplicate';
 
 jest.mock('@/application/services/domains', () => ({
@@ -59,6 +60,28 @@ describe('useLoadWorkspaces', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     localStorage.clear();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('renders with no saved workspace when localStorage is unavailable', () => {
+    jest.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+      throw new DOMException('Storage is disabled', 'SecurityError');
+    });
+
+    const { result } = renderHook(() => useLoadWorkspaces());
+
+    expect(result.current.selectedWorkspaceId).toBe('');
+  });
+
+  it('keeps workspace selection usable when localStorage persistence fails', () => {
+    jest.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new DOMException('Storage is full', 'QuotaExceededError');
+    });
+
+    expect(() => saveDuplicateSelectedWorkspaceId('workspace-a')).not.toThrow();
   });
 
   it('exposes a retryable error when loading spaces fails', async () => {

--- a/src/components/publish/header/duplicate/useDuplicate.test.ts
+++ b/src/components/publish/header/duplicate/useDuplicate.test.ts
@@ -1,0 +1,150 @@
+import { act, renderHook } from '@testing-library/react';
+
+import { WorkspaceService } from '@/application/services/domains';
+import { FolderView } from '@/application/types';
+import { useLoadWorkspaces } from '@/components/publish/header/duplicate/useDuplicate';
+
+jest.mock('@/application/services/domains', () => ({
+  WorkspaceService: {
+    getAll: jest.fn(),
+    getFolder: jest.fn(),
+  },
+}));
+
+jest.mock('@/components/_shared/notify', () => ({
+  notify: {
+    error: jest.fn(),
+  },
+}));
+
+jest.mock('@/components/main/app.hooks', () => ({
+  useCurrentUserOptional: () => ({ email: 'test@appflowy.io' }),
+  useIsAuthenticatedOptional: () => true,
+}));
+
+const mockWorkspaceService = WorkspaceService as jest.Mocked<typeof WorkspaceService>;
+
+function createFolder(workspaceId: string, spaceId: string, spaceName: string): FolderView {
+  return {
+    id: workspaceId,
+    icon: null,
+    extra: null,
+    name: workspaceId,
+    isSpace: false,
+    isPrivate: false,
+    children: [
+      {
+        id: spaceId,
+        icon: null,
+        extra: null,
+        name: spaceName,
+        isSpace: true,
+        isPrivate: false,
+        children: [],
+      },
+    ],
+  };
+}
+
+function createDeferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+
+  return { promise, resolve };
+}
+
+describe('useLoadWorkspaces', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    localStorage.clear();
+  });
+
+  it('exposes a retryable error when loading spaces fails', async () => {
+    const consoleError = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    mockWorkspaceService.getFolder
+      .mockRejectedValueOnce(new Error('Network error'))
+      .mockResolvedValueOnce(createFolder('workspace-a', 'space-a', 'General'));
+
+    const { result } = renderHook(() => useLoadWorkspaces());
+
+    await act(async () => {
+      await result.current.loadSpaces('workspace-a');
+    });
+
+    expect(result.current.spaceError).toBe(true);
+    expect(result.current.spaceLoading).toBe(false);
+    expect(result.current.spaceList).toEqual([]);
+
+    await act(async () => {
+      await result.current.loadSpaces('workspace-a');
+    });
+
+    expect(result.current.spaceError).toBe(false);
+    expect(result.current.spaceList).toEqual([
+      {
+        id: 'space-a',
+        name: 'General',
+        isPrivate: false,
+        extra: null,
+      },
+    ]);
+    expect(mockWorkspaceService.getFolder).toHaveBeenCalledTimes(2);
+    expect(mockWorkspaceService.getFolder).toHaveBeenNthCalledWith(1, 'workspace-a', 2);
+    expect(mockWorkspaceService.getFolder).toHaveBeenNthCalledWith(2, 'workspace-a', 2);
+
+    consoleError.mockRestore();
+  });
+
+  it('handles an account with no available workspaces', async () => {
+    mockWorkspaceService.getAll.mockResolvedValue([]);
+
+    const { result } = renderHook(() => useLoadWorkspaces());
+
+    await act(async () => {
+      await result.current.loadWorkspaces();
+    });
+
+    expect(result.current.workspaceList).toEqual([]);
+    expect(result.current.selectedWorkspaceId).toBe('');
+    expect(result.current.workspaceLoading).toBe(false);
+  });
+
+  it('ignores a stale response after switching workspaces', async () => {
+    const workspaceA = createDeferred<FolderView>();
+    const workspaceB = createDeferred<FolderView>();
+
+    mockWorkspaceService.getFolder.mockImplementation((workspaceId) => {
+      return workspaceId === 'workspace-a' ? workspaceA.promise : workspaceB.promise;
+    });
+
+    const { result } = renderHook(() => useLoadWorkspaces());
+    let loadWorkspaceA!: Promise<void>;
+    let loadWorkspaceB!: Promise<void>;
+
+    act(() => {
+      loadWorkspaceA = result.current.loadSpaces('workspace-a');
+      loadWorkspaceB = result.current.loadSpaces('workspace-b');
+    });
+
+    await act(async () => {
+      workspaceB.resolve(createFolder('workspace-b', 'space-b', 'Projects'));
+      await loadWorkspaceB;
+    });
+
+    expect(result.current.spaceList[0]?.id).toBe('space-b');
+    expect(result.current.spaceLoading).toBe(false);
+
+    await act(async () => {
+      workspaceA.resolve(createFolder('workspace-a', 'space-a', 'General'));
+      await loadWorkspaceA;
+    });
+
+    expect(result.current.spaceList[0]?.id).toBe('space-b');
+    expect(result.current.spaceError).toBe(false);
+    expect(mockWorkspaceService.getFolder).toHaveBeenCalledWith('workspace-a', 2);
+    expect(mockWorkspaceService.getFolder).toHaveBeenCalledWith('workspace-b', 2);
+  });
+});

--- a/src/components/publish/header/duplicate/useDuplicate.ts
+++ b/src/components/publish/header/duplicate/useDuplicate.ts
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
 
 import { WorkspaceService } from '@/application/services/domains';
@@ -6,7 +6,7 @@ import { SpaceView, Workspace } from '@/application/types';
 import { notify } from '@/components/_shared/notify';
 import { useCurrentUserOptional, useIsAuthenticatedOptional } from '@/components/main/app.hooks';
 
-export function useDuplicate () {
+export function useDuplicate() {
   const isAuthenticated = useIsAuthenticatedOptional();
   const [search, setSearch] = useSearchParams();
   const [loginOpen, setLoginOpen] = React.useState(false);
@@ -48,7 +48,7 @@ export function useDuplicate () {
   };
 }
 
-export function useLoadWorkspaces () {
+export function useLoadWorkspaces() {
   const currentUser = useCurrentUserOptional();
   const isAuthenticated = useIsAuthenticatedOptional() && Boolean(currentUser);
   const [spaceLoading, setSpaceLoading] = useState<boolean>(false);
@@ -61,6 +61,15 @@ export function useLoadWorkspaces () {
   const [workspaceList, setWorkspaceList] = useState<Workspace[]>([]);
 
   const [spaceList, setSpaceList] = useState<SpaceView[]>([]);
+  const [spaceError, setSpaceError] = useState(false);
+  const spaceRequestIdRef = useRef(0);
+  const loadedSpaceWorkspaceIdRef = useRef('');
+
+  useEffect(() => {
+    return () => {
+      spaceRequestIdRef.current += 1;
+    };
+  }, []);
 
   const loadWorkspaces = useCallback(async () => {
     if (!isAuthenticated) return;
@@ -68,10 +77,10 @@ export function useLoadWorkspaces () {
     try {
       const workspaces = await WorkspaceService.getAll();
 
-      if (workspaces) {
+      if (workspaces.length > 0) {
         setWorkspaceList(workspaces);
-        setSelectedWorkspaceId(prev => {
-          if (!prev || !workspaces.find(item => item.id === prev)) return workspaces[0].id;
+        setSelectedWorkspaceId((prev) => {
+          if (!prev || !workspaces.find((item) => item.id === prev)) return workspaces[0].id;
           return prev;
         });
       } else {
@@ -88,36 +97,50 @@ export function useLoadWorkspaces () {
   const loadSpaces = useCallback(
     async (selectedWorkspaceId: string) => {
       if (!isAuthenticated) return;
+      const requestId = ++spaceRequestIdRef.current;
+
+      if (loadedSpaceWorkspaceIdRef.current !== selectedWorkspaceId) {
+        loadedSpaceWorkspaceIdRef.current = selectedWorkspaceId;
+        setSpaceList([]);
+      }
+
+      setSpaceError(false);
+      setSelectedSpaceId('');
       setSpaceLoading(true);
       try {
-        const folder = await WorkspaceService.getFolder(selectedWorkspaceId);
+        const folder = await WorkspaceService.getFolder(selectedWorkspaceId, 2);
 
-        if (folder) {
-          const spaces = [];
+        if (requestId !== spaceRequestIdRef.current) return;
 
-          for (const child of folder.children) {
-            if (child.isSpace) {
-              spaces.push({
-                id: child.id,
-                name: child.name,
-                isPrivate: child.isPrivate,
-                extra: child.extra,
-              });
-            }
-          }
-
-          setSpaceList(spaces);
-        } else {
-          setSpaceList([]);
+        if (!folder) {
+          throw new Error('Workspace folder response is empty');
         }
+
+        const spaces = [];
+
+        for (const child of folder.children) {
+          if (child.isSpace) {
+            spaces.push({
+              id: child.id,
+              name: child.name,
+              isPrivate: child.isPrivate,
+              extra: child.extra,
+            });
+          }
+        }
+
+        setSpaceList(spaces);
       } catch (e) {
-        console.error('Failed to load spaces');
+        if (requestId !== spaceRequestIdRef.current) return;
+        console.error('Failed to load spaces', e);
+        setSpaceError(true);
       } finally {
-        setSelectedSpaceId('');
-        setSpaceLoading(false);
+        if (requestId === spaceRequestIdRef.current) {
+          setSpaceLoading(false);
+        }
       }
     },
-    [isAuthenticated],
+    [isAuthenticated]
   );
 
   return {
@@ -129,6 +152,7 @@ export function useLoadWorkspaces () {
     setSelectedSpaceId,
     workspaceLoading,
     spaceLoading,
+    spaceError,
     loadWorkspaces,
     loadSpaces,
   };

--- a/src/components/publish/header/duplicate/useDuplicate.ts
+++ b/src/components/publish/header/duplicate/useDuplicate.ts
@@ -6,6 +6,8 @@ import { SpaceView, Workspace } from '@/application/types';
 import { notify } from '@/components/_shared/notify';
 import { useCurrentUserOptional, useIsAuthenticatedOptional } from '@/components/main/app.hooks';
 
+import { loadDuplicateSelectedWorkspaceId } from './storage';
+
 export function useDuplicate() {
   const isAuthenticated = useIsAuthenticatedOptional();
   const [search, setSearch] = useSearchParams();
@@ -53,9 +55,7 @@ export function useLoadWorkspaces() {
   const isAuthenticated = useIsAuthenticatedOptional() && Boolean(currentUser);
   const [spaceLoading, setSpaceLoading] = useState<boolean>(false);
   const [workspaceLoading, setWorkspaceLoading] = useState<boolean>(false);
-  const [selectedWorkspaceId, setSelectedWorkspaceId] = useState<string>(() => {
-    return localStorage.getItem('duplicate_selected_workspace') || '';
-  });
+  const [selectedWorkspaceId, setSelectedWorkspaceId] = useState<string>(loadDuplicateSelectedWorkspaceId);
   const [selectedSpaceId, setSelectedSpaceId] = useState<string>('');
 
   const [workspaceList, setWorkspaceList] = useState<Workspace[]>([]);


### PR DESCRIPTION
## What changed

- Load the template destination hierarchy with `depth=2`, guard against stale workspace responses, and distinguish retryable failures from an empty space list.
- Resolve published relation rows from the attached snapshot before falling back to the live row service.
- Restore duplicated relation database identities from the duplication URL, persisted mappings, or refreshed workspace metadata.
- Display relation targets with their database container names instead of their first internal view names.
- Add a fixture-backed Playwright BDD feature covering five cross-account document-template cases: referenced database, inline database, referenced page, nested referenced database, and nested inline database.
- Extend the relation-template fixture scenario to assert that a copied relation database is named `Related DB`, while its relation cell resolves before and after reload.
- Every template scenario uses a different consumer account and clicks Start with this template.

## Validation

- Existing focused Web unit tests for space loading, relation snapshots, relation names, and duplication mappings: passed.
- `pnpm test:e2e:bdd --grep @published-document-template-dependencies`: 5 passed.
- `pnpm exec playwright test -c playwright.bdd.config.ts --grep @published-relation-template --workers=1`: 1 passed, including the depth-2 destination request and copied database name.
- Playwright BDD generation and Prettier checks passed.

## Server dependency

Requires [AppFlowy-Cloud-Premium PR #982](https://github.com/AppFlowy-IO/AppFlowy-Cloud-Premium/pull/982) for recursive publication of referenced pages, nested database dependencies, relation remapping, and relation-target container names.