### PR TITLE
fix(sidebar): reduce periodic outline polling and repeated 403 ancestor fetches

### DIFF
--- a/src/components/app/layers/AppBusinessLayer.tsx
+++ b/src/components/app/layers/AppBusinessLayer.tsx
@@ -49,6 +49,12 @@ const ROUTE_VIEW_EXISTS_REVALIDATE_MS = 10000;
 const PERMISSION_PROBE_TTL_MS = 10000;
 const PERMISSION_PROBE_CACHE_MAX = 200;
 
+// Stable "not resolvable" result for breadcrumb ancestors. Identity matters:
+// the fallback-crumb effect depends on `originalCrumbs`, and a fresh [] per
+// outline change would re-walk the ancestor chain (one server fetch per
+// ancestor, including permanently-403 ones) on every sidebar update.
+const NO_BREADCRUMB_ANCESTORS: View[] = [];
+
 type PermissionProbeVerdict = 'allowed' | 'denied' | 'unknown';
 type PermissionProbeResult = PermissionProbeTarget & { verdict: PermissionProbeVerdict };
 const permissionProbeCache = new Map<string, { probedAt: number; promise: Promise<PermissionProbeResult> }>();
@@ -596,8 +602,8 @@ export const AppBusinessLayer: FC<AppBusinessLayerProps> = ({ children }) => {
 
   // Calculate breadcrumbs based on current view
   const originalCrumbs = useMemo(() => {
-    if (!outline || !breadcrumbViewId) return [];
-    return findAncestors(outline, breadcrumbViewId) || [];
+    if (!outline || !breadcrumbViewId) return NO_BREADCRUMB_ANCESTORS;
+    return findAncestors(outline, breadcrumbViewId) || NO_BREADCRUMB_ANCESTORS;
   }, [outline, breadcrumbViewId]);
   const [fallbackCrumbs, setFallbackCrumbs] = useState<View[]>([]);
 

--- a/src/components/app/layers/__tests__/AppBusinessLayer.permissionGate.test.tsx
+++ b/src/components/app/layers/__tests__/AppBusinessLayer.permissionGate.test.tsx
@@ -373,4 +373,82 @@ describe('AppBusinessLayer permission gates', () => {
     });
     expect(deleteCollabDB).toHaveBeenCalledWith(routeViewId, { destroyDoc: true });
   });
+
+  it('walks breadcrumb fallback ancestors once while the route view stays unresolved across outline updates', async () => {
+    const eventEmitter = new EventEmitter();
+    const routeView = { ...createView(routeViewId), parent_view_id: parentViewId };
+
+    (AccessService.getObjectPermission as jest.Mock).mockResolvedValue({ can_read: true });
+    (ViewService.get as jest.Mock).mockImplementation((_workspaceId: string, id: string) =>
+      id === routeViewId ? Promise.resolve(routeView) : Promise.reject({ code: 403 })
+    );
+    (useSyncInternal as jest.Mock).mockReturnValue({
+      eventEmitter,
+      awarenessMap: {},
+      flushAllSync: jest.fn(),
+      revertCollabVersion: jest.fn(),
+      scheduleDeferredCleanup: jest.fn(),
+      syncAllToServer: jest.fn(),
+    });
+
+    // Production keeps one stable ref object; only the outline array identity
+    // changes across refreshes.
+    const stableOutlineRef = { current: [] as View[] } as MutableRefObject<View[]>;
+    const makeWorkspaceData = () => {
+      const outline = [createView(modalViewId)];
+
+      stableOutlineRef.current = outline;
+      return {
+        outline,
+        favoriteViews: [],
+        recentViews: [],
+        trashList: [],
+        workspaceDatabases: {},
+        stableOutlineRef,
+        loadedViewIds: new Set<string>(),
+      };
+    };
+
+    (useWorkspaceData as jest.Mock).mockReturnValue(makeWorkspaceData());
+
+    // Fresh elements per render — identical element references would let React
+    // bail out of re-rendering the layer, hiding the outline identity change.
+    const makeTree = () => (
+      <MemoryRouter
+        initialEntries={[`/${routeViewId}`]}
+        future={{ v7_relativeSplatPath: true, v7_startTransition: true }}
+      >
+        <Routes>
+          <Route
+            path={'/:viewId'}
+            element={
+              <AppBusinessLayer>
+                <NavigationProbe modalTargetId={modalViewId} />
+              </AppBusinessLayer>
+            }
+          />
+        </Routes>
+      </MemoryRouter>
+    );
+    const { rerender } = render(makeTree());
+
+    const parentFetchCount = () =>
+      (ViewService.get as jest.Mock).mock.calls.filter(([, id]) => id === parentViewId).length;
+
+    await waitFor(() => {
+      expect(parentFetchCount()).toBe(1);
+    });
+
+    // A new outline identity that still cannot resolve the route view must not
+    // re-walk the ancestor chain — that would refire one request per ancestor
+    // (including permanently denied ones) on every sidebar refresh.
+    (useWorkspaceData as jest.Mock).mockReturnValue(makeWorkspaceData());
+    rerender(makeTree());
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(parentFetchCount()).toBe(1);
+  });
 });

