### PR TITLE
fix(publish): synchronize document state and configure CI asset origin

### DIFF
--- a/.github/docker-compose-web-ci.override.yml
+++ b/.github/docker-compose-web-ci.override.yml
@@ -1,0 +1,4 @@
+services:
+  appflowy_cloud:
+    environment:
+      APPFLOWY_BASE_URL: ${APPFLOWY_BASE_URL}

--- a/.github/workflows/playwright-test.yml
+++ b/.github/workflows/playwright-test.yml
@@ -187,7 +187,10 @@ jobs:
           APPFLOWY_WORKER_VERSION: ${{ env.CLOUD_VERSION }}
           RUST_LOG: appflowy_cloud=info
         run: |
-          docker compose -f docker-compose-web-ci.yml up -d
+          docker compose \
+            -f docker-compose-web-ci.yml \
+            -f ../.github/docker-compose-web-ci.override.yml \
+            up -d
 
           echo "Waiting for backend services..."
           timeout 180 bash -c 'until curl -sf http://localhost/api/health > /dev/null 2>&1; do

--- a/src/components/app/hooks/__tests__/usePageOperations.publish.test.tsx
+++ b/src/components/app/hooks/__tests__/usePageOperations.publish.test.tsx
@@ -1,14 +1,15 @@
 import { act, renderHook } from '@testing-library/react';
-import type { MutableRefObject } from 'react';
 
 import { PageService, PublishService } from '@/application/services/domains';
 import { clearPublishViewInfoCache } from '@/application/services/js-services/cached-api';
-import { gatherDatabasePublishData } from '@/application/services/js-services/publish-database-data';
 import { publishCollabs } from '@/application/services/js-services/http/publish-api';
+import { gatherDatabasePublishData } from '@/application/services/js-services/publish-database-data';
 import { View, ViewLayout } from '@/application/types';
 import { AuthInternalContext, AuthInternalContextType } from '@/components/app/contexts/AuthInternalContext';
 
 import { usePageOperations } from '../usePageOperations';
