### PR TITLE
fix: support published database outlines and import task types

### DIFF
--- a/playwright/bdd/features/database/published-template-multiple-views.feature
+++ b/playwright/bdd/features/database/published-template-multiple-views.feature
@@ -25,3 +25,18 @@ Feature: Published database templates
     When the publisher unpublishes the published database child view
     Then the published outline no longer contains the source database
     And the former database child public link is unavailable
+
+  Scenario: Published database outline navigates and highlights database views
+    Given a publisher has a database container with a custom view order
+    When the publisher publishes the Board database view as a template
+    Then the published child-view outline keeps the database view order
+    When another account opens the published template
+    Then the published database views keep the publisher order
+    And the public outline shows the database container and dot-style child views
+    When the public outline opens the "Calendar" database view
+    Then the public database route keeps its published anchor and selects "Calendar"
+    And the public outline highlights only the container and active database view
+    When the public outline opens the database container
+    Then the public database route keeps its published anchor and selects "Grid"
+    And the public outline highlights only the container and active database view
+    And the public outline remains expanded

--- a/playwright/bdd/steps/published-template-multiple-views.steps.ts
+++ b/playwright/bdd/steps/published-template-multiple-views.steps.ts
@@ -291,6 +291,105 @@ Then('the published database views keep the publisher order', async ({ page }) =
     .toEqual(state.sourceViewOrder);
 });
 
