### PR TITLE
fix(database): align Web row visibility with Desktop

### DIFF
--- a/src/application/database-yjs/__tests__/row-order-visibility.test.ts
+++ b/src/application/database-yjs/__tests__/row-order-visibility.test.ts
@@ -1,0 +1,86 @@
+import * as Y from 'yjs';
+
+import { getInlineViewRowOrders, materializeVisibleRowOrders } from '@/application/database-yjs/row-order-visibility';
+import {
+  YDatabase,
+  YDatabaseMetas,
+  YDatabaseRowOrders,
+  YDatabaseView,
+  YDatabaseViews,
+  YjsDatabaseKey,
+} from '@/application/types';
+
+describe('materializeVisibleRowOrders', () => {
+  it('uses inline tombstones without intersecting linked-view membership', () => {
+    const linkedRows = [
+      { id: 'shared-row', height: 36 },
+      { id: 'linked-only-row', height: 36 },
+    ];
+    const inlineRows = [{ id: 'shared-row', height: 36, is_deleted: true }];
+
+    expect(materializeVisibleRowOrders(linkedRows, inlineRows)).toEqual([{ id: 'linked-only-row', height: 36 }]);
+  });
+
+  it('uses an active inline row to override a stale linked-view tombstone', () => {
+    const linkedRows = [{ id: 'row-id', height: 36, is_deleted: true }];
+    const inlineRows = [{ id: 'row-id', height: 36 }];
+
+    expect(materializeVisibleRowOrders(linkedRows, inlineRows)).toEqual([
+      { id: 'row-id', height: 36, is_deleted: false },
+    ]);
+  });
+
+  it('collapses duplicate visible IDs while preserving first position and last value', () => {
+    const linkedRows = [
+      { id: 'row-a', height: 36 },
+      { id: 'row-b', height: 36 },
+      { id: 'row-a', height: 72 },
+    ];
+
+    expect(materializeVisibleRowOrders(linkedRows)).toEqual([
+      { id: 'row-a', height: 72 },
+      { id: 'row-b', height: 36 },
+    ]);
+  });
+});
+
+describe('getInlineViewRowOrders', () => {
+  it('prefers the inline view ID stored in database metadata', () => {
+    const doc = new Y.Doc();
+    const database = new Y.Map() as YDatabase;
+    const views = new Y.Map() as YDatabaseViews;
+    const metas = new Y.Map() as YDatabaseMetas;
+    const metadataView = new Y.Map() as YDatabaseView;
+    const metadataRows = new Y.Array() as YDatabaseRowOrders;
+    const flaggedView = new Y.Map() as YDatabaseView;
+    const flaggedRows = new Y.Array() as YDatabaseRowOrders;
+
+    metadataView.set(YjsDatabaseKey.row_orders, metadataRows);
+    flaggedView.set(YjsDatabaseKey.is_inline, true);
+    flaggedView.set(YjsDatabaseKey.row_orders, flaggedRows);
+    views.set('metadata-inline-view', metadataView);
+    views.set('flagged-inline-view', flaggedView);
+    metas.set(YjsDatabaseKey.iid, 'metadata-inline-view');
+    database.set(YjsDatabaseKey.views, views);
+    database.set(YjsDatabaseKey.metas, metas);
+    doc.getMap('root').set('database', database);
+
+    expect(getInlineViewRowOrders(database)).toBe(metadataRows);
+  });
+
+  it('falls back to the inline flag when metadata is unavailable', () => {
+    const doc = new Y.Doc();
+    const database = new Y.Map() as YDatabase;
+    const views = new Y.Map() as YDatabaseViews;
+    const inlineView = new Y.Map() as YDatabaseView;
+    const inlineRows = new Y.Array() as YDatabaseRowOrders;
+
+    inlineView.set(YjsDatabaseKey.is_inline, true);
+    inlineView.set(YjsDatabaseKey.row_orders, inlineRows);
+    views.set('inline-view', inlineView);
+    database.set(YjsDatabaseKey.views, views);
+    doc.getMap('root').set('database', database);
+
+    expect(getInlineViewRowOrders(database)).toBe(inlineRows);
+  });
+});

--- a/src/application/database-yjs/__tests__/useRowOrdersSelector.test.tsx
+++ b/src/application/database-yjs/__tests__/useRowOrdersSelector.test.tsx
@@ -20,6 +20,7 @@ import {
 } from '@/application/database-yjs/dispatch';
 import { createRollupField } from '@/application/database-yjs/fields/rollup/utils';
 import * as databaseFilter from '@/application/database-yjs/filter';
