### PR TITLE
fix(publish): cover cleanup and preserve database view order

### DIFF
--- a/playwright/bdd/features/database/published-relation-unpublish.feature
+++ b/playwright/bdd/features/database/published-relation-unpublish.feature
@@ -1,0 +1,17 @@
+@published-relation-template @relation-unpublish-regression @mode:serial
+Feature: Unpublishing a relation-backed database
+  Publishing a database can automatically publish the database referenced by a
+  relation field. Unpublishing the source database must remove both publications
+  from the published pages list.
+
+  Background:
+    Given the seeded relation template fixture exists
+
+  Scenario: The automatically published relation target is removed with its source database
+    Given I sign in as the relation template fixture publisher
+    And the seeded relation cell resolves before publishing
+    When I publish only the seeded source database as a template
+    Then the source database and its relation target appear in the published pages list
+    When I unpublish the source database from the published pages list
+    Then the source database is removed from the published pages list
+    And the automatically published relation target is removed from the published pages list

--- a/playwright/bdd/features/database/published-template-multiple-views.feature
+++ b/playwright/bdd/features/database/published-template-multiple-views.feature
@@ -11,3 +11,17 @@ Feature: Published database templates
     When that account starts with the published template
     Then the duplicated database views keep the publisher order
     And the duplicated database contains the publisher row data
+
+  Scenario: Another account duplicates a published database child view with multiple views
+    Given a publisher has a database container with a custom view order
+    And the publisher adds identifiable row data
+    When the publisher publishes the Board database view as a template
+    Then the published child-view outline keeps the database view order
+    When another account opens the published template
+    Then the published database views keep the publisher order
+    When that account starts with the published template
+    Then the duplicated database views keep the publisher order
+    And the duplicated database contains the publisher row data
+    When the publisher unpublishes the published database child view
+    Then the published outline no longer contains the source database
+    And the former database child public link is unavailable

--- a/playwright/bdd/features/database/published-template-multiple-views.feature
+++ b/playwright/bdd/features/database/published-template-multiple-views.feature
@@ -3,9 +3,11 @@ Feature: Published database templates
   database views, their order, or row data.
 
   Scenario: Another account duplicates a database container with multiple views
-    Given a publisher has a database container with multiple ordered views
+    Given a publisher has a database container with a custom view order
     And the publisher adds identifiable row data
     When the publisher publishes the database container as a template
-    And another account starts with the published template
+    And another account opens the published template
+    Then the published database views keep the publisher order
+    When that account starts with the published template
     Then the duplicated database views keep the publisher order
     And the duplicated database contains the publisher row data

--- a/playwright/bdd/features/database/published-template-multiple-views.feature
+++ b/playwright/bdd/features/database/published-template-multiple-views.feature
@@ -1,11 +1,11 @@
 Feature: Published database templates
   A published database container can be reused without losing its sibling
-  database views or row data.
+  database views, their order, or row data.
 
   Scenario: Another account duplicates a database container with multiple views
-    Given a publisher has a database container with Grid and Board views
+    Given a publisher has a database container with multiple ordered views
     And the publisher adds identifiable row data
     When the publisher publishes the database container as a template
     And another account starts with the published template
-    Then the duplicated database container has views "Grid, Board"
+    Then the duplicated database views keep the publisher order
     And the duplicated database contains the publisher row data

--- a/playwright/bdd/features/database/seeded-nathan-publish-lifecycle.feature
+++ b/playwright/bdd/features/database/seeded-nathan-publish-lifecycle.feature
@@ -1,0 +1,15 @@
+@seeded-nathan-publish @mode:serial
+Feature: Nathan account database publish lifecycle
+  The stateful fixture account creates a temporary database so publishing can
+  be tested against an established workspace without changing its saved pages.
+
+  Scenario: Publishing and unpublishing a multi-view database updates every view
+    Given the Nathan publish account has a temporary database container with a custom view order
+    And the publisher adds identifiable row data
+    When the publisher publishes the database container as a template
+    And I open the temporary database public link in a fresh browser
+    Then the published database views keep the publisher order
+    And the published outline contains the temporary container and all its views in source order
+    When I unpublish the temporary database container from published pages
+    Then the published outline no longer contains the temporary container or its views
+    And the temporary database's former public link is unavailable

