### PR TITLE
fix(editor): paste text at the caret instead of the next line

### DIFF
--- a/playwright/bdd/features/editor/paste-at-cursor.feature
+++ b/playwright/bdd/features/editor/paste-at-cursor.feature
@@ -1,0 +1,38 @@
+Feature: Paste at cursor position
+  Reproduces the bug where pasted text lands on the next line instead of the
+  caret position. A single inline snippet — whether copied from another app
+  (text/html clipboard flavor) or from AppFlowy itself
+  (application/x-appflowy-fragment) — must be inserted into the current block
+  at the caret, not appended as a sibling paragraph below.
+
+  Background:
+    Given a blank document page is open
+
+  Scenario: Text copied from a web page pastes at the caret, not on the next line
+    When I type "The quick brown fox" in the editor
+    And I select text from offset 10 to offset 10 in editor block 0
+    And I paste html content at the current caret:
+      """
+      <meta charset="utf-8"><span style="color: rgb(55, 53, 47);">PASTED</span>
+      """
+    Then the editor has exactly 1 top-level block
+    And editor block 0 contains "The quick PASTEDbrown fox"
+
+  Scenario: A word copied inside AppFlowy pastes at the caret, not on the next line
+    When I type "The quick brown fox" in the editor
+    And I select text from offset 4 to offset 9 in editor block 0
+    And I copy the current editor selection
+    And I select text from offset 10 to offset 10 in editor block 0
+    And I paste the copied content at the current caret
+    Then the editor has exactly 1 top-level block
+    And editor block 0 contains "The quick quickbrown fox"
+
+  Scenario: Multi-line paste merges its first line at the caret
+    When I type "The quick brown fox" in the editor
+    And I select text from offset 10 to offset 10 in editor block 0
+    And I paste html content at the current caret:
+      """
+      <p>ALPHA</p><p>BETA</p>
+      """
+    Then editor block 0 contains "The quick ALPHA"
+    And the editor contains "BETA"