+
+import type { MutableRefObject } from 'react';
 
 jest.mock('@/application/services/domains', () => ({
   BillingService: {},
@@ -142,13 +143,16 @@ describe('usePageOperations publish', () => {
 
   it('retries document publishing while the folder projection is pending', async () => {
     jest.useFakeTimers();
+
+    const syncAllToServer = jest.fn(async () => undefined);
+
     jest
       .mocked(PublishService.publish)
       .mockRejectedValueOnce({ code: -2, message: 'Record not found: view is not projected yet' })
       .mockResolvedValueOnce(undefined);
 
     try {
-      const { result } = renderUsePageOperations();
+      const { result, workspaceId } = renderUsePageOperations({ syncAllToServer });
 
       await act(async () => {
         const publishPromise = result.current.publish(createView({ view_id: 'document-view-id' }));
@@ -158,6 +162,35 @@ describe('usePageOperations publish', () => {
       });
 
       expect(PublishService.publish).toHaveBeenCalledTimes(2);
+      expect(syncAllToServer).toHaveBeenCalledTimes(1);
+      expect(syncAllToServer).toHaveBeenCalledWith(workspaceId);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('reuses the same full sync across repeated folder projection retries', async () => {
+    jest.useFakeTimers();
+    const syncAllToServer = jest.fn(async () => undefined);
+
+    jest
+      .mocked(PublishService.publish)
+      .mockRejectedValueOnce({ code: -2, message: 'Record not exist in db' })
+      .mockRejectedValueOnce({ code: -2, message: 'Record not exist in db' })
+      .mockResolvedValueOnce(undefined);
+
+    try {
+      const { result } = renderUsePageOperations({ syncAllToServer });
+
+      await act(async () => {
+        const publishPromise = result.current.publish(createView({ view_id: 'document-view-id' }));
+
+        await jest.advanceTimersByTimeAsync(750);
+        await publishPromise;
+      });
+
+      expect(PublishService.publish).toHaveBeenCalledTimes(3);
+      expect(syncAllToServer).toHaveBeenCalledTimes(1);
     } finally {
       jest.useRealTimers();
     }

--- a/src/components/app/hooks/__tests__/usePageOperations.publish.test.tsx
+++ b/src/components/app/hooks/__tests__/usePageOperations.publish.test.tsx
@@ -56,6 +56,8 @@ function createView(overrides: Partial<View>): View {
 function renderUsePageOperations(options?: {
   outlineRef?: MutableRefObject<View[] | undefined>;
   getDatabaseIdForViewId?: (viewId: string) => Promise<string | null | undefined>;
+  flushAllSync?: () => Promise<boolean>;
+  syncAllToServer?: (workspaceId: string) => Promise<void>;
 }) {
   const workspaceId = 'workspace-id';
   const authContextValue: AuthInternalContextType = {
@@ -72,6 +74,8 @@ function renderUsePageOperations(options?: {
         outlineRef,
         loadOutline,
         getDatabaseIdForViewId: options?.getDatabaseIdForViewId,
+        flushAllSync: options?.flushAllSync,
+        syncAllToServer: options?.syncAllToServer,
       }),
     {
       wrapper: ({ children }) => (
@@ -90,6 +94,86 @@ function renderUsePageOperations(options?: {
 describe('usePageOperations publish', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    jest.mocked(PublishService.publish).mockResolvedValue(undefined);
+  });
+
+  it('flushes document state before server-side publishing', async () => {
+    const calls: string[] = [];
+    const flushAllSync = jest.fn(async () => {
+      calls.push('flush');
+      return true;
+    });
+    const syncAllToServer = jest.fn(async () => {
+      calls.push('sync');
+    });
+
+    jest.mocked(PublishService.publish).mockImplementation(async () => {
+      calls.push('publish');
+    });
+
+    const { result, workspaceId } = renderUsePageOperations({ flushAllSync, syncAllToServer });
+
+    await act(async () => {
+      await result.current.publish(createView({ view_id: 'document-view-id' }));
+    });
+
+    expect(flushAllSync).toHaveBeenCalledTimes(1);
+    expect(syncAllToServer).not.toHaveBeenCalled();
+    expect(PublishService.publish).toHaveBeenCalledWith(workspaceId, 'document-view-id', {
+      publish_name: undefined,
+      visible_database_view_ids: undefined,
+    });
+    expect(calls).toEqual(['flush', 'publish']);
+  });
+
+  it('uses full HTTP sync when the document outbox does not drain', async () => {
+    const flushAllSync = jest.fn(async () => false);
+    const syncAllToServer = jest.fn(async () => undefined);
+    const { result, workspaceId } = renderUsePageOperations({ flushAllSync, syncAllToServer });
+
+    await act(async () => {
+      await result.current.publish(createView({ view_id: 'document-view-id' }));
+    });
+
+    expect(flushAllSync).toHaveBeenCalledTimes(1);
+    expect(syncAllToServer).toHaveBeenCalledWith(workspaceId);
+    expect(PublishService.publish).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries document publishing while the folder projection is pending', async () => {
+    jest.useFakeTimers();
+    jest
+      .mocked(PublishService.publish)
+      .mockRejectedValueOnce({ code: -2, message: 'Record not found: view is not projected yet' })
+      .mockResolvedValueOnce(undefined);
+
+    try {
+      const { result } = renderUsePageOperations();
+
+      await act(async () => {
+        const publishPromise = result.current.publish(createView({ view_id: 'document-view-id' }));
+
+        await jest.advanceTimersByTimeAsync(250);
+        await publishPromise;
+      });
+
+      expect(PublishService.publish).toHaveBeenCalledTimes(2);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('does not retry non-projection publish failures', async () => {
+    const publishError = { code: -3, message: 'Not enough permissions' };
+
+    jest.mocked(PublishService.publish).mockRejectedValueOnce(publishError);
+    const { result } = renderUsePageOperations();
+
+    await act(async () => {
+      await expect(result.current.publish(createView({ view_id: 'document-view-id' }))).rejects.toBe(publishError);
+    });
+
+    expect(PublishService.publish).toHaveBeenCalledTimes(1);
   });
 
   it('resolves canonical database id before publishing legacy database views', async () => {

--- a/src/components/app/hooks/usePageOperations.ts
+++ b/src/components/app/hooks/usePageOperations.ts
@@ -4,8 +4,8 @@ import { toast } from 'sonner';
 import { BillingService, FileService, PageService, PublishService, ViewService } from '@/application/services/domains';
 import { deleteView as clearViewCache } from '@/application/services/js-services/cache';
 import { clearPublishViewInfoCache } from '@/application/services/js-services/cached-api';
-import { gatherDatabasePublishData } from '@/application/services/js-services/publish-database-data';
 import { publishCollabs, PublishCollabMetadata } from '@/application/services/js-services/http/publish-api';
+import { gatherDatabasePublishData } from '@/application/services/js-services/publish-database-data';
 import {
   CreateDatabaseViewPayload,
   CreateOrphanedViewPayload,
@@ -21,20 +21,20 @@ import {
   ViewIconType,
 } from '@/application/types';
 import { isDatabaseLayout } from '@/application/view-utils';
-import { Log } from '@/utils/log';
 import { findParentView, findView, findViewInShareWithMe } from '@/components/_shared/outline/utils';
+import { Log } from '@/utils/log';
 
 import { useAuthInternal } from '../contexts/AuthInternalContext';
 
 // Hook for managing page and space operations
 const DUPLICATE_PRE_SYNC_TIMEOUT_MS = 8000;
-const DOCUMENT_PUBLISH_PROJECTION_RETRY_DELAYS_MS = [250, 500, 1000, 2000] as const;
+const DOCUMENT_PUBLISH_SERVER_RETRY_DELAYS_MS = [250, 500, 1000, 2000, 4000, 6000] as const;
 
 function waitForDocumentPublishRetry(delayMs: number): Promise<void> {
   return new Promise((resolve) => window.setTimeout(resolve, delayMs));
 }
 
-function isPendingFolderProjection(error: unknown): boolean {
+function isPendingDocumentPublishData(error: unknown): boolean {
   if (!error || typeof error !== 'object') return false;
 
   const { code, message } = error as { code?: unknown; message?: unknown };
@@ -42,19 +42,21 @@ function isPendingFolderProjection(error: unknown): boolean {
   return code === -2 && typeof message === 'string' && /record not (?:found|exist)|view .* not found/i.test(message);
 }
 
-async function publishDocumentWhenProjectionIsReady(
+async function publishDocumentWhenServerStateIsReady(
   workspaceId: string,
   viewId: string,
-  payload: PublishViewPayload
+  payload: PublishViewPayload,
+  syncServerState?: () => Promise<void>
 ): Promise<void> {
   for (let attempt = 0; ; attempt += 1) {
     try {
       await PublishService.publish(workspaceId, viewId, payload);
       return;
     } catch (error) {
-      const retryDelay = DOCUMENT_PUBLISH_PROJECTION_RETRY_DELAYS_MS[attempt];
+      const retryDelay = DOCUMENT_PUBLISH_SERVER_RETRY_DELAYS_MS[attempt];
 
-      if (retryDelay === undefined || !isPendingFolderProjection(error)) throw error;
+      if (retryDelay === undefined || !isPendingDocumentPublishData(error)) throw error;
+      await syncServerState?.();
       await waitForDocumentPublishRetry(retryDelay);
     }
   }
@@ -494,19 +496,31 @@ export function usePageOperations({
         await publishCollabs(currentWorkspaceId, [{ meta, data }]);
         clearPublishViewInfoCache(viewId);
       } else {
-        // Document publishing gathers the folder and collab on the server. Push
-        // the browser's current state first, then tolerate the short interval
-        // before the folder projection becomes queryable under load.
+        // Document publishing gathers the folder, document, and referenced
+        // dependencies on the server. Push the browser's current state first,
+        // then tolerate the provisioning/projection interval under load.
         const outboxDrained = await flushAllSync?.();
+        let fullSyncPromise: Promise<void> | undefined;
+        const ensureServerState = syncAllToServer
+          ? () => {
+              fullSyncPromise ??= syncAllToServer(currentWorkspaceId);
+              return fullSyncPromise;
+            }
+          : undefined;
 
-        if (outboxDrained !== true && syncAllToServer) {
-          await syncAllToServer(currentWorkspaceId);
+        if (outboxDrained !== true) {
+          await ensureServerState?.();
         }
 
-        await publishDocumentWhenProjectionIsReady(currentWorkspaceId, viewId, {
-          publish_name: publishName,
-          visible_database_view_ids: visibleViewIds,
-        });
+        await publishDocumentWhenServerStateIsReady(
+          currentWorkspaceId,
+          viewId,
+          {
+            publish_name: publishName,
+            visible_database_view_ids: visibleViewIds,
+          },
+          ensureServerState
+        );
       }
 
       await loadOutline?.(currentWorkspaceId, false);

--- a/src/components/app/hooks/usePageOperations.ts
+++ b/src/components/app/hooks/usePageOperations.ts
@@ -13,6 +13,7 @@ import {
   CreatePagePayload,
   CreateSpacePayload,
   CreateSpaceWithInitialPagePayload,
+  PublishViewPayload,
   Role,
   UpdatePagePayload,
   UpdateSpacePayload,
@@ -27,6 +28,37 @@ import { useAuthInternal } from '../contexts/AuthInternalContext';
 
 // Hook for managing page and space operations
 const DUPLICATE_PRE_SYNC_TIMEOUT_MS = 8000;
+const DOCUMENT_PUBLISH_PROJECTION_RETRY_DELAYS_MS = [250, 500, 1000, 2000] as const;
+
+function waitForDocumentPublishRetry(delayMs: number): Promise<void> {
+  return new Promise((resolve) => window.setTimeout(resolve, delayMs));
+}
+
+function isPendingFolderProjection(error: unknown): boolean {
+  if (!error || typeof error !== 'object') return false;
+
+  const { code, message } = error as { code?: unknown; message?: unknown };
+
+  return code === -2 && typeof message === 'string' && /record not (?:found|exist)|view .* not found/i.test(message);
+}
+
+async function publishDocumentWhenProjectionIsReady(
+  workspaceId: string,
+  viewId: string,
+  payload: PublishViewPayload
+): Promise<void> {
+  for (let attempt = 0; ; attempt += 1) {
+    try {
+      await PublishService.publish(workspaceId, viewId, payload);
+      return;
+    } catch (error) {
+      const retryDelay = DOCUMENT_PUBLISH_PROJECTION_RETRY_DELAYS_MS[attempt];
+
+      if (retryDelay === undefined || !isPendingFolderProjection(error)) throw error;
+      await waitForDocumentPublishRetry(retryDelay);
+    }
+  }
+}
 
 export function usePageOperations({
   outlineRef,
@@ -462,8 +494,16 @@ export function usePageOperations({
         await publishCollabs(currentWorkspaceId, [{ meta, data }]);
         clearPublishViewInfoCache(viewId);
       } else {
-        // Document views: use existing server-side gathering
-        await PublishService.publish(currentWorkspaceId, viewId, {
+        // Document publishing gathers the folder and collab on the server. Push
+        // the browser's current state first, then tolerate the short interval
+        // before the folder projection becomes queryable under load.
+        const outboxDrained = await flushAllSync?.();
+
+        if (outboxDrained !== true && syncAllToServer) {
+          await syncAllToServer(currentWorkspaceId);
+        }
+
+        await publishDocumentWhenProjectionIsReady(currentWorkspaceId, viewId, {
           publish_name: publishName,
           visible_database_view_ids: visibleViewIds,
         });
@@ -471,7 +511,7 @@ export function usePageOperations({
 
       await loadOutline?.(currentWorkspaceId, false);
     },
-    [currentWorkspaceId, loadOutline, flushAllSync, outlineRef, getDatabaseIdForViewId]
+    [currentWorkspaceId, loadOutline, flushAllSync, syncAllToServer, outlineRef, getDatabaseIdForViewId]
   );
 
   // Unpublish view


### PR DESCRIPTION
## Summary
- drain pending document/folder sync before server-side document publishing
- fall back to one memoized full HTTP sync when the WebSocket outbox does not drain
- retry transient API code -2 record-not-found responses while a folder projection catches up
- pass APPFLOWY_BASE_URL to the Premium cloud container through a Web-owned Compose override

## CI root cause
The current page job was not failing on folder projection timing. A fresh user's default Getting started page references the Web Guide, whose template contains three legacy image URLs on beta.appflowy.cloud.

docker-compose-web-ci.yml did not pass APPFLOWY_BASE_URL into appflowy_cloud. That disabled publish asset same-origin filtering, so the server tried to copy those external images as private blobs from the fresh local workspace. Their metadata does not exist, and every publish attempt returned API code -2.

Failed job:
https://github.com/AppFlowy-IO/AppFlowy-Web/actions/runs/31503252455/job/93832322111

Companion server fix:
https://github.com/AppFlowy-IO/AppFlowy-Cloud-Premium/pull/995

## Validation
- 11 focused usePageOperations Jest tests
- pnpm type-check
- Docker Compose renders APPFLOWY_BASE_URL in the appflowy_cloud environment
- reproduced the original failure with a fresh account against the current Premium image
- applied the Web Compose override to unmodified server main
- successfully published the fresh account's Getting started page, including all three document dependencies and the embedded To-dos database