### PR TITLE
fix(database): load shared row documents with database context

### DIFF
--- a/playwright/bdd/features/database/row-document-member-permission.feature
+++ b/playwright/bdd/features/database/row-document-member-permission.feature
@@ -1,0 +1,16 @@
+@database @permissions @issue-8958
+Feature: Workspace members can open database row documents
+  A database row document inherits its access from the database that owns the row.
+  This must also work when the document exists without a legacy row-document registration.
+
+  Scenario: An invited workspace member opens a row document in a public space
+    Given an invited workspace member has default access to an issue 8958 public database
+    And the issue 8958 database has a row document without a legacy permission registration
+    When the invited member opens the issue 8958 database row
+    Then the invited member can read and edit the issue 8958 row document
+
+  Scenario: A private-space member opens a row document in a private space
+    Given an invited workspace member has edit access to an issue 8958 private database
+    And the issue 8958 database has a row document without a legacy permission registration
+    When the invited member opens the issue 8958 database row
+    Then the invited member can read and edit the issue 8958 row document

--- a/playwright/bdd/steps/row-document-member-permission.steps.ts
+++ b/playwright/bdd/steps/row-document-member-permission.steps.ts
@@ -1,0 +1,674 @@
+import { APIRequestContext, BrowserContext, expect, Page } from '@playwright/test';
+import { createBdd } from 'playwright-bdd';
+import { v4 as uuidv4, v5 as uuidv5 } from 'uuid';
+import * as Y from 'yjs';
+
+import { RowMetaKey } from '../../../src/application/database-yjs/database.type';
+import { getMetaIdMap } from '../../../src/application/database-yjs/row_meta';
+import { initializeDocumentStructure } from '../../../src/application/slate-yjs/utils/yjs';
+import { Types, ViewLayout, YDoc, YjsEditorKey } from '../../../src/application/types';
+import { AuthTestUtils } from '../../support/auth-utils';
+import { waitForGridReady } from '../../support/database-ui-helpers';
+import { openRowDetailByRowId } from '../../support/row-detail-helpers';
+import { DatabaseGridSelectors, RowDetailSelectors, SidebarSelectors } from '../../support/selectors';
+import { setupPageErrorHandling, TestConfig } from '../../support/test-config';
+
+const { Given, When, Then, Before, After } = createBdd();
+
+const PASSWORDLESS_TOKEN_TIMEOUT_MS = 30_000;
+const FIXTURE_TIMEOUT_MS = 45_000;
+const SPACE_PERMISSION_PUBLIC = 0;
+const SPACE_PERMISSION_PRIVATE = 1;
+const SPACE_MEMBER_EDIT_ACCESS = 30;
+
+type AuthTokenData = {
+  access_token?: string;
+  refresh_token?: string;
+  user?: { id?: string };
+  [key: string]: unknown;
+};
+
+type AuthSession = {
+  accessToken: string;
+  refreshToken: string;
+  tokenData: AuthTokenData;
+};
+
+type ApiResponse<T> = {
+  code?: number;
+  message?: string;
+  data?: T;
+};
+
+type UserWorkspaceInfo = {
+  visiting_workspace: { workspace_id: string };
+  workspaces: { workspace_id: string }[];
+};
+
+type CreatedPage = {
+  view_id: string;
+  database_id?: string;
+};
+
+type Issue8958State = {
+  runId: string;
+  ownerEmail: string;
+  memberEmail: string;
+  ownerSession?: AuthSession;
+  memberSession?: AuthSession;
+  workspaceId?: string;
+  spaceId?: string;
+  databasePageId?: string;
+  databaseId?: string;
+  rowId?: string;
+  rowDocumentId?: string;
+  rowTitle?: string;
+  rowBody?: string;
+  memberContext?: BrowserContext;
+  memberPage?: Page;
+  memberLoadRequests: string[];
+};
+
+type BrowserSyncContext = {
+  bindViewSync?: (doc: BrowserYDoc) => { flush?: () => Promise<boolean> } | null;
+  bindRowSync?: (rowId: string) => void;
+  checkIfRowDocumentExists?: (documentId: string) => Promise<boolean>;
+  ensureRow?: (rowId: string) => Promise<Y.Doc | undefined> | Y.Doc | undefined;
+};
+
+type BrowserYDoc = Y.Doc & {
+  object_id?: string;
+  view_id?: string;
+  _collabType?: Types;
+  _syncBound?: boolean;
+};
+
+type Issue8958TestWindow = Window & {
+  Y?: typeof Y;
+  __TEST_DATABASE_CONTEXT__?: BrowserSyncContext;
+  __ISSUE_8958_ROW_DOCUMENT__?: BrowserYDoc;
+};
+
+const stateByPage = new WeakMap<Page, Issue8958State>();
+
+Before(async ({ page }) => {
+  setupPageErrorHandling(page);
+  await page.setViewportSize({ width: 1440, height: 900 });
+  const runId = uuidv4();
+
+  stateByPage.set(page, {
+    runId,
+    ownerEmail: `issue-8958-owner-${runId}@appflowy.io`,
+    memberEmail: `issue-8958-member-${runId}@appflowy.io`,
+    memberLoadRequests: [],
+  });
+});
+
+After(async ({ page, request }) => {
+  const state = stateByPage.get(page);
+
+  await state?.memberContext?.close().catch(() => undefined);
+
+  if (state?.ownerSession && state.workspaceId && state.spaceId) {
+    await apiPost<void>(
+      request,
+      state.ownerSession.accessToken,
+      `/api/workspace/${state.workspaceId}/page-view/${state.spaceId}/move-to-trash`,
+      {}
+    ).catch(() => undefined);
+  }
+
+  stateByPage.delete(page);
+});
+
+Given('an invited workspace member has default access to an issue 8958 public database', async ({ page, request }) => {
+  await prepareDatabaseFixture(page, request, false);
+});
+
+Given('an invited workspace member has edit access to an issue 8958 private database', async ({ page, request }) => {
+  await prepareDatabaseFixture(page, request, true);
+});
+
+Given(
+  'the issue 8958 database has a row document without a legacy permission registration',
+  async ({ page, request }) => {
+    const state = requireDatabaseState(page);
+    const rowTitle = `Issue 8958 row ${state.runId.slice(0, 8)}`;
+    const rowBody = `Issue 8958 protected row body ${state.runId.slice(0, 8)}`;
+    const rowId = await apiPost<string>(
+      request,
+      state.ownerSession.accessToken,
+      `/api/workspace/${state.workspaceId}/database/${state.databaseId}/row`,
+      {
+        cells: { Name: rowTitle },
+        document: null,
+        parse_link_as_link_preview: false,
+      }
+    );
+    const rowDocumentId = uuidv5(RowMetaKey.DocumentId, rowId);
+    const isDocumentEmptyKey = getMetaIdMap(rowId).get(RowMetaKey.IsDocumentEmpty);
+
+    if (!isDocumentEmptyKey) {
+      throw new Error(`Could not derive the is-document-empty key for row ${rowId}`);
+    }
+
+    state.rowId = rowId;
+    state.rowDocumentId = rowDocumentId;
+    state.rowTitle = rowTitle;
+    state.rowBody = rowBody;
+
+    await expect(DatabaseGridSelectors.rowById(page, rowId)).toContainText(rowTitle, { timeout: FIXTURE_TIMEOUT_MS });
+
+    const rowDocumentUpdate = createRowDocumentUpdate(rowDocumentId, rowBody);
+    const seeded = await page.evaluate(
+      async ({ collabType, dataSectionKey, documentId, isEmptyKey, metaKey, rowId: targetRowId, update }) => {
+        const testWindow = window as Issue8958TestWindow;
+        const yjs = testWindow.Y;
+        const databaseContext = testWindow.__TEST_DATABASE_CONTEXT__;
+
+        if (!yjs || !databaseContext?.bindViewSync || !databaseContext.ensureRow) {
+          return { ok: false, reason: 'database test sync context is unavailable' };
+        }
+
+        const rowDoc = await databaseContext.ensureRow(targetRowId);
+        const rowMeta = rowDoc?.getMap(dataSectionKey).get(metaKey) as Y.Map<unknown> | undefined;
+
+        if (!rowDoc || !rowMeta) {
+          return { ok: false, reason: 'database row metadata is unavailable' };
+        }
+
+        databaseContext.bindRowSync?.(targetRowId);
+        rowMeta.set(isEmptyKey, false);
+
+        const rowDocument = new yjs.Doc({ guid: documentId }) as BrowserYDoc;
+
+        yjs.applyUpdate(rowDocument, new Uint8Array(update));
+        rowDocument.object_id = documentId;
+        rowDocument.view_id = documentId;
+        rowDocument._collabType = collabType;
+        rowDocument._syncBound = false;
+
+        const syncContext = databaseContext.bindViewSync(rowDocument);
+
+        if (!syncContext) {
+          return { ok: false, reason: 'row-document sync context was not registered' };
+        }
+
+        testWindow.__ISSUE_8958_ROW_DOCUMENT__ = rowDocument;
+        return { ok: true, reason: '' };
+      },
+      {
+        collabType: Types.Document,
+        dataSectionKey: YjsEditorKey.data_section,
+        documentId: rowDocumentId,
+        isEmptyKey: isDocumentEmptyKey,
+        metaKey: YjsEditorKey.meta,
+        rowId,
+        update: Array.from(rowDocumentUpdate),
+      }
+    );
+
+    expect(seeded.ok, seeded.reason).toBe(true);
+
+    await expect
+      .poll(
+        () =>
+          page.evaluate(async (documentId) => {
+            const context = (window as Issue8958TestWindow).__TEST_DATABASE_CONTEXT__;
+
+            return (await context?.checkIfRowDocumentExists?.(documentId)) ?? false;
+          }, rowDocumentId),
+        {
+          timeout: FIXTURE_TIMEOUT_MS,
+          message: `waiting for row document ${rowDocumentId} to persist through realtime sync`,
+        }
+      )
+      .toBe(true);
+
+    const legacyResult = await getApiEnvelope(
+      request,
+      state.memberSession.accessToken,
+      `/api/workspace/${state.workspaceId}/page-view/${rowDocumentId}`
+    );
+    const contextualResult = await getApiEnvelope(
+      request,
+      state.memberSession.accessToken,
+      `/api/workspace/v1/${state.workspaceId}/collab/${rowDocumentId}?${new URLSearchParams({
+        collab_type: String(Types.Document),
+        database_id: state.databaseId,
+        row_id: rowId,
+        row_document_id: rowDocumentId,
+      })}`
+    );
+
+    expect(
+      legacyResult.code,
+      `Fixture must reproduce the missing legacy row permission. Response: ${JSON.stringify(legacyResult)}`
+    ).toBe(1012);
+    expect(
+      contextualResult.code,
+      `Fixture member must inherit row-document access from the database. Response: ${JSON.stringify(contextualResult)}`
+    ).toBe(0);
+    console.log(
+      `[issue-8958] fixture ${state.runId.slice(0, 8)}: ` +
+        `legacy page-view code=${legacyResult.code}, contextual collab code=${contextualResult.code}`
+    );
+  }
+);
+
+When('the invited member opens the issue 8958 database row', async ({ page, browser }) => {
+  const state = requireRowDocumentState(page);
+  const memberContext = await browser.newContext({
+    baseURL: new URL(page.url()).origin,
+    viewport: { width: 1440, height: 900 },
+  });
+  const memberPage = await memberContext.newPage();
+
+  state.memberContext = memberContext;
+  state.memberPage = memberPage;
+  setupPageErrorHandling(memberPage);
+  memberPage.on('response', (response) => {
+    if (response.url().includes(state.rowDocumentId)) {
+      state.memberLoadRequests.push(`${response.request().method()} ${response.url()} -> ${response.status()}`);
+    }
+  });
+
+  await signBrowserInWithSession(memberPage, state.memberSession);
+  await memberPage.goto(`/app/${state.workspaceId}/${state.databasePageId}`, { waitUntil: 'domcontentloaded' });
+  await waitForGridReady(memberPage);
+  await expect(DatabaseGridSelectors.rowById(memberPage, state.rowId)).toContainText(state.rowTitle, {
+    timeout: FIXTURE_TIMEOUT_MS,
+  });
+
+  const isDocumentEmptyKey = getMetaIdMap(state.rowId).get(RowMetaKey.IsDocumentEmpty);
+
+  if (!isDocumentEmptyKey) {
+    throw new Error(`Could not derive the is-document-empty key for row ${state.rowId}`);
+  }
+
+  await expect
+    .poll(
+      () =>
+        memberPage.evaluate(
+          async ({ dataSectionKey, isEmptyKey, metaKey, rowId }) => {
+            const context = (window as Issue8958TestWindow).__TEST_DATABASE_CONTEXT__;
+            const rowDoc = await context?.ensureRow?.(rowId);
+            const meta = rowDoc?.getMap(dataSectionKey).get(metaKey) as Y.Map<unknown> | undefined;
+
+            return meta?.get(isEmptyKey);
+          },
+          {
+            dataSectionKey: YjsEditorKey.data_section,
+            isEmptyKey: isDocumentEmptyKey,
+            metaKey: YjsEditorKey.meta,
+            rowId: state.rowId,
+          }
+        ),
+      { timeout: FIXTURE_TIMEOUT_MS, message: 'waiting for the invited member to receive non-empty row metadata' }
+    )
+    .toBe(false);
+
+  await openRowDetailByRowId(memberPage, state.rowId);
+});
+
+Then('the invited member can read and edit the issue 8958 row document', async ({ page }) => {
+  const state = requireMemberPageState(page);
+  const memberPage = state.memberPage;
+  const modal = RowDetailSelectors.modal(memberPage);
+  const body = modal.getByText(state.rowBody, { exact: true });
+  const noAccess = modal.getByTestId('row-document-no-access');
+  let outcome: 'loading' | 'ready' | 'forbidden' = 'loading';
+
+  await expect
+    .poll(
+      async () => {
+        if (await body.isVisible().catch(() => false)) outcome = 'ready';
+        else if (await noAccess.isVisible().catch(() => false)) outcome = 'forbidden';
+        else outcome = 'loading';
+        return outcome;
+      },
+      {
+        timeout: FIXTURE_TIMEOUT_MS,
+        message: `row document did not open; requests: ${state.memberLoadRequests.join(', ') || 'none'}`,
+      }
+    )
+    .not.toBe('loading');
+  expect(outcome, `row document did not open; requests: ${state.memberLoadRequests.join(', ') || 'none'}`).toBe('ready');
+
+  const editor = modal.locator('[data-slate-editor="true"]').first();
+  const memberEdit = ` — edited by invited member ${state.runId.slice(0, 8)}`;
+
+  await expect(editor).toHaveAttribute('contenteditable', 'true');
+  await body.click();
+  await memberPage.keyboard.press('End');
+  await memberPage.keyboard.type(memberEdit);
+  await expect(editor).toContainText(memberEdit.trim(), { timeout: FIXTURE_TIMEOUT_MS });
+});
+
+async function prepareDatabaseFixture(page: Page, request: APIRequestContext, privateSpace: boolean): Promise<void> {
+  const state = getState(page);
+  const ownerSession = await signInFixtureAccount(request, state.ownerEmail);
+  const memberSession = await signInFixtureAccount(request, state.memberEmail);
+
+  state.ownerSession = ownerSession;
+  state.memberSession = memberSession;
+
+  await signBrowserInWithSession(page, ownerSession);
+
+  const ownerWorkspace = await apiGet<UserWorkspaceInfo>(request, ownerSession.accessToken, '/api/user/workspace');
+  const workspaceId = ownerWorkspace.visiting_workspace.workspace_id;
+
+  await joinWorkspaceByInviteCode(request, ownerSession.accessToken, memberSession.accessToken, workspaceId);
+
+  const visibilityLabel = privateSpace ? 'private' : 'public';
+  const space = await apiPost<{ view_id: string }>(
+    request,
+    ownerSession.accessToken,
+    `/api/workspace/${workspaceId}/space`,
+    {
+      name: `Issue 8958 ${visibilityLabel} space ${state.runId.slice(0, 8)}`,
+      space_icon: privateSpace ? 'lock' : 'earth',
+      space_icon_color: '#555555',
+      space_permission: privateSpace ? SPACE_PERMISSION_PRIVATE : SPACE_PERMISSION_PUBLIC,
+    }
+  );
+  const databasePage = await apiPost<CreatedPage>(
+    request,
+    ownerSession.accessToken,
+    `/api/workspace/${workspaceId}/page-view`,
+    {
+      parent_view_id: space.view_id,
+      layout: ViewLayout.Grid,
+      name: `Issue 8958 ${visibilityLabel} database ${state.runId.slice(0, 8)}`,
+    }
+  );
+
+  if (!databasePage.database_id) {
+    throw new Error(`Database page creation returned no database id: ${JSON.stringify(databasePage)}`);
+  }
+
+  if (privateSpace) {
+    const memberUid = await findWorkspaceMemberUid(request, ownerSession.accessToken, workspaceId, state.memberEmail);
+
+    await postRawJson(
+      request,
+      ownerSession.accessToken,
+      `/api/workspace/${workspaceId}/spaces/${space.view_id}/members`,
+      `{"uid":${memberUid},"role":"member","access_level":${SPACE_MEMBER_EDIT_ACCESS}}`
+    );
+  }
+
+  state.workspaceId = workspaceId;
+  state.spaceId = space.view_id;
+  state.databasePageId = databasePage.view_id;
+  state.databaseId = databasePage.database_id;
+
+  await page.goto(`/app/${workspaceId}/${databasePage.view_id}`, { waitUntil: 'domcontentloaded' });
+  await waitForGridReady(page);
+}
+
+function createRowDocumentUpdate(documentId: string, body: string): Uint8Array {
+  const doc = new Y.Doc({ guid: documentId }) as YDoc;
+
+  initializeDocumentStructure(doc, true, documentId);
+
+  const sharedRoot = doc.getMap(YjsEditorKey.data_section);
+  const document = sharedRoot.get(YjsEditorKey.document) as Y.Map<unknown>;
+  const blocks = document.get(YjsEditorKey.blocks) as Y.Map<Y.Map<unknown>>;
+  const meta = document.get(YjsEditorKey.meta) as Y.Map<unknown>;
+  const childrenMap = meta.get(YjsEditorKey.children_map) as Y.Map<Y.Array<string>>;
+  const textMap = meta.get(YjsEditorKey.text_map) as Y.Map<Y.Text>;
+  const pageId = document.get(YjsEditorKey.page_id) as string;
+  const paragraphId = childrenMap.get(pageId)?.get(0);
+  const paragraph = paragraphId ? blocks.get(paragraphId) : undefined;
+  const paragraphTextId = paragraph?.get(YjsEditorKey.block_external_id) as string | undefined;
+  const paragraphText = paragraphTextId ? textMap.get(paragraphTextId) : undefined;
+
+  if (!paragraphText) {
+    throw new Error(`Could not initialize paragraph text for row document ${documentId}`);
+  }
+
+  paragraphText.insert(0, body);
+  return Y.encodeStateAsUpdate(doc);
+}
+
+async function joinWorkspaceByInviteCode(
+  request: APIRequestContext,
+  ownerToken: string,
+  memberToken: string,
+  workspaceId: string
+): Promise<void> {
+  const memberWorkspace = await apiGet<UserWorkspaceInfo>(request, memberToken, '/api/user/workspace');
+
+  if (memberWorkspace.workspaces.some((workspace) => workspace.workspace_id === workspaceId)) return;
+
+  const createdInvite = await apiPost<{ code: string | null }>(
+    request,
+    ownerToken,
+    `/api/workspace/${workspaceId}/invite-code`,
+    { validity_period_hours: 24 }
+  );
+  const inviteCode =
+    createdInvite.code ??
+    (await apiGet<{ code: string | null }>(request, ownerToken, `/api/workspace/${workspaceId}/invite-code`)).code;
+
+  if (!inviteCode) {
+    throw new Error(`Workspace ${workspaceId} did not return an invite code`);
+  }
+
+  await apiPost<{ workspace_id: string }>(request, memberToken, '/api/workspace/join-by-invite-code', {
+    code: inviteCode,
+  });
+}
+
+async function findWorkspaceMemberUid(
+  request: APIRequestContext,
+  token: string,
+  workspaceId: string,
+  email: string
+): Promise<string> {
+  const response = await request.get(`${TestConfig.apiUrl}/api/workspace/${workspaceId}/member?include_pending=true`, {
+    headers: apiHeaders(token),
+    failOnStatusCode: false,
+  });
+  const responseText = await response.text();
+
+  if (!response.ok()) {
+    throw new Error(`Workspace member lookup failed: HTTP ${response.status()} ${responseText}`);
+  }
+
+  const normalized = responseText.replace(/"uid"\s*:\s*(\d{16,})/g, '"uid":"$1"');
+  const body = JSON.parse(normalized) as ApiResponse<Array<{ uid?: string | number; email: string }>>;
+  const member = body.data?.find((candidate) => candidate.email.toLowerCase() === email.toLowerCase());
+
+  if (member?.uid === undefined || member.uid === null) {
+    throw new Error(`Workspace member uid was not found for ${email}: ${responseText}`);
+  }
+
+  return String(member.uid);
+}
+
+async function postRawJson(request: APIRequestContext, token: string, path: string, rawBody: string): Promise<void> {
+  const response = await request.post(`${TestConfig.apiUrl}${path}`, {
+    headers: apiHeaders(token),
+    data: rawBody,
+    failOnStatusCode: false,
+  });
+  const responseText = await response.text();
+  const body = parseJson<ApiResponse<unknown>>(responseText);
+
+  if (!response.ok() || body?.code !== 0) {
+    throw new Error(`API POST failed for ${path}: HTTP ${response.status()} ${responseText}`);
+  }
+}
+
+async function signInFixtureAccount(request: APIRequestContext, email: string): Promise<AuthSession> {
+  const authUtils = new AuthTestUtils();
+  const callbackLink = await authUtils.generateSignInUrl(request, email);
+  const hashIndex = callbackLink.indexOf('#');
+
+  if (hashIndex === -1) {
+    throw new Error(`Fixture auth callback for ${email} did not contain a token hash`);
+  }
+
+  const params = new URLSearchParams(callbackLink.slice(hashIndex + 1));
+  const accessToken = params.get('access_token');
+  const refreshToken = params.get('refresh_token');
+
+  if (!accessToken || !refreshToken) {
+    throw new Error(`Fixture auth callback for ${email} did not include access and refresh tokens`);
+  }
+
+  const verifyResponse = await request.get(`${TestConfig.apiUrl}/api/user/verify/${accessToken}`, {
+    failOnStatusCode: false,
+    timeout: PASSWORDLESS_TOKEN_TIMEOUT_MS,
+  });
+
+  if (!verifyResponse.ok()) {
+    throw new Error(`Failed to verify fixture account ${email}: HTTP ${verifyResponse.status()}`);
+  }
+
+  const tokenResponse = await request.post(`${TestConfig.gotrueUrl}/token?grant_type=refresh_token`, {
+    data: { refresh_token: refreshToken },
+    headers: { 'Content-Type': 'application/json' },
+    failOnStatusCode: false,
+  });
+
+  if (!tokenResponse.ok()) {
+    throw new Error(`Failed to refresh fixture token for ${email}: HTTP ${tokenResponse.status()}`);
+  }
+
+  const tokenData = (await tokenResponse.json()) as AuthTokenData;
+  const refreshedAccessToken = tokenData.access_token || accessToken;
+  const refreshedRefreshToken = tokenData.refresh_token || refreshToken;
+
+  return {
+    accessToken: refreshedAccessToken,
+    refreshToken: refreshedRefreshToken,
+    tokenData: {
+      ...tokenData,
+      access_token: refreshedAccessToken,
+      refresh_token: refreshedRefreshToken,
+    },
+  };
+}
+
+async function signBrowserInWithSession(page: Page, session: AuthSession): Promise<void> {
+  await page.addInitScript(() => {
+    (window as Window & { Cypress?: boolean }).Cypress = true;
+  });
+  await page.goto('/', { waitUntil: 'domcontentloaded' });
+  await page.evaluate(({ accessToken, refreshToken, tokenData }) => {
+    const storedToken = {
+      ...tokenData,
+      access_token: tokenData.access_token || accessToken,
+      refresh_token: tokenData.refresh_token || refreshToken,
+    };
+
+    localStorage.setItem('af_auth_token', storedToken.access_token);
+    localStorage.setItem('af_refresh_token', storedToken.refresh_token);
+    if (storedToken.user?.id) localStorage.setItem('af_user_id', storedToken.user.id);
+    localStorage.setItem('token', JSON.stringify(storedToken));
+  }, session);
+  await page.goto('/app', { waitUntil: 'domcontentloaded' });
+  await page.waitForURL(/\/app/, { timeout: FIXTURE_TIMEOUT_MS });
+  await expect(SidebarSelectors.pageHeader(page)).toBeVisible({ timeout: FIXTURE_TIMEOUT_MS });
+}
+
+async function apiGet<T>(request: APIRequestContext, token: string, path: string): Promise<T> {
+  const body = await getApiEnvelope<T>(request, token, path);
+
+  if (body.code !== 0 || body.data === undefined) {
+    throw new Error(`API GET failed for ${path}: ${JSON.stringify(body)}`);
+  }
+
+  return body.data;
+}
+
+async function apiPost<T>(request: APIRequestContext, token: string, path: string, data: unknown): Promise<T> {
+  const response = await request.post(`${TestConfig.apiUrl}${path}`, {
+    headers: apiHeaders(token),
+    data,
+    failOnStatusCode: false,
+  });
+  const responseText = await response.text();
+  const body = parseJson<ApiResponse<T>>(responseText);
+
+  if (!response.ok() || body?.code !== 0) {
+    throw new Error(`API POST failed for ${path}: HTTP ${response.status()} ${responseText}`);
+  }
+
+  return body.data as T;
+}
+
+async function getApiEnvelope<T = unknown>(
+  request: APIRequestContext,
+  token: string,
+  path: string
+): Promise<ApiResponse<T>> {
+  const response = await request.get(`${TestConfig.apiUrl}${path}`, {
+    headers: apiHeaders(token),
+    failOnStatusCode: false,
+  });
+  const responseText = await response.text();
+  const body = parseJson<ApiResponse<T>>(responseText);
+
+  if (!body) {
+    throw new Error(`API GET returned non-JSON for ${path}: HTTP ${response.status()} ${responseText}`);
+  }
+
+  return body;
+}
+
+function apiHeaders(token: string): Record<string, string> {
+  return {
+    Authorization: `Bearer ${token}`,
+    'Content-Type': 'application/json',
+  };
+}
+
+function parseJson<T>(value: string): T | null {
+  try {
+    return JSON.parse(value) as T;
+  } catch {
+    return null;
+  }
+}
+
+function getState(page: Page): Issue8958State {
+  const state = stateByPage.get(page);
+
+  if (!state) throw new Error('Issue 8958 scenario state has not been initialized');
+  return state;
+}
+
+function requireDatabaseState(page: Page) {
+  const state = getState(page);
+
+  if (!state.ownerSession || !state.memberSession || !state.workspaceId || !state.databaseId || !state.databasePageId) {
+    throw new Error('Issue 8958 database fixture has not been prepared');
+  }
+
+  return state as Issue8958State &
+    Required<Pick<Issue8958State, 'ownerSession' | 'memberSession' | 'workspaceId' | 'databaseId' | 'databasePageId'>>;
+}
+
+function requireRowDocumentState(page: Page) {
+  const state = requireDatabaseState(page);
+
+  if (!state.rowId || !state.rowDocumentId || !state.rowTitle || !state.rowBody) {
+    throw new Error('Issue 8958 row-document fixture has not been prepared');
+  }
+
+  return state as typeof state & Required<Pick<Issue8958State, 'rowId' | 'rowDocumentId' | 'rowTitle' | 'rowBody'>>;
+}
+
+function requireMemberPageState(page: Page) {
+  const state = requireRowDocumentState(page);
+
+  if (!state.memberPage) {
+    throw new Error('The invited member has not opened the issue 8958 database row');
+  }
+
+  return state as typeof state & Required<Pick<Issue8958State, 'memberPage'>>;
+}

