### PR TITLE
fix(database): resolve Relation targets in rollup cells

### DIFF
--- a/src/application/database-yjs/__tests__/rollup-relation-target.test.ts
+++ b/src/application/database-yjs/__tests__/rollup-relation-target.test.ts
@@ -1,0 +1,251 @@
+import * as Y from 'yjs';
+
+jest.mock('@/utils/runtime-config', () => ({
+  getConfigValue: (_key: string, defaultValue: string) => defaultValue,
+}));
+
+import { CalculationType, FieldType, RollupDisplayMode } from '@/application/database-yjs/database.type';
+import { createRelationField } from '@/application/database-yjs/fields/relation/utils';
+import { createRollupField } from '@/application/database-yjs/fields/rollup/utils';
+import { readRollupCell } from '@/application/database-yjs/rollup/cache';
+import {
+  YDatabase,
+  YDatabaseCell,
+  YDatabaseCells,
+  YDatabaseField,
+  YDatabaseFields,
+  YDatabaseRow,
+  YDoc,
+  YjsDatabaseKey,
+  YjsEditorKey,
+} from '@/application/types';
+
+function createTextField(fieldId: string, name: string, isPrimary = false): YDatabaseField {
+  const field = new Y.Map() as YDatabaseField;
+
+  field.set(YjsDatabaseKey.id, fieldId);
+  field.set(YjsDatabaseKey.name, name);
+  field.set(YjsDatabaseKey.type, FieldType.RichText);
+  if (isPrimary) {
+    field.set(YjsDatabaseKey.is_primary, true);
+  }
+
+  return field;
+}
+
+function createDatabaseDoc(databaseId: string, viewId: string, fields: YDatabaseFields): YDoc {
+  const doc = new Y.Doc() as YDoc;
+
+  doc.guid = viewId;
+  doc.object_id = viewId;
+  const sharedRoot = doc.getMap(YjsEditorKey.data_section);
+  const database = new Y.Map() as YDatabase;
+
+  database.set(YjsDatabaseKey.id, databaseId);
+  database.set(YjsDatabaseKey.fields, fields);
+  sharedRoot.set(YjsEditorKey.database, database);
+  return doc;
+}
+
+function createCell(data: unknown, fieldType: FieldType): YDatabaseCell {
+  const cell = new Y.Map() as YDatabaseCell;
+
+  cell.set(YjsDatabaseKey.data, data);
+  cell.set(YjsDatabaseKey.field_type, fieldType);
+  return cell;
+}
+
+function createRelationCell(rowIds: string[]): YDatabaseCell {
+  const ids = new Y.Array<string>();
+
+  ids.push(rowIds);
+  return createCell(ids, FieldType.Relation);
+}
+
+function createRowDoc(rowId: string, databaseId: string, cellMap: Record<string, YDatabaseCell>): YDoc {
+  const doc = new Y.Doc() as YDoc;
+  const sharedRoot = doc.getMap(YjsEditorKey.data_section);
+  const row = new Y.Map() as YDatabaseRow;
+  const cells = new Y.Map() as YDatabaseCells;
+
+  Object.entries(cellMap).forEach(([fieldId, cell]) => {
+    cells.set(fieldId, cell);
+  });
+
+  row.set(YjsDatabaseKey.id, rowId);
+  row.set(YjsDatabaseKey.database_id, databaseId);
+  row.set(YjsDatabaseKey.cells, cells);
+  row.set(YjsDatabaseKey.created_at, '0');
+  row.set(YjsDatabaseKey.last_modified, '0');
+  sharedRoot.set(YjsEditorKey.database_row, row);
+  return doc;
+}
+
+/**
+ * Reproduces the `project_templates` workspace: `03_epics.Opportunity` is a
+ * Rollup that walks `Related Proj` into `02_projects` and reads `Primary Opp`,
+ * which is itself a Relation into `01_opportunities`. The rolled-up value is a
+ * row id, so it only reads as a name after the second hop is resolved.
+ */
+function createChainFixture(suffix: string, showAs: RollupDisplayMode) {
+  const opportunityDatabaseId = `opportunity-db-${suffix}`;
+  const opportunityViewId = `opportunity-view-${suffix}`;
+  const projectDatabaseId = `project-db-${suffix}`;
+  const projectViewId = `project-view-${suffix}`;
+  const epicDatabaseId = `epic-db-${suffix}`;
+  const epicViewId = `epic-view-${suffix}`;
+
+  const opportunityNameFieldId = `opportunity-name-${suffix}`;
+  const projectNameFieldId = `project-name-${suffix}`;
+  const projectOpportunityFieldId = `primary-opp-${suffix}`;
+  const epicNameFieldId = `epic-name-${suffix}`;
+  const epicProjectFieldId = `related-proj-${suffix}`;
+  const rollupFieldId = `opportunity-rollup-${suffix}`;
+
+  const opportunityRowIds = [`opp-row-1-${suffix}`, `opp-row-2-${suffix}`];
+  const projectRowIds = [`project-row-1-${suffix}`, `project-row-2-${suffix}`];
+  const epicRowId = `epic-row-${suffix}`;
+
+  // 01_opportunities
+  const opportunityFields = new Y.Map() as YDatabaseFields;
+
+  opportunityFields.set(opportunityNameFieldId, createTextField(opportunityNameFieldId, 'Opportunity ID', true));
+  const opportunityDoc = createDatabaseDoc(opportunityDatabaseId, opportunityViewId, opportunityFields);
+
+  // 02_projects, holding a Relation into 01_opportunities
+  const projectOpportunityField = createRelationField(projectOpportunityFieldId, {
+    name: 'Primary Opp',
+    database_id: opportunityDatabaseId,
+  });
+  const projectFields = new Y.Map() as YDatabaseFields;
+
+  projectFields.set(projectNameFieldId, createTextField(projectNameFieldId, 'Project ID', true));
+  projectFields.set(projectOpportunityFieldId, projectOpportunityField);
+  const projectDoc = createDatabaseDoc(projectDatabaseId, projectViewId, projectFields);
+
+  // 03_epics, holding a Relation into 02_projects plus the Rollup under test
+  const epicProjectField = createRelationField(epicProjectFieldId, {
+    name: 'Related Proj',
+    database_id: projectDatabaseId,
+  });
+  const epicFields = new Y.Map() as YDatabaseFields;
+
+  epicFields.set(epicNameFieldId, createTextField(epicNameFieldId, 'Epic ID', true));
+  epicFields.set(epicProjectFieldId, epicProjectField);
+  epicFields.set(rollupFieldId, createRollupField(rollupFieldId));
+  const epicDoc = createDatabaseDoc(epicDatabaseId, epicViewId, epicFields);
+
+  const epicDatabase = epicDoc.getMap(YjsEditorKey.data_section).get(YjsEditorKey.database) as YDatabase;
+  const rollupOption = (epicDatabase.get(YjsDatabaseKey.fields)?.get(rollupFieldId) as YDatabaseField | undefined)
+    ?.get(YjsDatabaseKey.type_option)
+    ?.get(String(FieldType.Rollup));
+
+  rollupOption?.set(YjsDatabaseKey.relation_field_id, epicProjectFieldId);
+  rollupOption?.set(YjsDatabaseKey.target_field_id, projectOpportunityFieldId);
+  rollupOption?.set(YjsDatabaseKey.calculation_type, CalculationType.Count);
+  rollupOption?.set(YjsDatabaseKey.show_as, showAs);
+
+  const rowDocs = new Map<string, YDoc>();
+
+  rowDocs.set(
+    opportunityRowIds[0],
+    createRowDoc(opportunityRowIds[0], opportunityDatabaseId, {
+      [opportunityNameFieldId]: createCell('OPP-001', FieldType.RichText),
+    })
+  );
+  rowDocs.set(
+    opportunityRowIds[1],
+    createRowDoc(opportunityRowIds[1], opportunityDatabaseId, {
+      [opportunityNameFieldId]: createCell('OPP-002', FieldType.RichText),
+    })
+  );
+  // Both projects point at the same opportunity, so UniqueList must collapse them.
+  rowDocs.set(
+    projectRowIds[0],
+    createRowDoc(projectRowIds[0], projectDatabaseId, {
+      [projectNameFieldId]: createCell('PRJ-001', FieldType.RichText),
+      [projectOpportunityFieldId]: createRelationCell([opportunityRowIds[0]]),
+    })
+  );
+  rowDocs.set(
+    projectRowIds[1],
+    createRowDoc(projectRowIds[1], projectDatabaseId, {
+      [projectNameFieldId]: createCell('PRJ-002', FieldType.RichText),
+      [projectOpportunityFieldId]: createRelationCell([opportunityRowIds[0]]),
+    })
+  );
+
+  const epicRowDoc = createRowDoc(epicRowId, epicDatabaseId, {
+    [epicNameFieldId]: createCell('EPC-001', FieldType.RichText),
+    [epicProjectFieldId]: createRelationCell(projectRowIds),
+  });
+  const epicRow = epicRowDoc.getMap(YjsEditorKey.data_section).get(YjsEditorKey.database_row) as YDatabaseRow;
+
+  const docsByView: Record<string, YDoc> = {
+    [opportunityViewId]: opportunityDoc,
+    [projectViewId]: projectDoc,
+    [epicViewId]: epicDoc,
+  };
+  const viewIdByDatabaseId: Record<string, string> = {
+    [opportunityDatabaseId]: opportunityViewId,
+    [projectDatabaseId]: projectViewId,
+    [epicDatabaseId]: epicViewId,
+  };
+
+  return {
+    context: {
+      baseDoc: epicDoc,
+      database: epicDatabase,
+      rollupField: epicDatabase.get(YjsDatabaseKey.fields)?.get(rollupFieldId) as YDatabaseField,
+      row: epicRow,
+      rowId: epicRowId,
+      fieldId: rollupFieldId,
+      loadView: async (viewId: string) => docsByView[viewId] ?? null,
+      createRow: async (rowKey: string) => {
+        const rowId = rowKey.includes('_rows_') ? (rowKey.split('_rows_').pop() ?? '') : rowKey;
+
+        return rowDocs.get(rowId) as YDoc;
+      },
+      getViewIdFromDatabaseId: async (databaseId: string) => viewIdByDatabaseId[databaseId] ?? null,
+    },
+    opportunityRowIds,
+  };
+}
+
+describe('rollup over a Relation target field', () => {
+  it('resolves the second hop to related row names instead of raw row ids', async () => {
+    const { context, opportunityRowIds } = createChainFixture('original-list', RollupDisplayMode.OriginalList);
+
+    const result = await readRollupCell(context);
+
+    expect(result.list).toEqual(['OPP-001', 'OPP-001']);
+    expect(result.value).toBe('OPP-001, OPP-001');
+    opportunityRowIds.forEach((rowId) => {
+      expect(result.value).not.toContain(rowId);
+    });
+  });
+
+  it('deduplicates resolved names for UniqueList', async () => {
+    const { context } = createChainFixture('unique-list', RollupDisplayMode.UniqueList);
+
+    const result = await readRollupCell(context);
+
+    expect(result.list).toEqual(['OPP-001']);
+    expect(result.value).toBe('OPP-001');
+  });
+
+  it('counts related rows whose Relation target resolves to a name', async () => {
+    const { context } = createChainFixture('calculated', RollupDisplayMode.Calculated);
+    const countingContext = { ...context };
+
+    (
+      countingContext.rollupField.get(YjsDatabaseKey.type_option)?.get(String(FieldType.Rollup)) as
+        | { set: (key: string, value: unknown) => void }
+        | undefined
+    )?.set(YjsDatabaseKey.calculation_type, CalculationType.CountNonEmpty);
+
+    const result = await readRollupCell(countingContext);
+
+    expect(result.value).toBe('2');
+  });
+});

