### PR TITLE
fix(database): stop retrying denied row documents

### DIFF
--- a/src/@types/translations/en.json
+++ b/src/@types/translations/en.json
@@ -2064,6 +2064,9 @@
     }
   },
   "document": {
+    "rowDocument": {
+      "noAccess": "You don't have permission to view this row document"
+    },
     "inlineDatabase": {
       "viewInTrash": "This referenced database is in Trash",
       "viewDeleted": "This referenced database was permanently deleted",

--- a/src/application/__tests__/view-loader.test.ts
+++ b/src/application/__tests__/view-loader.test.ts
@@ -224,6 +224,7 @@ describe('view-loader row document retry policy', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     jest.useFakeTimers();
+    mockDeleteCollabDB.mockResolvedValue(undefined);
   });
 
   afterEach(() => {
@@ -258,6 +259,23 @@ describe('view-loader row document retry policy', () => {
 
     expect(result.doc).toBe(doc);
     expect(mockFetchPageCollab).toHaveBeenCalledTimes(1);
+    expect(jest.getTimerCount()).toBe(0);
+  });
+
+  it('rejects immediately and evicts the cache when a row document fetch is forbidden', async () => {
+    const documentId = '00000000-0000-4000-8000-000000000009';
+    const doc = createEmptyDoc(documentId);
+
+    mockGetOrCreateRowSubDoc.mockResolvedValue(doc);
+    mockFetchPageCollab.mockRejectedValue({ code: 1012, message: 'user is not allowed to access this view' });
+
+    const rejection = expect(openRowSubDocument('workspace-id', documentId)).rejects.toMatchObject({ code: 1012 });
+
+    await jest.runAllTimersAsync();
+    await rejection;
+
+    expect(mockFetchPageCollab).toHaveBeenCalledTimes(1);
+    expect(mockDeleteCollabDB).toHaveBeenCalledWith(documentId, { destroyDoc: true });
     expect(jest.getTimerCount()).toBe(0);
   });
 });

--- a/src/application/utils/error-utils.ts
+++ b/src/application/utils/error-utils.ts
@@ -272,6 +272,23 @@ export function determineErrorType(error: unknown): AppError {
 }
 
 /**
+ * Returns whether an error is an authoritative object-access denial.
+ *
+ * `ErrorType.Forbidden` is intentionally broader than permissions: storage,
+ * plan, and feature limits also map to it. Callers that render a no-access UI
+ * must use the server's permission code (or a bare HTTP 403) instead.
+ */
+export function isPermissionDeniedError(error: unknown): boolean {
+  const appError = determineErrorType(error);
+
+  if (appError.code !== undefined) {
+    return appError.code === ERROR_CODE.NOT_HAS_PERMISSION || appError.code === 403;
+  }
+
+  return appError.statusCode === 403;
+}
+
+/**
  * Type guard to check if error is an AppError
  */
 export function isAppError(error: unknown): error is AppError {

--- a/src/application/view-loader/index.ts
+++ b/src/application/view-loader/index.ts
@@ -24,7 +24,7 @@ import {
   YjsEditorKey,
   YSharedRoot,
 } from '@/application/types';
-import { determineErrorType, ErrorType } from '@/application/utils/error-utils';
+import { determineErrorType, ErrorType, isPermissionDeniedError } from '@/application/utils/error-utils';
 import { isDatabaseLayout } from '@/application/view-utils';
 import { applyYDoc } from '@/application/ydoc/apply';
 import { Log } from '@/utils/log';
@@ -469,6 +469,17 @@ export async function openRowSubDocument(
         fetched = true;
         break;
       } catch (e) {
+        // A permission denial cannot be repaired by retrying or by creating the
+        // row document. Remove the authoritative local copy before propagating
+        // the original error so the UI can render a terminal no-access state.
+        if (isPermissionDeniedError(e)) {
+          Log.debug('[ViewLoader] rowSubDoc permission denial — evicting local cache', {
+            documentId,
+          });
+          await deleteCollabDB(documentId, { destroyDoc: true }).catch(() => undefined);
+          throw e;
+        }
+
         Log.debug('[ViewLoader] rowSubDoc fetch failed', {
           documentId,
           attempt,

--- a/src/components/app/hooks/__tests__/useDatabaseOperations.rowPermission.test.tsx
+++ b/src/components/app/hooks/__tests__/useDatabaseOperations.rowPermission.test.tsx
@@ -1,0 +1,71 @@
+import { renderHook } from '@testing-library/react';
+
+import { ERROR_CODE } from '@/application/constants';
+import { ViewService } from '@/application/services/domains';
+import { openRowSubDocument } from '@/application/view-loader';
+import { useAuthInternal } from '@/components/app/contexts/AuthInternalContext';
+import { useDatabaseOperations } from '@/components/app/hooks/useDatabaseOperations';
+
+jest.mock('@/application/services/domains', () => ({
+  AIService: {},
+  ViewService: {
+    createOrphaned: jest.fn(),
+  },
+}));
+
+jest.mock('@/application/view-loader', () => ({
+  openRowSubDocument: jest.fn(),
+}));
+
+jest.mock('@/components/app/contexts/AuthInternalContext', () => ({
+  useAuthInternal: jest.fn(),
+}));
+
+const mockCreateOrphaned = ViewService.createOrphaned as jest.MockedFunction<typeof ViewService.createOrphaned>;
+const mockOpenRowSubDocument = openRowSubDocument as jest.MockedFunction<typeof openRowSubDocument>;
+const mockUseAuthInternal = useAuthInternal as jest.MockedFunction<typeof useAuthInternal>;
+
+describe('useDatabaseOperations row document permission errors', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseAuthInternal.mockReturnValue({
+      currentWorkspaceId: 'workspace-id',
+      aiEnabled: true,
+    } as ReturnType<typeof useAuthInternal>);
+  });
+
+  it.each([
+    { code: ERROR_CODE.NOT_HAS_PERMISSION, message: 'user is not allowed to access this view' },
+    { code: 403, message: 'forbidden' },
+  ])('rethrows permission denial $code from row document load and create operations', async (permissionError) => {
+    mockOpenRowSubDocument.mockRejectedValue(permissionError);
+    mockCreateOrphaned.mockRejectedValue(permissionError);
+
+    const { result } = renderHook(() => useDatabaseOperations());
+
+    await expect(result.current.loadRowDocument('document-id')).rejects.toBe(permissionError);
+    await expect(result.current.createRowDocument('document-id')).rejects.toBe(permissionError);
+  });
+
+  it('keeps recoverable row document failures as null results', async () => {
+    mockOpenRowSubDocument.mockRejectedValue(new Error('row document is not ready'));
+    mockCreateOrphaned.mockRejectedValue(new Error('row document is not ready'));
+
+    const { result } = renderHook(() => useDatabaseOperations());
+
+    await expect(result.current.loadRowDocument('document-id')).resolves.toBeNull();
+    await expect(result.current.createRowDocument('document-id')).resolves.toBeNull();
+  });
+
+  it('does not misclassify quota errors as object permission denials', async () => {
+    const quotaError = { code: ERROR_CODE.STORAGE_SPACE_NOT_ENOUGH, message: 'storage quota exceeded' };
+
+    mockOpenRowSubDocument.mockRejectedValue(quotaError);
+    mockCreateOrphaned.mockRejectedValue(quotaError);
+
+    const { result } = renderHook(() => useDatabaseOperations());
+
+    await expect(result.current.loadRowDocument('document-id')).resolves.toBeNull();
+    await expect(result.current.createRowDocument('document-id')).resolves.toBeNull();
+  });
+});

--- a/src/components/app/hooks/useDatabaseOperations.ts
+++ b/src/components/app/hooks/useDatabaseOperations.ts
@@ -20,6 +20,7 @@ import {
   YjsEditorKey,
 } from '@/application/types';
 import { openRowSubDocument } from '@/application/view-loader';
+import { isPermissionDeniedError } from '@/application/utils/error-utils';
 import { PromptDatabaseConfiguration } from '@/components/chat';
 import { Log } from '@/utils/log';
 
@@ -343,6 +344,7 @@ export function useDatabaseOperations(
         return doc;
       } catch (e) {
         Log.error('[loadRowDocument] failed to load', e);
+        if (isPermissionDeniedError(e)) throw e;
         return null;
       }
     },
@@ -367,6 +369,7 @@ export function useDatabaseOperations(
         return docState;
       } catch (e) {
         Log.error('[createRowDocument] failed', e);
+        if (isPermissionDeniedError(e)) throw e;
         return null;
       }
     },