--- a/src/components/app/outline/Outline.tsx
+++ b/src/components/app/outline/Outline.tsx
@@ -2,6 +2,7 @@ import React, { lazy, Suspense, useCallback, useEffect, useMemo, useRef, useStat
 import { createPortal } from 'react-dom';
 import { useTranslation } from 'react-i18next';
 
+import { APP_EVENTS } from '@/application/constants';
 import { Role, View, ViewLayout } from '@/application/types';
 import { isSpaceView } from '@/application/view-utils';
 import { ReactComponent as MoreIcon } from '@/assets/icons/more.svg';
@@ -17,6 +18,7 @@ import {
   useLoadViewChildren,
   useMarkViewChildrenStale,
   useEnsureViewVisibleInOutline,
+  useEventEmitter,
   useRevalidateSidebarOutline,
   useSidebarSelectedViewId,
   useUserWorkspaceInfo,
@@ -25,6 +27,7 @@ import { Favorite } from '@/components/app/favorite';
 import { useReorderableSidebarList } from '@/components/app/outline/reorder/useReorderableSidebarList';
 import {
   createSidebarOutlineRevalidationScheduleState,
+  floorSidebarOutlineRevalidationStateForOpenWebSocket,
   getSidebarOutlineRevalidationDelayMs,
   limitSidebarOutlineExpandedViewIds,
   nextSidebarOutlineRevalidationStateAfterFailure,
@@ -42,6 +45,9 @@ const ImportDialog = lazy(() => import('@/components/app/import/ImportDialog'));
 
 const AUTO_LOAD_RETRY_DELAY_MS = 15000;
 const NAVIGATION_HYDRATION_RETRY_DELAY_MS = 15000;
+
+const WS_READY_STATE_OPEN = 1;
+const WS_READY_STATE_CLOSED = 3;
 
 function collectSubtreeViewIds(rootView: View): string[] {
   const ids: string[] = [];
@@ -70,6 +76,7 @@ export function Outline({ width }: { width: number }) {
   const markViewChildrenStale = useMarkViewChildrenStale();
   const ensureViewVisibleInOutline = useEnsureViewVisibleInOutline();
   const revalidateSidebarOutline = useRevalidateSidebarOutline();
+  const eventEmitter = useEventEmitter();
   const selectedViewId = useSidebarSelectedViewId();
   const userWorkspaceInfo = useUserWorkspaceInfo();
   const canReorderSpaces = userWorkspaceInfo?.selectedWorkspace.role === Role.Owner;
@@ -216,11 +223,23 @@ export function Outline({ width }: { width: number }) {
       }
     };
 
+    const getWebSocketReadyState = () =>
+      typeof eventEmitter.webSocketReadyState === 'number' ? eventEmitter.webSocketReadyState : undefined;
+
     const scheduleNextTick = () => {
       clearPendingTimer();
+
+      // While the socket is open, folder notifications keep the outline fresh
+      // and this poll is only a dropped-notification safety net — floor it to
+      // the slow cadence. Disconnected tabs keep the full fast→slow schedule.
+      const scheduleState =
+        getWebSocketReadyState() === WS_READY_STATE_OPEN
+          ? floorSidebarOutlineRevalidationStateForOpenWebSocket(sidebarRevalidationStateRef.current)
+          : sidebarRevalidationStateRef.current;
+
       timer = window.setTimeout(() => {
         void tick();
-      }, getSidebarOutlineRevalidationDelayMs(sidebarRevalidationStateRef.current));
+      }, getSidebarOutlineRevalidationDelayMs(scheduleState));
     };
 
     const tick = async () => {
@@ -277,9 +296,37 @@ export function Outline({ width }: { width: number }) {
       }
     };
 
+    let lastReadyState = getWebSocketReadyState();
+    let disconnectedSinceLastOpen = lastReadyState === WS_READY_STATE_CLOSED;
+
+    const handleWebSocketStatus = () => {
+      const readyState = getWebSocketReadyState();
+
+      if (readyState === undefined || readyState === lastReadyState) return;
+      lastReadyState = readyState;
+
+      if (readyState === WS_READY_STATE_CLOSED) {
+        if (!disconnectedSinceLastOpen) {
+          disconnectedSinceLastOpen = true;
+          // The notification channel is gone; reschedule so the poll takes
+          // over at the fast cadence instead of waiting out a slow-tier delay.
+          scheduleNextTick();
+        }
+
+        return;
+      }
+
+      if (readyState === WS_READY_STATE_OPEN && disconnectedSinceLastOpen) {
+        disconnectedSinceLastOpen = false;
+        // Notifications sent while disconnected are not replayed; catch up.
+        runNow();
+      }
+    };
+
     rescheduleSidebarRevalidationRef.current = rescheduleFromFastInterval;
     document.addEventListener('visibilitychange', runNowWhenVisible);
     window.addEventListener('online', runNow);
+    eventEmitter.on(APP_EVENTS.WEBSOCKET_STATUS, handleWebSocketStatus);
 
     scheduleNextTick();
 
@@ -288,11 +335,12 @@ export function Outline({ width }: { width: number }) {
       clearPendingTimer();
       document.removeEventListener('visibilitychange', runNowWhenVisible);
       window.removeEventListener('online', runNow);
+      eventEmitter.off(APP_EVENTS.WEBSOCKET_STATUS, handleWebSocketStatus);
       if (rescheduleSidebarRevalidationRef.current === rescheduleFromFastInterval) {
         rescheduleSidebarRevalidationRef.current = () => undefined;
       }
     };
-  }, [currentWorkspaceId, revalidateSidebarOutline]);
+  }, [currentWorkspaceId, eventEmitter, revalidateSidebarOutline]);
 
   // Validate restored expanded IDs that are not in the current tree and prune only truly stale IDs.
   // This avoids keeping deleted/moved IDs forever, while preserving valid deep IDs.