--- a/playwright/bdd/steps/published-relation-template.steps.ts
+++ b/playwright/bdd/steps/published-relation-template.steps.ts
@@ -177,6 +177,90 @@ When('I publish only the seeded source database as a template', async ({ page, r
     .toBe(true);
 });
 
+Then('the source database and its relation target appear in the published pages list', async ({ page, request }) => {
+  await expect
+    .poll(() => isPublished(request, SOURCE_DATABASE_VIEW_ID), {
+      timeout: 30000,
+      message: 'Expected the source database to be published before opening the published pages list',
+    })
+    .toBe(true);
+
+  await expect
+    .poll(() => isPublished(request, RELATED_GRID_VIEW_ID), {
+      timeout: 30000,
+      message: 'Expected publishing the source database to auto-publish its relation target',
+    })
+    .toBe(true);
+
+  await openPublishedPagesList(page);
+
+  await expect
+    .poll(() => publishedPageState(page, request, SOURCE_DATABASE_VIEW_ID), {
+      timeout: 30000,
+      message: 'Expected the source database to appear in the published pages list',
+    })
+    .toEqual({ published: true, visible: true });
+  await expect
+    .poll(() => publishedPageState(page, request, RELATED_GRID_VIEW_ID), {
+      timeout: 30000,
+      message: 'Expected the auto-published relation target to appear in the published pages list',
+    })
+    .toEqual({ published: true, visible: true });
+});
+
+When('I unpublish the source database from the published pages list', async ({ page }) => {
+  const sourceRow = publishedPageRow(page, SOURCE_DATABASE_VIEW_ID);
+
+  await expect(sourceRow).toBeVisible({ timeout: 30000 });
+  await sourceRow.getByTestId('published-item-actions').click();
+
+  const unpublishAction = page.locator('[data-testid="published-item-action-unpublish"]:visible');
+
+  await expect(unpublishAction).toBeVisible({ timeout: 10000 });
+
+  const unpublishResponsePromise = page.waitForResponse(
+    (response) => {
+      const url = new URL(response.url());
+
+      return (
+        response.request().method() === 'POST' &&
+        url.pathname === `/api/workspace/${FIXTURE_WORKSPACE_ID}/page-view/${SOURCE_DATABASE_VIEW_ID}/unpublish`
+      );
+    },
+    { timeout: 60000 }
+  );
+
+  await unpublishAction.click();
+
+  const unpublishResponse = await unpublishResponsePromise;
+
+  expect(
+    unpublishResponse.ok(),
+    `Unpublishing the source database failed with HTTP ${unpublishResponse.status()}`
+  ).toBeTruthy();
+});
+
+Then('the source database is removed from the published pages list', async ({ page, request }) => {
+  await expect
+    .poll(() => publishedPageState(page, request, SOURCE_DATABASE_VIEW_ID), {
+      timeout: 30000,
+      message: 'Expected the directly unpublished source database to leave the published pages list',
+    })
+    .toEqual({ published: false, visible: false });
+});
+
+Then(
+  'the automatically published relation target is removed from the published pages list',
+  async ({ page, request }) => {
+    await expect
+      .poll(() => publishedPageState(page, request, RELATED_GRID_VIEW_ID), {
+        timeout: 30000,
+        message: 'Expected unpublishing the source database to remove its automatically published relation target',
+      })
+      .toEqual({ published: false, visible: false });
+  }
+);
+
 When('another account opens the published relation template', async ({ page, request, browser }) => {
   const state = getState(page);
   const publishedUrl = requirePublishedUrl(state);
@@ -362,6 +446,30 @@ async function openFixtureView(page: Page, viewId: string): Promise<void> {
   await page.goto(`/app/${FIXTURE_WORKSPACE_ID}/${viewId}`, { waitUntil: 'domcontentloaded' });
   await expect(DatabaseGridSelectors.grid(page)).toBeVisible({ timeout: 60000 });
   await expect(DatabaseGridSelectors.cells(page).first()).toBeVisible({ timeout: 60000 });
+}
+
+async function openPublishedPagesList(page: Page): Promise<void> {
+  await expect(ShareSelectors.openPublishSettingsButton(page)).toBeVisible({ timeout: 30000 });
+  await ShareSelectors.openPublishSettingsButton(page).click({ force: true });
+  await expect(ShareSelectors.publishManageModal(page)).toBeVisible({ timeout: 30000 });
+  await expect(ShareSelectors.publishManagePanel(page)).toBeVisible({ timeout: 30000 });
+}
+
+function publishedPageRow(page: Page, viewId: string) {
+  return ShareSelectors.publishManageModal(page).getByTestId(`published-item-row-${viewId}`);
+}
+
+async function publishedPageState(
+  page: Page,
+  request: APIRequestContext,
+  viewId: string
+): Promise<{ published: boolean; visible: boolean }> {
+  return {
+    published: await isPublished(request, viewId),
+    visible: await publishedPageRow(page, viewId)
+      .isVisible()
+      .catch(() => false),
+  };
 }
 
 async function getWorkspaceFolder(request: APIRequestContext, token: string, workspaceId: string): Promise<FolderView> {

--- a/playwright/bdd/steps/published-template-multiple-views.steps.ts
+++ b/playwright/bdd/steps/published-template-multiple-views.steps.ts
@@ -1,12 +1,15 @@
-import { BrowserContext, expect, Page } from '@playwright/test';
+import { APIRequestContext, BrowserContext, expect, Page } from '@playwright/test';
 import { createBdd } from 'playwright-bdd';
 
 import { signInAndWaitForApp } from '../../support/auth-flow-helpers';
 import { signInAndCreateDatabaseView, waitForGridReady } from '../../support/database-ui-helpers';
+import { editFirstGridCell } from '../../support/duplicate-test-helpers';
 import { DatabaseGridSelectors, DatabaseViewSelectors, ShareSelectors } from '../../support/selectors';
 import { generateRandomEmail, setupPageErrorHandling } from '../../support/test-config';
 
 const { Given, When, Then, After } = createBdd();
+// ViewLayout.Calendar's wire value. Keep this API fixture independent from app aliases.
+const CALENDAR_VIEW_LAYOUT = 3;
 
 type PublishedTemplateState = {
   marker: string;
@@ -15,6 +18,30 @@ type PublishedTemplateState = {
   publishedUrl?: string;
   consumerContext?: BrowserContext;
   consumerPage?: Page;
+};
+
+type CreateDatabaseViewPayload = {
+  parent_view_id: string;
+  prev_view_id?: string;
+  database_id: string;
+  layout: number;
+  name: string;
+  embedded: boolean;
+};
+
+type ApiResponse<T> = {
+  code?: number;
+  data?: T;
+  message?: string;
+};
+
+type CreateDatabaseViewResponse = {
+  view_id: string;
+};
+
+type DatabaseViewCreationRequest = {
+  url: string;
+  payload: CreateDatabaseViewPayload;
 };
 
 const stateByPage = new WeakMap<Page, PublishedTemplateState>();
@@ -26,7 +53,7 @@ After(async ({ page }) => {
   stateByPage.delete(page);
 });
 
-Given('a publisher has a database container with multiple ordered views', async ({ page, request }) => {
+Given('a publisher has a database container with a custom view order', async ({ page, request }) => {
   setupPageErrorHandling(page);
   await page.setViewportSize({ width: 1440, height: 900 });
 
@@ -38,17 +65,30 @@ Given('a publisher has a database container with multiple ordered views', async 
     },
   });
   await waitForGridReady(page);
-  await addDatabaseView(page, 'Board');
-  await addDatabaseView(page, 'Calendar');
+  const boardCreation = await addDatabaseView(page, 'Board');
+
+  await expect
+    .poll(() => databaseViewLabels(page), {
+      timeout: 30000,
+      message: 'Expected the first two database views to start in creation order',
+    })
+    .toEqual(['Grid', 'Board']);
 
   const gridTab = DatabaseViewSelectors.viewTab(page).filter({ hasText: 'Grid' }).first();
 
   await gridTab.click({ force: true });
   await waitForGridReady(page);
 
+  const gridViewId = await databaseViewIdByLabel(page, 'Grid');
+
+  // Create Calendar after Grid even though Board was created first. This makes
+  // folder order differ from creation order without relying on timestamps:
+  // folder = Grid, Calendar, Board; creation = Grid, Board, Calendar.
+  await addDatabaseViewAfter(page, request, boardCreation, 'Calendar', gridViewId);
+
   const sourceViewOrder = await databaseViewLabels(page);
 
-  expect(sourceViewOrder).toEqual(['Grid', 'Board', 'Calendar']);
+  expect(sourceViewOrder).toEqual(['Grid', 'Calendar', 'Board']);
 
   stateByPage.set(page, {
     marker: `Published template row ${Date.now()}`,
@@ -60,9 +100,7 @@ Given('a publisher has a database container with multiple ordered views', async 
 Given('the publisher adds identifiable row data', async ({ page }) => {
   const state = requireState(page);
 
-  await DatabaseGridSelectors.firstCell(page).click({ force: true });
-  await page.keyboard.type(state.marker);
-  await page.keyboard.press('Escape');
+  await editFirstGridCell(page, DatabaseGridSelectors.grid(page), state.marker);
   await expect(DatabaseGridSelectors.grid(page)).toContainText(state.marker, { timeout: 15000 });
 
   // Reload before publishing so the scenario proves the row reached the server,
@@ -70,6 +108,12 @@ Given('the publisher adds identifiable row data', async ({ page }) => {
   await page.reload({ waitUntil: 'domcontentloaded' });
   await waitForGridReady(page);
   await expect(DatabaseGridSelectors.grid(page)).toContainText(state.marker, { timeout: 30000 });
+  await expect
+    .poll(() => databaseViewLabels(page), {
+      timeout: 30000,
+      message: `Expected the custom database view order to survive reload: ${state.sourceViewOrder.join(', ')}`,
+    })
+    .toEqual(state.sourceViewOrder);
 });
 
 When('the publisher publishes the database container as a template', async ({ page }) => {
@@ -78,7 +122,7 @@ When('the publisher publishes the database container as a template', async ({ pa
   state.publishedUrl = await publishCurrentDatabase(page);
 });
 
-When('another account starts with the published template', async ({ page, request, browser }) => {
+When('another account opens the published template', async ({ page, request, browser }) => {
   const state = requireState(page);
   const publishedUrl = requirePublishedUrl(state);
   const origin = new URL(publishedUrl).origin;
@@ -104,6 +148,27 @@ When('another account starts with the published template', async ({ page, reques
   });
 
   await expect(startWithTemplate).toBeVisible({ timeout: 30000 });
+  await expect(DatabaseViewSelectors.viewTab(consumerPage).first()).toBeVisible({ timeout: 60000 });
+});
+
+Then('the published database views keep the publisher order', async ({ page }) => {
+  const state = requireState(page);
+  const consumerPage = requireConsumerPage(state);
+
+  await expect
+    .poll(() => databaseViewLabels(consumerPage), {
+      timeout: 60000,
+      message: `Expected published database views: ${state.sourceViewOrder.join(', ')}`,
+    })
+    .toEqual(state.sourceViewOrder);
+});
+
+When('that account starts with the published template', async ({ page }) => {
+  const consumerPage = requireConsumerPage(requireState(page));
+  const startWithTemplate = consumerPage.getByRole('button', {
+    name: 'Start with this template',
+  });
+
   await startWithTemplate.click();
 
   const destinationDialog = consumerPage.getByRole('dialog').filter({ hasText: 'Where would you like to add' }).last();
@@ -167,7 +232,7 @@ Then('the duplicated database contains the publisher row data', async ({ page })
   await expect(DatabaseGridSelectors.grid(consumerPage)).toContainText(state.marker, { timeout: 60000 });
 });
 
-async function addDatabaseView(page: Page, viewType: 'Board' | 'Calendar'): Promise<void> {
+async function addDatabaseView(page: Page, viewType: 'Board' | 'Calendar'): Promise<DatabaseViewCreationRequest> {
   const previousCount = await DatabaseViewSelectors.viewTab(page).count();
   const addButton = DatabaseViewSelectors.addViewButton(page);
 
@@ -177,11 +242,70 @@ async function addDatabaseView(page: Page, viewType: 'Board' | 'Calendar'): Prom
   const menuItem = DatabaseViewSelectors.viewTypeOption(page, viewType);
 
   await expect(menuItem).toBeVisible({ timeout: 10000 });
+  const createResponsePromise = page.waitForResponse(
+    (response) => response.request().method() === 'POST' && new URL(response.url()).pathname.endsWith('/database-view'),
+    { timeout: 30000 }
+  );
+
   await menuItem.click();
+
+  const createResponse = await createResponsePromise;
+
+  expect(createResponse.ok(), `Creating ${viewType} failed with HTTP ${createResponse.status()}`).toBeTruthy();
   await expect(DatabaseViewSelectors.viewTab(page)).toHaveCount(previousCount + 1, { timeout: 30000 });
   await expect(DatabaseViewSelectors.viewTab(page).filter({ hasText: viewType })).toBeVisible({
     timeout: 15000,
   });
+
+  return {
+    url: createResponse.url(),
+    payload: createResponse.request().postDataJSON() as CreateDatabaseViewPayload,
+  };
+}
+
+async function addDatabaseViewAfter(
+  page: Page,
+  request: APIRequestContext,
+  creationRequest: DatabaseViewCreationRequest,
+  viewType: 'Calendar',
+  prevViewId: string
+): Promise<void> {
+  const token = await requireAuthToken(page);
+  const response = await request.post(creationRequest.url, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    },
+    data: {
+      ...creationRequest.payload,
+      prev_view_id: prevViewId,
+      layout: CALENDAR_VIEW_LAYOUT,
+      name: viewType,
+    },
+    failOnStatusCode: false,
+  });
+  const body = (await response.json().catch(() => null)) as ApiResponse<CreateDatabaseViewResponse> | null;
+
+  if (!response.ok() || body?.code !== 0 || !body.data?.view_id) {
+    throw new Error(
+      `Creating ${viewType} in custom order failed with HTTP ${response.status()}: ${JSON.stringify(body)}`
+    );
+  }
+
+  await page.reload({ waitUntil: 'domcontentloaded' });
+  await waitForGridReady(page);
+  await expect(DatabaseViewSelectors.viewTab(page).filter({ hasText: viewType })).toBeVisible({ timeout: 30000 });
+}
+
+async function databaseViewIdByLabel(page: Page, label: string): Promise<string> {
+  const testId = await DatabaseViewSelectors.viewTab(page)
+    .filter({ hasText: label })
+    .first()
+    .getAttribute('data-testid');
+  const viewId = testId?.replace(/^view-tab-/, '');
+
+  if (!viewId || viewId === testId) throw new Error(`Could not resolve database view id for ${label}`);
+  return viewId;
 }
 
 async function publishCurrentDatabase(page: Page): Promise<string> {
@@ -196,7 +320,32 @@ async function publishCurrentDatabase(page: Page): Promise<string> {
   const publishButton = ShareSelectors.publishConfirmButton(page);
 
   await expect(publishButton).toBeEnabled({ timeout: 15000 });
+  const publishResponsePromise = page.waitForResponse(
+    (response) => {
+      const pathname = new URL(response.url()).pathname;
+
+      return response.request().method() === 'POST' && pathname.endsWith('/publish');
+    },
+    { timeout: 60000 }
+  );
+  const publishError = page.locator('[data-sonner-toast][data-type="error"]').last();
+  const publishErrorPromise = publishError.waitFor({ state: 'visible', timeout: 60000 }).then(async () => ({
+    error: (await publishError.innerText()).trim(),
+  }));
+
   await publishButton.click({ force: true });
+  const publishResult = await Promise.race([
+    publishResponsePromise.then((response) => ({ response })),
+    publishErrorPromise,
+  ]);
+
+  if ('error' in publishResult) {
+    throw new Error(`Publishing failed before sending the request: ${publishResult.error}`);
+  }
+
+  const { response: publishResponse } = publishResult;
+
+  expect(publishResponse.ok(), `Publishing failed with HTTP ${publishResponse.status()}`).toBeTruthy();
   await expect(ShareSelectors.publishNamespace(page)).toBeVisible({ timeout: 30000 });
 
   const namespace = ((await ShareSelectors.publishNamespace(page).textContent()) ?? '').trim();
@@ -215,6 +364,27 @@ async function databaseViewLabels(page: Page): Promise<string[]> {
   const labels = await DatabaseViewSelectors.viewTab(page).allInnerTexts();
 
   return labels.map((label) => label.trim());
+}
+
+async function requireAuthToken(page: Page): Promise<string> {
+  const token = await page.evaluate(() => {
+    const rawToken = localStorage.getItem('token');
+
+    if (rawToken) {
+      try {
+        const parsed = JSON.parse(rawToken) as { access_token?: string };
+
+        if (parsed.access_token) return parsed.access_token;
+      } catch {
+        // Fall back to the test-only token mirror below.
+      }
+    }
+
+    return localStorage.getItem('af_auth_token') ?? '';
+  });
+
+  if (!token) throw new Error('The signed-in browser has no access token');
+  return token;
 }
 
 function requireState(page: Page): PublishedTemplateState {
@@ -237,7 +407,7 @@ function requirePublishedUrl(state: PublishedTemplateState): string {
 
 function requireConsumerPage(state: PublishedTemplateState): Page {
   if (!state.consumerPage) {
-    throw new Error('The consumer account has not duplicated the template');
+    throw new Error('The consumer account has not opened the published template');
   }
 
   return state.consumerPage;

--- a/playwright/bdd/steps/published-template-multiple-views.steps.ts
+++ b/playwright/bdd/steps/published-template-multiple-views.steps.ts
@@ -1,23 +1,39 @@
-import { APIRequestContext, BrowserContext, expect, Page } from '@playwright/test';
+import { APIRequestContext, Browser, BrowserContext, expect, Page, test } from '@playwright/test';
 import { createBdd } from 'playwright-bdd';
 
 import { signInAndWaitForApp } from '../../support/auth-flow-helpers';
-import { signInAndCreateDatabaseView, waitForGridReady } from '../../support/database-ui-helpers';
+import { createDatabaseView, signInAndCreateDatabaseView, waitForGridReady } from '../../support/database-ui-helpers';
 import { editFirstGridCell } from '../../support/duplicate-test-helpers';
+import { currentViewIdFromUrl } from '../../support/page-utils';
 import { DatabaseGridSelectors, DatabaseViewSelectors, ShareSelectors } from '../../support/selectors';
-import { generateRandomEmail, setupPageErrorHandling } from '../../support/test-config';
+import { generateRandomEmail, setupPageErrorHandling, TestConfig } from '../../support/test-config';
 
 const { Given, When, Then, After } = createBdd();
 // ViewLayout.Calendar's wire value. Keep this API fixture independent from app aliases.
 const CALENDAR_VIEW_LAYOUT = 3;
+const NATHAN_PUBLISH_EMAIL = process.env.APPFLOWY_E2E_NATHAN_EMAIL?.trim() || 'nathan@avery.io';
+const NATHAN_PUBLISH_ENABLED = process.env.APPFLOWY_E2E_NATHAN_PUBLISH === 'true';
 
 type PublishedTemplateState = {
   marker: string;
   publisherEmail: string;
   sourceViewOrder: string[];
+  sourceViewIds?: string[];
+  publisherToken?: string;
+  publisherWorkspaceId?: string;
+  databaseContainerId?: string;
+  publishedViewId?: string;
+  cleanupPublisherDatabase?: boolean;
   publishedUrl?: string;
   consumerContext?: BrowserContext;
   consumerPage?: Page;
+};
+
+type FolderView = {
+  view_id: string;
+  name: string;
+  is_published?: boolean;
+  children?: FolderView[];
 };
 
 type CreateDatabaseViewPayload = {
@@ -39,6 +55,12 @@ type CreateDatabaseViewResponse = {
   view_id: string;
 };
 
+type PublishedInfo = {
+  namespace: string;
+  publish_name: string;
+  view_id: string;
+};
+
 type DatabaseViewCreationRequest = {
   url: string;
   payload: CreateDatabaseViewPayload;
@@ -46,11 +68,28 @@ type DatabaseViewCreationRequest = {
 
 const stateByPage = new WeakMap<Page, PublishedTemplateState>();
 
-After(async ({ page }) => {
+After(async ({ page, request }) => {
   const state = stateByPage.get(page);
 
-  await state?.consumerContext?.close();
+  if (!state) return;
+
+  const cleanupErrors: string[] = [];
+
+  await state.consumerContext?.close().catch((error) => {
+    cleanupErrors.push(`public browser cleanup: ${errorMessage(error)}`);
+  });
+
+  if (state.cleanupPublisherDatabase) {
+    await cleanupPublisherDatabase(request, state).catch((error) => {
+      cleanupErrors.push(`publisher database cleanup: ${errorMessage(error)}`);
+    });
+  }
+
   stateByPage.delete(page);
+
+  if (cleanupErrors.length > 0) {
+    throw new Error(`Published database template teardown failed:\n${cleanupErrors.join('\n')}`);
+  }
 });
 
 Given('a publisher has a database container with a custom view order', async ({ page, request }) => {
@@ -87,6 +126,15 @@ Given('a publisher has a database container with a custom view order', async ({ 
   await addDatabaseViewAfter(page, request, boardCreation, 'Calendar', gridViewId);
 
   const sourceViewOrder = await databaseViewLabels(page);
+  const sourceViewIds = await databaseViewIds(page);
+  const publisherToken = await requireAuthToken(page);
+  const publisherWorkspaceId = workspaceIdFromAppUrl(page.url());
+  const databaseContainerId = await expectDatabaseContainerId(
+    request,
+    publisherToken,
+    publisherWorkspaceId,
+    sourceViewIds
+  );
 
   expect(sourceViewOrder).toEqual(['Grid', 'Calendar', 'Board']);
 
@@ -94,8 +142,69 @@ Given('a publisher has a database container with a custom view order', async ({ 
     marker: `Published template row ${Date.now()}`,
     publisherEmail,
     sourceViewOrder,
+    sourceViewIds,
+    publisherToken,
+    publisherWorkspaceId,
+    databaseContainerId,
+    cleanupPublisherDatabase: true,
   });
 });
+
+Given(
+  'the Nathan publish account has a temporary database container with a custom view order',
+  async ({ page, request }) => {
+    test.skip(
+      !NATHAN_PUBLISH_ENABLED,
+      'Set APPFLOWY_E2E_NATHAN_PUBLISH=true to run the stateful nathan@avery.io publish regression.'
+    );
+
+    setupPageErrorHandling(page);
+    await page.setViewportSize({ width: 1440, height: 900 });
+    await signInAndWaitForApp(page, request, NATHAN_PUBLISH_EMAIL);
+
+    const publisherToken = await requireAuthToken(page);
+    const publisherWorkspaceId = workspaceIdFromAppUrl(page.url());
+    const rootsBefore = await workspaceRootIds(request, publisherToken, publisherWorkspaceId);
+
+    await createDatabaseView(page, 'Grid', 5000);
+    await waitForGridReady(page);
+
+    const databaseContainerId = await expectNewWorkspaceRoot(
+      request,
+      publisherToken,
+      publisherWorkspaceId,
+      rootsBefore,
+      currentViewIdFromUrl(page)
+    );
+    const state: PublishedTemplateState = {
+      marker: `Nathan published template row ${Date.now()}`,
+      publisherEmail: NATHAN_PUBLISH_EMAIL,
+      publisherToken,
+      publisherWorkspaceId,
+      databaseContainerId,
+      cleanupPublisherDatabase: true,
+      sourceViewOrder: [],
+    };
+
+    stateByPage.set(page, state);
+
+    const boardCreation = await addDatabaseView(page, 'Board');
+    const gridTab = DatabaseViewSelectors.viewTab(page).filter({ hasText: 'Grid' }).first();
+
+    await gridTab.click({ force: true });
+    await waitForGridReady(page);
+
+    const gridViewId = await databaseViewIdByLabel(page, 'Grid');
+
+    await addDatabaseViewAfter(page, request, boardCreation, 'Calendar', gridViewId);
+
+    state.sourceViewOrder = await databaseViewLabels(page);
+    state.sourceViewIds = await databaseViewIds(page);
+
+    expect(state.sourceViewOrder).toEqual(['Grid', 'Calendar', 'Board']);
+    await expectFolderViewOrder(request, state);
+  }
+);
 
 Given('the publisher adds identifiable row data', async ({ page }) => {
   const state = requireState(page);
@@ -120,6 +229,19 @@ When('the publisher publishes the database container as a template', async ({ pa
   const state = requireState(page);
 
   state.publishedUrl = await publishCurrentDatabase(page);
+});
+
+When('the publisher publishes the Board database view as a template', async ({ page, request }) => {
+  const state = requireState(page);
+  const sourceViewIds = requireValue(state.sourceViewIds, 'source database view ids');
+  const boardIndex = state.sourceViewOrder.indexOf('Board');
+
+  if (boardIndex < 0) throw new Error('The source database does not contain a Board view');
+
+  const boardViewId = requireValue(sourceViewIds[boardIndex], 'Board database view id');
+
+  state.publishedViewId = boardViewId;
+  state.publishedUrl = await publishDatabaseChildView(request, page, state, boardViewId);
 });
 
 When('another account opens the published template', async ({ page, request, browser }) => {
@@ -151,6 +273,12 @@ When('another account opens the published template', async ({ page, request, bro
   await expect(DatabaseViewSelectors.viewTab(consumerPage).first()).toBeVisible({ timeout: 60000 });
 });
 
+When('I open the temporary database public link in a fresh browser', async ({ page, browser }) => {
+  const state = requireState(page);
+
+  await openPublicDatabase(browser, state);
+});
+
 Then('the published database views keep the publisher order', async ({ page }) => {
   const state = requireState(page);
   const consumerPage = requireConsumerPage(state);
@@ -161,6 +289,187 @@ Then('the published database views keep the publisher order', async ({ page }) =
       message: `Expected published database views: ${state.sourceViewOrder.join(', ')}`,
     })
     .toEqual(state.sourceViewOrder);
+});
+
+Then('the published child-view outline keeps the database view order', async ({ page, request }) => {
+  const state = requireState(page);
+  const containerId = requireValue(state.databaseContainerId, 'database container id');
+  const sourceViewIds = requireValue(state.sourceViewIds, 'source database view ids');
+  const publishedViewId = requireValue(state.publishedViewId, 'published database view id');
+
+  await expect
+    .poll(async () => publishedOutlineDatabaseState(request, state), {
+      timeout: 30000,
+      message: 'Expected the published child view to retain its database container and source view order',
+    })
+    .toEqual({
+      containerId,
+      childViewIds: sourceViewIds,
+      publishedChildViewIds: [publishedViewId],
+    });
+});
+
+Then(
+  'the published outline contains the temporary container and all its views in source order',
+  async ({ page, request }) => {
+    const state = requireState(page);
+    const containerId = requireValue(state.databaseContainerId, 'database container id');
+    const sourceViewIds = requireValue(state.sourceViewIds, 'source database view ids');
+
+    await expect
+      .poll(async () => publishedOutlineDatabase(request, state), {
+        timeout: 30000,
+        message: 'Expected the published outline to contain every database view in source order',
+      })
+      .toEqual({ containerId, childViewIds: sourceViewIds });
+
+    await openPublishedPagesList(page);
+    await expect(publishedPageRow(page, containerId)).toBeVisible({ timeout: 30000 });
+
+    for (const viewId of sourceViewIds) {
+      await expect(publishedPageRow(page, viewId)).toBeHidden();
+    }
+  }
+);
+
+When('I unpublish the temporary database container from published pages', async ({ page }) => {
+  const state = requireState(page);
+  const workspaceId = requireValue(state.publisherWorkspaceId, 'publisher workspace id');
+  const databaseContainerId = requireValue(state.databaseContainerId, 'database container id');
+  const containerRow = publishedPageRow(page, databaseContainerId);
+
+  await expect(containerRow).toBeVisible({ timeout: 30000 });
+  await containerRow.getByTestId('published-item-actions').click();
+
+  const unpublishAction = page.locator('[data-testid="published-item-action-unpublish"]:visible');
+
+  await expect(unpublishAction).toBeVisible({ timeout: 10000 });
+
+  const unpublishResponsePromise = page.waitForResponse(
+    (response) => {
+      const pathname = new URL(response.url()).pathname;
+
+      return (
+        response.request().method() === 'POST' &&
+        pathname === `/api/workspace/${workspaceId}/page-view/${databaseContainerId}/unpublish`
+      );
+    },
+    { timeout: 60000 }
+  );
+
+  await unpublishAction.click();
+
+  const unpublishResponse = await unpublishResponsePromise;
+
+  expect(
+    unpublishResponse.ok(),
+    `Unpublishing the temporary database failed with HTTP ${unpublishResponse.status()}`
+  ).toBeTruthy();
+});
+
+When('the publisher unpublishes the published database child view', async ({ page, request }) => {
+  const state = requireState(page);
+  const token = requireValue(state.publisherToken, 'publisher token');
+  const workspaceId = requireValue(state.publisherWorkspaceId, 'publisher workspace id');
+  const publishedViewId = requireValue(state.publishedViewId, 'published database view id');
+
+  await postVoid(request, token, `/api/workspace/${workspaceId}/page-view/${publishedViewId}/unpublish`);
+});
+
+Then('the published outline no longer contains the temporary container or its views', async ({ page, request }) => {
+  const state = requireState(page);
+  const publishedViewIds = requirePublishedViewIds(state);
+  const containerId = requireValue(state.databaseContainerId, 'database container id');
+
+  await expect
+    .poll(() => isPublished(request, containerId), {
+      timeout: 30000,
+      message: 'Expected the database container publication to be removed',
+    })
+    .toBe(false);
+
+  await expect
+    .poll(
+      async () =>
+        publishedOutlineViewIds(request, state).then((viewIds) => publishedViewIds.some((id) => viewIds.has(id))),
+      {
+        timeout: 30000,
+        message: 'Expected the container and its database-view metadata to leave the published outline',
+      }
+    )
+    .toBe(false);
+
+  for (const viewId of publishedViewIds) {
+    await expect(publishedPageRow(page, viewId)).toBeHidden({ timeout: 30000 });
+  }
+});
+
+Then("the temporary database's former public link is unavailable", async ({ page }) => {
+  const state = requireState(page);
+  const publicPage = requireConsumerPage(state);
+  const publishedUrl = requirePublishedUrl(state);
+  const cacheBustedUrl = new URL(publishedUrl);
+
+  cacheBustedUrl.searchParams.set('unpublished-check', Date.now().toString());
+  await publicPage.goto(cacheBustedUrl.toString(), { waitUntil: 'domcontentloaded' });
+  await expect
+    .poll(
+      async () => {
+        const pathname = new URL(publicPage.url()).pathname;
+        const bodyText = await publicPage.locator('body').innerText();
+
+        return pathname === '/login' || bodyText.includes("This page hasn't been published yet");
+      },
+      {
+        timeout: 30000,
+        message: 'Expected the former public link to redirect to login or show the unpublished state',
+      }
+    )
+    .toBe(true);
+  await expect(DatabaseViewSelectors.viewTab(publicPage)).toHaveCount(0, { timeout: 30000 });
+});
+
+Then('the published outline no longer contains the source database', async ({ page, request }) => {
+  const state = requireState(page);
+  const sourceDatabaseViewIds = requirePublishedViewIds(state);
+
+  await expect
+    .poll(
+      async () => {
+        const publishedIds = await publishedOutlineViewIds(request, state);
+
+        return sourceDatabaseViewIds.some((viewId) => publishedIds.has(viewId));
+      },
+      {
+        timeout: 30000,
+        message: 'Expected the unpublished child view and its database outline metadata to be removed',
+      }
+    )
+    .toBe(false);
+});
+
+Then('the former database child public link is unavailable', async ({ page }) => {
+  const state = requireState(page);
+  const publicPage = requireConsumerPage(state);
+  const cacheBustedUrl = new URL(requirePublishedUrl(state));
+
+  cacheBustedUrl.searchParams.set('unpublished-check', Date.now().toString());
+  await publicPage.goto(cacheBustedUrl.toString(), { waitUntil: 'domcontentloaded' });
+  await expect
+    .poll(
+      async () => {
+        const pathname = new URL(publicPage.url()).pathname;
+        const bodyText = await publicPage.locator('body').innerText();
+
+        return pathname === '/login' || bodyText.includes("This page hasn't been published yet");
+      },
+      {
+        timeout: 30000,
+        message: 'Expected the former database child public link to become unavailable',
+      }
+    )
+    .toBe(true);
+  await expect(DatabaseViewSelectors.viewTab(publicPage)).toHaveCount(0, { timeout: 30000 });
 });
 
 When('that account starts with the published template', async ({ page }) => {
@@ -366,6 +675,405 @@ async function databaseViewLabels(page: Page): Promise<string[]> {
   return labels.map((label) => label.trim());
 }
 
+async function databaseViewIds(page: Page): Promise<string[]> {
+  const testIds = await DatabaseViewSelectors.viewTab(page).evaluateAll((tabs) =>
+    tabs.map((tab) => tab.getAttribute('data-testid') ?? '')
+  );
+
+  return testIds.map((testId) => {
+    const viewId = testId.replace(/^view-tab-/, '');
+
+    if (!viewId || viewId === testId) {
+      throw new Error(`Could not resolve a database view id from ${testId || 'an empty test id'}`);
+    }
+
+    return viewId;
+  });
+}
+
+async function publishDatabaseChildView(
+  request: APIRequestContext,
+  page: Page,
+  state: PublishedTemplateState,
+  viewId: string
+): Promise<string> {
+  const token = requireValue(state.publisherToken, 'publisher token');
+  const workspaceId = requireValue(state.publisherWorkspaceId, 'publisher workspace id');
+  const sourceViewIds = requireValue(state.sourceViewIds, 'source database view ids');
+
+  // The page-view endpoint exercises the direct child-view publish contract.
+  // Pass a deliberately reversed order so the published folder remains the
+  // authoritative source for the database tab order.
+  await postVoid(request, token, `/api/workspace/${workspaceId}/page-view/${viewId}/publish`, {
+    visible_database_view_ids: [...sourceViewIds].reverse(),
+    duplicate_enabled: true,
+  });
+
+  const publishInfo = await expectPublishedInfo(request, viewId);
+
+  return `${new URL(page.url()).origin}/${publishInfo.namespace}/${publishInfo.publish_name}`;
+}
+
+async function expectPublishedInfo(request: APIRequestContext, viewId: string): Promise<PublishedInfo> {
+  let publishedInfo: PublishedInfo | undefined;
+
+  await expect
+    .poll(
+      async () => {
+        const response = await request.get(`${TestConfig.apiUrl}/api/workspace/v1/published-info/${viewId}`, {
+          failOnStatusCode: false,
+        });
+        const body = (await response.json().catch(() => null)) as ApiResponse<PublishedInfo> | null;
+
+        publishedInfo = response.ok() && body?.code === 0 ? body.data : undefined;
+        return publishedInfo?.view_id;
+      },
+      {
+        timeout: 30000,
+        message: `Expected database view ${viewId} to be published`,
+      }
+    )
+    .toBe(viewId);
+
+  return requireValue(publishedInfo, 'published database view info');
+}
+
+async function openPublicDatabase(browser: Browser, state: PublishedTemplateState): Promise<void> {
+  const publishedUrl = requirePublishedUrl(state);
+  const publicContext = await browser.newContext({
+    baseURL: new URL(publishedUrl).origin,
+    viewport: { width: 1440, height: 900 },
+  });
+  const publicPage = await publicContext.newPage();
+
+  state.consumerContext = publicContext;
+  state.consumerPage = publicPage;
+  setupPageErrorHandling(publicPage);
+
+  await publicPage.goto(publishedUrl, { waitUntil: 'domcontentloaded' });
+  await expect(publicPage.locator('body')).not.toContainText("This page hasn't been published yet", {
+    timeout: 30000,
+  });
+  await expect(DatabaseViewSelectors.viewTab(publicPage).first()).toBeVisible({ timeout: 60000 });
+}
+
+async function openPublishedPagesList(page: Page): Promise<void> {
+  if (
+    await ShareSelectors.publishManageModal(page)
+      .isVisible()
+      .catch(() => false)
+  )
+    return;
+
+  await expect(ShareSelectors.shareButton(page)).toBeVisible({ timeout: 30000 });
+  await ShareSelectors.shareButton(page).click({ force: true });
+
+  const sharePopover = ShareSelectors.sharePopover(page);
+
+  await expect(sharePopover).toBeVisible({ timeout: 15000 });
+  await sharePopover.getByTestId('publish-tab').click({ force: true });
+  await expect(ShareSelectors.openPublishSettingsButton(page)).toBeVisible({ timeout: 30000 });
+  await ShareSelectors.openPublishSettingsButton(page).click({ force: true });
+  await expect(ShareSelectors.publishManageModal(page)).toBeVisible({ timeout: 30000 });
+  await expect(ShareSelectors.publishManagePanel(page)).toBeVisible({ timeout: 30000 });
+}
+
+function publishedPageRow(page: Page, viewId: string) {
+  return ShareSelectors.publishManageModal(page).getByTestId(`published-item-row-${viewId}`);
+}
+
+async function publishedOutlineDatabase(
+  request: APIRequestContext,
+  state: PublishedTemplateState
+): Promise<{ containerId: string; childViewIds: string[] } | null> {
+  const containerId = requireValue(state.databaseContainerId, 'database container id');
+  const outline = await getPublishedOutline(request, state);
+  const container = findFolderView(outline, containerId);
+
+  if (!container?.is_published) return null;
+
+  return {
+    containerId: container.view_id,
+    childViewIds: (container.children ?? []).map((view) => view.view_id),
+  };
+}
+
+async function publishedOutlineDatabaseState(
+  request: APIRequestContext,
+  state: PublishedTemplateState
+): Promise<{
+  containerId: string;
+  childViewIds: string[];
+  publishedChildViewIds: string[];
+} | null> {
+  const containerId = requireValue(state.databaseContainerId, 'database container id');
+  const outline = await getPublishedOutline(request, state);
+  const container = findFolderView(outline, containerId);
+
+  if (!container) return null;
+
+  return {
+    containerId: container.view_id,
+    childViewIds: (container.children ?? []).map((view) => view.view_id),
+    publishedChildViewIds: (container.children ?? []).filter((view) => view.is_published).map((view) => view.view_id),
+  };
+}
+
+async function publishedOutlineViewIds(request: APIRequestContext, state: PublishedTemplateState): Promise<Set<string>> {
+  const outline = await getPublishedOutline(request, state);
+  const viewIds = new Set<string>();
+
+  collectViewIds(outline, viewIds);
+  return viewIds;
+}
+
+async function getPublishedOutline(request: APIRequestContext, state: PublishedTemplateState): Promise<FolderView> {
+  const publishedUrl = new URL(requirePublishedUrl(state));
+  const namespace = publishedUrl.pathname.split('/').filter(Boolean)[0];
+
+  if (!namespace) throw new Error(`Could not read a publish namespace from ${publishedUrl.toString()}`);
+
+  const response = await request.get(
+    `${TestConfig.apiUrl}/api/workspace/published-outline/${encodeURIComponent(namespace)}`,
+    { failOnStatusCode: false }
+  );
+  const body = (await response.json().catch(() => null)) as ApiResponse<FolderView> | null;
+
+  if (!response.ok() || body?.code !== 0 || body.data === undefined) {
+    throw new Error(`Fetching the published outline failed with HTTP ${response.status()}: ${JSON.stringify(body)}`);
+  }
+
+  return body.data;
+}
+
+function findFolderView(view: FolderView, viewId: string): FolderView | undefined {
+  if (view.view_id === viewId) return view;
+
+  for (const child of view.children ?? []) {
+    const found = findFolderView(child, viewId);
+
+    if (found) return found;
+  }
+
+  return undefined;
+}
+
+function collectViewIds(view: FolderView, viewIds: Set<string>): void {
+  viewIds.add(view.view_id);
+
+  for (const child of view.children ?? []) {
+    collectViewIds(child, viewIds);
+  }
+}
+
+async function expectFolderViewOrder(request: APIRequestContext, state: PublishedTemplateState): Promise<void> {
+  const token = requireValue(state.publisherToken, 'publisher token');
+  const workspaceId = requireValue(state.publisherWorkspaceId, 'publisher workspace id');
+  const containerId = requireValue(state.databaseContainerId, 'database container id');
+  const sourceViewIds = requireValue(state.sourceViewIds, 'source database view ids');
+  const container = await getApi<FolderView>(
+    request,
+    token,
+    `/api/workspace/${workspaceId}/view/${containerId}?depth=2`
+  );
+
+  expect(
+    (container.children ?? []).map((view) => view.view_id),
+    'Expected the folder database-view order to match the source tab order'
+  ).toEqual(sourceViewIds);
+}
+
+async function expectDatabaseContainerId(
+  request: APIRequestContext,
+  token: string,
+  workspaceId: string,
+  sourceViewIds: string[]
+): Promise<string> {
+  let containerId = '';
+
+  await expect
+    .poll(
+      async () => {
+        const workspace = await getApi<FolderView>(
+          request,
+          token,
+          `/api/workspace/${workspaceId}/view/${workspaceId}?depth=4`
+        );
+
+        containerId = findDatabaseContainerByChildIds(workspace, sourceViewIds)?.view_id ?? '';
+        return containerId;
+      },
+      {
+        timeout: 30000,
+        message: 'Expected to find the database container for the source database views',
+      }
+    )
+    .not.toBe('');
+
+  return containerId;
+}
+
+function findDatabaseContainerByChildIds(view: FolderView, sourceViewIds: string[]): FolderView | undefined {
+  const childViewIds = new Set((view.children ?? []).map((child) => child.view_id));
+
+  if (sourceViewIds.length > 0 && sourceViewIds.every((viewId) => childViewIds.has(viewId))) {
+    return view;
+  }
+
+  for (const child of view.children ?? []) {
+    const container = findDatabaseContainerByChildIds(child, sourceViewIds);
+
+    if (container) return container;
+  }
+
+  return undefined;
+}
+
+async function workspaceRootIds(request: APIRequestContext, token: string, workspaceId: string): Promise<Set<string>> {
+  const workspace = await getApi<FolderView>(
+    request,
+    token,
+    `/api/workspace/${workspaceId}/view/${workspaceId}?depth=4`
+  );
+
+  return new Set(workspace.children?.flatMap((space) => space.children ?? []).map((view) => view.view_id) ?? []);
+}
+
+async function expectNewWorkspaceRoot(
+  request: APIRequestContext,
+  token: string,
+  workspaceId: string,
+  rootsBefore: Set<string>,
+  currentViewId: string
+): Promise<string> {
+  let createdRootId = '';
+
+  await expect
+    .poll(
+      async () => {
+        const workspace = await getApi<FolderView>(
+          request,
+          token,
+          `/api/workspace/${workspaceId}/view/${workspaceId}?depth=4`
+        );
+        const newRoots =
+          workspace.children
+            ?.flatMap((space) => space.children ?? [])
+            .filter((view) => !rootsBefore.has(view.view_id)) ?? [];
+        const matchingRoot = newRoots.find((view) => containsView(view, currentViewId));
+
+        createdRootId = matchingRoot?.view_id ?? (newRoots.length === 1 ? newRoots[0].view_id : '');
+        return createdRootId;
+      },
+      {
+        timeout: 30000,
+        message: 'Expected the temporary database container to appear in the workspace folder',
+      }
+    )
+    .not.toBe('');
+
+  return createdRootId;
+}
+
+function containsView(view: FolderView, viewId: string): boolean {
+  return view.view_id === viewId || (view.children ?? []).some((child) => containsView(child, viewId));
+}
+
+async function isPublished(request: APIRequestContext, viewId: string): Promise<boolean> {
+  const response = await request.get(`${TestConfig.apiUrl}/api/workspace/v1/published-info/${viewId}`, {
+    failOnStatusCode: false,
+  });
+  const body = (await response.json().catch(() => null)) as ApiResponse<unknown> | null;
+
+  return response.ok() && body?.code === 0 && body.data !== undefined;
+}
+
+async function getApi<T>(request: APIRequestContext, token: string, path: string): Promise<T> {
+  const response = await request.get(`${TestConfig.apiUrl}${path}`, {
+    headers: { Authorization: `Bearer ${token}` },
+    failOnStatusCode: false,
+  });
+  const body = (await response.json().catch(() => null)) as ApiResponse<T> | null;
+
+  if (!response.ok() || body?.code !== 0 || body.data === undefined) {
+    throw new Error(`GET ${path} failed with HTTP ${response.status()}: ${JSON.stringify(body)}`);
+  }
+
+  return body.data;
+}
+
+async function cleanupPublisherDatabase(request: APIRequestContext, state: PublishedTemplateState): Promise<void> {
+  const token = state.publisherToken;
+  const workspaceId = state.publisherWorkspaceId;
+  const containerId = state.databaseContainerId;
+
+  if (!token || !workspaceId || !containerId) return;
+
+  for (const viewId of [containerId, ...(state.sourceViewIds ?? [])]) {
+    if (await isPublished(request, viewId)) {
+      await postVoid(request, token, `/api/workspace/${workspaceId}/page-view/${viewId}/unpublish`);
+    }
+  }
+
+  await deleteWorkspaceView(request, token, workspaceId, containerId);
+}
+
+async function postVoid(
+  request: APIRequestContext,
+  token: string,
+  path: string,
+  data?: Record<string, unknown>
+): Promise<void> {
+  const response = await request.post(`${TestConfig.apiUrl}${path}`, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    },
+    data,
+    failOnStatusCode: false,
+  });
+  const body = (await response.json().catch(() => null)) as ApiResponse<unknown> | null;
+
+  if (!response.ok() || body?.code !== 0) {
+    throw new Error(`POST ${path} failed with HTTP ${response.status()}: ${JSON.stringify(body)}`);
+  }
+}
+
+async function deleteWorkspaceView(
+  request: APIRequestContext,
+  token: string,
+  workspaceId: string,
+  viewId: string
+): Promise<void> {
+  const moveResponse = await request.post(
+    `${TestConfig.apiUrl}/api/workspace/${workspaceId}/page-view/${viewId}/move-to-trash`,
+    {
+      headers: { Authorization: `Bearer ${token}` },
+      failOnStatusCode: false,
+    }
+  );
+
+  if (moveResponse.status() === 404) return;
+
+  const moveBody = (await moveResponse.json().catch(() => null)) as ApiResponse<unknown> | null;
+
+  if (!moveResponse.ok() || moveBody?.code !== 0) {
+    throw new Error(`Moving ${viewId} to trash failed with HTTP ${moveResponse.status()}: ${JSON.stringify(moveBody)}`);
+  }
+
+  const deleteResponse = await request.delete(`${TestConfig.apiUrl}/api/workspace/${workspaceId}/trash/${viewId}`, {
+    headers: { Authorization: `Bearer ${token}` },
+    failOnStatusCode: false,
+  });
+  const deleteBody = (await deleteResponse.json().catch(() => null)) as ApiResponse<unknown> | null;
+
+  if (deleteResponse.status() !== 404 && (!deleteResponse.ok() || deleteBody?.code !== 0)) {
+    throw new Error(
+      `Deleting ${viewId} from trash failed with HTTP ${deleteResponse.status()}: ${JSON.stringify(deleteBody)}`
+    );
+  }
+}
+
 async function requireAuthToken(page: Page): Promise<string> {
   const token = await page.evaluate(() => {
     const rawToken = localStorage.getItem('token');
@@ -411,4 +1119,29 @@ function requireConsumerPage(state: PublishedTemplateState): Page {
   }
 
   return state.consumerPage;
+}
+
+function requirePublishedViewIds(state: PublishedTemplateState): string[] {
+  return [
+    requireValue(state.databaseContainerId, 'database container id'),
+    ...requireValue(state.sourceViewIds, 'source database view ids'),
+  ];
+}
+
+function workspaceIdFromAppUrl(urlValue: string): string {
+  const segments = new URL(urlValue).pathname.split('/').filter(Boolean);
+  const appIndex = segments.indexOf('app');
+  const workspaceId = appIndex >= 0 ? segments[appIndex + 1] : undefined;
+
+  if (!workspaceId) throw new Error(`Could not read a workspace id from ${urlValue}`);
+  return workspaceId;
+}
+
+function requireValue<T>(value: T | undefined, label: string): T {
+  if (value === undefined) throw new Error(`Missing ${label}`);
+  return value;
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
 }

--- a/playwright/bdd/steps/published-template-multiple-views.steps.ts
+++ b/playwright/bdd/steps/published-template-multiple-views.steps.ts
@@ -11,6 +11,7 @@ const { Given, When, Then, After } = createBdd();
 type PublishedTemplateState = {
   marker: string;
   publisherEmail: string;
+  sourceViewOrder: string[];
   publishedUrl?: string;
   consumerContext?: BrowserContext;
   consumerPage?: Page;
@@ -25,7 +26,7 @@ After(async ({ page }) => {
   stateByPage.delete(page);
 });
 
-Given('a publisher has a database container with Grid and Board views', async ({ page, request }) => {
+Given('a publisher has a database container with multiple ordered views', async ({ page, request }) => {
   setupPageErrorHandling(page);
   await page.setViewportSize({ width: 1440, height: 900 });
 
@@ -38,15 +39,21 @@ Given('a publisher has a database container with Grid and Board views', async ({
   });
   await waitForGridReady(page);
   await addDatabaseView(page, 'Board');
+  await addDatabaseView(page, 'Calendar');
 
   const gridTab = DatabaseViewSelectors.viewTab(page).filter({ hasText: 'Grid' }).first();
 
   await gridTab.click({ force: true });
   await waitForGridReady(page);
 
+  const sourceViewOrder = await databaseViewLabels(page);
+
+  expect(sourceViewOrder).toEqual(['Grid', 'Board', 'Calendar']);
+
   stateByPage.set(page, {
     marker: `Published template row ${Date.now()}`,
     publisherEmail,
+    sourceViewOrder,
   });
 });
 
@@ -138,16 +145,16 @@ When('another account starts with the published template', async ({ page, reques
   await expect(consumerPage.locator('.appflowy-database')).toBeVisible({ timeout: 60000 });
 });
 
-Then('the duplicated database container has views {string}', async ({ page }, expectedViewLabels: string) => {
-  const consumerPage = requireConsumerPage(requireState(page));
-  const expected = expectedViewLabels.split(',').map((label) => label.trim());
+Then('the duplicated database views keep the publisher order', async ({ page }) => {
+  const state = requireState(page);
+  const consumerPage = requireConsumerPage(state);
 
   await expect
     .poll(() => databaseViewLabels(consumerPage), {
       timeout: 60000,
-      message: `Expected duplicated database views: ${expected.join(', ')}`,
+      message: `Expected duplicated database views: ${state.sourceViewOrder.join(', ')}`,
     })
-    .toEqual(expected);
+    .toEqual(state.sourceViewOrder);
 });
 
 Then('the duplicated database contains the publisher row data', async ({ page }) => {
@@ -160,7 +167,7 @@ Then('the duplicated database contains the publisher row data', async ({ page })
   await expect(DatabaseGridSelectors.grid(consumerPage)).toContainText(state.marker, { timeout: 60000 });
 });
 
-async function addDatabaseView(page: Page, viewType: 'Board'): Promise<void> {
+async function addDatabaseView(page: Page, viewType: 'Board' | 'Calendar'): Promise<void> {
   const previousCount = await DatabaseViewSelectors.viewTab(page).count();
   const addButton = DatabaseViewSelectors.addViewButton(page);
 

--- a/src/application/__tests__/view-utils.test.ts
+++ b/src/application/__tests__/view-utils.test.ts
@@ -50,6 +50,10 @@ describe('view-utils', () => {
       expect(isDatabaseLayout(ViewLayout.Calendar)).toBe(true);
     });
 
+    it('should return true for Chart layout', () => {
+      expect(isDatabaseLayout(ViewLayout.Chart)).toBe(true);
+    });
+
     it('should return false for Document layout', () => {
       expect(isDatabaseLayout(ViewLayout.Document)).toBe(false);
     });
@@ -804,7 +808,7 @@ describe('view-utils', () => {
     });
 
     it('returns true for all database layouts under document (non-container)', () => {
-      const databaseLayouts = [ViewLayout.Grid, ViewLayout.Board, ViewLayout.Calendar];
+      const databaseLayouts = [ViewLayout.Grid, ViewLayout.Board, ViewLayout.Calendar, ViewLayout.Chart];
       const parentView = createMockView({
         view_id: 'parent-doc',
         layout: ViewLayout.Document,

--- a/src/application/services/js-services/__tests__/publish-database-data.test.ts
+++ b/src/application/services/js-services/__tests__/publish-database-data.test.ts
@@ -33,18 +33,22 @@ function createRowDoc(rowId: string) {
   return doc;
 }
 
-function createDatabaseDoc() {
+type TestRowOrder = { id: string; height: number; is_deleted?: boolean };
+
+function createDatabaseDoc(
+  initialRowOrders: TestRowOrder[] = [
+    { id: 'live-row', height: 36 },
+    { id: 'trashed-row', height: 36, is_deleted: true },
+  ]
+) {
   const doc = new Y.Doc({ guid: 'database-id' });
   const sharedRoot = doc.getMap(YjsEditorKey.data_section);
   const database = new Y.Map() as YDatabase;
   const views = new Y.Map<YDatabaseView>();
   const view = new Y.Map() as YDatabaseView;
-  const rowOrders = new Y.Array<{ id: string; height: number; is_deleted?: boolean }>();
+  const rowOrders = new Y.Array<TestRowOrder>();
 
-  rowOrders.push([
-    { id: 'live-row', height: 36 },
-    { id: 'trashed-row', height: 36, is_deleted: true },
-  ]);
+  rowOrders.push(initialRowOrders);
   view.set(YjsDatabaseKey.row_orders, rowOrders);
   views.set('view-id', view);
   database.set(YjsDatabaseKey.id, 'database-id');
@@ -82,9 +86,7 @@ describe('gatherDatabasePublishData', () => {
     const publishedDoc = new Y.Doc();
 
     Y.applyUpdate(publishedDoc, Uint8Array.from(payload.database_collab));
-    const publishedDatabase = publishedDoc
-      .getMap(YjsEditorKey.data_section)
-      .get(YjsEditorKey.database) as YDatabase;
+    const publishedDatabase = publishedDoc.getMap(YjsEditorKey.data_section).get(YjsEditorKey.database) as YDatabase;
     const publishedRows = publishedDatabase
       .get(YjsDatabaseKey.views)
       ?.get('view-id')
@@ -96,5 +98,33 @@ describe('gatherDatabasePublishData', () => {
       { id: 'live-row', height: 36 },
       { id: 'trashed-row', height: 36, is_deleted: true },
     ]);
+  });
+
+  it('loads row collabs in bounded parallel batches while preserving row order', async () => {
+    const rowIds = Array.from({ length: 12 }, (_, index) => `row-${index}`);
+    const { doc } = createDatabaseDoc(rowIds.map((id) => ({ id, height: 36 })));
+    let activeLoads = 0;
+    let maxActiveLoads = 0;
+
+    jest.mocked(openCollabDB).mockResolvedValue(doc);
+    jest.mocked(createRow).mockImplementation(async (rowKey) => {
+      const rowId = rowKey.split('_rows_')[1];
+
+      activeLoads += 1;
+      maxActiveLoads = Math.max(maxActiveLoads, activeLoads);
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      activeLoads -= 1;
+
+      return createRowDoc(rowId);
+    });
+
+    const encoded = await gatherDatabasePublishData('view-id', undefined, 'database-id');
+    const payload = JSON.parse(new TextDecoder().decode(encoded)) as {
+      database_row_collabs: Record<string, number[]>;
+    };
+
+    expect(maxActiveLoads).toBeGreaterThan(1);
+    expect(maxActiveLoads).toBeLessThan(rowIds.length);
+    expect(Object.keys(payload.database_row_collabs)).toEqual(rowIds);
   });
 });

--- a/src/application/services/js-services/publish-database-data.ts
+++ b/src/application/services/js-services/publish-database-data.ts
@@ -11,17 +11,15 @@ import * as Y from 'yjs';
 import { openCollabDB } from '@/application/db';
 import { getRowKey } from '@/application/database-yjs/row_meta';
 import { createRow } from '@/application/services/js-services/cache';
-import {
-  YDatabase,
-  YjsDatabaseKey,
-  YjsEditorKey,
-} from '@/application/types';
+import { YDatabase, YjsDatabaseKey, YjsEditorKey } from '@/application/types';
 import { Log } from '@/utils/log';
 
 interface RowOrderEntry {
   id?: string;
   is_deleted?: boolean;
 }
+
+const PUBLISH_ROW_LOAD_CONCURRENCY = 8;
 
 /**
  * Publishing must not expose rows that only remain in the live collab as
@@ -49,12 +47,22 @@ function createDatabasePublishSnapshot(dbDoc: Y.Doc): { doc: Y.Doc; rowIds: stri
 
         if (row?.is_deleted) {
           rowOrders.delete(index);
-        } else if (row?.id) {
-          rowIdSet.add(row.id);
         }
       }
     });
   }, 'filterTombstonedRowsForPublish');
+
+  views?.forEach((view) => {
+    const rowOrders = view.get(YjsDatabaseKey.row_orders);
+
+    for (let index = 0; index < (rowOrders?.length ?? 0); index += 1) {
+      const row = rowOrders?.get(index) as RowOrderEntry | undefined;
+
+      if (row?.id) {
+        rowIdSet.add(row.id);
+      }
+    }
+  });
 
   return { doc: publishDoc, rowIds: Array.from(rowIdSet) };
 }
@@ -103,25 +111,39 @@ export async function gatherDatabasePublishData(
 
   publishDbDoc.destroy();
 
-  // 4. Encode each row collab
+  // 4. Encode each row collab. Row documents are independent, so load them in
+  // bounded parallel batches rather than adding one IndexedDB round trip per
+  // row to the critical path.
   const databaseRowCollabs: Record<string, number[]> = {};
 
-  for (const rowId of rowIds) {
-    try {
-      const rowKey = getRowKey(actualDatabaseId, rowId);
-      const rowDoc = await createRow(rowKey);
+  for (let start = 0; start < rowIds.length; start += PUBLISH_ROW_LOAD_CONCURRENCY) {
+    const rowBatch = rowIds.slice(start, start + PUBLISH_ROW_LOAD_CONCURRENCY);
+    const encodedRows = await Promise.all(
+      rowBatch.map(async (rowId): Promise<[string, number[]] | null> => {
+        try {
+          const rowKey = getRowKey(actualDatabaseId, rowId);
+          const rowDoc = await createRow(rowKey);
 
-      // Verify the row doc has data
-      const rowRoot = rowDoc.getMap(YjsEditorKey.data_section);
+          // Verify the row doc has data
+          const rowRoot = rowDoc.getMap(YjsEditorKey.data_section);
 
-      if (!rowRoot.has(YjsEditorKey.database_row)) {
-        Log.debug('[gatherDatabasePublishData] skipping empty row', { rowId });
-        continue;
+          if (!rowRoot.has(YjsEditorKey.database_row)) {
+            Log.debug('[gatherDatabasePublishData] skipping empty row', { rowId });
+            return null;
+          }
+
+          return [rowId, Array.from(Y.encodeStateAsUpdate(rowDoc))];
+        } catch (e) {
+          Log.debug('[gatherDatabasePublishData] failed to load row', { rowId, error: e });
+          return null;
+        }
+      })
+    );
+
+    for (const encodedRow of encodedRows) {
+      if (encodedRow) {
+        databaseRowCollabs[encodedRow[0]] = encodedRow[1];
       }
-
-      databaseRowCollabs[rowId] = Array.from(Y.encodeStateAsUpdate(rowDoc));
-    } catch (e) {
-      Log.debug('[gatherDatabasePublishData] failed to load row', { rowId, error: e });
     }
   }
 

--- a/src/application/view-loader/index.ts
+++ b/src/application/view-loader/index.ts
@@ -25,6 +25,7 @@ import {
   YSharedRoot,
 } from '@/application/types';
 import { determineErrorType, ErrorType } from '@/application/utils/error-utils';
+import { isDatabaseLayout } from '@/application/view-utils';
 import { applyYDoc } from '@/application/ydoc/apply';
 import { Log } from '@/utils/log';
 import * as Y from 'yjs';
@@ -55,6 +56,7 @@ const LAYOUT_COLLAB_TYPE_MAP: Partial<Record<ViewLayout, Types>> = {
   [ViewLayout.Grid]: Types.Database,
   [ViewLayout.Board]: Types.Database,
   [ViewLayout.Calendar]: Types.Database,
+  [ViewLayout.Chart]: Types.Database,
 };
 
 const DOC_KEY_COLLAB_TYPE_MAP: Record<string, Types> = {
@@ -100,10 +102,6 @@ function detectFromDocStructure(doc: YDoc): Types | null {
  */
 function detectCollabType(doc: YDoc, layout?: ViewLayout): Types {
   return detectFromLayout(layout) ?? detectFromDocStructure(doc) ?? Types.Document;
-}
-
-function isDatabaseLayout(layout?: ViewLayout): boolean {
-  return layout === ViewLayout.Grid || layout === ViewLayout.Board || layout === ViewLayout.Calendar;
 }
 
 function databaseDocContainsView(doc: YDoc, viewId: string): boolean | null {

--- a/src/application/view-utils.ts
+++ b/src/application/view-utils.ts
@@ -15,10 +15,15 @@
 import { View, ViewLayout } from './types';
 
 /**
- * Check if a layout is a database layout (Grid, Board, or Calendar)
+ * Check if a layout is supported as a database layout in Web.
  */
 export function isDatabaseLayout(layout: ViewLayout): boolean {
-  return layout === ViewLayout.Grid || layout === ViewLayout.Board || layout === ViewLayout.Calendar;
+  return (
+    layout === ViewLayout.Grid ||
+    layout === ViewLayout.Board ||
+    layout === ViewLayout.Calendar ||
+    layout === ViewLayout.Chart
+  );
 }
 
 /**

--- a/src/components/app/hooks/__tests__/usePageOperations.publish.test.tsx
+++ b/src/components/app/hooks/__tests__/usePageOperations.publish.test.tsx
@@ -137,6 +137,27 @@ describe('usePageOperations publish', () => {
     expect(gatherDatabasePublishData).toHaveBeenCalledWith(viewId, undefined, databaseId);
   });
 
+  it('publishes Chart views through the client-side database endpoint', async () => {
+    const viewId = 'chart-view-id';
+    const databaseId = 'chart-database-id';
+    const { result } = renderUsePageOperations();
+
+    await act(async () => {
+      await result.current.publish(
+        createView({
+          view_id: viewId,
+          name: 'Chart',
+          layout: ViewLayout.Chart,
+          extra: { is_space: false, database_id: databaseId },
+        })
+      );
+    });
+
+    expect(gatherDatabasePublishData).toHaveBeenCalledWith(viewId, undefined, databaseId);
+    expect(publishCollabs).toHaveBeenCalledTimes(1);
+    expect(PublishService.publish).not.toHaveBeenCalled();
+  });
+
   it('publishes metadata for visible database views under a database container', async () => {
     const containerViewId = 'database-container-id';
     const gridViewId = 'grid-view-id';

--- a/src/components/app/hooks/__tests__/usePageOperations.publish.test.tsx
+++ b/src/components/app/hooks/__tests__/usePageOperations.publish.test.tsx
@@ -140,6 +140,8 @@ describe('usePageOperations publish', () => {
   it('publishes metadata for visible database views under a database container', async () => {
     const containerViewId = 'database-container-id';
     const gridViewId = 'grid-view-id';
+    const boardViewId = 'board-view-id';
+    const calendarViewId = 'calendar-view-id';
     const databaseId = 'database-id';
     const gridView = createView({
       view_id: gridViewId,
@@ -147,22 +149,34 @@ describe('usePageOperations publish', () => {
       layout: ViewLayout.Grid,
       extra: { is_space: false, database_id: databaseId },
     });
+    const boardView = createView({
+      view_id: boardViewId,
+      name: 'Board',
+      layout: ViewLayout.Board,
+      extra: { is_space: false, database_id: databaseId },
+    });
+    const calendarView = createView({
+      view_id: calendarViewId,
+      name: 'Calendar',
+      layout: ViewLayout.Calendar,
+      extra: { is_space: false, database_id: databaseId },
+    });
     const containerView = createView({
       view_id: containerViewId,
       name: 'Publish database',
       layout: ViewLayout.Grid,
       extra: { is_space: false, database_id: databaseId, is_database_container: true },
-      children: [gridView],
+      children: [gridView, boardView, calendarView],
     });
     const { result, workspaceId } = renderUsePageOperations();
 
     await act(async () => {
-      await result.current.publish(containerView, undefined, [containerViewId, gridViewId]);
+      await result.current.publish(containerView, undefined, [containerViewId, calendarViewId, boardViewId, gridViewId]);
     });
 
     expect(gatherDatabasePublishData).toHaveBeenCalledWith(
       containerViewId,
-      [containerViewId, gridViewId],
+      [containerViewId, gridViewId, boardViewId, calendarViewId],
       databaseId
     );
     expect(publishCollabs).toHaveBeenCalledWith(workspaceId, [
@@ -176,11 +190,67 @@ describe('usePageOperations publish', () => {
                 name: 'Grid',
                 layout: ViewLayout.Grid,
               }),
+              expect.objectContaining({
+                view_id: boardViewId,
+                name: 'Board',
+                layout: ViewLayout.Board,
+              }),
+              expect.objectContaining({
+                view_id: calendarViewId,
+                name: 'Calendar',
+                layout: ViewLayout.Calendar,
+              }),
             ],
           }),
         }),
       }),
     ]);
+  });
+
+  it('publishes a database child view using its container view order', async () => {
+    const databaseId = 'database-id';
+    const gridView = createView({
+      view_id: 'grid-view-id',
+      name: 'Grid',
+      layout: ViewLayout.Grid,
+      extra: { is_space: false, database_id: databaseId },
+    });
+    const boardView = createView({
+      view_id: 'board-view-id',
+      name: 'Board',
+      layout: ViewLayout.Board,
+      extra: { is_space: false, database_id: databaseId },
+    });
+    const calendarView = createView({
+      view_id: 'calendar-view-id',
+      name: 'Calendar',
+      layout: ViewLayout.Calendar,
+      extra: { is_space: false, database_id: databaseId },
+    });
+    const containerView = createView({
+      view_id: 'database-container-id',
+      name: 'Publish database',
+      layout: ViewLayout.Grid,
+      extra: { is_space: false, database_id: databaseId, is_database_container: true },
+      children: [gridView, boardView, calendarView],
+    });
+    const spaceView = createView({
+      view_id: 'space-id',
+      name: 'General',
+      extra: { is_space: true },
+      children: [containerView],
+    });
+    const { result } = renderUsePageOperations({ outlineRef: { current: [spaceView] } });
+
+    await act(async () => {
+      await result.current.publish(boardView, undefined, [calendarView.view_id, boardView.view_id, gridView.view_id]);
+    });
+
+    expect(gatherDatabasePublishData).toHaveBeenCalledWith(
+      boardView.view_id,
+      [gridView.view_id, boardView.view_id, calendarView.view_id],
+      databaseId
+    );
   });
 });
 

--- a/src/components/app/hooks/usePageOperations.ts
+++ b/src/components/app/hooks/usePageOperations.ts
@@ -18,8 +18,8 @@ import {
   UpdateSpacePayload,
   View,
   ViewIconType,
-  ViewLayout,
 } from '@/application/types';
+import { isDatabaseLayout } from '@/application/view-utils';
 import { Log } from '@/utils/log';
 import { findParentView, findView, findViewInShareWithMe } from '@/components/_shared/outline/utils';
 
@@ -385,10 +385,9 @@ export function usePageOperations({
     async (view: View, publishName?: string, visibleViewIds?: string[]) => {
       if (!currentWorkspaceId) return;
       const viewId = view.view_id;
-      const isDatabaseLayout =
-        view.layout === ViewLayout.Grid || view.layout === ViewLayout.Board || view.layout === ViewLayout.Calendar;
+      const isDatabaseView = isDatabaseLayout(view.layout);
 
-      if (isDatabaseLayout) {
+      if (isDatabaseView) {
         // Database views: gather data client-side and send via binary publish endpoint
         // (same approach as the desktop client — fixes #8464). Kick the WS
         // drain in the background — the binary publish below carries the

--- a/src/components/app/hooks/usePageOperations.ts
+++ b/src/components/app/hooks/usePageOperations.ts
@@ -412,7 +412,9 @@ export function usePageOperations({
         // tab (Grid, Board, Calendar, etc.) appears on the published page.
         let resolvedVisibleViewIds = visibleViewIds;
 
-        if (outlineRef.current) {
+        if (view.extra?.is_database_container) {
+          resolvedVisibleViewIds = [viewId, ...view.children.map((child) => child.view_id)];
+        } else if (outlineRef.current) {
           const parentView = findParentView(outlineRef.current, viewId);
 
           if (parentView?.extra?.is_database_container && parentView.children?.length > 0) {
@@ -453,9 +455,7 @@ export function usePageOperations({
           publish_name: name,
           metadata: {
             view: toPublishViewInfo(view),
-            child_views: view.children
-              .filter((child) => visibleViewIdSet.has(child.view_id))
-              .map(toPublishViewInfo),
+            child_views: view.children.filter((child) => visibleViewIdSet.has(child.view_id)).map(toPublishViewInfo),
             ancestor_views: [],
           },
         };

--- a/src/components/app/share/PublishPanel.tsx
+++ b/src/components/app/share/PublishPanel.tsx
@@ -1,14 +1,11 @@
-import { Button, CircularProgress, Divider, Tooltip, Typography } from '@mui/material';
+import { Button, CircularProgress, Tooltip, Typography } from '@mui/material';
 import React, { useCallback, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import { AccessLevel, ViewLayout } from '@/application/types';
-import { ReactComponent as CheckboxCheckSvg } from '@/assets/icons/check_filled.svg';
+import { AccessLevel } from '@/application/types';
 import { ReactComponent as PublishIcon } from '@/assets/icons/earth.svg';
-import { ReactComponent as CheckboxUncheckSvg } from '@/assets/icons/uncheck.svg';
 import { notify } from '@/components/_shared/notify';
 import { Switch } from '@/components/_shared/switch';
-import PageIcon from '@/components/_shared/view-icon/PageIcon';
 import { usePublishing } from '@/components/app/app.hooks';
 import { useLoadPublishInfo } from '@/components/app/share/publish.hooks';
 import PublishLinkPreview from '@/components/app/share/PublishLinkPreview';
@@ -46,7 +43,6 @@ function PublishPanel({
   // Track publish/unpublish actions locally so the panel updates immediately,
   // even when the view object (e.g. server fallback) has a stale is_published flag.
   const [publishedOverride, setPublishedOverride] = React.useState<boolean | undefined>(undefined);
-  const [visibleViewId, setVisibleViewId] = React.useState<string[] | undefined>(undefined);
   const [commentEnabled, setCommentEnabled] = React.useState<boolean | undefined>(undefined);
   const [duplicateEnabled, setDuplicateEnabled] = React.useState<boolean | undefined>(undefined);
 
@@ -76,7 +72,7 @@ function PublishPanel({
       const newPublishName = publishName || publishInfo?.publishName || undefined;
 
       try {
-        await publish(view, newPublishName, visibleViewId);
+        await publish(view, newPublishName);
         setPublishedOverride(true);
         await loadPublishInfo();
         notify.success(t('publish.publishSuccessfully'));
@@ -87,7 +83,7 @@ function PublishPanel({
         setPublishLoading(false);
       }
     },
-    [loadPublishInfo, publish, t, view, publishInfo, visibleViewId]
+    [loadPublishInfo, publish, t, view, publishInfo]
   );
 
   const handleUnpublish = useCallback(async () => {
@@ -197,9 +193,6 @@ function PublishPanel({
     onOpenPublishManage,
   ]);
 
-  const layout = view?.layout;
-  const isDatabase =
-    layout !== undefined ? [ViewLayout.Grid, ViewLayout.Board, ViewLayout.Calendar].includes(layout) : false;
   // Use the publish API (scopedPublishInfo) as the authoritative source.
   // view.is_published from the outline can be stale after unpublish.
   const serverPublishedState = Boolean(scopedPublishInfo);
@@ -208,19 +201,8 @@ function PublishPanel({
   // - fallback to server-derived state when no local override exists
   const hasPublished = publishedOverride ?? serverPublishedState;
 
-  useEffect(() => {
-    if (!hasPublished && isDatabase && view) {
-      const childIds = [view.view_id, ...view.children.map((child) => child.view_id)];
-
-      setVisibleViewId(childIds);
-    } else {
-      setVisibleViewId(undefined);
-    }
-  }, [hasPublished, isDatabase, view]);
-
   const renderUnpublished = useCallback(() => {
     if (!view) return null;
-    const list = [view, ...view.children];
     const isReadOnlyUser = currentUserAccessLevel === AccessLevel.ReadOnly;
     const publishDisabled = isReadOnlyUser || shareDetailsLoading || publishLoading;
     const publishButton = (
@@ -242,57 +224,6 @@ function PublishPanel({
 
     return (
       <div className={'flex w-full flex-col gap-4'}>
-        {isDatabase && (
-          <div className={'mt-2 flex flex-col gap-3 rounded-[16px] border border-border-primary px-4 py-3 text-sm'}>
-            <div className={'text-text-secondary'}>
-              {t('publishSelectedViews', {
-                count: visibleViewId?.length || 0,
-              })}
-            </div>
-            <Divider />
-            <div className={'appflowy-scroller flex max-h-[300px] flex-col gap-1 overflow-y-auto overflow-x-hidden'}>
-              {list.map((item) => {
-                const id = item.view_id;
-                const isCurrentView = view.view_id === item.view_id;
-
-                const selected = visibleViewId?.includes(item.view_id);
-
-                return (
-                  <Button
-                    disabled={isCurrentView}
-                    onClick={() => {
-                      setVisibleViewId((prev) => {
-                        const checked = prev?.includes(id);
-
-                        if (checked) {
-                          return prev?.filter((i) => i !== id);
-                        } else {
-                          return [...(prev || []), id];
-                        }
-                      });
-                    }}
-                    key={id}
-                    className={'flex items-center justify-start'}
-                    size={'small'}
-                    startIcon={
-                      selected ? (
-                        <CheckboxCheckSvg />
-                      ) : (
-                        <CheckboxUncheckSvg className={'text-border-primary hover:text-border-primary-hover'} />
-                      )
-                    }
-                    color={'inherit'}
-                  >
-                    <div className={'flex items-center gap-2'}>
-                      <PageIcon view={item} className={'h-5 w-5'} />
-                      {item.name || t('untitled')}
-                    </div>
-                  </Button>
-                );
-              })}
-            </div>
-          </div>
-        )}
         <Tooltip
           disableHoverListener={!isReadOnlyUser}
           title={isReadOnlyUser ? t('shareAction.readOnlyPublishTooltip') : ''}
@@ -301,7 +232,7 @@ function PublishPanel({
         </Tooltip>
       </div>
     );
-  }, [currentUserAccessLevel, handlePublish, isDatabase, publishLoading, shareDetailsLoading, t, view, visibleViewId]);
+  }, [currentUserAccessLevel, handlePublish, publishLoading, shareDetailsLoading, t, view]);
 
   return (
     <div className='flex flex-col items-start gap-1 self-stretch px-3 py-4'>

--- a/src/components/publish-render/__tests__/PublishSnapshotView.test.tsx
+++ b/src/components/publish-render/__tests__/PublishSnapshotView.test.tsx
@@ -95,7 +95,7 @@ describe('PublishSnapshotView', () => {
       throw new Error('Expected database snapshot fixture');
     }
 
-    render(
+    const { unmount } = render(
       <MemoryRouter>
         <PublishSnapshotView snapshot={snapshot} />
       </MemoryRouter>
@@ -105,9 +105,7 @@ describe('PublishSnapshotView', () => {
     expect(mockDatabaseView).toHaveBeenCalledTimes(1);
 
     const databaseProps = mockDatabaseView.mock.calls[0][0] as DatabaseProps;
-    const database = databaseProps.doc
-      .getMap(YjsEditorKey.data_section)
-      .get(YjsEditorKey.database);
+    const database = databaseProps.doc.getMap(YjsEditorKey.data_section).get(YjsEditorKey.database);
 
     expect(databaseProps.workspaceId).toBe('publish');
     expect(databaseProps.variant).toBe(UIVariant.Publish);
@@ -126,10 +124,22 @@ describe('PublishSnapshotView', () => {
 
     const rowDocument = await databaseProps.loadRowDocument?.(publishedRowDocumentId);
     const rowDocumentContent = rowDocument ? yDocToSlateContent(rowDocument) : undefined;
-    const firstRowDocumentBlock = rowDocumentContent?.children[0] as {
-      children?: Array<{ children?: Array<{ text?: string }> }>;
-    } | undefined;
+    const firstRowDocumentBlock = rowDocumentContent?.children[0] as
+      | {
+          children?: Array<{ children?: Array<{ text?: string }> }>;
+        }
+      | undefined;
 
     expect(firstRowDocumentBlock?.children?.[0]?.children?.[0]?.text).toBe('Published row document body');
+
+    const databaseDocDestroy = jest.spyOn(databaseProps.doc, 'destroy');
+    const rowDocDestroy = jest.spyOn(databaseProps.initialRowMap!['published-row-id'], 'destroy');
+    const rowDocumentDestroy = jest.spyOn(rowDocument!, 'destroy');
+
+    unmount();
+
+    expect(databaseDocDestroy).toHaveBeenCalledTimes(1);
+    expect(rowDocDestroy).toHaveBeenCalledTimes(1);
+    expect(rowDocumentDestroy).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/components/publish-render/database/PublishedDatabaseRenderer.tsx
+++ b/src/components/publish-render/database/PublishedDatabaseRenderer.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo } from 'react';
+import { useCallback, useEffect, useMemo } from 'react';
 
 import { createDatabaseYjsRenderDocsFromSnapshot } from '@/application/publish-snapshot/database-yjs-render-bridge';
 import { createDocumentYjsRenderDocFromRawData } from '@/application/publish-snapshot/document-yjs-render-bridge';
@@ -6,10 +6,7 @@ import type { PublishedDatabaseSnapshot } from '@/application/publish-snapshot/t
 import { UIVariant, type ViewMetaProps, type YDoc } from '@/application/types';
 import DatabaseView from '@/components/publish/DatabaseView';
 import { usePublishContext } from '@/application/publish';
-import {
-  getPublishedViewCover,
-  parsePublishedViewExtra,
-} from '@/components/publish-render/shared/PublishedPageMeta';
+import { getPublishedViewCover, parsePublishedViewExtra } from '@/components/publish-render/shared/PublishedPageMeta';
 
 export function PublishedDatabaseRenderer({ snapshot }: { snapshot: PublishedDatabaseSnapshot }) {
   const publishContext = usePublishContext();
@@ -25,6 +22,17 @@ export function PublishedDatabaseRenderer({ snapshot }: { snapshot: PublishedDat
       ),
     [database.raw.row_documents]
   );
+
+  useEffect(() => {
+    return () => {
+      doc.destroy();
+
+      const ownedRowDocs = new Set([...Object.values(rowMap), ...Object.values(rowDocumentMap)]);
+
+      ownedRowDocs.forEach((rowDoc) => rowDoc.destroy());
+    };
+  }, [doc, rowDocumentMap, rowMap]);
+
   const extra = useMemo(() => parsePublishedViewExtra(view.extra), [view.extra]);
   const loadView = publishContext?.loadView;
   const contextLoadRowDocument = publishContext?.loadRowDocument;
@@ -45,20 +53,12 @@ export function PublishedDatabaseRenderer({ snapshot }: { snapshot: PublishedDat
       database_relations: view.databaseRelations,
       extra: extra as ViewMetaProps['extra'],
     }),
-    [
-      database.visibleViewIds,
-      extra,
-      view.databaseRelations,
-      view.icon,
-      view.layout,
-      view.name,
-      view.viewId,
-    ]
+    [database.visibleViewIds, extra, view.databaseRelations, view.icon, view.layout, view.name, view.viewId]
   );
 
   return (
     <DatabaseView
-      workspaceId="publish"
+      workspaceId='publish'
       doc={doc}
       initialRowMap={rowMap}
       viewMeta={viewMeta}

--- a/src/components/publish/header/duplicate/DuplicateModal.test.ts
+++ b/src/components/publish/header/duplicate/DuplicateModal.test.ts
@@ -1,0 +1,20 @@
+import { Types, ViewLayout } from '@/application/types';
+
+import { getCollabTypeFromViewLayout } from './DuplicateModal';
+
+describe('getCollabTypeFromViewLayout', () => {
+  it.each([ViewLayout.Grid, ViewLayout.Board, ViewLayout.Calendar, ViewLayout.Chart])(
+    'maps database layout %s to the database collab type',
+    (layout) => {
+      expect(getCollabTypeFromViewLayout(layout)).toBe(Types.Database);
+    }
+  );
+
+  it('maps document layouts to the document collab type', () => {
+    expect(getCollabTypeFromViewLayout(ViewLayout.Document)).toBe(Types.Document);
+  });
+
+  it('rejects unsupported layouts', () => {
+    expect(getCollabTypeFromViewLayout(ViewLayout.AIChat)).toBeNull();
+  });
+});

--- a/src/components/publish/header/duplicate/DuplicateModal.tsx
+++ b/src/components/publish/header/duplicate/DuplicateModal.tsx
@@ -4,6 +4,7 @@ import { Trans, useTranslation } from 'react-i18next';
 import { PublishContext } from '@/application/publish';
 import { PublishService } from '@/application/services/domains';
 import { Types, ViewLayout } from '@/application/types';
+import { isDatabaseLayout } from '@/application/view-utils';
 import { NormalModal } from '@/components/_shared/modal';
 import { notify } from '@/components/_shared/notify';
 import SelectWorkspace from '@/components/publish/header/duplicate/SelectWorkspace';
@@ -11,17 +12,11 @@ import SpaceList from '@/components/publish/header/duplicate/SpaceList';
 import { useLoadWorkspaces } from '@/components/publish/header/duplicate/useDuplicate';
 import { downloadPage, openAppFlowySchema } from '@/utils/url';
 
-function getCollabTypeFromViewLayout(layout: ViewLayout) {
-  switch (layout) {
-    case ViewLayout.Document:
-      return Types.Document;
-    case ViewLayout.Grid:
-    case ViewLayout.Board:
-    case ViewLayout.Calendar:
-      return Types.Database;
-    default:
-      return null;
-  }
+export function getCollabTypeFromViewLayout(layout: ViewLayout) {
+  if (layout === ViewLayout.Document) return Types.Document;
+  if (isDatabaseLayout(layout)) return Types.Database;
+
+  return null;
 }
 
 function DuplicateModal({ open, onClose }: { open: boolean; onClose: () => void }) {


### PR DESCRIPTION
## Summary

- keep the existing relation-backed unpublish regression coverage
- canonicalize database container publication from the container children order
- verify child-view publication resolves the same authoritative container order
- strengthen the published-template BDD flow to create Grid, Board, Calendar and compare the duplicated tabs with the captured source order after Start with this template
- add unit coverage that deliberately supplies shuffled visible view ids

## Reproduction

Before the fix, the container publish unit test passed through the shuffled caller order instead of the source container order. The server integration regression likewise produced Container, Board, Grid when the source was Container, Grid, Board.

The relation unpublish scenario also reproduces the original stale dependency problem against the old server and passes with AppFlowy-Cloud-Premium PR #987.

## Verification

- pnpm exec jest src/components/app/hooks/__tests__/usePageOperations.publish.test.tsx --runInBand — 5 passed
- pnpm type-check
- ESLint on the changed application and unit-test files
- pnpm exec bddgen test -c playwright.bdd.config.ts
- focused Playwright published-template scenario — 1 passed
- paired server integration tests for container and child-view publication — 2 passed