+import * as rowOrderVisibility from '@/application/database-yjs/row-order-visibility';
 import {
   RowId,
   YDatabase,
@@ -363,6 +364,34 @@ describe('useRowOrdersSelector', () => {
     });
 
     expect(result.current?.map((row) => row.id)).toEqual(['row-c', 'row-a', 'row-b']);
+  });
+
+  it('reconciles all-view row-order changes once per Yjs transaction', async () => {
+    const fixture = createDatabaseFixture();
+    const inlineRowOrders = addInlineView(fixture, fixture.rowOrders.toJSON());
+    const materializeSpy = jest.spyOn(rowOrderVisibility, 'materializeVisibleRowOrders');
+    const { result } = renderHook(() => useRowOrdersSelector(), {
+      wrapper: createWrapper(fixture),
+    });
+
+    await waitFor(() => {
+      expect(result.current?.map((row) => row.id)).toEqual(['row-c', 'row-a', 'row-b']);
+    });
+
+    materializeSpy.mockClear();
+
+    act(() => {
+      fixture.databaseDoc.transact(() => {
+        const row = { id: 'row-new', height: 44 };
+
+        fixture.rowOrders.push([row]);
+        inlineRowOrders.push([row]);
+      });
+    });
+
+    expect(result.current?.map((row) => row.id)).toEqual(['row-c', 'row-a', 'row-b', 'row-new']);
+    expect(materializeSpy).toHaveBeenCalledTimes(1);
+    materializeSpy.mockRestore();
   });
 
   it('renders a duplicate row-order ID once and keeps its last value', async () => {

--- a/src/application/database-yjs/__tests__/useRowOrdersSelector.test.tsx
+++ b/src/application/database-yjs/__tests__/useRowOrdersSelector.test.tsx
@@ -22,14 +22,17 @@ import { createRollupField } from '@/application/database-yjs/fields/rollup/util
 import * as databaseFilter from '@/application/database-yjs/filter';
 import {
   RowId,
+  YDatabase,
   YDatabaseCalculation,
   YDatabaseCalculations,
   YDatabaseField,
   YDatabaseFilter,
   YDatabaseFilters,
+  YDatabaseMetas,
   YDatabaseRowOrders,
   YDatabaseSorts,
   YDatabaseView,
+  YDatabaseViews,
   YDoc,
   YjsDatabaseKey,
   YjsEditorKey,
@@ -42,6 +45,7 @@ jest.mock('@/utils/runtime-config', () => ({
 }));
 
 type DatabaseFixture = {
+  database: YDatabase;
   databaseDoc: YDoc;
   fields: Y.Map<YDatabaseField>;
   filters: YDatabaseFilters;
@@ -49,6 +53,7 @@ type DatabaseFixture = {
   rowOrders: YDatabaseRowOrders;
   view: YDatabaseView;
   viewId: string;
+  views: YDatabaseViews;
 };
 
 const databaseId = 'database-id';
@@ -80,9 +85,9 @@ function createDatabaseFixture(): DatabaseFixture {
   const viewId = 'view-id';
   const databaseDoc = new Y.Doc() as unknown as YDoc;
   const sharedRoot = databaseDoc.getMap(YjsEditorKey.data_section);
-  const database = new Y.Map();
+  const database = new Y.Map() as YDatabase;
   const fields = new Y.Map<YDatabaseField>();
-  const views = new Y.Map();
+  const views = new Y.Map() as YDatabaseViews;
   const view = new Y.Map() as YDatabaseView;
   const rowOrders = new Y.Array<{ id: RowId; height: number }>();
   const filters = new Y.Array<YDatabaseFilter>() as YDatabaseFilters;
@@ -106,6 +111,7 @@ function createDatabaseFixture(): DatabaseFixture {
   sharedRoot.set(YjsEditorKey.database, database);
 
   return {
+    database,
     databaseDoc,
     fields,
     filters,
@@ -123,7 +129,24 @@ function createDatabaseFixture(): DatabaseFixture {
     rowOrders,
     view,
     viewId,
+    views,
   };
+}
+
+function addInlineView(fixture: DatabaseFixture, rows: Array<{ id: RowId; height: number; is_deleted?: boolean }>) {
+  const inlineViewId = 'inline-view-id';
+  const inlineView = new Y.Map() as YDatabaseView;
+  const inlineRowOrders = new Y.Array() as YDatabaseRowOrders;
+  const metas = new Y.Map() as YDatabaseMetas;
+
+  inlineRowOrders.push(rows);
+  inlineView.set(YjsDatabaseKey.is_inline, true);
+  inlineView.set(YjsDatabaseKey.row_orders, inlineRowOrders);
+  fixture.views.set(inlineViewId, inlineView);
+  metas.set(YjsDatabaseKey.iid, inlineViewId);
+  fixture.database.set(YjsDatabaseKey.metas, metas);
+
+  return inlineRowOrders;
 }
 
 function createWrapper(fixture: DatabaseFixture, contextOverrides: Partial<DatabaseContextState> = {}) {
@@ -304,6 +327,60 @@ describe('useRowOrdersSelector', () => {
     });
 
     expect(result.current?.map((row) => row.id)).toEqual(['row-new', 'row-a', 'row-b']);
+  });
+
+  it('updates linked-view visibility immediately when the inline tombstone changes', async () => {
+    const fixture = createDatabaseFixture();
+    const inlineRowOrders = addInlineView(fixture, fixture.rowOrders.toJSON());
+    const { result } = renderHook(() => useRowOrdersSelector(), {
+      wrapper: createWrapper(fixture),
+    });
+
+    await waitFor(() => {
+      expect(result.current?.map((row) => row.id)).toEqual(['row-c', 'row-a', 'row-b']);
+    });
+
+    act(() => {
+      const rowAIndex = inlineRowOrders.toJSON().findIndex(({ id }) => id === 'row-a');
+      const rowA = inlineRowOrders.get(rowAIndex);
+
+      fixture.databaseDoc.transact(() => {
+        inlineRowOrders.delete(rowAIndex);
+        inlineRowOrders.insert(rowAIndex, [{ ...rowA, is_deleted: true }]);
+      });
+    });
+
+    expect(result.current?.map((row) => row.id)).toEqual(['row-c', 'row-b']);
+
+    act(() => {
+      const rowAIndex = inlineRowOrders.toJSON().findIndex(({ id }) => id === 'row-a');
+      const rowA = inlineRowOrders.get(rowAIndex);
+
+      fixture.databaseDoc.transact(() => {
+        inlineRowOrders.delete(rowAIndex);
+        inlineRowOrders.insert(rowAIndex, [{ ...rowA, is_deleted: false }]);
+      });
+    });
+
+    expect(result.current?.map((row) => row.id)).toEqual(['row-c', 'row-a', 'row-b']);
+  });
+
+  it('renders a duplicate row-order ID once and keeps its last value', async () => {
+    const fixture = createDatabaseFixture();
+    const { result } = renderHook(() => useRowOrdersSelector(), {
+      wrapper: createWrapper(fixture),
+    });
+
+    await waitFor(() => {
+      expect(result.current?.map((row) => row.id)).toEqual(['row-c', 'row-a', 'row-b']);
+    });
+
+    act(() => {
+      fixture.rowOrders.push([{ id: 'row-a', height: 72 }]);
+    });
+
+    expect(result.current?.map((row) => row.id)).toEqual(['row-c', 'row-a', 'row-b']);
+    expect(result.current?.find((row) => row.id === 'row-a')?.height).toBe(72);
   });
 
   it('resubscribes when the row order array is replaced', async () => {

--- a/src/application/database-yjs/row-order-visibility.ts
+++ b/src/application/database-yjs/row-order-visibility.ts
@@ -1,0 +1,83 @@
+import { YDatabase, YDatabaseRowOrders, YjsDatabaseKey } from '@/application/types';
+
+export interface RowOrderVisibilityEntry {
+  id: string;
+  is_deleted?: boolean;
+}
+
+/**
+ * Resolve the inline view that owns Desktop's canonical soft-delete state.
+ * The metadata ID is authoritative; the flag fallback supports older imports.
+ */
+export function getInlineViewRowOrders(database?: YDatabase): YDatabaseRowOrders | undefined {
+  if (!database) return undefined;
+
+  const views = database.get(YjsDatabaseKey.views);
+
+  if (!views) return undefined;
+
+  const inlineViewId = database.get(YjsDatabaseKey.metas)?.get(YjsDatabaseKey.iid);
+  const metadataRowOrders = inlineViewId ? views.get(inlineViewId)?.get(YjsDatabaseKey.row_orders) : undefined;
+
+  if (metadataRowOrders) return metadataRowOrders;
+
+  let flaggedRowOrders: YDatabaseRowOrders | undefined;
+
+  views.forEach((view) => {
+    if (!flaggedRowOrders && view.get(YjsDatabaseKey.is_inline)) {
+      flaggedRowOrders = view.get(YjsDatabaseKey.row_orders);
+    }
+  });
+
+  return flaggedRowOrders;
+}
+
+/**
+ * Match Desktop row visibility without changing the selected view's membership.
+ *
+ * The selected view supplies row membership and order. When the inline view has
+ * the same row ID, its tombstone overrides the selected view's raw tombstone.
+ * Linked-only rows therefore remain visible, which avoids hiding recoverable
+ * data. Duplicate visible IDs are collapsed to one rendered row, matching the
+ * Desktop row cache: the first visible position is retained and the last value
+ * wins.
+ */
+export function materializeVisibleRowOrders<T extends RowOrderVisibilityEntry>(
+  rawRowOrders?: T[],
+  canonicalRowOrders?: RowOrderVisibilityEntry[]
+): T[] | undefined {
+  if (!rawRowOrders) return undefined;
+
+  const canonicalDeletedById = new Map<string, boolean>();
+
+  canonicalRowOrders?.forEach((rowOrder) => {
+    canonicalDeletedById.set(rowOrder.id, Boolean(rowOrder.is_deleted));
+  });
+
+  const visibleRows: T[] = [];
+  const visibleIndexById = new Map<string, number>();
+
+  rawRowOrders.forEach((rowOrder) => {
+    const hasCanonicalVisibility = canonicalDeletedById.has(rowOrder.id);
+    const isDeleted = hasCanonicalVisibility
+      ? canonicalDeletedById.get(rowOrder.id) === true
+      : Boolean(rowOrder.is_deleted);
+
+    if (isDeleted) return;
+
+    const visibleRow =
+      hasCanonicalVisibility && Boolean(rowOrder.is_deleted) !== isDeleted
+        ? ({ ...rowOrder, is_deleted: isDeleted } as T)
+        : rowOrder;
+    const existingIndex = visibleIndexById.get(rowOrder.id);
+
+    if (existingIndex === undefined) {
+      visibleIndexById.set(rowOrder.id, visibleRows.length);
+      visibleRows.push(visibleRow);
+    } else {
+      visibleRows[existingIndex] = visibleRow;
+    }
+  });
+
+  return visibleRows;
+}

--- a/src/application/database-yjs/selector.ts
+++ b/src/application/database-yjs/selector.ts
@@ -49,6 +49,7 @@ import {
   subscribeRollupCell,
   subscribeRollupCache,
 } from '@/application/database-yjs/rollup/cache';
+import { getInlineViewRowOrders, materializeVisibleRowOrders } from '@/application/database-yjs/row-order-visibility';
 import { getMetaJSON, getRowKey } from '@/application/database-yjs/row_meta';
 import { subscribeSharedYjsDeep } from '@/application/database-yjs/shared-yjs-observer';
 import { sortBy } from '@/application/database-yjs/sort';
@@ -1348,6 +1349,7 @@ export function useRowOrdersSelector() {
   const fields = useDatabaseFields();
   const filters = view?.get(YjsDatabaseKey.filters);
   const database = useDatabase();
+  const inlineRowOrders = getInlineViewRowOrders(database);
   const {
     databaseDoc,
     loadView,
@@ -1477,9 +1479,15 @@ export function useRowOrdersSelector() {
     [blobPrefetchComplete, ensureRow, loadRowFromSeed, markConditionRowsUnavailable, seedsReady]
   );
 
-  const syncUnconditionedRowOrders = useCallback(() => {
+  const readVisibleRowOrders = useCallback(() => {
     const rawRowOrders = rowOrders?.toJSON() as Row[] | undefined;
-    const originalRowOrders = rawRowOrders?.filter((row) => !row.is_deleted);
+    const canonicalRowOrders = inlineRowOrders?.toJSON() as Row[] | undefined;
+
+    return materializeVisibleRowOrders(rawRowOrders, canonicalRowOrders);
+  }, [inlineRowOrders, rowOrders]);
+
+  const syncUnconditionedRowOrders = useCallback(() => {
+    const originalRowOrders = readVisibleRowOrders();
 
     if (!originalRowOrders) return false;
 
@@ -1499,7 +1507,7 @@ export function useRowOrdersSelector() {
     filtersAppliedRef.current = false;
     setRowOrdersState({ rows: originalRowOrders, conditionSignature: conditionStateKey });
     return true;
-  }, [fields, filters, rowOrders, sorts, viewId]);
+  }, [fields, filters, readVisibleRowOrders, sorts, viewId]);
 
   // Getter for relation cell text (used in sorting/filtering)
   const relationTextGetter = useCallback(
@@ -1566,8 +1574,7 @@ export function useRowOrdersSelector() {
   const onConditionsChange = useCallback(() => {
     const shouldLogConditionCompute = shouldLogDatabaseConditionPerformance();
     const computeStartedAt = shouldLogConditionCompute ? performance.now() : 0;
-    const rawRowOrders = rowOrders?.toJSON() as Row[] | undefined;
-    const originalRowOrders = rawRowOrders?.filter((row) => !row.is_deleted);
+    const originalRowOrders = readVisibleRowOrders();
 
     if (!originalRowOrders) return;
 
@@ -1682,7 +1689,7 @@ export function useRowOrdersSelector() {
     filters,
     rowDocsForConditions,
     sorts,
-    rowOrders,
+    readVisibleRowOrders,
     relationTextGetter,
     rollupValueGetter,
     rollupTextGetter,
@@ -1723,6 +1730,9 @@ export function useRowOrdersSelector() {
     };
 
     rowOrders?.observeDeep(handleRowOrdersChange);
+    if (inlineRowOrders !== rowOrders) {
+      inlineRowOrders?.observeDeep(handleRowOrdersChange);
+    }
 
     const observers = new Map<string, () => void>();
     let relationFieldIds: string[] = [];
@@ -1804,6 +1814,10 @@ export function useRowOrdersSelector() {
 
     return () => {
       rowOrders?.unobserveDeep(handleRowOrdersChange);
+      if (inlineRowOrders !== rowOrders) {
+        inlineRowOrders?.unobserveDeep(handleRowOrdersChange);
+      }
+
       sorts?.unobserveDeep(handleSortFilterChange);
       filters?.unobserveDeep(handleSortFilterChange);
       fields?.unobserveDeep(handleFieldChange);
@@ -1816,7 +1830,7 @@ export function useRowOrdersSelector() {
         }
       });
     };
-  }, [onConditionsChange, rowOrders, fields, filters, sorts, rows, viewId, syncUnconditionedRowOrders]);
+  }, [onConditionsChange, rowOrders, inlineRowOrders, fields, filters, sorts, rows, viewId, syncUnconditionedRowOrders]);
 
   // Set up rollup field observers (extracted hook)
   useRollupFieldObservers(onConditionsChange, rollupWatchVersion);

--- a/src/application/database-yjs/selector.ts
+++ b/src/application/database-yjs/selector.ts
@@ -1,6 +1,7 @@
 import dayjs from 'dayjs';
 import { debounce } from 'lodash-es';
 import { useCallback, useDeferredValue, useEffect, useMemo, useRef, useState } from 'react';
+import type { Transaction } from 'yjs';
 
 import { isUngroupedColumnHidden, resolveBoardColumnVisibility } from '@/application/database-yjs/board-visibility';
 import { parseYDatabaseCellToCell } from '@/application/database-yjs/cell.parse';
@@ -1374,6 +1375,7 @@ export function useRowOrdersSelector() {
   const conditionComputeLogRef = useRef({ count: 0, lastLoggedAt: 0 });
   const pendingConditionRowLoadsRef = useRef(new Set<string>());
   const unavailableConditionRowsRef = useRef(new Set<string>());
+  const lastProcessedRowOrderTransactionRef = useRef<Transaction | null>(null);
 
   // Check if there are active conditions
   const hasConditions = (sorts?.length ?? 0) > 0 || hasEffectiveFilters(filters, fields);
@@ -1723,7 +1725,14 @@ export function useRowOrdersSelector() {
       onConditionsChange();
     }, 200);
 
-    const handleRowOrdersChange = () => {
+    const handleRowOrdersChange = (_events: unknown, transaction: Transaction) => {
+      // Row mutations normally update every view in one Yjs transaction. The
+      // selected and inline observers therefore receive the same transaction;
+      // reconcile it once instead of serializing both row-order arrays twice.
+      if (lastProcessedRowOrderTransactionRef.current === transaction) return;
+
+      lastProcessedRowOrderTransactionRef.current = transaction;
+
       if (!syncUnconditionedRowOrders()) {
         debouncedChange();
       }

--- a/src/application/types.ts
+++ b/src/application/types.ts
@@ -880,7 +880,11 @@ export interface YDatabaseView extends Y.Map<unknown> {
 
 export type YDatabaseFieldOrders = Y.Array<{ id: FieldId }>; // [ { id: FieldId } ]
 
-export type YDatabaseRowOrders = Y.Array<{ id: RowId; height: number }>; // [ { id: RowId, height: number } ]
+export type YDatabaseRowOrders = Y.Array<{
+  id: RowId;
+  height: number;
+  is_deleted?: boolean;
+}>; // [ { id: RowId, height: number, is_deleted?: boolean } ]
 
 export type YDatabaseGroups = Y.Array<YDatabaseGroup>;
 

--- a/src/components/database/components/board/card/NewCard.tsx
+++ b/src/components/database/components/board/card/NewCard.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useLayoutEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import { usePrimaryFieldId, useRowOrdersSelector } from '@/application/database-yjs';
+import { usePrimaryFieldId } from '@/application/database-yjs';
 import { useNewRowDispatch } from '@/application/database-yjs/dispatch';
 import { ReactComponent as PlusIcon } from '@/assets/icons/plus.svg';
 import { Button } from '@/components/ui/button';
@@ -25,7 +25,6 @@ function NewCard({
   isCreating: boolean;
   setIsCreating: (isCreating: boolean) => void;
 }) {
-  const rows = useRowOrdersSelector();
   const primaryFieldId = usePrimaryFieldId();
   const { t } = useTranslation();
   const [value, setValue] = useState('');
@@ -52,10 +51,6 @@ function NewCard({
 
   const handleSubmit = useCallback(
     (inputValue: string) => {
-      if (!rows) {
-        throw new Error('Rows not found');
-      }
-
       if (!primaryFieldId) {
         throw new Error('Primary field not found');
       }
@@ -72,7 +67,7 @@ function NewCard({
       });
       scrollToBottom();
     },
-    [beforeId, columnId, fieldId, onNewCard, primaryFieldId, rows, scrollToBottom]
+    [beforeId, columnId, fieldId, onNewCard, primaryFieldId, scrollToBottom]
   );
 
   useLayoutEffect(() => {


### PR DESCRIPTION
### **Description**

Align Web database row materialization with Desktop semantics.

- Resolve the inline view from database metadata, with an `is_inline` fallback for older imports.
- Use the selected view for membership and ordering while applying inline-view tombstones as the canonical soft-delete state.
- Keep linked-only rows visible so this change cannot silently hide recoverable data.
- Collapse duplicate visible row IDs to one rendered row, retaining the first visible position and the last value like the Desktop row cache.
- Observe both selected-view and inline-view row-order changes so remote deletes and restores update immediately.
- Extend the row-order type with the existing optional `is_deleted` field.

This fixes cases where Web displays a row that Desktop hides after a Desktop soft delete, and where duplicate row-order entries inflate Web row counts.

### **Safety**

This is a read-time materialization change only. It does not mutate row orders, delete row payloads, or repair cross-view membership automatically.

### **Testing**

- [x] Added unit and hook regression tests for canonical tombstones, stale linked tombstones, linked-only membership, duplicate IDs, metadata lookup, and live tombstone updates.
- [x] `pnpm type-check`
- [x] ESLint on all changed files
- [x] Database Yjs unit suite: 37 suites / 592 tests

---

### **Checklist**

#### **General**
- [x] Relevant behavior and safety constraints are documented in code.
- [ ] Tested in multiple browser/OS environments.

#### **Testing**
- [x] Added or updated tests to validate the changes.

#### **Feature-Specific**
- [x] Not a feature addition; preview is not applicable.
- [x] Verified integration through the complete database Yjs unit suite and type checking.

## Summary by Sourcery

Align Web row visibility and ordering with Desktop by deriving visible rows from both the selected view and the inline view’s canonical tombstones while supporting duplicate row-order entries and inline view metadata resolution.

New Features:
- Introduce helpers to resolve the inline view’s row orders from database metadata or inline flags and to materialize visible row orders from canonical tombstones and linked-view membership.

Enhancements:
- Extend the row-order type to carry an optional soft-delete flag used for visibility materialization.
- Update the row orders selector to consume materialized visible row orders and observe both selected and inline views so visibility reacts to inline tombstone changes.

Tests:
- Add unit tests for row-order visibility materialization, inline view resolution from metadata and flags, and for live updates and duplicate ID handling in the row orders selector.