--- a/playwright/bdd/steps/paste-at-cursor.steps.ts
+++ b/playwright/bdd/steps/paste-at-cursor.steps.ts
@@ -1,0 +1,144 @@
+import { createBdd } from 'playwright-bdd';
+
+const { When } = createBdd();
+
+type TestSlatePoint = {
+  path: number[];
+  offset: number;
+};
+
+type TestSlateRange = {
+  anchor: TestSlatePoint;
+  focus: TestSlatePoint;
+};
+
+type TestSlateEditor = {
+  select?: (range: TestSlateRange) => void;
+  insertData?: (data: DataTransfer) => void;
+  setFragmentData?: (data: Pick<DataTransfer, 'getData' | 'setData'>) => void;
+};
+
+type TestWindow = Window & {
+  __TEST_EDITOR__?: TestSlateEditor;
+  __TEST_EDITORS__?: Record<string, TestSlateEditor | undefined>;
+  __TEST_SELECTED_RANGE__?: TestSlateRange;
+  __TEST_COPIED_CLIPBOARD__?: Record<string, string>;
+};
+
+// The shared "I select text from offset ..." step stashes the chosen range on
+// __TEST_SELECTED_RANGE__ because the DOM selection sync can clobber
+// editor.selection between steps. Each step below re-applies the stashed range
+// right before acting, like insertTextIntoExpandedSelection in
+// editor-editing.steps does.
+
+/**
+ * Pastes html content at the current editor selection WITHOUT refocusing the
+ * editor first. The shared "I paste html content:" step clicks the editor,
+ * which moves the caret — these scenarios place the caret explicitly and must
+ * keep it where it is.
+ */
+When('I paste html content at the current caret:', async ({ page }, html: string) => {
+  await page.evaluate((html) => {
+    const testWindow = window as TestWindow;
+    const editor = testWindow.__TEST_EDITOR__ ?? Object.values(testWindow.__TEST_EDITORS__ ?? {})[0];
+
+    if (!editor?.insertData) {
+      throw new Error('No test editor with insertData() found');
+    }
+
+    const stashed = testWindow.__TEST_SELECTED_RANGE__;
+
+    if (stashed) {
+      editor.select?.(stashed);
+      delete testWindow.__TEST_SELECTED_RANGE__;
+    }
+
+    const plainText = html
+      .replace(/<[^>]+>/g, ' ')
+      .replace(/\s+/g, ' ')
+      .trim();
+    const dataTransfer = new DataTransfer();
+
+    dataTransfer.setData('text/html', html);
+    dataTransfer.setData('text/plain', plainText);
+    editor.insertData(dataTransfer);
+  }, html.trim());
+
+  await page.waitForTimeout(1000);
+});
+
+/**
+ * Captures what AppFlowy would put on the clipboard for the current selection
+ * (text/plain, text/html, and application/x-appflowy-fragment) via the
+ * editor's setFragmentData, and stashes it on the window for a later paste.
+ */
+When('I copy the current editor selection', async ({ page }) => {
+  const types = await page.evaluate(() => {
+    const testWindow = window as TestWindow;
+    const editor = testWindow.__TEST_EDITOR__ ?? Object.values(testWindow.__TEST_EDITORS__ ?? {})[0];
+
+    if (!editor?.setFragmentData) {
+      throw new Error('No test editor with setFragmentData() found');
+    }
+
+    const stashed = testWindow.__TEST_SELECTED_RANGE__;
+
+    if (stashed) {
+      editor.select?.(stashed);
+    }
+
+    const dataTransfer = new DataTransfer();
+
+    editor.setFragmentData(dataTransfer);
+
+    const captured: Record<string, string> = {};
+
+    for (const type of dataTransfer.types) {
+      captured[type] = dataTransfer.getData(type);
+    }
+
+    testWindow.__TEST_COPIED_CLIPBOARD__ = captured;
+    return Object.keys(captured);
+  });
+
+  if (types.length === 0) {
+    throw new Error('Copy captured no clipboard data — is the selection expanded?');
+  }
+});
+
+/**
+ * Pastes the clipboard data captured by "I copy the current editor selection"
+ * at the current editor selection, without refocusing the editor.
+ */
+When('I paste the copied content at the current caret', async ({ page }) => {
+  await page.evaluate(() => {
+    const testWindow = window as TestWindow;
+    const editor = testWindow.__TEST_EDITOR__ ?? Object.values(testWindow.__TEST_EDITORS__ ?? {})[0];
+    const captured = testWindow.__TEST_COPIED_CLIPBOARD__;
+
+    if (!editor?.insertData) {
+      throw new Error('No test editor with insertData() found');
+    }
+
+    if (!captured || Object.keys(captured).length === 0) {
+      throw new Error('No copied clipboard data — run "I copy the current editor selection" first');
+    }
+
+    const stashed = testWindow.__TEST_SELECTED_RANGE__;
+
+    if (stashed) {
+      editor.select?.(stashed);
+      delete testWindow.__TEST_SELECTED_RANGE__;
+    }
+
+    const dataTransfer = new DataTransfer();
+
+    for (const [type, value] of Object.entries(captured)) {
+      dataTransfer.setData(type, value);
+    }
+
+    editor.insertData(dataTransfer);
+  });
+
+  await page.waitForTimeout(1000);
+});

--- a/src/components/editor/plugins/withInsertData.ts
+++ b/src/components/editor/plugins/withInsertData.ts
@@ -1,19 +1,12 @@
-import { Editor, Element, Node, Range, Transforms } from 'slate';
+import { Element, Node } from 'slate';
 import { ReactEditor } from 'slate-react';
 
 import { YjsEditor } from '@/application/slate-yjs';
 import { CustomEditor } from '@/application/slate-yjs/command';