--- a/src/components/database/components/database-row/DatabaseRowSubDocument.tsx
+++ b/src/components/database/components/database-row/DatabaseRowSubDocument.tsx
@@ -1,4 +1,5 @@
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import * as Y from 'yjs';
 
 import {
@@ -12,7 +13,7 @@ import {
 } from '@/application/database-yjs';
 import { getCellDataText } from '@/application/database-yjs/cell.parse';
 import { useUpdateRowMetaDispatch } from '@/application/database-yjs/dispatch';
-import { openCollabDB } from '@/application/db';
+import { deleteCollabDB, openCollabDB } from '@/application/db';
 import { getCachedRowSubDoc, getOrCreateRowSubDoc, trackRowDocEnsure } from '@/application/services/js-services/cache';
 import { YjsEditor } from '@/application/slate-yjs';
 import { dataStringTOJson } from '@/application/slate-yjs/utils/yjs';
@@ -30,6 +31,7 @@ import {
   YjsDatabaseKey,
   YjsEditorKey,
 } from '@/application/types';
+import { isPermissionDeniedError } from '@/application/utils/error-utils';
 import { EditorSkeleton } from '@/components/_shared/skeleton/EditorSkeleton';
 import { useCurrentWorkspaceIdOptional } from '@/components/app/app.hooks';
 import { Editor } from '@/components/editor';
@@ -46,6 +48,7 @@ type ContentNode = {
 };
 
 type IsCurrentRowDocumentRequest = () => boolean;
+type RowDocumentAttempt = 'ready' | 'retryable' | 'forbidden';
 
 const ALWAYS_CURRENT_ROW_DOCUMENT_REQUEST = () => true;
 const CONFIRMED_ROW_DOCUMENT_LOAD_OPTIONS: LoadRowDocumentOptions = { maxAttempts: 1 };
@@ -58,9 +61,7 @@ function hasImageContent(data: Record<string, unknown> | undefined) {
   if (!data) return false;
 
   return (
-    hasNonEmptyString(data.url) ||
-    hasNonEmptyString(data.retry_local_url) ||
-    hasNonEmptyString(data.pending_upload_id)
+    hasNonEmptyString(data.url) || hasNonEmptyString(data.retry_local_url) || hasNonEmptyString(data.pending_upload_id)
   );
 }
 
@@ -128,6 +129,7 @@ export const DatabaseRowSubDocument = memo(function DatabaseRowSubDocument({
   contentPadding,
   onRegisterPendingMetaFlush,
 }: DatabaseRowSubDocumentProps) {
+  const { t } = useTranslation();
   const meta = useRowMetaSelector(rowId);
   const documentId = meta?.documentId;
   const database = useDatabase();
@@ -240,7 +242,43 @@ export const DatabaseRowSubDocument = memo(function DatabaseRowSubDocument({
   const retryLoadTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const ensureDocRetryTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const loadRequestGenerationRef = useRef(0);
+  const deniedDocumentIdRef = useRef<string | null>(null);
+  const mountedRef = useRef(true);
+  const [deniedDocumentId, setDeniedDocumentId] = useState<string | null>(null);
   const loadedDocMatchesCurrent = Boolean(doc && documentId && loadedDocumentIdRef.current === documentId);
+  const noAccess = Boolean(documentId && deniedDocumentId === documentId);
+
+  const markPermissionDenied = useCallback((deniedId: string) => {
+    if (!mountedRef.current || activeDocumentIdRef.current !== deniedId) return;
+
+    deniedDocumentIdRef.current = deniedId;
+    loadRequestGenerationRef.current += 1;
+    docReadyRef.current = false;
+    loadedDocumentIdRef.current = null;
+    editorRef.current = null;
+    rowDocEnsuredRef.current = false;
+    pendingNonEmptyRef.current = false;
+
+    if (pendingMetaUpdateRef.current) {
+      clearTimeout(pendingMetaUpdateRef.current);
+      pendingMetaUpdateRef.current = null;
+    }
+
+    if (retryLoadTimerRef.current) {
+      clearTimeout(retryLoadTimerRef.current);
+      retryLoadTimerRef.current = null;
+    }
+
+    if (ensureDocRetryTimerRef.current) {
+      clearTimeout(ensureDocRetryTimerRef.current);
+      ensureDocRetryTimerRef.current = null;
+    }
+
+    setDoc(null);
+    setLoading(false);
+    setDeniedDocumentId(deniedId);
+    void deleteCollabDB(deniedId, { destroyDoc: true }).catch(() => undefined);
+  }, []);
 
   const document = loadedDocMatchesCurrent ? doc?.getMap(YjsEditorKey.data_section)?.get(YjsEditorKey.document) : null;
   // undefined = meta hasn't loaded from Yjs yet (wait)
@@ -311,10 +349,10 @@ export const DatabaseRowSubDocument = memo(function DatabaseRowSubDocument({
       documentId: string,
       options?: LoadRowDocumentOptions,
       isCurrentRequest: IsCurrentRowDocumentRequest = ALWAYS_CURRENT_ROW_DOCUMENT_REQUEST
-    ): Promise<boolean> => {
+    ): Promise<RowDocumentAttempt> => {
       const isCurrent = () => isCurrentRequest() && activeDocumentIdRef.current === documentId;
 
-      if (!isCurrent()) return false;
+      if (!isCurrent()) return 'retryable';
 
       Log.debug('[DatabaseRowSubDocument] handleOpenDocument start', { rowId, documentId });
       setLoading(true);
@@ -325,16 +363,16 @@ export const DatabaseRowSubDocument = memo(function DatabaseRowSubDocument({
 
         if (!loadRowDocument) {
           Log.debug('[DatabaseRowSubDocument] loadRowDocument not available', { documentId });
-          return false;
+          return 'retryable';
         }
 
         const doc = await loadRowDocument(documentId, options);
 
-        if (!isCurrent()) return false;
+        if (!isCurrent()) return 'retryable';
 
         if (!doc) {
           Log.debug('[DatabaseRowSubDocument] loadRowDocument returned null', { documentId });
-          return false;
+          return 'retryable';
         }
 
         // Log document state after loading
@@ -376,28 +414,35 @@ export const DatabaseRowSubDocument = memo(function DatabaseRowSubDocument({
             rowId,
             documentId,
           });
-          return false;
+          return 'retryable';
         }
 
-        if (!isCurrent()) return false;
+        if (!isCurrent()) return 'retryable';
 
         setDoc(doc);
         loadedDocumentIdRef.current = documentId;
         docReadyRef.current = true;
         rowDocEnsuredRef.current = true; // Document exists on server since we loaded it successfully
-        return true;
+        deniedDocumentIdRef.current = null;
+        setDeniedDocumentId(null);
+        return 'ready';
       } catch (e) {
+        if (isPermissionDeniedError(e)) {
+          if (isCurrent()) markPermissionDenied(documentId);
+          return 'forbidden';
+        }
+
         Log.debug('[DatabaseRowSubDocument] loadRowDocument failed', {
           message: e instanceof Error ? e.message : String(e),
         });
-        return false;
+        return 'retryable';
       } finally {
         if (isCurrent()) {
           setLoading(false);
         }
       }
     },
-    [loadRowDocument, rowId]
+    [loadRowDocument, markPermissionDenied, rowId]
   );
   // Open document with server-provided doc_state (Y.js update)
   const openDocumentWithState = useCallback(
@@ -480,10 +525,10 @@ export const DatabaseRowSubDocument = memo(function DatabaseRowSubDocument({
       documentId: string,
       requireServerReady: boolean = false,
       isCurrentRequest: IsCurrentRowDocumentRequest = ALWAYS_CURRENT_ROW_DOCUMENT_REQUEST
-    ): Promise<boolean> => {
+    ): Promise<RowDocumentAttempt> => {
       const isCurrent = () => isCurrentRequest() && activeDocumentIdRef.current === documentId;
 
-      if (!documentId || !isCurrent()) return false;
+      if (!documentId || !isCurrent()) return 'retryable';
       setLoading(true);
       let docState: Uint8Array | null = null;
 
@@ -500,7 +545,7 @@ export const DatabaseRowSubDocument = memo(function DatabaseRowSubDocument({
 
         const localHasContent = await hasLocalDocContent(documentId);
 
-        if (!isCurrent()) return false;
+        if (!isCurrent()) return 'retryable';
 
         if (localHasContent) {
           Log.debug('[DatabaseRowSubDocument] local doc has content; creating server collab before binding', {
@@ -514,27 +559,32 @@ export const DatabaseRowSubDocument = memo(function DatabaseRowSubDocument({
             documentId,
             requireServerReady,
           });
-          return false;
+          return 'retryable';
         }
 
         try {
           Log.debug('[DatabaseRowSubDocument] calling createRowDocument', { documentId, requireServerReady });
           docState = await createRowDocument(documentId, rowDocumentSource);
         } catch (e) {
+          if (isPermissionDeniedError(e)) {
+            if (isCurrent()) markPermissionDenied(documentId);
+            return 'forbidden';
+          }
+
           Log.error('[DatabaseRowSubDocument] createRowDocument failed', e);
-          return false;
+          return 'retryable';
         }
 
-        if (!isCurrent()) return false;
+        if (!isCurrent()) return 'retryable';
 
-        // createRowDocument swallows API errors and returns null (e.g. the server
-        // hasn't persisted a freshly created row yet). Treat that as a failure so
-        // the caller schedules a retry instead of binding to a structureless doc.
+        // Retryable API failures resolve to null (e.g. the server hasn't persisted
+        // a freshly created row yet). Permission denials throw and were handled
+        // above, so only transient failures reach this retry path.
         if (!docState) {
           Log.warn('[DatabaseRowSubDocument] createRowDocument returned no doc state; will retry', {
             documentId,
           });
-          return false;
+          return 'retryable';
         }
 
         Log.debug('[DatabaseRowSubDocument] createRowDocument success', {
@@ -547,7 +597,9 @@ export const DatabaseRowSubDocument = memo(function DatabaseRowSubDocument({
           const success = await openDocumentWithState(documentId, docState, isCurrent);
 
           if (success) {
-            return true;
+            deniedDocumentIdRef.current = null;
+            setDeniedDocumentId(null);
+            return 'ready';
           }
 
           Log.warn('[DatabaseRowSubDocument] server doc_state invalid; will retry without local fallback', {
@@ -557,17 +609,17 @@ export const DatabaseRowSubDocument = memo(function DatabaseRowSubDocument({
         }
 
         if (loadRowDocument) {
-          const loaded = await handleOpenDocument(documentId, undefined, isCurrent);
+          const loadAttempt = await handleOpenDocument(documentId, undefined, isCurrent);
 
-          if (loaded) {
-            return true;
+          if (loadAttempt !== 'retryable') {
+            return loadAttempt;
           }
         }
 
         Log.warn('[DatabaseRowSubDocument] row document was not opened after server create', {
           documentId,
         });
-        return false;
+        return 'retryable';
       } finally {
         if (isCurrent()) {
           setLoading(false);
@@ -579,6 +631,7 @@ export const DatabaseRowSubDocument = memo(function DatabaseRowSubDocument({
       handleOpenDocument,
       hasLocalDocContent,
       loadRowDocument,
+      markPermissionDenied,
       openDocumentWithState,
       rowDocumentSource,
       rowId,
@@ -586,14 +639,19 @@ export const DatabaseRowSubDocument = memo(function DatabaseRowSubDocument({
   );
 
   const scheduleEnsureRowDocumentExists = useCallback(() => {
-    if (!documentId || activeDocumentIdRef.current !== documentId || ensureDocRetryTimerRef.current) {
+    if (
+      !documentId ||
+      activeDocumentIdRef.current !== documentId ||
+      deniedDocumentIdRef.current === documentId ||
+      ensureDocRetryTimerRef.current
+    ) {
       return;
     }
 
     ensureDocRetryTimerRef.current = setTimeout(async () => {
       ensureDocRetryTimerRef.current = null;
 
-      if (activeDocumentIdRef.current !== documentId) {
+      if (activeDocumentIdRef.current !== documentId || deniedDocumentIdRef.current === documentId) {
         return;
       }
 
@@ -638,7 +696,12 @@ export const DatabaseRowSubDocument = memo(function DatabaseRowSubDocument({
 
           pendingNonEmptyRef.current = false;
         }
-      } catch {
+      } catch (error) {
+        if (isPermissionDeniedError(error)) {
+          markPermissionDenied(documentId);
+          return;
+        }
+
         // Keep retrying until the backend accepts the row document.
       }
 
@@ -649,6 +712,7 @@ export const DatabaseRowSubDocument = memo(function DatabaseRowSubDocument({
     createRowDocument,
     documentId,
     isDocumentEmpty,
+    markPermissionDenied,
     rowDocumentSource,
     updateRowMeta,
     rowId,
@@ -663,6 +727,7 @@ export const DatabaseRowSubDocument = memo(function DatabaseRowSubDocument({
     lastIsEmptyRef.current = null;
     pendingNonEmptyRef.current = false;
     rowDocEnsuredRef.current = false;
+    deniedDocumentIdRef.current = null;
 
     if (pendingMetaUpdateRef.current) {
       clearTimeout(pendingMetaUpdateRef.current);
@@ -680,11 +745,12 @@ export const DatabaseRowSubDocument = memo(function DatabaseRowSubDocument({
     }
 
     setDoc(null);
+    setDeniedDocumentId(null);
     setLoading(Boolean(documentId));
   }, [documentId]);
 
   useEffect(() => {
-    if (!documentId) return;
+    if (!documentId || deniedDocumentIdRef.current === documentId) return;
 
     let cancelled = false;
     const requestGeneration = ++loadRequestGenerationRef.current;
@@ -700,9 +766,9 @@ export const DatabaseRowSubDocument = memo(function DatabaseRowSubDocument({
     };
 
     const scheduleRetry = (loadOptions?: LoadRowDocumentOptions) => {
-      if (retryLoadTimerRef.current) return;
+      if (retryLoadTimerRef.current || deniedDocumentIdRef.current === documentId) return;
       retryLoadTimerRef.current = setTimeout(async () => {
-        if (!isCurrentRequest()) return;
+        if (!isCurrentRequest() || deniedDocumentIdRef.current === documentId) return;
 
         // If doc is already loaded (e.g., by handleCreateDocument), skip retry
         // This prevents resetting the editor mid-typing
@@ -725,11 +791,11 @@ export const DatabaseRowSubDocument = memo(function DatabaseRowSubDocument({
         // entire retry window, so retry creation directly after propagation has
         // had another chance to complete.
         const retryingEmptyDocument = isDocumentEmptyResolved === true;
-        const retried = retryingEmptyDocument
+        const retryAttempt = retryingEmptyDocument
           ? await handleCreateDocument(documentId, false, isCurrentRequest)
           : await handleOpenDocument(documentId, loadOptions, isCurrentRequest);
 
-        if (retried || !isCurrentRequest()) {
+        if (retryAttempt !== 'retryable' || !isCurrentRequest()) {
           return;
         }
 
@@ -756,11 +822,14 @@ export const DatabaseRowSubDocument = memo(function DatabaseRowSubDocument({
           if (!isCurrentRequest()) return;
 
           if (localHasContent) {
-            Log.debug('[DatabaseRowSubDocument] max retries reached; local content found, creating server doc before binding', {
-              rowId,
-              documentId,
-              retryCount,
-            });
+            Log.debug(
+              '[DatabaseRowSubDocument] max retries reached; local content found, creating server doc before binding',
+              {
+                rowId,
+                documentId,
+                retryCount,
+              }
+            );
           }
 
           Log.debug('[DatabaseRowSubDocument] max retries reached; creating document', {
@@ -768,9 +837,9 @@ export const DatabaseRowSubDocument = memo(function DatabaseRowSubDocument({
             documentId,
             retryCount,
           });
-          const created = await handleCreateDocument(documentId, true, isCurrentRequest);
+          const createAttempt = await handleCreateDocument(documentId, true, isCurrentRequest);
 
-          if (!created && isCurrentRequest()) {
+          if (createAttempt === 'retryable' && isCurrentRequest()) {
             Log.warn('[DatabaseRowSubDocument] final row document creation attempt rejected', {
               rowId,
               documentId,
@@ -823,9 +892,9 @@ export const DatabaseRowSubDocument = memo(function DatabaseRowSubDocument({
           rowId,
           documentId,
         });
-        const created = await handleCreateDocument(documentId, false, isCurrentRequest);
+        const createAttempt = await handleCreateDocument(documentId, false, isCurrentRequest);
 
-        if (!created && isCurrentRequest()) {
+        if (createAttempt === 'retryable' && isCurrentRequest()) {
           scheduleRetry();
         }
 
@@ -847,9 +916,9 @@ export const DatabaseRowSubDocument = memo(function DatabaseRowSubDocument({
         }
 
         void (async () => {
-          const created = await handleCreateDocument(documentId, true, isCurrentRequest);
+          const createAttempt = await handleCreateDocument(documentId, true, isCurrentRequest);
 
-          if (!created && isCurrentRequest()) {
+          if (createAttempt === 'retryable' && isCurrentRequest()) {
             scheduleRetry();
           }
         })();
@@ -881,16 +950,20 @@ export const DatabaseRowSubDocument = memo(function DatabaseRowSubDocument({
           // present. Do one read attempt, then repair its row-document
           // registration and open the returned state instead of waiting
           // through the duplication-oriented backoff loop.
-          const success = await handleOpenDocument(documentId, CONFIRMED_ROW_DOCUMENT_LOAD_OPTIONS, isCurrentRequest);
+          const loadAttempt = await handleOpenDocument(
+            documentId,
+            CONFIRMED_ROW_DOCUMENT_LOAD_OPTIONS,
+            isCurrentRequest
+          );
 
-          if (!success && isCurrentRequest()) {
+          if (loadAttempt === 'retryable' && isCurrentRequest()) {
             Log.debug('[DatabaseRowSubDocument] repairing row document after load failure', {
               rowId,
               documentId,
             });
-            const repaired = await handleCreateDocument(documentId, true, isCurrentRequest);
+            const repairAttempt = await handleCreateDocument(documentId, true, isCurrentRequest);
 
-            if (!repaired && isCurrentRequest()) {
+            if (repairAttempt === 'retryable' && isCurrentRequest()) {
               scheduleRetry(CONFIRMED_ROW_DOCUMENT_LOAD_OPTIONS);
             }
           }
@@ -907,6 +980,11 @@ export const DatabaseRowSubDocument = memo(function DatabaseRowSubDocument({
         scheduleRetry();
       } catch (e) {
         if (!isCurrentRequest()) return;
+
+        if (isPermissionDeniedError(e)) {
+          markPermissionDenied(documentId);
+          return;
+        }
 
         Log.debug('[DatabaseRowSubDocument] checkIfRowDocumentExists failed; will retry', {
           rowId,
@@ -927,6 +1005,7 @@ export const DatabaseRowSubDocument = memo(function DatabaseRowSubDocument({
     checkIfRowDocumentExists,
     isDocumentEmptyResolved,
     hasLocalDocContent,
+    markPermissionDenied,
     rowId,
     doc,
   ]);
@@ -1002,7 +1081,9 @@ export const DatabaseRowSubDocument = memo(function DatabaseRowSubDocument({
   }, []);
 
   const ensureRowDocumentExists = useCallback(async () => {
-    if (!documentId || activeDocumentIdRef.current !== documentId) return false;
+    if (!documentId || activeDocumentIdRef.current !== documentId || deniedDocumentIdRef.current === documentId) {
+      return false;
+    }
 
     // Skip if we've already ensured this document exists (memoize to avoid redundant API calls)
     if (rowDocEnsuredRef.current) {
@@ -1018,7 +1099,12 @@ export const DatabaseRowSubDocument = memo(function DatabaseRowSubDocument({
         if (activeDocumentIdRef.current !== documentId) {
           return false;
         }
-      } catch {
+      } catch (error) {
+        if (isPermissionDeniedError(error)) {
+          markPermissionDenied(documentId);
+          return false;
+        }
+
         // Ignore and fall through to orphaned view creation attempt.
       }
     }
@@ -1045,14 +1131,18 @@ export const DatabaseRowSubDocument = memo(function DatabaseRowSubDocument({
 
         rowDocEnsuredRef.current = true;
         return true;
-      } catch {
+      } catch (error) {
+        if (isPermissionDeniedError(error)) {
+          markPermissionDenied(documentId);
+        }
+
         // Creation failed - don't mark as ensured so we can retry
         return false;
       }
     }
 
     return false;
-  }, [checkIfRowDocumentExists, createRowDocument, documentId, rowDocumentSource]);
+  }, [checkIfRowDocumentExists, createRowDocument, documentId, markPermissionDenied, rowDocumentSource]);
 
   useEffect(() => {
     if (!doc || !documentId || !loadedDocMatchesCurrent) return;
@@ -1161,13 +1251,30 @@ export const DatabaseRowSubDocument = memo(function DatabaseRowSubDocument({
   ]);
 
   useEffect(() => {
+    mountedRef.current = true;
+
     return () => {
+      mountedRef.current = false;
+
       if (ensureDocRetryTimerRef.current) {
         clearTimeout(ensureDocRetryTimerRef.current);
         ensureDocRetryTimerRef.current = null;
       }
     };
   }, []);
+
+  if (noAccess) {
+    return (
+      <div
+        role='alert'
+        data-testid='row-document-no-access'
+        className='flex min-h-[300px] w-full flex-col items-center justify-center gap-2 px-8 py-10 text-center'
+      >
+        <div className='text-base font-medium text-text-primary'>{t('landingPage.forbidden.title')}</div>
+        <div className='text-sm text-text-secondary'>{t('document.rowDocument.noAccess')}</div>
+      </div>
+    );
+  }
 
   if (loading || (doc && documentId && !loadedDocMatchesCurrent)) {
     return <EditorSkeleton />;

--- a/src/components/database/components/database-row/__tests__/DatabaseRowSubDocument.test.tsx
+++ b/src/components/database/components/database-row/__tests__/DatabaseRowSubDocument.test.tsx
@@ -25,6 +25,7 @@ jest.mock('@/application/database-yjs/dispatch', () => ({
 }));
 
 jest.mock('@/application/db', () => ({
+  deleteCollabDB: jest.fn().mockResolvedValue(true),
   openCollabDB: jest.fn(),
 }));
 
@@ -130,6 +131,7 @@ function configureRowDocumentTest({
   loadRowDocument,
   createRowDocument,
   checkIfRowDocumentExists,
+  isEmptyDocument = false,
   readOnly = false,
   canComment = false,
   canWrite = !readOnly,
@@ -139,6 +141,7 @@ function configureRowDocumentTest({
   loadRowDocument: jest.Mock;
   createRowDocument: jest.Mock;
   checkIfRowDocumentExists: jest.Mock;
+  isEmptyDocument?: boolean;
   readOnly?: boolean;
   canComment?: boolean;
   canWrite?: boolean;
@@ -163,7 +166,7 @@ function configureRowDocumentTest({
   mockUseRowData.mockImplementation((rowId) => rows.get(rowId));
   mockUseRowMetaSelector.mockImplementation((rowId) => ({
     documentId: documentIds[rowId],
-    isEmptyDocument: false,
+    isEmptyDocument,
   }));
   mockUseUpdateRowMetaDispatch.mockReturnValue(jest.fn());
   mockUseCurrentWorkspaceIdOptional.mockReturnValue('workspace-id');
@@ -271,6 +274,85 @@ describe('DatabaseRowSubDocument', () => {
     });
 
     expect(loadRowDocument).toHaveBeenNthCalledWith(2, documentId, { maxAttempts: 1 });
+  });
+
+  it('shows no access without repairing or retrying when an existing row document is forbidden', async () => {
+    jest.useFakeTimers();
+
+    const rowId = 'row-id';
+    const documentId = 'document-id';
+    const cachedDoc = new Y.Doc({ guid: documentId }) as YDoc;
+    const loadRowDocument = jest
+      .fn()
+      .mockRejectedValue({ code: 1012, message: 'user is not allowed to access this view' });
+    const createRowDocument = jest.fn();
+    const checkIfRowDocumentExists = jest.fn().mockResolvedValue(true);
+
+    configureRowDocumentTest({
+      documentIds: { [rowId]: documentId },
+      cachedDocs: new Map([[documentId, cachedDoc]]),
+      loadRowDocument,
+      createRowDocument,
+      checkIfRowDocumentExists,
+    });
+
+    render(<DatabaseRowSubDocument rowId={rowId} />);
+
+    await act(flushAsyncWork);
+
+    expect(screen.getByTestId('row-document-no-access')).not.toBeNull();
+    expect(checkIfRowDocumentExists).toHaveBeenCalledTimes(1);
+    expect(loadRowDocument).toHaveBeenCalledTimes(1);
+    expect(loadRowDocument).toHaveBeenCalledWith(documentId, { maxAttempts: 1 });
+    expect(createRowDocument).not.toHaveBeenCalled();
+    expect(jest.getTimerCount()).toBe(0);
+
+    await act(async () => {
+      await jest.advanceTimersByTimeAsync(10000);
+      await flushAsyncWork();
+    });
+
+    expect(loadRowDocument).toHaveBeenCalledTimes(1);
+    expect(createRowDocument).not.toHaveBeenCalled();
+  });
+
+  it('shows no access without retrying when empty row document creation is forbidden', async () => {
+    jest.useFakeTimers();
+
+    const rowId = 'row-id';
+    const documentId = 'document-id';
+    const cachedDoc = new Y.Doc({ guid: documentId }) as YDoc;
+    const loadRowDocument = jest.fn();
+    const createRowDocument = jest
+      .fn()
+      .mockRejectedValue({ code: 1012, message: 'user is not allowed to access this view' });
+    const checkIfRowDocumentExists = jest.fn();
+
+    configureRowDocumentTest({
+      documentIds: { [rowId]: documentId },
+      cachedDocs: new Map([[documentId, cachedDoc]]),
+      loadRowDocument,
+      createRowDocument,
+      checkIfRowDocumentExists,
+      isEmptyDocument: true,
+    });
+
+    render(<DatabaseRowSubDocument rowId={rowId} />);
+
+    await act(flushAsyncWork);
+
+    expect(screen.getByTestId('row-document-no-access')).not.toBeNull();
+    expect(createRowDocument).toHaveBeenCalledTimes(1);
+    expect(loadRowDocument).not.toHaveBeenCalled();
+    expect(checkIfRowDocumentExists).not.toHaveBeenCalled();
+    expect(jest.getTimerCount()).toBe(0);
+
+    await act(async () => {
+      await jest.advanceTimersByTimeAsync(10000);
+      await flushAsyncWork();
+    });
+
+    expect(createRowDocument).toHaveBeenCalledTimes(1);
   });
 
   it('ignores a stale repair response after switching rows', async () => {


### PR DESCRIPTION
### **Description**

Treat row-document permission denials as terminal instead of converting them into an empty local Y.Doc and starting the orphan-repair loop.

This keeps transient row-creation races retryable, propagates authoritative `1012`/bare `403` errors through the database operations adapter, evicts the denied row collab cache, and renders an inline no-access state in the row document area.

### Reported regression

| Bug | Evidence | Actual | Expected |
| --- | --- | --- | --- |
| Database row content does not load for affected self-hosted workspace members | Web logs report `createRowDocument` code `1012`, `loaded doc has no document structure; will retry`, and three rejected creation retries. Desktop reports `NotEnoughPermissions`. Reported stack: Web `0.16.7`, Cloud/Worker `0.17.2`, Admin `0.17.5`. | The Web loader swallows the permission error, returns an empty local document, misdiagnoses it as malformed structure, then repeatedly invokes the repair/create endpoint before rendering nothing. | A permission denial should make one fetch attempt, stop repair/create retries, evict the denied local collab, and show a clear inline access-denied state. Transient non-permission failures should retain their existing retry policy. |

### Reproduction

1. Open a database row whose row-document collab request returns `{ code: 1012, message: "user is not allowed to access this view" }`.
2. Observe `openRowSubDocument` exhaust its fetch attempts and return the empty cached Y.Doc.
3. Observe `DatabaseRowSubDocument` log that the document has no structure and invoke `createOrphaned`/repair repeatedly.
4. After the retry budget is exhausted, the row document area renders no actionable state.

### Root cause and provenance

| Bug | Root cause | Introducing change |
| --- | --- | --- |
| Swallowed row-document permission denial | `openRowSubDocument` caught every fetch error and returned the local Y.Doc after retry exhaustion. `loadRowDocument` and `createRowDocument` then converted thrown errors into `null`, while `DatabaseRowSubDocument` interpreted failure as retryable and entered repair/create. This erased the terminal permission signal at every layer. | Introduced by `2205f3552a038c49dd30dc3373809e44c37cd73e` (`Fix duplicate (#309)`), authored by Nathan.fooo `<86001920+appflowy@users.noreply.github.com>` on 2026-04-15. Its parent directly awaited the server fetch, allowing `1012` to reject; this commit added the catch-all retry/local-document fallback. |

### Fixes and commits

| Bug | Fix | Regression coverage | Commit |
| --- | --- | --- | --- |
| Swallowed row-document permission denial | Add a narrow permission predicate for AppFlowy `1012` and bare transport `403`; fast-fail and evict in the loader; selectively rethrow through database operations; use an internal `ready \| retryable \| forbidden` outcome in the row component; cancel load/ensure timers and render localized inline no-access UI for terminal denial. Quota/storage errors remain retryable/null fallbacks rather than being mislabeled as access denial. | `view-loader.test.ts`, `useDatabaseOperations.rowPermission.test.tsx`, and `DatabaseRowSubDocument.test.tsx` | `602fb1e14e7a185204f48e25b6733eb58ed58b0a` |

### Test integrity

- Pre-fix loader/UI tests:
  - `pnpm exec jest src/application/__tests__/view-loader.test.ts src/components/database/components/database-row/__tests__/DatabaseRowSubDocument.test.tsx --runInBand --no-coverage`
  - Result: 3 new assertions failed for the intended reasons: the loader resolved an empty Y.Doc and the UI did not render the no-access state.
- Pre-fix adapter test:
  - `pnpm exec jest src/components/app/hooks/__tests__/useDatabaseOperations.rowPermission.test.tsx --runInBand --no-coverage`
  - Result: permission denial resolved to `null` instead of rejecting.
- Post-fix focused suites:
  - `pnpm exec jest src/application/__tests__/view-loader.test.ts src/components/app/hooks/__tests__/useDatabaseOperations.rowPermission.test.tsx src/components/database/components/database-row/__tests__/DatabaseRowSubDocument.test.tsx --runInBand --no-coverage --silent`
  - Result: 3 suites passed, 19 tests passed.
- Revert check:
  - Temporarily reverted only the production implementation while retaining the tests, then ran the focused permission assertions.
  - Result: 5 assertions failed for the original swallow/retry/no-UI behavior. Restoring the implementation returned the suite to 19/19 passing.
- Static and build checks:
  - `pnpm lint` — passed.
  - `pnpm build` — passed. The build retained the repository's existing circular-chunk and large-chunk warnings.

### Scope and deployment note

This PR fixes the Web client's misleading recovery behavior; it does not grant access when the server returns an authoritative denial. Self-hosters on Cloud/Worker `0.17.2` should also upgrade to a current release containing the row-document registration and permission fallback repairs.

### Proof

No application video is attached because the supplied report did not include an accessible production workspace/row or credentials. The denial, retry suppression, cache eviction, and inline UI state are covered deterministically by the focused Web tests above.

---

### **Checklist**

#### **General**
- [x] I've included relevant documentation or comments for the changes introduced.
- [ ] I've tested the changes in multiple environments (e.g., different browsers, operating systems).

#### **Testing**
- [x] I've added or updated tests to validate the changes introduced for AppFlowy Web.

#### **Feature-Specific**
- [x] Not applicable: this is a bug fix, not a feature addition.
- [x] I've verified that this fix integrates with the existing transient row-document retry flow.

## Summary by Sourcery

Handle row-document permission denials as terminal errors instead of retryable failures, evicting local collab state and surfacing a clear no-access UI for forbidden database rows.

Bug Fixes:
- Stop retrying creation/repair flows when row-document fetch or creation fails with an authoritative permission denial, and propagate those errors through the database operations layer.
- Evict cached row collab documents when the server denies access so the client does not bind to empty or stale local state.
- Prevent orphan-repair and retry timers from running after a row document has been marked as forbidden.

Enhancements:
- Add a dedicated permission-denied error classifier to distinguish access denials from other forbidden/quota failures and drive terminal UI states.
- Introduce an explicit ready/retryable/forbidden outcome model for row-document load/create flows to simplify retry and error handling logic.
- Render a localized inline no-access message in the row document area for users without permission to view the row content.

Tests:
- Extend view-loader tests to cover permission-denied row document fetch behavior and cache eviction.
- Add hook tests to verify that row-document permission errors are rethrown while other failures still resolve to null in database operations.
- Add database row sub-document tests ensuring no-access UI is shown and retries/repairs are not scheduled when access is forbidden.