+Then('the public outline shows the database container and dot-style child views', async ({ page, request }) => {
+  const state = requireState(page);
+  const consumerPage = requireConsumerPage(state);
+  const containerId = requireValue(state.databaseContainerId, 'database container id');
+  const sourceViewIds = requireValue(state.sourceViewIds, 'source database view ids');
+  const container = await sourceDatabaseContainer(request, state);
+  const containerRow = publishedOutlineItem(consumerPage, containerId);
+
+  await expandPublishedOutlineSpace(consumerPage);
+  await expect(containerRow).toBeVisible({ timeout: 30000 });
+  await expandPublishedOutlineItem(containerRow);
+  await expect(containerRow.getByTestId('page-name')).toHaveText(container.name);
+  await expect(containerRow.getByTestId('database-view-dot')).toHaveCount(0);
+
+  for (const viewId of sourceViewIds) {
+    const childRow = publishedOutlineItem(consumerPage, viewId);
+
+    await expect(childRow).toBeVisible({ timeout: 30000 });
+    await expect(childRow.getByTestId('database-view-dot')).toHaveCount(1);
+  }
+});
+
+Then('the public outline highlights only the container and active database view', async ({ page }) => {
+  const state = requireState(page);
+  const consumerPage = requireConsumerPage(state);
+  const containerId = requireValue(state.databaseContainerId, 'database container id');
+  const sourceViewIds = requireValue(state.sourceViewIds, 'source database view ids');
+  const activeViewId = await activePublicDatabaseViewId(consumerPage);
+
+  await expect(publishedOutlineItem(consumerPage, containerId)).toHaveAttribute('data-selected', 'true');
+
+  for (const viewId of sourceViewIds) {
+    await expect(publishedOutlineItem(consumerPage, viewId)).toHaveAttribute(
+      'data-selected',
+      viewId === activeViewId ? 'true' : 'false'
+    );
+  }
+});
+
+When('the public outline opens the {string} database view', async ({ page }, viewLabel: string) => {
+  const state = requireState(page);
+  const consumerPage = requireConsumerPage(state);
+  const viewId = sourceViewIdByLabel(state, viewLabel);
+
+  await publishedOutlineItem(consumerPage, viewId).getByTestId('page-name').click({ force: true });
+});
+
+Then(
+  'the public database route keeps its published anchor and selects {string}',
+  async ({ page }, viewLabel: string) => {
+    const state = requireState(page);
+    const consumerPage = requireConsumerPage(state);
+    const publishedUrl = new URL(requirePublishedUrl(state));
+    const expectedViewId = sourceViewIdByLabel(state, viewLabel);
+
+    await expect
+      .poll(
+        () => {
+          const currentUrl = new URL(consumerPage.url());
+
+          return {
+            pathname: currentUrl.pathname,
+            selectedViewId: currentUrl.searchParams.get('v'),
+          };
+        },
+        {
+          timeout: 30000,
+          message: `Expected the public outline to select ${viewLabel} without leaving ${publishedUrl.pathname}`,
+        }
+      )
+      .toEqual({
+        pathname: publishedUrl.pathname,
+        selectedViewId: expectedViewId,
+      });
+    await expect(DatabaseViewSelectors.viewTab(consumerPage, expectedViewId)).toHaveAttribute('data-state', 'active');
+  }
+);
+
+When('the public outline opens the database container', async ({ page }) => {
+  const state = requireState(page);
+  const consumerPage = requireConsumerPage(state);
+  const containerId = requireValue(state.databaseContainerId, 'database container id');
+
+  await publishedOutlineItem(consumerPage, containerId).getByTestId('page-name').click({ force: true });
+});
+
+Then('the public outline remains expanded', async ({ page }) => {
+  const state = requireState(page);
+  const consumerPage = requireConsumerPage(state);
+  const containerId = requireValue(state.databaseContainerId, 'database container id');
+  const sourceViewIds = requireValue(state.sourceViewIds, 'source database view ids');
+
+  await expect(publishedOutlineItem(consumerPage, containerId).getByTestId('outline-toggle-collapse')).toBeVisible();
+
+  for (const viewId of sourceViewIds) {
+    await expect(publishedOutlineItem(consumerPage, viewId)).toBeVisible();
+  }
+});
+
 Then('the published child-view outline keeps the database view order', async ({ page, request }) => {
   const state = requireState(page);
   const containerId = requireValue(state.databaseContainerId, 'database container id');
@@ -689,6 +788,60 @@ async function databaseViewIds(page: Page): Promise<string[]> {
 
     return viewId;
   });
+}
+
+function publishedOutlineItem(page: Page, viewId: string) {
+  return page.locator(`[data-testid="outline-item-${viewId}"]:visible`).first();
+}
+
+async function expandPublishedOutlineSpace(page: Page): Promise<void> {
+  const spaceName = page.getByTestId('space-name').first();
+
+  await expect(spaceName).toBeVisible({ timeout: 30000 });
+
+  const spaceRow = spaceName.locator('xpath=ancestor::*[starts-with(@data-testid, "outline-item-")][1]');
+
+  await expandPublishedOutlineItem(spaceRow);
+}
+
+async function expandPublishedOutlineItem(outlineItem: ReturnType<typeof publishedOutlineItem>): Promise<void> {
+  const expandButton = outlineItem.getByTestId('outline-toggle-expand');
+
+  if (await expandButton.isVisible().catch(() => false)) {
+    await expandButton.click();
+  }
+
+  await expect(outlineItem.getByTestId('outline-toggle-collapse')).toBeVisible();
+}
+
+async function activePublicDatabaseViewId(page: Page): Promise<string> {
+  const testId = await DatabaseViewSelectors.activeViewTab(page).getAttribute('data-testid');
+  const viewId = testId?.replace(/^view-tab-/, '');
+
+  if (!viewId || viewId === testId) {
+    throw new Error(`Could not resolve the active public database view from ${testId || 'an empty test id'}`);
+  }
+
+  return viewId;
+}
+
+function sourceViewIdByLabel(state: PublishedTemplateState, viewLabel: string): string {
+  const sourceViewIds = requireValue(state.sourceViewIds, 'source database view ids');
+  const viewIndex = state.sourceViewOrder.indexOf(viewLabel);
+
+  if (viewIndex < 0 || !sourceViewIds[viewIndex]) {
+    throw new Error(`The source database does not contain a ${viewLabel} view`);
+  }
+
+  return sourceViewIds[viewIndex];
+}
+
+async function sourceDatabaseContainer(request: APIRequestContext, state: PublishedTemplateState): Promise<FolderView> {
+  const token = requireValue(state.publisherToken, 'publisher token');
+  const workspaceId = requireValue(state.publisherWorkspaceId, 'publisher workspace id');
+  const containerId = requireValue(state.databaseContainerId, 'database container id');
+
+  return getApi<FolderView>(request, token, `/api/workspace/${workspaceId}/view/${containerId}?depth=2`);
 }
 
 async function publishDatabaseChildView(

--- a/src/application/publish/__tests__/context.test.tsx
+++ b/src/application/publish/__tests__/context.test.tsx
@@ -11,7 +11,7 @@ import {
 } from '@/application/publish-snapshot/__fixtures__/published-page-snapshots';
 import { PublishContextType, PublishProvider, usePublishContext } from '@/application/publish';
 import { RowService } from '@/application/services/domains';
-import { ViewLayout, YjsEditorKey } from '@/application/types';
+import { View, ViewLayout, YjsEditorKey } from '@/application/types';
 import { yDocToSlateContent } from '@/application/slate-yjs/utils/convert';
 
 const mockNavigate = jest.fn();
@@ -93,6 +93,45 @@ function ContextProbe({ onContext }: { onContext: (context: PublishContextType) 
       <div data-testid="breadcrumbs">{context?.breadcrumbs.map((crumb) => crumb.name).join('/')}</div>
     </>
   );
+}
+
+function databaseChildView({
+  viewId,
+  parentViewId,
+  name,
+  layout,
+  isPublished,
+}: {
+  viewId: string;
+  parentViewId: string;
+  name: string;
+  layout: ViewLayout;
+  isPublished: boolean;
+}): View {
+  return {
+    view_id: viewId,
+    parent_view_id: parentViewId,
+    name,
+    layout,
+    children: [],
+    icon: null,
+    extra: { database_id: 'epics-database-id' },
+    is_published: isPublished,
+    is_private: false,
+  };
+}
+
+function unpublishedDatabaseContainer(viewId: string, children: View[]): View {
+  return {
+    view_id: viewId,
+    name: '03_epics',
+    layout: ViewLayout.Grid,
+    children,
+    icon: null,
+    extra: { database_id: 'epics-database-id', is_database_container: true },
+    is_published: false,
+    is_private: false,
+  };
 }
 
 describe('PublishProvider', () => {
@@ -400,6 +439,178 @@ describe('PublishProvider', () => {
     expect(mockGetViewInfo).not.toHaveBeenCalledWith(databaseContainerId);
     expect(mockGetViewInfo).not.toHaveBeenCalledWith(targetChildId);
     expect(mockNavigate).toHaveBeenCalledWith('/published-namespace/by-status?v=board-view-id', {
+      replace: true,
+    });
+  });
+
+  it('uses the requested published child instead of the first published sibling as the route anchor', async () => {
+    const currentSnapshot = normalizePublishedPageSnapshot(publishedDocumentPayload);
+    const databaseContainerId = 'epics-container-id';
+    const firstPublishedChildId = 'by-status-view-id';
+    const requestedPublishedChildId = 'board-view-id';
+    let latestContext: PublishContextType | undefined;
+
+    mockGetOutline.mockResolvedValue([
+      unpublishedDatabaseContainer(databaseContainerId, [
+        databaseChildView({
+          viewId: firstPublishedChildId,
+          parentViewId: databaseContainerId,
+          name: 'By Status',
+          layout: ViewLayout.Grid,
+          isPublished: true,
+        }),
+        databaseChildView({
+          viewId: requestedPublishedChildId,
+          parentViewId: databaseContainerId,
+          name: 'Board',
+          layout: ViewLayout.Board,
+          isPublished: true,
+        }),
+      ]),
+    ]);
+    mockGetViewInfo.mockImplementation(async (viewId: string) => {
+      if (viewId === firstPublishedChildId) {
+        return {
+          namespace: 'published-namespace',
+          publishName: 'by-status',
+          commentEnabled: false,
+          duplicateEnabled: false,
+        };
+      }
+
+      if (viewId === requestedPublishedChildId) {
+        return {
+          namespace: 'published-namespace',
+          publishName: 'board',
+          commentEnabled: true,
+          duplicateEnabled: true,
+        };
+      }
+
+      return {
+        namespace: currentSnapshot.namespace,
+        publishName: currentSnapshot.publishName,
+        commentEnabled: true,
+        duplicateEnabled: true,
+      };
+    });
+
+    render(
+      <PublishProvider
+        namespace={currentSnapshot.namespace}
+        publishName={currentSnapshot.publishName}
+        snapshot={currentSnapshot}
+      >
+        <ContextProbe
+          onContext={(context) => {
+            latestContext = context;
+          }}
+        />
+      </PublishProvider>
+    );
+
+    await waitFor(() => {
+      expect(latestContext?.outline).toHaveLength(1);
+      expect(latestContext?.duplicateEnabled).toBe(true);
+    });
+
+    mockGetViewInfo.mockClear();
+    await latestContext?.toView(requestedPublishedChildId);
+
+    expect(mockGetViewInfo).toHaveBeenCalledTimes(1);
+    expect(mockGetViewInfo).toHaveBeenCalledWith(requestedPublishedChildId);
+    expect(mockNavigate).toHaveBeenCalledWith('/published-namespace/board?v=board-view-id', {
+      replace: true,
+    });
+  });
+
+  it('keeps the current published child as the route anchor for an unpublished sibling', async () => {
+    const databaseContainerId = 'epics-container-id';
+    const firstPublishedChildId = 'by-status-view-id';
+    const currentPublishedChildId = 'epics-view-id';
+    const requestedUnpublishedChildId = 'board-view-id';
+    const baseSnapshot = normalizePublishedPageSnapshot(publishedDatabasePayload);
+    const currentSnapshot = {
+      ...baseSnapshot,
+      view: {
+        ...baseSnapshot.view,
+        viewId: currentPublishedChildId,
+      },
+    };
+    let latestContext: PublishContextType | undefined;
+
+    mockGetOutline.mockResolvedValue([
+      unpublishedDatabaseContainer(databaseContainerId, [
+        databaseChildView({
+          viewId: firstPublishedChildId,
+          parentViewId: databaseContainerId,
+          name: 'By Status',
+          layout: ViewLayout.Grid,
+          isPublished: true,
+        }),
+        databaseChildView({
+          viewId: currentPublishedChildId,
+          parentViewId: databaseContainerId,
+          name: 'Epics',
+          layout: ViewLayout.Grid,
+          isPublished: true,
+        }),
+        databaseChildView({
+          viewId: requestedUnpublishedChildId,
+          parentViewId: databaseContainerId,
+          name: 'Board',
+          layout: ViewLayout.Board,
+          isPublished: false,
+        }),
+      ]),
+    ]);
+    mockGetViewInfo.mockImplementation(async (viewId: string) => {
+      if (viewId === firstPublishedChildId) {
+        return {
+          namespace: 'published-namespace',
+          publishName: 'by-status',
+          commentEnabled: false,
+          duplicateEnabled: false,
+        };
+      }
+
+      if (viewId === currentPublishedChildId) {
+        return {
+          namespace: 'published-namespace',
+          publishName: 'epics',
+          commentEnabled: true,
+          duplicateEnabled: true,
+        };
+      }
+
+      throw new Error(`Unexpected published view info request: ${viewId}`);
+    });
+
+    render(
+      <PublishProvider
+        namespace={currentSnapshot.namespace}
+        publishName={currentSnapshot.publishName}
+        snapshot={currentSnapshot}
+      >
+        <ContextProbe
+          onContext={(context) => {
+            latestContext = context;
+          }}
+        />
+      </PublishProvider>
+    );
+
+    await waitFor(() => {
+      expect(latestContext?.outline).toHaveLength(1);
+      expect(latestContext?.duplicateEnabled).toBe(true);
+    });
+
+    mockGetViewInfo.mockClear();
+    await latestContext?.toView(requestedUnpublishedChildId);
+
+    expect(mockGetViewInfo).toHaveBeenCalledTimes(1);
+    expect(mockGetViewInfo).toHaveBeenCalledWith(currentPublishedChildId);
+    expect(mockNavigate).toHaveBeenCalledWith('/published-namespace/epics?v=board-view-id', {
       replace: true,
     });
   });

--- a/src/application/publish/__tests__/context.test.tsx
+++ b/src/application/publish/__tests__/context.test.tsx
@@ -11,7 +11,7 @@ import {
 } from '@/application/publish-snapshot/__fixtures__/published-page-snapshots';
 import { PublishContextType, PublishProvider, usePublishContext } from '@/application/publish';
 import { RowService } from '@/application/services/domains';
-import { YjsEditorKey } from '@/application/types';
+import { ViewLayout, YjsEditorKey } from '@/application/types';
 import { yDocToSlateContent } from '@/application/slate-yjs/utils/convert';
 
 const mockNavigate = jest.fn();
@@ -20,6 +20,7 @@ const mockGetView = jest.fn();
 const mockGetViewInfo = jest.fn();
 const mockGetViewMeta = jest.fn();
 const mockGetRowDocument = jest.fn();
+const mockGetOutline = jest.fn();
 
 jest.mock('dexie-react-hooks', () => ({
   useLiveQuery: jest.fn(() => undefined),
@@ -65,7 +66,7 @@ jest.mock('@/application/publish-snapshot/data-source', () => ({
 
 jest.mock('@/application/services/domains', () => ({
   PublishService: {
-    getOutline: jest.fn(async () => []),
+    getOutline: (...args: unknown[]) => mockGetOutline(...args),
     getView: (...args: unknown[]) => mockGetView(...args),
     getViewInfo: (...args: unknown[]) => mockGetViewInfo(...args),
     getViewMeta: (...args: unknown[]) => mockGetViewMeta(...args),
@@ -97,6 +98,7 @@ function ContextProbe({ onContext }: { onContext: (context: PublishContextType) 
 describe('PublishProvider', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockGetOutline.mockResolvedValue([]);
     mockGetViewInfo.mockResolvedValue({
       namespace: 'published-namespace',
       publishName: 'published-document',
@@ -239,5 +241,166 @@ describe('PublishProvider', () => {
 
     expect(firstRowDocumentBlock?.children?.[0]?.children?.[0]?.text).toBe('Published row document body');
     expect(mockGetRowDocument).not.toHaveBeenCalled();
+  });
+
+  it('opens a database child through its published container route', async () => {
+    const currentSnapshot = normalizePublishedPageSnapshot(publishedDocumentPayload);
+    const databaseChildId = 'in-progress-view-id';
+    const databaseContainerId = 'projects-container-id';
+    let latestContext: PublishContextType | undefined;
+
+    mockGetOutline.mockResolvedValue([
+      {
+        view_id: databaseContainerId,
+        name: 'projects',
+        layout: ViewLayout.Grid,
+        children: [
+          {
+            view_id: databaseChildId,
+            parent_view_id: databaseContainerId,
+            name: 'In Progress',
+            layout: ViewLayout.Grid,
+            children: [],
+            icon: null,
+            extra: { database_id: 'projects-database-id' },
+            is_published: true,
+            is_private: false,
+          },
+        ],
+        icon: null,
+        extra: { database_id: 'projects-database-id', is_database_container: true },
+        is_published: true,
+        is_private: false,
+      },
+    ]);
+    mockGetViewInfo.mockImplementation(async (viewId: string) => {
+      if (viewId === databaseContainerId) {
+        return {
+          namespace: 'published-namespace',
+          publishName: 'projects',
+          commentEnabled: true,
+          duplicateEnabled: true,
+        };
+      }
+
+      return {
+        namespace: currentSnapshot.namespace,
+        publishName: currentSnapshot.publishName,
+        commentEnabled: true,
+        duplicateEnabled: true,
+      };
+    });
+
+    render(
+      <PublishProvider
+        namespace={currentSnapshot.namespace}
+        publishName={currentSnapshot.publishName}
+        snapshot={currentSnapshot}
+      >
+        <ContextProbe onContext={(context) => {
+          latestContext = context;
+        }} />
+      </PublishProvider>
+    );
+
+    await waitFor(() => {
+      expect(latestContext?.outline).toHaveLength(1);
+    });
+
+    await latestContext?.toView(databaseChildId);
+
+    expect(mockGetViewInfo).toHaveBeenCalledWith(databaseContainerId);
+    expect(mockGetViewInfo).not.toHaveBeenCalledWith(databaseChildId);
+    expect(mockNavigate).toHaveBeenCalledWith('/published-namespace/projects?v=in-progress-view-id', {
+      replace: true,
+    });
+  });
+
+  it('opens an unpublished database container through its published child route', async () => {
+    const currentSnapshot = normalizePublishedPageSnapshot(publishedDatabasePayload);
+    const databaseContainerId = 'epics-container-id';
+    const publishedChildId = 'by-status-view-id';
+    const targetChildId = 'board-view-id';
+    let latestContext: PublishContextType | undefined;
+
+    mockGetOutline.mockResolvedValue([
+      {
+        view_id: databaseContainerId,
+        name: '03_epics',
+        layout: ViewLayout.Grid,
+        children: [
+          {
+            view_id: publishedChildId,
+            name: 'By Status',
+            layout: ViewLayout.Grid,
+            children: [],
+            icon: null,
+            extra: { database_id: 'epics-database-id' },
+            is_published: true,
+            is_private: false,
+          },
+          {
+            view_id: targetChildId,
+            name: 'Board',
+            layout: ViewLayout.Board,
+            children: [],
+            icon: null,
+            extra: { database_id: 'epics-database-id' },
+            is_published: false,
+            is_private: false,
+          },
+        ],
+        icon: null,
+        extra: { database_id: 'epics-database-id', is_database_container: true },
+        is_published: false,
+        is_private: false,
+      },
+    ]);
+    mockGetViewInfo.mockImplementation(async (viewId: string) => {
+      if (viewId === databaseContainerId) {
+        throw new Error('View has not been published yet');
+      }
+
+      if (viewId === publishedChildId) {
+        return {
+          namespace: 'published-namespace',
+          publishName: 'by-status',
+          commentEnabled: true,
+          duplicateEnabled: true,
+        };
+      }
+
+      return {
+        namespace: currentSnapshot.namespace,
+        publishName: currentSnapshot.publishName,
+        commentEnabled: true,
+        duplicateEnabled: true,
+      };
+    });
+
+    render(
+      <PublishProvider
+        namespace={currentSnapshot.namespace}
+        publishName={currentSnapshot.publishName}
+        snapshot={currentSnapshot}
+      >
+        <ContextProbe onContext={(context) => {
+          latestContext = context;
+        }} />
+      </PublishProvider>
+    );
+
+    await waitFor(() => {
+      expect(latestContext?.outline).toHaveLength(1);
+    });
+
+    await latestContext?.toView(targetChildId);
+
+    expect(mockGetViewInfo).toHaveBeenCalledWith(publishedChildId);
+    expect(mockGetViewInfo).not.toHaveBeenCalledWith(databaseContainerId);
+    expect(mockGetViewInfo).not.toHaveBeenCalledWith(targetChildId);
+    expect(mockNavigate).toHaveBeenCalledWith('/published-namespace/by-status?v=board-view-id', {
+      replace: true,
+    });
   });
 });

--- a/src/application/publish/context.tsx
+++ b/src/application/publish/context.tsx
@@ -22,8 +22,9 @@ import {
   ViewLayout,
   YDoc,
 } from '@/application/types';
+import { isDatabaseContainer, isDatabaseLayout } from '@/application/view-utils';
 import { notify } from '@/components/_shared/notify';
-import { findAncestors, findView } from '@/components/_shared/outline/utils';
+import { findAncestors, findParentView, findView } from '@/components/_shared/outline/utils';
 import { PublishService, RowService } from '@/application/services/domains';
 
 function publishedViewToViewInfo(view: PublishedView): ViewInfo {
@@ -356,10 +357,24 @@ export const PublishProvider = ({
 
   const toView = useCallback(
     async (viewId: string, blockId?: string) => {
-      try {
-        const view = await loadViewMeta(viewId);
+      const outlineView = findView(outline, viewId);
+      const outlineParent = findParentView(outline, viewId);
+      const databaseContainer =
+        outlineView && isDatabaseLayout(outlineView.layout) && isDatabaseContainer(outlineParent)
+          ? outlineParent
+          : undefined;
+      const publishedDatabaseRoute = databaseContainer?.is_published
+        ? databaseContainer
+        : databaseContainer?.children.find((child) => child.is_published);
+      let targetView = outlineView || undefined;
 
-        const res = await PublishService.getViewInfo(viewId);
+      try {
+        const view = targetView || (await loadViewMeta(viewId));
+        const routeViewId = publishedDatabaseRoute?.view_id || viewId;
+
+        targetView = view;
+
+        const res = await PublishService.getViewInfo(routeViewId);
 
         if (!res) {
           throw new Error('View has not been published yet');
@@ -389,6 +404,10 @@ export const PublishProvider = ({
           searchParams.set('template', 'true');
         }
 
+        if (databaseContainer) {
+          searchParams.set('v', viewId);
+        }
+
         let url = `/${viewNamespace}/${publishName}`;
 
         if (searchParams.toString()) {
@@ -400,20 +419,27 @@ export const PublishProvider = ({
         });
         return;
       } catch (e) {
-        // For unpublished sibling database views, switch the tab via URL parameter
-        // instead of navigating to a non-existent published page.
-        // Only apply this fallback when a ?v= param is already present (indicating
-        // we're on a database page with tabs). Otherwise, re-throw so callers
-        // (e.g., relation pills, @-mentions) can handle the error.
-        const currentParams = new URLSearchParams(window.location.search);
+        // A database tab may not have its own published route. If the current
+        // published page is already a database, switch tabs in place.
+        const targetDatabaseId = targetView?.extra?.database_id;
+        const currentDatabaseId = viewMeta ? findView(outline, viewMeta.view_id)?.extra?.database_id : undefined;
+        const isCurrentDatabaseTab =
+          Boolean(targetDatabaseId) && targetDatabaseId === currentDatabaseId;
 
-        currentParams.set('v', viewId);
-        navigate(`${window.location.pathname}?${currentParams.toString()}`, {
-          replace: true,
-        });
+        if (viewMeta && isDatabaseLayout(viewMeta.layout) && isCurrentDatabaseTab) {
+          const currentParams = new URLSearchParams(window.location.search);
+
+          currentParams.set('v', viewId);
+          navigate(`${window.location.pathname}?${currentParams.toString()}`, {
+            replace: true,
+          });
+          return;
+        }
+
+        throw e;
       }
     },
-    [loadViewMeta, isTemplate, navigate]
+    [isTemplate, loadViewMeta, navigate, outline, viewMeta]
   );
 
   const loadOutline = useCallback(async () => {

--- a/src/application/publish/context.tsx
+++ b/src/application/publish/context.tsx
@@ -359,13 +359,33 @@ export const PublishProvider = ({
     async (viewId: string, blockId?: string) => {
       const outlineView = findView(outline, viewId);
       const outlineParent = findParentView(outline, viewId);
+      let currentOutlineView: View | null | undefined;
+      const getCurrentOutlineView = () => {
+        if (currentOutlineView === undefined) {
+          currentOutlineView = viewMeta ? findView(outline, viewMeta.view_id) : null;
+        }
+
+        return currentOutlineView;
+      };
+
       const databaseContainer =
         outlineView && isDatabaseLayout(outlineView.layout) && isDatabaseContainer(outlineParent)
           ? outlineParent
           : undefined;
-      const publishedDatabaseRoute = databaseContainer?.is_published
-        ? databaseContainer
-        : databaseContainer?.children.find((child) => child.is_published);
+      const currentPublishedDatabaseView = databaseContainer?.children.find(
+        (child) => child.view_id === getCurrentOutlineView()?.view_id && child.is_published
+      );
+      let publishedDatabaseRoute: View | undefined;
+
+      if (databaseContainer?.is_published) {
+        publishedDatabaseRoute = databaseContainer;
+      } else if (outlineView?.is_published) {
+        publishedDatabaseRoute = outlineView;
+      } else {
+        publishedDatabaseRoute =
+          currentPublishedDatabaseView ?? databaseContainer?.children.find((child) => child.is_published);
+      }
+
       let targetView = outlineView || undefined;
 
       try {
@@ -422,7 +442,7 @@ export const PublishProvider = ({
         // A database tab may not have its own published route. If the current
         // published page is already a database, switch tabs in place.
         const targetDatabaseId = targetView?.extra?.database_id;
-        const currentDatabaseId = viewMeta ? findView(outline, viewMeta.view_id)?.extra?.database_id : undefined;
+        const currentDatabaseId = getCurrentOutlineView()?.extra?.database_id;
         const isCurrentDatabaseTab =
           Boolean(targetDatabaseId) && targetDatabaseId === currentDatabaseId;
 

--- a/src/application/services/domains/file.ts
+++ b/src/application/services/domains/file.ts
@@ -1,5 +1,6 @@
 export {
   cancelImportTask,
+  CreateImportTaskType,
   createImportTask,
   uploadImportFile,
   createDatabaseCsvImportTask as createCsvImportTask,

--- a/src/application/services/js-services/cached-api.ts
+++ b/src/application/services/js-services/cached-api.ts
@@ -33,6 +33,7 @@ import {
   signInWithUrl,
   uploadFileMultipart,
   cancelImportTask,
+  CreateImportTaskType,
   createImportTask,
   uploadImportFile,
   uploadImportFileMultipart,
@@ -526,8 +527,13 @@ export async function uploadFileWithTracking(
   }
 }
 
-export async function importFileWithUpload(file: File, onProgress: (progress: number) => void) {
-  const task = await createImportTask(file);
+export interface ImportFileWithUploadOptions {
+  taskType: CreateImportTaskType;
+  onProgress: (progress: number) => void;
+}
+
+export async function importFileWithUpload(file: File, { taskType, onProgress }: ImportFileWithUploadOptions) {
+  const task = await createImportTask(file, taskType);
 
   try {
     if (task.multipart) {

--- a/src/application/services/js-services/http/__tests__/file-import.integration.test.ts
+++ b/src/application/services/js-services/http/__tests__/file-import.integration.test.ts
@@ -75,7 +75,7 @@ describe('HTTP API - File Upload & Import Operations', () => {
             // Create a mock file
             const file = new File(['test content'], 'test.csv', { type: 'text/csv' });
             try {
-                const result = await APIService.createImportTask(file);
+                const result = await APIService.createImportTask(file, APIService.CreateImportTaskType.Notion);
                 expect(result).toBeDefined();
             } catch (error: any) {
                 // May fail for various reasons (file format, permissions, etc.)

--- a/src/application/services/js-services/http/__tests__/import-api.test.ts
+++ b/src/application/services/js-services/http/__tests__/import-api.test.ts
@@ -1,0 +1,50 @@
+import { executeAPIRequest, getAxios } from '@/application/services/js-services/http/core';
+
+import { createImportTask, CreateImportTaskType } from '../import-api';
+
+jest.mock('@/application/services/js-services/http/core', () => ({
+  executeAPIRequest: jest.fn(),
+  executeAPIVoidRequest: jest.fn(),
+  getAxios: jest.fn(),
+}));
+
+describe('createImportTask', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it.each([
+    ['AppFlowy workspace', CreateImportTaskType.Workspace],
+    ['Notion workspace', CreateImportTaskType.Notion],
+  ])('sends the selected task type for an %s import', async (_label, taskType) => {
+    const post = jest.fn();
+
+    jest.mocked(getAxios).mockReturnValue({ post } as never);
+    jest.mocked(executeAPIRequest).mockImplementation(async (request) => {
+      await request();
+      return {
+        task_id: 'task-id',
+        presigned_url: 'https://example.com/upload',
+        multipart: null,
+      };
+    });
+
+    const file = new File(['workspace'], 'My Workspace.zip', { type: 'application/zip' });
+
+    await createImportTask(file, taskType);
+
+    expect(post).toHaveBeenCalledWith(
+      '/api/import/create',
+      {
+        workspace_name: 'My Workspace',
+        content_length: file.size,
+        task_type: taskType,
+      },
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          'X-Host': expect.any(String),
+        }),
+      })
+    );
+  });
+});

--- a/src/application/services/js-services/http/http_api.ts
+++ b/src/application/services/js-services/http/http_api.ts
@@ -154,6 +154,7 @@ export {
 
 // Import
 export {
+  CreateImportTaskType,
   createImportTask,
   uploadImportFile,
   createDatabaseCsvImportTask,

--- a/src/application/services/js-services/http/import-api.ts
+++ b/src/application/services/js-services/http/import-api.ts
@@ -33,6 +33,11 @@ export interface ImportUploadTask {
   multipart: ImportMultipartUploadInfo | null;
 }
 
+export enum CreateImportTaskType {
+  Notion = 'Notion',
+  Workspace = 'Workspace',
+}
+
 export interface CreateNotionImportTaskPayload {
   content_length: number;
   md5_base64: string;
@@ -46,7 +51,7 @@ function toImportUploadTask(data: CreateImportTaskRaw): ImportUploadTask {
   };
 }
 
-export async function createImportTask(file: File): Promise<ImportUploadTask> {
+export async function createImportTask(file: File, taskType: CreateImportTaskType): Promise<ImportUploadTask> {
   const url = `/api/import/create`;
   const fileName = file.name.split('.').slice(0, -1).join('.') || crypto.randomUUID();
 
@@ -56,6 +61,7 @@ export async function createImportTask(file: File): Promise<ImportUploadTask> {
       {
         workspace_name: fileName,
         content_length: file.size,
+        task_type: taskType,
       },
       {
         headers: {

--- a/src/components/_shared/more-actions/importer/ImporterDialogContent.tsx
+++ b/src/components/_shared/more-actions/importer/ImporterDialogContent.tsx
@@ -2,8 +2,6 @@ import LinearProgress from '@mui/material/LinearProgress';
 import React, { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import { ReactComponent as AppFlowyIcon } from '@/assets/icons/appflowy.svg';
-import { ReactComponent as NotionIcon } from '@/assets/icons/notion.svg';
 import { FileService } from '@/application/services/domains';
 import FileDropzone from '@/components/_shared/file-dropzone/FileDropzone';
 import { notify } from '@/components/_shared/notify';
@@ -11,9 +9,11 @@ import { TabPanel, ViewTab, ViewTabs } from '@/components/_shared/tabs/ViewTabs'
 
 const ZIP_ACCEPT = '.zip,application/zip,application/x-zip,application/x-zip-compressed';
 
+type ImportSource = 'appflowy' | 'notion';
+
 function ImporterDialogContent({ source, onSuccess }: { source?: string; onSuccess: () => void }) {
   const { t } = useTranslation();
-  const [value, setValue] = React.useState<string>(source || 'notion');
+  const [value, setValue] = React.useState<ImportSource>(source === 'appflowy' ? 'appflowy' : 'notion');
   const [progress, setProgress] = React.useState<number>(0);
   const [isError, setIsError] = React.useState<boolean>(false);
 
@@ -21,7 +21,13 @@ function ImporterDialogContent({ source, onSuccess }: { source?: string; onSucce
     async (file: File) => {
       setIsError(false);
       try {
-        await FileService.importFile(file, setProgress);
+        const taskType =
+          value === 'appflowy' ? FileService.CreateImportTaskType.Workspace : FileService.CreateImportTaskType.Notion;
+
+        await FileService.importFile(file, {
+          taskType,
+          onProgress: setProgress,
+        });
         onSuccess();
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
       } catch (e: any) {
@@ -29,7 +35,7 @@ function ImporterDialogContent({ source, onSuccess }: { source?: string; onSucce
         setIsError(true);
       }
     },
-    [onSuccess]
+    [onSuccess, value]
   );
 
   const isUploading = !isError && progress < 1 && progress > 0;
@@ -41,18 +47,8 @@ function ImporterDialogContent({ source, onSuccess }: { source?: string; onSucce
         onChange={(_e, newValue) => setValue(newValue)}
         value={value}
       >
-        <ViewTab
-          className={'flex flex-row items-center justify-center gap-1.5'}
-          value={'appflowy'}
-          label={t('web.importFromAppFlowy')}
-          icon={<AppFlowyIcon className={'mb-0 h-4 w-4'} />}
-        />
-        <ViewTab
-          className={'flex flex-row items-center justify-center gap-1.5'}
-          value={'notion'}
-          label={t('web.importFromNotion')}
-          icon={<NotionIcon className={'mb-0 h-4 w-4'} />}
-        />
+        <ViewTab value={'appflowy'} label={t('web.importFromAppFlowy')} />
+        <ViewTab value={'notion'} label={t('web.importFromNotion')} />
       </ViewTabs>
       <div className={'p-2 pb-0'}>
         <TabPanel

--- a/src/components/_shared/more-actions/importer/__tests__/ImporterDialogContent.test.tsx
+++ b/src/components/_shared/more-actions/importer/__tests__/ImporterDialogContent.test.tsx
@@ -1,0 +1,52 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+import { FileService } from '@/application/services/domains';
+
+import ImporterDialogContent from '../ImporterDialogContent';
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+jest.mock('@/application/services/domains', () => ({
+  FileService: {
+    CreateImportTaskType: {
+      Notion: 'Notion',
+      Workspace: 'Workspace',
+    },
+    importFile: jest.fn(),
+  },
+}));
+
+const importFile = FileService.importFile as jest.MockedFunction<typeof FileService.importFile>;
+
+function uploadVisibleFile(file: File) {
+  const input = screen.getByTestId('file-dropzone').querySelector('input');
+
+  expect(input).not.toBeNull();
+  fireEvent.change(input!, { target: { files: [file] } });
+}
+
+describe('ImporterDialogContent', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    importFile.mockResolvedValue(undefined);
+  });
+
+  it.each([
+    ['appflowy', FileService.CreateImportTaskType.Workspace],
+    ['notion', FileService.CreateImportTaskType.Notion],
+  ] as const)('routes the %s tab to the matching import task type', async (source, taskType) => {
+    const file = new File(['workspace'], `${source}.zip`, { type: 'application/zip' });
+
+    render(<ImporterDialogContent source={source} onSuccess={jest.fn()} />);
+    uploadVisibleFile(file);
+
+    await waitFor(() => {
+      expect(importFile).toHaveBeenCalledWith(file, {
+        taskType,
+        onProgress: expect.any(Function),
+      });
+    });
+  });
+});

--- a/src/components/_shared/outline/OutlineItem.databaseContainer.test.tsx
+++ b/src/components/_shared/outline/OutlineItem.databaseContainer.test.tsx
@@ -1,0 +1,145 @@
+import { fireEvent, render, screen, within } from '@testing-library/react';
+
+import { UIVariant, View, ViewLayout } from '@/application/types';
+import OutlineItem from '@/components/_shared/outline/OutlineItem';
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+jest.mock('@/components/app/app.hooks', () => ({
+  useAIEnabled: () => true,
+}));
+
+jest.mock('@/components/_shared/outline/OutlineIcon', () => () => null);
+jest.mock('@/components/_shared/view-icon/PageIcon', () => () => <span data-testid='page-icon' />);
+jest.mock('@/components/_shared/view-icon/PublishIcon', () => () => null);
+jest.mock('@/components/_shared/view-icon/SpaceIcon', () => () => null);
+
+const completedView: View = {
+  view_id: 'completed-view-id',
+  parent_view_id: 'projects-container-id',
+  name: 'Completed Project',
+  layout: ViewLayout.Grid,
+  children: [],
+  icon: null,
+  extra: {
+    database_id: 'projects-database-id',
+  },
+  is_published: true,
+  is_private: false,
+};
+
+const inProgressView: View = {
+  ...completedView,
+  view_id: 'in-progress-view-id',
+  name: 'In Progress',
+};
+
+const projectsContainer: View = {
+  view_id: 'projects-container-id',
+  name: 'projects',
+  layout: ViewLayout.Grid,
+  children: [completedView, inProgressView],
+  icon: null,
+  extra: {
+    database_id: 'projects-database-id',
+    is_database_container: true,
+  },
+  is_published: true,
+  is_private: false,
+};
+
+describe('published outline database container', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    localStorage.setItem('outline_expanded', JSON.stringify({ [projectsContainer.view_id]: true }));
+  });
+
+  it('highlights both the container and active database view', () => {
+    render(
+      <OutlineItem
+        view={projectsContainer}
+        width={280}
+        selectedViewId={completedView.view_id}
+        variant={UIVariant.Publish}
+      />
+    );
+
+    expect(screen.getByTestId(`outline-item-${projectsContainer.view_id}`).getAttribute('data-selected')).toBe('true');
+    expect(screen.getByTestId(`outline-item-${completedView.view_id}`).getAttribute('data-selected')).toBe('true');
+    expect(screen.getByTestId(`outline-item-${inProgressView.view_id}`).getAttribute('data-selected')).toBe('false');
+  });
+
+  it('keeps the container highlighted in the favorites outline when a database view is active', () => {
+    render(
+      <OutlineItem
+        view={projectsContainer}
+        width={280}
+        selectedViewId={completedView.view_id}
+        variant={UIVariant.Favorite}
+      />
+    );
+
+    expect(screen.getByTestId(`outline-item-${projectsContainer.view_id}`).getAttribute('data-selected')).toBe('true');
+    expect(screen.getByTestId(`outline-item-${completedView.view_id}`).getAttribute('data-selected')).toBe('true');
+    expect(screen.getByTestId(`outline-item-${inProgressView.view_id}`).getAttribute('data-selected')).toBe('false');
+  });
+
+  it('renders dots instead of page icons for database views', () => {
+    render(<OutlineItem view={projectsContainer} width={280} variant={UIVariant.Publish} />);
+
+    const containerRow = screen.getByTestId(`outline-item-${projectsContainer.view_id}`);
+    const completedRow = screen.getByTestId(`outline-item-${completedView.view_id}`);
+    const inProgressRow = screen.getByTestId(`outline-item-${inProgressView.view_id}`);
+
+    expect(within(containerRow).queryByTestId('page-icon')).not.toBeNull();
+    expect(within(containerRow).queryByTestId('database-view-dot')).toBeNull();
+    expect(within(completedRow).queryByTestId('page-icon')).toBeNull();
+    expect(within(completedRow).queryByTestId('database-view-dot')).not.toBeNull();
+    expect(within(inProgressRow).queryByTestId('page-icon')).toBeNull();
+    expect(within(inProgressRow).queryByTestId('database-view-dot')).not.toBeNull();
+  });
+
+  it('opens the first database view when the container is clicked', () => {
+    const navigateToView = jest.fn(async () => undefined);
+
+    render(
+      <OutlineItem
+        view={projectsContainer}
+        width={280}
+        variant={UIVariant.Publish}
+        navigateToView={navigateToView}
+      />
+    );
+
+    const containerRow = screen.getByTestId(`outline-item-${projectsContainer.view_id}`);
+
+    fireEvent.click(within(containerRow).getByTestId('page-name'));
+
+    expect(navigateToView).toHaveBeenCalledWith(completedView.view_id);
+  });
+
+  it('opens an unpublished container instead of collapsing it', () => {
+    const navigateToView = jest.fn(async () => undefined);
+    const unpublishedContainer = {
+      ...projectsContainer,
+      is_published: false,
+    };
+
+    render(
+      <OutlineItem
+        view={unpublishedContainer}
+        width={280}
+        variant={UIVariant.Publish}
+        navigateToView={navigateToView}
+      />
+    );
+
+    const containerRow = screen.getByTestId(`outline-item-${unpublishedContainer.view_id}`);
+
+    fireEvent.click(within(containerRow).getByTestId('page-name'));
+
+    expect(navigateToView).toHaveBeenCalledWith(completedView.view_id);
+  });
+});

--- a/src/components/_shared/outline/OutlineItem.tsx
+++ b/src/components/_shared/outline/OutlineItem.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useEffect, useMemo } from 'react';
 
 import { UIVariant, View, ViewLayout } from '@/application/types';
+import { isDatabaseContainer } from '@/application/view-utils';
 import { ReactComponent as PrivateIcon } from '@/assets/icons/lock.svg';
 import OutlineIcon from '@/components/_shared/outline/OutlineIcon';
 import OutlineItemContent from '@/components/_shared/outline/OutlineItemContent';
@@ -14,6 +15,7 @@ function OutlineItem({
   navigateToView,
   selectedViewId,
   variant,
+  parentView,
 }: {
   view: View;
   width?: number;
@@ -21,8 +23,11 @@ function OutlineItem({
   selectedViewId?: string;
   navigateToView?: (viewId: string) => Promise<void>;
   variant?: UIVariant;
+  parentView?: View;
 }) {
-  const selected = selectedViewId === view.view_id;
+  const selected =
+    selectedViewId === view.view_id ||
+    (isDatabaseContainer(view) && Boolean(view.children?.some((child) => child.view_id === selectedViewId)));
   const aiEnabled = useAIEnabled();
   const [isExpanded, setIsExpanded] = React.useState(() => {
     return getOutlineExpands()[view.view_id] || false;
@@ -45,6 +50,7 @@ function OutlineItem({
       return (
         <div
           data-testid={`outline-item-${item.view_id}`}
+          data-selected={selected}
           className={`flex ${
             variant === UIVariant.App ? 'folder-view-item' : ''
           } my-0.5 h-fit w-full cursor-pointer justify-between`}
@@ -67,13 +73,14 @@ function OutlineItem({
               navigateToView={navigateToView}
               level={level}
               setIsExpanded={setIsExpanded}
+              parentView={parentView}
             />
             {item.is_private && <PrivateIcon className={'h-5 w-5 text-text-secondary'} />}
           </div>
         </div>
       );
     },
-    [variant, width, selected, getIcon, navigateToView, level]
+    [variant, width, selected, getIcon, navigateToView, level, parentView]
   );
 
   const children = useMemo(() => {
@@ -89,20 +96,21 @@ function OutlineItem({
           display: isExpanded ? 'block' : 'none',
         }}
       >
-        {children.map((item, index) => (
+        {children.map((item) => (
           <OutlineItem
             selectedViewId={selectedViewId}
             navigateToView={navigateToView}
             level={level + 1}
             width={width}
-            key={index}
+            key={item.view_id}
             view={item}
             variant={variant}
+            parentView={view}
           />
         ))}
       </div>
     );
-  }, [children, isExpanded, level, navigateToView, selectedViewId, width, variant]);
+  }, [children, isExpanded, level, navigateToView, selectedViewId, view, width, variant]);
 
   if (!aiEnabled && view.layout === ViewLayout.AIChat) return null;
 

--- a/src/components/_shared/outline/OutlineItemContent.tsx
+++ b/src/components/_shared/outline/OutlineItemContent.tsx
@@ -3,6 +3,7 @@ import React, { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { UIVariant, View } from '@/application/types';
+import { getFirstChildView, isDatabaseContainer, isReferencedDatabaseView } from '@/application/view-utils';
 import PageIcon from '@/components/_shared/view-icon/PageIcon';
 import PublishIcon from '@/components/_shared/view-icon/PublishIcon';
 import SpaceIcon from '@/components/_shared/view-icon/SpaceIcon';
@@ -13,31 +14,40 @@ function OutlineItemContent({
   navigateToView,
   level,
   variant,
+  parentView,
 }: {
   item: View;
   setIsExpanded: React.Dispatch<React.SetStateAction<boolean>>;
   navigateToView?: (viewId: string) => Promise<void>;
   level: number;
   variant?: UIVariant;
-
+  parentView?: View;
 }) {
   const { name, view_id, extra } = item;
   const [hovered, setHovered] = React.useState(false);
   const isSpace = extra?.is_space;
   const isDatabaseView = extra?.database_id && !extra?.is_database_container;
+  const isDatabaseContainerView = isDatabaseContainer(item);
+  const isPublishedDatabaseView = variant === UIVariant.Publish && isReferencedDatabaseView(item, parentView);
   const { t } = useTranslation();
 
   return (
     <div
       onClick={async() => {
 
-        if(isSpace || (!item.is_published && variant === 'publish' && !isDatabaseView)) {
+        if (
+          isSpace ||
+          (!item.is_published && variant === UIVariant.Publish && !isDatabaseView && !isDatabaseContainerView)
+        ) {
           setIsExpanded(prev => !prev);
           return;
         }
 
         try {
-          await navigateToView?.(view_id);
+          const targetViewId =
+            variant === UIVariant.Publish ? getFirstChildView(item)?.view_id || view_id : view_id;
+
+          await navigateToView?.(targetViewId);
         } catch(e) {
           // do nothing
         }
@@ -49,18 +59,25 @@ function OutlineItemContent({
       }}
       className={`flex flex-1 select-none items-center pointer gap-1.5 overflow-hidden`}
     >
-      {isSpace && extra ?
+      {isSpace && extra ? (
         <SpaceIcon
           bgColor={extra.space_icon_color}
           value={extra.space_icon || ''}
           char={extra.space_icon ? undefined : name.slice(0, 1)}
-        /> :
+        />
+      ) : isPublishedDatabaseView ? (
+        <span data-testid='database-view-dot' className={'flex h-full w-5 min-w-5 items-center justify-end'}>
+          <span className={'p-1.5'}>
+            <span className={'block h-1 w-1 rounded-full bg-text-secondary'} />
+          </span>
+        </span>
+      ) : (
         <PageIcon
           view={item}
           iconSize={20}
           className={'flex !w-5 !h-5 min-w-5 text-sm items-center justify-center'}
         />
-      }
+      )}
 
       <Tooltip
         title={name}

--- a/src/components/_shared/outline/OutlineItemContent.tsx
+++ b/src/components/_shared/outline/OutlineItemContent.tsx
@@ -1,4 +1,4 @@
-import { Tooltip } from '@mui/material';
+import Tooltip from '@mui/material/Tooltip';
 import React, { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -33,31 +33,34 @@ function OutlineItemContent({
 
   return (
     <div
-      onClick={async() => {
-
+      onClick={async () => {
         if (
           isSpace ||
           (!item.is_published && variant === UIVariant.Publish && !isDatabaseView && !isDatabaseContainerView)
         ) {
-          setIsExpanded(prev => !prev);
+          setIsExpanded((prev) => !prev);
           return;
         }
 
         try {
-          const targetViewId =
-            variant === UIVariant.Publish ? getFirstChildView(item)?.view_id || view_id : view_id;
+          const targetViewId = variant === UIVariant.Publish ? getFirstChildView(item)?.view_id || view_id : view_id;
 
           await navigateToView?.(targetViewId);
-        } catch(e) {
+        } catch (e) {
           // do nothing
         }
       }}
       onMouseEnter={() => setHovered(true)}
       onMouseLeave={() => setHovered(false)}
       style={{
-        paddingLeft: variant === 'favorite' || variant === 'recent' ? '8px' : item.children?.length ? 0 : 1.125 * (level + 1) + 'em',
+        paddingLeft:
+          variant === 'favorite' || variant === 'recent'
+            ? '8px'
+            : item.children?.length
+            ? 0
+            : 1.125 * (level + 1) + 'em',
       }}
-      className={`flex flex-1 select-none items-center pointer gap-1.5 overflow-hidden`}
+      className={`pointer flex flex-1 select-none items-center gap-1.5 overflow-hidden`}
     >
       {isSpace && extra ? (
         <SpaceIcon
@@ -72,23 +75,15 @@ function OutlineItemContent({
           </span>
         </span>
       ) : (
-        <PageIcon
-          view={item}
-          iconSize={20}
-          className={'flex !w-5 !h-5 min-w-5 text-sm items-center justify-center'}
-        />
+        <PageIcon view={item} iconSize={20} className={'flex !h-5 !w-5 min-w-5 items-center justify-center text-sm'} />
       )}
 
-      <Tooltip
-        title={name}
-        disableInteractive={true}
-      >
-        <div data-testid={isSpace ? 'space-name' : 'page-name'} className={'flex-1 truncate'}>{name || t('menuAppHeader.defaultNewPageName')}</div>
+      <Tooltip title={name} disableInteractive={true}>
+        <div data-testid={isSpace ? 'space-name' : 'page-name'} className={'flex-1 truncate'}>
+          {name || t('menuAppHeader.defaultNewPageName')}
+        </div>
       </Tooltip>
-      {hovered && variant === UIVariant.Publish && !isDatabaseView && <PublishIcon
-        variant={variant}
-        view={item}
-      />}
+      {hovered && variant === UIVariant.Publish && !isDatabaseView && <PublishIcon variant={variant} view={item} />}
     </div>
   );
 }

--- a/src/components/app/hooks/__tests__/resolveSidebarSelectedViewId.test.ts
+++ b/src/components/app/hooks/__tests__/resolveSidebarSelectedViewId.test.ts
@@ -73,12 +73,39 @@ describe('resolveSidebarSelectedViewId', () => {
     expect(resolveSidebarSelectedViewId({ routeViewId: gridViewId, tabViewId: null, outline })).toBe(gridViewId);
   });
 
+  it('selects the first database view when the route is a container', () => {
+    expect(resolveSidebarSelectedViewId({ routeViewId: containerViewId, tabViewId: null, outline })).toBe(gridViewId);
+  });
+
   it('falls back to routeViewId when tabViewId is unknown', () => {
     expect(resolveSidebarSelectedViewId({ routeViewId: gridViewId, tabViewId: 'missing', outline })).toBe(gridViewId);
   });
 
   it('uses tabViewId when both views are in same database container', () => {
     expect(resolveSidebarSelectedViewId({ routeViewId: gridViewId, tabViewId: boardViewId, outline })).toBe(boardViewId);
+  });
+
+  it('uses the selected tab from the outline tree when published children omit parent ids', () => {
+    const gridWithoutParent = { ...gridView, parent_view_id: undefined };
+    const boardWithoutParent = { ...boardView, parent_view_id: undefined };
+    const containerWithoutChildParentIds = {
+      ...containerView,
+      children: [gridWithoutParent, boardWithoutParent],
+    };
+    const outlineWithoutChildParentIds: View[] = [
+      {
+        ...outline[0],
+        children: [containerWithoutChildParentIds, documentView],
+      },
+    ];
+
+    expect(
+      resolveSidebarSelectedViewId({
+        routeViewId: containerViewId,
+        tabViewId: boardViewId,
+        outline: outlineWithoutChildParentIds,
+      })
+    ).toBe(boardViewId);
   });
 
   it('ignores tabViewId when route view is not a database view', () => {
@@ -125,6 +152,12 @@ describe('resolveSidebarSelectedViewId', () => {
   });
 
   describe('resolveSidebarHighlightedViewIds', () => {
+    it('highlights the first database view and its container on a container route', () => {
+      expect(
+        resolveSidebarHighlightedViewIds({ routeViewId: containerViewId, tabViewId: null, outline })
+      ).toEqual([gridViewId, containerViewId]);
+    });
+
     it('highlights the active child and database container when the active route view is a loaded child', () => {
       expect(resolveSidebarHighlightedViewIds({ routeViewId: gridViewId, tabViewId: null, outline })).toEqual([
         gridViewId,
@@ -161,6 +194,24 @@ describe('resolveSidebarSelectedViewId', () => {
         boardViewId,
         containerViewId,
       ]);
+    });
+
+    it('finds the selected tab parent structurally when parent ids are absent', () => {
+      const boardWithoutParent = { ...boardView, parent_view_id: undefined };
+      const outlineWithoutChildParentIds: View[] = [
+        {
+          ...outline[0],
+          children: [{ ...containerView, children: [{ ...gridView, parent_view_id: undefined }, boardWithoutParent] }],
+        },
+      ];
+
+      expect(
+        resolveSidebarHighlightedViewIds({
+          routeViewId: containerViewId,
+          tabViewId: boardViewId,
+          outline: outlineWithoutChildParentIds,
+        })
+      ).toEqual([boardViewId, containerViewId]);
     });
 
     it('keeps non-database child views selected normally', () => {

--- a/src/components/app/hooks/resolveSidebarSelectedViewId.ts
+++ b/src/components/app/hooks/resolveSidebarSelectedViewId.ts
@@ -1,8 +1,48 @@
 import { View } from '@/application/types';
-import { isDatabaseContainer, isDatabaseLayout } from '@/application/view-utils';
-import { findView } from '@/components/_shared/outline/utils';
+import { getFirstChildView, isDatabaseContainer, isDatabaseLayout } from '@/application/view-utils';
 
 export const DATABASE_TAB_VIEW_ID_QUERY_PARAM = 'v';
+
+interface OutlineIndex {
+  parentById: Map<string, View>;
+  viewById: Map<string, View>;
+}
+
+// Outline updates replace the root array, so a weak cache keeps recursive item
+// lookups O(1) without retaining outlines that are no longer rendered.
+const outlineIndexCache = new WeakMap<View[], OutlineIndex>();
+
+function getOutlineIndex(outline: View[]): OutlineIndex {
+  const cached = outlineIndexCache.get(outline);
+
+  if (cached) return cached;
+
+  const parentById = new Map<string, View>();
+  const viewById = new Map<string, View>();
+  const stack: Array<{ parent?: View; view: View }> = [];
+
+  for (let index = outline.length - 1; index >= 0; index -= 1) {
+    stack.push({ view: outline[index] });
+  }
+
+  while (stack.length > 0) {
+    const entry = stack.pop();
+
+    if (!entry || viewById.has(entry.view.view_id)) continue;
+
+    viewById.set(entry.view.view_id, entry.view);
+    if (entry.parent) parentById.set(entry.view.view_id, entry.parent);
+
+    for (let index = entry.view.children.length - 1; index >= 0; index -= 1) {
+      stack.push({ parent: entry.view, view: entry.view.children[index] });
+    }
+  }
+
+  const outlineIndex = { parentById, viewById };
+
+  outlineIndexCache.set(outline, outlineIndex);
+  return outlineIndex;
+}
 
 export function resolveSidebarSelectedViewId(params: {
   routeViewId?: string;
@@ -12,24 +52,40 @@ export function resolveSidebarSelectedViewId(params: {
   const { routeViewId, tabViewId, outline } = params;
 
   if (!routeViewId) return undefined;
-  if (!tabViewId || tabViewId === routeViewId) return routeViewId;
   if (!outline) return routeViewId;
 
-  const routeView = findView(outline, routeViewId);
-  const tabView = findView(outline, tabViewId);
+  const { parentById, viewById } = getOutlineIndex(outline);
+  const routeView = viewById.get(routeViewId);
 
-  if (!routeView || !tabView) return routeViewId;
+  if (!routeView) return routeViewId;
+
+  const defaultViewId = getFirstChildView(routeView)?.view_id ?? routeViewId;
+
+  if (!tabViewId || tabViewId === routeViewId) return defaultViewId;
+
+  const tabView = viewById.get(tabViewId);
+
+  if (!tabView) return defaultViewId;
 
   const routeIsDatabase = isDatabaseLayout(routeView.layout) || isDatabaseContainer(routeView);
   const tabIsDatabase = isDatabaseLayout(tabView.layout);
 
-  if (!routeIsDatabase || !tabIsDatabase) return routeViewId;
+  if (!routeIsDatabase || !tabIsDatabase) return defaultViewId;
 
-  const containerId = isDatabaseContainer(routeView) ? routeView.view_id : routeView.parent_view_id;
+  const routeParent = parentById.get(routeView.view_id);
+  const containerId = isDatabaseContainer(routeView)
+    ? routeView.view_id
+    : isDatabaseContainer(routeParent)
+      ? routeParent.view_id
+      : routeView.parent_view_id;
 
-  if (!containerId) return routeViewId;
+  if (!containerId) return defaultViewId;
 
-  return tabView.parent_view_id === containerId || tabView.view_id === containerId ? tabViewId : routeViewId;
+  const tabParent = parentById.get(tabView.view_id);
+  const tabBelongsToContainer =
+    tabView.parent_view_id === containerId || tabParent?.view_id === containerId || tabView.view_id === containerId;
+
+  return tabBelongsToContainer ? tabViewId : defaultViewId;
 }
 
 export function resolveSidebarHighlightedViewIds(params: {
@@ -53,8 +109,11 @@ export function resolveSidebarHighlightedViewIds(params: {
     return Array.from(highlightedViewIds);
   }
 
-  const selectedView = outline ? findView(outline, selectedViewId) : undefined;
-  const outlineParent = selectedView?.parent_view_id && outline ? findView(outline, selectedView.parent_view_id) : undefined;
+  const outlineIndex = outline ? getOutlineIndex(outline) : undefined;
+  const selectedView = outlineIndex?.viewById.get(selectedViewId);
+  const outlineParent =
+    outlineIndex?.parentById.get(selectedViewId) ||
+    (selectedView?.parent_view_id ? outlineIndex?.viewById.get(selectedView.parent_view_id) : undefined);
 
   if (outlineParent && isDatabaseContainer(outlineParent)) {
     highlightedViewIds.add(outlineParent.view_id);

--- a/src/components/app/settings/ManageDataPanel.tsx
+++ b/src/components/app/settings/ManageDataPanel.tsx
@@ -36,8 +36,11 @@ export function ManageDataPanel() {
     async (file: File) => {
       setImporting(true);
       try {
-        await FileService.importFile(file, () => {
-          /* progress is surfaced via the in-progress state */
+        await FileService.importFile(file, {
+          taskType: FileService.CreateImportTaskType.Workspace,
+          onProgress: () => {
+            /* progress is surfaced via the in-progress state */
+          },
         });
         toast.success(t('settings.manageData.importWorkspace.success'));
         // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/components/publish/DatabaseView.tsx
+++ b/src/components/publish/DatabaseView.tsx
@@ -22,7 +22,8 @@ import DocumentSkeleton from '@/components/_shared/skeleton/DocumentSkeleton';
 import GridSkeleton from '@/components/_shared/skeleton/GridSkeleton';
 import KanbanSkeleton from '@/components/_shared/skeleton/KanbanSkeleton';
 import { Database } from '@/components/database';
-import { findParentView } from '@/components/_shared/outline/utils';
+import { useContainerVisibleViewIds } from '@/components/database/hooks';
+import { findParentView, findView } from '@/components/_shared/outline/utils';
 import { cn } from '@/lib/utils';
 
 import ViewMetaPreview from 'src/components/view-meta/ViewMetaPreview';
@@ -48,10 +49,38 @@ export interface DatabaseProps {
 
 function DatabaseView({ viewMeta, navigateToView, ...props }: DatabaseProps) {
   const [search, setSearch] = useSearchParams();
-  const visibleViewIds = useMemo(() => viewMeta.visibleViewIds || [], [viewMeta]);
 
   const isTemplateThumb = usePublishContext()?.isTemplateThumb;
   const outline = usePublishContext()?.outline;
+  const outlineView = useMemo(() => {
+    if (!outline || !viewMeta.viewId) return;
+    return findView(outline, viewMeta.viewId) || undefined;
+  }, [outline, viewMeta.viewId]);
+  const { containerView } = useContainerVisibleViewIds({
+    view: outlineView,
+    outline,
+    parentViewId: viewMeta.parentViewId,
+    databaseId: viewMeta.extra?.database_id,
+    embedded: viewMeta.extra?.embedded,
+  });
+  const pageView = containerView || outlineView;
+  const pageMeta = useMemo<ViewMetaProps>(() => {
+    if (!pageView) return viewMeta;
+
+    return {
+      ...viewMeta,
+      viewId: pageView.view_id,
+      name: pageView.name,
+      icon: pageView.icon || undefined,
+      extra: pageView.extra,
+      cover: pageView.extra?.cover,
+      layout: pageView.layout,
+    };
+  }, [pageView, viewMeta]);
+  const visibleViewIds = useMemo(() => {
+    if (viewMeta.visibleViewIds?.length) return viewMeta.visibleViewIds;
+    return containerView?.children.map((child) => child.view_id) || [];
+  }, [containerView, viewMeta.visibleViewIds]);
 
   // Build a loadViewMeta that returns the database container from the outline
   // with correct folder names for all sibling views (used by DatabaseTabs).
@@ -63,28 +92,29 @@ function DatabaseView({ viewMeta, navigateToView, ...props }: DatabaseProps) {
     return async (viewId: string, callback?: (meta: View | null) => void) => {
       // Try to find the container in the outline for this database view
       const parent = findParentView(outline, viewId);
+      const resolvedContainer = containerView?.view_id === viewId ? containerView : parent;
 
-      if (parent?.extra?.is_database_container && parent.children?.length > 0) {
-        const containerView: View = {
-          ...parent,
+      if (resolvedContainer?.extra?.is_database_container && resolvedContainer.children?.length > 0) {
+        const containerMeta: View = {
+          ...resolvedContainer,
           is_published: false,
           is_private: false,
         };
 
-        callback?.(containerView);
-        return containerView;
+        callback?.(containerMeta);
+        return containerMeta;
       }
 
       // Fall back to original loadViewMeta
       return originalLoadViewMeta(viewId, callback);
     };
-  }, [outline, props.loadViewMeta]);
+  }, [containerView, outline, props.loadViewMeta]);
 
   /**
    * The database's page ID in the folder/outline structure.
    * This is the main entry point for the database and remains constant.
    */
-  const databasePageId = viewMeta.viewId;
+  const databasePageId = containerView?.view_id || viewMeta.viewId;
 
   const doc = props.doc;
   const database = doc?.getMap(YjsEditorKey.data_section)?.get(YjsEditorKey.database) as YDatabase;
@@ -187,11 +217,11 @@ function DatabaseView({ viewMeta, navigateToView, ...props }: DatabaseProps) {
       }}
       className={cn('relative flex w-full flex-col', !isPublishVariant && 'h-full')}
     >
-      {rowId ? null : <ViewMetaPreview {...viewMeta} readOnly={true} />}
+      {rowId ? null : <ViewMetaPreview {...pageMeta} readOnly={true} />}
 
       <Suspense fallback={skeleton}>
         <Database
-          databaseName={viewMeta.name || ''}
+          databaseName={pageMeta.name || ''}
           databasePageId={databasePageId || ''}
           {...props}
           loadViewMeta={publishLoadViewMeta}

--- a/src/components/publish/DatabaseView.tsx
+++ b/src/components/publish/DatabaseView.tsx
@@ -22,7 +22,7 @@ import DocumentSkeleton from '@/components/_shared/skeleton/DocumentSkeleton';
 import GridSkeleton from '@/components/_shared/skeleton/GridSkeleton';
 import KanbanSkeleton from '@/components/_shared/skeleton/KanbanSkeleton';
 import { Database } from '@/components/database';
-import { useContainerVisibleViewIds } from '@/components/database/hooks';
+import { useContainerVisibleViewIds } from '@/components/database/hooks/visibleViewIds/useContainerVisibleViewIds';
 import { findParentView, findView } from '@/components/_shared/outline/utils';
 import { cn } from '@/lib/utils';
 
@@ -127,6 +127,7 @@ function DatabaseView({ viewMeta, navigateToView, ...props }: DatabaseProps) {
 
     return views ? Array.from(views.keys()) : [];
   }, [database]);
+  const tabViewId = search.get('v');
 
   /**
    * The currently active/selected view tab ID (Grid, Board, or Calendar).
@@ -137,11 +138,11 @@ function DatabaseView({ viewMeta, navigateToView, ...props }: DatabaseProps) {
   const activeViewId = useMemo(() => {
     return resolveActiveDatabaseViewId({
       databasePageId,
-      tabViewId: search.get('v'),
+      tabViewId,
       visibleViewIds,
       existingViewIds,
     });
-  }, [search, databasePageId, visibleViewIds, existingViewIds]);
+  }, [databasePageId, existingViewIds, tabViewId, visibleViewIds]);
 
   const handleChangeView = useCallback(
     (viewId: string) => {

--- a/src/components/publish/SideBar.tsx
+++ b/src/components/publish/SideBar.tsx
@@ -4,6 +4,10 @@ import { usePublishContext } from '@/application/publish';
 import { UIVariant } from '@/application/types';
 import { OutlineDrawer } from '@/components/_shared/outline';
 import Outline from '@/components/_shared/outline/Outline';
+import {
+  DATABASE_TAB_VIEW_ID_QUERY_PARAM,
+  resolveSidebarSelectedViewId,
+} from '@/components/app/hooks/resolveSidebarSelectedViewId';
 
 interface SideBarProps {
   drawerWidth: number;
@@ -19,9 +23,12 @@ function SideBar ({
   const outline = usePublishContext()?.outline;
 
   const baseViewId = usePublishContext()?.viewMeta?.view_id;
-  // Use the active database tab (?v= param) for sidebar highlight
   const [searchParams] = useSearchParams();
-  const viewId = searchParams.get('v') || baseViewId;
+  const viewId = resolveSidebarSelectedViewId({
+    routeViewId: baseViewId,
+    tabViewId: searchParams.get(DATABASE_TAB_VIEW_ID_QUERY_PARAM),
+    outline,
+  });
   const navigateToView = usePublishContext()?.toView;
 
   return (

--- a/src/components/publish/__tests__/DatabaseView.databaseContainer.test.tsx
+++ b/src/components/publish/__tests__/DatabaseView.databaseContainer.test.tsx
@@ -3,7 +3,7 @@ import { render } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import * as Y from 'yjs';
 
-import { ViewLayout, ViewMetaProps, YDoc, YjsEditorKey } from '@/application/types';
+import { View, ViewLayout, ViewMetaProps, YDoc, YjsEditorKey } from '@/application/types';
 import DatabaseView from '@/components/publish/DatabaseView';
 
 declare global {
@@ -11,12 +11,17 @@ declare global {
   var __publishDatabaseViewTestState:
     | {
         capturedDatabaseProps?: unknown;
+        capturedPageMetaProps?: unknown;
+        outline?: View[];
       }
     | undefined;
 }
 
 jest.mock('@/application/publish', () => ({
-  usePublishContext: () => ({ isTemplateThumb: false, outline: [] }),
+  usePublishContext: () => ({
+    isTemplateThumb: false,
+    outline: global.__publishDatabaseViewTestState?.outline || [],
+  }),
 }));
 
 jest.mock('@/components/database', () => ({
@@ -29,7 +34,13 @@ jest.mock('@/components/database', () => ({
   },
 }));
 
-jest.mock('src/components/view-meta/ViewMetaPreview', () => () => null);
+jest.mock('src/components/view-meta/ViewMetaPreview', () => (props: unknown) => {
+  global.__publishDatabaseViewTestState = {
+    ...(global.__publishDatabaseViewTestState || {}),
+    capturedPageMetaProps: props,
+  };
+  return null;
+});
 
 function createDatabaseDoc(databaseViewIds: string[] = []): YDoc {
   const doc = new Y.Doc() as unknown as YDoc;
@@ -63,7 +74,10 @@ describe('published DatabaseView database container', () => {
     };
 
     render(
-      <MemoryRouter initialEntries={['/published/database']}>
+      <MemoryRouter
+        initialEntries={['/published/database']}
+        future={{ v7_relativeSplatPath: true, v7_startTransition: true }}
+      >
         <DatabaseView doc={createDatabaseDoc()} workspaceId='workspace-id' viewMeta={viewMeta} />
       </MemoryRouter>
     );
@@ -92,7 +106,10 @@ describe('published DatabaseView database container', () => {
     };
 
     render(
-      <MemoryRouter initialEntries={['/published/database']}>
+      <MemoryRouter
+        initialEntries={['/published/database']}
+        future={{ v7_relativeSplatPath: true, v7_startTransition: true }}
+      >
         <DatabaseView
           doc={createDatabaseDoc(['inline-view-id', 'grid-view-id'])}
           workspaceId='workspace-id'
@@ -107,5 +124,66 @@ describe('published DatabaseView database container', () => {
 
     expect(databaseProps?.databasePageId).toBe('container-id');
     expect(databaseProps?.activeViewId).toBe('grid-view-id');
+  });
+
+  it('uses the outline container name when the published route is a database child', () => {
+    const childView: View = {
+      view_id: 'by-status-view-id',
+      parent_view_id: 'epics-container-id',
+      name: 'By Status',
+      layout: ViewLayout.Grid,
+      children: [],
+      icon: null,
+      extra: { database_id: 'epics-database-id' },
+      is_published: true,
+      is_private: false,
+    };
+    const containerView: View = {
+      view_id: 'epics-container-id',
+      name: '03_epics',
+      layout: ViewLayout.Grid,
+      children: [childView],
+      icon: null,
+      extra: { database_id: 'epics-database-id', is_database_container: true },
+      is_published: true,
+      is_private: false,
+    };
+    const viewMeta: ViewMetaProps = {
+      viewId: childView.view_id,
+      name: childView.name,
+      layout: childView.layout,
+      icon: undefined,
+      extra: childView.extra,
+      workspaceId: 'workspace-id',
+      visibleViewIds: [childView.view_id],
+    };
+
+    global.__publishDatabaseViewTestState = {
+      outline: [containerView],
+    };
+
+    render(
+      <MemoryRouter
+        initialEntries={['/published/database']}
+        future={{ v7_relativeSplatPath: true, v7_startTransition: true }}
+      >
+        <DatabaseView
+          doc={createDatabaseDoc([childView.view_id])}
+          workspaceId='workspace-id'
+          viewMeta={viewMeta}
+        />
+      </MemoryRouter>
+    );
+
+    const pageMetaProps = global.__publishDatabaseViewTestState?.capturedPageMetaProps as ViewMetaProps | undefined;
+    const databaseProps = global.__publishDatabaseViewTestState?.capturedDatabaseProps as
+      | { databaseName?: string; databasePageId?: string; activeViewId?: string }
+      | undefined;
+
+    expect(pageMetaProps?.name).toBe('03_epics');
+    expect(pageMetaProps?.viewId).toBe(containerView.view_id);
+    expect(databaseProps?.databaseName).toBe('03_epics');
+    expect(databaseProps?.databasePageId).toBe(containerView.view_id);
+    expect(databaseProps?.activeViewId).toBe(childView.view_id);
   });
 });

--- a/src/components/publish/header/PublishViewHeader.test.tsx
+++ b/src/components/publish/header/PublishViewHeader.test.tsx
@@ -1,0 +1,95 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+
+import { PublishViewHeader } from '@/components/publish/header/PublishViewHeader';
+
+jest.mock('@/application/publish', () => ({
+  usePublishContext: () => ({
+    viewMeta: { view_id: 'projects-container-id' },
+    outline: [
+      {
+        view_id: 'projects-container-id',
+        name: 'projects',
+        layout: 1,
+        children: [
+          {
+            view_id: 'completed-view-id',
+            parent_view_id: 'projects-container-id',
+            name: 'Completed Project',
+            layout: 1,
+            children: [],
+            icon: null,
+            extra: { database_id: 'projects-database-id' },
+            is_published: true,
+            is_private: false,
+          },
+        ],
+        icon: null,
+        extra: { database_id: 'projects-database-id', is_database_container: true },
+        is_published: true,
+        is_private: false,
+      },
+    ],
+    toView: jest.fn(),
+    breadcrumbs: [],
+    rendered: false,
+  }),
+}));
+
+jest.mock('@/components/_shared/breadcrumb', () => ({
+  Breadcrumb: () => null,
+}));
+
+jest.mock('@/components/_shared/outline', () => ({
+  OutlinePopover: ({ content }: { content: React.ReactNode }) => <>{content}</>,
+}));
+
+jest.mock('@/components/_shared/outline/Outline', () => ({
+  __esModule: true,
+  default: ({ selectedViewId }: { selectedViewId?: string }) => (
+    <div data-testid='header-outline' data-selected-view-id={selectedViewId} />
+  ),
+}));
+
+jest.mock('@/components/_shared/outline/outline.hooks', () => ({
+  useOutlinePopover: () => ({
+    openPopover: true,
+    debounceClosePopover: jest.fn(),
+    handleOpenPopover: jest.fn(),
+    debounceOpenPopover: jest.fn(),
+    handleClosePopover: jest.fn(),
+  }),
+}));
+
+jest.mock('@/components/_shared/skeleton/BreadcrumbSkeleton', () => () => null);
+
+jest.mock('@/utils/platform', () => ({
+  getPlatform: () => ({ isMobile: false }),
+}));
+
+function renderHeader(path: string) {
+  return render(
+    <MemoryRouter initialEntries={[path]} future={{ v7_relativeSplatPath: true, v7_startTransition: true }}>
+      <PublishViewHeader
+        drawerWidth={280}
+        onOpenDrawer={jest.fn()}
+        openDrawer={false}
+        onCloseDrawer={jest.fn()}
+      />
+    </MemoryRouter>
+  );
+}
+
+describe('PublishViewHeader outline selection', () => {
+  it('uses the active database view from the query string', () => {
+    renderHeader('/namespace/projects?v=completed-view-id');
+
+    expect(screen.getByTestId('header-outline').getAttribute('data-selected-view-id')).toBe('completed-view-id');
+  });
+
+  it('selects the first database view when the published route is a container', () => {
+    renderHeader('/namespace/projects');
+
+    expect(screen.getByTestId('header-outline').getAttribute('data-selected-view-id')).toBe('completed-view-id');
+  });
+});

--- a/src/components/publish/header/PublishViewHeader.tsx
+++ b/src/components/publish/header/PublishViewHeader.tsx
@@ -1,5 +1,6 @@
 import { IconButton } from '@mui/material';
 import { lazy, Suspense, useMemo } from 'react';
+import { useSearchParams } from 'react-router-dom';
 
 import { HEADER_HEIGHT } from '@/application/constants';
 import { usePublishContext } from '@/application/publish';
@@ -10,6 +11,10 @@ import { OutlinePopover } from '@/components/_shared/outline';
 import Outline from '@/components/_shared/outline/Outline';
 import { useOutlinePopover } from '@/components/_shared/outline/outline.hooks';
 import BreadcrumbSkeleton from '@/components/_shared/skeleton/BreadcrumbSkeleton';
+import {
+  DATABASE_TAB_VIEW_ID_QUERY_PARAM,
+  resolveSidebarSelectedViewId,
+} from '@/components/app/hooks/resolveSidebarSelectedViewId';
 import { getPlatform } from '@/utils/platform';
 
 const RightMenu = lazy(() => import('@/components/publish/header/RightMenu'));
@@ -39,7 +44,12 @@ export function PublishViewHeader({
   const isMobile = useMemo(() => {
     return getPlatform().isMobile;
   }, []);
-  const viewId = viewMeta?.view_id;
+  const [searchParams] = useSearchParams();
+  const viewId = resolveSidebarSelectedViewId({
+    routeViewId: viewMeta?.view_id,
+    tabViewId: searchParams.get(DATABASE_TAB_VIEW_ID_QUERY_PARAM),
+    outline,
+  });
   const rendered = usePublishContext()?.rendered;
 
   return (

--- a/src/components/publish/header/PublishViewHeader.tsx
+++ b/src/components/publish/header/PublishViewHeader.tsx
@@ -1,4 +1,4 @@
-import { IconButton } from '@mui/material';
+import IconButton from '@mui/material/IconButton';
 import { lazy, Suspense, useMemo } from 'react';
 import { useSearchParams } from 'react-router-dom';
 


### PR DESCRIPTION
### **Description**

Fixes the import flow and published database outline behavior.

- Send the selected AppFlowy Workspace or Notion task type when creating an import task.
- Remove provider icons from the import-source tabs.
- Render database child views as dots and synchronize container/child selection state.
- Open a database container on its first view and route child views through a published anchor when the container itself is unpublished.
- Keep published page titles, visible views, sidebar state, and database tab query parameters aligned with the active container.
- Cache outline ID/parent lookups and use stable view IDs for recursive React keys.

### **Testing**

- pnpm lint
- 32 focused unit tests across import, publish context, outline, sidebar, header, and database rendering

---

### **Checklist**

#### **General**
- [x] I have included relevant comments for the navigation and lookup behavior.
- [ ] I have tested the changes in multiple environments.

#### **Testing**
- [x] I have added or updated tests to validate the changes.

#### **Feature-Specific**
- [x] Not applicable; this PR fixes existing behavior.

## Summary by Sourcery

Improve published database navigation and import task creation to align routes, titles, tabs, and task types with active containers and sources.

New Features:
- Support specifying Notion vs AppFlowy workspace task types when creating import tasks.
- Route unpublished database containers through a published child or container view while keeping database tabs addressable via query parameters.

Bug Fixes:
- Ensure published database child and container navigation uses consistent routes and sidebar/header selection state.
- Prevent outline interactions from collapsing unpublished database containers when a child view should open instead.
- Keep database page titles and visible views in published DatabaseView aligned with the container when navigating via child routes.

Enhancements:
- Cache outline parent/child lookups to stabilize sidebar selection and highlighting for database containers and their tabs.
- Render published database child views as dot indicators in the outline while keeping containers highlighted when any child is active.
- Align publish sidebar and header selection with active database tabs using shared query-param resolution logic.
- Update importer UI to remove provider icons while preserving tab behavior.

Tests:
- Add unit tests covering database container outline behavior, published header selection, importer dialog task-type routing, import API payloads, and publish context database routing.
- Extend existing publish context, sidebar selection, and database container tests to cover database container/child relationships and tab query handling.