-import { slateContentInsertToYData } from '@/application/slate-yjs/utils/convert';
-import {
-  findSlateEntryByBlockId,
-  getBlockEntry,
-  getSharedRoot,
-  isInsideSimpleTableCell,
-} from '@/application/slate-yjs/utils/editor';
-import { assertDocExists, getBlock, getChildrenArray } from '@/application/slate-yjs/utils/yjs';
+import { TEXT_BLOCK_TYPES } from '@/application/slate-yjs/command/const';
+import { findSlateEntryByBlockId, getBlockEntry, isInsideSimpleTableCell } from '@/application/slate-yjs/utils/editor';
 import {
   BlockType,
-  CollabOrigin,
   FieldURLType,
   FileBlockData,
   ImageBlockData,
@@ -24,6 +17,7 @@ import { extractAppFlowyClipboardFragment } from '@/components/editor/clipboard/
 import { stripInlineCommentIds } from '@/components/editor/clipboard/inline-comment-metadata';
 import { containsSimpleTableBlocks, extractTSVFromTableFragment } from '@/components/editor/clipboard/table-fragment';
 import { convertSlateFragmentTo } from '@/components/editor/utils/fragment';
+import { insertBlocksAtCaret } from '@/components/editor/utils/insert-blocks-at-caret';
 import { FileHandler } from '@/utils/file';
 import { Log } from '@/utils/log';
 import { createPendingUploadId } from '@/utils/pending-upload';
@@ -347,111 +341,58 @@ function decodeSlateFragment(raw: string): Node[] | null {
 }
 
 /**
- * Inserts a Slate fragment as siblings of the current block using the YJS
- * shared doc, mirroring the path used by `insertParsedBlocks` for HTML paste.
+ * Fragment block types whose inline text merges into the block under the
+ * caret when they arrive first in a pasted fragment. Unlike external
+ * HTML/markdown paste (where only paragraphs merge), an internal copy that
+ * starts mid-line carries the source block's type — copying part of a heading
+ * still yields a heading node — so any plain text block merges here, matching
+ * Slate's `insertFragment` and the desktop editor. Code blocks keep their
+ * block identity, and table cells never arrive here (handled earlier).
+ */
+const MERGEABLE_FIRST_FRAGMENT_TYPES = TEXT_BLOCK_TYPES.filter(
+  (type) => type !== BlockType.CodeBlock && type !== BlockType.SimpleTableCellBlock
+);
+
+function shouldMergeFirstFragmentNodeInline(node: Node): boolean {
+  return (
+    Element.isElement(node) &&
+    MERGEABLE_FIRST_FRAGMENT_TYPES.includes(node.type as BlockType) &&
+    node.children.length === 1
+  );
+}
+
+/**
+ * Inserts a Slate fragment relative to the caret using the YJS shared doc,
+ * sharing the insertion path used by `insertParsedBlocks` for HTML paste:
+ * a leading text block merges inline at the cursor, everything else lands as
+ * sibling blocks at the same indent level.
  *
  * Returns true if the fragment was inserted; false if the caller should fall
  * back to Slate's default `insertFragment`.
- *
- * Mirrors two behaviors of Slate's `Transforms.insertFragment`:
- *  - If the selection is expanded, delete the selected range first.
- *  - After insertion, place the cursor at the end of the last inserted block.
  */
 function insertFragmentAsSiblings(editor: YjsEditor, fragment: Node[]): boolean {
   if (fragment.length === 0) return false;
 
-  try {
-    // Every fragment node must be a block-level element with a text wrapper
-    // child — anything else (loose text, inline-only fragments) goes through
-    // Slate's default path so inline pastes still work.
-    const allBlocks = fragment.every((n) => {
-      if (!Element.isElement(n)) return false;
-      const children = n.children;
+  // Every fragment node must be a block-level element with a text wrapper
+  // child — anything else (loose text, inline-only fragments) goes through
+  // Slate's default path so those pastes still work.
+  const allBlocks = fragment.every((n) => {
+    if (!Element.isElement(n)) return false;
+    const children = n.children;
 
-      return (
-        Array.isArray(children) &&
-        children.length > 0 &&
-        Element.isElement(children[0]) &&
-        children[0].type === YjsEditorKey.text
-      );
-    });
+    return (
+      Array.isArray(children) &&
+      children.length > 0 &&
+      Element.isElement(children[0]) &&
+      children[0].type === YjsEditorKey.text
+    );
+  });
 
-    if (!allBlocks) return false;
+  if (!allBlocks) return false;
 
-    // Match Slate's default `Transforms.insertFragment`: collapse expanded
-    // selection by deleting the selected range first. Re-fetch the block
-    // entry afterward because the deletion changes which block holds the
-    // cursor and whether it is empty.
-    if (editor.selection && !Range.isCollapsed(editor.selection)) {
-      Transforms.delete(editor);
-    }
-
-    const entry = getBlockEntry(editor);
-
-    if (!entry) return false;
-
-    const [node] = entry;
-    const blockId = (node as BlockElement).blockId;
-
-    if (!blockId) return false;
-
-    const sharedRoot = getSharedRoot(editor);
-    const block = getBlock(blockId, sharedRoot);
-
-    if (!block) return false;
-
-    const parentId = block.get(YjsEditorKey.block_parent);
-    const parent = getBlock(parentId, sharedRoot);
-
-    if (!parent) return false;
-
-    const parentChildren = getChildrenArray(parent.get(YjsEditorKey.block_children), sharedRoot);
-    const index = parentChildren.toArray().findIndex((id) => id === blockId);
-
-    if (index < 0) return false;
-
-    // If the current block is empty (no text, no children), the user expects
-    // paste to fill that block — not push it above the pasted content. Insert
-    // at the current index and remove the empty original.
-    const isEmpty = CustomEditor.getBlockTextContent(node as Node).length === 0 && (node.children?.length ?? 0) <= 1;
-
-    const doc = assertDocExists(sharedRoot);
-    let insertedIds: string[] = [];
-
-    doc.transact(() => {
-      if (isEmpty) {
-        insertedIds = slateContentInsertToYData(parentId, index, fragment, doc);
-        CustomEditor.deleteBlock(editor, blockId);
-      } else {
-        insertedIds = slateContentInsertToYData(parentId, index + 1, fragment, doc);
-      }
-    }, CollabOrigin.LocalManual);
-
-    // Place the cursor at the end of the last inserted block so subsequent
-    // edits target a valid location (not the now-deleted original block).
-    const lastId = insertedIds[insertedIds.length - 1];
-
-    if (lastId) {
-      const lastEntry = findSlateEntryByBlockId(editor, lastId);
-
-      if (lastEntry) {
-        const [, path] = lastEntry;
-
-        try {
-          Transforms.select(editor, Editor.end(editor, path));
-        } catch (err) {
-          // Editor.end can throw if the path was rebuilt mid-transact; the
-          // selection will be re-derived on the next user keystroke.
-          Log.warn('insertFragmentAsSiblings: could not set selection', err);
-        }
-      }
-    }
-
-    return true;
-  } catch (err) {
-    Log.error('insertFragmentAsSiblings failed', err);
-    return false;
-  }
+  return insertBlocksAtCaret(editor, fragment as Element[], {
+    mergeFirstBlockInline: shouldMergeFirstFragmentNodeInline(fragment[0]),
+  });
 }
 
 function createTextDataTransfer(text: string, html?: string): DataTransfer {

--- a/src/components/editor/plugins/withPasted.ts
+++ b/src/components/editor/plugins/withPasted.ts
@@ -21,6 +21,7 @@ import { ParsedBlock } from '@/components/editor/parsers/types';
 import { PASTE_AS_MENU_EVENT } from '@/components/editor/components/panels/paste-as-panel/constants';
 import type { PasteAsMenuPayload } from '@/components/editor/components/panels/paste-as-panel/constants';
 import { getRangeRect } from '@/components/editor/components/toolbar/selection-toolbar/utils';
+import { insertBlocksAtCaret } from '@/components/editor/utils/insert-blocks-at-caret';
 import { detectMarkdown, detectTSV } from '@/components/editor/utils/markdown-detector';
 import { isSingleURLText, parseAppFlowyPageLink, processUrl, workspaceIdFromAppPathname } from '@/utils/url';
 
@@ -657,6 +658,15 @@ function parsedBlockToTextNodes(block: ParsedBlock): Text[] {
  */
 const TABLE_BLOCK_TYPES = [BlockType.SimpleTableBlock, BlockType.SimpleTableRowBlock, BlockType.SimpleTableCellBlock];
 
+/**
+ * A first pasted paragraph merges inline at the caret. Headings, lists,
+ * quotes, etc. keep their block identity and insert as new blocks, so
+ * pasting "# Title" markdown or an HTML heading never degrades to plain text.
+ */
+function shouldMergeFirstParsedBlockInline(block: ParsedBlock): boolean {
+  return block.type === BlockType.Paragraph && block.children.length === 0 && block.text.length > 0;
+}
+
 function insertParsedBlocks(editor: ReactEditor, blocks: ParsedBlock[]): boolean {
   if (blocks.length === 0) return false;
 
@@ -674,27 +684,20 @@ function insertParsedBlocks(editor: ReactEditor, blocks: ParsedBlock[]): boolean
 
     if (!blockId) return false;
 
-    const sharedRoot = getSharedRoot(editor as YjsEditor);
-    const block = getBlock(blockId, sharedRoot);
-
     // Check if we're pasting inside a table cell
     const insideTable = isInsideSimpleTableCell(editor as YjsEditor, blockId);
 
     if (insideTable) {
+      const sharedRoot = getSharedRoot(editor as YjsEditor);
+
       // Split blocks: text-like blocks go inside the cell, table blocks go after the parent table
       const cellBlocks = blocks.filter((b) => !TABLE_BLOCK_TYPES.includes(b.type));
       const tableBlocks = blocks.filter((b) => TABLE_BLOCK_TYPES.includes(b.type));
 
       // Insert text blocks inside the cell
       if (cellBlocks.length > 0) {
-        const parent = getBlock(block.get(YjsEditorKey.block_parent), sharedRoot);
-        const parentChildren = getChildrenArray(parent.get(YjsEditorKey.block_children), sharedRoot);
-        const index = parentChildren.toArray().findIndex((id) => id === blockId);
-        const doc = assertDocExists(sharedRoot);
-        const slateNodes = cellBlocks.map(parsedBlockToSlateElement);
-
-        doc.transact(() => {
-          slateContentInsertToYData(block.get(YjsEditorKey.block_parent), index + 1, slateNodes, doc);
+        insertBlocksAtCaret(editor as YjsEditor, cellBlocks.map(parsedBlockToSlateElement), {
+          mergeFirstBlockInline: shouldMergeFirstParsedBlockInline(cellBlocks[0]),
         });
       }
 
@@ -734,21 +737,12 @@ function insertParsedBlocks(editor: ReactEditor, blocks: ParsedBlock[]): boolean
       return true;
     }
 
-    // Normal paste (not inside table cell)
-    const parent = getBlock(block.get(YjsEditorKey.block_parent), sharedRoot);
-    const parentChildren = getChildrenArray(parent.get(YjsEditorKey.block_children), sharedRoot);
-    const index = parentChildren.toArray().findIndex((id) => id === blockId);
-    const doc = assertDocExists(sharedRoot);
-
-    // Convert parsed blocks to Slate elements with proper text wrapper
-    const slateNodes = blocks.map(parsedBlockToSlateElement);
-
-    // Insert into YJS document
-    doc.transact(() => {
-      slateContentInsertToYData(block.get(YjsEditorKey.block_parent), index + 1, slateNodes, doc);
+    // Normal paste (not inside table cell): insert relative to the caret —
+    // a leading paragraph merges inline at the cursor, everything else lands
+    // as sibling blocks below.
+    return insertBlocksAtCaret(editor as YjsEditor, blocks.map(parsedBlockToSlateElement), {
+      mergeFirstBlockInline: shouldMergeFirstParsedBlockInline(blocks[0]),
     });
-
-    return true;
   } catch (error) {
     console.error('Error inserting parsed blocks:', error);
     return false;

--- a/src/components/editor/utils/insert-blocks-at-caret.ts
+++ b/src/components/editor/utils/insert-blocks-at-caret.ts
@@ -1,0 +1,306 @@
+import { Editor, Element, Node, Path, Range, Text, Transforms } from 'slate';
+
+import { YjsEditor } from '@/application/slate-yjs';
+import { CustomEditor } from '@/application/slate-yjs/command';
+import { TEXT_BLOCK_TYPES } from '@/application/slate-yjs/command/const';
+import { slateContentInsertToYData } from '@/application/slate-yjs/utils/convert';
+import { findSlateEntryByBlockId, getBlockEntry, getSharedRoot } from '@/application/slate-yjs/utils/editor';
+import { assertDocExists, getBlock, getChildrenArray } from '@/application/slate-yjs/utils/yjs';
+import { BlockType, CollabOrigin, YjsEditorKey } from '@/application/types';
+import { Log } from '@/utils/log';
+
+type BlockElement = Element & { blockId?: string };
+
+/**
+ * Inserts a sequence of pasted block elements relative to the caret,
+ * mirroring the semantics of Slate's `insertFragment` (and the desktop
+ * editor's paste command) while going through the YJS insertion path so
+ * blocks land as siblings at the right indent level:
+ *
+ * - An expanded selection is deleted first, like any native paste.
+ * - If the current block is empty, the pasted blocks replace it so the first
+ *   block keeps its type (pasting a heading into an empty line yields a
+ *   heading, not a paragraph with the heading's text).
+ * - If `mergeFirstBlockInline` is set and both the first pasted block and the
+ *   block under the caret can merge, the first block's inline content is
+ *   inserted AT the caret instead of below the line — this is what makes
+ *   paste land at the cursor position. For multi-block pastes the text after
+ *   the caret moves to the end of the last pasted block, preserving reading
+ *   order exactly like Slate's split-based `insertFragment`.
+ * - Otherwise every block is inserted as a sibling after the current block
+ *   (the previous behavior).
+ *
+ * Every element must be block-level with a text wrapper as its first child —
+ * callers are responsible for converting/validating their input.
+ *
+ * Returns true when the content was inserted; false when the caller should
+ * fall back to its own default handling.
+ */
+export function insertBlocksAtCaret(
+  editor: YjsEditor,
+  nodes: Element[],
+  options: { mergeFirstBlockInline: boolean }
+): boolean {
+  if (nodes.length === 0) return false;
+
+  try {
+    // Match Slate's default `insertFragment`: a paste over an expanded
+    // selection replaces it.
+    if (editor.selection && Range.isExpanded(editor.selection)) {
+      Transforms.delete(editor);
+    }
+
+    const entry = getBlockEntry(editor);
+
+    if (!entry) return false;
+
+    const [node, nodePath] = entry;
+    const blockId = (node as BlockElement).blockId;
+
+    if (!blockId) return false;
+
+    const sharedRoot = getSharedRoot(editor);
+    const block = getBlock(blockId, sharedRoot);
+
+    if (!block) return false;
+
+    const parentId = block.get(YjsEditorKey.block_parent);
+    const parent = getBlock(parentId, sharedRoot);
+
+    if (!parent) return false;
+
+    const parentChildren = getChildrenArray(parent.get(YjsEditorKey.block_children), sharedRoot);
+    const index = parentChildren.toArray().findIndex((id) => id === blockId);
+
+    if (index < 0) return false;
+
+    const doc = assertDocExists(sharedRoot);
+
+    // If the current block is empty (no text, no children), the user expects
+    // paste to fill that block — not push it above the pasted content. Insert
+    // at the current index and remove the empty original.
+    const isEmpty = CustomEditor.getBlockTextContent(node as Node).length === 0 && (node.children?.length ?? 0) <= 1;
+
+    if (isEmpty) {
+      let insertedIds: string[] = [];
+
+      doc.transact(() => {
+        insertedIds = slateContentInsertToYData(parentId, index, nodes, doc);
+        CustomEditor.deleteBlock(editor, blockId);
+      }, CollabOrigin.LocalManual);
+
+      selectBlockTextOffset(editor, insertedIds[insertedIds.length - 1]);
+      return true;
+    }
+
+    const mergeSource = options.mergeFirstBlockInline ? extractMergeableInlineNodes(nodes[0]) : null;
+
+    if (mergeSource && mergeSource.length > 0 && canMergeIntoBlock(node as BlockElement, nodePath, editor.selection)) {
+      insertWithFirstBlockMerged(editor, doc, mergeSource, nodes.slice(1), {
+        nodePath,
+        parentId,
+        index,
+      });
+      return true;
+    }
+
+    // Default: insert every block as a sibling after the current block.
+    let insertedIds: string[] = [];
+
+    doc.transact(() => {
+      insertedIds = slateContentInsertToYData(parentId, index + 1, nodes, doc);
+    }, CollabOrigin.LocalManual);
+
+    selectBlockTextOffset(editor, insertedIds[insertedIds.length - 1]);
+    return true;
+  } catch (err) {
+    Log.error('insertBlocksAtCaret failed', err);
+    return false;
+  }
+}
+
+/**
+ * Inserts the first pasted block's inline content at the caret and the
+ * remaining blocks as siblings below. When there are remaining blocks, the
+ * text after the caret moves to the end of the last pasted block so the
+ * document keeps reading in order (Slate's split semantics).
+ */
+function insertWithFirstBlockMerged(
+  editor: YjsEditor,
+  doc: ReturnType<typeof assertDocExists>,
+  mergeSource: Text[],
+  rest: Element[],
+  { nodePath, parentId, index }: { nodePath: Path; parentId: string; index: number }
+) {
+  const selection = editor.selection;
+
+  if (!selection) return;
+
+  const caret = Range.start(selection);
+
+  if (rest.length === 0) {
+    Transforms.insertNodes(editor, mergeSource, { at: caret, select: true, voids: false });
+    return;
+  }
+
+  // Move the text between the caret and the end of the current line into the
+  // last pasted block, when that block can hold text. Otherwise the tail
+  // stays on the current line right after the merged text.
+  const last = rest[rest.length - 1];
+  const lastWrapper = getTextWrapper(last);
+  const lastAcceptsTail = lastWrapper !== null && TEXT_BLOCK_TYPES.includes(last.type as BlockType);
+  let restNodes = rest;
+  let caretOffsetInLastBlock: number | null = null;
+
+  if (lastAcceptsTail && lastWrapper) {
+    const textWrapperPath = caret.path.slice(0, nodePath.length + 1);
+    const wrapperEnd = Editor.end(editor, textWrapperPath);
+    const tailRange: Range = { anchor: caret, focus: wrapperEnd };
+
+    if (!Range.isCollapsed(tailRange)) {
+      const tailNodes = extractInlineNodesFromRangeFragment(Editor.fragment(editor, tailRange));
+
+      Transforms.delete(editor, { at: tailRange });
+
+      if (tailNodes.length > 0) {
+        caretOffsetInLastBlock = inlineTextLength(lastWrapper.children);
+        const mergedLast = {
+          ...last,
+          children: [
+            { ...lastWrapper, children: [...lastWrapper.children, ...tailNodes] } as Element,
+            ...last.children.slice(1),
+          ],
+        } as Element;
+
+        restNodes = [...rest.slice(0, -1), mergedLast];
+      }
+    }
+  }
+
+  Transforms.insertNodes(editor, mergeSource, { at: caret, select: true, voids: false });
+
+  let insertedIds: string[] = [];
+
+  doc.transact(() => {
+    insertedIds = slateContentInsertToYData(parentId, index + 1, restNodes, doc);
+  }, CollabOrigin.LocalManual);
+
+  // Leave the caret at the end of the pasted content — before any moved tail.
+  selectBlockTextOffset(editor, insertedIds[insertedIds.length - 1], caretOffsetInLastBlock ?? undefined);
+}
+
+/**
+ * Returns the first pasted block's inline text nodes when the block is a pure
+ * text block (a single text-wrapper child holding only text leaves), or null
+ * when its structure cannot be merged inline.
+ */
+function extractMergeableInlineNodes(node: Element): Text[] | null {
+  if (node.children?.length !== 1) return null;
+
+  const wrapper = getTextWrapper(node);
+
+  if (!wrapper) return null;
+
+  const children = wrapper.children;
+
+  if (!children.every((child) => Text.isText(child))) return null;
+
+  return (children as Text[]).filter((child) => child.text.length > 0);
+}
+
+/** The block under the caret can receive inline text at the caret position. */
+function canMergeIntoBlock(node: BlockElement, nodePath: Path, selection: Range | null): boolean {
+  if (!selection) return false;
+
+  const type = node.type as BlockType;
+
+  // Code blocks take plain text only and are handled by the soft-break path.
+  if (!TEXT_BLOCK_TYPES.includes(type) || type === BlockType.CodeBlock) return false;
+
+  const wrapper = getTextWrapper(node);
+
+  if (!wrapper) return false;
+
+  // The caret must sit inside the block's text wrapper (child 0).
+  const wrapperPath = [...nodePath, 0];
+
+  return Path.isCommon(wrapperPath, Range.start(selection).path);
+}
+
+function getTextWrapper(node: Element): Element | null {
+  const wrapper = node.children?.[0];
+
+  if (!Element.isElement(wrapper) || wrapper.type !== YjsEditorKey.text) return null;
+
+  return wrapper;
+}
+
+function inlineTextLength(children: Element['children']): number {
+  return children.reduce((sum, child) => sum + (Text.isText(child) ? child.text.length : 0), 0);
+}
+
+/**
+ * Extracts the inline text leaves from a fragment produced by
+ * `Editor.fragment` over a range inside one block's text wrapper.
+ */
+function extractInlineNodesFromRangeFragment(fragment: Node[]): Text[] {
+  const block = fragment[0];
+
+  if (!Element.isElement(block)) return [];
+
+  const wrapper = getTextWrapper(block);
+
+  if (!wrapper) return [];
+
+  return wrapper.children.filter((child): child is Text => Text.isText(child) && child.text.length > 0);
+}
+
+/**
+ * Places the caret inside the given block's text: at `offset` characters into
+ * its text wrapper, or at the block's end when no offset is given.
+ */
+function selectBlockTextOffset(editor: YjsEditor, blockId: string | undefined, offset?: number) {
+  if (!blockId) return;
+
+  const entry = findSlateEntryByBlockId(editor, blockId);
+
+  if (!entry) return;
+
+  const [node, path] = entry;
+
+  try {
+    if (offset === undefined) {
+      Transforms.select(editor, Editor.end(editor, path));
+      return;
+    }
+
+    const wrapper = getTextWrapper(node);
+    const wrapperPath = [...path, 0];
+
+    if (!wrapper) {
+      Transforms.select(editor, Editor.end(editor, path));
+      return;
+    }
+
+    let remaining = offset;
+
+    for (let i = 0; i < wrapper.children.length; i++) {
+      const child = wrapper.children[i];
+
+      if (!Text.isText(child)) continue;
+
+      if (remaining <= child.text.length) {
+        Transforms.select(editor, { path: [...wrapperPath, i], offset: remaining });
+        return;
+      }
+
+      remaining -= child.text.length;
+    }
+
+    Transforms.select(editor, Editor.end(editor, wrapperPath));
+  } catch (err) {
+    // Editor.end can throw if the path was rebuilt mid-transact; the
+    // selection will be re-derived on the next user keystroke.
+    Log.warn('selectBlockTextOffset: could not set selection', err);
+  }
+}


### PR DESCRIPTION
## Problem

Pasting text landed on the **next line** instead of at the cursor position. Two paste paths shared the flaw:

- **External paste with a `text/html` flavor** (any copy from a browser, Word, VSCode, mail…): `insertParsedBlocks` always inserted the parsed blocks as siblings *after* the current block (`index + 1`) and never merged the first block's inline content at the caret. Since almost every real-world copy carries `text/html`, ordinary text pastes hit this path.
- **Internal AppFlowy copy/paste** (`application/x-appflowy-fragment`): a copied inline word arrives as `[{type:'paragraph', children:[{type:'text', …}]}]`, so `insertFragmentAsSiblings` treated it as a block paste and inserted it below (regression from #342, which replaced Slate's default `insertFragment` — and its first-block inline merge — with always-sibling insertion to fix block nesting).

Plain-text-only pastes were unaffected (they already insert inline), which made the bug look intermittent.

## Fix

Both paths now funnel through a shared `insertBlocksAtCaret` helper (`src/components/editor/utils/insert-blocks-at-caret.ts`) that mirrors Slate's `insertFragment` semantics while keeping the YJS sibling-insertion path from #342 (so blocks still never nest under the current block):

- An expanded selection is replaced first, like any native paste (previously the HTML path ignored the selection).
- A **leading text block merges inline at the caret** — this is what makes paste land at the cursor.
  - External HTML/markdown paste merges only *paragraphs*, so pasted headings/lists/quotes keep their block identity (pasting `# Title` still produces a heading).
  - Internal fragments merge any plain text block, because a mid-line copy carries the source block's type (copying part of a heading yields a heading node). Code blocks are excluded.
- For **multi-block pastes**, the text after the caret moves to the end of the last pasted block, preserving reading order exactly like Slate's split-based `insertFragment`.
- An **empty current block is replaced** by the pasted blocks (the HTML path previously left an empty line above the pasted content).
- The caret lands at the end of the pasted content.

Table-cell TSV distribution, URL/mention paste, and the paste-as menu are untouched.

## Tests

New BDD feature `playwright/bdd/features/editor/paste-at-cursor.feature` reproduces the bug (all three scenarios fail on `main`) and passes with this fix:

1. Text copied from a web page (`text/html` flavor) pastes at the caret — `The quick |brown fox` + paste `PASTED` → `The quick PASTEDbrown fox`, still 1 block.
2. A word copied inside AppFlowy (`setFragmentData` → real 3-flavor clipboard payload replayed through `insertData`) pastes at the caret.
3. A multi-line paste merges its first line at the caret.

- `npx jest --no-coverage`: 324 suites / 3137 tests pass
- All 64 editor BDD tests pass (including the existing `editor-editing.feature` HTML/markdown/plain paste scenario)
- `pnpm type-check` and `eslint --quiet` clean
- `nested-database-interoperability.feature`: its paste scenario passes; the "Renaming a nested database title synchronizes and persists" scenario fails identically against unmodified `main` in my environment (pre-existing sync flake, unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Insert pasted content at the caret while preserving block structure and native paste semantics.

Bug Fixes:
- Ensure external HTML and internal AppFlowy fragment pastes insert text at the caret instead of as a new line.
- Preserve reading order and replace expanded selections correctly during multi-block pastes.

Enhancements:
- Consolidate block paste behavior into shared caret-aware insertion logic while preserving sibling-level block insertion and block formatting.

Tests:
- Add editor BDD coverage for HTML paste, internal AppFlowy copy/paste, and multi-line paste at the caret.