### PR TITLE
fix(database): restore relation metadata and loading feedback

### DIFF
--- a/src/components/app/hooks/__tests__/useDatabaseIdentity.test.ts
+++ b/src/components/app/hooks/__tests__/useDatabaseIdentity.test.ts
@@ -22,9 +22,12 @@ const DATABASE_MAPPINGS = {
   [DATABASE_ID]: [PRIMARY_VIEW_ID, SECONDARY_VIEW_ID],
 };
 
-function renderDatabaseIdentity() {
+type LoadDatabaseRelations = (options?: { refresh?: boolean }) => Promise<Record<string, string> | undefined>;
+
+function renderDatabaseIdentity(loadDatabaseRelations?: LoadDatabaseRelations) {
   const params: Parameters<typeof useDatabaseIdentity>[0] = {
     currentWorkspaceId: WORKSPACE_ID,
+    loadDatabaseRelations,
   };
 
   return renderHook(() => useDatabaseIdentity(params));
@@ -85,6 +88,20 @@ describe('useDatabaseIdentity', () => {
 
     await expect(result.current.getViewIdFromDatabaseId(DATABASE_ID)).resolves.toBe(PRIMARY_VIEW_ID);
     expect(getViewIdFromWorkspaceCatalog).toHaveBeenCalledWith(WORKSPACE_ID, DATABASE_ID);
+  });
+
+  it('falls back to refreshed workspace relation metadata when the catalog misses a legacy database', async () => {
+    const loadDatabaseRelations = jest
+      .fn<ReturnType<LoadDatabaseRelations>, Parameters<LoadDatabaseRelations>>()
+      .mockResolvedValueOnce({})
+      .mockResolvedValueOnce({ [DATABASE_ID]: PRIMARY_VIEW_ID });
+    const { result } = renderDatabaseIdentity(loadDatabaseRelations);
+
+    await expect(result.current.getViewIdFromDatabaseId(DATABASE_ID)).resolves.toBe(PRIMARY_VIEW_ID);
+
+    expect(getViewIdFromWorkspaceCatalog).toHaveBeenCalledWith(WORKSPACE_ID, DATABASE_ID);
+    expect(loadDatabaseRelations).toHaveBeenNthCalledWith(1);
+    expect(loadDatabaseRelations).toHaveBeenNthCalledWith(2, { refresh: true });
   });
 
   it('resolves a database ID through the IndexedDB-backed workspace catalog', async () => {

--- a/src/components/app/hooks/useDatabaseIdentity.ts
+++ b/src/components/app/hooks/useDatabaseIdentity.ts
@@ -161,7 +161,11 @@ export function useDatabaseIdentity({ currentWorkspaceId, loadDatabaseRelations 
             return relatedViewId;
           }
         } catch (error) {
-          Log.warn('[useDatabaseIdentity] failed to load workspace relation metadata', error);
+          Log.warn('[useDatabaseIdentity] failed to load workspace relation metadata', {
+            workspaceId: currentWorkspaceId,
+            databaseId,
+            error,
+          });
         }
       }
 

--- a/src/components/app/hooks/useDatabaseIdentity.ts
+++ b/src/components/app/hooks/useDatabaseIdentity.ts
@@ -1,12 +1,13 @@
 import { useCallback } from 'react';
 
 import { getDatabaseIdFromWorkspaceCatalog, getViewIdFromWorkspaceCatalog } from '@/application/services/domains/view';
-import { DatabaseId, Types, ViewId, YDoc } from '@/application/types';
+import { DatabaseId, DatabaseRelations, Types, ViewId, YDoc } from '@/application/types';
 import { getDatabaseIdFromDoc } from '@/application/view-loader';
 import { Log } from '@/utils/log';
 
 type UseDatabaseIdentityParams = {
   currentWorkspaceId?: string;
+  loadDatabaseRelations?: (options?: { refresh?: boolean }) => Promise<DatabaseRelations | undefined>;
 };
 
 type DatabaseMappings = Record<DatabaseId, ViewId[]>;
@@ -81,7 +82,7 @@ function getTemplateDatabaseMappings(workspaceId: string): DatabaseMappings {
  * - `viewId` = database-view id (grid/board/calendar layout)
  * - `objectId` = shared database id
  */
-export function useDatabaseIdentity({ currentWorkspaceId }: UseDatabaseIdentityParams) {
+export function useDatabaseIdentity({ currentWorkspaceId, loadDatabaseRelations }: UseDatabaseIdentityParams) {
   const getDatabaseIdForViewId = useCallback(
     async (viewId: string) => {
       if (!currentWorkspaceId) return;
@@ -125,17 +126,48 @@ export function useDatabaseIdentity({ currentWorkspaceId }: UseDatabaseIdentityP
       }
 
       try {
-        return await getViewIdFromWorkspaceCatalog(currentWorkspaceId, databaseId);
+        const catalogViewId = await getViewIdFromWorkspaceCatalog(currentWorkspaceId, databaseId);
+
+        if (catalogViewId) {
+          return catalogViewId;
+        }
       } catch (error) {
         Log.warn('[useDatabaseIdentity] failed to resolve a database view from the workspace catalog', {
           workspaceId: currentWorkspaceId,
           databaseId,
           error,
         });
-        return null;
       }
+
+      // Legacy and recently duplicated workspaces can have a complete
+      // WorkspaceDatabase collab before the server's folder projection has
+      // been backfilled. Keep that metadata as a compatibility fallback so a
+      // catalog miss does not get presented to the user as an access failure.
+      if (loadDatabaseRelations) {
+        try {
+          let databaseRelations = await loadDatabaseRelations();
+          let relatedViewId = databaseRelations?.[databaseId];
+
+          if (!relatedViewId && databaseRelations) {
+            databaseRelations = await loadDatabaseRelations({ refresh: true });
+            relatedViewId = databaseRelations?.[databaseId];
+          }
+
+          if (relatedViewId) {
+            Log.debug('[useDatabaseIdentity] found viewId from workspace relation metadata', {
+              databaseId,
+              viewId: relatedViewId,
+            });
+            return relatedViewId;
+          }
+        } catch (error) {
+          Log.warn('[useDatabaseIdentity] failed to load workspace relation metadata', error);
+        }
+      }
+
+      return null;
     },
-    [currentWorkspaceId]
+    [currentWorkspaceId, loadDatabaseRelations]
   );
 
   const resolveCollabObjectId = useCallback(

--- a/src/components/app/hooks/useViewOperations.ts
+++ b/src/components/app/hooks/useViewOperations.ts
@@ -5,7 +5,16 @@ import * as Y from 'yjs';
 
 import { APP_EVENTS } from '@/application/constants';
 import { CollabService, ViewService, WorkspaceService } from '@/application/services/domains';
-import { AccessLevel, LoadViewOptions, Types, View, ViewLayout, YDoc, YDocWithMeta } from '@/application/types';
+import {
+  AccessLevel,
+  DatabaseRelations,
+  LoadViewOptions,
+  Types,
+  View,
+  ViewLayout,
+  YDoc,
+  YDocWithMeta,
+} from '@/application/types';
 import { openView } from '@/application/view-loader';
 import {
   getDatabaseIdFromExtra,
@@ -120,7 +129,11 @@ export function getViewCanWriteStatus(viewId: string, outline?: View[], fallback
 }
 
 // Hook for managing view-related operations
-export function useViewOperations() {
+export function useViewOperations({
+  loadDatabaseRelations,
+}: {
+  loadDatabaseRelations?: (options?: { refresh?: boolean }) => Promise<DatabaseRelations | undefined>;
+} = {}) {
   const { currentWorkspaceId } = useAuthInternal();
   const { registerSyncContext, eventEmitter } = useSyncInternal();
   const navigate = useNavigate();
@@ -157,6 +170,7 @@ export function useViewOperations() {
 
   const { resolveCollabObjectId, getDatabaseIdForViewId, getViewIdFromDatabaseId } = useDatabaseIdentity({
     currentWorkspaceId,
+    loadDatabaseRelations,
   });
 
   // Check if view should be readonly based on access permissions

--- a/src/components/app/layers/AppBusinessLayer.tsx
+++ b/src/components/app/layers/AppBusinessLayer.tsx
@@ -198,7 +198,7 @@ export const AppBusinessLayer: FC<AppBusinessLayerProps> = ({ children }) => {
     bindViewSync,
     getCollabHistory,
     previewCollabVersion,
-  } = useViewOperations();
+  } = useViewOperations({ loadDatabaseRelations });
 
   // Initialize row operations
   const { createRow } = useRowOperations();

--- a/src/components/database/components/cell/relation/RelationCellMenuContent.tsx
+++ b/src/components/database/components/cell/relation/RelationCellMenuContent.tsx
@@ -393,7 +393,8 @@ function RelationCellMenuContent({
   // may want to remove.
   // `rowIdsLoaded` keeps an empty list from reading as "nothing matched" while it is really
   // "nothing has arrived yet".
-  const noResult = filteredRowIds.length === 0 && filteredRelatedRowIds.length === 0 && !loading && rowIdsLoaded;
+  const isLoadingRows = loading || !rowIdsLoaded;
+  const noResult = filteredRowIds.length === 0 && filteredRelatedRowIds.length === 0 && !isLoadingRows;
 
   const renderItem = useCallback(
     (id: string) => {
@@ -478,7 +479,7 @@ function RelationCellMenuContent({
   // any non-empty query exposes the create affordance, even when the live
   // results already match. The user shouldn't have to clear partial matches
   // to create a new row that happens to share a substring.
-  const showCreateAndLink = trimmedSearch.length > 0 && !loading && !noAccess && primaryFieldId !== null;
+  const showCreateAndLink = trimmedSearch.length > 0 && !isLoadingRows && !noAccess && primaryFieldId !== null;
 
   const handleCreateAndLink = useCallback(async () => {
     const targetDoc = targetDocRef.current;
@@ -622,7 +623,15 @@ function RelationCellMenuContent({
           <Separator className={'mt-2'} />
         </div>
         <div className={'relative flex-1 p-2 pt-0'}>
-          {noResult ? (
+          {isLoadingRows ? (
+            <div
+              aria-label={t('grid.row.loading', 'Loading rows')}
+              className={'flex min-h-[160px] items-center justify-center'}
+              role={'status'}
+            >
+              <Progress aria-hidden variant={'primary'} />
+            </div>
+          ) : noResult ? (
             <div className={'flex items-center py-2 text-sm text-text-secondary'}>{t('findAndReplace.noResult')}</div>
           ) : (
             !noAccess &&

--- a/src/components/database/components/cell/relation/RelationCellMenuContent.tsx
+++ b/src/components/database/components/cell/relation/RelationCellMenuContent.tsx
@@ -14,6 +14,7 @@ import { ReactComponent as PlusIcon } from '@/assets/icons/plus.svg';
 import RelationRowItem from '@/components/database/components/cell/relation/RelationRowItem';
 import { getLiveRelationRowIds } from '@/components/database/components/cell/relation/relationRowOrders';
 import { useNavigationKey } from '@/components/database/components/cell/relation/useNavigationKey';
+import { useCurrentUserOptional } from '@/components/main/app.hooks';
 import { Button } from '@/components/ui/button';
 import { dropdownMenuItemVariants, DropdownMenuLabel } from '@/components/ui/dropdown-menu';
 import { Progress } from '@/components/ui/progress';
@@ -21,7 +22,6 @@ import { SearchInput } from '@/components/ui/search-input';
 import { Separator } from '@/components/ui/separator';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 import { cn } from '@/lib/utils';
-import { useCurrentUserOptional } from '@/components/main/app.hooks';
 
 const recentRelationRowsByView = new Map<string, string[]>();
 
@@ -103,9 +103,7 @@ function RelationCellMenuContent({
   const actorUid = resolveUserAttributionUid(currentUser);
   const { navigateToView, loadView, navigateToRow, createRow, bindViewSync } = useDatabaseContext();
   const [element, setElement] = useState<HTMLElement | null>(null);
-  const selectedViewId = useMemo(() => {
-    return selectedView?.view_id;
-  }, [selectedView]);
+  const selectedViewId = selectedView?.view_id;
   const openRelatedRow = useCallback(
     (rowId: string) => {
       onClose?.();

--- a/src/components/database/components/cell/relation/__tests__/RelationCellMenuContent.loading.test.tsx
+++ b/src/components/database/components/cell/relation/__tests__/RelationCellMenuContent.loading.test.tsx
@@ -38,6 +38,7 @@ const PRIMARY_FIELD_ID = 'primary-field';
 const UNTITLED = 'menuAppHeader.defaultNewPageName';
 const DELETED = 'document.mention.deletedPage';
 const NO_RESULT = 'findAndReplace.noResult';
+const ROWS_LOADING = 'grid.row.loading';
 
 function deferred<T>() {
   let resolve!: (value: T) => void;
@@ -289,5 +290,24 @@ describe('RelationCellMenuContent loading states', () => {
     view.resolve(createTargetDoc([]));
 
     await waitFor(() => expect(screen.getByText(NO_RESULT)).toBeTruthy());
+  });
+
+  it('shows a centered loading indicator while the relation row list is in flight', async () => {
+    const view = deferred<YDoc>();
+
+    mockDatabaseContext.loadView.mockReturnValue(view.promise);
+
+    renderPicker();
+
+    await waitFor(() => expect(mockDatabaseContext.loadView).toHaveBeenCalled());
+
+    const indicator = screen.getByRole('status', { name: ROWS_LOADING });
+
+    expect(indicator.className).toContain('min-h-[160px]');
+
+    view.resolve(createTargetDoc([]));
+
+    await waitFor(() => expect(screen.queryByRole('status', { name: ROWS_LOADING })).toBeNull());
+    expect(screen.getByText(NO_RESULT)).toBeTruthy();
   });
 });

--- a/src/components/database/components/cell/relation/__tests__/RelationCellMenuContent.loading.test.tsx
+++ b/src/components/database/components/cell/relation/__tests__/RelationCellMenuContent.loading.test.tsx
@@ -301,9 +301,7 @@ describe('RelationCellMenuContent loading states', () => {
 
     await waitFor(() => expect(mockDatabaseContext.loadView).toHaveBeenCalled());
 
-    const indicator = screen.getByRole('status', { name: ROWS_LOADING });
-
-    expect(indicator.className).toContain('min-h-[160px]');
+    expect(screen.getByRole('status', { name: ROWS_LOADING })).toBeTruthy();
 
     view.resolve(createTargetDoc([]));
 


### PR DESCRIPTION
### **Description**

Fixes two relation-field problems reported from production:

| Problem | User-visible behavior | Resolution |
| --- | --- | --- |
| Relation metadata lookup | Relation cells showed `No access` even when the related databases were siblings under the same parent | Keep the workspace catalog as the fast path, then fall back to the legacy workspace-database relation map when the catalog is missing, stale, or fails to load |
| Relation row loading | The row-list area in the relation picker was blank while the target database was loading | Render a centered, accessible progress indicator until the target row order is available |

Database placement in the sidebar does not determine relation access. The first symptom occurred because the relation stores a database ID, while rendering needs a target view ID; production legacy/template metadata could still provide that mapping even when the newer workspace catalog could not.

#### Root cause and provenance

| Problem | Root cause | History |
| --- | --- | --- |
| `No access` relation cells | The catalog-only path returned `null` for a missing database mapping and no longer consulted `loadDatabaseRelations`. The relation renderer treated the unresolved target as inaccessible. | Introduced by [`4fc4d3dc`](https://github.com/AppFlowy-IO/AppFlowy-Web/commit/4fc4d3dc161821669ddb0715eaa0d9801b2015d5) / [#483](https://github.com/AppFlowy-IO/AppFlowy-Web/pull/483), authored by Nathan.fooo on 2026-08-19. The parent revision still had the fallback. |
| Blank loading area | `RelationCellMenuContent` tracked `rowIdsLoaded` and suppressed the premature “No result” message, but had no render branch for the pending state. | No single introducing commit was established; the blank pending state predates the current fix. |

#### Implementation

- Restore relation metadata fallback on catalog misses and catalog-load failures.
- Refresh the legacy relation map once when its cached value misses the requested database.
- Thread `loadDatabaseRelations` through `AppBusinessLayer` and `useViewOperations` again.
- Derive one row-list loading state from `loading || !rowIdsLoaded`.
- Show the existing `Progress` component in a stable-height list area with `role="status"` and an accessible label.
- Keep “create and link” hidden until the target rows finish loading.

Each reported problem has one focused commit, followed by one review cleanup:

- `19fe0e3e` — restore relation metadata fallback
- `d0943b21` — show relation row loading indicator
- `cf38f8d7` — apply React review feedback

#### React best-practices review

- Removed unnecessary `useMemo` around the primitive `selectedView?.view_id` value; it is now derived directly during render.
- Kept the catalog and metadata requests serial because the second request is a conditional fallback, not independent work suitable for `Promise.all`.
- Replaced a brittle Tailwind-class assertion with the accessible loading-state contract.
- Added workspace and database identifiers to fallback failure logs.
- Cleared the import-order warning in the touched relation component.

#### Test integrity

- Metadata fallback regression: with the regression test retained and only the production fallback removed, Jest failed with `expected "view-1", received null`; restoring the implementation made it pass.
- Loading indicator regression: with the regression test retained and only the production spinner branch removed, Jest failed because it could not find `role="status"` named `grid.row.loading`; restoring the implementation made all 9 relation-loading tests pass.
- The Web code path is covered by focused Jest hook/component tests; Flutter BDD is not applicable here.

#### Validation

- `pnpm exec jest ... --runInBand --no-coverage --silent` — 4 suites, 25 tests passed.
- `pnpm run type-check` — passed.
- Targeted ESLint — passed with zero errors or warnings for the reviewed production files.
- `pnpm run build` — passed; only the existing Rollup circular-chunk and chunk-size warnings were emitted.
- Manual Chrome verification for the metadata fallback: forced a workspace-catalog miss, confirmed all six relation values rendered instead of `No access`, and observed zero console errors. All temporary diagnostics were removed.

#### Feature Preview

The relation picker now displays a centered progress indicator in the row-list area while its target database rows are in flight, then replaces it with rows or “No result” once loading settles.

---

### **Checklist**

#### **General**
- [x] I've included relevant documentation or comments for the changes introduced.
- [ ] I've tested the changes in multiple environments (e.g., different browsers, operating systems).

#### **Testing**
- [x] I've added or updated tests to validate the changes introduced for AppFlowy Web.

#### **Feature-Specific**
- [ ] For feature additions, I've added a preview (video, screenshot, or demo) in the "Feature Preview" section. (N/A: bug fix)
- [x] I've verified that this feature integrates seamlessly with existing functionality.
