### PR TITLE
feat(database): support relation and person grouping

### DIFF
--- a/playwright/e2e/database/database-identifier-grouping.spec.ts
+++ b/playwright/e2e/database/database-identifier-grouping.spec.ts
@@ -1,35 +1,39 @@
 /**
  * Relation and Person grouping coverage for multi-value identifier fields.
  *
- * Both scenarios create isolated databases. The Person fixture uses the real
- * member IDs in Nathan's seeded workspace and deletes its temporary database;
- * the Relation fixture runs in a fresh test account. Number grouping remains
- * covered by database-grid-grouping.spec.ts.
+ * Both scenarios use Nathan's seeded workspaces without changing a shared
+ * database view. Relation grouping creates and deletes a temporary view of the
+ * seeded 03_epics database. Person grouping creates and deletes a temporary
+ * database populated with the real workspace member IDs. Number grouping
+ * remains covered by database-grid-grouping.spec.ts.
  */
 import { expect, test } from '@playwright/test';
 import type { APIRequestContext, Locator, Page } from '@playwright/test';
 
-import { signInAndWaitForApp, signInWithPasswordViaUi } from '../../support/auth-flow-helpers';
+import { signInWithPasswordViaUi } from '../../support/auth-flow-helpers';
 import { waitForGridReady } from '../../support/database-ui-helpers';
-import { deletePageByExactText } from '../../support/duplicate-test-helpers';
+import { openPageByExactText } from '../../support/duplicate-test-helpers';
 import { addFieldWithType, setupFieldTypeTest } from '../../support/field-type-helpers';
+import { createNamedGridDatabase } from '../../support/relation-test-helpers';
 import {
-  createNamedGridDatabase,
-  createOneWayRelationField,
-  setRelationCellDirect,
-} from '../../support/relation-test-helpers';
-import { FieldType, WorkspaceSelectors } from '../../support/selectors';
-import { generateRandomEmail, setupPageErrorHandling, TestConfig } from '../../support/test-config';
+  DatabaseViewSelectors,
+  FieldType,
+  HeaderSelectors,
+  ModalSelectors,
+  ViewActionSelectors,
+  WorkspaceSelectors,
+} from '../../support/selectors';
+import { expandSpaceByName } from '../../support/page/flows';
+import { setupPageErrorHandling, TestConfig } from '../../support/test-config';
 
 const SEEDED_USER_EMAIL = process.env.SEEDED_USER_EMAIL || 'nathan@appflowy.io';
 const SEEDED_USER_PASSWORD = process.env.SEEDED_USER_PASSWORD || 'AppFlowy!@123';
 const PERSON_WORKSPACE_NAME = 'nathan workspace';
+const RELATION_WORKSPACE_NAME = 'project_templates';
+const RELATION_SPACE_NAME = 'Project Management';
+const RELATION_DATABASE_NAME = '03_epics';
 
 const gridGroupHeaders = (page: Page) => page.locator('[data-testid^="grid-group-header-"]');