--- a/src/application/database-yjs/rollup/cache.ts
+++ b/src/application/database-yjs/rollup/cache.ts
@@ -13,6 +13,7 @@ import { getRowKey } from '@/application/database-yjs/row_meta';
 import {
   RowId,
   YDatabase,
+  YDatabaseCell,
   YDatabaseField,
   YDatabaseFields,
   YDatabaseRow,
@@ -188,6 +189,90 @@ function isEmptyValue(value: string) {
   return value.trim() === '';
 }
 
+function getPrimaryFieldId(database: YDatabase): string | undefined {
+  const fields = database?.get(YjsDatabaseKey.fields);
+
+  return Array.from(fields?.keys() || []).find((fieldId) => fields?.get(fieldId)?.get(YjsDatabaseKey.is_primary));
+}
+
+/**
+ * A Rollup whose target is itself a Relation yields row ids, not text. Resolving
+ * them needs a second hop into the database that Relation points at, mirroring
+ * how a Relation cell renders its own value.
+ */
+type RelationTargetResolver = {
+  doc: YDoc;
+  primaryFieldId: string;
+  primaryField: YDatabaseField;
+};
+
+async function createRelationTargetResolver(
+  targetField: YDatabaseField,
+  context: RollupComputeContext
+): Promise<RelationTargetResolver | null> {
+  const targetRelationOption = parseRelationTypeOption(targetField);
+
+  if (!targetRelationOption?.database_id) return null;
+
+  const viewId = await context.getViewIdFromDatabaseId?.(targetRelationOption.database_id);
+
+  if (!viewId) return null;
+
+  const doc = await loadRelatedDoc(viewId, context.loadView);
+
+  if (!doc) return null;
+
+  const database = doc.getMap(YjsEditorKey.data_section)?.get(YjsEditorKey.database) as YDatabase | undefined;
+
+  if (!database) return null;
+
+  const primaryFieldId = getPrimaryFieldId(database);
+
+  if (!primaryFieldId) return null;
+
+  const primaryField = (database.get(YjsDatabaseKey.fields) as YDatabaseFields | undefined)?.get(primaryFieldId);
+
+  if (!primaryField) return null;
+
+  return { doc, primaryFieldId, primaryField };
+}
+
+/**
+ * Row ids that no longer resolve are dropped rather than shown raw, matching how
+ * a Relation cell renders and keeping row ids out of the UI.
+ */
+async function resolveRelationTargetText(
+  cell: YDatabaseCell,
+  resolver: RelationTargetResolver,
+  context: RollupComputeContext
+): Promise<string> {
+  const nestedRowIds = getRelationRowIdsFromCell(cell);
+
+  if (nestedRowIds.length === 0) return '';
+
+  const names: string[] = [];
+
+  for (const nestedRowId of nestedRowIds) {
+    if (!context.createRow) continue;
+    const nestedRowDoc = await context.createRow(getRowKey(resolver.doc.guid, nestedRowId));
+    const nestedRow = nestedRowDoc?.getMap(YjsEditorKey.data_section)?.get(YjsEditorKey.database_row) as
+      | YDatabaseRow
+      | undefined;
+
+    if (!nestedRow) continue;
+    const primaryCell = nestedRow.get(YjsDatabaseKey.cells)?.get(resolver.primaryFieldId);
+
+    if (!primaryCell) continue;
+    const name = decodeCellToText(primaryCell, resolver.primaryField);
+
+    if (!isEmptyValue(name)) {
+      names.push(name);
+    }
+  }
+
+  return names.join(', ');
+}
+
 function parseNumber(value: unknown): number | null {
   if (typeof value === 'number') {
     return Number.isFinite(value) ? value : null;
@@ -359,6 +444,8 @@ async function computeRollupCellValue(context: RollupComputeContext): Promise<Ro
   if (!relatedDatabase || !targetField) return { value: '' };
 
   const targetFieldType = Number(targetField.get(YjsDatabaseKey.type)) as FieldType;
+  const relationTargetResolver =
+    targetFieldType === FieldType.Relation ? await createRelationTargetResolver(targetField, context) : null;
   const values: string[] = [];
   const numericValues: number[] = [];
   const timestampValues: number[] = [];
@@ -393,6 +480,8 @@ async function computeRollupCellValue(context: RollupComputeContext): Promise<Ro
         text = formatDateValue(targetField, ts);
         timestampValues.push(ts);
       }
+    } else if (cell && targetFieldType === FieldType.Relation) {
+      text = relationTargetResolver ? await resolveRelationTargetText(cell, relationTargetResolver, context) : '';
     } else if (cell) {
       text = decodeCellToText(cell, targetField);
       if (targetFieldType === FieldType.DateTime) {


### PR DESCRIPTION
## Problem

A Rollup column whose **target field is itself a Relation** rendered raw row UUIDs instead of the related row's name.

Reported after importing a workspace, but the import is not at fault: the same imported workspace renders correctly in the desktop app, whose `rollup_engine.rs` already resolves this second hop. Verifying the restored collabs against the source archive (ID mapping applied) showed fields, rows, cells, relation references and row orders all matched exactly, and the full rollup chain resolved to the right names server-side.

In the reporter's workspace both broken columns are two-hop rollups; every column that rendered correctly is one hop:

| Column | Rollup walks | into | reads target | which is |
|---|---|---|---|---|
| `04_tasks.Project` | `Related Epics` | `03_epics` | `Related Proj` | Relation → `02_projects` |
| `03_epics.Opportunity` | `Related Proj` | `02_projects` | `Primary Opp` | Relation → `01_opportunities` |

## Cause

`computeRollupCellValue` called `decodeCellToText(cell, targetField)` for every target type. For a Relation field that returns the raw row ids:

```ts
case FieldType.Relation:
  return getRelationRowIdsFromCell(cell).join(',');
```

so the rolled-up value was a row id string, which the cell then displayed verbatim.

## Fix

Resolve the second hop the way a Relation cell already does — read the target Relation's `database_id`, load that database via the existing `getViewIdFromDatabaseId` + `loadRelatedDoc` cache, find its primary field, and map each nested row id to its primary-field text.

- The resolver is built **once per cell computation**, not per related row, so the extra database load is shared across all rows in the cell.
- Row ids that no longer resolve are **dropped rather than shown raw**, matching how one-hop Relation cells render. A stale id can no longer leak a UUID into the grid.
- `decode.ts` is deliberately untouched: it is synchronous and shared with sorting and filters, while this resolution is inherently async. The change is scoped to the rollup cache.

## Tests

New `src/application/database-yjs/__tests__/rollup-relation-target.test.ts` builds the reported three-database chain (epics → projects → opportunities, with two projects sharing one opportunity) and covers `OriginalList`, `UniqueList` dedupe, and `CountNonEmpty`.

Before the change it failed with `["opp-row-1-…", "opp-row-1-…"]`; it now returns `["OPP-001"]`.

- `npx jest src/application/database-yjs` — 852/852 pass (54 suites)
- `npx tsc -p tsconfig.web.json --noEmit` — clean
- `npx eslint` on the changed files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Resolve rollup cells that target Relation fields to show related row names instead of raw row IDs.

Bug Fixes:
- Fix rollup over Relation target fields so they resolve through the related database and render primary field text rather than UUIDs.

Enhancements:
- Add async resolution logic and primary-field lookup for relation-backed rollups, sharing a single resolver per cell computation.

Tests:
- Add rollup-relation-target test coverage for two-hop rollups, including OriginalList, UniqueList deduplication, and CountNonEmpty calculations.