--- a/src/application/__tests__/view-loader.test.ts
+++ b/src/application/__tests__/view-loader.test.ts
@@ -4,7 +4,7 @@ import * as Y from 'yjs';
 import { deleteCollabDB, openCollabDB, openCollabDBWithProvider } from '@/application/db';
 import { getOrCreateRowSubDoc } from '@/application/services/js-services/cache';
 import { invalidateViewCache } from '@/application/services/js-services/cached-api';
-import { fetchPageCollab } from '@/application/services/js-services/fetch';
+import { fetchPageCollab, fetchRowDocumentCollab } from '@/application/services/js-services/fetch';
 import { enqueueOutboxUpdate } from '@/application/sync-outbox';
 import { Types, ViewLayout, YDoc, YjsDatabaseKey, YjsEditorKey } from '@/application/types';
 import { getDatabaseIdFromDoc, openRowSubDocument, openView } from '@/application/view-loader';
@@ -30,6 +30,7 @@ jest.mock('@/application/services/js-services/cache', () => ({
 
 jest.mock('@/application/services/js-services/fetch', () => ({
   fetchPageCollab: jest.fn(),
+  fetchRowDocumentCollab: jest.fn(),
 }));
 
 jest.mock('@/application/sync-outbox', () => ({
@@ -42,6 +43,7 @@ const mockDeleteCollabDB = deleteCollabDB as jest.MockedFunction<typeof deleteCo
 const mockInvalidateViewCache = invalidateViewCache as jest.MockedFunction<typeof invalidateViewCache>;
 const mockGetOrCreateRowSubDoc = getOrCreateRowSubDoc as jest.MockedFunction<typeof getOrCreateRowSubDoc>;
 const mockFetchPageCollab = fetchPageCollab as jest.MockedFunction<typeof fetchPageCollab>;
+const mockFetchRowDocumentCollab = fetchRowDocumentCollab as jest.MockedFunction<typeof fetchRowDocumentCollab>;
 const mockEnqueueOutboxUpdate = enqueueOutboxUpdate as jest.MockedFunction<typeof enqueueOutboxUpdate>;
 
 function createEmptyDoc(guid: string): YDoc {
@@ -55,6 +57,14 @@ function createDatabaseDoc(guid: string, databaseId = guid): YDoc {
 
   database.set(YjsDatabaseKey.id, databaseId);
   root.set(YjsEditorKey.database, database);
+  return doc;
+}
+
+function createDocumentDoc(guid: string): YDoc {
+  const doc = createEmptyDoc(guid);
+  const root = doc.getMap(YjsEditorKey.data_section);
+
+  root.set(YjsEditorKey.document, new Y.Map());
   return doc;
 }
 
@@ -231,12 +241,35 @@ describe('view-loader row document retry policy', () => {
     jest.useRealTimers();
   });
 
+  it('fetches row documents through the contextual collab endpoint', async () => {
+    const documentId = '00000000-0000-4000-8000-000000000006';
+    const doc = createEmptyDoc(documentId);
+    const serverDoc = createDocumentDoc(documentId);
+    const rowDocumentSource = {
+      database_id: '00000000-0000-4000-8000-000000000003',
+      database_view_id: '00000000-0000-4000-8000-000000000004',
+      row_id: '00000000-0000-4000-8000-000000000005',
+    };
+
+    mockGetOrCreateRowSubDoc.mockResolvedValue(doc);
+    mockFetchRowDocumentCollab.mockResolvedValue({ data: Y.encodeStateAsUpdate(serverDoc) });
+
+    const result = await openRowSubDocument('workspace-id', documentId, {
+      maxAttempts: 1,
+      rowDocumentSource,
+    });
+
+    expect(result.doc.getMap(YjsEditorKey.data_section).has(YjsEditorKey.document)).toBe(true);
+    expect(mockFetchRowDocumentCollab).toHaveBeenCalledWith('workspace-id', documentId, rowDocumentSource);
+    expect(mockFetchPageCollab).not.toHaveBeenCalled();
+  });
+
   it('keeps the default retry budget for a row document that may still be created', async () => {
     const documentId = '00000000-0000-4000-8000-000000000007';
     const doc = createEmptyDoc(documentId);
 
     mockGetOrCreateRowSubDoc.mockResolvedValue(doc);
-    mockFetchPageCollab.mockRejectedValue(new Error('row document is not ready'));
+    mockFetchRowDocumentCollab.mockRejectedValue(new Error('row document is not ready'));
 
     const resultPromise = openRowSubDocument('workspace-id', documentId);
 
@@ -245,7 +278,7 @@ describe('view-loader row document retry policy', () => {
     const result = await resultPromise;
 
     expect(result.doc).toBe(doc);
-    expect(mockFetchPageCollab).toHaveBeenCalledTimes(6);
+    expect(mockFetchRowDocumentCollab).toHaveBeenCalledTimes(6);
   });
 
   it('honors a one-attempt limit when existence was already confirmed', async () => {
@@ -253,12 +286,12 @@ describe('view-loader row document retry policy', () => {
     const doc = createEmptyDoc(documentId);
 
     mockGetOrCreateRowSubDoc.mockResolvedValue(doc);
-    mockFetchPageCollab.mockRejectedValue(new Error('page view is not registered yet'));
+    mockFetchRowDocumentCollab.mockRejectedValue(new Error('row document is not registered yet'));
 
     const result = await openRowSubDocument('workspace-id', documentId, { maxAttempts: 1 });
 
     expect(result.doc).toBe(doc);
-    expect(mockFetchPageCollab).toHaveBeenCalledTimes(1);
+    expect(mockFetchRowDocumentCollab).toHaveBeenCalledTimes(1);
     expect(jest.getTimerCount()).toBe(0);
   });
 
@@ -267,14 +300,14 @@ describe('view-loader row document retry policy', () => {
     const doc = createEmptyDoc(documentId);
 
     mockGetOrCreateRowSubDoc.mockResolvedValue(doc);
-    mockFetchPageCollab.mockRejectedValue({ code: 1012, message: 'user is not allowed to access this view' });
+    mockFetchRowDocumentCollab.mockRejectedValue({ code: 1012, message: 'user is not allowed to access this view' });
 
     const rejection = expect(openRowSubDocument('workspace-id', documentId)).rejects.toMatchObject({ code: 1012 });
 
     await jest.runAllTimersAsync();
     await rejection;
 
-    expect(mockFetchPageCollab).toHaveBeenCalledTimes(1);
+    expect(mockFetchRowDocumentCollab).toHaveBeenCalledTimes(1);
     expect(mockDeleteCollabDB).toHaveBeenCalledWith(documentId, { destroyDoc: true });
     expect(jest.getTimerCount()).toBe(0);
   });

--- a/src/application/services/js-services/__tests__/fetch.test.ts
+++ b/src/application/services/js-services/__tests__/fetch.test.ts
@@ -1,10 +1,12 @@
 import { expect } from '@jest/globals';
-import { fetchPublishView, fetchPublishViewMeta, fetchViewInfo } from '../fetch';
+import { fetchPublishView, fetchPublishViewMeta, fetchRowDocumentCollab, fetchViewInfo } from '../fetch';
 import {
+  getCollab,
   getPublishView,
   getPublishInfoWithViewId,
   getPublishViewMeta,
 } from '@/application/services/js-services/http';
+import { Types } from '@/application/types';
 
 jest.mock('@/application/services/js-services/http', () => {
   return {
@@ -12,6 +14,7 @@ jest.mock('@/application/services/js-services/http', () => {
     getPublishViewMeta: jest.fn(),
     getPublishInfoWithViewId: jest.fn(),
     getPageCollab: jest.fn(),
+    getCollab: jest.fn(),
   };
 });
 
@@ -81,6 +84,27 @@ describe('Collab fetch functions with deduplication', () => {
       await expect(result1).resolves.toEqual(mockResponse);
       await expect(result2).resolves.toEqual(mockResponse);
       expect(getPublishInfoWithViewId).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('fetchRowDocumentCollab', () => {
+    it('deduplicates contextual row-document requests', async () => {
+      const source = {
+        database_id: 'database-1',
+        database_view_id: 'database-view-1',
+        row_id: 'row-1',
+      };
+      const mockResponse = { data: new Uint8Array([1, 2, 3]) };
+
+      (getCollab as jest.Mock).mockResolvedValue(mockResponse);
+
+      const result1 = fetchRowDocumentCollab('workspace-1', 'document-1', source);
+      const result2 = fetchRowDocumentCollab('workspace-1', 'document-1', { ...source });
+
+      expect(result1).toBe(result2);
+      await expect(result1).resolves.toEqual(mockResponse);
+      expect(getCollab).toHaveBeenCalledTimes(1);
+      expect(getCollab).toHaveBeenCalledWith('workspace-1', 'document-1', Types.Document, source);
     });
   });
 

--- a/src/application/services/js-services/fetch.ts
+++ b/src/application/services/js-services/fetch.ts
@@ -1,9 +1,11 @@
 import {
+  getCollab,
   getPublishView as getPublishViewAPI,
   getPageCollab,
   getPublishInfoWithViewId,
   getPublishViewMeta as getPublishViewMetaAPI,
 } from '@/application/services/js-services/http';
+import { RowDocumentSourcePayload, Types } from '@/application/types';
 
 const pendingRequests = new Map();
 
@@ -45,6 +47,12 @@ export function fetchPageCollab (workspaceId: string, viewId: string) {
   const fetchFunction = () => getPageCollab(workspaceId, viewId);
 
   return fetchWithDeduplication(`fetchPageCollab_${workspaceId}`, { viewId }, fetchFunction);
+}
+
+export function fetchRowDocumentCollab (workspaceId: string, documentId: string, source?: RowDocumentSourcePayload) {
+  const fetchFunction = () => getCollab(workspaceId, documentId, Types.Document, source);
+
+  return fetchWithDeduplication(`fetchRowDocumentCollab_${workspaceId}`, { documentId, source }, fetchFunction);
 }
 
 export function fetchViewInfo (viewId: string) {

--- a/src/application/services/js-services/http/__tests__/http_api.test.ts
+++ b/src/application/services/js-services/http/__tests__/http_api.test.ts
@@ -7,6 +7,7 @@ import {
   SpaceMemberRole,
   SpaceSidebarEditPolicy,
   SpaceVisibility,
+  Types,
 } from '@/application/types';
 
 const mockAxiosInstance = {
@@ -91,6 +92,37 @@ describe('http_api client (unit)', () => {
     // Subsequent init calls should no-op
     module.initAPIService({ ...baseConfig, baseURL: 'https://ignored.example.com' });
     expect(mockAxiosCreate).toHaveBeenCalledTimes(1);
+  });
+
+  it('fetches row documents with their parent database context', async () => {
+    const module = await import('../http_api');
+
+    module.initAPIService(baseConfig);
+    mockAxiosInstance.get.mockResolvedValueOnce({
+      data: {
+        code: 0,
+        data: {
+          doc_state: [1, 2, 3],
+          object_id: 'document-1',
+        },
+      },
+    });
+
+    await expect(
+      module.getCollab('workspace-1', 'document-1', Types.Document, {
+        database_id: 'database-1',
+        database_view_id: 'database-view-1',
+        row_id: 'row-1',
+      })
+    ).resolves.toEqual({ data: new Uint8Array([1, 2, 3]) });
+    expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/workspace/v1/workspace-1/collab/document-1', {
+      params: {
+        collab_type: Types.Document,
+        database_id: 'database-1',
+        row_id: 'row-1',
+        row_document_id: 'document-1',
+      },
+    });
   });
 
   it('re-exports space-group ACL update and revoke clients', async () => {

--- a/src/application/services/js-services/http/collab-api.ts
+++ b/src/application/services/js-services/http/collab-api.ts
@@ -1,7 +1,7 @@
 import { toBase64 } from 'lib0/buffer';
 
 import { getOrCreateDeviceId } from '@/application/services/js-services/device-id';
-import { RowId, Types, User, View } from '@/application/types';
+import { RowDocumentSourcePayload, RowId, Types, User, View } from '@/application/types';
 import { database_blob } from '@/proto/database_blob';
 import { collab } from '@/proto/messages';
 import { Log } from '@/utils/log';
@@ -323,7 +323,12 @@ export async function collabFullSyncBatch(
   return results;
 }
 
-export async function getCollab(workspaceId: string, objectId: string, collabType: Types) {
+export async function getCollab(
+  workspaceId: string,
+  objectId: string,
+  collabType: Types,
+  rowDocumentSource?: RowDocumentSourcePayload
+) {
   const url = `/api/workspace/v1/${workspaceId}/collab/${objectId}`;
 
   const data = await executeAPIRequest<{
@@ -338,6 +343,13 @@ export async function getCollab(workspaceId: string, objectId: string, collabTyp
     >(url, {
       params: {
         collab_type: collabType,
+        ...(rowDocumentSource
+          ? {
+              database_id: rowDocumentSource.database_id,
+              row_id: rowDocumentSource.row_id,
+              row_document_id: objectId,
+            }
+          : {}),
       },
     })
   );

--- a/src/application/types.ts
+++ b/src/application/types.ts
@@ -1259,6 +1259,7 @@ export type LoadView = (
 
 export interface LoadRowDocumentOptions {
   maxAttempts?: number;
+  rowDocumentSource?: RowDocumentSourcePayload;
 }
 
 export type LoadRowDocument = (documentId: string, options?: LoadRowDocumentOptions) => Promise<YDoc | null>;

--- a/src/application/view-loader/index.ts
+++ b/src/application/view-loader/index.ts
@@ -13,7 +13,7 @@
 import { deleteCollabDB, openCollabDB, openCollabDBWithProvider } from '@/application/db';
 import { getOrCreateRowSubDoc, hasCollabCache } from '@/application/services/js-services/cache';
 import { invalidateViewCache } from '@/application/services/js-services/cached-api';
-import { fetchPageCollab } from '@/application/services/js-services/fetch';
+import { fetchPageCollab, fetchRowDocumentCollab } from '@/application/services/js-services/fetch';
 import { enqueueOutboxUpdate } from '@/application/sync-outbox';
 import {
   LoadRowDocumentOptions,
@@ -227,6 +227,28 @@ async function fetchAndApply(workspaceId: string, viewId: string, doc: YDoc): Pr
     viewId,
     dataBytes: data.length,
     rowCount: rows ? Object.keys(rows).length : 0,
+    fetchDurationMs: Date.now() - fetchStartedAt,
+  });
+
+  applyYDoc(doc, data);
+}
+
+async function fetchRowDocumentAndApply(
+  workspaceId: string,
+  documentId: string,
+  doc: YDoc,
+  options: LoadRowDocumentOptions
+): Promise<void> {
+  Log.debug('[ViewLoader] fetching row document from server', { documentId });
+
+  const fetchStartedAt = Date.now();
+  // Row documents inherit access from their parent database. Pass that
+  // context so authorization does not depend on a direct document ACL.
+  const { data } = await fetchRowDocumentCollab(workspaceId, documentId, options.rowDocumentSource);
+
+  Log.debug('[ViewLoader] row document fetch complete', {
+    documentId,
+    dataBytes: data.length,
     fetchDurationMs: Date.now() - fetchStartedAt,
   });
 
@@ -465,7 +487,7 @@ export async function openRowSubDocument(
 
     for (let attempt = 1; attempt <= maxAttempts; attempt++) {
       try {
-        await fetchAndApply(workspaceId, documentId, doc);
+        await fetchRowDocumentAndApply(workspaceId, documentId, doc, options);
         fetched = true;
         break;
       } catch (e) {

--- a/src/components/database/components/database-row/DatabaseRowSubDocument.tsx
+++ b/src/components/database/components/database-row/DatabaseRowSubDocument.tsx
@@ -369,7 +369,13 @@ export const DatabaseRowSubDocument = memo(function DatabaseRowSubDocument({
           return 'retryable';
         }
 
-        const doc = await loadRowDocument(documentId, options);
+        const loadOptions = rowDocumentSource
+          ? {
+              ...options,
+              rowDocumentSource,
+            }
+          : options;
+        const doc = await loadRowDocument(documentId, loadOptions);
 
         if (!isCurrent()) return 'retryable';
 
@@ -445,7 +451,7 @@ export const DatabaseRowSubDocument = memo(function DatabaseRowSubDocument({
         }
       }
     },
-    [loadRowDocument, markPermissionDenied, rowId]
+    [loadRowDocument, markPermissionDenied, rowDocumentSource, rowId]
   );
   // Open document with server-provided doc_state (Y.js update)
   const openDocumentWithState = useCallback(

--- a/src/components/database/components/database-row/__tests__/DatabaseRowSubDocument.test.tsx
+++ b/src/components/database/components/database-row/__tests__/DatabaseRowSubDocument.test.tsx
@@ -234,7 +234,14 @@ describe('DatabaseRowSubDocument', () => {
     expect(editor.getAttribute('data-content-padding')).toBe('template');
     expect(screen.queryByTestId('editor-skeleton')).toBeNull();
     expect(checkIfRowDocumentExists).toHaveBeenCalledTimes(1);
-    expect(loadRowDocument).toHaveBeenCalledWith(documentId, { maxAttempts: 1 });
+    expect(loadRowDocument).toHaveBeenCalledWith(documentId, {
+      maxAttempts: 1,
+      rowDocumentSource: {
+        database_id: 'database-id',
+        database_view_id: 'database-view-id',
+        row_id: rowId,
+      },
+    });
     expect(loadRowDocument).toHaveBeenCalledTimes(1);
     expect(createRowDocument).toHaveBeenCalledWith(documentId, {
       database_id: 'database-id',
@@ -266,7 +273,14 @@ describe('DatabaseRowSubDocument', () => {
 
     await act(flushAsyncWork);
 
-    expect(loadRowDocument).toHaveBeenNthCalledWith(1, documentId, { maxAttempts: 1 });
+    expect(loadRowDocument).toHaveBeenNthCalledWith(1, documentId, {
+      maxAttempts: 1,
+      rowDocumentSource: {
+        database_id: 'database-id',
+        database_view_id: 'database-view-id',
+        row_id: rowId,
+      },
+    });
     expect(createRowDocument).toHaveBeenCalledTimes(1);
     expect(jest.getTimerCount()).toBe(1);
 
@@ -275,7 +289,14 @@ describe('DatabaseRowSubDocument', () => {
       await flushAsyncWork();
     });
 
-    expect(loadRowDocument).toHaveBeenNthCalledWith(2, documentId, { maxAttempts: 1 });
+    expect(loadRowDocument).toHaveBeenNthCalledWith(2, documentId, {
+      maxAttempts: 1,
+      rowDocumentSource: {
+        database_id: 'database-id',
+        database_view_id: 'database-view-id',
+        row_id: rowId,
+      },
+    });
   });
 
   it('shows no access without repairing or retrying when an existing row document is forbidden', async () => {
@@ -305,7 +326,14 @@ describe('DatabaseRowSubDocument', () => {
     expect(screen.getByTestId('row-document-no-access')).not.toBeNull();
     expect(checkIfRowDocumentExists).toHaveBeenCalledTimes(1);
     expect(loadRowDocument).toHaveBeenCalledTimes(1);
-    expect(loadRowDocument).toHaveBeenCalledWith(documentId, { maxAttempts: 1 });
+    expect(loadRowDocument).toHaveBeenCalledWith(documentId, {
+      maxAttempts: 1,
+      rowDocumentSource: {
+        database_id: 'database-id',
+        database_view_id: 'database-view-id',
+        row_id: rowId,
+      },
+    });
     expect(createRowDocument).not.toHaveBeenCalled();
     expect(jest.getTimerCount()).toBe(0);
 


### PR DESCRIPTION
### **Description**

Fixes AppFlowy-IO/AppFlowy#8958.

AppFlowy Web loaded database row bodies through the legacy `/page-view/{row_document_id}` endpoint. That endpoint authorizes the row document as a standalone object, so a collaborator who inherits edit access from the parent database can receive code `1012` when the row-document registration or direct ACL is missing.

This change:

- passes the database and row source context through the row-document loader;
- loads row bodies through `/api/workspace/v1/{workspace_id}/collab/{row_document_id}`;
- includes `database_id`, `row_id`, and `row_document_id` so Cloud can authorize against the parent database, matching the desktop implementation;
- preserves request deduplication, retry behavior, and permission-denied cache eviction;
- adds focused coverage at the component, view-loader, fetch-deduplication, and HTTP-client layers.

#### Validation

- Live local Cloud probe with the registration row intentionally absent and a non-owner workspace member:
  - legacy page-view response: AppFlowy code `1012`
  - contextual collab response: AppFlowy code `0`
- `pnpm exec jest src/application/__tests__/view-loader.test.ts src/components/database/components/database-row/__tests__/DatabaseRowSubDocument.test.tsx src/application/services/js-services/__tests__/fetch.test.ts src/application/services/js-services/http/__tests__/http_api.test.ts --runInBand --no-coverage --silent` — 48 tests passed
- `pnpm type-check`
- targeted ESLint — no errors
- `pnpm build`

No visual behavior changed, so a feature preview is not applicable.

---

### **Checklist**

#### **General**
- [x] Relevant implementation comments are included.
- [ ] Tested in multiple browsers and operating systems.

#### **Testing**
- [x] Tests were added or updated for the change.

#### **Feature-Specific**
- [x] Existing page and database loading behavior remains covered.
- [x] Feature preview is not applicable because this is a permission-path bug fix.

## Summary by Sourcery

Load database row documents through the contextual collaboration endpoint so database members can access inherited row permissions reliably.

Bug Fixes:
- Load database row documents with parent database context so inherited member permissions work without a direct row-document ACL or legacy registration.

Enhancements:
- Preserve row-document request deduplication, retry handling, and permission-denied cache eviction while routing loads through the contextual collaboration API.

Tests:
- Add unit, component, HTTP-client, and end-to-end coverage for contextual row-document authorization and member read/edit access.