### PR TITLE
fix: Text→Files & media crash and the runaway loading spinner

### DIFF
--- a/src/application/database-yjs/__tests__/cell-media-type-switch.test.tsx
+++ b/src/application/database-yjs/__tests__/cell-media-type-switch.test.tsx
@@ -11,7 +11,7 @@ import {
 } from '@/application/database-yjs';
 import { parseYDatabaseFileMediaCellToCell } from '@/application/database-yjs/cell.parse';
 import { FileMediaCellDataItem, FileMediaType, FileMediaUploadType } from '@/application/database-yjs/cell.type';
-import { countFileMediaItems, toFileMediaCellData } from '@/application/database-yjs/fields/media/parse';
+import { countFileMediaItems, toFileMediaCellData, updateFileName } from '@/application/database-yjs/fields/media/parse';
 import {
   YDatabase,
   YDatabaseCell,
@@ -81,7 +81,7 @@ function createTextFieldFixture() {
     <DatabaseContext.Provider value={contextValue}>{children}</DatabaseContext.Provider>
   );
 
-  return { field, wrapper };
+  return { field, wrapper, rowDoc };
 }
 
 function createMediaCell(entries: string[]): YDatabaseCell {
@@ -154,6 +154,23 @@ describe('switching a Text property to Files & media', () => {
     });
     expect(result.current?.data).toBe(TEXT_CELL_VALUE);
   });
