### PR TITLE
feat(database): support relation defaults in row templates

### DIFF
--- a/playwright/bdd/features/database/row-template-relation.feature
+++ b/playwright/bdd/features/database/row-template-relation.feature
@@ -1,0 +1,15 @@
+Feature: Row template relation and rollup
+
+  Scenario: A template relation default applies to created rows and the rollup computes
+    Given the RowTemplate test app is initialized
+    When the RowTemplate user signs in anonymously
+    Then the RowTemplate user sees the home page with get started page
+
+    When the user prepares relation and rollup grids for row templates
+    And the user creates a row template named "Task Template" with a relation default to "Alpha"
+    Then the template editor shows "1 linked rows"
+    And the template editor lists the read-only rollup property
+
+    When the user closes the row template editor dialog
+    And the user creates a row from the row template named "Task Template"
+    Then the newest grid row links "Alpha" with rollup count "1"

--- a/playwright/bdd/steps/row-template-relation.steps.ts
+++ b/playwright/bdd/steps/row-template-relation.steps.ts
@@ -1,0 +1,154 @@
+import { expect, type Page } from '@playwright/test';
+import { createBdd } from 'playwright-bdd';
+
+import { signInAndWaitForApp } from '../../support/auth-flow-helpers';
+import {
+  createNamedGridDatabase,
+  createOneWayRelationField,
+  createRollupCountFieldDirect,
+} from '../../support/relation-test-helpers';
+import { closeRowDetailWithEscape } from '../../support/row-detail-helpers';
+import { DatabaseGridSelectors, RowDetailSelectors } from '../../support/selectors';
+import { generateRandomEmail, setupPageErrorHandling } from '../../support/test-config';
+
+const { Given, Then, When } = createBdd();
+
+interface RowTemplateFixture {
+  relationFieldId: string;
+  rollupFieldId: string;
+  rollupFieldName: string;
+  relationFieldName: string;
+}
+
+const fixtures = new WeakMap<Page, RowTemplateFixture>();
+
+function fixture(page: Page): RowTemplateFixture {
+  const value = fixtures.get(page);
+
+  if (!value) throw new Error('Row template fixture was not prepared for this page.');
+
+  return value;
+}
+
+function templateEditor(page: Page) {
+  return page.getByTestId('database-template-editor');
+}
+
+Given('the RowTemplate test app is initialized', async ({ page }) => {
+  setupPageErrorHandling(page);
+  await page.setViewportSize({ height: 900, width: 1440 });
+});
+
+When('the RowTemplate user signs in anonymously', async ({ page, request }) => {
+  await signInAndWaitForApp(page, request, generateRandomEmail());
+});
+
+Then('the RowTemplate user sees the home page with get started page', async ({ page }) => {
+  await expect(page).toHaveURL(/\/app/, { timeout: 30_000 });
+  await expect(page.locator('[data-testid="inline-add-page"], [data-testid="new-page-button"]').first()).toBeVisible({
+    timeout: 20_000,
+  });
+});
+
+When('the user prepares relation and rollup grids for row templates', async ({ page }) => {
+  const target = await createNamedGridDatabase(page, 'Template Relation Projects', ['Alpha', 'Beta']);
+  const source = await createNamedGridDatabase(page, 'Template Relation Tasks', ['Task seed']);
+
+  expect(source.databaseId).not.toBe(target.databaseId);
+
+  const relationFieldName = 'Linked Project';
+  const rollupFieldName = 'Project Count';
+  const relationFieldId = await createOneWayRelationField(page, {
+    fieldName: relationFieldName,
+    relatedDatabaseId: target.databaseId,
+  });
+  const rollupFieldId = await createRollupCountFieldDirect(page, {
+    fieldName: rollupFieldName,
+    relationFieldId,
+  });
+
+  fixtures.set(page, { relationFieldId, relationFieldName, rollupFieldId, rollupFieldName });
+});
+
+When(
+  'the user creates a row template named {string} with a relation default to {string}',
+  async ({ page }, templateName: string, targetRowName: string) => {
+    const { relationFieldName } = fixture(page);
+
+    await page.getByTestId('database-template-menu-trigger').click();
+    await expect(page.getByTestId('database-template-menu')).toBeVisible({ timeout: 10_000 });
+    await page.getByTestId('database-template-create').click();
+
+    const editor = templateEditor(page);
+
+    await expect(editor).toBeVisible({ timeout: 20_000 });
+
+    const title = editor.getByTestId('row-title-input');
+
+    await expect(title).toBeVisible({ timeout: 10_000 });
+    await title.fill(templateName);
+
+    // An empty relation property renders its "Add <field>" placeholder;
+    // clicking the property opens the real relation picker.
+    await editor.getByText(`Add ${relationFieldName}`, { exact: true }).click();
+
+    const unlinkedLabel = page.getByText('Link another row', { exact: true });
+
+    await expect(unlinkedLabel).toBeVisible({ timeout: 15_000 });
+    await page
+      .getByText(targetRowName, { exact: true })
+      .last()
+      .click();
+  }
+);
+
+Then('the template editor shows {string}', async ({ page }, text: string) => {
+  await expect(page.getByText(text, { exact: true })).toBeVisible({ timeout: 15_000 });
+  await page.keyboard.press('Escape');
+});
+
+Then('the template editor lists the read-only rollup property', async ({ page }) => {
+  const { rollupFieldName } = fixture(page);
+  const editor = templateEditor(page);
+
+  await expect(editor.getByText(rollupFieldName, { exact: true })).toBeVisible({ timeout: 10_000 });
+  // Rollups are computed, so the template editor must not offer an editable
+  // "Add <field>" affordance for them.
+  await expect(editor.getByText(`Add ${rollupFieldName}`, { exact: true })).toHaveCount(0);
+});
+
+When('the user closes the row template editor dialog', async ({ page }) => {
+  // MUI only handles Escape while focus is inside the dialog's focus trap;
+  // closing the relation popover can drop focus back to <body>. Re-enter the
+  // dialog through its inert banner before sending Escape.
+  await page.getByTestId('database-template-editor-banner').click();
+  await page.keyboard.press('Escape');
+  await expect(templateEditor(page)).toHaveCount(0, { timeout: 15_000 });
+});
+
+When('the user creates a row from the row template named {string}', async ({ page }, templateName: string) => {
+  await page.getByTestId('database-template-menu-trigger').click();
+  const list = page.getByTestId('database-template-list');
+
+  await expect(list).toBeVisible({ timeout: 10_000 });
+  await list.getByText(templateName, { exact: true }).click();
+
+  // Creating from a template opens the new row's detail modal.
+  await expect(RowDetailSelectors.modal(page).last()).toBeVisible({ timeout: 20_000 });
+  await closeRowDetailWithEscape(page);
+  await expect(DatabaseGridSelectors.grid(page)).toBeVisible({ timeout: 15_000 });
+});
+
+Then(
+  'the newest grid row links {string} with rollup count {string}',
+  async ({ page }, targetRowName: string, rollupCount: string) => {
+    const { relationFieldId, rollupFieldId } = fixture(page);
+    const relationCell = page.locator(`[data-testid^="grid-cell-"][data-testid$="-${relationFieldId}"]`).last();
+
+    await expect(relationCell).toContainText(targetRowName, { timeout: 20_000 });
+
+    const rollupCell = page.locator(`[data-testid^="rollup-cell-"][data-testid$="-${rollupFieldId}"]`).last();
+
+    await expect(rollupCell).toHaveText(rollupCount, { timeout: 20_000 });
+  }
+);