--- a/src/components/app/outline/__tests__/Outline.navigationContext.test.tsx
+++ b/src/components/app/outline/__tests__/Outline.navigationContext.test.tsx
@@ -13,6 +13,8 @@ declare global {
   var __outlineNavigationTestEnsureViewVisible: jest.Mock<Promise<string[]>, [viewId: string]> | undefined;
   // eslint-disable-next-line no-var
   var __outlineNavigationTestToView: jest.Mock<Promise<void>, [viewId: string]> | undefined;
+  // eslint-disable-next-line no-var
+  var __outlineNavigationTestEventEmitter: { on: jest.Mock; off: jest.Mock } | undefined;
 }
 
 jest.mock('react-i18next', () => ({
@@ -29,6 +31,7 @@ jest.mock('@/components/app/app.hooks', () => ({
   useCurrentWorkspaceId: () => 'workspace-id',
   useCurrentWorkspaceIdOptional: () => 'workspace-id',
   useEnsureViewVisibleInOutline: () => global.__outlineNavigationTestEnsureViewVisible,
+  useEventEmitter: () => global.__outlineNavigationTestEventEmitter,
   useLoadedViewIds: () => new Set<string>(),
   useLoadViewChildren: () => jest.fn().mockResolvedValue([]),
   useLoadViewChildrenBatch: () => jest.fn().mockResolvedValue([]),
@@ -217,6 +220,7 @@ describe('Outline navigation context hydration', () => {
     global.__outlineNavigationTestEnsureViewVisible = undefined;
     global.__outlineNavigationTestSelectedViewId = undefined;
     global.__outlineNavigationTestToView = undefined;
+    global.__outlineNavigationTestEventEmitter = { on: jest.fn(), off: jest.fn() };
   });
 
   it('hydrates and expands a notification target path when the selected view is missing locally', async () => {

--- a/src/components/app/outline/__tests__/sidebarRevalidation.test.ts
+++ b/src/components/app/outline/__tests__/sidebarRevalidation.test.ts
@@ -1,5 +1,6 @@
 import {
   createSidebarOutlineRevalidationScheduleState,
+  floorSidebarOutlineRevalidationStateForOpenWebSocket,
   getSidebarOutlineRevalidationDelayMs,
   nextSidebarOutlineRevalidationStateAfterFailure,
   nextSidebarOutlineRevalidationStateAfterResult,
@@ -52,5 +53,25 @@ describe('sidebar outline revalidation schedule', () => {
 
     state = nextSidebarOutlineRevalidationStateAfterResult(state, 'changed');
     expect(getSidebarOutlineRevalidationDelayMs(state, () => 0)).toBe(SIDEBAR_OUTLINE_REVALIDATION_INTERVAL_MS);
+  });
+
+  it('floors the schedule to the slow cadence while the WebSocket is open', () => {
+    const fresh = createSidebarOutlineRevalidationScheduleState();
+    const floored = floorSidebarOutlineRevalidationStateForOpenWebSocket(fresh);
+
+    expect(getSidebarOutlineRevalidationDelayMs(floored, () => 0)).toBe(SIDEBAR_OUTLINE_REVALIDATION_SLOW_INTERVAL_MS);
+
+    let slow = fresh;
+
+    for (let index = 0; index < 7; index += 1) {
+      slow = nextSidebarOutlineRevalidationStateAfterResult(slow, 'unchanged');
+    }
+
+    expect(floorSidebarOutlineRevalidationStateForOpenWebSocket(slow)).toBe(slow);
+
+    const failing = nextSidebarOutlineRevalidationStateAfterFailure(fresh);
+
+    expect(floorSidebarOutlineRevalidationStateForOpenWebSocket(failing)).toBe(failing);
+    expect(getSidebarOutlineRevalidationDelayMs(failing, () => 0)).toBe(SIDEBAR_OUTLINE_REVALIDATION_FAILURE_BASE_MS);
   });
 });

--- a/src/components/app/outline/sidebarRevalidation.ts
+++ b/src/components/app/outline/sidebarRevalidation.ts
@@ -43,6 +43,25 @@ export function nextSidebarOutlineRevalidationStateAfterFailure(
   };
 }
 
+/**
+ * While the workspace WebSocket is open, folder notifications are the primary
+ * freshness channel and the poll is only a safety net for dropped
+ * notifications, so it can run at the slow cadence right away. Failure backoff
+ * keeps its own schedule so transport-level retries stay bounded.
+ */
+export function floorSidebarOutlineRevalidationStateForOpenWebSocket(
+  state: SidebarOutlineRevalidationScheduleState
+): SidebarOutlineRevalidationScheduleState {
+  if (state.failureCount > 0 || state.unchangedCount >= SIDEBAR_OUTLINE_REVALIDATION_SLOW_AFTER) {
+    return state;
+  }
+
+  return {
+    ...state,
+    unchangedCount: SIDEBAR_OUTLINE_REVALIDATION_SLOW_AFTER,
+  };
+}
+
 export function getSidebarOutlineRevalidationDelayMs(
   state: SidebarOutlineRevalidationScheduleState = createSidebarOutlineRevalidationScheduleState(),
   random = Math.random


### PR DESCRIPTION
## Problem

The network tab shows the sidebar constantly refetching `trash`, `favorite`, the root outline, and individual views — including a recurring **403** for a page the user never opened (an ancestor of the current page that is not shared with them).

Two client-side loops caused most of the periodic traffic:

1. **The sidebar revalidation poll never backs off during active editing.** It polls the root outline every 30–60s even while the WebSocket is connected and folder notifications are already keeping the outline fresh, and each "changed" tick redoes the full pass (trash refresh, subtree cache invalidation, expanded-subtree refetch).
2. **The breadcrumb fallback walker re-runs on every outline update.** When the current page cannot be resolved from the lazy sidebar outline, breadcrumbs are built by walking the ancestor chain with one `GET /view/{id}?depth=1` per ancestor. The not-found memo returned a fresh `[]` on every outline identity change, so every sidebar refresh re-walked the chain and re-fetched every ancestor — including a permanently-403 parent, forever.

## Changes

- **WS-aware poll cadence** (`Outline.tsx`, `sidebarRevalidation.ts`): while the socket is open, the revalidation schedule is floored to the slow (~5–7min) tier; notifications are the primary freshness channel and the poll is only a dropped-notification safety net. When the socket closes, the poll immediately reschedules at the fast cadence, and on reconnect after a disconnect the sidebar revalidates once — notifications sent while disconnected are never replayed, and nothing previously caught the client up.
- **Stable breadcrumb fallback** (`AppBusinessLayer.tsx`): the unresolved-ancestors memo returns a stable constant, so the fallback walk runs once per page (and once per absence transition), not once per sidebar outline update.

## Tests

- New unit test for the schedule floor (fast/quiet states floor to slow; failure backoff and already-slow states unchanged).
- New regression test: "walks breadcrumb fallback ancestors once while the route view stays unresolved across outline updates" — verified to fail against the previous code.
- `Outline.navigationContext.test.tsx` mock extended for the new `useEventEmitter` usage.
- 63 tests across the 5 affected suites pass; `pnpm type-check` and eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Reduce sidebar network traffic by coordinating revalidation with WebSocket status and stabilizing unresolved breadcrumb fallback results.

Bug Fixes:
- Reduce unnecessary sidebar outline polling while WebSocket notifications are available and promptly recover when the connection changes.
- Prevent repeated breadcrumb ancestor requests, including recurring forbidden requests, while the current page remains unresolved.

Enhancements:
- Make sidebar revalidation WebSocket-aware by using slower safety polling when connected and faster catch-up behavior after disconnection.
- Add regression coverage for WebSocket polling cadence and stable breadcrumb fallback behavior.

Tests:
- Add unit coverage for WebSocket-aware revalidation scheduling and a regression test ensuring unresolved breadcrumb ancestors are fetched only once.