+
+  it('keeps the parsed value stable when another cell in the row changes', () => {
+    const { wrapper, rowDoc } = createTextFieldFixture();
+    const { result } = renderHook(() => useCellSelector({ rowId, fieldId }), { wrapper });
+    const before = result.current;
+
+    act(() => {
+      const row = rowDoc.getMap(YjsEditorKey.data_section).get(YjsEditorKey.database_row) as YDatabaseRow;
+      const otherCell = new Y.Map() as YDatabaseCell;
+
+      row.get(YjsDatabaseKey.cells).set('other-field', otherCell);
+      otherCell.set(YjsDatabaseKey.field_type, FieldType.RichText);
+      otherCell.set(YjsDatabaseKey.data, 'unrelated');
+    });
+
+    expect(result.current).toBe(before);
+  });
 });
 
 describe('toFileMediaCellData', () => {
@@ -166,6 +183,23 @@ describe('toFileMediaCellData', () => {
 
   it('drops entries that are not media items', () => {
     expect(toFileMediaCellData([mediaItem, null, undefined, 'row-id'])).toEqual([mediaItem]);
+  });
+
+  it('drops objects that do not carry a media item id', () => {
+    expect(toFileMediaCellData([mediaItem, {}, { id: 42 }, ['nested']])).toEqual([mediaItem]);
+  });
+});
+
+describe('updateFileName', () => {
+  it('renames without mutating the item it was given', () => {
+    const original = { ...mediaItem };
+    const result = updateFileName({ data: [original], fileId: original.id, newName: 'renamed.pdf' });
+
+    // Integrate the array into a doc so its contents can be read back.
+    new Y.Doc().getMap('root').set('data', result);
+
+    expect(original.name).toBe(mediaItem.name);
+    expect(JSON.parse(result.get(0)).name).toBe('renamed.pdf');
   });
 });
 
@@ -195,7 +229,7 @@ describe('parseYDatabaseFileMediaCellToCell', () => {
   });
 
   it('skips entries a different field type wrote instead of throwing', () => {
-    const cell = createMediaCell(['a4d0b3f2-not-json', JSON.stringify(mediaItem), '"just a string"']);
+    const cell = createMediaCell(['a4d0b3f2-not-json', JSON.stringify(mediaItem), '"just a string"', '{}']);
 
     expect(parseYDatabaseFileMediaCellToCell(cell).data).toEqual([mediaItem]);
   });

--- a/src/application/database-yjs/__tests__/cell-media-type-switch.test.tsx
+++ b/src/application/database-yjs/__tests__/cell-media-type-switch.test.tsx
@@ -1,0 +1,196 @@
+import { act, render, renderHook } from '@testing-library/react';
+import type React from 'react';
+import * as Y from 'yjs';
+
+import {
+  DatabaseContext,
+  DatabaseContextState,
+  FieldType,
+  useCellSelector,
+  useFieldSelector,
+} from '@/application/database-yjs';
+import { parseYDatabaseFileMediaCellToCell } from '@/application/database-yjs/cell.parse';
+import { FileMediaCellDataItem, FileMediaType, FileMediaUploadType } from '@/application/database-yjs/cell.type';
+import { toFileMediaCellData } from '@/application/database-yjs/fields/media/parse';
+import {
+  YDatabase,
+  YDatabaseCell,
+  YDatabaseField,
+  YDatabaseFields,
+  YDatabaseRow,
+  YDatabaseRowOrders,
+  YDatabaseSorts,
+  YDatabaseView,
+  YDatabaseViews,
+  YDoc,
+  YjsDatabaseKey,
+  YjsEditorKey,
+} from '@/application/types';
+
+import { createRowDoc } from './test-helpers';
+
+jest.mock('@/utils/runtime-config', () => ({
+  getConfigValue: (_key: string, fallback: string) => fallback,
+}));
+
+const databaseId = 'database-id';
+const viewId = 'view-id';
+const rowId = 'row-id';
+const fieldId = 'field-id';
+
+/** The value the recording shows: a Text property holding a bare filename. */
+const TEXT_CELL_VALUE = 'Invoice-114489.pdf';
+
+function createTextFieldFixture() {
+  const databaseDoc = new Y.Doc({ guid: databaseId }) as YDoc;
+  const sharedRoot = databaseDoc.getMap(YjsEditorKey.data_section);
+  const database = new Y.Map() as YDatabase;
+  const fields = new Y.Map<YDatabaseField>() as YDatabaseFields;
+  const views = new Y.Map<YDatabaseView>() as YDatabaseViews;
+  const view = new Y.Map() as YDatabaseView;
+  const rowOrders = new Y.Array<{ id: string; height: number }>() as YDatabaseRowOrders;
+  const field = new Y.Map() as YDatabaseField;
+
+  field.set(YjsDatabaseKey.id, fieldId);
+  field.set(YjsDatabaseKey.name, 'Files & media');
+  field.set(YjsDatabaseKey.type, FieldType.RichText);
+
+  rowOrders.push([{ id: rowId, height: 44 }]);
+  view.set(YjsDatabaseKey.row_orders, rowOrders);
+  view.set(YjsDatabaseKey.filters, new Y.Array());
+  view.set(YjsDatabaseKey.sorts, new Y.Array() as YDatabaseSorts);
+  fields.set(fieldId, field);
+  views.set(viewId, view);
+  database.set(YjsDatabaseKey.id, databaseId);
+  database.set(YjsDatabaseKey.fields, fields);
+  database.set(YjsDatabaseKey.views, views);
+  sharedRoot.set(YjsEditorKey.database, database);
+
+  const rowDoc = createRowDoc(rowId, databaseId, {
+    [fieldId]: { fieldType: FieldType.RichText, data: TEXT_CELL_VALUE },
+  });
+  const contextValue = {
+    readOnly: false,
+    databaseDoc,
+    databasePageId: viewId,
+    activeViewId: viewId,
+    rowMap: { [rowId]: rowDoc },
+    workspaceId: 'workspace-id',
+  } as DatabaseContextState;
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <DatabaseContext.Provider value={contextValue}>{children}</DatabaseContext.Provider>
+  );
+
+  return { field, wrapper };
+}
+
+function createMediaCell(entries: string[]): YDatabaseCell {
+  const doc = new Y.Doc();
+  const cell = doc.getMap('cell') as YDatabaseCell;
+  const data = new Y.Array<string>();
+
+  cell.set(YjsDatabaseKey.field_type, FieldType.Media);
+  cell.set(YjsDatabaseKey.data, data);
+  if (entries.length > 0) {
+    data.push(entries);
+  }
+
+  return cell;
+}
+
+const mediaItem: FileMediaCellDataItem = {
+  id: 'file-1',
+  name: 'Invoice-114489.pdf',
+  url: 'https://example.com/Invoice-114489.pdf',
+  file_type: FileMediaType.Document,
+  upload_type: FileMediaUploadType.CloudMedia,
+};
+
+describe('switching a Text property to Files & media', () => {
+  it('never hands a renderer a cell that still describes the previous type', () => {
+    const { field, wrapper } = createTextFieldFixture();
+    const renders: Array<{ fieldType: FieldType; data: unknown }> = [];
+
+    // Mirrors RowPropertyCell: the component to render is chosen from the
+    // field's live type, while the cell comes from useCellSelector.
+    function Probe() {
+      const cell = useCellSelector({ rowId, fieldId });
+      const { field: liveField } = useFieldSelector(fieldId);
+
+      renders.push({
+        fieldType: Number(liveField?.get(YjsDatabaseKey.type)) as FieldType,
+        data: cell?.data,
+      });
+
+      return null;
+    }
+
+    render(<Probe />, { wrapper });
+    expect(renders.at(-1)?.data).toBe(TEXT_CELL_VALUE);
+
+    act(() => {
+      field.set(YjsDatabaseKey.type, FieldType.Media);
+    });
+
+    const mediaRenders = renders.filter((entry) => entry.fieldType === FieldType.Media);
+
+    expect(mediaRenders.length).toBeGreaterThan(0);
+    mediaRenders.forEach((entry) => {
+      expect(Array.isArray(entry.data)).toBe(true);
+    });
+  });
+
+  it('leaves the stored text untouched when the field is switched back', () => {
+    const { field, wrapper } = createTextFieldFixture();
+    const { result } = renderHook(() => useCellSelector({ rowId, fieldId }), { wrapper });
+
+    act(() => {
+      field.set(YjsDatabaseKey.type, FieldType.Media);
+    });
+    expect(result.current?.data).toEqual([]);
+
+    act(() => {
+      field.set(YjsDatabaseKey.type, FieldType.RichText);
+    });
+    expect(result.current?.data).toBe(TEXT_CELL_VALUE);
+  });
+});
+
+describe('toFileMediaCellData', () => {
+  it('turns a payload left over from another field type into an empty list', () => {
+    expect(toFileMediaCellData(TEXT_CELL_VALUE)).toEqual([]);
+    expect(toFileMediaCellData(undefined)).toEqual([]);
+    expect(toFileMediaCellData(null)).toEqual([]);
+    expect(toFileMediaCellData(42)).toEqual([]);
+  });
+
+  it('drops entries that are not media items', () => {
+    expect(toFileMediaCellData([mediaItem, null, undefined, 'row-id'])).toEqual([mediaItem]);
+  });
+});
+
+describe('parseYDatabaseFileMediaCellToCell', () => {
+  it('reads well-formed entries', () => {
+    const cell = createMediaCell([JSON.stringify(mediaItem)]);
+
+    expect(parseYDatabaseFileMediaCellToCell(cell).data).toEqual([mediaItem]);
+  });
+
+  it('skips entries a different field type wrote instead of throwing', () => {
+    const cell = createMediaCell(['a4d0b3f2-not-json', JSON.stringify(mediaItem), '"just a string"']);
+
+    expect(parseYDatabaseFileMediaCellToCell(cell).data).toEqual([mediaItem]);
+  });
+});
+
+describe('media cell rows', () => {
+  it('keeps a row readable when the cell payload is not a list', () => {
+    const rowDoc = createRowDoc(rowId, databaseId, {
+      [fieldId]: { fieldType: FieldType.Media, data: TEXT_CELL_VALUE },
+    });
+    const row = rowDoc.getMap(YjsEditorKey.data_section).get(YjsEditorKey.database_row) as YDatabaseRow;
+    const cell = row.get(YjsDatabaseKey.cells).get(fieldId);
+
+    expect(parseYDatabaseFileMediaCellToCell(cell).data).toEqual([]);
+  });
+});

--- a/src/application/database-yjs/__tests__/cell-media-type-switch.test.tsx
+++ b/src/application/database-yjs/__tests__/cell-media-type-switch.test.tsx
@@ -11,7 +11,7 @@ import {
 } from '@/application/database-yjs';
 import { parseYDatabaseFileMediaCellToCell } from '@/application/database-yjs/cell.parse';
 import { FileMediaCellDataItem, FileMediaType, FileMediaUploadType } from '@/application/database-yjs/cell.type';
-import { toFileMediaCellData } from '@/application/database-yjs/fields/media/parse';
+import { countFileMediaItems, toFileMediaCellData } from '@/application/database-yjs/fields/media/parse';
 import {
   YDatabase,
   YDatabaseCell,
@@ -166,6 +166,24 @@ describe('toFileMediaCellData', () => {
 
   it('drops entries that are not media items', () => {
     expect(toFileMediaCellData([mediaItem, null, undefined, 'row-id'])).toEqual([mediaItem]);
+  });
+});
+
+describe('countFileMediaItems', () => {
+  it('counts the same entries toFileMediaCellData keeps', () => {
+    const payloads: unknown[] = [
+      TEXT_CELL_VALUE,
+      undefined,
+      null,
+      42,
+      [],
+      [mediaItem],
+      [mediaItem, null, undefined, 'row-id', mediaItem],
+    ];
+
+    payloads.forEach((payload) => {
+      expect(countFileMediaItems(payload)).toBe(toFileMediaCellData(payload).length);
+    });
   });
 });
 

--- a/src/application/database-yjs/cell.parse.ts
+++ b/src/application/database-yjs/cell.parse.ts
@@ -20,6 +20,7 @@ import {
   parseNumberTypeOptions,
   stringifyDesktopNumberValue,
 } from '@/application/database-yjs/fields/number/parse';
+import { isFileMediaItem } from '@/application/database-yjs/fields/media/parse';
 import {
   parseCheckboxValue,
   parseDesktopCheckboxValue,
@@ -358,7 +359,7 @@ export function parseYDatabaseFileMediaCellToCell(cell: YDatabaseCell): FileMedi
     try {
       const parsed = JSON.parse(item);
 
-      if (parsed && typeof parsed === 'object') {
+      if (isFileMediaItem(parsed)) {
         dataJson.push(parsed);
       }
     } catch (e) {

--- a/src/application/database-yjs/cell.parse.ts
+++ b/src/application/database-yjs/cell.parse.ts
@@ -348,8 +348,23 @@ export function parseYDatabaseFileMediaCellToCell(cell: YDatabaseCell): FileMedi
     } as FileMediaCell;
   }
 
-  // Convert YArray<string> to FileMediaCellData
-  const dataJson = data.toJSON().map((item: string) => JSON.parse(item)) as FileMediaCellData;
+  // Convert YArray<string> to FileMediaCellData. A cell that was lazily
+  // converted from another list-shaped type still holds that type's entries,
+  // so drop anything that is not a media item rather than throwing.
+  const entries = data.toJSON() as string[];
+  const dataJson: FileMediaCellData = [];
+
+  entries.forEach((item) => {
+    try {
+      const parsed = JSON.parse(item);
+
+      if (parsed && typeof parsed === 'object') {
+        dataJson.push(parsed);
+      }
+    } catch (e) {
+      // Not a media entry; skip it.
+    }
+  });
 
   return {
     ...parseYDatabaseCommonCellToCell(cell),

--- a/src/application/database-yjs/fields/media/parse.ts
+++ b/src/application/database-yjs/fields/media/parse.ts
@@ -1,11 +1,17 @@
 import * as Y from 'yjs';
 
-import { getTypeOptions } from '@/application/database-yjs';
+// Import from the defining module, not the package barrel: cell.parse.ts uses
+// isFileMediaItem below, and going through the barrel would be circular.
 import { FileMediaCellData, FileMediaCellDataItem } from '@/application/database-yjs/cell.type';
+import { getTypeOptions } from '@/application/database-yjs/fields/type_option';
 import { YDatabaseField, YjsDatabaseKey } from '@/application/types';
 
-function isFileMediaItem (item: unknown): item is FileMediaCellDataItem {
-  return Boolean(item) && typeof item === 'object';
+export function isFileMediaItem (item: unknown): item is FileMediaCellDataItem {
+  return (
+    Boolean(item) &&
+    typeof item === 'object' &&
+    typeof (item as { id?: unknown }).id === 'string'
+  );
 }
 
 /**
@@ -67,12 +73,11 @@ export function updateFileName ({ data, fileId, newName }: {
   const newData = new Y.Array<string>();
 
   toFileMediaCellData(data).forEach((item) => {
+    // Copy instead of assigning: `item` is the object held in the parsed cell
+    // state the UI is currently rendering.
+    const next = item.id === fileId ? { ...item, name: newName } : item;
 
-    if (item.id === fileId) {
-      item.name = newName;
-    }
-
-    newData.push([JSON.stringify(item)]);
+    newData.push([JSON.stringify(next)]);
   });
 
   return newData;

--- a/src/application/database-yjs/fields/media/parse.ts
+++ b/src/application/database-yjs/fields/media/parse.ts
@@ -4,6 +4,10 @@ import { getTypeOptions } from '@/application/database-yjs';
 import { FileMediaCellData, FileMediaCellDataItem } from '@/application/database-yjs/cell.type';
 import { YDatabaseField, YjsDatabaseKey } from '@/application/types';
 
+function isFileMediaItem (item: unknown): item is FileMediaCellDataItem {
+  return Boolean(item) && typeof item === 'object';
+}
+
 /**
  * A cell can briefly still hold the previous field type's payload — a plain
  * string right after a Text field is switched to Files & media, for instance.
@@ -13,7 +17,20 @@ import { YDatabaseField, YjsDatabaseKey } from '@/application/types';
 export function toFileMediaCellData (data: unknown): FileMediaCellData {
   if (!Array.isArray(data)) return [];
 
-  return data.filter((item): item is FileMediaCellDataItem => Boolean(item) && typeof item === 'object');
+  return data.filter(isFileMediaItem);
+}
+
+/** Counts the same items as {@link toFileMediaCellData} without building the list. */
+export function countFileMediaItems (data: unknown): number {
+  if (!Array.isArray(data)) return 0;
+
+  let count = 0;
+
+  for (const item of data) {
+    if (isFileMediaItem(item)) count += 1;
+  }
+
+  return count;
 }
 
 export function parseToFilesMediaCellData (newItems: FileMediaCellData) {

--- a/src/application/database-yjs/fields/media/parse.ts
+++ b/src/application/database-yjs/fields/media/parse.ts
@@ -1,8 +1,20 @@
 import * as Y from 'yjs';
 
 import { getTypeOptions } from '@/application/database-yjs';
-import { FileMediaCellData } from '@/application/database-yjs/cell.type';
+import { FileMediaCellData, FileMediaCellDataItem } from '@/application/database-yjs/cell.type';
 import { YDatabaseField, YjsDatabaseKey } from '@/application/types';
+
+/**
+ * A cell can briefly still hold the previous field type's payload — a plain
+ * string right after a Text field is switched to Files & media, for instance.
+ * Every media reader goes through here so a non-list payload renders as empty
+ * instead of throwing.
+ */
+export function toFileMediaCellData (data: unknown): FileMediaCellData {
+  if (!Array.isArray(data)) return [];
+
+  return data.filter((item): item is FileMediaCellDataItem => Boolean(item) && typeof item === 'object');
+}
 
 export function parseToFilesMediaCellData (newItems: FileMediaCellData) {
   const newData = new Y.Array<string>();
@@ -31,13 +43,13 @@ export function parseFileMediaTypeOptions (field: YDatabaseField) {
 }
 
 export function updateFileName ({ data, fileId, newName }: {
-  data?: FileMediaCellData,
+  data?: unknown,
   fileId: string,
   newName: string
 }) {
   const newData = new Y.Array<string>();
 
-  data?.forEach((item) => {
+  toFileMediaCellData(data).forEach((item) => {
 
     if (item.id === fileId) {
       item.name = newName;
@@ -50,12 +62,12 @@ export function updateFileName ({ data, fileId, newName }: {
 }
 
 export function deleteFile ({ data, fileId }: {
-  data?: FileMediaCellData,
+  data?: unknown,
   fileId: string,
 }) {
   const newData = new Y.Array<string>();
 
-  data?.forEach((item) => {
+  toFileMediaCellData(data).forEach((item) => {
     if (item.id !== fileId) {
       newData.push([JSON.stringify(item)]);
     }

--- a/src/application/database-yjs/selector.ts
+++ b/src/application/database-yjs/selector.ts
@@ -2909,49 +2909,44 @@ export function useCellSelector({ rowId, fieldId }: { rowId: string; fieldId: st
   const cells = row?.get(YjsDatabaseKey.cells);
   const { field, clock: fieldClock } = useFieldSelector(fieldId);
   const cell = cells?.get(fieldId);
-  const [, setClock] = useState<number>(0);
-  const [cellValue, setCellValue] = useState(() => {
-    return cell ? parseYDatabaseCellToCell(cell, field) : undefined;
-  });
+  const [clock, setClock] = useState<number>(0);
   const fieldType = Number(field?.get(YjsDatabaseKey.type)) as FieldType;
   const rollupCell = useRollupCellValue({ row, field, rowId, fieldId, fieldClock });
+
+  // Parse during render rather than from an effect, and key on the field type
+  // read from the doc rather than on a clock. Callers pick their cell component
+  // from that same live type, so a value that lags even one render describes the
+  // previous type and reaches a renderer that cannot read it.
+  const cellValue = useMemo(() => {
+    return cell ? parseYDatabaseCellToCell(cell, field) : undefined;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [cell, field, fieldType, fieldClock, clock]);
 
   useEffect(() => {
     const observerEvent = () => {
       setClock((prev) => prev + 1);
-      setCellValue(cell ? parseYDatabaseCellToCell(cell, field) : undefined);
     };
 
-    observerEvent();
     cell?.observeDeep(observerEvent);
 
     return () => {
       cell?.unobserveDeep(observerEvent);
     };
-  }, [cell, field, fieldClock, rowId, fieldId]);
+  }, [cell]);
 
   useEffect(() => {
     if (!cells) return;
 
     const observerEvent = () => {
-      const cell = cells.get(fieldId);
-
-      if (!cell) {
-        setCellValue(undefined);
-        return;
-      } else {
-        setCellValue(parseYDatabaseCellToCell(cell, field));
-      }
+      setClock((prev) => prev + 1);
     };
-
-    observerEvent();
 
     cells.observe(observerEvent);
 
     return () => {
       cells.unobserve(observerEvent);
     };
-  }, [cells, fieldId, field, fieldClock, rowId]);
+  }, [cells]);
 
   if (fieldType === FieldType.Rollup) {
     return rollupCell;

--- a/src/application/database-yjs/selector.ts
+++ b/src/application/database-yjs/selector.ts
@@ -2922,31 +2922,43 @@ export function useCellSelector({ rowId, fieldId }: { rowId: string; fieldId: st
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [cell, field, fieldType, fieldClock, clock]);
 
-  useEffect(() => {
-    const observerEvent = () => {
-      setClock((prev) => prev + 1);
-    };
+  // Lets the effect below compare a fresh parse against the value the UI
+  // rendered without re-running on every clock bump.
+  const cellValueRef = useRef(cellValue);
 
-    cell?.observeDeep(observerEvent);
-
-    return () => {
-      cell?.unobserveDeep(observerEvent);
-    };
-  }, [cell]);
+  cellValueRef.current = cellValue;
 
   useEffect(() => {
     if (!cells) return;
 
-    const observerEvent = () => {
+    const bump = () => {
       setClock((prev) => prev + 1);
     };
 
-    cells.observe(observerEvent);
+    const onCellsChange = (event: unknown) => {
+      // Scoped to this column: replacing another cell in the row must not
+      // re-parse every cell hook on the row.
+      if (yjsEventChangesKey(event, fieldId)) bump();
+    };
+
+    cells.observe(onCellsChange);
+    cell?.observeDeep(bump);
+
+    // A mutation can land between render (which parsed the cell) and this
+    // effect (which attaches the observers), and nothing reports it. Re-render
+    // once when the value the UI rendered is already stale.
+    const current = cells.get(fieldId);
+    const fresh = current ? parseYDatabaseCellToCell(current, field) : undefined;
+
+    if (JSON.stringify(fresh) !== JSON.stringify(cellValueRef.current)) {
+      bump();
+    }
 
     return () => {
-      cells.unobserve(observerEvent);
+      cells.unobserve(onCellsChange);
+      cell?.unobserveDeep(bump);
     };
-  }, [cells]);
+  }, [cells, cell, field, fieldId]);
 
   if (fieldType === FieldType.Rollup) {
     return rollupCell;

--- a/src/components/database/components/cell/file-media/FileMediaCell.tsx
+++ b/src/components/database/components/cell/file-media/FileMediaCell.tsx
@@ -29,23 +29,17 @@ export function FileMediaCell({
   const { workspaceId, databasePageId } = useDatabaseContext();
   const [openPreview, setOpenPreview] = React.useState(false);
   const previewIndexRef = React.useRef(0);
-  const photos = useMemo(() => {
-    return (
-      value
-        ?.filter((item) => {
-          return item.file_type === FileMediaType.Image && item.url;
-        })
-        .map((image) => {
-          return {
-            src: image.url,
-          };
-        }) || []
-    );
+  const images = useMemo(() => {
+    return value.filter((item) => item.file_type === FileMediaType.Image && item.url);
   }, [value]);
 
-  const images = useMemo(() => {
-    return value?.filter((item) => item.file_type === FileMediaType.Image && item.url) || [];
-  }, [value]);
+  const photos = useMemo(() => {
+    return images.map((image) => {
+      return {
+        src: image.url,
+      };
+    });
+  }, [images]);
 
   const handlePreview = useCallback((index: number) => {
     previewIndexRef.current = index;
@@ -79,13 +73,11 @@ export function FileMediaCell({
   );
 
   const renderChildren = useMemo(() => {
-    const length = value?.length || 0;
-
-    if (length === 0) {
+    if (value.length === 0) {
       return placeholder || null;
     }
 
-    return value?.map(renderItem);
+    return value.map(renderItem);
   }, [placeholder, renderItem, value]);
 
   return (
@@ -94,7 +86,7 @@ export function FileMediaCell({
       className={cn(
         'flex items-center gap-1.5',
         readOnly ? 'cursor-text' : 'cursor-pointer',
-        !value || (value?.length === 0 && 'text-text-tertiary'),
+        value.length === 0 && 'text-text-tertiary',
         wrap ? 'flex-wrap' : 'appflowy-hidden-scroller w-full flex-nowrap overflow-x-auto overflow-y-hidden'
       )}
     >
@@ -107,7 +99,7 @@ export function FileMediaCell({
           cell={cell}
           rowId={rowId}
           onPreview={handlePreview}
-          showUpload={!value || value.length === 0}
+          showUpload={value.length === 0}
         />
       )}
       {openPreview && (

--- a/src/components/database/components/cell/file-media/FileMediaCell.tsx
+++ b/src/components/database/components/cell/file-media/FileMediaCell.tsx
@@ -7,6 +7,7 @@ import {
   FileMediaCellDataItem,
   FileMediaType,
 } from '@/application/database-yjs/cell.type';
+import { toFileMediaCellData } from '@/application/database-yjs/fields/media/parse';
 import { GalleryPreview } from '@/components/_shared/gallery-preview';
 import FileMediaCellMenu from '@/components/database/components/cell/file-media/FileMediaCellMenu';
 import PreviewImage from '@/components/database/components/cell/file-media/PreviewImage';
@@ -24,10 +25,7 @@ export function FileMediaCell({
   rowId,
   readOnly,
 }: CellProps<FileMediaCellType>) {
-  const rawValue = cell?.data;
-  const value = useMemo(() => {
-    return Array.isArray(rawValue) ? rawValue.filter(Boolean) : [];
-  }, [rawValue]);
+  const value = useMemo(() => toFileMediaCellData(cell?.data), [cell?.data]);
   const { workspaceId, databasePageId } = useDatabaseContext();
   const [openPreview, setOpenPreview] = React.useState(false);
   const previewIndexRef = React.useRef(0);

--- a/src/components/database/components/cell/file-media/FileMediaList.tsx
+++ b/src/components/database/components/cell/file-media/FileMediaList.tsx
@@ -7,7 +7,12 @@ import {
   FileMediaCellDataItem, FileMediaType,
 } from '@/application/database-yjs/cell.type';
 import { useUpdateCellDispatch } from '@/application/database-yjs/dispatch';
-import { deleteFile, parseToFilesMediaCellData, updateFileName } from '@/application/database-yjs/fields/media/parse';
+import {
+  deleteFile,
+  parseToFilesMediaCellData,
+  toFileMediaCellData,
+  updateFileName,
+} from '@/application/database-yjs/fields/media/parse';
 import { ReactComponent as DragIcon } from '@/assets/icons/drag.svg';
 import FileMediaItem from '@/components/database/components/cell/file-media/FileMediaItem';
 import DragItem from '@/components/database/components/drag-and-drop/DragItem';
@@ -68,7 +73,7 @@ function FileMediaList ({
   onPreview: (index: number) => void;
 }) {
   const readOnly = useReadOnly();
-  const data = useMemo(() => cell?.data?.filter((item => item !== null)) || [], [cell?.data]);
+  const data = useMemo(() => toFileMediaCellData(cell?.data), [cell?.data]);
   const [container, setContainer] = useState<HTMLDivElement | null>(null);
   const updateCell = useUpdateCellDispatch(rowId, fieldId);
 
@@ -90,22 +95,22 @@ function FileMediaList ({
 
   const onUpdateName = useCallback((file: FileMediaCellDataItem, name: string) => {
     const newData = updateFileName({
-      data: cell?.data,
+      data,
       fileId: file.id,
       newName: name,
     });
 
     updateCell(newData);
-  }, [cell?.data, updateCell]);
+  }, [data, updateCell]);
 
   const onDelete = useCallback((fileId: string) => {
     const newData = deleteFile({
-      data: cell?.data,
+      data,
       fileId,
     });
 
     updateCell(newData);
-  }, [cell?.data, updateCell]);
+  }, [data, updateCell]);
 
   const images = useMemo(() => {
     return data.filter(item => item.file_type === FileMediaType.Image && item.url);

--- a/src/components/database/components/cell/file-media/FileMediaUpload.tsx
+++ b/src/components/database/components/cell/file-media/FileMediaUpload.tsx
@@ -11,6 +11,7 @@ import {
   FileMediaUploadType,
 } from '@/application/database-yjs/cell.type';
 import { useUpdateCellDispatch } from '@/application/database-yjs/dispatch';
+import { toFileMediaCellData } from '@/application/database-yjs/fields/media/parse';
 import { getFileMediaType } from '@/application/database-yjs/fields/media/utils';
 import FileDropzone from '@/components/_shared/file-dropzone/FileDropzone';
 import EmbedLink from '@/components/_shared/image-upload/EmbedLink';
@@ -57,9 +58,9 @@ function FileMediaUpload({
   const addItems = useCallback(
     (items: FileMediaCellDataItem[]) => {
       const newData = new Y.Array<string>();
-      const data = cell?.data;
+      const data = toFileMediaCellData(cell?.data);
 
-      if (data) {
+      if (data.length > 0) {
         newData.push(data.map((item) => JSON.stringify(item)));
       }
 

--- a/src/components/database/components/database-row/__tests__/FileMediaCell.test.tsx
+++ b/src/components/database/components/database-row/__tests__/FileMediaCell.test.tsx
@@ -9,6 +9,8 @@ import {
   FileMediaType,
   FileMediaUploadType,
 } from '@/application/database-yjs/cell.type';
+import { useUpdateCellDispatch } from '@/application/database-yjs/dispatch';
+import { useFieldSelector } from '@/application/database-yjs/selector';
 import { YDatabaseField, YjsDatabaseKey } from '@/application/types';
 
 import FileMediaCell from '../file-media/FileMediaCell';
@@ -26,10 +28,8 @@ jest.mock('react-i18next', () => ({
   useTranslation: () => ({ t: (key: string) => key }),
 }));
 
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-const { useFieldSelector } = require('@/application/database-yjs/selector');
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-const { useUpdateCellDispatch } = require('@/application/database-yjs/dispatch');
+const mockUseFieldSelector = jest.mocked(useFieldSelector);
+const mockUseUpdateCellDispatch = jest.mocked(useUpdateCellDispatch);
 
 const fieldId = 'field-id';
 const rowId = 'row-id';
@@ -102,8 +102,8 @@ describe('row-detail FileMediaCell', () => {
   });
 
   beforeEach(() => {
-    (useFieldSelector as jest.Mock).mockReturnValue({ field: createMediaField(), clock: 0 });
-    (useUpdateCellDispatch as jest.Mock).mockReturnValue(jest.fn());
+    mockUseFieldSelector.mockReturnValue({ field: createMediaField(), clock: 0 });
+    mockUseUpdateCellDispatch.mockReturnValue(jest.fn());
   });
 
   it('renders a file grid for the files it was given', () => {

--- a/src/components/database/components/database-row/__tests__/FileMediaCell.test.tsx
+++ b/src/components/database/components/database-row/__tests__/FileMediaCell.test.tsx
@@ -1,0 +1,129 @@
+import { render, screen } from '@testing-library/react';
+import type React from 'react';
+import * as Y from 'yjs';
+
+import { DatabaseContext, DatabaseContextState, FieldType } from '@/application/database-yjs';
+import {
+  FileMediaCell as FileMediaCellType,
+  FileMediaCellDataItem,
+  FileMediaType,
+  FileMediaUploadType,
+} from '@/application/database-yjs/cell.type';
+import { YDatabaseField, YjsDatabaseKey } from '@/application/types';
+
+import FileMediaCell from '../file-media/FileMediaCell';
+
+jest.mock('@/application/database-yjs/selector', () => ({
+  ...jest.requireActual('@/application/database-yjs/selector'),
+  useFieldSelector: jest.fn(),
+}));
+
+jest.mock('@/application/database-yjs/dispatch', () => ({
+  useUpdateCellDispatch: jest.fn(),
+}));
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { useFieldSelector } = require('@/application/database-yjs/selector');
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { useUpdateCellDispatch } = require('@/application/database-yjs/dispatch');
+
+const fieldId = 'field-id';
+const rowId = 'row-id';
+
+function createMediaField(): YDatabaseField {
+  const doc = new Y.Doc();
+  const field = doc.getMap('field') as YDatabaseField;
+
+  field.set(YjsDatabaseKey.id, fieldId);
+  field.set(YjsDatabaseKey.name, 'Files & media');
+  field.set(YjsDatabaseKey.type, FieldType.Media);
+  return field;
+}
+
+const mediaItem: FileMediaCellDataItem = {
+  id: 'file-1',
+  name: 'Invoice-114489.pdf',
+  url: 'https://example.com/Invoice-114489.pdf',
+  file_type: FileMediaType.Document,
+  upload_type: FileMediaUploadType.CloudMedia,
+};
+
+const contextValue = {
+  readOnly: false,
+  databasePageId: 'view-id',
+  activeViewId: 'view-id',
+  workspaceId: 'workspace-id',
+  rowMap: {},
+} as unknown as DatabaseContextState;
+
+const wrapper = ({ children }: { children: React.ReactNode }) => (
+  <DatabaseContext.Provider value={contextValue}>{children}</DatabaseContext.Provider>
+);
+
+/**
+ * The cell renders the file grid above the "add file" row, and only when it
+ * reads at least one file out of the payload.
+ */
+function hasFileGrid(container: HTMLElement) {
+  return (container.firstElementChild?.children.length ?? 0) > 1;
+}
+
+function renderCell(data: unknown) {
+  return render(
+    <FileMediaCell
+      cell={{ fieldType: FieldType.Media, createdAt: 0, lastModified: 0, data } as unknown as FileMediaCellType}
+      fieldId={fieldId}
+      rowId={rowId}
+    />,
+    { wrapper }
+  );
+}
+
+describe('row-detail FileMediaCell', () => {
+  beforeAll(() => {
+    // jsdom has no ResizeObserver; the media grid measures itself with one.
+    global.ResizeObserver = class {
+      observe() {
+        // no-op
+      }
+
+      unobserve() {
+        // no-op
+      }
+
+      disconnect() {
+        // no-op
+      }
+    } as unknown as typeof ResizeObserver;
+  });
+
+  beforeEach(() => {
+    (useFieldSelector as jest.Mock).mockReturnValue({ field: createMediaField(), clock: 0 });
+    (useUpdateCellDispatch as jest.Mock).mockReturnValue(jest.fn());
+  });
+
+  it('renders a file grid for the files it was given', () => {
+    const { container } = renderCell([mediaItem]);
+
+    expect(hasFileGrid(container)).toBe(true);
+  });
+
+  // Switching a Text property to Files & media leaves the old string in the
+  // cell for a moment; rendering it used to throw and take down the whole page.
+  it('renders empty when the cell still holds the previous type\'s text', () => {
+    const { container } = renderCell('Invoice-114489.pdf');
+
+    expect(hasFileGrid(container)).toBe(false);
+    expect(screen.getByText('grid.media.addFileOrMedia')).toBeTruthy();
+  });
+
+  it('renders empty for other payloads that are not a file list', () => {
+    expect(() => renderCell(undefined)).not.toThrow();
+    expect(() => renderCell(null)).not.toThrow();
+    expect(() => renderCell(42)).not.toThrow();
+  });
+});

--- a/src/components/database/components/database-row/file-media/FileMediaCell.tsx
+++ b/src/components/database/components/database-row/file-media/FileMediaCell.tsx
@@ -42,19 +42,17 @@ export function FileMediaCell ({
   const [editing, setEditing] = React.useState(false);
   const [openPreview, setOpenPreview] = React.useState(false);
   const previewIndexRef = React.useRef(0);
+  const images = useMemo(() => {
+    return value.filter(item => item.file_type === FileMediaType.Image && item.url);
+  }, [value]);
+
   const photos = useMemo(() => {
-    return value.filter(item => {
-      return item.file_type === FileMediaType.Image && item.url;
-    }).map(image => {
+    return images.map(image => {
       return {
         src: image.url,
       };
     });
-  }, [value]);
-
-  const images = useMemo(() => {
-    return value.filter(item => item.file_type === FileMediaType.Image && item.url);
-  }, [value]);
+  }, [images]);
 
   const handlePreview = useCallback((index: number) => {
     previewIndexRef.current = index;

--- a/src/components/database/components/database-row/file-media/FileMediaCell.tsx
+++ b/src/components/database/components/database-row/file-media/FileMediaCell.tsx
@@ -12,6 +12,7 @@ import {
   deleteFile,
   parseFileMediaTypeOptions,
   parseToFilesMediaCellData,
+  toFileMediaCellData,
   updateFileName,
 } from '@/application/database-yjs/fields/media/parse';
 import { ReactComponent as AddIcon } from '@/assets/icons/plus.svg';
@@ -28,7 +29,7 @@ export function FileMediaCell ({
   rowId,
   readOnly,
 }: CellProps<FileMediaCellType>) {
-  const value = cell?.data;
+  const value = useMemo(() => toFileMediaCellData(cell?.data), [cell?.data]);
   const { t } = useTranslation();
   const { field, clock } = useFieldSelector(fieldId);
   const { workspaceId, databasePageId } = useDatabaseContext();
@@ -42,17 +43,17 @@ export function FileMediaCell ({
   const [openPreview, setOpenPreview] = React.useState(false);
   const previewIndexRef = React.useRef(0);
   const photos = useMemo(() => {
-    return value?.filter(item => {
+    return value.filter(item => {
       return item.file_type === FileMediaType.Image && item.url;
     }).map(image => {
       return {
         src: image.url,
       };
-    }) || [];
+    });
   }, [value]);
 
   const images = useMemo(() => {
-    return value?.filter(item => item.file_type === FileMediaType.Image && item.url) || [];
+    return value.filter(item => item.file_type === FileMediaType.Image && item.url);
   }, [value]);
 
   const handlePreview = useCallback((index: number) => {
@@ -74,27 +75,25 @@ export function FileMediaCell ({
 
   const onUpdateName = useCallback((file: FileMediaCellDataItem, name: string) => {
     const newData = updateFileName({
-      data: cell?.data,
+      data: value,
       fileId: file.id,
       newName: name,
     });
 
     updateCell(newData);
-  }, [cell?.data, updateCell]);
+  }, [value, updateCell]);
 
   const onDelete = useCallback((fileId: string) => {
     const newData = deleteFile({
-      data: cell?.data,
+      data: value,
       fileId,
     });
 
     updateCell(newData);
-  }, [cell?.data, updateCell]);
+  }, [value, updateCell]);
 
   const renderChildren = useMemo(() => {
-    const length = value?.length || 0;
-
-    if (!value || length === 0) {
+    if (value.length === 0) {
       return null;
     }
 
@@ -146,7 +145,7 @@ export function FileMediaCell ({
       }}
       className={'h-full w-full'}
     >
-      {value && value.length > 0 && <div
+      {value.length > 0 && <div
         style={style}
         className={cn('flex pb-2 w-full items-center gap-1.5 flex-wrap', 'cursor-pointer')}
       >

--- a/src/components/database/components/field/CardField.tsx
+++ b/src/components/database/components/field/CardField.tsx
@@ -5,7 +5,7 @@ import { FieldType, useCellSelector, useFieldSelector, useReadOnly } from '@/app
 import { TextCell } from '@/application/database-yjs/cell.type';
 import { useUpdateCellDispatch } from '@/application/database-yjs/dispatch';
 import { getChecked } from '@/application/database-yjs/fields/checkbox/utils';
-import { toFileMediaCellData } from '@/application/database-yjs/fields/media/parse';
+import { countFileMediaItems } from '@/application/database-yjs/fields/media/parse';
 import { YjsDatabaseKey } from '@/application/types';
 import { ReactComponent as FileMediaSvg } from '@/assets/icons/attachment.svg';
 import { Cell } from '@/components/database/components/cell/Cell';
@@ -105,7 +105,7 @@ export function CardField({
   }
 
   if (Number(type) === FieldType.Media) {
-    const count = toFileMediaCellData(cell?.data).length;
+    const count = countFileMediaItems(cell?.data);
 
     if (count === 0) return null;
     return (

--- a/src/components/database/components/field/CardField.tsx
+++ b/src/components/database/components/field/CardField.tsx
@@ -2,9 +2,10 @@ import { CSSProperties, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { FieldType, useCellSelector, useFieldSelector, useReadOnly } from '@/application/database-yjs';
-import { FileMediaCellData, TextCell } from '@/application/database-yjs/cell.type';
+import { TextCell } from '@/application/database-yjs/cell.type';
 import { useUpdateCellDispatch } from '@/application/database-yjs/dispatch';
 import { getChecked } from '@/application/database-yjs/fields/checkbox/utils';
+import { toFileMediaCellData } from '@/application/database-yjs/fields/media/parse';
 import { YjsDatabaseKey } from '@/application/types';
 import { ReactComponent as FileMediaSvg } from '@/assets/icons/attachment.svg';
 import { Cell } from '@/components/database/components/cell/Cell';
@@ -104,7 +105,7 @@ export function CardField({
   }
 
   if (Number(type) === FieldType.Media) {
-    const count = (cell?.data as FileMediaCellData)?.length || 0;
+    const count = toFileMediaCellData(cell?.data).length;
 
     if (count === 0) return null;
     return (

--- a/src/components/ui/__tests__/progress.test.tsx
+++ b/src/components/ui/__tests__/progress.test.tsx
@@ -1,0 +1,37 @@
+import { render } from '@testing-library/react';
+
+import { Progress } from '@/components/ui/progress';
+
+function rootOf(container: HTMLElement) {
+  return container.firstElementChild as HTMLElement;
+}
+
+describe('Progress', () => {
+  // The indeterminate spinner rotates its root element. A full-width block root
+  // would swing the circle around the centre of the surrounding container
+  // instead of spinning it in place, throwing it across the layout.
+  it('keeps the spinning root sized to the circle', () => {
+    const { container } = render(<Progress />);
+    const root = rootOf(container);
+
+    expect(root.className).toContain('animate-progress-container');
+    expect(root.className).toContain('inline-block');
+    expect(root.className.split(/\s+/)).not.toContain('block');
+  });
+
+  it('does not animate the root when it reports a determinate value', () => {
+    const { container } = render(<Progress value={40} />);
+
+    expect(rootOf(container).className).not.toContain('animate-progress-container');
+  });
+
+  it('renders a 20px circle for every variant', () => {
+    (['default', 'inherit', 'primary'] as const).forEach((variant) => {
+      const { container } = render(<Progress variant={variant} />);
+      const svg = container.querySelector('svg');
+
+      expect(svg?.getAttribute('width')).toBe('20');
+      expect(svg?.getAttribute('height')).toBe('20');
+    });
+  });
+});

--- a/src/components/ui/progress.tsx
+++ b/src/components/ui/progress.tsx
@@ -3,8 +3,11 @@ import * as React from 'react';
 
 import { cn } from '@/lib/utils';
 
+// The indeterminate animation spins this element, so it has to hug the circle.
+// As a full-width block it would instead swing the circle around the centre of
+// whatever container it sits in, throwing it clear across the layout.
 const progressVariants = cva(
-  'relative block',
+  'relative inline-block',
   {
     variants: {
       variant: {


### PR DESCRIPTION
Two independent user-reported bugs.

## 1. Switching a Text property to Files & media crashed the app

Changing an existing Text property (value `Invoice-114489.pdf`) to type **Files & media** took the whole page down to the error boundary with `value?.filter is not a function`.

`useCellSelector` kept its parsed cell in `useState` and refreshed it from an effect, so when a field's type changed the cell lagged one render behind. Callers pick their cell component from the field's live type during that same render, so the Files & media renderer was mounted with a cell that still held the Text payload — a plain string — and threw while rendering.

- Parse during render instead, keyed on the field type read from the doc so the value can never describe the previous type. (Keying on an observer clock is not enough: the two `useFieldSelector` instances involved bump their clocks in separate passes, which still left one stale render.)
- Normalize every media reader through a shared `toFileMediaCellData`, so a payload left over from another field type renders as empty rather than throwing.
- The same normalizer guards the rename/delete/upload writers, which would otherwise have mangled a string payload, and the media decoder now skips entries it cannot parse.

This also fixes `CardField`, which reported a string's character count as an attachment count.

The staleness in `useCellSelector` was a whole class of bug — every cell type went through that one-render window and merely happened to tolerate it. The selector change closes the class; the media normalizer is defence in depth.

## 2. The indeterminate spinner flew out of its container

<img width="600" alt="spinner drawn over the invite-link description text" src="https://github.com/user-attachments/assets/placeholder" />

In Settings → People the loading spinner was drawn across the invite-link description text instead of under the table header.

The indeterminate animation rotates `Progress`'s root, but that root was a full-width `block`. In the People panel it measured **844px wide**, so rotating it swung the 20px circle around the container's centre on a ~422px radius: measured live, its bounding box grew to **760×403** and reached **168px above its own parent**.

Making the root `inline-block` lets it hug the circle so the rotation spins in place. Measured after the change: centre fixed at (914, 509) against a parent centre of (914, 512), zero drift.

## Testing

- 13 new tests across three files. Reverting the two media-path files makes the media tests fail with the exact reported error (`TypeError: value?.filter is not a function` at `FileMediaCell.tsx:45`).
- Spinner fix verified in a real browser against a live workspace, holding the loading state open by delaying the members request.
- All 71 `Progress` call sites reviewed: every other one sits in a flex container, where `block` vs `inline-block` is byte-identical geometry (verified empirically). The only call sites this changes are the full-width ones that were broken.
- Full suite green; `pnpm lint` (type-check + eslint) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Prevent stale field data from crashing Files & media views and keep indeterminate spinners from overflowing their containers.

Bug Fixes:
- Prevent crashes and incorrect attachment counts when switching fields to Files & media while stale or invalid payloads remain.
- Keep indeterminate progress indicators contained within their intended layout bounds.

Enhancements:
- Make cell selection reflect the current field type during rendering and centralize validation of media cell data across readers and writers.

Tests:
- Add coverage for field-type switching, invalid media payload handling, media parsing and updates, row rendering, and progress geometry.