-const groupHeaderByLabel = (page: Page, label: string) =>
-  gridGroupHeaders(page).filter({
-    has: page.getByText(label, { exact: true }),
-  });
 
 async function openGridGroupSettings(page: Page) {
   await page.getByTestId('database-actions-settings').click();
@@ -58,6 +62,158 @@ async function expectRowInExactlyTheseGroups(row: Locator, expectedGroupIds: str
   );
 
   expect([...actualGroupIds].sort()).toEqual([...expectedGroupIds].sort());
+}
+
+type ExpectedGridGroupDisplay = {
+  groupId: string;
+  label: string;
+  rows: Array<{ rowId: string; title: string }>;
+};
+
+async function expectFinalGroupedGridDisplay(
+  page: Page,
+  expectedGroups: ExpectedGridGroupDisplay[],
+  options: { exactGroups?: boolean } = {}
+) {
+  const exactGroups = options.exactGroups ?? true;
+
+  if (exactGroups) {
+    await expect(gridGroupHeaders(page)).toHaveCount(expectedGroups.length);
+    await expect
+      .poll(() =>
+        gridGroupHeaders(page).evaluateAll((headers) =>
+          headers.map((header) => header.getAttribute('data-group-id') || '').sort()
+        )
+      )
+      .toEqual(expectedGroups.map(({ groupId }) => groupId).sort());
+  }
+
+  const expectedRowKeys: string[] = [];
+
+  for (const group of expectedGroups) {
+    const header = page.getByTestId(`grid-group-header-${group.groupId}`);
+
+    await expect(header).toBeVisible();
+    await expect(header.getByText(group.label, { exact: true })).toBeVisible();
+    await expect(header.getByTestId('grid-group-row-count')).toHaveText(String(group.rows.length));
+
+    for (const row of group.rows) {
+      const rowKey = `group:${group.groupId}:row:${row.rowId}`;
+      const renderedRow = page.locator(`[data-testid="grid-row-${row.rowId}"][data-row-key="${rowKey}"]`);
+
+      expectedRowKeys.push(rowKey);
+      await expect(renderedRow).toHaveCount(1);
+      await expect(renderedRow).toContainText(row.title);
+    }
+  }
+
+  if (exactGroups) {
+    await expect
+      .poll(() =>
+        page
+          .locator('[data-testid^="grid-row-"][data-row-key^="group:"][data-row-key*=":row:"]')
+          .evaluateAll((rows) => rows.map((row) => row.getAttribute('data-row-key') || '').sort())
+      )
+      .toEqual(expectedRowKeys.sort());
+  }
+}
+
+async function createTemporaryGridView(page: Page) {
+  const existingViewIds = await DatabaseViewSelectors.viewTab(page).evaluateAll((tabs) =>
+    tabs.map((tab) => tab.getAttribute('data-testid') || '')
+  );
+
+  await DatabaseViewSelectors.addViewButton(page).click({ force: true });
+  await DatabaseViewSelectors.viewTypeOption(page, 'Grid').click({ force: true });
+  await expect(DatabaseViewSelectors.viewTab(page)).toHaveCount(existingViewIds.length + 1, { timeout: 20000 });
+
+  const activeTab = DatabaseViewSelectors.activeViewTab(page);
+
+  await expect(activeTab).toBeVisible({ timeout: 20000 });
+  const testId = await activeTab.getAttribute('data-testid');
+  const viewId = testId?.replace('view-tab-', '') || '';
+
+  if (!viewId || existingViewIds.includes(`view-tab-${viewId}`)) {
+    throw new Error(`Expected a newly created active Grid view, received ${String(testId)}`);
+  }
+
+  await waitForGridReady(page);
+  return viewId;
+}
+
+async function deleteDatabaseView(page: Page, viewId: string) {
+  const tab = DatabaseViewSelectors.viewTab(page, viewId);
+
+  if ((await tab.count()) === 0) return;
+
+  await tab.click({ button: 'right', force: true });
+  await expect(DatabaseViewSelectors.tabActionDelete(page)).toBeVisible({ timeout: 10000 });
+  await DatabaseViewSelectors.tabActionDelete(page).click({ force: true });
+  await expect(DatabaseViewSelectors.deleteViewConfirmButton(page)).toBeVisible({ timeout: 10000 });
+  await DatabaseViewSelectors.deleteViewConfirmButton(page).click({ force: true });
+  await expect(tab).toHaveCount(0, { timeout: 20000 });
+}
+
+async function deleteCurrentPage(page: Page, pageName: string) {
+  await HeaderSelectors.moreActionsButton(page).click({ force: true });
+  await expect(ViewActionSelectors.deleteButton(page)).toBeVisible({ timeout: 10000 });
+  await ViewActionSelectors.deleteButton(page).click({ force: true });
+
+  const confirmButton = ModalSelectors.confirmDeleteButton(page);
+
+  if (await confirmButton.isVisible().catch(() => false)) {
+    await confirmButton.click({ force: true });
+  }
+
+  await expect(page.getByTestId('page-title-input').filter({ hasText: pageName })).toHaveCount(0, { timeout: 30000 });
+}
+
+async function gridRowIdByTitle(page: Page, title: string) {
+  const row = page.locator('[data-testid^="grid-row-"]').filter({ hasText: title }).first();
+
+  await expect(row).toBeVisible({ timeout: 20000 });
+  const testId = await row.getAttribute('data-testid');
+  const rowId = testId?.replace('grid-row-', '') || '';
+
+  if (!rowId) throw new Error(`Could not resolve the row ID for ${title}`);
+  return rowId;
+}
+
+async function databaseFieldIdByName(page: Page, fieldName: string) {
+  let fieldId = '';
+
+  await expect
+    .poll(
+      async () => {
+        fieldId = await page.evaluate((expectedName) => {
+          const database = (window as any).__TEST_DATABASE_CONTEXT__?.databaseDoc?.getMap('data').get('database');
+          const fields = database?.get('fields');
+          let match = '';
+
+          fields?.forEach((field: any, id: string) => {
+            if (field.get('name') === expectedName) match = id;
+          });
+          return match;
+        }, fieldName);
+        return fieldId;
+      },
+      { timeout: 20000, message: `Waiting for the ${fieldName} database field` }
+    )
+    .not.toBe('');
+
+  return fieldId;
+}
+
+async function groupIdByLabel(page: Page, label: string) {
+  const header = gridGroupHeaders(page)
+    .filter({ has: page.getByText(label, { exact: true }) })
+    .first();
+
+  await expect(header).toBeVisible({ timeout: 20000 });
+  const groupId = (await header.getAttribute('data-group-id')) || '';
+
+  if (!groupId) throw new Error(`Could not resolve the group ID for ${label}`);
+  return groupId;
 }
 
 async function switchWorkspace(page: Page, workspaceName: string) {
@@ -185,31 +341,45 @@ test.describe('Database identifier grouping', () => {
     await page.setViewportSize({ width: 1440, height: 900 });
   });
 
-  test('groups one source row into exactly three Relation groups using related row titles', async ({
-    page,
-    request,
-  }) => {
-    await signInAndWaitForApp(page, request, generateRandomEmail());
+  test('groups EPC-001 into its three rendered Relation groups in an isolated 03_epics view', async ({ page }) => {
+    await signInWithPasswordViaUi(page, SEEDED_USER_EMAIL, SEEDED_USER_PASSWORD);
+    await switchWorkspace(page, RELATION_WORKSPACE_NAME);
+    await expandSpaceByName(page, RELATION_SPACE_NAME);
+    await openPageByExactText(page, RELATION_DATABASE_NAME);
 
-    const runId = `${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
-    const target = await createNamedGridDatabase(page, `Relation targets ${runId}`, ['TSK-001', 'TSK-002', 'TSK-003']);
-    const source = await createNamedGridDatabase(page, `Relation sources ${runId}`, ['EPC-001', 'EPC-002', 'EPC-003']);
-    const relationFieldId = await createOneWayRelationField(page, {
-      fieldName: 'Tasks',
-      relatedDatabaseId: target.databaseId,
-    });
+    let temporaryViewId = '';
 
-    await setRelationCellDirect(page, relationFieldId, 0, target.rowIds.slice(0, 3));
-    await groupGridByField(page, relationFieldId);
+    try {
+      temporaryViewId = await createTemporaryGridView(page);
+      const relationFieldId = await databaseFieldIdByName(page, 'Tasks');
 
-    for (const title of ['TSK-001', 'TSK-002', 'TSK-003']) {
-      await expect(groupHeaderByLabel(page, title)).toBeVisible({ timeout: 30000 });
+      if (!relationFieldId) throw new Error('The seeded 03_epics database must contain the Tasks relation field');
+
+      const epicRowId = await gridRowIdByTitle(page, 'EPC-001');
+
+      await groupGridByField(page, relationFieldId);
+
+      const taskGroups = await Promise.all(
+        ['TSK-001', 'TSK-002', 'TSK-003'].map(async (label) => ({ label, groupId: await groupIdByLabel(page, label) }))
+      );
+
+      await expectRowInExactlyTheseGroups(
+        page.getByTestId(`grid-row-${epicRowId}`),
+        taskGroups.map(({ groupId }) => groupId)
+      );
+      await expectFinalGroupedGridDisplay(
+        page,
+        taskGroups.map(({ groupId, label }) => ({
+          groupId,
+          label,
+          rows: [{ rowId: epicRowId, title: 'EPC-001' }],
+        })),
+        { exactGroups: false }
+      );
+    } finally {
+      await page.keyboard.press('Escape').catch(() => undefined);
+      if (temporaryViewId) await deleteDatabaseView(page, temporaryViewId);
     }
-
-    await expectRowInExactlyTheseGroups(page.getByTestId(`grid-row-${source.rowIds[0]}`), target.rowIds.slice(0, 3));
-    await expect(
-      page.getByTestId(`grid-group-header-${relationFieldId}`).getByTestId('grid-group-row-count')
-    ).toHaveText('2');
   });
 
   test('groups rows by the real Annie and Eva members in a temporary Person grid', async ({ page, request }) => {
@@ -249,20 +419,36 @@ test.describe('Database identifier grouping', () => {
 
       await groupGridByField(page, personFieldId);
 
-      await expect(groupHeaderByLabel(page, annieLabel)).toBeVisible({ timeout: 30000 });
-      await expect(groupHeaderByLabel(page, evaLabel)).toBeVisible({ timeout: 30000 });
       await expectRowInExactlyTheseGroups(page.getByTestId(`grid-row-${database.rowIds[0]}`), [
         annie.person_id,
         eva.person_id,
       ]);
       await expectRowInExactlyTheseGroups(page.getByTestId(`grid-row-${database.rowIds[1]}`), [annie.person_id]);
-      await expect(
-        page.getByTestId(`grid-group-header-${personFieldId}`).getByTestId('grid-group-row-count')
-      ).toHaveText('1');
+      await expectRowInExactlyTheseGroups(page.getByTestId(`grid-row-${database.rowIds[2]}`), [personFieldId]);
+      await expectFinalGroupedGridDisplay(page, [
+        {
+          groupId: annie.person_id,
+          label: annieLabel,
+          rows: [
+            { rowId: database.rowIds[0], title: 'Shared task' },
+            { rowId: database.rowIds[1], title: 'Annie task' },
+          ],
+        },
+        {
+          groupId: eva.person_id,
+          label: evaLabel,
+          rows: [{ rowId: database.rowIds[0], title: 'Shared task' }],
+        },
+        {
+          groupId: personFieldId,
+          label: 'No Assignee',
+          rows: [{ rowId: database.rowIds[2], title: 'Unassigned task' }],
+        },
+      ]);
     } finally {
       await page.keyboard.press('Escape').catch(() => undefined);
       await waitForGridReady(page).catch(() => undefined);
-      if (databaseCreated) await deletePageByExactText(page, databaseName);
+      if (databaseCreated) await deleteCurrentPage(page, databaseName);
     }
   });
 });

--- a/playwright/e2e/database/database-identifier-grouping.spec.ts
+++ b/playwright/e2e/database/database-identifier-grouping.spec.ts
@@ -1,0 +1,268 @@
+/**
+ * Relation and Person grouping coverage for multi-value identifier fields.
+ *
+ * Both scenarios create isolated databases. The Person fixture uses the real
+ * member IDs in Nathan's seeded workspace and deletes its temporary database;
+ * the Relation fixture runs in a fresh test account. Number grouping remains
+ * covered by database-grid-grouping.spec.ts.
+ */
+import { expect, test } from '@playwright/test';
+import type { APIRequestContext, Locator, Page } from '@playwright/test';
+
+import { signInAndWaitForApp, signInWithPasswordViaUi } from '../../support/auth-flow-helpers';
+import { waitForGridReady } from '../../support/database-ui-helpers';
+import { deletePageByExactText } from '../../support/duplicate-test-helpers';
+import { addFieldWithType, setupFieldTypeTest } from '../../support/field-type-helpers';
+import {
+  createNamedGridDatabase,
+  createOneWayRelationField,
+  setRelationCellDirect,
+} from '../../support/relation-test-helpers';
+import { FieldType, WorkspaceSelectors } from '../../support/selectors';
+import { generateRandomEmail, setupPageErrorHandling, TestConfig } from '../../support/test-config';
+
+const SEEDED_USER_EMAIL = process.env.SEEDED_USER_EMAIL || 'nathan@appflowy.io';
+const SEEDED_USER_PASSWORD = process.env.SEEDED_USER_PASSWORD || 'AppFlowy!@123';
+const PERSON_WORKSPACE_NAME = 'nathan workspace';
+
+const gridGroupHeaders = (page: Page) => page.locator('[data-testid^="grid-group-header-"]');
+const groupHeaderByLabel = (page: Page, label: string) =>
+  gridGroupHeaders(page).filter({
+    has: page.getByText(label, { exact: true }),
+  });
+
+async function openGridGroupSettings(page: Page) {
+  await page.getByTestId('database-actions-settings').click();
+  await page.getByTestId('grid-group-settings-trigger').click();
+  await expect(page.getByTestId('grid-group-settings-menu')).toBeVisible();
+}
+
+async function groupGridByField(page: Page, fieldId: string) {
+  await openGridGroupSettings(page);
+  await page.getByTestId(`grid-group-by-field-${fieldId}`).click();
+  await page.keyboard.press('Escape');
+  await page.keyboard.press('Escape');
+  await expect(gridGroupHeaders(page).first()).toBeVisible({ timeout: 20000 });
+}
+
+async function expectRowInExactlyTheseGroups(row: Locator, expectedGroupIds: string[]) {
+  await expect(row).toHaveCount(expectedGroupIds.length);
+  const actualGroupIds = await row.evaluateAll((rows) =>
+    rows.map((element) => {
+      const key = element.getAttribute('data-row-key') || '';
+      const match = /^group:(.*):row:/.exec(key);
+
+      if (!match) throw new Error(`Grouped row has an invalid data-row-key: ${key}`);
+      return match[1];
+    })
+  );
+
+  expect([...actualGroupIds].sort()).toEqual([...expectedGroupIds].sort());
+}
+
+async function switchWorkspace(page: Page, workspaceName: string) {
+  const currentWorkspaceName = page.getByTestId('current-workspace-name');
+
+  if ((await currentWorkspaceName.textContent())?.trim() === workspaceName) return;
+
+  await WorkspaceSelectors.dropdownTrigger(page).click();
+  await expect(WorkspaceSelectors.dropdownContent(page)).toBeVisible({ timeout: 15000 });
+  await WorkspaceSelectors.item(page).filter({ hasText: workspaceName }).first().click();
+  await expect(currentWorkspaceName).toHaveText(workspaceName, { timeout: 30000 });
+}
+
+type MentionablePerson = {
+  person_id: string;
+  name?: string;
+  email?: string;
+  avatar_url?: string;
+};
+
+async function getAccessToken(page: Page) {
+  return page.evaluate(() => {
+    const raw = localStorage.getItem('token');
+
+    if (raw) {
+      try {
+        const parsed = JSON.parse(raw) as { access_token?: string };
+
+        if (parsed.access_token) return parsed.access_token;
+      } catch {
+        // Fall through to the test-only token mirror.
+      }
+    }
+
+    return localStorage.getItem('af_auth_token') || '';
+  });
+}
+
+async function getMentionablePeople(page: Page, request: APIRequestContext) {
+  const workspaceId = new URL(page.url()).pathname.split('/')[2];
+  const token = await getAccessToken(page);
+
+  if (!workspaceId || !token) throw new Error('Could not resolve the current workspace session');
+
+  const response = await request.get(`${TestConfig.apiUrl}/api/workspace/${workspaceId}/mentionable-person`, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+
+  if (!response.ok()) {
+    throw new Error(`Mentionable-person request failed with HTTP ${response.status()}`);
+  }
+
+  const body = (await response.json()) as { data?: { persons?: MentionablePerson[] } };
+
+  return body.data?.persons ?? [];
+}
+
+async function seedPersonGroupingCells(
+  page: Page,
+  fieldId: string,
+  rows: Array<{ rowId: string; people: MentionablePerson[] }>,
+  knownPeople: MentionablePerson[]
+) {
+  await page.evaluate(
+    async ({ fieldId, rows, knownPeople, personFieldType }) => {
+      const win = window as any;
+      const ctx = win.__TEST_DATABASE_CONTEXT__;
+      const Y = win.Y;
+      const database = ctx.databaseDoc.getMap('data').get('database');
+      const databaseId = database.get('id') || ctx.databaseDoc.guid;
+      const field = database.get('fields').get(fieldId);
+      const typeOptionMap = field.get('type_option');
+      let typeOption = typeOptionMap.get(String(personFieldType));
+
+      if (!typeOption) {
+        typeOption = new Y.Map();
+        typeOptionMap.set(String(personFieldType), typeOption);
+      }
+
+      field.set('name', 'Assignee');
+      typeOption.set(
+        'persons',
+        JSON.stringify(
+          knownPeople.map((person) => ({
+            id: person.person_id,
+            name: person.name || person.email || '',
+            avatar_url: person.avatar_url || '',
+          }))
+        )
+      );
+
+      for (const assignment of rows) {
+        let rowDoc = ctx.rowMap?.[assignment.rowId];
+
+        if (!rowDoc && ctx.ensureRow) rowDoc = await ctx.ensureRow(assignment.rowId);
+        if (!rowDoc) rowDoc = await ctx.createRow(`${databaseId}_rows_${assignment.rowId}`);
+
+        rowDoc.transact(() => {
+          const now = String(Math.floor(Date.now() / 1000));
+          const row = rowDoc.getMap('data').get('data');
+          const cells = row.get('cells');
+          let cell = cells.get(fieldId);
+
+          if (!cell) {
+            cell = new Y.Map();
+            cells.set(fieldId, cell);
+          }
+
+          cell.set('created_at', cell.get('created_at') || now);
+          cell.set('last_modified', now);
+          cell.set('field_type', personFieldType);
+          cell.set('data', JSON.stringify(assignment.people.map((person) => person.person_id)));
+          row.set('last_modified', now);
+        });
+      }
+    },
+    { fieldId, rows, knownPeople, personFieldType: FieldType.Person }
+  );
+}
+
+test.describe('Database identifier grouping', () => {
+  test.beforeEach(async ({ page }) => {
+    setupPageErrorHandling(page);
+    setupFieldTypeTest(page);
+    await page.setViewportSize({ width: 1440, height: 900 });
+  });
+
+  test('groups one source row into exactly three Relation groups using related row titles', async ({
+    page,
+    request,
+  }) => {
+    await signInAndWaitForApp(page, request, generateRandomEmail());
+
+    const runId = `${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+    const target = await createNamedGridDatabase(page, `Relation targets ${runId}`, ['TSK-001', 'TSK-002', 'TSK-003']);
+    const source = await createNamedGridDatabase(page, `Relation sources ${runId}`, ['EPC-001', 'EPC-002', 'EPC-003']);
+    const relationFieldId = await createOneWayRelationField(page, {
+      fieldName: 'Tasks',
+      relatedDatabaseId: target.databaseId,
+    });
+
+    await setRelationCellDirect(page, relationFieldId, 0, target.rowIds.slice(0, 3));
+    await groupGridByField(page, relationFieldId);
+
+    for (const title of ['TSK-001', 'TSK-002', 'TSK-003']) {
+      await expect(groupHeaderByLabel(page, title)).toBeVisible({ timeout: 30000 });
+    }
+
+    await expectRowInExactlyTheseGroups(page.getByTestId(`grid-row-${source.rowIds[0]}`), target.rowIds.slice(0, 3));
+    await expect(
+      page.getByTestId(`grid-group-header-${relationFieldId}`).getByTestId('grid-group-row-count')
+    ).toHaveText('2');
+  });
+
+  test('groups rows by the real Annie and Eva members in a temporary Person grid', async ({ page, request }) => {
+    await signInWithPasswordViaUi(page, SEEDED_USER_EMAIL, SEEDED_USER_PASSWORD);
+    await switchWorkspace(page, PERSON_WORKSPACE_NAME);
+
+    const databaseName = `__bdd_person_group_web__${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+    let databaseCreated = false;
+
+    try {
+      const database = await createNamedGridDatabase(page, databaseName, [
+        'Shared task',
+        'Annie task',
+        'Unassigned task',
+      ]);
+
+      databaseCreated = true;
+      const personFieldId = await addFieldWithType(page, FieldType.Person);
+      const people = await getMentionablePeople(page, request);
+      const annie = people.find((person) => person.email === 'annie@appflowy.io');
+      const eva = people.find((person) => person.email === 'eva@appflowy.io');
+
+      if (!annie || !eva) throw new Error('Nathan workspace must contain the Annie and Eva fixtures');
+
+      await seedPersonGroupingCells(
+        page,
+        personFieldId,
+        [
+          { rowId: database.rowIds[0], people: [annie, eva] },
+          { rowId: database.rowIds[1], people: [annie] },
+        ],
+        [annie, eva]
+      );
+
+      const annieLabel = annie.name?.trim() || annie.email || '';
+      const evaLabel = eva.name?.trim() || eva.email || '';
+
+      await groupGridByField(page, personFieldId);
+
+      await expect(groupHeaderByLabel(page, annieLabel)).toBeVisible({ timeout: 30000 });
+      await expect(groupHeaderByLabel(page, evaLabel)).toBeVisible({ timeout: 30000 });
+      await expectRowInExactlyTheseGroups(page.getByTestId(`grid-row-${database.rowIds[0]}`), [
+        annie.person_id,
+        eva.person_id,
+      ]);
+      await expectRowInExactlyTheseGroups(page.getByTestId(`grid-row-${database.rowIds[1]}`), [annie.person_id]);
+      await expect(
+        page.getByTestId(`grid-group-header-${personFieldId}`).getByTestId('grid-group-row-count')
+      ).toHaveText('1');
+    } finally {
+      await page.keyboard.press('Escape').catch(() => undefined);
+      await waitForGridReady(page).catch(() => undefined);
+      if (databaseCreated) await deletePageByExactText(page, databaseName);
+    }
+  });
+});

--- a/playwright/e2e/database/database-identifier-grouping.spec.ts
+++ b/playwright/e2e/database/database-identifier-grouping.spec.ts
@@ -1,37 +1,34 @@
 /**
  * Relation and Person grouping coverage for multi-value identifier fields.
  *
- * Both scenarios use Nathan's seeded workspaces without changing a shared
- * database view. Relation grouping creates and deletes a temporary view of the
- * seeded 03_epics database. Person grouping creates and deletes a temporary
- * database populated with the real workspace member IDs. Number grouping
- * remains covered by database-grid-grouping.spec.ts.
+ * Relation grouping uses an isolated account with temporary source and target
+ * databases. Person grouping uses Nathan's seeded workspace to populate a
+ * temporary database with real workspace member IDs. Number grouping remains
+ * covered by database-grid-grouping.spec.ts.
  */
 import { expect, test } from '@playwright/test';
 import type { APIRequestContext, Locator, Page } from '@playwright/test';
 
-import { signInWithPasswordViaUi } from '../../support/auth-flow-helpers';
+import { signInAndWaitForApp, signInWithPasswordViaUi } from '../../support/auth-flow-helpers';
 import { waitForGridReady } from '../../support/database-ui-helpers';
-import { openPageByExactText } from '../../support/duplicate-test-helpers';
 import { addFieldWithType, setupFieldTypeTest } from '../../support/field-type-helpers';
-import { createNamedGridDatabase } from '../../support/relation-test-helpers';
 import {
-  DatabaseViewSelectors,
+  createNamedGridDatabase,
+  createOneWayRelationField,
+  setRelationCellDirect,
+} from '../../support/relation-test-helpers';
+import {
   FieldType,
   HeaderSelectors,
   ModalSelectors,
   ViewActionSelectors,
   WorkspaceSelectors,
 } from '../../support/selectors';
-import { expandSpaceByName } from '../../support/page/flows';
-import { setupPageErrorHandling, TestConfig } from '../../support/test-config';
+import { generateRandomEmail, setupPageErrorHandling, TestConfig } from '../../support/test-config';
 
 const SEEDED_USER_EMAIL = process.env.SEEDED_USER_EMAIL || 'nathan@appflowy.io';
 const SEEDED_USER_PASSWORD = process.env.SEEDED_USER_PASSWORD || 'AppFlowy!@123';
 const PERSON_WORKSPACE_NAME = 'nathan workspace';
-const RELATION_WORKSPACE_NAME = 'project_templates';
-const RELATION_SPACE_NAME = 'Project Management';
-const RELATION_DATABASE_NAME = '03_epics';
 
 const gridGroupHeaders = (page: Page) => page.locator('[data-testid^="grid-group-header-"]');
 
@@ -118,42 +115,6 @@ async function expectFinalGroupedGridDisplay(
   }
 }
 
-async function createTemporaryGridView(page: Page) {
-  const existingViewIds = await DatabaseViewSelectors.viewTab(page).evaluateAll((tabs) =>
-    tabs.map((tab) => tab.getAttribute('data-testid') || '')
-  );
-
-  await DatabaseViewSelectors.addViewButton(page).click({ force: true });
-  await DatabaseViewSelectors.viewTypeOption(page, 'Grid').click({ force: true });
-  await expect(DatabaseViewSelectors.viewTab(page)).toHaveCount(existingViewIds.length + 1, { timeout: 20000 });
-
-  const activeTab = DatabaseViewSelectors.activeViewTab(page);
-
-  await expect(activeTab).toBeVisible({ timeout: 20000 });
-  const testId = await activeTab.getAttribute('data-testid');
-  const viewId = testId?.replace('view-tab-', '') || '';
-
-  if (!viewId || existingViewIds.includes(`view-tab-${viewId}`)) {
-    throw new Error(`Expected a newly created active Grid view, received ${String(testId)}`);
-  }
-
-  await waitForGridReady(page);
-  return viewId;
-}
-
-async function deleteDatabaseView(page: Page, viewId: string) {
-  const tab = DatabaseViewSelectors.viewTab(page, viewId);
-
-  if ((await tab.count()) === 0) return;
-
-  await tab.click({ button: 'right', force: true });
-  await expect(DatabaseViewSelectors.tabActionDelete(page)).toBeVisible({ timeout: 10000 });
-  await DatabaseViewSelectors.tabActionDelete(page).click({ force: true });
-  await expect(DatabaseViewSelectors.deleteViewConfirmButton(page)).toBeVisible({ timeout: 10000 });
-  await DatabaseViewSelectors.deleteViewConfirmButton(page).click({ force: true });
-  await expect(tab).toHaveCount(0, { timeout: 20000 });
-}
-
 async function deleteCurrentPage(page: Page, pageName: string) {
   await HeaderSelectors.moreActionsButton(page).click({ force: true });
   await expect(ViewActionSelectors.deleteButton(page)).toBeVisible({ timeout: 10000 });
@@ -166,54 +127,6 @@ async function deleteCurrentPage(page: Page, pageName: string) {
   }
 
   await expect(page.getByTestId('page-title-input').filter({ hasText: pageName })).toHaveCount(0, { timeout: 30000 });
-}
-
-async function gridRowIdByTitle(page: Page, title: string) {
-  const row = page.locator('[data-testid^="grid-row-"]').filter({ hasText: title }).first();
-
-  await expect(row).toBeVisible({ timeout: 20000 });
-  const testId = await row.getAttribute('data-testid');
-  const rowId = testId?.replace('grid-row-', '') || '';
-
-  if (!rowId) throw new Error(`Could not resolve the row ID for ${title}`);
-  return rowId;
-}
-
-async function databaseFieldIdByName(page: Page, fieldName: string) {
-  let fieldId = '';
-
-  await expect
-    .poll(
-      async () => {
-        fieldId = await page.evaluate((expectedName) => {
-          const database = (window as any).__TEST_DATABASE_CONTEXT__?.databaseDoc?.getMap('data').get('database');
-          const fields = database?.get('fields');
-          let match = '';
-
-          fields?.forEach((field: any, id: string) => {
-            if (field.get('name') === expectedName) match = id;
-          });
-          return match;
-        }, fieldName);
-        return fieldId;
-      },
-      { timeout: 20000, message: `Waiting for the ${fieldName} database field` }
-    )
-    .not.toBe('');
-
-  return fieldId;
-}
-
-async function groupIdByLabel(page: Page, label: string) {
-  const header = gridGroupHeaders(page)
-    .filter({ has: page.getByText(label, { exact: true }) })
-    .first();
-
-  await expect(header).toBeVisible({ timeout: 20000 });
-  const groupId = (await header.getAttribute('data-group-id')) || '';
-
-  if (!groupId) throw new Error(`Could not resolve the group ID for ${label}`);
-  return groupId;
 }
 
 async function switchWorkspace(page: Page, workspaceName: string) {
@@ -341,45 +254,42 @@ test.describe('Database identifier grouping', () => {
     await page.setViewportSize({ width: 1440, height: 900 });
   });
 
-  test('groups EPC-001 into its three rendered Relation groups in an isolated 03_epics view', async ({ page }) => {
-    await signInWithPasswordViaUi(page, SEEDED_USER_EMAIL, SEEDED_USER_PASSWORD);
-    await switchWorkspace(page, RELATION_WORKSPACE_NAME);
-    await expandSpaceByName(page, RELATION_SPACE_NAME);
-    await openPageByExactText(page, RELATION_DATABASE_NAME);
+  test('groups EPC-001 into its three rendered Relation groups in isolated grids', async ({ page, request }) => {
+    const suffix = Date.now().toString(36);
 
-    let temporaryViewId = '';
+    await signInAndWaitForApp(page, request, generateRandomEmail());
+    const target = await createNamedGridDatabase(page, `relation-target-${suffix}`, ['TSK-001', 'TSK-002', 'TSK-003']);
+    const source = await createNamedGridDatabase(page, `relation-source-${suffix}`, ['EPC-001']);
+    const relationFieldId = await createOneWayRelationField(page, {
+      fieldName: 'Tasks',
+      relatedDatabaseId: target.databaseId,
+    });
+    const taskGroups = target.rowIds.slice(0, 3).map((groupId, index) => ({
+      groupId,
+      label: `TSK-00${index + 1}`,
+    }));
 
-    try {
-      temporaryViewId = await createTemporaryGridView(page);
-      const relationFieldId = await databaseFieldIdByName(page, 'Tasks');
+    await setRelationCellDirect(
+      page,
+      relationFieldId,
+      0,
+      taskGroups.map(({ groupId }) => groupId)
+    );
+    await groupGridByField(page, relationFieldId);
 
-      if (!relationFieldId) throw new Error('The seeded 03_epics database must contain the Tasks relation field');
-
-      const epicRowId = await gridRowIdByTitle(page, 'EPC-001');
-
-      await groupGridByField(page, relationFieldId);
-
-      const taskGroups = await Promise.all(
-        ['TSK-001', 'TSK-002', 'TSK-003'].map(async (label) => ({ label, groupId: await groupIdByLabel(page, label) }))
-      );
-
-      await expectRowInExactlyTheseGroups(
-        page.getByTestId(`grid-row-${epicRowId}`),
-        taskGroups.map(({ groupId }) => groupId)
-      );
-      await expectFinalGroupedGridDisplay(
-        page,
-        taskGroups.map(({ groupId, label }) => ({
-          groupId,
-          label,
-          rows: [{ rowId: epicRowId, title: 'EPC-001' }],
-        })),
-        { exactGroups: false }
-      );
-    } finally {
-      await page.keyboard.press('Escape').catch(() => undefined);
-      if (temporaryViewId) await deleteDatabaseView(page, temporaryViewId);
-    }
+    await expectRowInExactlyTheseGroups(
+      page.getByTestId(`grid-row-${source.rowIds[0]}`),
+      taskGroups.map(({ groupId }) => groupId)
+    );
+    await expectFinalGroupedGridDisplay(
+      page,
+      taskGroups.map(({ groupId, label }) => ({
+        groupId,
+        label,
+        rows: [{ rowId: source.rowIds[0], title: 'EPC-001' }],
+      })),
+      { exactGroups: false }
+    );
   });
 
   test('groups rows by the real Annie and Eva members in a temporary Person grid', async ({ page, request }) => {

--- a/src/application/database-yjs/__tests__/group.test.ts
+++ b/src/application/database-yjs/__tests__/group.test.ts
@@ -11,6 +11,7 @@ import {
   groupByCheckbox,
   groupByDate,
   groupByField,
+  groupByIdentifier,
   groupByNumber,
   groupBySelectOption,
   groupByText,
@@ -18,6 +19,8 @@ import {
   getGroupLabel,
   getNumberGroupId,
   isDatabaseGroupableFieldType,
+  isDynamicDatabaseGroupFieldType,
+  normalizeGroupIdentifiers,
 } from '@/application/database-yjs/group';
 import { DateGroupCondition, FieldType, FilterType } from '@/application/database-yjs/database.type';
 import { CheckboxFilterCondition, SelectOptionFilterCondition } from '@/application/database-yjs/fields';
@@ -32,7 +35,7 @@ import {
   YjsEditorKey,
 } from '@/application/types';
 
-import { createCell, createField, createRowDoc } from './test-helpers';
+import { createCell, createField, createFieldWithTypeOption, createRowDoc } from './test-helpers';
 
 function createFilter(fieldId: string, condition: number, content: string = ''): YDatabaseFilter {
   const doc = new Y.Doc();
@@ -194,16 +197,85 @@ describe('desktop-model lazy conversion grouping', () => {
     expect(result?.get('opt-a')?.map((row) => row.id)).toEqual(['row-a']);
     expect(result?.get(fieldId)).toEqual([]);
   });
+
+  it('does not treat a preserved text payload as person identifiers', () => {
+    const fieldId = 'converted-person';
+    const field = createField(fieldId, FieldType.Person);
+    const rows: Row[] = [{ id: 'row-a', height: 0 }];
+    const rowMetas: Record<RowId, YDoc> = {
+      'row-a': createRowDoc('row-a', databaseId, {
+        [fieldId]: createCell(FieldType.RichText, 'person-a,person-b'),
+      }),
+    };
+
+    const result = groupByIdentifier(rows, rowMetas, field);
+
+    expect([...result.keys()]).toEqual([fieldId]);
+    expect(result.get(fieldId)?.map((row) => row.id)).toEqual(['row-a']);
+  });
 });
 
 describe('group by field fallback', () => {
   it('returns undefined for unsupported field types', () => {
     const fields = new Y.Map() as YDatabaseFields;
-    const field = createField('relation-field', FieldType.Relation);
-    fields.set('relation-field', field);
+    const field = createField('media-field', FieldType.Media);
+    fields.set('media-field', field);
 
     const result = groupByField([], {}, field);
     expect(result).toBeUndefined();
+  });
+});
+
+describe.each([
+  ['Relation', FieldType.Relation],
+  ['Person', FieldType.Person],
+] as const)('%s identifier grouping', (_name, fieldType) => {
+  const fieldId = `${String(_name).toLowerCase()}-field`;
+  const field = createField(fieldId, fieldType);
+  const rows: Row[] = ['multi', 'single', 'empty', 'duplicate'].map((id) => ({ id, height: 0 }));
+  const value = (identifiers: string[]) => (fieldType === FieldType.Person ? JSON.stringify(identifiers) : identifiers);
+  const rowMetas: Record<RowId, YDoc> = {
+    multi: createRowDoc('multi', 'identifier-db', {
+      [fieldId]: createCell(fieldType, value([' id-a ', 'id-b'])),
+    }),
+    single: createRowDoc('single', 'identifier-db', {
+      [fieldId]: createCell(fieldType, value(['id-b'])),
+    }),
+    empty: createRowDoc('empty', 'identifier-db', {
+      [fieldId]: createCell(fieldType, value([])),
+    }),
+    duplicate: createRowDoc('duplicate', 'identifier-db', {
+      [fieldId]: createCell(fieldType, value(['id-a', 'id-a', ' ', 'id-c'])),
+    }),
+  };
+
+  it('places multi-value rows in every stable, normalized identifier group', () => {
+    const result = groupByIdentifier(rows, rowMetas, field);
+
+    expect([...result.keys()]).toEqual([fieldId, 'id-a', 'id-b', 'id-c']);
+    expect(result.get('id-a')?.map(({ id }) => id)).toEqual(['multi', 'duplicate']);
+    expect(result.get('id-b')?.map(({ id }) => id)).toEqual(['multi', 'single']);
+    expect(result.get('id-c')?.map(({ id }) => id)).toEqual(['duplicate']);
+    expect(result.get(fieldId)?.map(({ id }) => id)).toEqual(['empty']);
+  });
+
+  it('moves a row between concrete and default groups after a live cell edit', () => {
+    const row = rowMetas.single.getMap(YjsEditorKey.data_section).get(YjsEditorKey.database_row) as YDatabaseRow;
+    const cell = row.get(YjsDatabaseKey.cells).get(fieldId);
+
+    cell?.set(YjsDatabaseKey.data, value([]));
+    const result = groupByField(rows, rowMetas, field);
+
+    expect(result?.get('id-b')?.map(({ id }) => id)).toEqual(['multi']);
+    expect(result?.get(fieldId)?.map(({ id }) => id)).toEqual(['single', 'empty']);
+  });
+});
+
+describe('identifier normalization', () => {
+  it('accepts JSON, comma-delimited, and array values without duplicate identifiers', () => {
+    expect(normalizeGroupIdentifiers('[" a ","b","a",""]')).toEqual(['a', 'b']);
+    expect(normalizeGroupIdentifiers(' a, b, a, ')).toEqual(['a', 'b']);
+    expect(normalizeGroupIdentifiers(['a', ' a ', 'b'])).toEqual(['a', 'b']);
   });
 });
 
@@ -334,7 +406,7 @@ describe('desktop Grid dynamic grouping parity', () => {
     expect(result.get('A')?.map(({ id }) => id)).toEqual(['row-2', 'row-0']);
   });
 
-  it('supports exactly the seven desktop Grid grouping field types', () => {
+  it('supports exactly the nine desktop Grid grouping field types', () => {
     expect(
       [
         FieldType.RichText,
@@ -344,10 +416,14 @@ describe('desktop Grid dynamic grouping parity', () => {
         FieldType.SingleSelect,
         FieldType.MultiSelect,
         FieldType.DateTime,
+        FieldType.Relation,
+        FieldType.Person,
       ].every(isDatabaseGroupableFieldType)
     ).toBe(true);
-    expect(isDatabaseGroupableFieldType(FieldType.Relation)).toBe(false);
     expect(isDatabaseGroupableFieldType(FieldType.Media)).toBe(false);
+    expect(isDynamicDatabaseGroupFieldType(FieldType.Relation)).toBe(true);
+    expect(isDynamicDatabaseGroupFieldType(FieldType.Person)).toBe(true);
+    expect(isDynamicDatabaseGroupFieldType(FieldType.SingleSelect)).toBe(false);
   });
 
   it('uses desktop-compatible group labels and new-row values', () => {
@@ -358,6 +434,13 @@ describe('desktop Grid dynamic grouping parity', () => {
       disable_color: false,
       options: [{ id: 'todo', name: 'To do', color: 1 }],
     });
+    const personField = createField('assignee', FieldType.Person, {
+      persons: [{ id: 'person-a', name: 'Annie' }],
+    });
+    const splitPersonField = createFieldWithTypeOption('watchers', FieldType.Person, {
+      [YjsDatabaseKey.persons]: JSON.stringify([{ id: 'person-b', name: 'Eva' }]),
+    });
+    const relationField = createField('project', FieldType.Relation);
 
     expect(getGroupLabel('number_range_-100_0', numberField)).toBe('-100 to 0');
     expect(getGroupLabel('amount', numberField)).toBe('No Amount');
@@ -365,6 +448,15 @@ describe('desktop Grid dynamic grouping parity', () => {
     expect(getGroupCellData('number_range_200_300', numberField)).toBe('200');
     expect(getGroupCellData('status', selectField)).toBeUndefined();
     expect(getGroupCellData('2026/08/13', dateField)).toMatch(/^\d+$/);
+    expect(getGroupCellData('person-a', personField)).toBe('["person-a"]');
+    expect(getGroupCellData('row-a', relationField)).toBe('["row-a"]');
+    expect(getGroupLabel('person-a', personField)).toBe('Annie');
+    expect(getGroupLabel('person-b', splitPersonField)).toBe('Eva');
+    expect(getGroupLabel('person-missing', personField)).toBe('Unknown person');
+    expect(getGroupLabel('row-a', relationField, undefined, new Date(), new Map([['row-a', 'Project A']]))).toBe(
+      'Project A'
+    );
+    expect(getGroupLabel('row-missing', relationField)).toBe('Untitled relation');
   });
 
   it('calculates number group IDs at desktop range boundaries', () => {
@@ -442,6 +534,15 @@ describe('get group columns', () => {
     const field = createField('checkbox-field', FieldType.Checkbox);
     expect(getGroupColumns(field)).toEqual([{ id: 'Yes' }, { id: 'No' }]);
   });
+
+  it.each([FieldType.Relation, FieldType.Person])(
+    'starts identifier field type %s with only its default group',
+    (type) => {
+      const field = createField('identifier-field', type);
+
+      expect(getGroupColumns(field)).toEqual([{ id: 'identifier-field' }]);
+    }
+  );
 });
 
 describe('rows loading in a grouped board', () => {

--- a/src/application/database-yjs/__tests__/relation-rollup.test.ts
+++ b/src/application/database-yjs/__tests__/relation-rollup.test.ts
@@ -1,3 +1,5 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { useSyncExternalStore } from 'react';
 import * as Y from 'yjs';
 
 jest.mock('@/utils/runtime-config', () => ({
@@ -8,7 +10,12 @@ import { CalculationType, FieldType, RollupDisplayMode } from '@/application/dat
 import { parseRelationTypeOption } from '@/application/database-yjs/fields/relation/parse';
 import { createRelationField } from '@/application/database-yjs/fields/relation/utils';
 import { createRollupField } from '@/application/database-yjs/fields/rollup/utils';
-import { readRelationCellText, subscribeRelationCache } from '@/application/database-yjs/relation/cache';
+import {
+  getRelationCacheRevision,
+  readRelationCellText,
+  readRelationGroupLabel,
+  subscribeRelationCache,
+} from '@/application/database-yjs/relation/cache';
 import { readRollupCellSync, subscribeRollupCell } from '@/application/database-yjs/rollup/cache';
 import {
   YDatabase,
@@ -60,11 +67,7 @@ function createCell(data: unknown, fieldType: FieldType): YDatabaseCell {
   return cell;
 }
 
-function createRowDoc(
-  rowId: string,
-  databaseId: string,
-  cellMap: Record<string, YDatabaseCell>
-): YDoc {
+function createRowDoc(rowId: string, databaseId: string, cellMap: Record<string, YDatabaseCell>): YDoc {
   const doc = new Y.Doc() as YDoc;
   const sharedRoot = doc.getMap(YjsEditorKey.data_section);
   const row = new Y.Map() as YDatabaseRow;
@@ -143,9 +146,7 @@ function createFixture({
   const baseRowDoc = createRowDoc(baseRowId, baseDatabaseId, {
     [relationFieldId]: createCell(relationIds, FieldType.Relation),
   });
-  const baseRow = baseRowDoc
-    .getMap(YjsEditorKey.data_section)
-    .get(YjsEditorKey.database_row) as YDatabaseRow;
+  const baseRow = baseRowDoc.getMap(YjsEditorKey.data_section).get(YjsEditorKey.database_row) as YDatabaseRow;
 
   const createRow = async (rowKey: string) => {
     const rowId = rowKey.includes('_rows_') ? rowKey.split('_rows_').pop() ?? '' : rowKey;
@@ -155,25 +156,19 @@ function createFixture({
   const getViewIdFromDatabaseId = async (databaseId: string) =>
     databaseId === relatedDatabaseId ? relatedViewId : null;
 
-  const baseDatabase = baseDoc
-    .getMap(YjsEditorKey.data_section)
-    .get(YjsEditorKey.database) as YDatabase;
+  const baseDatabase = baseDoc.getMap(YjsEditorKey.data_section).get(YjsEditorKey.database) as YDatabase;
 
-  const integratedRelationField = baseDatabase
-    .get(YjsDatabaseKey.fields)
-    ?.get(relationFieldId) as YDatabaseField | undefined;
+  const integratedRelationField = baseDatabase.get(YjsDatabaseKey.fields)?.get(relationFieldId) as
+    | YDatabaseField
+    | undefined;
   const integratedRelationOption = integratedRelationField
     ?.get(YjsDatabaseKey.type_option)
     ?.get(String(FieldType.Relation));
   integratedRelationOption?.set(YjsDatabaseKey.database_id, relatedDatabaseId);
 
   rollups.forEach((rollupConfig) => {
-    const rollupField = baseDatabase
-      .get(YjsDatabaseKey.fields)
-      ?.get(rollupConfig.fieldId) as YDatabaseField | undefined;
-    const rollupOption = rollupField
-      ?.get(YjsDatabaseKey.type_option)
-      ?.get(String(FieldType.Rollup));
+    const rollupField = baseDatabase.get(YjsDatabaseKey.fields)?.get(rollupConfig.fieldId) as YDatabaseField | undefined;
+    const rollupOption = rollupField?.get(YjsDatabaseKey.type_option)?.get(String(FieldType.Rollup));
     rollupOption?.set(YjsDatabaseKey.relation_field_id, relationFieldId);
     rollupOption?.set(YjsDatabaseKey.target_field_id, rollupConfig.targetFieldId);
     rollupOption?.set(YjsDatabaseKey.calculation_type, rollupConfig.calculationType);
@@ -199,6 +194,159 @@ function createFixture({
 }
 
 describe('relation and rollup basics', () => {
+  it('observes a group-label resolution that emits between render and subscription', async () => {
+    const fixture = createFixture({ suffix: 'group-label-external-store' });
+    const context = {
+      relationField: fixture.relationField,
+      relatedRowId: fixture.relatedRowIds[0],
+      loadView: fixture.loadView,
+      createRow: fixture.createRow,
+      getViewIdFromDatabaseId: fixture.getViewIdFromDatabaseId,
+    };
+    const initialRevision = getRelationCacheRevision();
+    const { result } = renderHook(() => {
+      const revision = useSyncExternalStore(subscribeRelationCache, getRelationCacheRevision, getRelationCacheRevision);
+
+      return { label: readRelationGroupLabel(context), revision };
+    });
+
+    expect(result.current.label).toBe('');
+    await waitFor(() => expect(result.current.label).toBe('Alice'));
+    expect(result.current.revision).toBeGreaterThan(initialRevision);
+  });
+
+  it('resolves a relation group identifier to the related primary title', async () => {
+    const fixture = createFixture({ suffix: 'group-label' });
+    const context = {
+      relationField: fixture.relationField,
+      relatedRowId: fixture.relatedRowIds[0],
+      loadView: fixture.loadView,
+      createRow: fixture.createRow,
+      getViewIdFromDatabaseId: fixture.getViewIdFromDatabaseId,
+    };
+
+    const resultPromise = new Promise<string>((resolve) => {
+      const unsubscribe = subscribeRelationCache(() => {
+        const value = readRelationGroupLabel(context);
+
+        if (!value) return;
+        unsubscribe();
+        resolve(value);
+      });
+    });
+
+    expect(readRelationGroupLabel(context)).toBe('');
+    await expect(resultPromise).resolves.toBe('Alice');
+  });
+
+  it('refreshes a relation group label when the related primary cell changes', async () => {
+    const fixture = createFixture({ suffix: 'live-group-label' });
+    const relatedRowId = fixture.relatedRowIds[0];
+    const context = {
+      relationField: fixture.relationField,
+      relatedRowId,
+      loadView: fixture.loadView,
+      createRow: fixture.createRow,
+      getViewIdFromDatabaseId: fixture.getViewIdFromDatabaseId,
+    };
+    const initial = new Promise<string>((resolve) => {
+      const unsubscribe = subscribeRelationCache(() => {
+        const value = readRelationGroupLabel(context);
+
+        if (!value) return;
+        unsubscribe();
+        resolve(value);
+      });
+    });
+
+    readRelationGroupLabel(context);
+    await expect(initial).resolves.toBe('Alice');
+
+    const updated = new Promise<string>((resolve) => {
+      const unsubscribe = subscribeRelationCache(() => {
+        const value = readRelationGroupLabel(context);
+
+        if (value !== 'Alicia') return;
+        unsubscribe();
+        resolve(value);
+      });
+    });
+    const relatedRowDoc = await fixture.createRow(`${fixture.relatedViewId}_rows_${relatedRowId}`);
+    const relatedRow = relatedRowDoc?.getMap(YjsEditorKey.data_section).get(YjsEditorKey.database_row) as YDatabaseRow;
+
+    relatedRow.get(YjsDatabaseKey.cells).get(fixture.primaryFieldId)?.set(YjsDatabaseKey.data, 'Alicia');
+
+    await expect(updated).resolves.toBe('Alicia');
+  });
+
+  it('does not let stale in-flight label work overwrite a newer related title', async () => {
+    const fixture = createFixture({ suffix: 'group-label-race' });
+    const relatedRowId = fixture.relatedRowIds[0];
+    const canonicalRowDoc = await fixture.createRow(`${fixture.relatedViewId}_rows_${relatedRowId}`);
+    const staleRowDoc = createRowDoc(relatedRowId, fixture.relatedDatabaseId, {
+      [fixture.primaryFieldId]: createCell('Alice', FieldType.RichText),
+    });
+    let createRowCall = 0;
+    let releaseStaleLookup: ((rowDoc: YDoc) => void) | undefined;
+    let markStaleLookupStarted: (() => void) | undefined;
+    const staleLookupStarted = new Promise<void>((resolve) => {
+      markStaleLookupStarted = resolve;
+    });
+    const staleLookup = new Promise<YDoc>((resolve) => {
+      releaseStaleLookup = resolve;
+    });
+    const context = {
+      relationField: fixture.relationField,
+      relatedRowId,
+      loadView: fixture.loadView,
+      getViewIdFromDatabaseId: fixture.getViewIdFromDatabaseId,
+      createRow: async () => {
+        createRowCall += 1;
+
+        if (createRowCall === 2) {
+          markStaleLookupStarted?.();
+          return staleLookup;
+        }
+
+        return canonicalRowDoc as YDoc;
+      },
+    };
+    const waitForLabel = (expected: string) =>
+      new Promise<string>((resolve) => {
+        const unsubscribe = subscribeRelationCache(() => {
+          const value = readRelationGroupLabel(context);
+
+          if (value !== expected) return;
+          unsubscribe();
+          resolve(value);
+        });
+
+        readRelationGroupLabel(context);
+      });
+
+    await expect(waitForLabel('Alice')).resolves.toBe('Alice');
+
+    const canonicalPrimaryCell = canonicalRowDoc
+      ?.getMap(YjsEditorKey.data_section)
+      .get(YjsEditorKey.database_row)
+      ?.get(YjsDatabaseKey.cells)
+      .get(fixture.primaryFieldId);
+
+    canonicalPrimaryCell?.set(YjsDatabaseKey.data, 'Alicia');
+    readRelationGroupLabel(context);
+    await staleLookupStarted;
+
+    canonicalPrimaryCell?.set(YjsDatabaseKey.data, 'Beatrice');
+    const newestLabel = waitForLabel('Beatrice');
+
+    await expect(newestLabel).resolves.toBe('Beatrice');
+    releaseStaleLookup?.(staleRowDoc);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(readRelationGroupLabel(context)).toBe('Beatrice');
+  });
+
   it('resolves relation cell text from related primary field values', async () => {
     const fixture = createFixture({ suffix: 'relation' });
     const relationOption = parseRelationTypeOption(fixture.relationField);

--- a/src/application/database-yjs/__tests__/relation-rollup.test.ts
+++ b/src/application/database-yjs/__tests__/relation-rollup.test.ts
@@ -1,5 +1,5 @@
-import { renderHook, waitFor } from '@testing-library/react';
-import { useSyncExternalStore } from 'react';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { useEffect, useSyncExternalStore } from 'react';
 import * as Y from 'yjs';
 
 jest.mock('@/utils/runtime-config', () => ({
@@ -11,10 +11,13 @@ import { parseRelationTypeOption } from '@/application/database-yjs/fields/relat
 import { createRelationField } from '@/application/database-yjs/fields/relation/utils';
 import { createRollupField } from '@/application/database-yjs/fields/rollup/utils';
 import {
-  getRelationCacheRevision,
+  ensureRelationGroupLabel,
+  getRelationGroupLabelRevision,
   readRelationCellText,
   readRelationGroupLabel,
+  retainRelationGroupLabels,
   subscribeRelationCache,
+  subscribeRelationGroupLabels,
 } from '@/application/database-yjs/relation/cache';
 import { readRollupCellSync, subscribeRollupCell } from '@/application/database-yjs/rollup/cache';
 import {
@@ -203,9 +206,19 @@ describe('relation and rollup basics', () => {
       createRow: fixture.createRow,
       getViewIdFromDatabaseId: fixture.getViewIdFromDatabaseId,
     };
-    const initialRevision = getRelationCacheRevision();
+    const initialRevision = getRelationGroupLabelRevision();
     const { result } = renderHook(() => {
-      const revision = useSyncExternalStore(subscribeRelationCache, getRelationCacheRevision, getRelationCacheRevision);
+      const revision = useSyncExternalStore(
+        subscribeRelationGroupLabels,
+        getRelationGroupLabelRevision,
+        getRelationGroupLabelRevision
+      );
+
+      // Reading stays pure; the lookup runs after commit, matching how
+      // useDatabaseGroupingSelector drives it.
+      useEffect(() => {
+        ensureRelationGroupLabel(context);
+      });
 
       return { label: readRelationGroupLabel(context), revision };
     });
@@ -213,6 +226,87 @@ describe('relation and rollup basics', () => {
     expect(result.current.label).toBe('');
     await waitFor(() => expect(result.current.label).toBe('Alice'));
     expect(result.current.revision).toBeGreaterThan(initialRevision);
+  });
+
+  it('refreshes an empty group label when its cold row document hydrates', async () => {
+    const fixture = createFixture({ suffix: 'group-label-cold-hydration' });
+    const coldRowDoc = new Y.Doc() as YDoc;
+    const createRow = jest.fn(async () => coldRowDoc);
+    const context = {
+      relationField: fixture.relationField,
+      relatedRowId: fixture.relatedRowIds[0],
+      loadView: fixture.loadView,
+      createRow,
+      getViewIdFromDatabaseId: fixture.getViewIdFromDatabaseId,
+    };
+    const initialRevision = getRelationGroupLabelRevision();
+    const { result } = renderHook(() => {
+      const revision = useSyncExternalStore(
+        subscribeRelationGroupLabels,
+        getRelationGroupLabelRevision,
+        getRelationGroupLabelRevision
+      );
+
+      useEffect(() => {
+        ensureRelationGroupLabel(context);
+      });
+
+      return { label: readRelationGroupLabel(context), revision };
+    });
+
+    await waitFor(() => {
+      expect(createRow).toHaveBeenCalledTimes(1);
+      expect(result.current.revision).toBeGreaterThan(initialRevision);
+    });
+    expect(result.current.label).toBe('');
+
+    const hydratedRowDoc = createRowDoc(fixture.relatedRowIds[0], fixture.relatedDatabaseId, {
+      [fixture.primaryFieldId]: createCell('Alice', FieldType.RichText),
+    });
+
+    act(() => {
+      Y.applyUpdate(coldRowDoc, Y.encodeStateAsUpdate(hydratedRowDoc));
+    });
+
+    await waitFor(() => expect(result.current.label).toBe('Alice'));
+    expect(createRow).toHaveBeenCalledTimes(2);
+  });
+
+  it('keeps serving a resolved group label after its cache entry goes stale', async () => {
+    const fixture = createFixture({ suffix: 'group-label-ttl' });
+    const context = {
+      relationField: fixture.relationField,
+      relatedRowId: fixture.relatedRowIds[0],
+      loadView: fixture.loadView,
+      createRow: fixture.createRow,
+      getViewIdFromDatabaseId: fixture.getViewIdFromDatabaseId,
+    };
+    const resolved = new Promise<string>((resolve) => {
+      const unsubscribe = subscribeRelationGroupLabels(() => {
+        const value = readRelationGroupLabel(context);
+
+        if (!value) return;
+        unsubscribe();
+        resolve(value);
+      });
+    });
+
+    ensureRelationGroupLabel(context);
+    await expect(resolved).resolves.toBe('Alice');
+
+    const realNow = Date.now;
+    const base = realNow();
+
+    // Well past both the 5s entry TTL and the 2s prune interval, with no edit
+    // to the related row. A header must never fall back to its placeholder
+    // just because the entry is due for revalidation.
+    Date.now = () => base + 60_000;
+    try {
+      ensureRelationGroupLabel(context);
+      expect(readRelationGroupLabel(context)).toBe('Alice');
+    } finally {
+      Date.now = realNow;
+    }
   });
 
   it('resolves a relation group identifier to the related primary title', async () => {
@@ -226,7 +320,7 @@ describe('relation and rollup basics', () => {
     };
 
     const resultPromise = new Promise<string>((resolve) => {
-      const unsubscribe = subscribeRelationCache(() => {
+      const unsubscribe = subscribeRelationGroupLabels(() => {
         const value = readRelationGroupLabel(context);
 
         if (!value) return;
@@ -236,7 +330,74 @@ describe('relation and rollup basics', () => {
     });
 
     expect(readRelationGroupLabel(context)).toBe('');
+    ensureRelationGroupLabel(context);
     await expect(resultPromise).resolves.toBe('Alice');
+  });
+
+  it('keeps every active group label cached when a grouping exceeds the soft limit', async () => {
+    const fixture = createFixture({ suffix: 'group-label-active-cache' });
+    const sharedRowDoc = createRowDoc('shared-active-row', fixture.relatedDatabaseId, {
+      [fixture.primaryFieldId]: createCell('Alice', FieldType.RichText),
+    });
+    const createRow = jest.fn(async () => sharedRowDoc);
+    const contexts = Array.from({ length: 501 }, (_, index) => ({
+      relationField: fixture.relationField,
+      relatedRowId: `active-row-${index}`,
+      loadView: fixture.loadView,
+      createRow,
+      getViewIdFromDatabaseId: fixture.getViewIdFromDatabaseId,
+    }));
+    const release = retainRelationGroupLabels(contexts);
+
+    try {
+      contexts.forEach(ensureRelationGroupLabel);
+
+      await waitFor(
+        () => {
+          expect(contexts.every((context) => readRelationGroupLabel(context) === 'Alice')).toBe(true);
+        },
+        { timeout: 3_000 }
+      );
+      expect(createRow).toHaveBeenCalledTimes(contexts.length);
+
+      contexts.forEach(ensureRelationGroupLabel);
+      await Promise.resolve();
+      expect(createRow).toHaveBeenCalledTimes(contexts.length);
+    } finally {
+      release();
+    }
+  });
+
+  it('does not wake group-label subscribers when a relation cell resolves', async () => {
+    const fixture = createFixture({ suffix: 'group-label-channel' });
+    const cellContext = {
+      baseDoc: fixture.baseDoc,
+      database: fixture.baseDatabase,
+      relationField: fixture.relationField,
+      row: fixture.baseRow,
+      rowId: fixture.baseRowId,
+      fieldId: fixture.relationFieldId,
+      loadView: fixture.loadView,
+      createRow: fixture.createRow,
+      getViewIdFromDatabaseId: fixture.getViewIdFromDatabaseId,
+    };
+    const groupLabelWakeups = jest.fn();
+    const unsubscribe = subscribeRelationGroupLabels(groupLabelWakeups);
+    const cellResolved = new Promise<string>((resolve) => {
+      const unsubscribeCells = subscribeRelationCache(() => {
+        const value = readRelationCellText(cellContext);
+
+        if (!value) return;
+        unsubscribeCells();
+        resolve(value);
+      });
+    });
+
+    readRelationCellText(cellContext);
+    await expect(cellResolved).resolves.toContain('Alice');
+
+    unsubscribe();
+    expect(groupLabelWakeups).not.toHaveBeenCalled();
   });
 
   it('refreshes a relation group label when the related primary cell changes', async () => {
@@ -250,7 +411,7 @@ describe('relation and rollup basics', () => {
       getViewIdFromDatabaseId: fixture.getViewIdFromDatabaseId,
     };
     const initial = new Promise<string>((resolve) => {
-      const unsubscribe = subscribeRelationCache(() => {
+      const unsubscribe = subscribeRelationGroupLabels(() => {
         const value = readRelationGroupLabel(context);
 
         if (!value) return;
@@ -259,11 +420,14 @@ describe('relation and rollup basics', () => {
       });
     });
 
-    readRelationGroupLabel(context);
+    ensureRelationGroupLabel(context);
     await expect(initial).resolves.toBe('Alice');
 
     const updated = new Promise<string>((resolve) => {
-      const unsubscribe = subscribeRelationCache(() => {
+      const unsubscribe = subscribeRelationGroupLabels(() => {
+        // A revision bump is what sends the consumer back through its effect,
+        // so re-requesting here mirrors useDatabaseGroupingSelector.
+        ensureRelationGroupLabel(context);
         const value = readRelationGroupLabel(context);
 
         if (value !== 'Alicia') return;
@@ -313,7 +477,8 @@ describe('relation and rollup basics', () => {
     };
     const waitForLabel = (expected: string) =>
       new Promise<string>((resolve) => {
-        const unsubscribe = subscribeRelationCache(() => {
+        const unsubscribe = subscribeRelationGroupLabels(() => {
+          ensureRelationGroupLabel(context);
           const value = readRelationGroupLabel(context);
 
           if (value !== expected) return;
@@ -321,7 +486,7 @@ describe('relation and rollup basics', () => {
           resolve(value);
         });
 
-        readRelationGroupLabel(context);
+        ensureRelationGroupLabel(context);
       });
 
     await expect(waitForLabel('Alice')).resolves.toBe('Alice');
@@ -333,7 +498,7 @@ describe('relation and rollup basics', () => {
       .get(fixture.primaryFieldId);
 
     canonicalPrimaryCell?.set(YjsDatabaseKey.data, 'Alicia');
-    readRelationGroupLabel(context);
+    ensureRelationGroupLabel(context);
     await staleLookupStarted;
 
     canonicalPrimaryCell?.set(YjsDatabaseKey.data, 'Beatrice');

--- a/src/application/database-yjs/__tests__/useNewRowTemplateDispatch.test.tsx
+++ b/src/application/database-yjs/__tests__/useNewRowTemplateDispatch.test.tsx
@@ -5,6 +5,7 @@ import { DatabaseContext, DatabaseContextState } from '@/application/database-yj
 import { FieldType, RowMetaKey } from '@/application/database-yjs/database.type';
 import { useNewRowDispatch } from '@/application/database-yjs/dispatch/row';
 import { TextFilterCondition } from '@/application/database-yjs/fields';
+import { createRelationField } from '@/application/database-yjs/fields/relation/utils';
 import { getMetaIdMap, getRowKey } from '@/application/database-yjs/row_meta';
 import { DatabaseRowTemplateStore } from '@/application/database-yjs/template';
 import {
@@ -124,6 +125,42 @@ function createWrapper(context: DatabaseContextState): ({ children }: { children
 }
 
 describe('useNewRowDispatch database templates', () => {
+  it('writes grouped relation prefills as canonical relation data before reciprocal handling', async () => {
+    const { doc, database } = createDatabaseDoc();
+    const relationFieldId = 'relation-field-id';
+    const relationField = createRelationField(relationFieldId);
+
+    database.get(YjsDatabaseKey.fields)?.set(relationFieldId, relationField);
+    const createdRows = new Map<string, YDoc>();
+    const context: DatabaseContextState = {
+      readOnly: false,
+      databaseDoc: doc,
+      databasePageId: viewId,
+      activeViewId: viewId,
+      rowMap: {},
+      workspaceId: 'workspace-id',
+      createRow: async (key) => {
+        const rowDoc = new Y.Doc({ guid: key }) as YDoc;
+
+        createdRows.set(key, rowDoc);
+        return rowDoc;
+      },
+    };
+    const { result } = renderHook(() => useNewRowDispatch(), { wrapper: createWrapper(context) });
+    let rowId = '';
+
+    await act(async () => {
+      rowId = (await result.current({
+        cellsData: { [relationFieldId]: '[" related-row ","related-row"]' },
+      })) as string;
+    });
+
+    const data = cellData(createdRows.get(getRowKey(databaseDocId, rowId)) as YDoc, relationFieldId);
+
+    expect(data).toBeInstanceOf(Y.Array);
+    expect((data as Y.Array<string>).toJSON()).toEqual(['related-row']);
+  });
+
   it('uses an explicit template and lets contextual cells override defaults in every view', async () => {
     const { doc, database } = createDatabaseDoc();
     const template = addTemplate(database);

--- a/src/application/database-yjs/dispatch.ts
+++ b/src/application/database-yjs/dispatch.ts
@@ -261,6 +261,8 @@ function generateGroupByField(field: YDatabaseField) {
     case FieldType.RichText:
     case FieldType.Number:
     case FieldType.URL:
+    case FieldType.Relation:
+    case FieldType.Person:
       group.set(YjsDatabaseKey.content, '');
       columns.push([createYDatabaseGroupColumn({ id: fieldId })]);
       break;

--- a/src/application/database-yjs/dispatch/row.ts
+++ b/src/application/database-yjs/dispatch/row.ts
@@ -41,6 +41,7 @@ import {
   normalizeFilterNode,
   relationFilterFillData,
 } from '@/application/database-yjs/filter';
+import { normalizeGroupIdentifiers } from '@/application/database-yjs/group';
 import { initialDatabaseRow } from '@/application/database-yjs/row';
 import { generateRowMeta, getMetaIdMap, getMetaJSON, getRowKey } from '@/application/database-yjs/row_meta';
 import { useDatabaseViewLayout, useCalendarLayoutSetting, getPrimaryFieldId } from '@/application/database-yjs/selector';
@@ -726,17 +727,35 @@ export function useNewRowDispatch() {
             const cell = new Y.Map() as YDatabaseCell;
             const field = database.get(YjsDatabaseKey.fields)?.get(fieldId);
 
+            if (!field) return;
+
             // The raw cell payload replaces whatever a template or filter
             // wrote for this field, so any queued reciprocal backfill for it
             // would no longer match the final cell state.
             relationPrefills.delete(fieldId);
 
             const type = Number(field.get(YjsDatabaseKey.type));
+            const rawData = typeof data === 'object' ? data.data : data;
 
             cell.set(YjsDatabaseKey.created_at, String(dayjs().unix()));
             cell.set(YjsDatabaseKey.field_type, type);
 
-            if (typeof data === 'object') {
+            if (type === FieldType.Relation) {
+              const relationOption = parseRelationTypeOption(field);
+              const identifiers = normalizeGroupIdentifiers(rawData);
+              const rowIds =
+                relationOption.source_limit === RelationLimit.OneOnly && identifiers.length > 1
+                  ? [identifiers[identifiers.length - 1]]
+                  : identifiers;
+              const relationData = new Y.Array<string>();
+
+              if (rowIds.length > 0) {
+                relationData.push(rowIds);
+                relationPrefills.set(fieldId, rowIds);
+              }
+
+              cell.set(YjsDatabaseKey.data, relationData);
+            } else if (typeof data === 'object') {
               cell.set(YjsDatabaseKey.data, data.data);
               cell.set(YjsDatabaseKey.end_timestamp, data.endTimestamp);
               cell.set(YjsDatabaseKey.is_range, data.isRange);

--- a/src/application/database-yjs/fields/person/parse.ts
+++ b/src/application/database-yjs/fields/person/parse.ts
@@ -1,22 +1,43 @@
-import { YDatabaseField, YjsDatabaseKey } from "@/application/types";
+import { YDatabaseField, YjsDatabaseKey } from '@/application/types';
 
-import { getTypeOptions } from "../type_option";
+import { getTypeOptions } from '../type_option';
 
-import { PersonCellData, PersonTypeOption } from "./person.type";
+import { PersonCellData, PersonTypeOption } from './person.type';
 
-export function parsePersonTypeOptions(field: YDatabaseField) {
-  const content = getTypeOptions(field)?.get(YjsDatabaseKey.content);
-
-  if (!content)
-    return {
-      persons: [],
-    };
+function parsePersons(value: unknown): PersonTypeOption['persons'] {
+  if (Array.isArray(value)) return value as PersonTypeOption['persons'];
+  if (typeof value !== 'string') return [];
 
   try {
-    return JSON.parse(content) as PersonTypeOption;
+    const parsed = JSON.parse(value) as unknown;
+
+    return Array.isArray(parsed) ? (parsed as PersonTypeOption['persons']) : [];
+  } catch {
+    return [];
+  }
+}
+
+export function parsePersonTypeOptions(field: YDatabaseField) {
+  const typeOptions = getTypeOptions(field);
+  const content = typeOptions?.get(YjsDatabaseKey.content);
+  const storedPersons = parsePersons(typeOptions?.get(YjsDatabaseKey.persons));
+
+  if (!content) {
+    return {
+      persons: storedPersons,
+    };
+  }
+
+  try {
+    const parsed = JSON.parse(content) as PersonTypeOption;
+
+    return {
+      ...parsed,
+      persons: parsed.persons?.length ? parsed.persons : storedPersons,
+    };
   } catch (e) {
     return {
-      persons: [],
+      persons: storedPersons,
     };
   }
 }

--- a/src/application/database-yjs/group.ts
+++ b/src/application/database-yjs/group.ts
@@ -1,5 +1,5 @@
-import { parseYDatabaseCellToCell } from '@/application/database-yjs/cell.parse';
 import { getStoredCellFieldType } from '@/application/database-yjs/cell.field-type';
+import { parseYDatabaseCellToCell } from '@/application/database-yjs/cell.parse';
 import { hasRowConditionData } from '@/application/database-yjs/condition-value-cache';
 import { getCell } from '@/application/database-yjs/const';
 import { DateGroupCondition, FieldType } from '@/application/database-yjs/database.type';

--- a/src/application/database-yjs/group.ts
+++ b/src/application/database-yjs/group.ts
@@ -1,14 +1,17 @@
 import { parseYDatabaseCellToCell } from '@/application/database-yjs/cell.parse';
+import { getStoredCellFieldType } from '@/application/database-yjs/cell.field-type';
 import { hasRowConditionData } from '@/application/database-yjs/condition-value-cache';
 import { getCell } from '@/application/database-yjs/const';
 import { DateGroupCondition, FieldType } from '@/application/database-yjs/database.type';
 import {
   CheckboxFilterCondition,
+  parsePersonTypeOptions,
   parseSelectOptionTypeOptions,
   SelectOptionFilterCondition,
 } from '@/application/database-yjs/fields';
 import { parseCheckboxValue } from '@/application/database-yjs/fields/text/utils';
 import { checkboxFilterCheck, selectOptionFilterCheck } from '@/application/database-yjs/filter';
+import { getRelationRowIdsFromCell } from '@/application/database-yjs/relation/cell';
 import type { Row } from '@/application/database-yjs/selector';
 import { RowId, YDatabaseField, YDatabaseFilter, YDoc, YjsDatabaseKey } from '@/application/types';
 
@@ -22,6 +25,8 @@ export const DATABASE_GROUPABLE_FIELD_TYPES: readonly FieldType[] = [
   FieldType.SingleSelect,
   FieldType.MultiSelect,
   FieldType.DateTime,
+  FieldType.Relation,
+  FieldType.Person,
 ];
 
 export const DATABASE_DYNAMIC_GROUP_FIELD_TYPES: readonly FieldType[] = [
@@ -29,6 +34,8 @@ export const DATABASE_DYNAMIC_GROUP_FIELD_TYPES: readonly FieldType[] = [
   FieldType.Number,
   FieldType.URL,
   FieldType.DateTime,
+  FieldType.Relation,
+  FieldType.Person,
 ];
 
 export interface DateGroupConfiguration {
@@ -105,6 +112,10 @@ export function groupByField(
     return groupByDate(rows, rowMetas, field, groupContent);
   }
 
+  if ([FieldType.Relation, FieldType.Person].includes(fieldType)) {
+    return groupByIdentifier(rows, rowMetas, field);
+  }
+
   return;
 }
 
@@ -142,6 +153,87 @@ function getGroupingCellData(rowId: RowId, rowMetas: Record<RowId, YDoc>, field:
   const cell = getCell(rowId, fieldId, rowMetas);
 
   return cell ? parseYDatabaseCellToCell(cell, field).data : undefined;
+}
+
+/**
+ * Person and relation cells both model an ordered set of stable identifiers.
+ * Keep this normalization independent of their storage format so imported and
+ * lazily converted data cannot create duplicate or whitespace-only groups.
+ */
+export function normalizeGroupIdentifiers(value: unknown): string[] {
+  let identifiers: unknown[] = [];
+
+  if (Array.isArray(value)) {
+    identifiers = value;
+  } else if (value && typeof value === 'object' && 'toArray' in value) {
+    identifiers = (value as { toArray: () => unknown[] }).toArray();
+  } else if (value && typeof value === 'object' && 'toJSON' in value) {
+    const json = (value as { toJSON: () => unknown }).toJSON();
+
+    identifiers = Array.isArray(json) ? json : [];
+  } else if (typeof value === 'string') {
+    try {
+      const json = JSON.parse(value) as unknown;
+
+      identifiers = Array.isArray(json) ? json : [];
+    } catch {
+      identifiers = value.split(',');
+    }
+  }
+
+  const seen = new Set<string>();
+
+  return identifiers.reduce<string[]>((result, identifier) => {
+    const normalized = String(identifier ?? '').trim();
+
+    if (!normalized || seen.has(normalized)) return result;
+    seen.add(normalized);
+    result.push(normalized);
+    return result;
+  }, []);
+}
+
+function getIdentifierGroupIds(rowId: RowId, rowMetas: Record<RowId, YDoc>, field: YDatabaseField) {
+  const fieldId = field.get(YjsDatabaseKey.id);
+  const cell = getCell(rowId, fieldId, rowMetas);
+  const fieldType = Number(field.get(YjsDatabaseKey.type)) as FieldType;
+
+  if (fieldType === FieldType.Relation) {
+    return normalizeGroupIdentifiers(getRelationRowIdsFromCell(cell));
+  }
+
+  if (!cell || getStoredCellFieldType(cell, FieldType.Person) !== FieldType.Person) {
+    return [];
+  }
+
+  const data = cell?.get(YjsDatabaseKey.data);
+
+  return normalizeGroupIdentifiers(data);
+}
+
+export function groupByIdentifier(rows: Row[], rowMetas: Record<RowId, YDoc>, field: YDatabaseField) {
+  const fieldId = field.get(YjsDatabaseKey.id);
+  const result = new Map<string, Row[]>([[fieldId, []]]);
+
+  rows.forEach((row) => {
+    if (!hasRowConditionData(rowMetas[row.id])) return;
+
+    const identifiers = getIdentifierGroupIds(row.id, rowMetas, field);
+
+    if (identifiers.length === 0) {
+      result.get(fieldId)?.push(row);
+      return;
+    }
+
+    identifiers.forEach((identifier) => {
+      const groupRows = result.get(identifier) ?? [];
+
+      groupRows.push(row);
+      result.set(identifier, groupRows);
+    });
+  });
+
+  return result;
 }
 
 export function groupByText(rows: Row[], rowMetas: Record<RowId, YDoc>, field: YDatabaseField) {
@@ -354,7 +446,8 @@ export function getGroupLabel(
   groupId: string,
   field: YDatabaseField,
   groupContent?: string,
-  now: Date = new Date()
+  now: Date = new Date(),
+  identifierLabels?: ReadonlyMap<string, string>
 ): string {
   const fieldId = field.get(YjsDatabaseKey.id);
   const fieldName = field.get(YjsDatabaseKey.name) || '';
@@ -362,6 +455,20 @@ export function getGroupLabel(
   if (groupId === fieldId) return `No ${fieldName}`.trim();
 
   const fieldType = Number(field.get(YjsDatabaseKey.type)) as FieldType;
+
+  if ([FieldType.Relation, FieldType.Person].includes(fieldType)) {
+    const resolved = identifierLabels?.get(groupId)?.trim();
+
+    if (resolved) return resolved;
+
+    if (fieldType === FieldType.Person) {
+      const person = parsePersonTypeOptions(field).persons.find((person) => person.id === groupId);
+
+      return person?.name?.trim() || 'Unknown person';
+    }
+
+    return 'Untitled relation';
+  }
 
   if ([FieldType.SingleSelect, FieldType.MultiSelect].includes(fieldType)) {
     return parseSelectOptionTypeOptions(field)?.options.find((option) => option.id === groupId)?.name ?? groupId;
@@ -430,6 +537,10 @@ export function getGroupCellData(groupId: string, field: YDatabaseField): string
     const date = parseDateGroupId(groupId);
 
     return date ? String(Math.floor(date.getTime() / 1000)) : undefined;
+  }
+
+  if ([FieldType.Relation, FieldType.Person].includes(fieldType)) {
+    return JSON.stringify([groupId]);
   }
 
   return groupId;

--- a/src/application/database-yjs/relation/cache.ts
+++ b/src/application/database-yjs/relation/cache.ts
@@ -36,6 +36,14 @@ export type RelationComputeContext = {
   getViewIdFromDatabaseId?: (databaseId: string) => Promise<string | null>;
 };
 
+export type RelationGroupLabelContext = {
+  relationField: YDatabaseField;
+  relatedRowId: RowId;
+  loadView?: (viewId: string) => Promise<YDoc | null>;
+  createRow?: (rowKey: string) => Promise<YDoc>;
+  getViewIdFromDatabaseId?: (databaseId: string) => Promise<string | null>;
+};
+
 const RELATION_CACHE_TTL_MS = 5_000;
 const RELATION_CACHE_PRUNE_INTERVAL_MS = 2_000;
 const RELATION_MAX_CONCURRENCY = 8;
@@ -71,10 +79,15 @@ class Semaphore {
 const semaphore = new Semaphore(RELATION_MAX_CONCURRENCY);
 const cache = new Map<string, RelationCacheEntry>();
 const inflight = new Map<string, Promise<RelationCellValue>>();
+const groupLabelCache = new Map<string, RelationCacheEntry>();
+const groupLabelInflight = new Map<string, Promise<RelationCellValue>>();
+const groupLabelGenerations = new Map<string, number>();
+const observedGroupLabelDocs = new WeakMap<YDoc, Set<string>>();
 const generations = new Map<string, number>();
 const listeners = new Set<() => void>();
 const relatedDocCache = new Map<string, Promise<YDoc | null>>();
 let lastPruneAt = 0;
+let relationCacheRevision = 0;
 
 function getGeneration(cellId: string) {
   return generations.get(cellId) ?? 0;
@@ -95,7 +108,40 @@ function isEntryFresh(entry: RelationCacheEntry, generation: number) {
 }
 
 function emit() {
+  relationCacheRevision += 1;
   listeners.forEach((cb) => cb());
+}
+
+function getGroupLabelGeneration(labelId: string) {
+  return groupLabelGenerations.get(labelId) ?? 0;
+}
+
+function bumpGroupLabelGeneration(labelId: string) {
+  groupLabelGenerations.set(labelId, getGroupLabelGeneration(labelId) + 1);
+  groupLabelCache.delete(labelId);
+  // The work cannot be cancelled, but removing its identity lets the next
+  // render start a fresh lookup. Its captured generation prevents a stale
+  // completion from overwriting the newer value.
+  groupLabelInflight.delete(labelId);
+}
+
+function observeGroupLabelDoc(rowDoc: YDoc, labelId: string) {
+  const observedLabels = observedGroupLabelDocs.get(rowDoc);
+
+  if (observedLabels) {
+    observedLabels.add(labelId);
+    return;
+  }
+
+  const labelIds = new Set([labelId]);
+
+  observedGroupLabelDocs.set(rowDoc, labelIds);
+  rowDoc.on('update', () => {
+    labelIds.forEach((id) => {
+      bumpGroupLabelGeneration(id);
+    });
+    emit();
+  });
 }
 
 function pruneCache(now = Date.now()) {
@@ -105,6 +151,12 @@ function pruneCache(now = Date.now()) {
   for (const [cellId, entry] of cache) {
     if (now - entry.updatedAt > RELATION_CACHE_TTL_MS) {
       cache.delete(cellId);
+    }
+  }
+
+  for (const [labelId, entry] of groupLabelCache) {
+    if (now - entry.updatedAt > RELATION_CACHE_TTL_MS) {
+      groupLabelCache.delete(labelId);
     }
   }
 }
@@ -128,10 +180,11 @@ function getPrimaryFieldId(database: YDatabase): string | undefined {
   return Array.from(fields?.keys() || []).find((fieldId) => fields?.get(fieldId)?.get(YjsDatabaseKey.is_primary));
 }
 
-async function loadRelatedDoc(
-  viewId: string,
-  loadView?: (viewId: string) => Promise<YDoc | null>
-) {
+function getDatabaseFromDoc(doc: YDoc): YDatabase | undefined {
+  return doc.getMap(YjsEditorKey.data_section)?.get(YjsEditorKey.database) as YDatabase | undefined;
+}
+
+async function loadRelatedDoc(viewId: string, loadView?: (viewId: string) => Promise<YDoc | null>) {
   if (!loadView) return null;
   const cached = relatedDocCache.get(viewId);
 
@@ -217,6 +270,50 @@ async function computeRelationCellValue(context: RelationComputeContext): Promis
   }
 }
 
+async function computeRelationGroupLabel(
+  context: RelationGroupLabelContext,
+  labelId: string
+): Promise<RelationCellValue> {
+  try {
+    if (Number(context.relationField.get(YjsDatabaseKey.type)) !== FieldType.Relation) {
+      return { value: '' };
+    }
+
+    const relationOption = parseRelationTypeOption(context.relationField);
+
+    if (!relationOption.database_id || !context.relatedRowId || !context.createRow) {
+      return { value: '' };
+    }
+
+    const viewId = await context.getViewIdFromDatabaseId?.(relationOption.database_id);
+
+    if (!viewId) return { value: '' };
+
+    const relatedDoc = await loadRelatedDoc(viewId, context.loadView);
+
+    if (!relatedDoc) return { value: '' };
+
+    const relatedDatabase = getDatabaseFromDoc(relatedDoc);
+    const primaryFieldId = relatedDatabase ? getPrimaryFieldId(relatedDatabase) : undefined;
+    const primaryField = primaryFieldId ? relatedDatabase?.get(YjsDatabaseKey.fields)?.get(primaryFieldId) : undefined;
+
+    if (!primaryFieldId || !primaryField) return { value: '' };
+
+    const relatedRowDoc = await context.createRow(getRowKey(relatedDoc.guid, context.relatedRowId));
+
+    observeGroupLabelDoc(relatedRowDoc, labelId);
+    const relatedRow = relatedRowDoc?.getMap(YjsEditorKey.data_section)?.get(YjsEditorKey.database_row) as
+      | YDatabaseRow
+      | undefined;
+    const primaryCell = relatedRow?.get(YjsDatabaseKey.cells)?.get(primaryFieldId);
+
+    return { value: primaryCell ? decodeCellToText(primaryCell, primaryField).trim() : '' };
+  } catch (error) {
+    Log.error('Failed to compute relation group label', error);
+    return { value: '' };
+  }
+}
+
 export function subscribeRelationCache(cb: () => void) {
   listeners.add(cb);
   return () => {
@@ -224,8 +321,60 @@ export function subscribeRelationCache(cb: () => void) {
   };
 }
 
+export function getRelationCacheRevision() {
+  return relationCacheRevision;
+}
+
 export function invalidateRelationCell(cellId: string) {
   bumpGeneration(cellId);
+}
+
+/**
+ * Returns the cached primary-field title immediately and starts one bounded
+ * lookup when it is missing. Consumers subscribe through relation cache so
+ * headers update without exposing relation row UUIDs while data is loading.
+ */
+export function readRelationGroupLabel(context: RelationGroupLabelContext): string {
+  pruneCache();
+  const databaseId = parseRelationTypeOption(context.relationField).database_id;
+
+  if (!databaseId || !context.relatedRowId) return '';
+
+  const labelId = `${databaseId}:${context.relatedRowId}`;
+  const generation = getGroupLabelGeneration(labelId);
+  const cached = groupLabelCache.get(labelId);
+
+  if (cached && isEntryFresh(cached, generation)) return cached.value;
+
+  if (!groupLabelInflight.has(labelId)) {
+    const promise = (async () => {
+      const release = await semaphore.acquire();
+
+      try {
+        const value = await computeRelationGroupLabel(context, labelId);
+
+        if (getGroupLabelGeneration(labelId) === generation) {
+          groupLabelCache.set(labelId, {
+            value: value.value,
+            generation,
+            updatedAt: Date.now(),
+          });
+          emit();
+        }
+
+        return value;
+      } finally {
+        release();
+        if (getGroupLabelGeneration(labelId) === generation) {
+          groupLabelInflight.delete(labelId);
+        }
+      }
+    })();
+
+    groupLabelInflight.set(labelId, promise);
+  }
+
+  return cached?.value ?? '';
 }
 
 export function readRelationCellText(context: RelationComputeContext): string {

--- a/src/application/database-yjs/relation/cache.ts
+++ b/src/application/database-yjs/relation/cache.ts
@@ -15,6 +15,8 @@ import {
 } from '@/application/types';
 import { Log } from '@/utils/log';
 
+import type { YEvent } from 'yjs';
+
 type RelationCellValue = {
   value: string;
 };
@@ -36,9 +38,14 @@ export type RelationComputeContext = {
   getViewIdFromDatabaseId?: (databaseId: string) => Promise<string | null>;
 };
 
-export type RelationGroupLabelContext = {
+/** Identifies a group label. This is all a render-time read needs. */
+export type RelationGroupLabelKey = {
   relationField: YDatabaseField;
   relatedRowId: RowId;
+};
+
+/** Adds the loaders only a resolution needs, so reads cannot trigger one. */
+export type RelationGroupLabelContext = RelationGroupLabelKey & {
   loadView?: (viewId: string) => Promise<YDoc | null>;
   createRow?: (rowKey: string) => Promise<YDoc>;
   getViewIdFromDatabaseId?: (databaseId: string) => Promise<string | null>;
@@ -48,6 +55,7 @@ const RELATION_CACHE_TTL_MS = 5_000;
 const RELATION_CACHE_PRUNE_INTERVAL_MS = 2_000;
 const RELATION_MAX_CONCURRENCY = 8;
 const RELATION_RELATED_DOC_CACHE_MAX = 50;
+const RELATION_GROUP_LABEL_CACHE_MAX = 500;
 
 class Semaphore {
   private count = 0;
@@ -82,12 +90,17 @@ const inflight = new Map<string, Promise<RelationCellValue>>();
 const groupLabelCache = new Map<string, RelationCacheEntry>();
 const groupLabelInflight = new Map<string, Promise<RelationCellValue>>();
 const groupLabelGenerations = new Map<string, number>();
+const retainedGroupLabels = new Map<string, number>();
 const observedGroupLabelDocs = new WeakMap<YDoc, Set<string>>();
 const generations = new Map<string, number>();
 const listeners = new Set<() => void>();
+// Group labels get their own channel. Cell text resolves once per relation cell
+// during sorting and filtering, so folding both into one counter would make
+// every one of those resolutions invalidate every grouped view's memo.
+const groupLabelListeners = new Set<() => void>();
 const relatedDocCache = new Map<string, Promise<YDoc | null>>();
 let lastPruneAt = 0;
-let relationCacheRevision = 0;
+let groupLabelRevision = 0;
 
 function getGeneration(cellId: string) {
   return generations.get(cellId) ?? 0;
@@ -108,8 +121,12 @@ function isEntryFresh(entry: RelationCacheEntry, generation: number) {
 }
 
 function emit() {
-  relationCacheRevision += 1;
   listeners.forEach((cb) => cb());
+}
+
+function emitGroupLabels() {
+  groupLabelRevision += 1;
+  groupLabelListeners.forEach((cb) => cb());
 }
 
 function getGroupLabelGeneration(labelId: string) {
@@ -120,12 +137,46 @@ function bumpGroupLabelGeneration(labelId: string) {
   groupLabelGenerations.set(labelId, getGroupLabelGeneration(labelId) + 1);
   groupLabelCache.delete(labelId);
   // The work cannot be cancelled, but removing its identity lets the next
-  // render start a fresh lookup. Its captured generation prevents a stale
-  // completion from overwriting the newer value.
+  // lookup start fresh. Its captured generation prevents a stale completion
+  // from overwriting the newer value.
   groupLabelInflight.delete(labelId);
 }
 
-function observeGroupLabelDoc(rowDoc: YDoc, labelId: string) {
+function pruneGroupLabelCacheToLimit() {
+  if (groupLabelCache.size <= RELATION_GROUP_LABEL_CACHE_MAX) return;
+
+  for (const labelId of groupLabelCache.keys()) {
+    if (retainedGroupLabels.has(labelId)) continue;
+
+    // Only the title is dropped. groupLabelGenerations must survive eviction:
+    // resetting a label's generation would let work that is still in flight
+    // match again and write its stale title back.
+    groupLabelCache.delete(labelId);
+    if (groupLabelCache.size <= RELATION_GROUP_LABEL_CACHE_MAX) return;
+  }
+}
+
+function touchGroupLabelCache(labelId: string, entry: RelationCacheEntry) {
+  groupLabelCache.delete(labelId);
+  groupLabelCache.set(labelId, entry);
+  pruneGroupLabelCacheToLimit();
+}
+
+function eventTouchesGroupLabel(event: YEvent, primaryFieldId: string) {
+  const [rowKey, cellsKey, fieldId] = event.path;
+
+  // A cold row document has no nested row/cells maps yet. Treat creation of
+  // either map as label hydration so an initially empty lookup is retried.
+  if (rowKey === undefined) return event.changes.keys.has(YjsEditorKey.database_row);
+  if (rowKey !== YjsEditorKey.database_row) return false;
+  if (cellsKey === undefined) return event.changes.keys.has(YjsDatabaseKey.cells);
+  if (cellsKey !== YjsDatabaseKey.cells) return false;
+  if (fieldId === undefined) return event.changes.keys.has(primaryFieldId);
+
+  return fieldId === primaryFieldId;
+}
+
+function observeGroupLabelRow(rowDoc: YDoc, primaryFieldId: string, labelId: string) {
   const observedLabels = observedGroupLabelDocs.get(rowDoc);
 
   if (observedLabels) {
@@ -136,11 +187,15 @@ function observeGroupLabelDoc(rowDoc: YDoc, labelId: string) {
   const labelIds = new Set([labelId]);
 
   observedGroupLabelDocs.set(rowDoc, labelIds);
-  rowDoc.on('update', () => {
+  // Observe the always-available root before reading its nested maps. This
+  // catches WebSocket hydration of a row that was absent from IndexedDB while
+  // still ignoring edits outside the primary cell once the row exists.
+  rowDoc.getMap(YjsEditorKey.data_section).observeDeep((events: YEvent[]) => {
+    if (!events.some((event) => eventTouchesGroupLabel(event, primaryFieldId))) return;
     labelIds.forEach((id) => {
       bumpGroupLabelGeneration(id);
     });
-    emit();
+    emitGroupLabels();
   });
 }
 
@@ -154,11 +209,11 @@ function pruneCache(now = Date.now()) {
     }
   }
 
-  for (const [labelId, entry] of groupLabelCache) {
-    if (now - entry.updatedAt > RELATION_CACHE_TTL_MS) {
-      groupLabelCache.delete(labelId);
-    }
-  }
+  // Group labels are deliberately not evicted on TTL. A header that dropped
+  // back to its "Untitled relation" placeholder while revalidating would read
+  // as real data, so the stale title is served until a newer one resolves.
+  // Live edits already invalidate through bumpGroupLabelGeneration, and size
+  // is bounded by touchGroupLabelCache.
 }
 
 function touchRelatedDocCache(viewId: string, promise: Promise<YDoc | null>) {
@@ -301,11 +356,15 @@ async function computeRelationGroupLabel(
 
     const relatedRowDoc = await context.createRow(getRowKey(relatedDoc.guid, context.relatedRowId));
 
-    observeGroupLabelDoc(relatedRowDoc, labelId);
-    const relatedRow = relatedRowDoc?.getMap(YjsEditorKey.data_section)?.get(YjsEditorKey.database_row) as
+    // createRow can resolve with a sync-bound but still empty document. Install
+    // the observer before the first read so later hydration invalidates the
+    // empty result and schedules a fresh lookup through subscribers.
+    observeGroupLabelRow(relatedRowDoc, primaryFieldId, labelId);
+    const relatedRow = relatedRowDoc.getMap(YjsEditorKey.data_section).get(YjsEditorKey.database_row) as
       | YDatabaseRow
       | undefined;
-    const primaryCell = relatedRow?.get(YjsDatabaseKey.cells)?.get(primaryFieldId);
+    const relatedCells = relatedRow?.get(YjsDatabaseKey.cells);
+    const primaryCell = relatedCells?.get(primaryFieldId);
 
     return { value: primaryCell ? decodeCellToText(primaryCell, primaryField).trim() : '' };
   } catch (error) {
@@ -321,60 +380,129 @@ export function subscribeRelationCache(cb: () => void) {
   };
 }
 
-export function getRelationCacheRevision() {
-  return relationCacheRevision;
+/**
+ * Group labels resolve independently of relation cell text, so they publish on
+ * their own channel. Subscribers here are not woken by the per-cell lookups
+ * that sorting and filtering trigger.
+ */
+export function subscribeRelationGroupLabels(cb: () => void) {
+  groupLabelListeners.add(cb);
+  return () => {
+    groupLabelListeners.delete(cb);
+  };
+}
+
+export function getRelationGroupLabelRevision() {
+  return groupLabelRevision;
 }
 
 export function invalidateRelationCell(cellId: string) {
   bumpGeneration(cellId);
 }
 
-/**
- * Returns the cached primary-field title immediately and starts one bounded
- * lookup when it is missing. Consumers subscribe through relation cache so
- * headers update without exposing relation row UUIDs while data is loading.
- */
-export function readRelationGroupLabel(context: RelationGroupLabelContext): string {
-  pruneCache();
+function getGroupLabelId(context: RelationGroupLabelKey): string | undefined {
   const databaseId = parseRelationTypeOption(context.relationField).database_id;
 
-  if (!databaseId || !context.relatedRowId) return '';
+  if (!databaseId || !context.relatedRowId) return undefined;
 
-  const labelId = `${databaseId}:${context.relatedRowId}`;
+  return `${databaseId}:${context.relatedRowId}`;
+}
+
+/**
+ * Pins labels used by a mounted grouping so the bounded LRU only evicts
+ * inactive entries. The cache may exceed its soft limit when a single active
+ * grouping contains more labels; it returns to the limit after release.
+ */
+export function retainRelationGroupLabels(contexts: readonly RelationGroupLabelKey[]): () => void {
+  const labelIds = new Set<string>();
+
+  contexts.forEach((context) => {
+    const labelId = getGroupLabelId(context);
+
+    if (labelId) labelIds.add(labelId);
+  });
+  labelIds.forEach((labelId) => {
+    retainedGroupLabels.set(labelId, (retainedGroupLabels.get(labelId) ?? 0) + 1);
+  });
+
+  let released = false;
+
+  return () => {
+    if (released) return;
+    released = true;
+    labelIds.forEach((labelId) => {
+      const retainCount = retainedGroupLabels.get(labelId) ?? 0;
+
+      if (retainCount <= 1) {
+        retainedGroupLabels.delete(labelId);
+      } else {
+        retainedGroupLabels.set(labelId, retainCount - 1);
+      }
+    });
+    pruneGroupLabelCacheToLimit();
+  };
+}
+
+/**
+ * Pure read of the last resolved primary-field title, or '' when nothing has
+ * resolved yet. Safe to call while rendering: it never starts work and never
+ * mutates module state. Pair it with ensureRelationGroupLabel in an effect.
+ */
+export function readRelationGroupLabel(context: RelationGroupLabelKey): string {
+  const labelId = getGroupLabelId(context);
+
+  if (!labelId) return '';
+
+  return groupLabelCache.get(labelId)?.value ?? '';
+}
+
+/**
+ * Starts one bounded lookup when the cached title is missing or past its TTL.
+ * This mutates module state and schedules async work, so call it from an
+ * effect rather than during render.
+ */
+export function ensureRelationGroupLabel(context: RelationGroupLabelContext): void {
+  pruneCache();
+  const labelId = getGroupLabelId(context);
+
+  if (!labelId) return;
+
   const generation = getGroupLabelGeneration(labelId);
   const cached = groupLabelCache.get(labelId);
 
-  if (cached && isEntryFresh(cached, generation)) return cached.value;
+  if (cached && isEntryFresh(cached, generation)) return;
+  if (groupLabelInflight.has(labelId)) return;
 
-  if (!groupLabelInflight.has(labelId)) {
-    const promise = (async () => {
-      const release = await semaphore.acquire();
+  const promise = (async () => {
+    const release = await semaphore.acquire();
 
-      try {
-        const value = await computeRelationGroupLabel(context, labelId);
+    try {
+      const value = await computeRelationGroupLabel(context, labelId);
 
-        if (getGroupLabelGeneration(labelId) === generation) {
-          groupLabelCache.set(labelId, {
-            value: value.value,
-            generation,
-            updatedAt: Date.now(),
-          });
-          emit();
-        }
+      if (getGroupLabelGeneration(labelId) === generation) {
+        const changed = cached?.value !== value.value;
 
-        return value;
-      } finally {
-        release();
-        if (getGroupLabelGeneration(labelId) === generation) {
-          groupLabelInflight.delete(labelId);
-        }
+        touchGroupLabelCache(labelId, {
+          value: value.value,
+          generation,
+          updatedAt: Date.now(),
+        });
+        // A TTL revalidation that confirms the same title must not wake
+        // subscribers; re-rendering every grouped view on an unchanged
+        // value is exactly the churn this cache exists to avoid.
+        if (changed) emitGroupLabels();
       }
-    })();
 
-    groupLabelInflight.set(labelId, promise);
-  }
+      return value;
+    } finally {
+      release();
+      if (getGroupLabelGeneration(labelId) === generation) {
+        groupLabelInflight.delete(labelId);
+      }
+    }
+  })();
 
-  return cached?.value ?? '';
+  groupLabelInflight.set(labelId, promise);
 }
 
 export function readRelationCellText(context: RelationComputeContext): string {

--- a/src/application/database-yjs/selector.ts
+++ b/src/application/database-yjs/selector.ts
@@ -30,6 +30,7 @@ import {
   getDateCellStr,
   getFieldDateTimeFormats,
   getTypeOptions,
+  parsePersonTypeOptions,
   parseRelationTypeOption,
   parseRollupTypeOption,
   parseSelectOptionTypeOptions,
@@ -63,11 +64,14 @@ import {
   useRollupFieldObservers,
 } from '@/application/database-yjs/hooks';
 import {
-  getRelationCacheRevision,
+  ensureRelationGroupLabel,
+  getRelationGroupLabelRevision,
   invalidateRelationCell,
   readRelationGroupLabel,
   readRelationCellText,
+  retainRelationGroupLabels,
   subscribeRelationCache,
+  subscribeRelationGroupLabels,
 } from '@/application/database-yjs/relation/cache';
 import { getRelationRowIdsFromCell } from '@/application/database-yjs/relation/cell';
 import {
@@ -1852,10 +1856,21 @@ export function useDatabaseGroupingSelector(layout: DatabaseViewLayout): Databas
     getCellLocalMutationSnapshot,
     getCellLocalMutationSnapshot
   );
+  // Only relation grouping renders resolved titles, so every other grouping
+  // field type holds a constant snapshot and never recomputes for them.
+  const groupsByRelation = persistedGroupingFieldType === FieldType.Relation;
+  const subscribeToRelationGroupLabels = useCallback(
+    (onStoreChange: () => void) => (groupsByRelation ? subscribeRelationGroupLabels(onStoreChange) : () => undefined),
+    [groupsByRelation]
+  );
+  const getRelationGroupLabelSnapshot = useCallback(
+    () => (groupsByRelation ? getRelationGroupLabelRevision() : 0),
+    [groupsByRelation]
+  );
   const relationGroupLabelRevision = useSyncExternalStore(
-    subscribeRelationCache,
-    getRelationCacheRevision,
-    getRelationCacheRevision
+    subscribeToRelationGroupLabels,
+    getRelationGroupLabelSnapshot,
+    getRelationGroupLabelSnapshot
   );
 
   const rowsHydrated = Boolean(allRowOrders && areGroupRowsHydrated(allRowOrders, groupingRows));
@@ -1882,7 +1897,7 @@ export function useDatabaseGroupingSelector(layout: DatabaseViewLayout): Databas
     cellLocalMutationRevision,
   ]);
 
-  return useMemo(() => {
+  const grouping = useMemo(() => {
     void groupingViewRevision;
     void cellLocalMutationRevision;
     void relationGroupLabelRevision;
@@ -1996,6 +2011,13 @@ export function useDatabaseGroupingSelector(layout: DatabaseViewLayout): Databas
     const identifierLabels = new Map<string, string>();
 
     if (fieldType === FieldType.Person) {
+      // Seed from the field's own type option once. getGroupLabel falls back to
+      // parsing it per group otherwise, which is a JSON.parse for every header.
+      parsePersonTypeOptions(field).persons.forEach((person) => {
+        const label = person.name?.trim();
+
+        if (label) identifierLabels.set(person.id, label);
+      });
       mentionableUsers.forEach((person) => {
         const label = person.name?.trim() || person.email?.trim();
 
@@ -2005,18 +2027,13 @@ export function useDatabaseGroupingSelector(layout: DatabaseViewLayout): Databas
       displayIds.forEach((id) => {
         if (id === currentFieldId) return;
 
-        const label = readRelationGroupLabel({
-          relationField: field,
-          relatedRowId: id,
-          loadView,
-          createRow,
-          getViewIdFromDatabaseId,
-        });
+        const label = readRelationGroupLabel({ relationField: field, relatedRowId: id });
 
         if (label) identifierLabels.set(id, label);
       });
     }
 
+    const now = new Date();
     const groups = displayIds.map((id): GridGroup => {
       const groupRows = result?.get(id) ?? [];
       const hidden = columnsById.get(id)?.visible === false;
@@ -2031,7 +2048,7 @@ export function useDatabaseGroupingSelector(layout: DatabaseViewLayout): Databas
 
       return {
         id,
-        label: getGroupLabel(id, field, content, new Date(), identifierLabels),
+        label: getGroupLabel(id, field, content, now, identifierLabels),
         rows: groupRows,
         isDefault: id === currentFieldId,
         visible: !hidden && !automaticallyHidden,
@@ -2062,14 +2079,11 @@ export function useDatabaseGroupingSelector(layout: DatabaseViewLayout): Databas
     };
   }, [
     allRowOrders,
-    createRow,
     fields,
-    getViewIdFromDatabaseId,
     groupingRows,
     groupingViewRevision,
     hasCellLocalMutation,
     layout,
-    loadView,
     metadataSyncKey,
     mentionableUsers,
     relationGroupLabelRevision,
@@ -2078,6 +2092,55 @@ export function useDatabaseGroupingSelector(layout: DatabaseViewLayout): Databas
     rowsHydrated,
     view,
   ]);
+
+  const groupingField = grouping.field;
+  const relationDatabaseId =
+    groupingField && grouping.fieldType === FieldType.Relation
+      ? parseRelationTypeOption(groupingField).database_id
+      : undefined;
+  const relationGroupLabelIdsKey = relationDatabaseId
+    ? JSON.stringify(grouping.activeGroupIds.filter((id) => id !== grouping.fieldId))
+    : undefined;
+  const relationGroupLabelIds = useMemo(
+    () => (relationGroupLabelIdsKey === undefined ? undefined : (JSON.parse(relationGroupLabelIdsKey) as RowId[])),
+    [relationGroupLabelIdsKey]
+  );
+
+  useEffect(() => {
+    if (!groupingField || !relationDatabaseId || !relationGroupLabelIds) return;
+
+    return retainRelationGroupLabels(
+      relationGroupLabelIds.map((relatedRowId) => ({ relationField: groupingField, relatedRowId }))
+    );
+  }, [groupingField, relationDatabaseId, relationGroupLabelIds]);
+
+  useEffect(() => {
+    // Resolving a title loads a related document, so it belongs after commit
+    // rather than inside the memo. Each resolution publishes on the group-label
+    // channel, which brings the memo back through relationGroupLabelRevision.
+    void relationGroupLabelRevision;
+    if (!groupingField || !relationDatabaseId || !relationGroupLabelIds) return;
+
+    relationGroupLabelIds.forEach((id) => {
+      ensureRelationGroupLabel({
+        relationField: groupingField,
+        relatedRowId: id,
+        loadView,
+        createRow,
+        getViewIdFromDatabaseId,
+      });
+    });
+  }, [
+    createRow,
+    getViewIdFromDatabaseId,
+    groupingField,
+    loadView,
+    relationDatabaseId,
+    relationGroupLabelIds,
+    relationGroupLabelRevision,
+  ]);
+
+  return grouping;
 }
 
 export function useGridGroupingSelector(): GridGrouping {

--- a/src/application/database-yjs/selector.ts
+++ b/src/application/database-yjs/selector.ts
@@ -63,7 +63,9 @@ import {
   useRollupFieldObservers,
 } from '@/application/database-yjs/hooks';
 import {
+  getRelationCacheRevision,
   invalidateRelationCell,
+  readRelationGroupLabel,
   readRelationCellText,
   subscribeRelationCache,
 } from '@/application/database-yjs/relation/cache';
@@ -105,6 +107,7 @@ import {
   YSharedRoot,
 } from '@/application/types';
 import { MetadataKey } from '@/application/user-metadata';
+import { useMentionableUsersWithAutoFetch } from '@/components/database/components/cell/person/useMentionableUsers';
 import { useCurrentUser } from '@/components/main/app.hooks';
 import { getDateFormat, getTimeFormat, renderDate } from '@/utils/time';
 
@@ -1714,7 +1717,14 @@ function orderDatabaseGroupsForPrimarySort(
  * observing only the database view is not sufficient when a cell is edited.
  */
 export function useDatabaseGroupingSelector(layout: DatabaseViewLayout): DatabaseGrouping {
-  const { getCellLocalMutationRevision, hasCellLocalMutation, subscribeToCellLocalMutations } = useDatabaseContext();
+  const {
+    createRow,
+    getCellLocalMutationRevision,
+    getViewIdFromDatabaseId,
+    hasCellLocalMutation,
+    loadView,
+    subscribeToCellLocalMutations,
+  } = useDatabaseContext();
   const view = useDatabaseView();
   const viewId = useDatabaseViewId();
   const database = useDatabase();
@@ -1724,6 +1734,9 @@ export function useDatabaseGroupingSelector(layout: DatabaseViewLayout): Databas
   const persistedGroups = view?.get(YjsDatabaseKey.groups);
   const persistedGroup = persistedGroups?.toArray()?.[0];
   const fieldId = persistedGroup?.get(YjsDatabaseKey.field_id);
+  const persistedGroupingField = fieldId ? fields?.get(fieldId) : undefined;
+  const persistedGroupingFieldType = Number(persistedGroupingField?.get(YjsDatabaseKey.type)) as FieldType;
+  const { users: mentionableUsers } = useMentionableUsersWithAutoFetch(persistedGroupingFieldType === FieldType.Person);
   const rawRowOrders = view?.get(YjsDatabaseKey.row_orders);
   const inlineRowOrders = getInlineViewRowOrders(database);
   const { cachedRowDocs, getCachedRowDocs, subscribeToCachedRowDocChanges } = useBackgroundRowDocLoader(
@@ -1839,6 +1852,11 @@ export function useDatabaseGroupingSelector(layout: DatabaseViewLayout): Databas
     getCellLocalMutationSnapshot,
     getCellLocalMutationSnapshot
   );
+  const relationGroupLabelRevision = useSyncExternalStore(
+    subscribeRelationCache,
+    getRelationCacheRevision,
+    getRelationCacheRevision
+  );
 
   const rowsHydrated = Boolean(allRowOrders && areGroupRowsHydrated(allRowOrders, groupingRows));
   const metadataSyncKey = useMemo(() => {
@@ -1867,6 +1885,7 @@ export function useDatabaseGroupingSelector(layout: DatabaseViewLayout): Databas
   return useMemo(() => {
     void groupingViewRevision;
     void cellLocalMutationRevision;
+    void relationGroupLabelRevision;
 
     const group = view?.get(YjsDatabaseKey.groups)?.toArray()?.[0];
     const currentFieldId = group?.get(YjsDatabaseKey.field_id);
@@ -1974,6 +1993,30 @@ export function useDatabaseGroupingSelector(layout: DatabaseViewLayout): Databas
       primarySortCondition === undefined
         ? orderedIds
         : orderDatabaseGroupsForPrimarySort(orderedIds, result, rowOrders, primarySortCondition);
+    const identifierLabels = new Map<string, string>();
+
+    if (fieldType === FieldType.Person) {
+      mentionableUsers.forEach((person) => {
+        const label = person.name?.trim() || person.email?.trim();
+
+        if (label) identifierLabels.set(person.person_id, label);
+      });
+    } else if (fieldType === FieldType.Relation) {
+      displayIds.forEach((id) => {
+        if (id === currentFieldId) return;
+
+        const label = readRelationGroupLabel({
+          relationField: field,
+          relatedRowId: id,
+          loadView,
+          createRow,
+          getViewIdFromDatabaseId,
+        });
+
+        if (label) identifierLabels.set(id, label);
+      });
+    }
+
     const groups = displayIds.map((id): GridGroup => {
       const groupRows = result?.get(id) ?? [];
       const hidden = columnsById.get(id)?.visible === false;
@@ -1988,7 +2031,7 @@ export function useDatabaseGroupingSelector(layout: DatabaseViewLayout): Databas
 
       return {
         id,
-        label: getGroupLabel(id, field, content),
+        label: getGroupLabel(id, field, content, new Date(), identifierLabels),
         rows: groupRows,
         isDefault: id === currentFieldId,
         visible: !hidden && !automaticallyHidden,
@@ -2019,12 +2062,17 @@ export function useDatabaseGroupingSelector(layout: DatabaseViewLayout): Databas
     };
   }, [
     allRowOrders,
+    createRow,
     fields,
+    getViewIdFromDatabaseId,
     groupingRows,
     groupingViewRevision,
     hasCellLocalMutation,
     layout,
+    loadView,
     metadataSyncKey,
+    mentionableUsers,
+    relationGroupLabelRevision,
     cellLocalMutationRevision,
     rowOrders,
     rowsHydrated,

--- a/src/application/types.ts
+++ b/src/application/types.ts
@@ -1143,6 +1143,8 @@ export interface YMapFieldTypeOption extends Y.Map<unknown> {
   // Person
   // eslint-disable-next-line @typescript-eslint/unified-signatures
   get(key: YjsDatabaseKey.is_single_select | YjsDatabaseKey.disable_notification): boolean;
+
+  get(key: YjsDatabaseKey.persons): string | unknown[] | undefined;
 }
 
 export enum Types {


### PR DESCRIPTION
## Summary
- add Relation and Person as dynamic Grid/List group-by field types alongside existing Number and Date support
- resolve Person group labels from workspace members and Relation labels from related primary cells, including live cache invalidation
- preserve multi-value membership and canonical grouped-row creation for Person and reciprocal Relation cells
- use nathan@appflowy.io for both identifier-grouping Playwright scenarios
- test Relation in a temporary Grid view of project_templates / Project Management / 03_epics and Person in a temporary database in nathan workspace, without changing shared database views
- assert final rendered group labels, counts, row titles, and exact multi-group membership, then clean up each fixture

## Validation
- 101 focused Jest tests
- pnpm type-check
- targeted ESLint
- Playwright Relation/Person final UI grouping: 2 passed
- existing Playwright Number final UI grouping: 1 passed
- git diff --check