### PR TITLE
fix: stop remounting the app shell on every page navigation

### DIFF
--- a/src/components/app/components/AppContextConsumer.tsx
+++ b/src/components/app/components/AppContextConsumer.tsx
@@ -69,10 +69,10 @@ function InlineCommentScope({ children, openModalViewId }: { children: React.Rea
 
   return (
     <InlineCommentProvider
-      // Keyed by the route view only: opening the modal or a full-page row swaps
-      // `viewId` while staying on the same route, and remounting here would tear
-      // down the whole app shell underneath it.
-      key={`${workspaceId ?? ''}:${routeViewId ?? ''}`}
+      // Never key this provider: it wraps the whole app shell (sidebar, header,
+      // content), so a key remounts all of it on every change. Document swaps
+      // are handled in place — the outgoing editor's unregister cleanup resets
+      // the comment state, exactly as the page modal and row-page flows rely on.
       eventEmitter={eventEmitter}
       viewId={viewId}
       workspaceId={workspaceId}

--- a/src/components/inline-comment/InlineCommentContext.tsx
+++ b/src/components/inline-comment/InlineCommentContext.tsx
@@ -825,9 +825,13 @@ export function InlineCommentProvider({
         setActive(false);
         setPanelOpen(false);
         setFocusedCommentId(null);
+        // The provider outlives the document (it is deliberately not keyed, so
+        // navigation cannot remount the app shell) — restore the default filter
+        // here so the next document starts a fresh comment session.
+        setFilter('open');
       };
     },
-    [cancelPendingComment, setFocusedCommentId, stopAnchorRefreshRetry, updateAnchors, viewId]
+    [cancelPendingComment, setFilter, setFocusedCommentId, stopAnchorRefreshRetry, updateAnchors, viewId]
   );
 
   const updateEditorAccess = useCallback(


### PR DESCRIPTION
## Problem

Since #458, selecting any page in the sidebar visibly "refreshes the whole screen": the sidebar flickers and re-animates, the header rebuilds, and the content area restarts from scratch — even though the sidebar content didn't change.

## Root cause

`InlineCommentProvider` wraps the **entire app shell** (sidebar drawer, header, and routed content all render beneath it), and #458 keyed it by the route view id:

```tsx
<InlineCommentProvider key={`${workspaceId}:${routeViewId}`} ...>
```

Every navigation changes `routeViewId`, the key changes, and React destroys and rebuilds the whole subtree — `MainLayoutContent`, the MUI drawer, every outline item, and the page content.

Verified empirically in the live app with React fiber identity tracking: after a sidebar click, every fiber from `InlineCommentProvider` down was brand new and the drawer DOM node was disconnected ~126ms after the click, while everything above (`AppBusinessLayer`, routers) survived.

## Fix

Remove the `key`. The provider already handles document swaps in place — the outgoing editor's unregister cleanup resets comments, anchors, reactions, panel/focus state and bumps the in-flight request id. That is precisely the path the page modal and full-page row flows already rely on (they change `viewId` **without** changing the key). The only state a remount reset that the cleanup did not is the comment `filter`, so it is restored to `'open'` there.

## Verification

- Live fiber-identity probe: with the fix, the full component chain (`MainLayoutContent`, drawer, outline items) survives navigation; the layout DOM node is identical before/after (`anyRemount: false`).
- `pnpm type-check` clean; eslint clean on changed files.
- Inline-comment unit tests: 27/27 pass.
- Inline-comment BDD e2e: 7/7 pass against the local stack, including "add an inline comment in a full-page database row document" and cross-navigation scenarios.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Prevent the inline comment provider from remounting the entire app shell on every route change while ensuring comment state is correctly reset between documents.

Bug Fixes:
- Stop full app shell (sidebar, header, content) from being remounted on each navigation due to the inline comment provider being keyed by route view.
- Restore the default inline comment filter state when switching documents so each document starts with a fresh open-comments view.