--- a/playwright/support/relation-test-helpers.ts
+++ b/playwright/support/relation-test-helpers.ts
@@ -1304,3 +1304,71 @@ async function addRelationFieldToCurrentDatabase(
     { fieldId, options }
   );
 }
+
+/**
+ * Injects a Count rollup field over the given relation field into the current
+ * database. Count is the one calculation that needs no target field, which
+ * keeps the rendered value deterministic for assertions.
+ */
+export async function createRollupCountFieldDirect(
+  page: Page,
+  options: { fieldName: string; relationFieldId: string }
+): Promise<string> {
+  const fieldId = makeTestId('rollup');
+
+  await waitForDatabaseTestContext(page);
+  await page.evaluate(
+    ({ fieldId, options }) => {
+      /* eslint-disable @typescript-eslint/no-explicit-any */
+      const win = window as any;
+      const ctx = win.__TEST_DATABASE_CONTEXT__;
+      const Y = win.Y;
+      const doc = ctx.databaseDoc;
+      const database = doc.getMap('data').get('database');
+      const now = String(Math.floor(Date.now() / 1000));
+      const field = new Y.Map();
+      const typeOptionMap = new Y.Map();
+      const typeOption = new Y.Map();
+
+      field.set('name', options.fieldName);
+      field.set('id', fieldId);
+      field.set('ty', 16);
+      field.set('created_at', now);
+      field.set('last_modified', now);
+      field.set('is_primary', false);
+      field.set('icon', '');
+
+      typeOption.set('relation_field_id', options.relationFieldId);
+      typeOption.set('target_field_id', '');
+      typeOption.set('calculation_type', 5);
+      typeOption.set('show_as', 0);
+      typeOption.set('condition_value', '');
+      typeOptionMap.set('16', typeOption);
+      field.set('type_option', typeOptionMap);
+
+      doc.transact(() => {
+        database.get('fields').set(fieldId, field);
+        database.get('views').forEach((view: any) => {
+          const fieldOrders = view.get('field_orders');
+
+          if (!fieldOrders.toArray().some((order: { id: string }) => order.id === fieldId)) {
+            fieldOrders.push([{ id: fieldId }]);
+          }
+
+          const fieldSettings = view.get('field_settings');
+
+          if (!fieldSettings.get(fieldId)) {
+            const setting = new Y.Map();
+
+            setting.set('visibility', 0);
+            fieldSettings.set(fieldId, setting);
+          }
+        });
+      });
+      /* eslint-enable @typescript-eslint/no-explicit-any */
+    },
+    { fieldId, options }
+  );
+  await expect(GridFieldSelectors.fieldHeader(page, fieldId).last()).toBeVisible({ timeout: 20000 });
+  return fieldId;
+}

--- a/src/application/database-yjs/context.ts
+++ b/src/application/database-yjs/context.ts
@@ -61,6 +61,12 @@ export interface DatabaseContextState {
    */
   activeViewId: string;
   rowMap: Record<RowId, YDoc> | null;
+  /**
+   * Set while the row-template editor edits its hidden source row. That row
+   * never joins `row_orders`, so relation edits on it must not write
+   * reciprocal back-links from real rows to the phantom template row.
+   */
+  templateEditingRowId?: RowId;
   ensureRow?: (rowId: string) => Promise<YDoc | undefined> | void;
   loadRowFromSeed?: (rowId: string) => Promise<YDoc | undefined>;
   /**

--- a/src/application/database-yjs/dispatch/relation.ts
+++ b/src/application/database-yjs/dispatch/relation.ts
@@ -549,6 +549,14 @@ export function useUpdateRelationCell(rowId: RowId, fieldId: FieldId) {
         return;
       }
 
+      // The template editor edits a hidden source row that never joins
+      // row_orders; reciprocal links would point real rows at that phantom
+      // row id. The default is applied to real rows created from the
+      // template, whose reciprocals are backfilled by useNewRowDispatch.
+      if (context.templateEditingRowId === rowId) {
+        return;
+      }
+
       const relatedDoc = await loadRelatedDatabaseDoc({
         sourceDatabase: database,
         sourceDatabaseDoc: context.databaseDoc,

--- a/src/application/database-yjs/dispatch/row.ts
+++ b/src/application/database-yjs/dispatch/row.ts
@@ -620,7 +620,17 @@ export function useNewRowDispatch() {
         const cells = row.get(YjsDatabaseKey.cells);
 
         if (selectedTemplate) {
-          applyTemplateCellsToRow(row, database, selectedTemplate.defaultCells);
+          const appliedCells = applyTemplateCellsToRow(row, database, selectedTemplate.defaultCells);
+
+          // Template relation defaults join the same reciprocal-backfill queue
+          // as filter prefills. A later filter prefill on the same field
+          // overwrites both the cell and this queue entry, so the backfill
+          // always mirrors the final cell state.
+          Object.entries(appliedCells).forEach(([fieldId, value]) => {
+            if (value.type === 'relation' && value.value.length > 0) {
+              relationPrefills.set(fieldId, value.value);
+            }
+          });
         }
 
         filterArray.forEach((filter) => {
@@ -715,6 +725,11 @@ export function useNewRowDispatch() {
           Object.entries(cellsData).forEach(([fieldId, data]) => {
             const cell = new Y.Map() as YDatabaseCell;
             const field = database.get(YjsDatabaseKey.fields)?.get(fieldId);
+
+            // The raw cell payload replaces whatever a template or filter
+            // wrote for this field, so any queued reciprocal backfill for it
+            // would no longer match the final cell state.
+            relationPrefills.delete(fieldId);
 
             const type = Number(field.get(YjsDatabaseKey.type));
 

--- a/src/application/database-yjs/template/__tests__/cell.test.ts
+++ b/src/application/database-yjs/template/__tests__/cell.test.ts
@@ -1,6 +1,8 @@
 import * as Y from 'yjs';
 
 import { FieldType, RowMetaKey } from '@/application/database-yjs/database.type';
+import { RelationLimit } from '@/application/database-yjs/fields/relation/relation.type';
+import { createRelationField } from '@/application/database-yjs/fields/relation/utils';
 import { initialDatabaseRow } from '@/application/database-yjs/row';
 import { getMetaIdMap } from '@/application/database-yjs/row_meta';
 import {
@@ -25,6 +27,8 @@ import { DatabaseRowTemplate, TemplateCellValue } from '../types';
 const databaseId = 'database-id';
 const rowId = 'f73d479a-ae7e-438f-8fc8-e62b985f8126';
 const personId = '6ca46703-b9ad-4476-912a-273d78e53cc0';
+const relatedRowIdA = '0a67d8f8-4e07-4a2f-9c26-1b8a34cfd6b1';
+const relatedRowIdB = '55f24c1e-9d92-4b3b-8a49-6f2f3f6a7c02';
 
 function field(id: string, type: FieldType, primary = false, optionIds: string[] = []): YDatabaseField {
   const value = new Y.Map() as YDatabaseField;
@@ -64,7 +68,13 @@ function database(): YDatabase {
   fields.set('single', field('single', FieldType.SingleSelect, false, ['one', 'two']));
   fields.set('multi', field('multi', FieldType.MultiSelect, false, ['one', 'two']));
   fields.set('person', field('person', FieldType.Person));
-  fields.set('unsupported', field('unsupported', FieldType.Relation));
+  fields.set('relation', createRelationField('relation', { database_id: 'related-db-id' }));
+  fields.set(
+    'relationOne',
+    createRelationField('relationOne', { database_id: 'related-db-id', source_limit: RelationLimit.OneOnly })
+  );
+  fields.set('relationNoDb', createRelationField('relationNoDb'));
+  fields.set('unsupported', field('unsupported', FieldType.Rollup));
   value.set(YjsDatabaseKey.id, databaseId);
   value.set(YjsDatabaseKey.fields, fields);
   root.set(YjsEditorKey.database, value);
@@ -98,6 +108,7 @@ describe('database row template cells', () => {
       single: { type: 'select', value: ['missing', 'two', 'one'] },
       multi: { type: 'select', value: ['one', 'missing', 'one', 'two'] },
       person: { type: 'person', value: ['not-a-uuid', personId] },
+      relation: { type: 'relation', value: [relatedRowIdA, 'not-a-uuid', relatedRowIdA, relatedRowIdB] },
       deleted: { type: 'text', value: 'drop me' },
       unsupported: { type: 'text', value: 'drop me too' },
     });
@@ -112,6 +123,7 @@ describe('database row template cells', () => {
       single: { type: 'select', value: ['two'] },
       multi: { type: 'select', value: ['one', 'two'] },
       person: { type: 'person', value: ['not-a-uuid', personId] },
+      relation: { type: 'relation', value: [relatedRowIdA, relatedRowIdB] },
     });
   });
 
@@ -127,18 +139,35 @@ describe('database row template cells', () => {
       check: { type: 'checkbox', value: false },
       multi: { type: 'select', value: ['one', 'two'] },
       person: { type: 'person', value: [personId] },
+      relation: { type: 'relation', value: [relatedRowIdA, relatedRowIdB] },
     });
 
     const cells = row.get(YjsDatabaseKey.cells);
+    const relationData = cells.get('relation')?.get(YjsDatabaseKey.data);
 
     expect(cells.get('check')?.get(YjsDatabaseKey.data)).toBe('false');
     expect(cells.get('multi')?.get(YjsDatabaseKey.data)).toBe('one,two');
     expect(cells.get('person')?.get(YjsDatabaseKey.data)).toBe(JSON.stringify([personId]));
+    expect(relationData).toBeInstanceOf(Y.Array);
+    expect((relationData as Y.Array<string>).toArray()).toEqual([relatedRowIdA, relatedRowIdB]);
+    expect(cells.get('relation')?.get(YjsDatabaseKey.field_type)).toBe(FieldType.Relation);
     expect(extractTemplateCellsFromRow(row, db)).toEqual({
       name: { type: 'text', value: 'Issue' },
       check: { type: 'checkbox', value: false },
       multi: { type: 'select', value: ['one', 'two'] },
       person: { type: 'person', value: [personId] },
+      relation: { type: 'relation', value: [relatedRowIdA, relatedRowIdB] },
+    });
+  });
+
+  it('enforces relation source limits and target database presence like Desktop', () => {
+    const result = sanitizeTemplateCells(database(), {
+      relationOne: { type: 'relation', value: [relatedRowIdA, relatedRowIdB] },
+      relationNoDb: { type: 'relation', value: [relatedRowIdA] },
+    });
+
+    expect(result).toEqual({
+      relationOne: { type: 'relation', value: [relatedRowIdA] },
     });
   });
 
@@ -202,12 +231,14 @@ describe('database row template cells', () => {
       single: { type: 'legacy', value: '["missing","one","two"]' },
       multi: { type: 'legacy', value: 'two, missing, one, two' },
       person: { type: 'legacy', value: `${personId},not-valid` },
+      relation: { type: 'legacy', value: `${relatedRowIdB}, not-valid, ${relatedRowIdA}` },
     });
 
     expect(result).toEqual({
       single: { type: 'select', value: ['one'] },
       multi: { type: 'select', value: ['two', 'one'] },
       person: { type: 'person', value: [personId] },
+      relation: { type: 'relation', value: [relatedRowIdB, relatedRowIdA] },
     });
   });
 

--- a/src/application/database-yjs/template/__tests__/codec.test.ts
+++ b/src/application/database-yjs/template/__tests__/codec.test.ts
@@ -21,6 +21,7 @@ const template: DatabaseRowTemplate = {
     title: { type: 'text', value: 'Bug' },
     done: { type: 'checkbox', value: true },
     labels: { type: 'select', value: ['urgent', 'web'] },
+    project: { type: 'relation', value: ['row-a', 'row-b'] },
   },
   icon: '🐞',
   cover: '{"cover_type":0,"data":"1"}',
@@ -89,6 +90,7 @@ describe('database row template codec', () => {
             { field_id: 'url', type: 'url', value: 'https://appflowy.io' },
             { field_id: 'select', type: 'select', value: ['one', '', 'two'] },
             { field_id: 'person', type: 'person', value: ['person-id', ''] },
+            { field_id: 'relation', type: 'relation', value: ['row-a', 'row-b'] },
           ],
           created_at_ms: 1,
           updated_at_ms: 2,
@@ -105,6 +107,7 @@ describe('database row template codec', () => {
       url: { type: 'url', value: 'https://appflowy.io' },
       select: { type: 'select', value: ['one', '', 'two'] },
       person: { type: 'person', value: ['person-id', ''] },
+      relation: { type: 'relation', value: ['row-a', 'row-b'] },
     });
   });
 
@@ -220,6 +223,7 @@ describe('database row template codec', () => {
           { field_id: 'title', type: 'text', value: 'Bug' },
           { field_id: 'done', type: 'checkbox', value: true },
           { field_id: 'labels', type: 'select', value: ['urgent', 'web'] },
+          { field_id: 'project', type: 'relation', value: ['row-a', 'row-b'] },
         ],
         created_at_ms: 10,
         updated_at_ms: 20,

--- a/src/application/database-yjs/template/cell.ts
+++ b/src/application/database-yjs/template/cell.ts
@@ -4,7 +4,10 @@ import * as Y from 'yjs';
 
 import { FieldType, RowMetaKey } from '@/application/database-yjs/database.type';
 import { getChecked } from '@/application/database-yjs/fields/checkbox/utils';
+import { parseRelationTypeOption } from '@/application/database-yjs/fields/relation/parse';
+import { RelationLimit } from '@/application/database-yjs/fields/relation/relation.type';
 import { parseSelectOptionTypeOptions } from '@/application/database-yjs/fields/select-option/parse';
+import { getRelationRowIdsFromCell } from '@/application/database-yjs/relation/cell';
 import { initialDatabaseRow } from '@/application/database-yjs/row';
 import { generateRowMeta, getMetaIdMap, getMetaJSON } from '@/application/database-yjs/row_meta';
 import {
@@ -133,6 +136,29 @@ export function sanitizeTemplateCells(
               .filter((id) => id.length > 0 && isUuid(id));
 
       if (ids.length > 0) sanitized = { type: 'person', value: ids };
+    } else if (fieldType === FieldType.Relation) {
+      const rawIds =
+        value.type === 'relation'
+          ? value.value
+          : (stringValue(value) ?? '')
+              .split(',')
+              .map((id) => id.trim())
+              .filter(Boolean);
+      const seen = new Set<string>();
+      const validIds = rawIds.filter((id) => isUuid(id) && !seen.has(id) && seen.add(id));
+
+      if (validIds.length > 0) {
+        const typeOption = parseRelationTypeOption(field);
+
+        // Desktop drops relation defaults whose field has no target database;
+        // whether the linked rows still exist is resolved lazily on display.
+        if (typeOption.database_id) {
+          sanitized = {
+            type: 'relation',
+            value: typeOption.source_limit === RelationLimit.OneOnly ? validIds.slice(0, 1) : validIds,
+          };
+        }
+      }
     }
 
     if (sanitized) result[fieldId] = sanitized;
@@ -159,6 +185,8 @@ export function templateCellToRawData(value: TemplateCellValue, fieldType: Field
       // Web's person-cell codec is a JSON string; Desktop's template codec is
       // an ID list, so the boundary conversion intentionally happens here.
       return fieldType === FieldType.Person ? JSON.stringify(value.value) : value.value.join(',');
+    case 'relation':
+      return value.value.join(',');
   }
 }
 
@@ -167,7 +195,16 @@ export function createTemplateCell(fieldId: string, fieldType: FieldType, value:
   const cell = new Y.Map() as YDatabaseCell;
 
   cell.set(YjsDatabaseKey.id, fieldId);
-  cell.set(YjsDatabaseKey.data, templateCellToRawData(value, fieldType));
+  if (value.type === 'relation' && fieldType === FieldType.Relation) {
+    // Relation cells store a Y.Array of row ids, not a string payload.
+    const data = new Y.Array<string>();
+
+    data.push([...value.value]);
+    cell.set(YjsDatabaseKey.data, data);
+  } else {
+    cell.set(YjsDatabaseKey.data, templateCellToRawData(value, fieldType));
+  }
+
   cell.set(YjsDatabaseKey.field_type, fieldType);
   cell.set(YjsDatabaseKey.created_at, now);
   cell.set(YjsDatabaseKey.last_modified, now);
@@ -242,6 +279,10 @@ export function extractTemplateCellsFromRow(row: YDatabaseRow, database: YDataba
       const ids = parsePersonIds(raw);
 
       if (ids.length > 0) values[fieldId] = { type: 'person', value: Array.from(new Set(ids)) };
+    } else if (fieldType === FieldType.Relation) {
+      const ids = getRelationRowIdsFromCell(cell);
+
+      if (ids.length > 0) values[fieldId] = { type: 'relation', value: [...ids] };
     }
   });
 

--- a/src/application/database-yjs/template/codec.ts
+++ b/src/application/database-yjs/template/codec.ts
@@ -69,7 +69,8 @@ export function parseTemplateCellValue(value: unknown): TemplateCellValue | null
     }
 
     case 'select':
-    case 'person': {
+    case 'person':
+    case 'relation': {
       const items = parseStringList(value.value);
 
       return items ? { type, value: items } : null;

--- a/src/application/database-yjs/template/types.ts
+++ b/src/application/database-yjs/template/types.ts
@@ -12,6 +12,7 @@ export type TemplateCellValue =
   | { type: 'url'; value: string }
   | { type: 'select'; value: string[] }
   | { type: 'person'; value: string[] }
+  | { type: 'relation'; value: string[] }
   | { type: 'legacy'; value: string };
 
 /**

--- a/src/application/services/js-services/__tests__/cached-api.app-view-cache.test.ts
+++ b/src/application/services/js-services/__tests__/cached-api.app-view-cache.test.ts
@@ -154,12 +154,30 @@ describe('cached app view cache user scoping', () => {
       workspace_id: 'workspace-a',
       view_id: view.view_id,
       data: view,
-      updated_at: 1,
+      updated_at: Date.now(),
     });
 
     await expect(getCachedAppViewFromDisk('workspace-a', view.view_id)).resolves.toBe(view);
 
     expect(appViewCacheTable.get).toHaveBeenCalledWith(['user-a', 'workspace-a', view.view_id]);
+  });
+
+  it('drops and deletes over-age durable view cache records', async () => {
+    const view = createView('view-too-old', 'stale disk cache');
+    const eightDaysMs = 8 * 24 * 60 * 60 * 1000;
+
+    setCurrentUser('user-a');
+    appViewCacheTable.get.mockResolvedValue({
+      user_id: 'user-a',
+      workspace_id: 'workspace-a',
+      view_id: view.view_id,
+      data: view,
+      updated_at: Date.now() - eightDaysMs,
+    });
+
+    await expect(getCachedAppViewFromDisk('workspace-a', view.view_id)).resolves.toBeUndefined();
+
+    expect(appViewCacheTable.delete).toHaveBeenCalledWith(['user-a', 'workspace-a', view.view_id]);
   });
 
   it('does not promote durable fallback data into the fresh in-memory cache', async () => {
@@ -174,7 +192,7 @@ describe('cached app view cache user scoping', () => {
       workspace_id: workspaceId,
       view_id: viewId,
       data: diskView,
-      updated_at: 1,
+      updated_at: Date.now(),
     });
     getViewMock.mockResolvedValue(serverView);
 

--- a/src/application/services/js-services/cache/index.ts
+++ b/src/application/services/js-services/cache/index.ts
@@ -1043,6 +1043,15 @@ export async function getOrCreateRowSubDoc(documentId: string): Promise<YDoc> {
 
   rowSubDocs.set(documentId, entry);
 
+  // Auto-evict when the doc is destroyed via an external path (version reset,
+  // access revoked, deleteCollabDB) so later callers don't get a stale,
+  // destroyed Y.Doc back from this cache.
+  entry.doc.on('destroy', () => {
+    if (rowSubDocs.get(documentId) === entry) {
+      rowSubDocs.delete(documentId);
+    }
+  });
+
   await whenSynced;
 
   // Log final state after sync

--- a/src/application/services/js-services/cached-api.ts
+++ b/src/application/services/js-services/cached-api.ts
@@ -102,6 +102,10 @@ const publishViewInfo = new Map<
 const _getAppViewInFlight = new Map<string, Promise<View>>();
 const _getAppViewCache = new Map<string, { data: View; expiresAt: number }>();
 const VIEW_CACHE_TTL_MS = 5000;
+// Disk records are a fast-paint/offline fallback that is normally replaced by a
+// network refresh; the age cap only bounds how stale that fallback can get when
+// the refresh fails.
+const VIEW_DISK_CACHE_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000;
 const ANONYMOUS_VIEW_CACHE_SCOPE = 'anonymous';
 
 const _getAppTrashInFlight = new Map<string, Promise<View[]>>();
@@ -200,7 +204,17 @@ export async function getAppViewCached(workspaceId: string, viewId: string) {
 }
 
 export function getCachedAppView(workspaceId: string, viewId: string): View | undefined {
-  return _getAppViewCache.get(getAppViewCacheKey(getCurrentAppViewCacheUserId(), workspaceId, viewId))?.data;
+  const key = getAppViewCacheKey(getCurrentAppViewCacheUserId(), workspaceId, viewId);
+  const cached = _getAppViewCache.get(key);
+
+  if (!cached) return undefined;
+
+  if (Date.now() >= cached.expiresAt) {
+    _getAppViewCache.delete(key);
+    return undefined;
+  }
+
+  return cached.data;
 }
 
 export async function getCachedAppViewFromDisk(workspaceId: string, viewId: string): Promise<View | undefined> {
@@ -210,7 +224,14 @@ export async function getCachedAppViewFromDisk(workspaceId: string, viewId: stri
 
   const record = await db.app_view_cache.get([userId, workspaceId, viewId]);
 
-  return record?.data;
+  if (!record) return undefined;
+
+  if (Date.now() - record.updated_at > VIEW_DISK_CACHE_MAX_AGE_MS) {
+    void db.app_view_cache.delete([userId, workspaceId, viewId]).catch(() => undefined);
+    return undefined;
+  }
+
+  return record.data;
 }
 
 export async function refreshAppViewCache(workspaceId: string, viewId: string) {

--- a/src/application/services/js-services/http/core.ts
+++ b/src/application/services/js-services/http/core.ts
@@ -9,6 +9,22 @@ import { initGrantService, refreshToken } from './gotrue';
 
 let axiosInstance: AxiosInstance | null = null;
 
+// References to the ETag/response stores created inside initAPIService, so the
+// session layer can clear them on logout/session invalidation.
+let activeEtagStore: Map<string, string> | null = null;
+let activeResponseStore: Map<string, unknown> | null = null;
+
+/**
+ * Clear the ETag/304 response caches. Must be called when the session becomes
+ * invalid (logout, token expiry): the cache key is the request URL without any
+ * user identity, so stale entries could otherwise be replayed to a different
+ * user logging in later in the same tab.
+ */
+export function clearHttpResponseCaches() {
+  activeEtagStore?.clear();
+  activeResponseStore?.clear();
+}
+
 export function getAxiosInstance() {
   return axiosInstance;
 }
@@ -493,9 +509,17 @@ export function initAPIService(config: AFCloudConfig) {
   // For programmatic requests (axios.get), the browser doesn't always use its HTTP
   // cache, so we also keep a lightweight JS response cache as fallback. Query params
   // are part of the key so GET endpoints with different targets cannot collide.
+  //
+  // The cache key does NOT include the user identity, so these stores must be
+  // cleared when the session ends (see clearHttpResponseCaches) — otherwise a
+  // later login as a different user in the same tab could be served the
+  // previous user's cached bodies via 304 replay.
   // ---------------------------------------------------------------------------
   const etagStore = new Map<string, string>();
   const responseStore = new Map<string, unknown>();
+
+  activeEtagStore = etagStore;
+  activeResponseStore = responseStore;
 
   // Request: attach stored ETag as If-None-Match
   axiosInstance.interceptors.request.use((config) => {

--- a/src/components/app/app.hooks.tsx
+++ b/src/components/app/app.hooks.tsx
@@ -146,6 +146,21 @@ export function useUserWorkspaceInfo() {
 }
 
 /**
+ * Returns a function that force-refreshes the workspace list. Call after
+ * mutations that change it (rename/delete/leave, membership changes).
+ * Throws if used outside AppProvider.
+ */
+export function useRefreshUserWorkspaceInfo() {
+  const context = useContext(AuthInternalContext);
+
+  if (!context) {
+    throw new Error('useRefreshUserWorkspaceInfo must be used within an AppProvider');
+  }
+
+  return context.refreshUserWorkspaceInfo;
+}
+
+/**
  * Returns whether page history is enabled for the current workspace plan.
  * Fails open (returns true) when outside AppProvider — e.g. on publish pages.
  */

--- a/src/components/app/contexts/AuthInternalContext.ts
+++ b/src/components/app/contexts/AuthInternalContext.ts
@@ -50,6 +50,12 @@ export interface AuthInternalContextType {
   workspaceInfoError?: Error;
   /** Retry loading workspace info after a failure. */
   retryLoadWorkspaceInfo?: () => Promise<UserWorkspaceInfo | undefined>;
+  /**
+   * Force-refresh the workspace list. Call after mutations that change it
+   * (rename/delete/leave a workspace, membership changes) so consumers of
+   * `userWorkspaceInfo` don't keep a stale snapshot.
+   */
+  refreshUserWorkspaceInfo?: () => Promise<UserWorkspaceInfo | undefined>;
 }
 
 export const AuthInternalContext = createContext<AuthInternalContextType | null>(null);

--- a/src/components/app/hooks/usePageOperations.ts
+++ b/src/components/app/hooks/usePageOperations.ts
@@ -97,6 +97,7 @@ export function usePageOperations({
       try {
         const response = await PageService.add(currentWorkspaceId, parentViewId, payload);
 
+        ViewService.invalidateCache(currentWorkspaceId, parentViewId);
         // Keep a resilient fallback when realtime delivery is unavailable.
         // This guarantees sidebar eventual consistency after creation.
         void loadOutline?.(currentWorkspaceId, false);
@@ -122,7 +123,14 @@ export function usePageOperations({
       }
 
       try {
+        const parentView = findParentView(outlineRef.current || [], id);
+
         await PageService.moveToTrash(currentWorkspaceId, id);
+        ViewService.invalidateCache(currentWorkspaceId, id);
+        if (parentView) {
+          ViewService.invalidateCache(currentWorkspaceId, parentView.view_id);
+        }
+
         void loadTrash?.(currentWorkspaceId);
         void loadOutline?.(currentWorkspaceId, false);
         return;
@@ -142,6 +150,9 @@ export function usePageOperations({
 
       try {
         await PageService.update(currentWorkspaceId, viewId, payload);
+        // Drop the cached view metadata (memory + disk) so a stale name/icon
+        // can't be re-served if the WebSocket notification is dropped.
+        ViewService.invalidateCache(currentWorkspaceId, viewId);
         // Sidebar refresh is handled by WebSocket notification (FOLDER_OUTLINE_CHANGED)
         return;
       } catch (e) {
@@ -160,6 +171,7 @@ export function usePageOperations({
 
       try {
         await PageService.updateIcon(currentWorkspaceId, viewId, icon);
+        ViewService.invalidateCache(currentWorkspaceId, viewId);
         return;
       } catch (e) {
         return Promise.reject(e);
@@ -177,6 +189,7 @@ export function usePageOperations({
 
       try {
         await PageService.updateName(currentWorkspaceId, viewId, name);
+        ViewService.invalidateCache(currentWorkspaceId, viewId);
         // Sidebar refresh is handled by WebSocket notification (FOLDER_OUTLINE_CHANGED)
         return;
       } catch (e) {
@@ -239,8 +252,15 @@ export function usePageOperations({
       try {
         const lastChild = findView(outlineRef.current || [], parentId)?.children?.slice(-1)[0];
         const prevId = prevViewId || lastChild?.view_id;
+        const oldParentView = findParentView(outlineRef.current || [], viewId);
 
         await PageService.moveTo(currentWorkspaceId, viewId, parentId, prevId);
+        // Both the old and new parents' cached subtrees changed.
+        if (oldParentView) {
+          ViewService.invalidateCache(currentWorkspaceId, oldParentView.view_id);
+        }
+
+        ViewService.invalidateCache(currentWorkspaceId, parentId);
         void loadOutline?.(currentWorkspaceId, false);
         return;
       } catch (e) {

--- a/src/components/app/hooks/useWorkspaceData.ts
+++ b/src/components/app/hooks/useWorkspaceData.ts
@@ -1989,6 +1989,9 @@ export function useWorkspaceData() {
     favoriteViewsLoadedRef.current = false;
     setFavoriteViews(undefined);
     setRecentViews(undefined);
+    // Deleted-page routing derives from `trashList` — without this reset the
+    // previous workspace's trash stays live until the new loadTrash resolves.
+    setTrashList(undefined);
     // Clear database relations cache when switching workspaces to prevent
     // cross-workspace data contamination
     workspaceDatabasesRef.current = undefined;

--- a/src/components/app/layers/AppAuthLayer.tsx
+++ b/src/components/app/layers/AppAuthLayer.tsx
@@ -15,6 +15,9 @@ interface AppAuthLayerProps {
 }
 
 const RETRY_WORKSPACE_INFO_DELAY_MS = 5000;
+// Minimum age of the loaded workspace info before a focus/visibility/online
+// event triggers a background revalidation.
+const REVALIDATE_WORKSPACE_INFO_MIN_AGE_MS = 30_000;
 
 type LoadWorkspaceInfoOptions = { force?: boolean };
 
@@ -68,6 +71,7 @@ export const AppAuthLayer: React.FC<AppAuthLayerProps> = ({ children }) => {
   const [syncLimitsLoaded, setSyncLimitsLoaded] = useState(false);
   const workspaceInfoPromiseRef = useRef<Promise<UserWorkspaceInfo | undefined> | null>(null);
   const workspaceInfoRequestIdRef = useRef(0);
+  const workspaceInfoLoadedAtRef = useRef(0);
   const pendingWorkspaceChangeRef = useRef<string | null>(null);
 
   // Calculate current workspace ID from URL params or user info
@@ -97,6 +101,7 @@ export const AppAuthLayer: React.FC<AppAuthLayerProps> = ({ children }) => {
       .then(() => UserService.getWorkspaceInfo())
       .then((res) => {
         if (workspaceInfoRequestIdRef.current === requestId) {
+          workspaceInfoLoadedAtRef.current = Date.now();
           setUserWorkspaceInfo(res);
         }
 
@@ -331,7 +336,37 @@ export const AppAuthLayer: React.FC<AppAuthLayerProps> = ({ children }) => {
     };
   }, [isAuthenticated, userWorkspaceInfo, workspaceInfoError, loadUserWorkspaceInfo]);
 
+  // Once loaded, the workspace list (names, icons, roles, member counts) is a
+  // mount-time snapshot: nothing else re-reads it and there is no membership
+  // WebSocket notification. Revalidate on focus/visibility/online (throttled)
+  // so changes made on other devices eventually reach a long-lived tab.
+  useEffect(() => {
+    if (!isAuthenticated || !userWorkspaceInfo) return;
+
+    const revalidate = () => {
+      if (Date.now() - workspaceInfoLoadedAtRef.current < REVALIDATE_WORKSPACE_INFO_MIN_AGE_MS) return;
+      void loadUserWorkspaceInfo();
+    };
+
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === 'visible') {
+        revalidate();
+      }
+    };
+
+    window.addEventListener('online', revalidate);
+    window.addEventListener('focus', revalidate);
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+
+    return () => {
+      window.removeEventListener('online', revalidate);
+      window.removeEventListener('focus', revalidate);
+      document.removeEventListener('visibilitychange', handleVisibilityChange);
+    };
+  }, [isAuthenticated, userWorkspaceInfo, loadUserWorkspaceInfo]);
+
   const retryLoadWorkspaceInfo = useCallback(() => loadUserWorkspaceInfo({ force: true }), [loadUserWorkspaceInfo]);
+  const refreshUserWorkspaceInfo = useCallback(() => loadUserWorkspaceInfo({ force: true }), [loadUserWorkspaceInfo]);
 
   // Auto-switch workspace when the URL points to a different workspace than
   // the currently selected one (e.g. guest opening a shared direct link).
@@ -386,6 +421,7 @@ export const AppAuthLayer: React.FC<AppAuthLayerProps> = ({ children }) => {
       onChangeWorkspace,
       workspaceInfoError,
       retryLoadWorkspaceInfo,
+      refreshUserWorkspaceInfo,
     }),
     [
       userWorkspaceInfo,
@@ -399,6 +435,7 @@ export const AppAuthLayer: React.FC<AppAuthLayerProps> = ({ children }) => {
       onChangeWorkspace,
       workspaceInfoError,
       retryLoadWorkspaceInfo,
+      refreshUserWorkspaceInfo,
     ]
   );
 

--- a/src/components/app/outline/Outline.tsx
+++ b/src/components/app/outline/Outline.tsx
@@ -41,6 +41,7 @@ import { Log } from '@/utils/log';
 const ImportDialog = lazy(() => import('@/components/app/import/ImportDialog'));
 
 const AUTO_LOAD_RETRY_DELAY_MS = 15000;
+const NAVIGATION_HYDRATION_RETRY_DELAY_MS = 15000;
 
 function collectSubtreeViewIds(rootView: View): string[] {
   const ids: string[] = [];
@@ -115,9 +116,12 @@ export function Outline({ width }: { width: number }) {
   const loadingViewIdsRef = useRef<Set<string>>(new Set());
   const navigationHydrationInFlightRef = useRef<Set<string>>(new Set());
   // Selected views that navigation hydration could not place in the outline
-  // (not found server-side, or access denied). Tracked so we don't re-fetch
-  // navigation on every subsequent `outline` change for an unresolvable id.
-  const navigationHydrationUnresolvedRef = useRef<Set<string>>(new Set());
+  // (not found server-side, or access denied), mapped to a retry-after
+  // timestamp. Throttles re-fetching navigation on every `outline` change for
+  // an unresolvable id, while still retrying later — a freshly duplicated view
+  // can race the folder projection and become resolvable seconds after the
+  // first attempt fails.
+  const navigationHydrationRetryAfterRef = useRef<Map<string, number>>(new Map());
   const autoLoadRetryAfterRef = useRef<Map<string, number>>(new Map());
   const validatingRestoreIdsRef = useRef<Set<string>>(new Set());
   const validatedExistingRestoreIdsRef = useRef<Set<string>>(new Set());
@@ -138,7 +142,7 @@ export function Outline({ width }: { width: number }) {
     if (!selectedViewId || !outline || !ensureViewVisibleInOutline) return;
     if (findView(outline, selectedViewId)) return;
     if (navigationHydrationInFlightRef.current.has(selectedViewId)) return;
-    if (navigationHydrationUnresolvedRef.current.has(selectedViewId)) return;
+    if ((navigationHydrationRetryAfterRef.current.get(selectedViewId) ?? 0) > Date.now()) return;
 
     navigationHydrationInFlightRef.current.add(selectedViewId);
 
@@ -147,12 +151,13 @@ export function Outline({ width }: { width: number }) {
         if (ancestorIds.length === 0) {
           // Either the view resolved at the sidebar root (it's now in the
           // outline, so findView short-circuits on the next run) or it could
-          // not be resolved. Mark it so we don't re-fetch on every outline
+          // not be resolved. Throttle so we don't re-fetch on every outline
           // change while it stays selected.
-          navigationHydrationUnresolvedRef.current.add(selectedViewId);
+          navigationHydrationRetryAfterRef.current.set(selectedViewId, Date.now() + NAVIGATION_HYDRATION_RETRY_DELAY_MS);
           return;
         }
 
+        navigationHydrationRetryAfterRef.current.delete(selectedViewId);
         ancestorIds.forEach((id) => setOutlineExpands(id, true));
         setExpandViewIds((prev) => {
           const next = new Set(prev);
@@ -167,7 +172,7 @@ export function Outline({ width }: { width: number }) {
         });
       })
       .catch((error) => {
-        navigationHydrationUnresolvedRef.current.add(selectedViewId);
+        navigationHydrationRetryAfterRef.current.set(selectedViewId, Date.now() + NAVIGATION_HYDRATION_RETRY_DELAY_MS);
         Log.warn('[Outline] [navigation-context] failed to hydrate selected view', {
           viewId: selectedViewId,
           error,
@@ -190,7 +195,7 @@ export function Outline({ width }: { width: number }) {
     setPendingAutoLoadIds(restoredExpandedIds);
     loadingViewIdsRef.current = new Set();
     navigationHydrationInFlightRef.current = new Set();
-    navigationHydrationUnresolvedRef.current = new Set();
+    navigationHydrationRetryAfterRef.current = new Map();
     autoLoadRetryAfterRef.current = new Map();
     validatingRestoreIdsRef.current = new Set();
     validatedExistingRestoreIdsRef.current = new Set();

--- a/src/components/app/workspaces/DeleteWorkspace.tsx
+++ b/src/components/app/workspaces/DeleteWorkspace.tsx
@@ -4,7 +4,7 @@ import { toast } from 'sonner';
 
 import { WorkspaceService } from '@/application/services/domains';
 import { NormalModal } from '@/components/_shared/modal';
-import { useCurrentWorkspaceId } from '@/components/app/app.hooks';
+import { useCurrentWorkspaceId, useRefreshUserWorkspaceInfo } from '@/components/app/app.hooks';
 import { HIDDEN_BUTTON_PROPS, MODAL_CLASSES, MODAL_PAPER_PROPS } from '@/components/app/workspaces/modal-props';
 import { Button } from '@/components/ui/button';
 
@@ -22,6 +22,7 @@ function DeleteWorkspace({
   const { t } = useTranslation();
   const [loading, setLoading] = useState(false);
   const currentWorkspaceId = useCurrentWorkspaceId();
+  const refreshUserWorkspaceInfo = useRefreshUserWorkspaceInfo();
 
   const handleOk = async () => {
     try {
@@ -30,6 +31,10 @@ function DeleteWorkspace({
       openOnChange(false);
       if (currentWorkspaceId === workspaceId) {
         window.location.href = `/app`;
+      } else {
+        // Deleting a non-current workspace doesn't reload the page — refresh
+        // the workspace list so the deleted workspace doesn't linger in it.
+        void refreshUserWorkspaceInfo?.();
       }
       // eslint-disable-next-line
     } catch (e: any) {

--- a/src/components/app/workspaces/LeaveWorkspace.tsx
+++ b/src/components/app/workspaces/LeaveWorkspace.tsx
@@ -4,7 +4,7 @@ import { toast } from 'sonner';
 
 import { WorkspaceService } from '@/application/services/domains';
 import { NormalModal } from '@/components/_shared/modal';
-import { useCurrentWorkspaceId } from '@/components/app/app.hooks';
+import { useCurrentWorkspaceId, useRefreshUserWorkspaceInfo } from '@/components/app/app.hooks';
 import { HIDDEN_BUTTON_PROPS, MODAL_CLASSES, MODAL_PAPER_PROPS } from '@/components/app/workspaces/modal-props';
 import { Button } from '@/components/ui/button';
 
@@ -22,6 +22,7 @@ function LeaveWorkspace({
   const { t } = useTranslation();
   const [loading, setLoading] = useState(false);
   const currentWorkspaceId = useCurrentWorkspaceId();
+  const refreshUserWorkspaceInfo = useRefreshUserWorkspaceInfo();
 
   const handleOk = async () => {
     try {
@@ -30,6 +31,10 @@ function LeaveWorkspace({
       openOnChange(false);
       if (currentWorkspaceId === workspaceId) {
         window.location.href = `/app`;
+      } else {
+        // Leaving a non-current workspace doesn't reload the page — refresh
+        // the workspace list so the left workspace doesn't linger in it.
+        void refreshUserWorkspaceInfo?.();
       }
       // eslint-disable-next-line
     } catch (e: any) {

--- a/src/components/app/workspaces/WorkspaceList.tsx
+++ b/src/components/app/workspaces/WorkspaceList.tsx
@@ -41,6 +41,17 @@ function WorkspaceList({
   autoScrollContainerRef?: ScrollContainerRef;
 }) {
   const [workspaces, setWorkspaces] = useState<Workspace[]>(defaultWorkspaces || []);
+
+  // `defaultWorkspaces` seeds the initial paint, but the shared workspace list
+  // can be force-refreshed while this list stays mounted (rename/delete/leave
+  // from a modal, mobile drawer kept open). Follow those updates instead of
+  // freezing the mount-time snapshot.
+  useEffect(() => {
+    if (defaultWorkspaces) {
+      setWorkspaces(defaultWorkspaces);
+    }
+  }, [defaultWorkspaces]);
+
   const fetchWorkspaces = useCallback(async () => {
     try {
       const workspaces = await WorkspaceService.getAll();

--- a/src/components/app/workspaces/Workspaces.tsx
+++ b/src/components/app/workspaces/Workspaces.tsx
@@ -12,7 +12,13 @@ import { ReactComponent as SettingsIcon } from '@/assets/icons/settings.svg';
 import { ReactComponent as UpgradeIcon } from '@/assets/icons/upgrade.svg';
 import Import from '@/components/_shared/more-actions/importer/Import';
 import { notify } from '@/components/_shared/notify';
-import { useAIEnabled, useAppOperations, useCurrentWorkspaceId, useUserWorkspaceInfo } from '@/components/app/app.hooks';
+import {
+  useAIEnabled,
+  useAppOperations,
+  useCurrentWorkspaceId,
+  useRefreshUserWorkspaceInfo,
+  useUserWorkspaceInfo,
+} from '@/components/app/app.hooks';
 import CurrentWorkspace from '@/components/app/workspaces/CurrentWorkspace';
 import DeleteWorkspace from '@/components/app/workspaces/DeleteWorkspace';
 import EditWorkspace from '@/components/app/workspaces/EditWorkspace';
@@ -44,6 +50,7 @@ import { SettingsDialog } from '@/components/app/settings';
 export function Workspaces() {
   const { t } = useTranslation();
   const userWorkspaceInfo = useUserWorkspaceInfo();
+  const refreshUserWorkspaceInfo = useRefreshUserWorkspaceInfo();
   const currentWorkspaceId = useCurrentWorkspaceId();
   const currentUser = useCurrentUser();
   const aiEnabled = useAIEnabled();
@@ -120,9 +127,14 @@ export function Workspaces() {
         });
       }
 
+      // The optimistic patch above only covers the current workspace's local
+      // state — refresh the shared workspace list so every consumer (header,
+      // mobile switcher, members panel) drops the old name.
+      void refreshUserWorkspaceInfo?.();
+
       setOpenRenameWorkspace(null);
     },
-    [openRenameWorkspace, currentWorkspaceId]
+    [openRenameWorkspace, currentWorkspaceId, refreshUserWorkspaceInfo]
   );
 
   return (

--- a/src/components/database/components/template/DatabaseTemplateButton.tsx
+++ b/src/components/database/components/template/DatabaseTemplateButton.tsx
@@ -167,6 +167,7 @@ function DatabaseTemplateEditor({
     () => ({
       ...parentContext,
       isDatabaseRowPage: false,
+      templateEditingRowId: editing.templateId,
       rowMap: { ...(parentContext.rowMap ?? {}), [editing.templateId]: editing.rowDoc },
       ensureRow: (rowId: string) =>
         rowId === editing.templateId ? Promise.resolve(editing.rowDoc) : parentContext.ensureRow?.(rowId),

--- a/src/components/main/AppConfig.tsx
+++ b/src/components/main/AppConfig.tsx
@@ -4,7 +4,7 @@ import React, { Suspense, useCallback, useEffect, useMemo, useState } from 'reac
 
 import { clearData, db } from '@/application/db';
 import { UserService } from '@/application/services/domains';
-import { initAPIService } from '@/application/services/js-services/http/core';
+import { clearHttpResponseCaches, initAPIService } from '@/application/services/js-services/http/core';
 import { EventType, on } from '@/application/session';
 import { getTokenParsed, isTokenValid } from '@/application/session/token';
 import { User } from '@/application/types';
@@ -84,7 +84,14 @@ function AppConfig({ children }: { children: React.ReactNode }) {
   // 1. Cross-tab synchronization via storage events
   useEffect(() => {
     const handleStorageChange = (event: StorageEvent) => {
-      if (event.key === 'token') setIsAuthenticated(isTokenValid());
+      if (event.key !== 'token') return;
+
+      const valid = isTokenValid();
+
+      // Token removed/replaced by another tab — same cross-user replay
+      // concern as the SESSION_INVALID handler below.
+      if (!valid) clearHttpResponseCaches();
+      setIsAuthenticated(valid);
     };
 
     window.addEventListener('storage', handleStorageChange);
@@ -139,6 +146,10 @@ function AppConfig({ children }: { children: React.ReactNode }) {
   // 4. Event-based session invalidation from failed API calls
   useEffect(() => {
     return on(EventType.SESSION_INVALID, () => {
+      // The HTTP ETag/response cache is keyed by URL without user identity —
+      // drop it so a later login as a different user can't be served the
+      // previous user's cached bodies.
+      clearHttpResponseCaches();
       setIsAuthenticated(false);
     });
   }, []);


### PR DESCRIPTION
## What

Ports the Desktop row-template relation support (AppFlowy-Premium#1252) to Web. Row templates can now hold **relation default values**, edited through the template editor's real relation picker and applied when rows are created from the template. **Rollup** stays excluded from template defaults — it is computed on read (`rollup/cache.ts`) and renders read-only in the template editor — matching Desktop.

Web's templates and relation/rollup fields were already complete; the gap was the `relation` variant in the template pipeline plus two template-context guards.

## Changes

- **Codec/contract**: `TemplateCellValue` gains the `relation` variant; the codec reads and writes Desktop's exact `{"type":"relation","value":[row-ids]}` metadata contract, so relation defaults now round-trip between Desktop and Web instead of being silently dropped.
- **Sanitization** (`sanitizeTemplateCells`): mirrors Desktop's rules — row-UUID validation, order-preserving de-dup, drop when the field has no target database, `source_limit === OneOnly` truncation, legacy comma-list parsing.
- **Apply/extract**: `createTemplateCell` writes relation defaults as the canonical `Y.Array<string>` payload; `extractTemplateCellsFromRow` reads them back via `getRelationRowIdsFromCell` — which is what makes the template editor's relation picker persist into `default_cells` automatically.
- **Reciprocal backfill**: `useNewRowDispatch` queues applied relation defaults into the existing `relationPrefills` backfill, so two-way relations get their back-links on rows created from templates. Later filter prefills or raw `cellsData` writes for the same field replace the queue entry, keeping the backfill in sync with the final cell state.
- **Template-editor guard**: the editor marks its hidden source row via `templateEditingRowId` on `DatabaseContext`, and `useUpdateRelationCell` skips reciprocal writes for it — that row never joins `row_orders`, so back-links would otherwise point real rows at a phantom row id.

## Tests

- **Jest**: template suites updated — the old "relation is unsupported" assertions now assert support (the unsupported-type fixture moved to Rollup), with new cases for OneOnly truncation, missing-target-database drops, legacy list parsing, and the `Y.Array` round-trip. Codec tests carry the relation variant through both directions of the Desktop contract. All 850 `database-yjs` tests and 15 template component tests pass; `pnpm lint` (tsc + eslint) clean.
- **Playwright BDD**: new `row-template-relation.feature` drives the real UI end to end — creates two grids, injects a relation field and a Count rollup, creates and names a template through the editor dialog, picks the relation default in the editor's relation picker ("1 linked rows" asserted, rollup asserted read-only), creates a row from the template dropdown, and strictly asserts the grid renders the linked row title and rollup count. Adds `createRollupCountFieldDirect` to the relation test helpers. Passes against a local stack; the neighboring `gallery-relation-prefill` scenario (same dispatch path) stays green.

## Note

The branch also carries a pre-existing base commit (`485b5a5f chore: stale data`) with workspace-info revalidation and cross-user HTTP-cache clearing, which predates this work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add relation default support in database row templates and improve workspace, navigation, and caching robustness across the app.

New Features:
- Allow database row templates to store and apply relation default values, including codec support and Yjs integration.
- Add a Playwright BDD scenario to verify end-to-end relation defaults and rollup behavior in row templates.

Bug Fixes:
- Ensure navigation hydration retries for selected views that initially fail to resolve, avoiding permanent unresolved states.
- Prevent cross-user replay of cached HTTP responses and stale app view cache entries in memory and on disk.
- Fix stale workspace and trash list data by revalidating and refreshing workspace info and workspace-derived lists after mutations and on lifecycle events.
- Avoid reciprocal relation writes from the hidden template source row to prevent links to non-existent rows.
- Automatically evict destroyed row sub-documents from the cache to avoid returning invalid Y.Docs.
- Expire in-memory and disk app-view caches after defined TTLs to avoid serving overly stale views.
- Prevent outline cache inconsistencies by invalidating view caches on page create, move, rename, icon update, trash, and move operations.

Enhancements:
- Introduce a direct helper to inject a Count rollup field over a relation in Playwright relation tests, keeping assertions deterministic.
- Throttle workspace-info revalidation on focus/visibility/online events to refresh membership data in long-lived tabs without excessive requests.
- Synchronize workspace lists across components by exposing a refresh hook and wiring it into workspace rename, delete, and leave flows.
- Keep WorkspaceList synchronized with the latest workspace snapshot instead of the initial mount-time list.
- Throttle navigation hydration retries for unresolvable selected views to balance freshness with network load.
- Reset workspace-specific trash state on workspace switch to avoid cross-workspace contamination.
- Track row-template editing context in the database layer so relation dispatch logic can distinguish template edits from real-row edits.

Tests:
- Extend database template cell and codec tests to cover relation defaults, legacy parsing, and Desktop-compatible sanitization and limits.
- Add a new Playwright BDD flow for row template relations and rollups, including supporting test helpers.