### PR TITLE
fix: streamline relation loading and coalesce trash requests

### DIFF
--- a/src/application/__tests__/view-loader.test.ts
+++ b/src/application/__tests__/view-loader.test.ts
@@ -4,7 +4,11 @@ import * as Y from 'yjs';
 import { deleteCollabDB, openCollabDB, openCollabDBWithProvider } from '@/application/db';
 import { getOrCreateRowSubDoc } from '@/application/services/js-services/cache';
 import { invalidateViewCache } from '@/application/services/js-services/cached-api';
-import { fetchPageCollab, fetchRowDocumentCollab } from '@/application/services/js-services/fetch';
+import {
+  fetchDatabaseCollab,
+  fetchPageCollab,
+  fetchRowDocumentCollab,
+} from '@/application/services/js-services/fetch';
 import { enqueueOutboxUpdate } from '@/application/sync-outbox';
 import { Types, ViewLayout, YDoc, YjsDatabaseKey, YjsEditorKey } from '@/application/types';
 import { getDatabaseIdFromDoc, openRowSubDocument, openView } from '@/application/view-loader';
@@ -29,6 +33,7 @@ jest.mock('@/application/services/js-services/cache', () => ({
 }));
 
 jest.mock('@/application/services/js-services/fetch', () => ({
+  fetchDatabaseCollab: jest.fn(),
   fetchPageCollab: jest.fn(),
   fetchRowDocumentCollab: jest.fn(),
 }));
@@ -42,6 +47,7 @@ const mockOpenCollabDBWithProvider = openCollabDBWithProvider as jest.MockedFunc
 const mockDeleteCollabDB = deleteCollabDB as jest.MockedFunction<typeof deleteCollabDB>;
 const mockInvalidateViewCache = invalidateViewCache as jest.MockedFunction<typeof invalidateViewCache>;
 const mockGetOrCreateRowSubDoc = getOrCreateRowSubDoc as jest.MockedFunction<typeof getOrCreateRowSubDoc>;
+const mockFetchDatabaseCollab = fetchDatabaseCollab as jest.MockedFunction<typeof fetchDatabaseCollab>;
 const mockFetchPageCollab = fetchPageCollab as jest.MockedFunction<typeof fetchPageCollab>;
 const mockFetchRowDocumentCollab = fetchRowDocumentCollab as jest.MockedFunction<typeof fetchRowDocumentCollab>;
 const mockEnqueueOutboxUpdate = enqueueOutboxUpdate as jest.MockedFunction<typeof enqueueOutboxUpdate>;
@@ -57,6 +63,21 @@ function createDatabaseDoc(guid: string, databaseId = guid): YDoc {
 
   database.set(YjsDatabaseKey.id, databaseId);
   root.set(YjsEditorKey.database, database);
+  return doc;
+}
+
+function createCompleteDatabaseDoc(guid: string, databaseId: string, viewId: string): YDoc {
+  const doc = createDatabaseDoc(guid, databaseId);
+  const database = doc.getMap(YjsEditorKey.data_section).get(YjsEditorKey.database) as Y.Map<unknown>;
+  const fields = new Y.Map<Y.Map<unknown>>();
+  const primaryField = new Y.Map<unknown>();
+  const views = new Y.Map<Y.Map<unknown>>();
+
+  primaryField.set(YjsDatabaseKey.is_primary, true);
+  fields.set('primary-field', primaryField);
+  views.set(viewId, new Y.Map());
+  database.set(YjsDatabaseKey.fields, fields);
+  database.set(YjsDatabaseKey.views, views);
   return doc;
 }
 
@@ -121,7 +142,7 @@ describe('view-loader database cache identity', () => {
     const databaseId = '00000000-0000-4000-8000-000000000004';
     const canonicalDoc = createEmptyDoc(databaseId);
     const legacyDoc = createEmptyDoc(viewId);
-    const serverDoc = createDatabaseDoc(databaseId);
+    const serverDoc = createCompleteDatabaseDoc(databaseId, databaseId, viewId);
     const docs = new Map([
       [databaseId, canonicalDoc],
       [viewId, legacyDoc],
@@ -150,6 +171,71 @@ describe('view-loader database cache identity', () => {
     expect(result.fromCache).toBe(false);
     expect(getDatabaseIdFromDoc(canonicalDoc)).toBe(databaseId);
     expect(mockFetchPageCollab).toHaveBeenCalledWith('workspace-id', viewId);
+  });
+
+  it('fetches only the canonical database collab for metadata-only relation loads', async () => {
+    const viewId = '00000000-0000-4000-8000-000000000013';
+    const databaseId = '00000000-0000-4000-8000-000000000014';
+    const canonicalDoc = createEmptyDoc(databaseId);
+    const legacyDoc = createEmptyDoc(viewId);
+    const serverDoc = createCompleteDatabaseDoc(databaseId, databaseId, viewId);
+    const docs = new Map([
+      [databaseId, canonicalDoc],
+      [viewId, legacyDoc],
+    ]);
+
+    mockOpenCollabDBWithProvider.mockImplementation(async (name: string) => {
+      const doc = docs.get(name);
+
+      if (!doc) throw new Error(`Unexpected open ${name}`);
+      return createProvider(doc) as never;
+    });
+    mockFetchDatabaseCollab.mockResolvedValue({
+      data: Y.encodeStateAsUpdate(serverDoc),
+    });
+
+    const result = await openView('workspace-id', viewId, undefined, {
+      databaseId,
+      databaseMetadataOnly: true,
+    });
+
+    expect(result.doc).toBe(canonicalDoc);
+    expect(result.fromCache).toBe(false);
+    expect(getDatabaseIdFromDoc(canonicalDoc)).toBe(databaseId);
+    expect(mockFetchDatabaseCollab).toHaveBeenCalledWith('workspace-id', databaseId);
+    expect(mockFetchPageCollab).not.toHaveBeenCalled();
+  });
+
+  it('refetches a partial canonical cache for metadata-only relation loads', async () => {
+    const viewId = '00000000-0000-4000-8000-000000000015';
+    const databaseId = '00000000-0000-4000-8000-000000000016';
+    const canonicalDoc = createDatabaseDoc(databaseId);
+    const legacyDoc = createEmptyDoc(viewId);
+    const serverDoc = createCompleteDatabaseDoc(databaseId, databaseId, viewId);
+    const docs = new Map([
+      [databaseId, canonicalDoc],
+      [viewId, legacyDoc],
+    ]);
+
+    mockOpenCollabDBWithProvider.mockImplementation(async (name: string) => {
+      const doc = docs.get(name);
+
+      if (!doc) throw new Error(`Unexpected open ${name}`);
+      return createProvider(doc) as never;
+    });
+    mockFetchDatabaseCollab.mockResolvedValue({
+      data: Y.encodeStateAsUpdate(serverDoc),
+    });
+
+    const result = await openView('workspace-id', viewId, undefined, {
+      databaseId,
+      databaseMetadataOnly: true,
+    });
+
+    expect(result.doc).toBe(canonicalDoc);
+    expect(result.fromCache).toBe(false);
+    expect(mockFetchDatabaseCollab).toHaveBeenCalledWith('workspace-id', databaseId);
+    expect(mockFetchPageCollab).not.toHaveBeenCalled();
   });
 
   it('uses the canonical databaseId cache when the database layout was discovered after the first load', async () => {

--- a/src/application/constants.ts
+++ b/src/application/constants.ts
@@ -61,6 +61,7 @@ export const ERROR_CODE = {
 export const APP_EVENTS = {
   // App lifecycle events
   OUTLINE_LOADED: 'outline-loaded',
+  TRASH_UPDATED: 'trash-updated',                     // Fresh workspace trash payload accepted by app state
   RECONNECT_WEBSOCKET: 'reconnect-websocket',
   WEBSOCKET_STATUS: 'websocket-status',
   

--- a/src/application/database-yjs/__tests__/useDatabaseIdFromField.test.tsx
+++ b/src/application/database-yjs/__tests__/useDatabaseIdFromField.test.tsx
@@ -1,0 +1,53 @@
+import { act, renderHook } from '@testing-library/react';
+import * as Y from 'yjs';
+
+import {
+  DatabaseContext,
+  type DatabaseContextState,
+  useDatabaseIdFromField,
+} from '@/application/database-yjs';
+import { FieldType } from '@/application/database-yjs/database.type';
+import { createRelationField } from '@/application/database-yjs/fields/relation/utils';
+import {
+  type YDatabase,
+  type YDatabaseFields,
+  type YDoc,
+  YjsDatabaseKey,
+  YjsEditorKey,
+} from '@/application/types';
+
+describe('useDatabaseIdFromField', () => {
+  it('returns the relation database synchronously and tracks field updates', () => {
+    const databaseDoc = new Y.Doc() as YDoc;
+    const database = new Y.Map() as YDatabase;
+    const fields = new Y.Map() as YDatabaseFields;
+    const relationField = createRelationField('relation', { database_id: 'database-b' });
+
+    fields.set('relation', relationField);
+    database.set(YjsDatabaseKey.fields, fields);
+    databaseDoc.getMap(YjsEditorKey.data_section).set(YjsEditorKey.database, database);
+
+    const context: DatabaseContextState = {
+      activeViewId: 'database-a-view',
+      databaseDoc,
+      databasePageId: 'database-a-view',
+      readOnly: false,
+      rowMap: null,
+      workspaceId: 'workspace',
+    };
+    const { result } = renderHook(() => useDatabaseIdFromField('relation'), {
+      wrapper: ({ children }) => <DatabaseContext.Provider value={context}>{children}</DatabaseContext.Provider>,
+    });
+
+    expect(result.current).toBe('database-b');
+
+    act(() => {
+      relationField
+        .get(YjsDatabaseKey.type_option)
+        .get(String(FieldType.Relation))
+        .set(YjsDatabaseKey.database_id, 'database-c');
+    });
+
+    expect(result.current).toBe('database-c');
+  });
+});

--- a/src/application/database-yjs/hooks/__tests__/rollupMetadataLoading.test.tsx
+++ b/src/application/database-yjs/hooks/__tests__/rollupMetadataLoading.test.tsx
@@ -1,0 +1,153 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import type React from 'react';
+import * as Y from 'yjs';
+
+import {
+  DatabaseContext,
+  DatabaseContextState,
+  FieldType,
+  useCellSelector,
+} from '@/application/database-yjs';
+import { createRelationField } from '@/application/database-yjs/fields/relation/utils';
+import { createRollupField } from '@/application/database-yjs/fields/rollup/utils';
+import { useRollupFieldObservers } from '@/application/database-yjs/hooks/useRollupFieldObservers';
+import * as rollupCache from '@/application/database-yjs/rollup/cache';
+import {
+  LoadView,
+  YDatabase,
+  YDatabaseField,
+  YDatabaseFields,
+  YDatabaseSort,
+  YDatabaseSorts,
+  YDatabaseView,
+  YDatabaseViews,
+  YDoc,
+  YjsDatabaseKey,
+  YjsEditorKey,
+} from '@/application/types';
+
+import { createRowDoc, setRelationCellRowIds } from '../../__tests__/test-helpers';
+
+const baseDatabaseId = 'base-database-id';
+const baseViewId = 'base-view-id';
+const baseRowId = 'base-row-id';
+const relationFieldId = 'relation-field-id';
+const rollupFieldId = 'rollup-field-id';
+const relatedDatabaseId = 'related-database-id';
+const relatedViewId = 'related-view-id';
+const relatedRowId = 'related-row-id';
+const targetFieldId = 'target-field-id';
+
+function createFixture() {
+  const relatedDoc = new Y.Doc({ guid: relatedViewId }) as YDoc;
+  const relatedDatabase = new Y.Map() as YDatabase;
+  const relatedFields = new Y.Map<YDatabaseField>() as YDatabaseFields;
+  const targetField = new Y.Map() as YDatabaseField;
+
+  targetField.set(YjsDatabaseKey.id, targetFieldId);
+  targetField.set(YjsDatabaseKey.name, 'Target');
+  targetField.set(YjsDatabaseKey.type, FieldType.RichText);
+  targetField.set(YjsDatabaseKey.is_primary, true);
+  relatedFields.set(targetFieldId, targetField);
+  relatedDatabase.set(YjsDatabaseKey.id, relatedDatabaseId);
+  relatedDatabase.set(YjsDatabaseKey.fields, relatedFields);
+  relatedDoc.getMap(YjsEditorKey.data_section).set(YjsEditorKey.database, relatedDatabase);
+
+  const baseDoc = new Y.Doc({ guid: baseViewId }) as YDoc;
+  const baseDatabase = new Y.Map() as YDatabase;
+  const fields = new Y.Map<YDatabaseField>() as YDatabaseFields;
+  const views = new Y.Map<YDatabaseView>() as YDatabaseViews;
+  const view = new Y.Map() as YDatabaseView;
+  const sorts = new Y.Array<YDatabaseSort>() as YDatabaseSorts;
+  const sort = new Y.Map() as YDatabaseSort;
+  const relationField = createRelationField(relationFieldId, {
+    database_id: relatedDatabaseId,
+  });
+  const rollupField = createRollupField(rollupFieldId);
+
+  fields.set(relationFieldId, relationField);
+  fields.set(rollupFieldId, rollupField);
+  sort.set(YjsDatabaseKey.field_id, rollupFieldId);
+  sorts.push([sort]);
+  view.set(YjsDatabaseKey.sorts, sorts);
+  views.set(baseViewId, view);
+  baseDatabase.set(YjsDatabaseKey.id, baseDatabaseId);
+  baseDatabase.set(YjsDatabaseKey.fields, fields);
+  baseDatabase.set(YjsDatabaseKey.views, views);
+  baseDoc.getMap(YjsEditorKey.data_section).set(YjsEditorKey.database, baseDatabase);
+  const integratedRollupField = fields.get(rollupFieldId);
+  const rollupOption = integratedRollupField
+    ?.get(YjsDatabaseKey.type_option)
+    ?.get(String(FieldType.Rollup));
+
+  rollupOption?.set(YjsDatabaseKey.relation_field_id, relationFieldId);
+  rollupOption?.set(YjsDatabaseKey.target_field_id, targetFieldId);
+
+  const baseRowDoc = createRowDoc(baseRowId, baseDatabaseId, {
+    [relationFieldId]: { fieldType: FieldType.Relation },
+    [rollupFieldId]: { fieldType: FieldType.Rollup },
+  });
+
+  setRelationCellRowIds(baseRowDoc, relationFieldId, [relatedRowId]);
+
+  const relatedRowDoc = createRowDoc(relatedRowId, relatedDatabaseId, {
+    [targetFieldId]: { fieldType: FieldType.RichText, data: 'Related value' },
+  });
+  const loadView = jest.fn(async () => relatedDoc) as jest.MockedFunction<LoadView>;
+  const createRow = jest.fn(async () => relatedRowDoc);
+  const getViewIdFromDatabaseId = jest.fn(async (databaseId: string) =>
+    databaseId === relatedDatabaseId ? relatedViewId : null
+  );
+  const contextValue: DatabaseContextState = {
+    readOnly: false,
+    databaseDoc: baseDoc,
+    databasePageId: baseViewId,
+    activeViewId: baseViewId,
+    rowMap: { [baseRowId]: baseRowDoc },
+    workspaceId: 'workspace-id',
+    loadView,
+    createRow,
+    getViewIdFromDatabaseId,
+  };
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <DatabaseContext.Provider value={contextValue}>{children}</DatabaseContext.Provider>
+  );
+
+  return { getViewIdFromDatabaseId, loadView, wrapper };
+}
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe('rollup target database loading', () => {
+  it('loads selector observer metadata without page row data', async () => {
+    const { getViewIdFromDatabaseId, loadView, wrapper } = createFixture();
+
+    jest.spyOn(rollupCache, 'readRollupCell').mockResolvedValue({ value: '' });
+    renderHook(() => useCellSelector({ rowId: baseRowId, fieldId: rollupFieldId }), { wrapper });
+
+    await waitFor(() => {
+      expect(getViewIdFromDatabaseId).toHaveBeenCalled();
+      expect(loadView).toHaveBeenCalledWith(relatedViewId, false, false, {
+        databaseId: relatedDatabaseId,
+        databaseMetadataOnly: true,
+      });
+    });
+    expect(loadView).toHaveBeenCalledTimes(1);
+  });
+
+  it('loads sort-triggered observer metadata without page row data', async () => {
+    const { loadView, wrapper } = createFixture();
+
+    renderHook(() => useRollupFieldObservers(jest.fn(), 0), { wrapper });
+
+    await waitFor(() => {
+      expect(loadView).toHaveBeenCalledWith(relatedViewId, false, false, {
+        databaseId: relatedDatabaseId,
+        databaseMetadataOnly: true,
+      });
+    });
+    expect(loadView).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/application/database-yjs/hooks/useRollupFieldObservers.ts
+++ b/src/application/database-yjs/hooks/useRollupFieldObservers.ts
@@ -92,7 +92,10 @@ export function useRollupFieldObservers(onConditionsChange: () => void, rollupWa
         return null;
       }
 
-      const doc = await loadView(viewId);
+      const doc = await loadView(viewId, false, false, {
+        databaseId,
+        databaseMetadataOnly: true,
+      });
 
       if (cancelled) return null;
       relatedDocCache.set(databaseId, doc);

--- a/src/application/database-yjs/relation/cache.ts
+++ b/src/application/database-yjs/relation/cache.ts
@@ -5,6 +5,7 @@ import { getRelationRowIdsFromCell } from '@/application/database-yjs/relation/c
 import { getRowKey } from '@/application/database-yjs/row_meta';
 import {
   RowId,
+  LoadViewOptions,
   YDatabase,
   YDatabaseField,
   YDatabaseFields,
@@ -21,6 +22,13 @@ type RelationCellValue = {
   value: string;
 };
 
+type RelatedViewLoader = (
+  viewId: string,
+  isSubDocument?: boolean,
+  loadAwareness?: boolean,
+  options?: LoadViewOptions
+) => Promise<YDoc | null>;
+
 type RelationCacheEntry = RelationCellValue & {
   generation: number;
   updatedAt: number;
@@ -33,7 +41,7 @@ export type RelationComputeContext = {
   row: YDatabaseRow;
   rowId: RowId;
   fieldId: string;
-  loadView?: (viewId: string) => Promise<YDoc | null>;
+  loadView?: RelatedViewLoader;
   createRow?: (rowKey: string) => Promise<YDoc>;
   getViewIdFromDatabaseId?: (databaseId: string) => Promise<string | null>;
 };
@@ -46,7 +54,7 @@ export type RelationGroupLabelKey = {
 
 /** Adds the loaders only a resolution needs, so reads cannot trigger one. */
 export type RelationGroupLabelContext = RelationGroupLabelKey & {
-  loadView?: (viewId: string) => Promise<YDoc | null>;
+  loadView?: RelatedViewLoader;
   createRow?: (rowKey: string) => Promise<YDoc>;
   getViewIdFromDatabaseId?: (databaseId: string) => Promise<string | null>;
 };
@@ -239,21 +247,22 @@ function getDatabaseFromDoc(doc: YDoc): YDatabase | undefined {
   return doc.getMap(YjsEditorKey.data_section)?.get(YjsEditorKey.database) as YDatabase | undefined;
 }
 
-async function loadRelatedDoc(viewId: string, loadView?: (viewId: string) => Promise<YDoc | null>) {
+async function loadRelatedDoc(viewId: string, databaseId: string, loadView?: RelatedViewLoader) {
   if (!loadView) return null;
-  const cached = relatedDocCache.get(viewId);
+  const cacheKey = `${databaseId}:${viewId}`;
+  const cached = relatedDocCache.get(cacheKey);
 
   if (cached) {
-    touchRelatedDocCache(viewId, cached);
+    touchRelatedDocCache(cacheKey, cached);
     return cached;
   }
 
-  const promise = loadView(viewId).catch(() => {
-    relatedDocCache.delete(viewId);
+  const promise = loadView(viewId, false, false, { databaseId, databaseMetadataOnly: true }).catch(() => {
+    relatedDocCache.delete(cacheKey);
     return null;
   });
 
-  touchRelatedDocCache(viewId, promise);
+  touchRelatedDocCache(cacheKey, promise);
   return promise;
 }
 
@@ -280,7 +289,7 @@ async function computeRelationCellValue(context: RelationComputeContext): Promis
 
     if (!viewId) return { value: '' };
 
-    const relatedDoc = await loadRelatedDoc(viewId, context.loadView);
+    const relatedDoc = await loadRelatedDoc(viewId, relationOption.database_id, context.loadView);
 
     if (!relatedDoc) return { value: '' };
 
@@ -344,7 +353,7 @@ async function computeRelationGroupLabel(
 
     if (!viewId) return { value: '' };
 
-    const relatedDoc = await loadRelatedDoc(viewId, context.loadView);
+    const relatedDoc = await loadRelatedDoc(viewId, relationOption.database_id, context.loadView);
 
     if (!relatedDoc) return { value: '' };
 

--- a/src/application/database-yjs/rollup/cache.ts
+++ b/src/application/database-yjs/rollup/cache.ts
@@ -7,10 +7,11 @@ import { EnhancedBigStats } from '@/application/database-yjs/fields/number/Enhan
 import { parseNumberTypeOptions } from '@/application/database-yjs/fields/number/parse';
 import { parseRelationTypeOption } from '@/application/database-yjs/fields/relation/parse';
 import { parseRollupTypeOption } from '@/application/database-yjs/fields/rollup/parse';
-import { getRelationRowIdsFromCell } from '@/application/database-yjs/relation/cell';
 import { parseCheckboxValue } from '@/application/database-yjs/fields/text/utils';
+import { getRelationRowIdsFromCell } from '@/application/database-yjs/relation/cell';
 import { getRowKey } from '@/application/database-yjs/row_meta';
 import {
+  LoadViewOptions,
   RowId,
   YDatabase,
   YDatabaseCell,
@@ -28,6 +29,13 @@ export type RollupCellValue = {
   list?: string[];
 };
 
+type RelatedViewLoader = (
+  viewId: string,
+  isSubDocument?: boolean,
+  loadAwareness?: boolean,
+  options?: LoadViewOptions
+) => Promise<YDoc | null>;
+
 type RollupCacheEntry = RollupCellValue & {
   generation: number;
   updatedAt: number;
@@ -40,7 +48,7 @@ type RollupComputeContext = {
   row: YDatabaseRow;
   rowId: RowId;
   fieldId: string;
-  loadView?: (viewId: string) => Promise<YDoc | null>;
+  loadView?: RelatedViewLoader;
   createRow?: (rowKey: string) => Promise<YDoc>;
   getViewIdFromDatabaseId?: (databaseId: string) => Promise<string | null>;
 };
@@ -167,21 +175,22 @@ function touchRelatedDocCache(viewId: string, promise: Promise<YDoc | null>) {
   }
 }
 
-async function loadRelatedDoc(viewId: string, loadView?: (viewId: string) => Promise<YDoc | null>) {
+async function loadRelatedDoc(viewId: string, databaseId: string, loadView?: RelatedViewLoader) {
   if (!loadView) return null;
-  const cached = relatedDocCache.get(viewId);
+  const cacheKey = `${databaseId}:${viewId}`;
+  const cached = relatedDocCache.get(cacheKey);
 
   if (cached) {
-    touchRelatedDocCache(viewId, cached);
+    touchRelatedDocCache(cacheKey, cached);
     return cached;
   }
 
-  const promise = loadView(viewId).catch(() => {
-    relatedDocCache.delete(viewId);
+  const promise = loadView(viewId, false, false, { databaseId, databaseMetadataOnly: true }).catch(() => {
+    relatedDocCache.delete(cacheKey);
     return null;
   });
 
-  touchRelatedDocCache(viewId, promise);
+  touchRelatedDocCache(cacheKey, promise);
   return promise;
 }
 
@@ -218,7 +227,7 @@ async function createRelationTargetResolver(
 
   if (!viewId) return null;
 
-  const doc = await loadRelatedDoc(viewId, context.loadView);
+  const doc = await loadRelatedDoc(viewId, targetRelationOption.database_id, context.loadView);
 
   if (!doc) return null;
 
@@ -432,7 +441,7 @@ async function computeRollupCellValue(context: RollupComputeContext): Promise<Ro
 
   if (!viewId) return { value: '' };
 
-  const relatedDoc = await loadRelatedDoc(viewId, context.loadView);
+  const relatedDoc = await loadRelatedDoc(viewId, relationOption.database_id, context.loadView);
 
   if (!relatedDoc) return { value: '' };
 

--- a/src/application/database-yjs/selector.ts
+++ b/src/application/database-yjs/selector.ts
@@ -2843,7 +2843,10 @@ function useRollupCellValue({
       const viewId = await getViewIdFromDatabaseId?.(relationOption.database_id);
 
       if (cancelled || !viewId) return;
-      const relatedDoc = await loadView(viewId);
+      const relatedDoc = await loadView(viewId, false, false, {
+        databaseId: relationOption.database_id,
+        databaseMetadataOnly: true,
+      });
 
       if (cancelled || !relatedDoc) return;
       const docGuid = relatedDoc.guid;

--- a/src/application/database-yjs/selector.ts
+++ b/src/application/database-yjs/selector.ts
@@ -532,25 +532,22 @@ export function useFieldSelector(fieldId: string) {
 export function useDatabaseIdFromField(fieldId: string) {
   const database = useDatabase();
   const field = database?.get(YjsDatabaseKey.fields)?.get(fieldId);
-  const [databaseId, setDatabaseId] = useState<string | null>(null);
+  const subscribe = useCallback(
+    (onStoreChange: () => void) => {
+      if (!field) return () => undefined;
 
-  useEffect(() => {
-    if (!field) return;
+      field.observe(onStoreChange);
+      return () => {
+        field.unobserve(onStoreChange);
+      };
+    },
+    [field]
+  );
+  const getSnapshot = useCallback(() => parseRelationTypeOption(field)?.database_id ?? null, [field]);
 
-    const observerEvent = () => {
-      setDatabaseId(parseRelationTypeOption(field)?.database_id);
-    };
-
-    observerEvent();
-
-    field.observe(observerEvent);
-
-    return () => {
-      field.unobserve(observerEvent);
-    };
-  }, [database, field, fieldId]);
-
-  return databaseId;
+  // Relation cells need this value during their first render so an existing
+  // relation never paints an empty frame before its loading indicator.
+  return useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
 }
 
 export function useFiltersSelector() {

--- a/src/application/services/domains/view.ts
+++ b/src/application/services/domains/view.ts
@@ -25,6 +25,10 @@ export {
   getDatabaseContainerView,
   getDatabaseIdFromWorkspaceCatalog,
   getDatabasePrimaryView,
+  getWorkspaceDatabaseCatalog as getDatabaseCatalog,
+  getWorkspaceDatabaseCatalog,
   getViewIdFromWorkspaceCatalog,
+  invalidateWorkspaceDatabaseCatalog as invalidateDatabaseCatalog,
+  invalidateWorkspaceDatabaseCatalog,
   refreshWorkspaceDatabaseCatalog,
 } from '../js-services/workspace-database-catalog';

--- a/src/application/services/js-services/__tests__/cached-api.app-trash-cache.test.ts
+++ b/src/application/services/js-services/__tests__/cached-api.app-trash-cache.test.ts
@@ -98,6 +98,17 @@ jest.mock('@/utils/upload-tracker', () => ({
 const getTokenParsedMock = getTokenParsed as jest.Mock;
 const getAppTrashMock = getAppTrash as jest.Mock;
 
+function createDeferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+
+  return { promise, resolve, reject };
+}
+
 function setCurrentUser(userId: string | undefined) {
   getTokenParsedMock.mockReturnValue(
     userId
@@ -181,6 +192,68 @@ describe('cached app trash', () => {
 
     // The refreshed payload replaces the TTL cache entry
     await expect(getAppTrashCached(workspaceId)).resolves.toBe(refreshed);
+    expect(getAppTrashMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('queues one fresh request when an app mutation arrives during a DatabaseBlock cache read', async () => {
+    const workspaceId = 'workspace-trash-cache-then-mutation';
+    const beforeMutation = [createTrashView('before-mutation')];
+    const afterMutation = [createTrashView('after-mutation')];
+    const initialRequest = createDeferred<View[]>();
+
+    getAppTrashMock.mockReturnValueOnce(initialRequest.promise).mockResolvedValueOnce(afterMutation);
+
+    const databaseBlockRead = getAppTrashCached(workspaceId);
+    const appRefresh = refreshAppTrashCache(workspaceId, 'folder:2-1');
+    const duplicateObserver = refreshAppTrashCache(workspaceId, 'folder:2-1');
+
+    expect(getAppTrashMock).toHaveBeenCalledTimes(1);
+
+    initialRequest.resolve(beforeMutation);
+
+    await expect(databaseBlockRead).resolves.toBe(beforeMutation);
+    await expect(Promise.all([appRefresh, duplicateObserver])).resolves.toEqual([
+      afterMutation,
+      afterMutation,
+    ]);
+    expect(getAppTrashMock).toHaveBeenCalledTimes(2);
+
+    await expect(getAppTrashCached(workspaceId)).resolves.toBe(afterMutation);
+    expect(getAppTrashMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('coalesces multiple newer mutation keys into one trailing refresh', async () => {
+    const workspaceId = 'workspace-trash-one-trailing-refresh';
+    const initialRequest = createDeferred<View[]>();
+    const latest = [createTrashView('latest-trash')];
+
+    getAppTrashMock.mockReturnValueOnce(initialRequest.promise).mockResolvedValueOnce(latest);
+
+    const initialRead = getAppTrashCached(workspaceId);
+    const firstMutation = refreshAppTrashCache(workspaceId, 'folder:3-1');
+    const secondMutation = refreshAppTrashCache(workspaceId, 'folder:4-1');
+
+    initialRequest.resolve([]);
+
+    await expect(initialRead).resolves.toEqual([]);
+    await expect(Promise.all([firstMutation, secondMutation])).resolves.toEqual([latest, latest]);
+    expect(getAppTrashMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('runs a queued mutation refresh after the leading request fails', async () => {
+    const workspaceId = 'workspace-trash-leading-failure';
+    const initialRequest = createDeferred<View[]>();
+    const recovered = [createTrashView('recovered-trash')];
+
+    getAppTrashMock.mockReturnValueOnce(initialRequest.promise).mockResolvedValueOnce(recovered);
+
+    const initialRead = getAppTrashCached(workspaceId);
+    const mutationRefresh = refreshAppTrashCache(workspaceId, 'folder:6-1');
+
+    initialRequest.reject(new Error('initial request failed'));
+
+    await expect(initialRead).rejects.toThrow('initial request failed');
+    await expect(mutationRefresh).resolves.toBe(recovered);
     expect(getAppTrashMock).toHaveBeenCalledTimes(2);
   });
 

--- a/src/application/services/js-services/__tests__/workspace-database-catalog.test.ts
+++ b/src/application/services/js-services/__tests__/workspace-database-catalog.test.ts
@@ -269,6 +269,63 @@ describe('workspace database catalog', () => {
     expect(listWorkspaceDatabases).toHaveBeenCalledTimes(2);
   });
 
+  it('does not return a view mapping invalidated while its IndexedDB read is pending', async () => {
+    const cachedRead = createDeferred<{ database_id: string } | undefined>();
+
+    catalogTable.get.mockReturnValue(cachedRead.promise);
+    jest.mocked(listWorkspaceDatabases).mockResolvedValue([]);
+
+    const lookup = getDatabaseIdFromWorkspaceCatalog('workspace-1', 'grid-1');
+
+    await Promise.resolve();
+    expect(catalogTable.get).toHaveBeenCalledTimes(1);
+
+    invalidateWorkspaceDatabaseCatalog('workspace-1');
+    cachedRead.resolve({ database_id: 'stale-database' });
+
+    await expect(lookup).resolves.toBeNull();
+    expect(listWorkspaceDatabases).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not return a database mapping invalidated while its IndexedDB read is pending', async () => {
+    const cachedRead = createDeferred<Array<{ view_order: number; view: (typeof database.views)[number] }>>();
+
+    readDatabaseRecords.mockReturnValue(cachedRead.promise);
+    jest.mocked(listWorkspaceDatabases).mockResolvedValue([]);
+
+    const lookup = getViewIdFromWorkspaceCatalog('workspace-1', 'database-1');
+
+    await Promise.resolve();
+    expect(readDatabaseRecords).toHaveBeenCalledTimes(1);
+
+    invalidateWorkspaceDatabaseCatalog('workspace-1');
+    cachedRead.resolve([
+      { view_order: 0, view: database.views[0] },
+      { view_order: 1, view: database.views[1] },
+    ]);
+
+    await expect(lookup).resolves.toBeNull();
+    expect(listWorkspaceDatabases).toHaveBeenCalledTimes(1);
+  });
+
+  it('terminates an IndexedDB lookup when the session changes during the read', async () => {
+    const cachedRead = createDeferred<{ database_id: string } | undefined>();
+
+    catalogTable.get.mockReturnValue(cachedRead.promise);
+
+    const lookup = getDatabaseIdFromWorkspaceCatalog('workspace-1', 'grid-1');
+
+    await Promise.resolve();
+    expect(catalogTable.get).toHaveBeenCalledTimes(1);
+
+    emit(EventType.SESSION_INVALID);
+    setCurrentUser(`${currentTestUserId}-other`);
+    cachedRead.resolve({ database_id: 'stale-database' });
+
+    await expect(lookup).rejects.toMatchObject({ name: 'AbortError' });
+    expect(listWorkspaceDatabases).not.toHaveBeenCalled();
+  });
+
   it('isolates successful lookup responses by user and workspace', async () => {
     jest.mocked(listWorkspaceDatabases).mockResolvedValue([]);
 
@@ -288,6 +345,25 @@ describe('workspace database catalog', () => {
     await expect(getWorkspaceDatabaseCatalog('workspace-1')).resolves.toEqual([]);
 
     expect(listWorkspaceDatabases).toHaveBeenCalledTimes(2);
+  });
+
+  it('terminates an in-flight caller on account switch without requesting under the new session', async () => {
+    const staleRequest = createDeferred<(typeof database)[]>();
+
+    jest.mocked(listWorkspaceDatabases).mockReturnValue(staleRequest.promise);
+
+    const oldCaller = getWorkspaceDatabaseCatalog('workspace-1');
+
+    await Promise.resolve();
+    expect(listWorkspaceDatabases).toHaveBeenCalledTimes(1);
+
+    emit(EventType.SESSION_INVALID);
+    setCurrentUser(`${currentTestUserId}-other`);
+    staleRequest.resolve([database]);
+
+    await expect(oldCaller).rejects.toMatchObject({ name: 'AbortError' });
+    expect(listWorkspaceDatabases).toHaveBeenCalledTimes(1);
+    expect(transaction).not.toHaveBeenCalled();
   });
 
   it('does not cache a failed catalog refresh', async () => {

--- a/src/application/services/js-services/__tests__/workspace-database-catalog.test.ts
+++ b/src/application/services/js-services/__tests__/workspace-database-catalog.test.ts
@@ -1,11 +1,14 @@
 import { db } from '@/application/db';
+import { emit, EventType } from '@/application/session/event';
 import { getTokenParsed } from '@/application/session/token';
 import { ViewLayout } from '@/application/types';
 
 import {
   getDatabaseContainerEntries,
   getDatabaseIdFromWorkspaceCatalog,
+  getWorkspaceDatabaseCatalog,
   getViewIdFromWorkspaceCatalog,
+  invalidateWorkspaceDatabaseCatalog,
   refreshWorkspaceDatabaseCatalog,
 } from '../workspace-database-catalog';
 import { listWorkspaceDatabases } from '../http/view-api';
@@ -37,6 +40,19 @@ const catalogTable = db.workspace_database_catalog as unknown as {
 const transaction = db.transaction as jest.Mock;
 const deleteWorkspaceRecords = jest.fn();
 const readDatabaseRecords = jest.fn();
+let testUserSequence = 0;
+let currentTestUserId = '';
+
+function createDeferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+
+  return { promise, reject, resolve };
+}
 
 const database = {
   database_id: 'database-1',
@@ -62,6 +78,18 @@ const database = {
   ],
 };
 
+function databaseWithId(databaseId: string) {
+  return {
+    ...database,
+    database_id: databaseId,
+    views: database.views.map((view) => ({
+      ...view,
+      view_id: `${databaseId}-${view.is_container ? 'container' : 'grid'}`,
+      parent_view_id: view.is_container ? 'space-1' : `${databaseId}-container`,
+    })),
+  };
+}
+
 function setCurrentUser(userId = 'user-1') {
   jest.mocked(getTokenParsed).mockReturnValue({
     access_token: 'access-token',
@@ -75,7 +103,8 @@ describe('workspace database catalog', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     jest.spyOn(console, 'warn').mockImplementation(() => undefined);
-    setCurrentUser();
+    currentTestUserId = `test-user-${++testUserSequence}`;
+    setCurrentUser(currentTestUserId);
     catalogTable.bulkPut.mockResolvedValue(undefined);
     catalogTable.get.mockResolvedValue(undefined);
     deleteWorkspaceRecords.mockResolvedValue(undefined);
@@ -97,7 +126,7 @@ describe('workspace database catalog', () => {
 
     await expect(getDatabaseIdFromWorkspaceCatalog('workspace-1', 'grid-1')).resolves.toBe('database-1');
 
-    expect(catalogTable.get).toHaveBeenCalledWith(['user-1', 'workspace-1', 'grid-1']);
+    expect(catalogTable.get).toHaveBeenCalledWith([currentTestUserId, 'workspace-1', 'grid-1']);
     expect(listWorkspaceDatabases).not.toHaveBeenCalled();
   });
 
@@ -124,13 +153,13 @@ describe('workspace database catalog', () => {
     expect(deleteWorkspaceRecords).toHaveBeenCalledTimes(1);
     expect(catalogTable.bulkPut).toHaveBeenCalledWith([
       expect.objectContaining({
-        user_id: 'user-1',
+        user_id: currentTestUserId,
         workspace_id: 'workspace-1',
         database_id: 'database-1',
         view_id: 'container-1',
       }),
       expect.objectContaining({
-        user_id: 'user-1',
+        user_id: currentTestUserId,
         workspace_id: 'workspace-1',
         database_id: 'database-1',
         view_id: 'grid-1',
@@ -155,6 +184,122 @@ describe('workspace database catalog', () => {
 
     resolveRequest?.([database]);
     await expect(Promise.all([first, second])).resolves.toEqual(['database-1', 'database-1']);
+  });
+
+  it('reuses a successful catalog response for sequential lookup misses', async () => {
+    jest.mocked(listWorkspaceDatabases).mockResolvedValue([]);
+
+    await expect(getViewIdFromWorkspaceCatalog('workspace-1', 'missing-database')).resolves.toBeNull();
+    await expect(getDatabaseIdFromWorkspaceCatalog('workspace-1', 'missing-view')).resolves.toBeNull();
+
+    expect(listWorkspaceDatabases).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps one shared snapshot until an explicit refresh replaces it', async () => {
+    jest.mocked(listWorkspaceDatabases).mockResolvedValueOnce([]).mockResolvedValueOnce([database]);
+
+    const initial = await getWorkspaceDatabaseCatalog('workspace-1');
+    const shared = await getWorkspaceDatabaseCatalog('workspace-1');
+
+    expect(shared).toBe(initial);
+    expect(listWorkspaceDatabases).toHaveBeenCalledTimes(1);
+
+    const refreshed = await refreshWorkspaceDatabaseCatalog('workspace-1');
+
+    expect(refreshed).toEqual([database]);
+    await expect(getWorkspaceDatabaseCatalog('workspace-1')).resolves.toBe(refreshed);
+    expect(listWorkspaceDatabases).toHaveBeenCalledTimes(2);
+  });
+
+  it('supersedes a request invalidated while IndexedDB persistence is pending', async () => {
+    const staleDatabase = databaseWithId('stale-database');
+    const currentDatabase = databaseWithId('current-database');
+    const staleDelete = createDeferred<void>();
+
+    jest
+      .mocked(listWorkspaceDatabases)
+      .mockResolvedValueOnce([staleDatabase])
+      .mockResolvedValueOnce([currentDatabase]);
+    deleteWorkspaceRecords.mockReturnValueOnce(staleDelete.promise).mockResolvedValueOnce(undefined);
+
+    let staleCallerSettled = false;
+    const staleCaller = getWorkspaceDatabaseCatalog('workspace-1').then((value) => {
+      staleCallerSettled = true;
+      return value;
+    });
+
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(deleteWorkspaceRecords).toHaveBeenCalledTimes(1);
+
+    invalidateWorkspaceDatabaseCatalog('workspace-1');
+    const currentRequest = refreshWorkspaceDatabaseCatalog('workspace-1');
+
+    await expect(currentRequest).resolves.toEqual([currentDatabase]);
+    expect(staleCallerSettled).toBe(false);
+
+    staleDelete.resolve();
+    await expect(staleCaller).resolves.toEqual([currentDatabase]);
+    await expect(getWorkspaceDatabaseCatalog('workspace-1')).resolves.toBe(await currentRequest);
+
+    expect(catalogTable.bulkPut).toHaveBeenCalledTimes(1);
+    expect(catalogTable.bulkPut).toHaveBeenCalledWith([
+      expect.objectContaining({ database_id: 'current-database' }),
+      expect.objectContaining({ database_id: 'current-database' }),
+    ]);
+  });
+
+  it('bypasses stale positive IndexedDB mappings after invalidation', async () => {
+    await refreshWorkspaceDatabaseCatalog('workspace-1');
+    invalidateWorkspaceDatabaseCatalog('workspace-1');
+    jest.mocked(listWorkspaceDatabases).mockResolvedValue([]);
+    catalogTable.get.mockClear();
+    readDatabaseRecords.mockClear();
+    catalogTable.get.mockResolvedValue({ database_id: 'database-1' });
+    readDatabaseRecords.mockResolvedValue([
+      { view_order: 0, view: database.views[0] },
+      { view_order: 1, view: database.views[1] },
+    ]);
+
+    await expect(getDatabaseIdFromWorkspaceCatalog('workspace-1', 'grid-1')).resolves.toBeNull();
+    await expect(getViewIdFromWorkspaceCatalog('workspace-1', 'database-1')).resolves.toBeNull();
+
+    expect(catalogTable.get).not.toHaveBeenCalled();
+    expect(readDatabaseRecords).not.toHaveBeenCalled();
+    expect(listWorkspaceDatabases).toHaveBeenCalledTimes(2);
+  });
+
+  it('isolates successful lookup responses by user and workspace', async () => {
+    jest.mocked(listWorkspaceDatabases).mockResolvedValue([]);
+
+    await expect(getViewIdFromWorkspaceCatalog('workspace-1', 'missing-database')).resolves.toBeNull();
+    await expect(getViewIdFromWorkspaceCatalog('workspace-2', 'missing-database')).resolves.toBeNull();
+    setCurrentUser(`${currentTestUserId}-other`);
+    await expect(getViewIdFromWorkspaceCatalog('workspace-1', 'missing-database')).resolves.toBeNull();
+
+    expect(listWorkspaceDatabases).toHaveBeenCalledTimes(3);
+  });
+
+  it('drops shared snapshots when the session becomes invalid', async () => {
+    jest.mocked(listWorkspaceDatabases).mockResolvedValue([]);
+
+    await expect(getWorkspaceDatabaseCatalog('workspace-1')).resolves.toEqual([]);
+    emit(EventType.SESSION_INVALID);
+    await expect(getWorkspaceDatabaseCatalog('workspace-1')).resolves.toEqual([]);
+
+    expect(listWorkspaceDatabases).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not cache a failed catalog refresh', async () => {
+    jest
+      .mocked(listWorkspaceDatabases)
+      .mockRejectedValueOnce(new Error('Unavailable'))
+      .mockResolvedValueOnce([]);
+
+    await expect(getViewIdFromWorkspaceCatalog('workspace-1', 'missing-database')).rejects.toThrow('Unavailable');
+    await expect(getViewIdFromWorkspaceCatalog('workspace-1', 'missing-database')).resolves.toBeNull();
+
+    expect(listWorkspaceDatabases).toHaveBeenCalledTimes(2);
   });
 
   it('uses the cached primary non-container view for a database ID', async () => {

--- a/src/application/services/js-services/cached-api.ts
+++ b/src/application/services/js-services/cached-api.ts
@@ -7,7 +7,6 @@ import * as random from 'lib0/random';
 import * as Y from 'yjs';
 
 import { db, openCollabDB } from '@/application/db';
-import { Log } from '@/utils/log';
 import {
   createRow,
   deleteRow,
@@ -75,6 +74,7 @@ import {
   YjsEditorKey,
 } from '@/application/types';
 import { applyYDoc } from '@/application/ydoc/apply';
+import { Log } from '@/utils/log';
 import { registerUpload, unregisterUpload } from '@/utils/upload-tracker';
 
 // ============================================================================
@@ -108,7 +108,20 @@ const VIEW_CACHE_TTL_MS = 5000;
 const VIEW_DISK_CACHE_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000;
 const ANONYMOUS_VIEW_CACHE_SCOPE = 'anonymous';
 
-const _getAppTrashInFlight = new Map<string, Promise<View[]>>();
+type AppTrashPendingRefresh = {
+  promise: Promise<View[]>;
+  resolve: (views: View[]) => void;
+  reject: (error: unknown) => void;
+};
+
+type AppTrashRequestState = {
+  active: Promise<View[]> | null;
+  activeFreshnessKey: string | undefined;
+  pendingRefresh: AppTrashPendingRefresh | null;
+  pendingFreshnessKey: string | undefined;
+};
+
+const _getAppTrashRequests = new Map<string, AppTrashRequestState>();
 const _getAppTrashCache = new Map<string, { data: View[]; expiresAt: number }>();
 const TRASH_CACHE_TTL_MS = 5000;
 
@@ -267,33 +280,109 @@ function getAppTrashCacheKey(userId: string | undefined, workspaceId: string) {
   return `${userId ?? ANONYMOUS_VIEW_CACHE_SCOPE}:${workspaceId}`;
 }
 
-function requestAppTrash(workspaceId: string, userId = getCurrentAppViewCacheUserId()) {
-  const key = getAppTrashCacheKey(userId, workspaceId);
-  const existing = _getAppTrashInFlight.get(key);
+function getAppTrashRequestState(key: string) {
+  let state = _getAppTrashRequests.get(key);
 
-  if (existing) {
-    return existing;
+  if (!state) {
+    state = {
+      active: null,
+      activeFreshnessKey: undefined,
+      pendingRefresh: null,
+      pendingFreshnessKey: undefined,
+    };
+    _getAppTrashRequests.set(key, state);
   }
 
-  const request = getAppTrash(workspaceId)
-    .then((views) => {
-      _getAppTrashCache.set(key, {
-        data: views,
-        expiresAt: Date.now() + TRASH_CACHE_TTL_MS,
-      });
-      return views;
-    })
-    .finally(() => {
-      _getAppTrashInFlight.delete(key);
-    });
+  return state;
+}
 
-  _getAppTrashInFlight.set(key, request);
+function startAppTrashRequest(
+  workspaceId: string,
+  userId: string | undefined,
+  key: string,
+  state: AppTrashRequestState,
+  freshnessKey?: string
+) {
+  const request = getAppTrash(workspaceId).then((views) => {
+    _getAppTrashCache.set(key, {
+      data: views,
+      expiresAt: Date.now() + TRASH_CACHE_TTL_MS,
+    });
+    return views;
+  });
+
+  state.active = request;
+  state.activeFreshnessKey = freshnessKey;
+
+  // A refresh requested while this call is active represents a notification
+  // that may have been committed after the request started. Run exactly one
+  // trailing request and let every waiter share it. This avoids returning a
+  // pre-mutation response without allowing request storms.
+  void request.then(
+    () => finishAppTrashRequest(workspaceId, userId, key, state, request),
+    () => finishAppTrashRequest(workspaceId, userId, key, state, request)
+  );
+
   return request;
+}
+
+function finishAppTrashRequest(
+  workspaceId: string,
+  userId: string | undefined,
+  key: string,
+  state: AppTrashRequestState,
+  request: Promise<View[]>
+) {
+  if (state.active !== request) return;
+
+  state.active = null;
+  state.activeFreshnessKey = undefined;
+  const pendingRefresh = state.pendingRefresh;
+  const pendingFreshnessKey = state.pendingFreshnessKey;
+
+  if (!pendingRefresh) {
+    if (_getAppTrashRequests.get(key) === state) {
+      _getAppTrashRequests.delete(key);
+    }
+
+    return;
+  }
+
+  state.pendingRefresh = null;
+  state.pendingFreshnessKey = undefined;
+  const trailingRequest = startAppTrashRequest(workspaceId, userId, key, state, pendingFreshnessKey);
+
+  void trailingRequest.then(pendingRefresh.resolve, pendingRefresh.reject);
+}
+
+function requestAppTrash(workspaceId: string, userId = getCurrentAppViewCacheUserId()) {
+  const key = getAppTrashCacheKey(userId, workspaceId);
+  const state = getAppTrashRequestState(key);
+
+  if (state.active) {
+    return state.active;
+  }
+
+  return startAppTrashRequest(workspaceId, userId, key, state);
 }
 
 export async function getAppTrashCached(workspaceId: string) {
   const userId = getCurrentAppViewCacheUserId();
-  const cached = _getAppTrashCache.get(getAppTrashCacheKey(userId, workspaceId));
+  const key = getAppTrashCacheKey(userId, workspaceId);
+  const activeState = _getAppTrashRequests.get(key);
+
+  // Prefer an authoritative refresh already underway over a still-valid cache.
+  // If that refresh itself has a newer mutation queued, wait for the trailing
+  // payload so a mounting DatabaseBlock cannot briefly apply stale trash.
+  if (activeState?.pendingRefresh) {
+    return activeState.pendingRefresh.promise;
+  }
+
+  if (activeState?.active) {
+    return activeState.active;
+  }
+
+  const cached = _getAppTrashCache.get(key);
 
   if (cached && Date.now() < cached.expiresAt) {
     return cached.data;
@@ -303,12 +392,41 @@ export async function getAppTrashCached(workspaceId: string) {
 }
 
 /**
- * Bypasses the TTL cache but still shares any in-flight request, so
- * concurrent refreshers (e.g. every embedded database re-checking on
- * OUTLINE_LOADED) collapse into a single network call.
+ * Bypasses the TTL cache. Callers may pass a mutation/revision key. Repeated
+ * observers of the same key share the active request; a newer keyed refresh
+ * queues at most one trailing request rather than trusting a response that may
+ * have started before that mutation. Unkeyed concurrent callers simply share.
  */
-export async function refreshAppTrashCache(workspaceId: string) {
-  return requestAppTrash(workspaceId);
+export async function refreshAppTrashCache(workspaceId: string, freshnessKey?: string) {
+  const userId = getCurrentAppViewCacheUserId();
+  const key = getAppTrashCacheKey(userId, workspaceId);
+  const state = getAppTrashRequestState(key);
+
+  if (!state.active) {
+    return startAppTrashRequest(workspaceId, userId, key, state, freshnessKey);
+  }
+
+  if (state.pendingRefresh) {
+    return state.pendingRefresh.promise;
+  }
+
+  // Unkeyed refreshes are ordinary concurrent callers and share the active
+  // request. A keyed refresh denotes a concrete mutation/revision; repeated
+  // observers of that same revision share as well.
+  if (!freshnessKey || state.activeFreshnessKey === freshnessKey) {
+    return state.active;
+  }
+
+  let resolve!: (views: View[]) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<View[]>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+
+  state.pendingRefresh = { promise, resolve, reject };
+  state.pendingFreshnessKey = freshnessKey;
+  return promise;
 }
 
 export async function getPageDocCached(

--- a/src/application/services/js-services/fetch.ts
+++ b/src/application/services/js-services/fetch.ts
@@ -49,6 +49,12 @@ export function fetchPageCollab (workspaceId: string, viewId: string) {
   return fetchWithDeduplication(`fetchPageCollab_${workspaceId}`, { viewId }, fetchFunction);
 }
 
+export function fetchDatabaseCollab (workspaceId: string, databaseId: string) {
+  const fetchFunction = () => getCollab(workspaceId, databaseId, Types.Database);
+
+  return fetchWithDeduplication(`fetchDatabaseCollab_${workspaceId}`, { databaseId }, fetchFunction);
+}
+
 export function fetchRowDocumentCollab (workspaceId: string, documentId: string, source?: RowDocumentSourcePayload) {
   const fetchFunction = () => getCollab(workspaceId, documentId, Types.Document, source);
 

--- a/src/application/services/js-services/workspace-database-catalog.ts
+++ b/src/application/services/js-services/workspace-database-catalog.ts
@@ -35,6 +35,14 @@ function getSuccessfulRefresh(userId: string | undefined, workspaceId: string) {
   return successfulRefreshes.get(requestKey(userId, workspaceId));
 }
 
+function sessionChangedError(): DOMException {
+  return new DOMException('The workspace database catalog request was superseded by a session change', 'AbortError');
+}
+
+function isSameSession(requestSessionGeneration: number, userId: string | undefined): boolean {
+  return sessionGeneration === requestSessionGeneration && currentUserId() === userId;
+}
+
 /** Mark the shared snapshot stale after a remote or local catalog mutation. */
 export function invalidateWorkspaceDatabaseCatalog(workspaceId: string): void {
   const key = requestKey(currentUserId(), workspaceId);
@@ -192,25 +200,34 @@ export async function refreshWorkspaceDatabaseCatalog(workspaceId: string): Prom
   if (pending) return pending;
 
   const request = (async () => {
+    const isSessionCurrent = () => isSameSession(requestSessionGeneration, userId);
     const isCurrent = () =>
-      sessionGeneration === requestSessionGeneration &&
-      (catalogGenerations.get(key) ?? 0) === requestCatalogGeneration;
+      isSessionCurrent() && (catalogGenerations.get(key) ?? 0) === requestCatalogGeneration;
+    const useReplacementCatalog = () => {
+      // Catalog invalidations within the same signed-in session may join the
+      // replacement request. A session transition belongs to a different
+      // principal, so the old caller must terminate instead of starting or
+      // receiving a request under the new session.
+      if (!isSessionCurrent()) throw sessionChangedError();
+      return getWorkspaceDatabaseCatalog(workspaceId);
+    };
+
     let databases: WorkspaceDatabaseWithViews[];
 
     try {
       databases = await listWorkspaceDatabases(workspaceId);
     } catch (error) {
-      if (!isCurrent()) return getWorkspaceDatabaseCatalog(workspaceId);
+      if (!isCurrent()) return useReplacementCatalog();
       throw error;
     }
 
-    if (!isCurrent()) return getWorkspaceDatabaseCatalog(workspaceId);
+    if (!isCurrent()) return useReplacementCatalog();
 
     if (userId) {
       try {
         await replaceCachedCatalog(userId, workspaceId, databases, isCurrent);
       } catch (error) {
-        if (!isCurrent()) return getWorkspaceDatabaseCatalog(workspaceId);
+        if (!isCurrent()) return useReplacementCatalog();
         // IndexedDB is an optimization. Browser storage failures must not hide
         // a successful authoritative response from the caller.
         Log.warn('[WorkspaceDatabaseCatalog] failed to persist the server catalog', {
@@ -223,7 +240,7 @@ export async function refreshWorkspaceDatabaseCatalog(workspaceId: string): Prom
 
     // Persistence is asynchronous; re-check after it settles so an
     // invalidation that arrived mid-transaction cannot publish the old list.
-    if (!isCurrent()) return getWorkspaceDatabaseCatalog(workspaceId);
+    if (!isCurrent()) return useReplacementCatalog();
 
     // Keep the complete successful response so every workspace consumer shares
     // positive and negative lookup results. IndexedDB stores positive view
@@ -261,6 +278,8 @@ export async function getWorkspaceDatabaseCatalog(workspaceId: string): Promise<
 export async function getDatabaseIdFromWorkspaceCatalog(workspaceId: string, viewId: string): Promise<string | null> {
   const userId = currentUserId();
   const key = requestKey(userId, workspaceId);
+  const requestSessionGeneration = sessionGeneration;
+  const requestCatalogGeneration = catalogGenerations.get(key) ?? 0;
   const catalogSnapshot = getSuccessfulRefresh(userId, workspaceId);
 
   if (catalogSnapshot) {
@@ -271,9 +290,16 @@ export async function getDatabaseIdFromWorkspaceCatalog(workspaceId: string, vie
 
   const cached = invalidatedCatalogs.has(key) ? undefined : await cachedViewRecord(userId, workspaceId, viewId);
 
-  if (cached) return cached.database_id;
+  if (!isSameSession(requestSessionGeneration, userId)) throw sessionChangedError();
+
+  const cachedMappingIsCurrent =
+    !invalidatedCatalogs.has(key) && (catalogGenerations.get(key) ?? 0) === requestCatalogGeneration;
+
+  if (cached && cachedMappingIsCurrent) return cached.database_id;
 
   const databases = await getWorkspaceDatabaseCatalog(workspaceId);
+
+  if (!isSameSession(requestSessionGeneration, userId)) throw sessionChangedError();
 
   return databases.find((database) => database.views.some((view) => view.view_id === viewId))?.database_id ?? null;
 }
@@ -282,6 +308,8 @@ export async function getDatabaseIdFromWorkspaceCatalog(workspaceId: string, vie
 export async function getViewIdFromWorkspaceCatalog(workspaceId: string, databaseId: string): Promise<string | null> {
   const userId = currentUserId();
   const key = requestKey(userId, workspaceId);
+  const requestSessionGeneration = sessionGeneration;
+  const requestCatalogGeneration = catalogGenerations.get(key) ?? 0;
   const catalogSnapshot = getSuccessfulRefresh(userId, workspaceId);
 
   if (catalogSnapshot) {
@@ -292,7 +320,12 @@ export async function getViewIdFromWorkspaceCatalog(workspaceId: string, databas
 
   const cached = invalidatedCatalogs.has(key) ? [] : await cachedDatabaseRecords(userId, workspaceId, databaseId);
 
-  if (cached.length > 0) {
+  if (!isSameSession(requestSessionGeneration, userId)) throw sessionChangedError();
+
+  const cachedMappingIsCurrent =
+    !invalidatedCatalogs.has(key) && (catalogGenerations.get(key) ?? 0) === requestCatalogGeneration;
+
+  if (cached.length > 0 && cachedMappingIsCurrent) {
     const cachedDatabase: WorkspaceDatabaseWithViews = {
       database_id: databaseId,
       views: cached.sort((left, right) => left.view_order - right.view_order).map((record) => record.view),
@@ -303,6 +336,8 @@ export async function getViewIdFromWorkspaceCatalog(workspaceId: string, databas
   }
 
   const databases = await getWorkspaceDatabaseCatalog(workspaceId);
+
+  if (!isSameSession(requestSessionGeneration, userId)) throw sessionChangedError();
   const database = databases.find((entry) => entry.database_id === databaseId);
 
   return database ? getDatabasePrimaryView(database)?.view_id ?? null : null;

--- a/src/application/services/js-services/workspace-database-catalog.ts
+++ b/src/application/services/js-services/workspace-database-catalog.ts
@@ -1,7 +1,8 @@
 import { db } from '@/application/db';
 import { WorkspaceDatabaseCatalogRecord } from '@/application/db/tables/workspace_database_catalog';
-import { getTokenParsed } from '@/application/session/token';
 import { WorkspaceDatabaseViewItem, WorkspaceDatabaseWithViews } from '@/application/services/services.type';
+import { EventType, on } from '@/application/session/event';
+import { getTokenParsed } from '@/application/session/token';
 import { View } from '@/application/types';
 import { Log } from '@/utils/log';
 
@@ -9,6 +10,18 @@ import { listWorkspaceDatabases } from './http/view-api';
 
 const ANONYMOUS_CATALOG_SCOPE = 'anonymous';
 const refreshRequests = new Map<string, Promise<WorkspaceDatabaseWithViews[]>>();
+const successfulRefreshes = new Map<string, WorkspaceDatabaseWithViews[]>();
+const catalogGenerations = new Map<string, number>();
+const invalidatedCatalogs = new Set<string>();
+let sessionGeneration = 0;
+
+on(EventType.SESSION_INVALID, () => {
+  sessionGeneration += 1;
+  refreshRequests.clear();
+  successfulRefreshes.clear();
+  catalogGenerations.clear();
+  invalidatedCatalogs.clear();
+});
 
 function currentUserId(): string | undefined {
   return getTokenParsed()?.user?.id;
@@ -16,6 +29,23 @@ function currentUserId(): string | undefined {
 
 function requestKey(userId: string | undefined, workspaceId: string): string {
   return `${userId ?? ANONYMOUS_CATALOG_SCOPE}:${workspaceId}`;
+}
+
+function getSuccessfulRefresh(userId: string | undefined, workspaceId: string) {
+  return successfulRefreshes.get(requestKey(userId, workspaceId));
+}
+
+/** Mark the shared snapshot stale after a remote or local catalog mutation. */
+export function invalidateWorkspaceDatabaseCatalog(workspaceId: string): void {
+  const key = requestKey(currentUserId(), workspaceId);
+
+  catalogGenerations.set(key, (catalogGenerations.get(key) ?? 0) + 1);
+  invalidatedCatalogs.add(key);
+  successfulRefreshes.delete(key);
+  // A response started before the invalidation must not be shared by the next
+  // reader. Its captured generation also prevents it from repopulating the
+  // memory or IndexedDB snapshots when it eventually settles.
+  refreshRequests.delete(key);
 }
 
 function catalogRecords(
@@ -42,14 +72,17 @@ function catalogRecords(
 async function replaceCachedCatalog(
   userId: string,
   workspaceId: string,
-  databases: WorkspaceDatabaseWithViews[]
+  databases: WorkspaceDatabaseWithViews[],
+  isCurrent: () => boolean
 ): Promise<void> {
   const records = catalogRecords(userId, workspaceId, databases);
 
   await db.transaction('rw', db.workspace_database_catalog, async () => {
+    if (!isCurrent()) return;
+
     await db.workspace_database_catalog.where('[user_id+workspace_id]').equals([userId, workspaceId]).delete();
 
-    if (records.length > 0) {
+    if (records.length > 0 && isCurrent()) {
       await db.workspace_database_catalog.bulkPut(records);
     }
   });
@@ -152,17 +185,32 @@ export function databaseCatalogViewToView(databaseId: string, view: WorkspaceDat
 export async function refreshWorkspaceDatabaseCatalog(workspaceId: string): Promise<WorkspaceDatabaseWithViews[]> {
   const userId = currentUserId();
   const key = requestKey(userId, workspaceId);
+  const requestSessionGeneration = sessionGeneration;
+  const requestCatalogGeneration = catalogGenerations.get(key) ?? 0;
   const pending = refreshRequests.get(key);
 
   if (pending) return pending;
 
   const request = (async () => {
-    const databases = await listWorkspaceDatabases(workspaceId);
+    const isCurrent = () =>
+      sessionGeneration === requestSessionGeneration &&
+      (catalogGenerations.get(key) ?? 0) === requestCatalogGeneration;
+    let databases: WorkspaceDatabaseWithViews[];
+
+    try {
+      databases = await listWorkspaceDatabases(workspaceId);
+    } catch (error) {
+      if (!isCurrent()) return getWorkspaceDatabaseCatalog(workspaceId);
+      throw error;
+    }
+
+    if (!isCurrent()) return getWorkspaceDatabaseCatalog(workspaceId);
 
     if (userId) {
       try {
-        await replaceCachedCatalog(userId, workspaceId, databases);
+        await replaceCachedCatalog(userId, workspaceId, databases, isCurrent);
       } catch (error) {
+        if (!isCurrent()) return getWorkspaceDatabaseCatalog(workspaceId);
         // IndexedDB is an optimization. Browser storage failures must not hide
         // a successful authoritative response from the caller.
         Log.warn('[WorkspaceDatabaseCatalog] failed to persist the server catalog', {
@@ -172,6 +220,17 @@ export async function refreshWorkspaceDatabaseCatalog(workspaceId: string): Prom
         });
       }
     }
+
+    // Persistence is asynchronous; re-check after it settles so an
+    // invalidation that arrived mid-transaction cannot publish the old list.
+    if (!isCurrent()) return getWorkspaceDatabaseCatalog(workspaceId);
+
+    // Keep the complete successful response so every workspace consumer shares
+    // positive and negative lookup results. IndexedDB stores positive view
+    // mappings, but cannot represent that a database or view was absent from a
+    // catalog snapshot. Explicit refreshes replace this object atomically.
+    successfulRefreshes.set(key, databases);
+    invalidatedCatalogs.delete(key);
 
     return databases;
   })();
@@ -187,20 +246,51 @@ export async function refreshWorkspaceDatabaseCatalog(workspaceId: string): Prom
   }
 }
 
-/** Resolve a database ID locally first, refreshing the server catalog on miss. */
+/**
+ * Return the shared workspace catalog snapshot, refreshing it only when no
+ * successful snapshot exists. Every consumer receives the same array object,
+ * so relation cells, property menus, and linked-database pickers do not independently
+ * request the workspace-wide list. Call `refreshWorkspaceDatabaseCatalog`
+ * explicitly after a catalog-changing mutation or permission change.
+ */
+export async function getWorkspaceDatabaseCatalog(workspaceId: string): Promise<WorkspaceDatabaseWithViews[]> {
+  return getSuccessfulRefresh(currentUserId(), workspaceId) ?? refreshWorkspaceDatabaseCatalog(workspaceId);
+}
+
+/** Resolve a database ID from the shared snapshot or its positive disk cache. */
 export async function getDatabaseIdFromWorkspaceCatalog(workspaceId: string, viewId: string): Promise<string | null> {
-  const cached = await cachedViewRecord(currentUserId(), workspaceId, viewId);
+  const userId = currentUserId();
+  const key = requestKey(userId, workspaceId);
+  const catalogSnapshot = getSuccessfulRefresh(userId, workspaceId);
+
+  if (catalogSnapshot) {
+    return (
+      catalogSnapshot.find((database) => database.views.some((view) => view.view_id === viewId))?.database_id ?? null
+    );
+  }
+
+  const cached = invalidatedCatalogs.has(key) ? undefined : await cachedViewRecord(userId, workspaceId, viewId);
 
   if (cached) return cached.database_id;
 
-  const databases = await refreshWorkspaceDatabaseCatalog(workspaceId);
+  const databases = await getWorkspaceDatabaseCatalog(workspaceId);
 
   return databases.find((database) => database.views.some((view) => view.view_id === viewId))?.database_id ?? null;
 }
 
 /** Resolve the primary, non-container view used to open a database. */
 export async function getViewIdFromWorkspaceCatalog(workspaceId: string, databaseId: string): Promise<string | null> {
-  const cached = await cachedDatabaseRecords(currentUserId(), workspaceId, databaseId);
+  const userId = currentUserId();
+  const key = requestKey(userId, workspaceId);
+  const catalogSnapshot = getSuccessfulRefresh(userId, workspaceId);
+
+  if (catalogSnapshot) {
+    const database = catalogSnapshot.find((entry) => entry.database_id === databaseId);
+
+    return database ? getDatabasePrimaryView(database)?.view_id ?? null : null;
+  }
+
+  const cached = invalidatedCatalogs.has(key) ? [] : await cachedDatabaseRecords(userId, workspaceId, databaseId);
 
   if (cached.length > 0) {
     const cachedDatabase: WorkspaceDatabaseWithViews = {
@@ -212,7 +302,7 @@ export async function getViewIdFromWorkspaceCatalog(workspaceId: string, databas
     if (cachedView) return cachedView.view_id;
   }
 
-  const databases = await refreshWorkspaceDatabaseCatalog(workspaceId);
+  const databases = await getWorkspaceDatabaseCatalog(workspaceId);
   const database = databases.find((entry) => entry.database_id === databaseId);
 
   return database ? getDatabasePrimaryView(database)?.view_id ?? null : null;

--- a/src/application/types.ts
+++ b/src/application/types.ts
@@ -1247,6 +1247,8 @@ export type AppendBreadcrumb = (view?: View) => void;
 export type CreateRow = (rowKey: string, options?: { forceSync?: boolean }) => Promise<YDoc>;
 export interface LoadViewOptions {
   databaseId?: string | null;
+  /** Load only the canonical database collab, without page-view row_data. */
+  databaseMetadataOnly?: boolean;
   forceFetch?: boolean;
 }
 

--- a/src/application/view-loader/index.ts
+++ b/src/application/view-loader/index.ts
@@ -10,10 +10,16 @@
  * before the component finishes rendering.
  */
 
+import * as Y from 'yjs';
+
 import { deleteCollabDB, openCollabDB, openCollabDBWithProvider } from '@/application/db';
 import { getOrCreateRowSubDoc, hasCollabCache } from '@/application/services/js-services/cache';
 import { invalidateViewCache } from '@/application/services/js-services/cached-api';
-import { fetchPageCollab, fetchRowDocumentCollab } from '@/application/services/js-services/fetch';
+import {
+  fetchDatabaseCollab,
+  fetchPageCollab,
+  fetchRowDocumentCollab,
+} from '@/application/services/js-services/fetch';
 import { enqueueOutboxUpdate } from '@/application/sync-outbox';
 import {
   LoadRowDocumentOptions,
@@ -28,7 +34,6 @@ import { determineErrorType, ErrorType, isPermissionDeniedError } from '@/applic
 import { isDatabaseLayout } from '@/application/view-utils';
 import { applyYDoc } from '@/application/ydoc/apply';
 import { Log } from '@/utils/log';
-import * as Y from 'yjs';
 
 // ============================================================================
 // Types
@@ -42,6 +47,7 @@ export interface ViewLoaderResult {
 
 export interface OpenViewOptions {
   databaseId?: string | null;
+  databaseMetadataOnly?: boolean;
   forceFetch?: boolean;
 }
 
@@ -118,6 +124,22 @@ function databaseDocContainsView(doc: YDoc, viewId: string): boolean | null {
   } catch {
     return null;
   }
+}
+
+function databaseDocHasCompleteMetadata(doc: YDoc, viewId: string): boolean {
+  const sharedRoot = doc.getMap(YjsEditorKey.data_section) as YSharedRoot | undefined;
+  const database = sharedRoot?.get(YjsEditorKey.database);
+
+  if (!(database instanceof Y.Map)) return false;
+
+  const fields = database.get(YjsDatabaseKey.fields);
+  const views = database.get(YjsDatabaseKey.views);
+
+  if (!(fields instanceof Y.Map) || !(views instanceof Y.Map) || !views.has(viewId)) return false;
+
+  return Array.from(fields.values()).some(
+    (field) => field instanceof Y.Map && Boolean(field.get(YjsDatabaseKey.is_primary))
+  );
 }
 
 async function mergeLegacyDatabaseViewCache(viewId: string, databaseId: string, targetDoc: YDoc): Promise<boolean> {
@@ -217,16 +239,32 @@ export async function hasCache(viewId: string): Promise<boolean> {
 /**
  * Fetch and apply document data from server
  */
-async function fetchAndApply(workspaceId: string, viewId: string, doc: YDoc): Promise<void> {
+async function fetchAndApply(
+  workspaceId: string,
+  viewId: string,
+  doc: YDoc,
+  options: OpenViewOptions = {}
+): Promise<void> {
   Log.debug('[ViewLoader] fetching from server', { viewId });
 
   const fetchStartedAt = Date.now();
-  const { data, rows } = await fetchPageCollab(workspaceId, viewId);
+  let data: Uint8Array;
+  let rowCount = 0;
+
+  if (options.databaseMetadataOnly && options.databaseId) {
+    ({ data } = await fetchDatabaseCollab(workspaceId, options.databaseId));
+  } else {
+    const pageCollab = await fetchPageCollab(workspaceId, viewId);
+
+    data = pageCollab.data;
+    rowCount = pageCollab.rows ? Object.keys(pageCollab.rows).length : 0;
+  }
 
   Log.debug('[ViewLoader] fetch complete', {
     viewId,
     dataBytes: data.length,
-    rowCount: rows ? Object.keys(rows).length : 0,
+    rowCount,
+    databaseMetadataOnly: options.databaseMetadataOnly ?? false,
     fetchDurationMs: Date.now() - fetchStartedAt,
   });
 
@@ -316,6 +354,18 @@ export async function openView(
     }
   }
 
+  // A database root alone is enough for the generic cache detector, but not
+  // enough to render relation labels or populate the relation picker. These
+  // metadata-only consumers do not bind database realtime, so force the raw
+  // canonical fetch when fields/views have only been partially cached.
+  if (fromCache && options.databaseMetadataOnly && !databaseDocHasCompleteMetadata(doc, viewId)) {
+    Log.debug('[ViewLoader] cached database metadata is incomplete, re-fetching', {
+      viewId,
+      databaseId: options.databaseId,
+    });
+    fromCache = false;
+  }
+
   if (fromCache && options.databaseId && viewId !== options.databaseId) {
     const containsLinkedView = databaseDocContainsView(doc, viewId);
 
@@ -343,7 +393,7 @@ export async function openView(
 
     for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
       try {
-        await fetchAndApply(workspaceId, viewId, doc);
+        await fetchAndApply(workspaceId, viewId, doc, options);
         break;
       } catch (e) {
         // Permission denials are permanent for this attempt — retrying cannot

--- a/src/components/app/contexts/AppOutlineContext.ts
+++ b/src/components/app/contexts/AppOutlineContext.ts
@@ -58,7 +58,7 @@ export interface AppOutlineContextType {
   /** Fetch the user's recently visited views. */
   loadRecentViews?: () => Promise<View[] | undefined>;
   /** Fetch the trash list for a given workspace. */
-  loadTrash?: (workspaceId: string) => Promise<void>;
+  loadTrash?: (workspaceId: string, options?: { ensureFreshAfterInFlight?: boolean }) => Promise<void>;
   /** Load views with an optional UI variant filter (e.g. mobile vs desktop). */
   loadViews?: (variant?: UIVariant) => Promise<View[] | undefined>;
   /** Force-reload the entire outline tree from the server. */

--- a/src/components/app/hooks/__tests__/usePageOperations.publish.test.tsx
+++ b/src/components/app/hooks/__tests__/usePageOperations.publish.test.tsx
@@ -1,6 +1,6 @@
 import { act, renderHook } from '@testing-library/react';
 
-import { PageService, PublishService } from '@/application/services/domains';
+import { PageService, PublishService, ViewService } from '@/application/services/domains';
 import { clearPublishViewInfoCache } from '@/application/services/js-services/cached-api';
 import { publishCollabs } from '@/application/services/js-services/http/publish-api';
 import { gatherDatabasePublishData } from '@/application/services/js-services/publish-database-data';
@@ -16,12 +16,18 @@ jest.mock('@/application/services/domains', () => ({
   FileService: {},
   PageService: {
     add: jest.fn(),
+    createDatabaseView: jest.fn(),
+    moveToTrash: jest.fn(),
   },
   PublishService: {
     publish: jest.fn(),
     unpublish: jest.fn(),
   },
-  ViewService: {},
+  ViewService: {
+    invalidateDatabaseCatalog: jest.fn(),
+    invalidateCache: jest.fn(),
+    refreshWorkspaceDatabaseCatalog: jest.fn(),
+  },
 }));
 
 jest.mock('@/application/services/js-services/cached-api', () => ({
@@ -413,5 +419,56 @@ describe('usePageOperations addPage', () => {
     });
 
     expect(loadOutline).not.toHaveBeenCalled();
+  });
+
+  it('refreshes the shared catalog after creating a database view', async () => {
+    jest.mocked(PageService.createDatabaseView).mockResolvedValue({
+      view_id: 'linked-view-id',
+      database_id: 'database-id',
+    });
+    jest.mocked(ViewService.refreshWorkspaceDatabaseCatalog).mockResolvedValue([]);
+    const { result, workspaceId } = renderUsePageOperations();
+    const payload = {
+      parent_view_id: 'parent-view-id',
+      database_id: 'database-id',
+      layout: ViewLayout.Grid,
+    };
+
+    await act(async () => {
+      await result.current.createDatabaseView('request-view-id', payload);
+    });
+
+    expect(PageService.createDatabaseView).toHaveBeenCalledWith(workspaceId, 'request-view-id', payload);
+    expect(ViewService.invalidateDatabaseCatalog).toHaveBeenCalledWith(workspaceId);
+    expect(ViewService.refreshWorkspaceDatabaseCatalog).toHaveBeenCalledWith(workspaceId);
+    expect(jest.mocked(ViewService.invalidateDatabaseCatalog).mock.invocationCallOrder[0]).toBeLessThan(
+      jest.mocked(ViewService.refreshWorkspaceDatabaseCatalog).mock.invocationCallOrder[0]
+    );
+  });
+
+  it('refreshes the shared catalog after moving a database view to trash', async () => {
+    jest.mocked(PageService.moveToTrash).mockResolvedValue(undefined);
+    jest.mocked(ViewService.refreshWorkspaceDatabaseCatalog).mockResolvedValue([]);
+    const databaseView = createView({
+      view_id: 'database-view-id',
+      layout: ViewLayout.Grid,
+      extra: { database_id: 'database-id', is_space: false },
+    });
+    const parentView = createView({
+      view_id: 'parent-view-id',
+      children: [databaseView],
+    });
+    const { result, workspaceId } = renderUsePageOperations({ outlineRef: { current: [parentView] } });
+
+    await act(async () => {
+      await result.current.deletePage(databaseView.view_id);
+    });
+
+    expect(PageService.moveToTrash).toHaveBeenCalledWith(workspaceId, databaseView.view_id);
+    expect(ViewService.invalidateDatabaseCatalog).toHaveBeenCalledWith(workspaceId);
+    expect(ViewService.refreshWorkspaceDatabaseCatalog).toHaveBeenCalledWith(workspaceId);
+    expect(jest.mocked(ViewService.invalidateDatabaseCatalog).mock.invocationCallOrder[0]).toBeLessThan(
+      jest.mocked(ViewService.refreshWorkspaceDatabaseCatalog).mock.invocationCallOrder[0]
+    );
   });
 });

--- a/src/components/app/hooks/__tests__/usePageOperations.trash.test.tsx
+++ b/src/components/app/hooks/__tests__/usePageOperations.trash.test.tsx
@@ -1,0 +1,134 @@
+import { act, renderHook } from '@testing-library/react';
+import { type ReactNode } from 'react';
+
+import { PageService, ViewService } from '@/application/services/domains';
+import { Role, View, ViewLayout } from '@/application/types';
+import { AuthInternalContext, AuthInternalContextType } from '@/components/app/contexts/AuthInternalContext';
+import { Log } from '@/utils/log';
+
+import { usePageOperations } from '../usePageOperations';
+
+jest.mock('@/application/services/domains', () => ({
+  BillingService: {},
+  FileService: {},
+  PageService: {
+    moveToTrash: jest.fn(),
+  },
+  PublishService: {},
+  ViewService: {
+    invalidateCache: jest.fn(),
+  },
+}));
+
+jest.mock('@/application/services/js-services/cache', () => ({
+  deleteView: jest.fn(),
+}));
+
+jest.mock('@/application/services/js-services/cached-api', () => ({
+  clearPublishViewInfoCache: jest.fn(),
+}));
+
+jest.mock('@/application/services/js-services/http/publish-api', () => ({
+  publishCollabs: jest.fn(),
+}));
+
+jest.mock('@/application/services/js-services/publish-database-data', () => ({
+  gatherDatabasePublishData: jest.fn(),
+}));
+
+const workspaceId = 'workspace-id';
+
+function createView(viewId: string, children: View[] = []): View {
+  return {
+    view_id: viewId,
+    name: viewId,
+    icon: null,
+    layout: ViewLayout.Document,
+    extra: null,
+    children,
+    is_published: false,
+    is_private: false,
+  };
+}
+
+function Wrapper({ children }: { children: ReactNode }) {
+  const authContext: AuthInternalContextType = {
+    currentWorkspaceId: workspaceId,
+    isAuthenticated: true,
+    onChangeWorkspace: jest.fn(),
+    userWorkspaceInfo: {
+      userId: 'user-id',
+      selectedWorkspace: {
+        id: workspaceId,
+        databaseStorageId: 'database-storage-id',
+        role: Role.Owner,
+      },
+    } as AuthInternalContextType['userWorkspaceInfo'],
+  };
+
+  return <AuthInternalContext.Provider value={authContext}>{children}</AuthInternalContext.Provider>;
+}
+
+describe('usePageOperations trash refresh', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (PageService.moveToTrash as jest.Mock).mockResolvedValue(undefined);
+  });
+
+  it('starts exactly one centralized trash refresh after a local move to trash', async () => {
+    const loadTrash = jest.fn().mockResolvedValue(undefined);
+    const loadOutline = jest.fn().mockResolvedValue(undefined);
+    const outlineRef = {
+      current: [createView('space-id', [createView('page-id')])],
+    };
+
+    const { result } = renderHook(
+      () =>
+        usePageOperations({
+          outlineRef,
+          loadOutline,
+          loadTrash,
+        }),
+      { wrapper: Wrapper }
+    );
+
+    await act(async () => {
+      await result.current.deletePage('page-id');
+    });
+
+    expect(PageService.moveToTrash).toHaveBeenCalledWith(workspaceId, 'page-id');
+    expect(ViewService.invalidateCache).toHaveBeenCalledWith(workspaceId, 'page-id');
+    expect(ViewService.invalidateCache).toHaveBeenCalledWith(workspaceId, 'space-id');
+    expect(loadTrash).toHaveBeenCalledTimes(1);
+    expect(loadTrash).toHaveBeenCalledWith(workspaceId, { ensureFreshAfterInFlight: true });
+  });
+
+  it('does not turn a background trash refresh failure into a delete failure', async () => {
+    const refreshError = new Error('refresh unavailable');
+    const loadTrash = jest.fn().mockRejectedValue(refreshError);
+    const warn = jest.spyOn(Log, 'warn').mockImplementation(() => undefined);
+    const outlineRef = {
+      current: [createView('space-id', [createView('page-id')])],
+    };
+    const { result } = renderHook(
+      () =>
+        usePageOperations({
+          outlineRef,
+          loadTrash,
+        }),
+      { wrapper: Wrapper }
+    );
+
+    await expect(
+      act(async () => {
+        await result.current.deletePage('page-id');
+      })
+    ).resolves.toBeUndefined();
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(warn).toHaveBeenCalledWith('[Trash] Failed to refresh after moving a page to trash', refreshError);
+    warn.mockRestore();
+  });
+});

--- a/src/components/app/hooks/__tests__/useWorkspaceData.sidebarRevalidation.test.tsx
+++ b/src/components/app/hooks/__tests__/useWorkspaceData.sidebarRevalidation.test.tsx
@@ -31,6 +31,7 @@ jest.mock('lodash-es', () => ({
     });
   },
 }));
+jest.mock('lodash-es/isEqual', () => jest.requireActual('lodash/isEqual'));
 
 jest.mock('@/application/services/domains', () => ({
   AccessService: {
@@ -46,9 +47,10 @@ jest.mock('@/application/services/domains', () => ({
     getMultiple: jest.fn(),
     getNavigation: jest.fn(),
     getOutline: jest.fn(),
-    getTrash: jest.fn(),
+    getTrashCached: jest.fn(),
     invalidateCache: jest.fn(),
     refresh: jest.fn(),
+    refreshTrash: jest.fn(),
   },
   WorkspaceService: {
     getMentionableUsers: jest.fn(),
@@ -175,7 +177,8 @@ describe('useWorkspaceData sidebar outline revalidation', () => {
     (ViewService.refresh as jest.Mock).mockImplementation((activeWorkspaceId: string, viewId: string) =>
       ViewService.get(activeWorkspaceId, viewId)
     );
-    (ViewService.getTrash as jest.Mock).mockResolvedValue([]);
+    (ViewService.getTrashCached as jest.Mock).mockResolvedValue([]);
+    (ViewService.refreshTrash as jest.Mock).mockResolvedValue([]);
     (deleteCollabDB as jest.Mock).mockResolvedValue(undefined);
   });
 

--- a/src/components/app/hooks/__tests__/useWorkspaceData.trashRefresh.test.tsx
+++ b/src/components/app/hooks/__tests__/useWorkspaceData.trashRefresh.test.tsx
@@ -9,6 +9,7 @@ import { AccessService, ViewService } from '@/application/services/domains';
 import { Role, View, ViewLayout } from '@/application/types';
 import { AuthInternalContext, AuthInternalContextType } from '@/components/app/contexts/AuthInternalContext';
 import { SyncInternalContext, SyncInternalContextType } from '@/components/app/contexts/SyncInternalContext';
+import { Log } from '@/utils/log';
 
 import { useWorkspaceData } from '../useWorkspaceData';
 
@@ -36,11 +37,14 @@ jest.mock('@/application/services/domains', () => ({
   },
   ViewService: {
     get: jest.fn(),
+    getDatabaseCatalog: jest.fn(),
     getDatabaseRelations: jest.fn(),
+    getFavorites: jest.fn(),
     getMultiple: jest.fn(),
     getOutline: jest.fn(),
     getTrashCached: jest.fn(),
     refreshTrash: jest.fn(),
+    invalidateDatabaseCatalog: jest.fn(),
     invalidateCache: jest.fn(),
   },
   WorkspaceService: {
@@ -120,12 +124,30 @@ describe('useWorkspaceData trash refresh', () => {
     jest.clearAllMocks();
 
     (AccessService.getShareWithMe as jest.Mock).mockResolvedValue(null);
+    (ViewService.getDatabaseCatalog as jest.Mock).mockResolvedValue([]);
     (ViewService.getDatabaseRelations as jest.Mock).mockResolvedValue({});
+    (ViewService.getFavorites as jest.Mock).mockResolvedValue([]);
     (ViewService.getMultiple as jest.Mock).mockResolvedValue([]);
     (ViewService.getOutline as jest.Mock).mockResolvedValue({
       outline: [],
       folderRid: '1-1',
     });
+  });
+
+  it('warms the shared database catalog once on workspace mount', async () => {
+    const eventEmitter = new EventEmitter();
+
+    (ViewService.refreshTrash as jest.Mock).mockResolvedValue([]);
+    const { rerender } = renderHook(() => useWorkspaceData(), {
+      wrapper: createWrapper(eventEmitter),
+    });
+
+    await waitFor(() => {
+      expect(ViewService.getDatabaseCatalog).toHaveBeenCalledWith(workspaceId);
+    });
+
+    rerender();
+    expect(ViewService.getDatabaseCatalog).toHaveBeenCalledTimes(1);
   });
 
   it('refreshes stale trash state when a remote restore adds the view back to the folder', async () => {
@@ -159,6 +181,433 @@ describe('useWorkspaceData trash refresh', () => {
     await waitFor(() => {
       expect(ViewService.refreshTrash).toHaveBeenCalledTimes(initialTrashRequestCount + 1);
       expect(result.current.trashList).toEqual([]);
+    });
+  });
+
+  it('does not refresh trash when VIEW_ADDED creates a view that is not in known trash', async () => {
+    const eventEmitter = new EventEmitter();
+
+    (ViewService.refreshTrash as jest.Mock).mockResolvedValue([]);
+
+    renderHook(() => useWorkspaceData(), {
+      wrapper: createWrapper(eventEmitter),
+    });
+
+    await waitFor(() => {
+      expect(ViewService.refreshTrash).toHaveBeenCalledTimes(1);
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    const initialTrashRequestCount = (ViewService.refreshTrash as jest.Mock).mock.calls.length;
+    const newView = createView('new-row-document', {
+      parent_view_id: 'new-row-document',
+    });
+
+    await act(async () => {
+      eventEmitter.emit(APP_EVENTS.FOLDER_VIEW_CHANGED, {
+        changeType: 1,
+        parentViewId: newView.view_id,
+        viewJson: JSON.stringify(newView),
+      });
+      await Promise.resolve();
+    });
+
+    expect(ViewService.refreshTrash).toHaveBeenCalledTimes(initialTrashRequestCount);
+    expect(ViewService.invalidateDatabaseCatalog).not.toHaveBeenCalled();
+  });
+
+  it('invalidates the shared catalog when a database view is added', async () => {
+    const eventEmitter = new EventEmitter();
+    const space = createView('space-id');
+
+    (ViewService.refreshTrash as jest.Mock).mockResolvedValue([]);
+    (ViewService.getOutline as jest.Mock).mockResolvedValue({ outline: [space], folderRid: '1-1' });
+    const { result } = renderHook(() => useWorkspaceData(), {
+      wrapper: createWrapper(eventEmitter),
+    });
+
+    await waitFor(() => {
+      expect(ViewService.getDatabaseCatalog).toHaveBeenCalledTimes(1);
+      expect(result.current.outline?.map((view) => view.view_id)).toEqual(['space-id']);
+    });
+
+    const databaseView = createView('database-view-id', {
+      layout: ViewLayout.Grid,
+      parent_view_id: 'space-id',
+      extra: { database_id: 'database-id', is_space: false },
+    });
+
+    act(() => {
+      eventEmitter.emit(APP_EVENTS.FOLDER_VIEW_CHANGED, {
+        changeType: 1,
+        folderRid: '2-1',
+        parentViewId: 'space-id',
+        viewJson: JSON.stringify(databaseView),
+      });
+    });
+
+    expect(ViewService.invalidateDatabaseCatalog).toHaveBeenCalledTimes(1);
+    expect(ViewService.invalidateDatabaseCatalog).toHaveBeenCalledWith(workspaceId);
+  });
+
+  it('invalidates the catalog for a database VIEW_ADDED below an unloaded parent', async () => {
+    const eventEmitter = new EventEmitter();
+
+    (ViewService.refreshTrash as jest.Mock).mockResolvedValue([]);
+    renderHook(() => useWorkspaceData(), {
+      wrapper: createWrapper(eventEmitter),
+    });
+
+    await waitFor(() => {
+      expect(ViewService.getDatabaseCatalog).toHaveBeenCalledTimes(1);
+    });
+
+    const orphanDatabaseView = createView('orphan-database-view', {
+      layout: ViewLayout.Grid,
+      parent_view_id: 'unloaded-parent-view',
+      extra: { database_id: 'orphan-database-id', is_space: false },
+    });
+
+    act(() => {
+      eventEmitter.emit(APP_EVENTS.FOLDER_VIEW_CHANGED, {
+        changeType: 1,
+        parentViewId: 'unloaded-parent-view',
+        viewJson: JSON.stringify(orphanDatabaseView),
+      });
+    });
+
+    expect(ViewService.invalidateDatabaseCatalog).toHaveBeenCalledTimes(1);
+    expect(ViewService.invalidateDatabaseCatalog).toHaveBeenCalledWith(workspaceId);
+  });
+
+  it('does not invalidate the catalog for a self-parent document VIEW_ADDED notification', async () => {
+    const eventEmitter = new EventEmitter();
+
+    (ViewService.refreshTrash as jest.Mock).mockResolvedValue([]);
+    renderHook(() => useWorkspaceData(), {
+      wrapper: createWrapper(eventEmitter),
+    });
+
+    await waitFor(() => {
+      expect(ViewService.getDatabaseCatalog).toHaveBeenCalledTimes(1);
+    });
+
+    const rowDocumentView = createView('row-document-view', {
+      layout: ViewLayout.Document,
+      parent_view_id: 'row-document-view',
+      extra: { is_space: false },
+    });
+
+    act(() => {
+      eventEmitter.emit(APP_EVENTS.FOLDER_VIEW_CHANGED, {
+        changeType: 1,
+        parentViewId: rowDocumentView.view_id,
+        viewJson: JSON.stringify(rowDocumentView),
+      });
+    });
+
+    expect(ViewService.invalidateDatabaseCatalog).not.toHaveBeenCalled();
+  });
+
+  it('bounds VIEW_ADDED retries after the initial trash request fails', async () => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2026-08-20T00:00:00.000Z'));
+    const consoleError = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    try {
+      const eventEmitter = new EventEmitter();
+
+      (ViewService.refreshTrash as jest.Mock)
+        .mockRejectedValueOnce(new Error('trash unavailable'))
+        .mockResolvedValueOnce([]);
+
+      const { result, unmount } = renderHook(() => useWorkspaceData(), {
+        wrapper: createWrapper(eventEmitter),
+      });
+
+      await act(async () => {
+        await Promise.resolve();
+        await Promise.resolve();
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      expect(result.current.trashList).toBeUndefined();
+      expect(ViewService.refreshTrash).toHaveBeenCalledTimes(1);
+
+      act(() => {
+        for (let index = 0; index < 20; index += 1) {
+          const newView = createView(`new-row-document-${index}`, {
+            parent_view_id: `new-row-document-${index}`,
+          });
+
+          eventEmitter.emit(APP_EVENTS.FOLDER_VIEW_CHANGED, {
+            changeType: 1,
+            parentViewId: newView.view_id,
+            viewJson: JSON.stringify(newView),
+          });
+        }
+      });
+
+      expect(ViewService.refreshTrash).toHaveBeenCalledTimes(1);
+
+      await act(async () => {
+        jest.advanceTimersByTime(29_999);
+        await Promise.resolve();
+      });
+      expect(ViewService.refreshTrash).toHaveBeenCalledTimes(1);
+
+      await act(async () => {
+        jest.advanceTimersByTime(1);
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      expect(ViewService.refreshTrash).toHaveBeenCalledTimes(2);
+      expect(result.current.trashList).toEqual([]);
+      unmount();
+    } finally {
+      consoleError.mockRestore();
+      jest.useRealTimers();
+    }
+  });
+
+  it('bounds no-RID no-op outline fallback refreshes to one per 30-second cooldown', async () => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2026-08-20T00:00:00.000Z'));
+
+    try {
+      const eventEmitter = new EventEmitter();
+      const debug = jest.spyOn(Log, 'debug').mockImplementation(() => undefined);
+      const existingOutline = [createView('space-id', { has_children: false })];
+
+      (ViewService.getOutline as jest.Mock).mockResolvedValue({
+        outline: existingOutline,
+        folderRid: '1-1',
+      });
+      (ViewService.refreshTrash as jest.Mock).mockResolvedValue([]);
+
+      const { result, unmount } = renderHook(() => useWorkspaceData(), {
+        wrapper: createWrapper(eventEmitter),
+      });
+
+      await act(async () => {
+        await Promise.resolve();
+        await Promise.resolve();
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      expect(result.current.trashList).toEqual([]);
+      expect(result.current.outline).toEqual(existingOutline);
+      expect(ViewService.refreshTrash).toHaveBeenCalledTimes(1);
+
+      await act(async () => {
+        await result.current.loadFavoriteViews?.();
+      });
+      expect(ViewService.getFavorites).toHaveBeenCalledTimes(1);
+
+      const outlineReference = result.current.outline;
+      const outlineLoaded = jest.fn();
+
+      eventEmitter.on(APP_EVENTS.OUTLINE_LOADED, outlineLoaded);
+
+      const noOpReplacement = JSON.stringify([{ op: 'replace', path: '/outline', value: existingOutline }]);
+
+      act(() => {
+        for (let index = 0; index < 20; index += 1) {
+          eventEmitter.emit(APP_EVENTS.FOLDER_OUTLINE_CHANGED, {
+            outlineDiffJson: noOpReplacement,
+          });
+        }
+      });
+
+      expect(ViewService.refreshTrash).toHaveBeenCalledTimes(1);
+      expect(ViewService.getFavorites).toHaveBeenCalledTimes(1);
+      expect(result.current.outline).toBe(outlineReference);
+      expect(outlineLoaded).not.toHaveBeenCalled();
+
+      await act(async () => {
+        jest.advanceTimersByTime(29_999);
+        await Promise.resolve();
+      });
+      expect(ViewService.refreshTrash).toHaveBeenCalledTimes(1);
+
+      await act(async () => {
+        jest.advanceTimersByTime(1);
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+      expect(ViewService.refreshTrash).toHaveBeenCalledTimes(2);
+      expect(ViewService.getFavorites).toHaveBeenCalledTimes(1);
+      expect(result.current.outline).toBe(outlineReference);
+      expect(outlineLoaded).not.toHaveBeenCalled();
+
+      const parsedPatchLog = debug.mock.calls.find(
+        ([message]) => message === '[Outline] [FolderOutlineChanged] parsed patch'
+      );
+
+      expect(parsedPatchLog?.[1]).toEqual({
+        folderRid: null,
+        byteLength: noOpReplacement.length,
+        operationCount: 1,
+        operations: [{ op: 'replace', path: '/outline' }],
+        operationsTruncated: false,
+      });
+
+      unmount();
+      eventEmitter.off(APP_EVENTS.OUTLINE_LOADED, outlineLoaded);
+      debug.mockRestore();
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('refreshes a revisioned no-op VIEW_REMOVED once for a possible remote permanent delete', async () => {
+    const eventEmitter = new EventEmitter();
+    const child = createView('child-id', { has_children: false });
+    const parent = createView('parent-id', {
+      children: [child],
+      has_children: true,
+    });
+
+    (ViewService.getOutline as jest.Mock).mockResolvedValue({
+      outline: [parent],
+      folderRid: '1-1',
+    });
+    (ViewService.refreshTrash as jest.Mock).mockResolvedValue([]);
+
+    const { result } = renderHook(() => useWorkspaceData(), {
+      wrapper: createWrapper(eventEmitter),
+    });
+
+    await waitFor(() => {
+      expect(result.current.outline).toEqual([parent]);
+      expect(result.current.trashList).toEqual([]);
+    });
+
+    const initialTrashRequestCount = (ViewService.refreshTrash as jest.Mock).mock.calls.length;
+    const outlineReference = result.current.outline;
+    const payload = {
+      changeType: 2,
+      folderRid: '2-1',
+      viewId: parent.view_id,
+      childViewIds: [child.view_id],
+    };
+
+    await act(async () => {
+      eventEmitter.emit(APP_EVENTS.FOLDER_VIEW_CHANGED, payload);
+      eventEmitter.emit(APP_EVENTS.FOLDER_VIEW_CHANGED, payload);
+      await Promise.resolve();
+    });
+
+    await waitFor(() => {
+      expect(ViewService.refreshTrash).toHaveBeenCalledTimes(initialTrashRequestCount + 1);
+    });
+    expect(result.current.outline).toBe(outlineReference);
+  });
+
+  it('bounds unrevisioned no-op VIEW_REMOVED permanent-delete fallbacks to the 30-second cooldown', async () => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2026-08-20T00:00:00.000Z'));
+
+    try {
+      const eventEmitter = new EventEmitter();
+      const child = createView('child-id', { has_children: false });
+      const parent = createView('parent-id', {
+        children: [child],
+        has_children: true,
+      });
+
+      (ViewService.getOutline as jest.Mock).mockResolvedValue({
+        outline: [parent],
+        folderRid: '1-1',
+      });
+      (ViewService.refreshTrash as jest.Mock).mockResolvedValue([]);
+
+      const { result, unmount } = renderHook(() => useWorkspaceData(), {
+        wrapper: createWrapper(eventEmitter),
+      });
+
+      await act(async () => {
+        await Promise.resolve();
+        await Promise.resolve();
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      expect(result.current.outline).toEqual([parent]);
+      expect(result.current.trashList).toEqual([]);
+      expect(ViewService.refreshTrash).toHaveBeenCalledTimes(1);
+
+      const outlineReference = result.current.outline;
+
+      act(() => {
+        for (let index = 0; index < 20; index += 1) {
+          eventEmitter.emit(APP_EVENTS.FOLDER_VIEW_CHANGED, {
+            changeType: 2,
+            viewId: parent.view_id,
+            childViewIds: [child.view_id],
+          });
+        }
+      });
+
+      expect(ViewService.refreshTrash).toHaveBeenCalledTimes(1);
+      expect(result.current.outline).toBe(outlineReference);
+
+      await act(async () => {
+        jest.advanceTimersByTime(30_000);
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      expect(ViewService.refreshTrash).toHaveBeenCalledTimes(2);
+      expect(result.current.outline).toBe(outlineReference);
+      unmount();
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('refreshes trash immediately when an outline replacement removes a view', async () => {
+    const eventEmitter = new EventEmitter();
+    const removedView = createView('removed-view');
+    const space = createView('space-id', {
+      children: [removedView],
+      has_children: true,
+    });
+
+    (ViewService.getOutline as jest.Mock).mockResolvedValue({
+      outline: [space],
+      folderRid: '1-1',
+    });
+    (ViewService.refreshTrash as jest.Mock).mockResolvedValue([]);
+
+    const { result } = renderHook(() => useWorkspaceData(), {
+      wrapper: createWrapper(eventEmitter),
+    });
+
+    await waitFor(() => {
+      expect(result.current.outline?.[0]?.children.map((view) => view.view_id)).toEqual([removedView.view_id]);
+    });
+
+    const initialTrashRequestCount = (ViewService.refreshTrash as jest.Mock).mock.calls.length;
+    const nextSpace = createView('space-id', {
+      children: [],
+      has_children: false,
+    });
+
+    await act(async () => {
+      eventEmitter.emit(APP_EVENTS.FOLDER_OUTLINE_CHANGED, {
+        folderRid: '2-1',
+        outlineDiffJson: JSON.stringify([{ op: 'replace', path: '/outline', value: [nextSpace] }]),
+      });
+    });
+
+    await waitFor(() => {
+      expect(ViewService.refreshTrash).toHaveBeenCalledTimes(initialTrashRequestCount + 1);
     });
   });
 
@@ -273,9 +722,9 @@ describe('useWorkspaceData trash refresh', () => {
       });
     });
 
-    await waitFor(() => {
-      expect(trashRequests).toHaveLength(2);
-    });
+    // The full replacement is a no-op for membership, so wait for the
+    // granular VIEW_ADDED payload to identify this revision as a restore.
+    expect(trashRequests).toHaveLength(1);
 
     await act(async () => {
       eventEmitter.emit(APP_EVENTS.FOLDER_VIEW_CHANGED, {
@@ -286,7 +735,9 @@ describe('useWorkspaceData trash refresh', () => {
       });
     });
 
-    expect(trashRequests).toHaveLength(2);
+    await waitFor(() => {
+      expect(trashRequests).toHaveLength(2);
+    });
 
     await act(async () => {
       trashRequests[1].resolve([]);

--- a/src/components/app/hooks/__tests__/useWorkspaceData.trashRefresh.test.tsx
+++ b/src/components/app/hooks/__tests__/useWorkspaceData.trashRefresh.test.tsx
@@ -311,6 +311,182 @@ describe('useWorkspaceData trash refresh', () => {
     expect(ViewService.invalidateDatabaseCatalog).not.toHaveBeenCalled();
   });
 
+  it('invalidates the catalog when database display metadata changes', async () => {
+    const eventEmitter = new EventEmitter();
+    const databaseView = createView('database-view-id', {
+      layout: ViewLayout.Grid,
+      name: 'Before',
+      extra: { database_id: 'database-id', is_database_container: true, is_space: false },
+    });
+
+    (ViewService.refreshTrash as jest.Mock).mockResolvedValue([]);
+    (ViewService.getOutline as jest.Mock).mockResolvedValue({ outline: [databaseView], folderRid: '1-1' });
+    const { result } = renderHook(() => useWorkspaceData(), {
+      wrapper: createWrapper(eventEmitter),
+    });
+
+    await waitFor(() => {
+      expect(result.current.outline?.[0]?.name).toBe('Before');
+    });
+
+    act(() => {
+      eventEmitter.emit(APP_EVENTS.FOLDER_VIEW_CHANGED, {
+        changeType: 0,
+        folderRid: '2-1',
+        viewJson: JSON.stringify({ ...databaseView, name: 'After' }),
+      });
+    });
+
+    expect(ViewService.invalidateDatabaseCatalog).toHaveBeenCalledTimes(1);
+    expect(ViewService.invalidateDatabaseCatalog).toHaveBeenCalledWith(workspaceId);
+  });
+
+  it('keeps the catalog snapshot for database fields that are not part of the catalog response', async () => {
+    const eventEmitter = new EventEmitter();
+    const databaseView = createView('database-view-id', {
+      layout: ViewLayout.Grid,
+      extra: { database_id: 'database-id', is_database_container: true, is_space: false },
+      is_favorite: false,
+    });
+
+    (ViewService.refreshTrash as jest.Mock).mockResolvedValue([]);
+    (ViewService.getOutline as jest.Mock).mockResolvedValue({ outline: [databaseView], folderRid: '1-1' });
+    const { result } = renderHook(() => useWorkspaceData(), {
+      wrapper: createWrapper(eventEmitter),
+    });
+
+    await waitFor(() => {
+      expect(result.current.outline?.[0]?.view_id).toBe(databaseView.view_id);
+    });
+
+    act(() => {
+      eventEmitter.emit(APP_EVENTS.FOLDER_VIEW_CHANGED, {
+        changeType: 0,
+        folderRid: '2-1',
+        viewJson: JSON.stringify({ ...databaseView, is_favorite: true }),
+      });
+    });
+
+    expect(ViewService.invalidateDatabaseCatalog).not.toHaveBeenCalled();
+  });
+
+  it('invalidates the catalog when a full outline replacement changes database metadata', async () => {
+    const eventEmitter = new EventEmitter();
+    const databaseView = createView('database-view-id', {
+      layout: ViewLayout.Grid,
+      name: 'Before',
+      extra: { database_id: 'database-id', is_database_container: true, is_space: false },
+    });
+
+    (ViewService.refreshTrash as jest.Mock).mockResolvedValue([]);
+    (ViewService.getOutline as jest.Mock).mockResolvedValue({ outline: [databaseView], folderRid: '1-1' });
+    const { result } = renderHook(() => useWorkspaceData(), {
+      wrapper: createWrapper(eventEmitter),
+    });
+
+    await waitFor(() => {
+      expect(result.current.outline?.[0]?.name).toBe('Before');
+    });
+
+    act(() => {
+      eventEmitter.emit(APP_EVENTS.FOLDER_OUTLINE_CHANGED, {
+        folderRid: '2-1',
+        outlineDiffJson: JSON.stringify([
+          { op: 'replace', path: '/outline', value: [{ ...databaseView, name: 'After' }] },
+        ]),
+      });
+    });
+
+    expect(ViewService.invalidateDatabaseCatalog).toHaveBeenCalledTimes(1);
+    expect(ViewService.invalidateDatabaseCatalog).toHaveBeenCalledWith(workspaceId);
+  });
+
+  it('invalidates the catalog when VIEW_REMOVED targets an unloaded parent', async () => {
+    const eventEmitter = new EventEmitter();
+
+    (ViewService.refreshTrash as jest.Mock).mockResolvedValue([]);
+    renderHook(() => useWorkspaceData(), {
+      wrapper: createWrapper(eventEmitter),
+    });
+
+    await waitFor(() => {
+      expect(ViewService.getDatabaseCatalog).toHaveBeenCalledTimes(1);
+    });
+
+    act(() => {
+      eventEmitter.emit(APP_EVENTS.FOLDER_VIEW_CHANGED, {
+        changeType: 2,
+        folderRid: '2-1',
+        viewId: 'unloaded-parent-id',
+        childViewIds: [],
+      });
+    });
+
+    expect(ViewService.invalidateDatabaseCatalog).toHaveBeenCalledTimes(1);
+    expect(ViewService.invalidateDatabaseCatalog).toHaveBeenCalledWith(workspaceId);
+  });
+
+  it('keeps the catalog snapshot when a visible removed subtree contains only documents', async () => {
+    const eventEmitter = new EventEmitter();
+    const documentView = createView('document-view-id');
+    const parent = createView('parent-id', {
+      children: [documentView],
+      has_children: true,
+    });
+
+    (ViewService.refreshTrash as jest.Mock).mockResolvedValue([]);
+    (ViewService.getOutline as jest.Mock).mockResolvedValue({ outline: [parent], folderRid: '1-1' });
+    const { result } = renderHook(() => useWorkspaceData(), {
+      wrapper: createWrapper(eventEmitter),
+    });
+
+    await waitFor(() => {
+      expect(result.current.outline?.[0]?.children.map((view) => view.view_id)).toEqual([documentView.view_id]);
+    });
+
+    act(() => {
+      eventEmitter.emit(APP_EVENTS.FOLDER_VIEW_CHANGED, {
+        changeType: 2,
+        folderRid: '2-1',
+        viewId: parent.view_id,
+        childViewIds: [],
+      });
+    });
+
+    expect(ViewService.invalidateDatabaseCatalog).not.toHaveBeenCalled();
+  });
+
+  it('invalidates the catalog when a removed visible document still has unloaded descendants', async () => {
+    const eventEmitter = new EventEmitter();
+    const lazyDocumentView = createView('lazy-document-view-id', { has_children: true });
+    const parent = createView('parent-id', {
+      children: [lazyDocumentView],
+      has_children: true,
+    });
+
+    (ViewService.refreshTrash as jest.Mock).mockResolvedValue([]);
+    (ViewService.getOutline as jest.Mock).mockResolvedValue({ outline: [parent], folderRid: '1-1' });
+    const { result } = renderHook(() => useWorkspaceData(), {
+      wrapper: createWrapper(eventEmitter),
+    });
+
+    await waitFor(() => {
+      expect(result.current.outline?.[0]?.children.map((view) => view.view_id)).toEqual([lazyDocumentView.view_id]);
+    });
+
+    act(() => {
+      eventEmitter.emit(APP_EVENTS.FOLDER_VIEW_CHANGED, {
+        changeType: 2,
+        folderRid: '2-1',
+        viewId: parent.view_id,
+        childViewIds: [],
+      });
+    });
+
+    expect(ViewService.invalidateDatabaseCatalog).toHaveBeenCalledTimes(1);
+    expect(ViewService.invalidateDatabaseCatalog).toHaveBeenCalledWith(workspaceId);
+  });
+
   it('bounds VIEW_ADDED retries after the initial trash request fails', async () => {
     jest.useFakeTimers();
     jest.setSystemTime(new Date('2026-08-20T00:00:00.000Z'));
@@ -374,7 +550,7 @@ describe('useWorkspaceData trash refresh', () => {
     }
   });
 
-  it('bounds no-RID no-op outline fallback refreshes to one per 30-second cooldown', async () => {
+  it('runs one trailing no-RID no-op outline refresh after the notification stream becomes quiet', async () => {
     jest.useFakeTimers();
     jest.setSystemTime(new Date('2026-08-20T00:00:00.000Z'));
 
@@ -460,6 +636,93 @@ describe('useWorkspaceData trash refresh', () => {
       unmount();
       eventEmitter.off(APP_EVENTS.OUTLINE_LOADED, outlineLoaded);
       debug.mockRestore();
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('does not turn a continuous no-RID no-op outline stream into periodic trash polling', async () => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2026-08-20T00:00:00.000Z'));
+
+    try {
+      const eventEmitter = new EventEmitter();
+      const existingOutline = [createView('space-id', { has_children: false })];
+
+      (ViewService.getOutline as jest.Mock).mockResolvedValue({
+        outline: existingOutline,
+        folderRid: '1-1',
+      });
+      (ViewService.refreshTrash as jest.Mock).mockResolvedValue([]);
+
+      const { unmount } = renderHook(() => useWorkspaceData(), {
+        wrapper: createWrapper(eventEmitter),
+      });
+
+      await act(async () => {
+        await Promise.resolve();
+        await Promise.resolve();
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      expect(ViewService.refreshTrash).toHaveBeenCalledTimes(1);
+      const noOpReplacement = JSON.stringify([{ op: 'replace', path: '/outline', value: existingOutline }]);
+      const emitNoop = () => {
+        eventEmitter.emit(APP_EVENTS.FOLDER_OUTLINE_CHANGED, {
+          outlineDiffJson: noOpReplacement,
+        });
+      };
+
+      act(emitNoop);
+
+      await act(async () => {
+        jest.advanceTimersByTime(29_000);
+        emitNoop();
+        await Promise.resolve();
+      });
+      expect(ViewService.refreshTrash).toHaveBeenCalledTimes(1);
+
+      // The burst gets one maximum-latency probe even though it has not gone
+      // quiet, so a real permanent delete near the start is not stale forever.
+      await act(async () => {
+        jest.advanceTimersByTime(1_000);
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+      expect(ViewService.refreshTrash).toHaveBeenCalledTimes(2);
+
+      for (let index = 0; index < 3; index += 1) {
+        await act(async () => {
+          jest.advanceTimersByTime(20_000);
+          emitNoop();
+          await Promise.resolve();
+        });
+      }
+
+      // More than two cooldown windows have elapsed. The stream receives one
+      // max-latency probe, not periodic probes for as long as noise continues.
+      expect(ViewService.refreshTrash).toHaveBeenCalledTimes(2);
+
+      await act(async () => {
+        jest.advanceTimersByTime(29_999);
+        await Promise.resolve();
+      });
+      expect(ViewService.refreshTrash).toHaveBeenCalledTimes(2);
+
+      await act(async () => {
+        jest.advanceTimersByTime(1);
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+      expect(ViewService.refreshTrash).toHaveBeenCalledTimes(3);
+
+      await act(async () => {
+        jest.advanceTimersByTime(90_000);
+        await Promise.resolve();
+      });
+      expect(ViewService.refreshTrash).toHaveBeenCalledTimes(3);
+      unmount();
     } finally {
       jest.useRealTimers();
     }

--- a/src/components/app/hooks/__tests__/useWorkspaceData.trashRefresh.test.tsx
+++ b/src/components/app/hooks/__tests__/useWorkspaceData.trashRefresh.test.tsx
@@ -27,6 +27,7 @@ jest.mock('lodash-es', () => ({
     });
   },
 }));
+jest.mock('lodash-es/isEqual', () => jest.requireActual('lodash/isEqual'));
 
 jest.mock('@/application/services/domains', () => ({
   AccessService: {
@@ -38,7 +39,8 @@ jest.mock('@/application/services/domains', () => ({
     getDatabaseRelations: jest.fn(),
     getMultiple: jest.fn(),
     getOutline: jest.fn(),
-    getTrash: jest.fn(),
+    getTrashCached: jest.fn(),
+    refreshTrash: jest.fn(),
     invalidateCache: jest.fn(),
   },
   WorkspaceService: {
@@ -131,7 +133,7 @@ describe('useWorkspaceData trash refresh', () => {
     const restoredView = createView(restoredViewId);
     let trashResponse: View[] = [restoredView];
 
-    (ViewService.getTrash as jest.Mock).mockImplementation(async () => trashResponse);
+    (ViewService.refreshTrash as jest.Mock).mockImplementation(async () => trashResponse);
 
     const { result } = renderHook(() => useWorkspaceData(), {
       wrapper: createWrapper(eventEmitter),
@@ -141,7 +143,7 @@ describe('useWorkspaceData trash refresh', () => {
       expect(result.current.trashList?.map((view) => view.view_id)).toEqual([restoredViewId]);
     });
 
-    const initialTrashRequestCount = (ViewService.getTrash as jest.Mock).mock.calls.length;
+    const initialTrashRequestCount = (ViewService.refreshTrash as jest.Mock).mock.calls.length;
 
     trashResponse = [];
 
@@ -155,7 +157,7 @@ describe('useWorkspaceData trash refresh', () => {
     });
 
     await waitFor(() => {
-      expect(ViewService.getTrash).toHaveBeenCalledTimes(initialTrashRequestCount + 1);
+      expect(ViewService.refreshTrash).toHaveBeenCalledTimes(initialTrashRequestCount + 1);
       expect(result.current.trashList).toEqual([]);
     });
   });
@@ -175,7 +177,7 @@ describe('useWorkspaceData trash refresh', () => {
         folderRid: '2-1',
       });
 
-    (ViewService.getTrash as jest.Mock).mockImplementation(async () => trashResponse);
+    (ViewService.refreshTrash as jest.Mock).mockImplementation(async () => trashResponse);
 
     const { result } = renderHook(() => useWorkspaceData(), {
       wrapper: createWrapper(eventEmitter),
@@ -185,7 +187,7 @@ describe('useWorkspaceData trash refresh', () => {
       expect(result.current.trashList?.map((view) => view.view_id)).toEqual([restoredViewId]);
     });
 
-    const initialTrashRequestCount = (ViewService.getTrash as jest.Mock).mock.calls.length;
+    const initialTrashRequestCount = (ViewService.refreshTrash as jest.Mock).mock.calls.length;
 
     trashResponse = [];
 
@@ -198,17 +200,50 @@ describe('useWorkspaceData trash refresh', () => {
     expect(revalidationResult).toBe('changed');
 
     await waitFor(() => {
-      expect(ViewService.getTrash).toHaveBeenCalledTimes(initialTrashRequestCount + 1);
+      expect(ViewService.refreshTrash).toHaveBeenCalledTimes(initialTrashRequestCount + 1);
       expect(result.current.trashList).toEqual([]);
     });
   });
 
-  it('ignores stale trash refresh responses from overlapping folder notifications', async () => {
+  it('preserves the trash state reference when a refresh returns equivalent data', async () => {
+    const eventEmitter = new EventEmitter();
+    let trashResponse: View[] = [createView(restoredViewId)];
+    const acceptedPayloads: Array<{ workspaceId: string; trashItems: View[] }> = [];
+
+    eventEmitter.on(APP_EVENTS.TRASH_UPDATED, (payload) => acceptedPayloads.push(payload));
+    (ViewService.refreshTrash as jest.Mock).mockImplementation(async () => trashResponse);
+
+    const { result } = renderHook(() => useWorkspaceData(), {
+      wrapper: createWrapper(eventEmitter),
+    });
+
+    await waitFor(() => {
+      expect(result.current.trashList?.map((view) => view.view_id)).toEqual([restoredViewId]);
+    });
+
+    const initialTrashList = result.current.trashList;
+    const initialRequestCount = (ViewService.refreshTrash as jest.Mock).mock.calls.length;
+
+    trashResponse = [createView(restoredViewId)];
+    await act(async () => {
+      eventEmitter.emit(APP_EVENTS.FOLDER_OUTLINE_CHANGED, { folderRid: '2-1' });
+    });
+
+    await waitFor(() => {
+      expect(ViewService.refreshTrash).toHaveBeenCalledTimes(initialRequestCount + 1);
+      expect(acceptedPayloads).toHaveLength(2);
+    });
+
+    expect(result.current.trashList).toBe(initialTrashList);
+    expect(acceptedPayloads[1].trashItems).toBe(initialTrashList);
+  });
+
+  it('coalesces paired folder notifications for the same revision across separate frames', async () => {
     const eventEmitter = new EventEmitter();
     const restoredView = createView(restoredViewId);
     const trashRequests: Array<ReturnType<typeof createDeferred<View[]>>> = [];
 
-    (ViewService.getTrash as jest.Mock).mockImplementation(() => {
+    (ViewService.refreshTrash as jest.Mock).mockImplementation(() => {
       const deferred = createDeferred<View[]>();
 
       trashRequests.push(deferred);
@@ -232,15 +267,76 @@ describe('useWorkspaceData trash refresh', () => {
     });
 
     await act(async () => {
+      eventEmitter.emit(APP_EVENTS.FOLDER_OUTLINE_CHANGED, {
+        folderRid: '2-1',
+        outlineDiffJson: JSON.stringify([{ op: 'replace', path: '/outline', value: [] }]),
+      });
+    });
+
+    await waitFor(() => {
+      expect(trashRequests).toHaveLength(2);
+    });
+
+    await act(async () => {
       eventEmitter.emit(APP_EVENTS.FOLDER_VIEW_CHANGED, {
         changeType: 1,
         folderRid: '2-1',
         parentViewId: 'space-id',
         viewJson: JSON.stringify(restoredView),
       });
+    });
+
+    expect(trashRequests).toHaveLength(2);
+
+    await act(async () => {
+      trashRequests[1].resolve([]);
+    });
+
+    await waitFor(() => {
+      expect(result.current.trashList).toEqual([]);
+    });
+  });
+
+  it('allows the same folder revision to retry after a terminal trash failure', async () => {
+    const eventEmitter = new EventEmitter();
+    const trashRequests: Array<ReturnType<typeof createDeferred<View[]>>> = [];
+
+    (ViewService.refreshTrash as jest.Mock).mockImplementation(() => {
+      const deferred = createDeferred<View[]>();
+
+      trashRequests.push(deferred);
+      return deferred.promise;
+    });
+
+    renderHook(() => useWorkspaceData(), {
+      wrapper: createWrapper(eventEmitter),
+    });
+
+    await waitFor(() => {
+      expect(trashRequests).toHaveLength(1);
+    });
+
+    await act(async () => {
+      trashRequests[0].resolve([]);
+    });
+
+    const payload = { folderRid: '5-1' };
+
+    await act(async () => {
+      eventEmitter.emit(APP_EVENTS.FOLDER_OUTLINE_CHANGED, payload);
+    });
+
+    await waitFor(() => {
+      expect(trashRequests).toHaveLength(2);
+    });
+
+    await act(async () => {
+      trashRequests[1].reject(new Error('network unavailable'));
+    });
+
+    await act(async () => {
       eventEmitter.emit(APP_EVENTS.FOLDER_OUTLINE_CHANGED, {
-        folderRid: '3-1',
-        outlineDiffJson: JSON.stringify([{ op: 'replace', path: '/outline', value: [] }]),
+        ...payload,
       });
     });
 
@@ -250,18 +346,6 @@ describe('useWorkspaceData trash refresh', () => {
 
     await act(async () => {
       trashRequests[2].resolve([]);
-    });
-
-    await waitFor(() => {
-      expect(result.current.trashList).toEqual([]);
-    });
-
-    await act(async () => {
-      trashRequests[1].resolve([restoredView]);
-    });
-
-    await waitFor(() => {
-      expect(result.current.trashList).toEqual([]);
     });
   });
 });

--- a/src/components/app/hooks/usePageOperations.ts
+++ b/src/components/app/hooks/usePageOperations.ts
@@ -69,6 +69,7 @@ export function usePageOperations({
   syncAllToServer,
   loadViewChildren,
   getDatabaseIdForViewId,
+  loadTrash,
 }: {
   outlineRef: MutableRefObject<View[] | undefined>;
   loadOutline?: (workspaceId: string, force?: boolean) => Promise<void>;
@@ -76,6 +77,7 @@ export function usePageOperations({
   syncAllToServer?: (workspaceId: string) => Promise<void>;
   loadViewChildren?: (viewId: string) => Promise<View[]>;
   getDatabaseIdForViewId?: (viewId: string) => Promise<string | null | undefined>;
+  loadTrash?: (workspaceId: string, options?: { ensureFreshAfterInFlight?: boolean }) => Promise<void>;
 }) {
   const { currentWorkspaceId, userWorkspaceInfo } = useAuthInternal();
   const role = userWorkspaceInfo?.selectedWorkspace.role;
@@ -111,7 +113,7 @@ export function usePageOperations({
 
   // Delete a page (move to trash)
   const deletePage = useCallback(
-    async (id: string, loadTrash?: (workspaceId: string) => Promise<void>) => {
+    async (id: string) => {
       if (!currentWorkspaceId) {
         throw new Error('No workspace or service found');
       }
@@ -131,14 +133,16 @@ export function usePageOperations({
           ViewService.invalidateCache(currentWorkspaceId, parentView.view_id);
         }
 
-        void loadTrash?.(currentWorkspaceId);
+        void loadTrash?.(currentWorkspaceId, { ensureFreshAfterInFlight: true }).catch((error) => {
+          Log.warn('[Trash] Failed to refresh after moving a page to trash', error);
+        });
         void loadOutline?.(currentWorkspaceId, false);
         return;
       } catch (e) {
         return Promise.reject(e);
       }
     },
-    [currentWorkspaceId, outlineRef, role, loadOutline]
+    [currentWorkspaceId, outlineRef, role, loadOutline, loadTrash]
   );
 
   // Update page (rename) - uses WebSocket notification for sidebar refresh
@@ -286,7 +290,7 @@ export function usePageOperations({
         } else {
           // Delete all — fetch trash list first to know which caches to clear
           try {
-            const trashItems = await ViewService.getTrash(currentWorkspaceId);
+            const trashItems = await ViewService.refreshTrash(currentWorkspaceId, 'delete-all-snapshot');
 
             viewIdsToClear = trashItems?.map((item) => item.view_id) || [];
           } catch {

--- a/src/components/app/hooks/usePageOperations.ts
+++ b/src/components/app/hooks/usePageOperations.ts
@@ -34,6 +34,23 @@ function waitForDocumentPublishRetry(delayMs: number): Promise<void> {
   return new Promise((resolve) => window.setTimeout(resolve, delayMs));
 }
 
+function refreshDatabaseCatalogAfterMutation(workspaceId: string): void {
+  // Supersede any warm/read request that began before the mutation. The new
+  // authoritative request runs in the background so page creation is not held
+  // behind a workspace-wide catalog response.
+  ViewService.invalidateDatabaseCatalog?.(workspaceId);
+  void ViewService.refreshWorkspaceDatabaseCatalog?.(workspaceId).catch((error) => {
+    Log.warn('[WorkspaceDatabaseCatalog] failed to refresh after a database mutation', error);
+  });
+}
+
+function isDatabaseCatalogView(view: View | null | undefined): boolean {
+  return Boolean(
+    view &&
+      (isDatabaseLayout(view.layout) || view.extra?.is_database_container || typeof view.extra?.database_id === 'string')
+  );
+}
+
 function isPendingDocumentPublishData(error: unknown): boolean {
   if (!error || typeof error !== 'object') return false;
 
@@ -100,6 +117,10 @@ export function usePageOperations({
         const response = await PageService.add(currentWorkspaceId, parentViewId, payload);
 
         ViewService.invalidateCache(currentWorkspaceId, parentViewId);
+        if (isDatabaseLayout(payload.layout)) {
+          refreshDatabaseCatalogAfterMutation(currentWorkspaceId);
+        }
+
         // Keep a resilient fallback when realtime delivery is unavailable.
         // This guarantees sidebar eventual consistency after creation.
         void loadOutline?.(currentWorkspaceId, false);
@@ -126,8 +147,13 @@ export function usePageOperations({
 
       try {
         const parentView = findParentView(outlineRef.current || [], id);
+        const deletedView = findView(outlineRef.current || [], id);
 
         await PageService.moveToTrash(currentWorkspaceId, id);
+        if (isDatabaseCatalogView(deletedView)) {
+          refreshDatabaseCatalogAfterMutation(currentWorkspaceId);
+        }
+
         ViewService.invalidateCache(currentWorkspaceId, id);
         if (parentView) {
           ViewService.invalidateCache(currentWorkspaceId, parentView.view_id);
@@ -229,6 +255,7 @@ export function usePageOperations({
         await afterPreSync?.();
 
         await PageService.duplicate(currentWorkspaceId, viewId, duplicateOptions);
+        refreshDatabaseCatalogAfterMutation(currentWorkspaceId);
         await loadOutline?.(currentWorkspaceId, false);
 
         if (duplicateOptions.parentViewId) {
@@ -299,6 +326,7 @@ export function usePageOperations({
         }
 
         await PageService.deleteTrash(currentWorkspaceId, viewId);
+        refreshDatabaseCatalogAfterMutation(currentWorkspaceId);
 
         // Clear IndexedDB cache for permanently deleted views (parallel)
         await Promise.allSettled(viewIdsToClear.map((id) => clearViewCache(id)));
@@ -321,6 +349,7 @@ export function usePageOperations({
 
       try {
         await PageService.restore(currentWorkspaceId, viewId);
+        refreshDatabaseCatalogAfterMutation(currentWorkspaceId);
         void loadOutline?.(currentWorkspaceId, false);
         return;
       } catch (e) {
@@ -396,6 +425,7 @@ export function usePageOperations({
       try {
         const res = await PageService.createDatabaseView(currentWorkspaceId, viewId, payload);
 
+        refreshDatabaseCatalogAfterMutation(currentWorkspaceId);
         await loadOutline?.(currentWorkspaceId, false);
         return res;
       } catch (e) {

--- a/src/components/app/hooks/useViewOperations.ts
+++ b/src/components/app/hooks/useViewOperations.ts
@@ -242,6 +242,7 @@ export function useViewOperations({
         // Use view-loader to open document (handles cache vs fetch)
         let { doc, collabType: detectedCollabType } = await openView(currentWorkspaceId, viewId, layout, {
           databaseId: databaseIdHint,
+          databaseMetadataOnly: options?.databaseMetadataOnly,
           forceFetch: options?.forceFetch,
         });
 
@@ -264,6 +265,7 @@ export function useViewOperations({
         if (collabType === Types.Database && !databaseIdHint && collabObjectId !== viewId) {
           const canonical = await openView(currentWorkspaceId, viewId, layout, {
             databaseId: collabObjectId,
+            databaseMetadataOnly: options?.databaseMetadataOnly,
             forceFetch: options?.forceFetch,
           });
 

--- a/src/components/app/hooks/useWorkspaceData.ts
+++ b/src/components/app/hooks/useWorkspaceData.ts
@@ -1,6 +1,7 @@
 import { applyPatch, type Operation, type ReplaceOperation } from 'fast-json-patch';
 import { sortBy, uniqBy } from 'lodash-es';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import isEqual from 'lodash-es/isEqual';
+import { useCallback, useEffect, useId, useMemo, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { validate as uuidValidate } from 'uuid';
 
@@ -444,6 +445,12 @@ export function useWorkspaceData() {
   const workspaceDatabasesRef = useRef<DatabaseRelations | undefined>(undefined);
   const [requestAccessError, setRequestAccessError] = useState<RequestAccessError | null>(null);
   const trashRequestSeqRef = useRef(0);
+  const trashLoaderInstanceId = useId();
+  const trashListRef = useRef<View[] | undefined>(undefined);
+  const lastTrashRefreshRidRef = useRef<FolderRid | null>(null);
+  const lastAcceptedTrashRefreshRidRef = useRef<FolderRid | null>(null);
+  const scheduledTrashRefreshWorkspaceIdRef = useRef<string | null>(null);
+  const scheduledTrashRefreshKeyRef = useRef<string | undefined>(undefined);
   const shareAccessProbeGenerationsRef = useRef(new Map<string, number>());
   const permissionRefreshRevisionRef = useRef(0);
 
@@ -1292,36 +1299,139 @@ export function useWorkspaceData() {
     []
   );
 
-  // Load trash list
-  const loadTrash = useCallback(async (currentWorkspaceId: string) => {
-    const requestSeq = ++trashRequestSeqRef.current;
+  const requestTrash = useCallback(
+    async (workspaceId: string, refresh: boolean, freshnessKey?: string | null) => {
+      const requestSeq = ++trashRequestSeqRef.current;
 
-    try {
-      const res = await ViewService.getTrash(currentWorkspaceId);
+      try {
+        const res = refresh
+          ? await ViewService.refreshTrash(
+              workspaceId,
+              freshnessKey === null
+                ? undefined
+                : freshnessKey ??
+                    `manual:${trashLoaderInstanceId}:${workspaceRevisionRef.current}:${requestSeq}`
+            )
+          : await ViewService.getTrashCached(workspaceId);
 
-      if (!res) {
-        throw new Error('App trash not found');
+        if (!res) {
+          throw new Error('App trash not found');
+        }
+
+        // A response from the previous workspace or an older request must not
+        // update app state or wake embedded database blocks.
+        if (requestSeq !== trashRequestSeqRef.current || currentWorkspaceIdRef.current !== workspaceId) {
+          return false;
+        }
+
+        const nextTrashList = sortBy(uniqBy(res, 'view_id') as unknown as View[], 'last_edited_time').reverse();
+        const acceptedTrashList = isEqual(trashListRef.current, nextTrashList)
+          ? (trashListRef.current as View[])
+          : nextTrashList;
+
+        if (acceptedTrashList !== trashListRef.current) {
+          trashListRef.current = acceptedTrashList;
+          setTrashList(acceptedTrashList);
+        }
+
+        eventEmitter?.emit(APP_EVENTS.TRASH_UPDATED, {
+          workspaceId,
+          trashItems: acceptedTrashList,
+        });
+        return true;
+      } catch (e) {
+        return Promise.reject('App trash not found');
       }
+    },
+    [eventEmitter, trashLoaderInstanceId]
+  );
 
-      if (requestSeq !== trashRequestSeqRef.current) {
-        return;
-      }
-
-      setTrashList(sortBy(uniqBy(res, 'view_id') as unknown as View[], 'last_edited_time').reverse());
-    } catch (e) {
-      return Promise.reject('App trash not found');
-    }
-  }, []);
+  // Public loads always bypass the TTL. Read-only mounts share an active
+  // request; mutation callers opt into one trailing request when an older read
+  // was already active, preserving freshness while bounding concurrency.
+  const loadTrash = useCallback(
+    async (workspaceId: string, options: { ensureFreshAfterInFlight?: boolean } = {}) => {
+      await requestTrash(workspaceId, true, options.ensureFreshAfterInFlight ? undefined : null);
+    },
+    [requestTrash]
+  );
 
   // Remote delete/restore arrives as folder changes. Keep the app-level trash
   // state fresh because deleted-page routing is derived from `trashList`.
-  const refreshTrashListInBackground = useCallback(() => {
-    if (!currentWorkspaceId) return;
+  const refreshTrashListInBackground = useCallback(
+    (folderRidValue?: string | null) => {
+      if (!currentWorkspaceId) return;
 
-    void loadTrash(currentWorkspaceId).catch((error) => {
-      Log.warn('[Trash] Failed to refresh trash list after folder change', error);
-    });
-  }, [currentWorkspaceId, loadTrash]);
+      const folderRid = parseFolderRid(folderRidValue);
+      const lastTrashRefreshRid = lastTrashRefreshRidRef.current;
+
+      // FolderViewChanged and FolderChanged can arrive in separate websocket
+      // frames for the same folder revision. Refresh once for that revision.
+      if (folderRid && lastTrashRefreshRid && compareFolderRid(folderRid, lastTrashRefreshRid) <= 0) {
+        return;
+      }
+
+      if (folderRid) {
+        lastTrashRefreshRidRef.current = folderRid;
+      }
+
+      const workspaceId = currentWorkspaceId;
+      const freshnessKey = folderRidValue
+        ? `folder:${folderRidValue}`
+        : `legacy:${trashLoaderInstanceId}:${workspaceId}:${trashRequestSeqRef.current + 1}`;
+
+      // Same-tick callers without a RID are a fallback path for legacy server
+      // notifications. Newer frames arriving after the request starts are
+      // handled by the coordinator's single trailing refresh.
+      if (scheduledTrashRefreshWorkspaceIdRef.current === workspaceId) {
+        scheduledTrashRefreshKeyRef.current = freshnessKey;
+        return;
+      }
+
+      scheduledTrashRefreshWorkspaceIdRef.current = workspaceId;
+      scheduledTrashRefreshKeyRef.current = freshnessKey;
+      queueMicrotask(() => {
+        if (scheduledTrashRefreshWorkspaceIdRef.current !== workspaceId) return;
+
+        const scheduledFreshnessKey = scheduledTrashRefreshKeyRef.current;
+
+        scheduledTrashRefreshWorkspaceIdRef.current = null;
+        scheduledTrashRefreshKeyRef.current = undefined;
+        if (currentWorkspaceIdRef.current !== workspaceId) return;
+
+        const scheduledFolderRid = scheduledFreshnessKey?.startsWith('folder:')
+          ? parseFolderRid(scheduledFreshnessKey.slice('folder:'.length))
+          : null;
+
+        void requestTrash(workspaceId, true, scheduledFreshnessKey)
+          .then((accepted) => {
+            if (!accepted || !scheduledFolderRid) return;
+
+            const lastAcceptedRid = lastAcceptedTrashRefreshRidRef.current;
+
+            if (!lastAcceptedRid || compareFolderRid(scheduledFolderRid, lastAcceptedRid) > 0) {
+              lastAcceptedTrashRefreshRidRef.current = scheduledFolderRid;
+            }
+          })
+          .catch((error) => {
+            const lastTrashRefreshRid = lastTrashRefreshRidRef.current;
+
+            // Allow a redelivered revision to retry after terminal failure,
+            // but never roll the watermark back past a newer scheduled RID.
+            if (
+              scheduledFolderRid &&
+              lastTrashRefreshRid &&
+              compareFolderRid(scheduledFolderRid, lastTrashRefreshRid) === 0
+            ) {
+              lastTrashRefreshRidRef.current = lastAcceptedTrashRefreshRidRef.current;
+            }
+
+            Log.warn('[Trash] Failed to refresh trash list after folder change', error);
+          });
+      });
+    },
+    [currentWorkspaceId, requestTrash, trashLoaderInstanceId]
+  );
 
   const revalidateSidebarOutline = useCallback(
     async (expandedViewIds: string[] = []): Promise<SidebarOutlineRevalidationResult> => {
@@ -1658,7 +1768,7 @@ export function useWorkspaceData() {
       // If no diff JSON provided, fall back to full outline reload
       if (!payload?.outlineDiffJson) {
         Log.debug('[Outline] [FolderOutlineChanged] No diff JSON, reloading outline');
-        refreshTrashListInBackground();
+        refreshTrashListInBackground(payload.folderRid);
         refreshRequestedFavoriteViewsInBackground(currentWorkspaceId);
         void loadOutline(currentWorkspaceId, false);
         return;
@@ -1671,13 +1781,13 @@ export function useWorkspaceData() {
         patch = JSON.parse(payload.outlineDiffJson) as JsonPatchOperation[];
       } catch (error) {
         Log.warn('[Outline] [FolderOutlineChanged] Failed to parse outline diff, reloading outline', error);
-        refreshTrashListInBackground();
+        refreshTrashListInBackground(payload.folderRid);
         void loadOutline(currentWorkspaceId, false);
         return;
       }
 
       if (!patch || !Array.isArray(patch)) {
-        refreshTrashListInBackground();
+        refreshTrashListInBackground(payload.folderRid);
         void loadOutline(currentWorkspaceId, false);
         return;
       }
@@ -1698,7 +1808,7 @@ export function useWorkspaceData() {
         return;
       }
 
-      refreshTrashListInBackground();
+      refreshTrashListInBackground(payload.folderRid);
       if (folderOutlinePatchMayAffectFavorites(patch)) {
         refreshRequestedFavoriteViewsInBackground(currentWorkspaceId);
       }
@@ -1923,14 +2033,14 @@ export function useWorkspaceData() {
         default: {
           // Unknown change type — fall back to full reload
           Log.debug('[Outline] [FolderViewChanged] Unknown change_type, reloading outline', changeType);
-          refreshTrashListInBackground();
+          refreshTrashListInBackground(payload.folderRid);
           void loadOutline(currentWorkspaceId, false);
           return;
         }
       }
 
       if (shouldRefreshTrash) {
-        refreshTrashListInBackground();
+        refreshTrashListInBackground(payload.folderRid);
       }
 
       if (folderRid) {
@@ -2134,6 +2244,11 @@ export function useWorkspaceData() {
   // Load data when workspace changes
   useEffect(() => {
     if (!currentWorkspaceId) return;
+    trashRequestSeqRef.current += 1;
+    lastTrashRefreshRidRef.current = null;
+    lastAcceptedTrashRefreshRidRef.current = null;
+    scheduledTrashRefreshWorkspaceIdRef.current = null;
+    scheduledTrashRefreshKeyRef.current = undefined;
     lastFolderRidRef.current = null;
     lastFolderViewRidRef.current = null;
     lastAppliedRootOutlineRidRef.current = null;
@@ -2156,6 +2271,7 @@ export function useWorkspaceData() {
     setRecentViews(undefined);
     // Deleted-page routing derives from `trashList` — without this reset the
     // previous workspace's trash stays live until the new loadTrash resolves.
+    trashListRef.current = undefined;
     setTrashList(undefined);
     // Clear database relations cache when switching workspaces to prevent
     // cross-workspace data contamination
@@ -2164,7 +2280,10 @@ export function useWorkspaceData() {
     void loadOutline(currentWorkspaceId, true);
     void (async () => {
       try {
-        await loadTrash(currentWorkspaceId);
+        // Always revalidate on workspace mount. The unkeyed refresh shares a
+        // simultaneous DatabaseBlock cache miss instead of adding a trailing
+        // request; mutation-driven loads use keyed freshness below.
+        await requestTrash(currentWorkspaceId, true, null);
       } catch (e) {
         console.error(e);
       }

--- a/src/components/app/hooks/useWorkspaceData.ts
+++ b/src/components/app/hooks/useWorkspaceData.ts
@@ -10,6 +10,7 @@ import { deleteCollabDB } from '@/application/db';
 import { AccessService, ViewService, WorkspaceService } from '@/application/services/domains';
 import { invalidToken } from '@/application/session/token';
 import { DatabaseRelations, MentionablePerson, UIVariant, View, ViewLayout } from '@/application/types';
+import { isDatabaseLayout } from '@/application/view-utils';
 import {
   addViewToOutline,
   deduplicateOutlineChildren,
@@ -73,6 +74,34 @@ function buildViewDepthIndex(views: View[]): Map<string, number> {
 
   walk(views, 0);
   return depths;
+}
+
+function isDatabaseCatalogView(view: View | null | undefined): boolean {
+  return Boolean(
+    view &&
+      (isDatabaseLayout(view.layout) || view.extra?.is_database_container || typeof view.extra?.database_id === 'string')
+  );
+}
+
+function collectDatabaseCatalogViewIds(views: View[]): Set<string> {
+  const ids = new Set<string>();
+
+  const walk = (items: View[]) => {
+    for (const view of items) {
+      if (isDatabaseCatalogView(view)) ids.add(view.view_id);
+      if (view.children?.length) walk(view.children);
+    }
+  };
+
+  walk(views);
+  return ids;
+}
+
+function databaseCatalogMembershipChanged(previous: View[], next: View[]): boolean {
+  const previousIds = collectDatabaseCatalogViewIds(previous);
+  const nextIds = collectDatabaseCatalogViewIds(next);
+
+  return previousIds.size !== nextIds.size || Array.from(previousIds).some((viewId) => !nextIds.has(viewId));
 }
 
 function collectViewPath(root: View, targetViewId: string): View[] | null {
@@ -292,6 +321,7 @@ const ACCESS_REVOKED_PROBE_ERROR_CODES = new Set<number>([
 ]);
 
 const PERMISSION_SUBTREE_REHYDRATE_MAX_ATTEMPTS = 2;
+const NOOP_FOLDER_TRASH_REFRESH_COOLDOWN_MS = 30_000;
 
 function getRefreshErrorCode(error: unknown): number | undefined {
   if (typeof error !== 'object' || error === null) return undefined;
@@ -377,6 +407,25 @@ function createRootOutlineFingerprint(views: View[]): string {
   return JSON.stringify(normalizeRootOutlineForComparison(views));
 }
 
+function collectOutlineViewIds(views: View[], ids = new Set<string>()): Set<string> {
+  for (const view of views) {
+    ids.add(view.view_id);
+    collectOutlineViewIds(view.children ?? [], ids);
+  }
+
+  return ids;
+}
+
+function getOutlineMembershipChange(previousOutline: View[], nextOutline: View[]) {
+  const previousIds = collectOutlineViewIds(previousOutline);
+  const nextIds = collectOutlineViewIds(nextOutline);
+
+  return {
+    addedIds: Array.from(nextIds).filter((viewId) => !previousIds.has(viewId)),
+    removedIds: Array.from(previousIds).filter((viewId) => !nextIds.has(viewId)),
+  };
+}
+
 function createFolderViewFieldsFingerprint(view: View): string {
   return JSON.stringify(
     normalizeRootOutlineForComparison({
@@ -451,6 +500,9 @@ export function useWorkspaceData() {
   const lastAcceptedTrashRefreshRidRef = useRef<FolderRid | null>(null);
   const scheduledTrashRefreshWorkspaceIdRef = useRef<string | null>(null);
   const scheduledTrashRefreshKeyRef = useRef<string | undefined>(undefined);
+  const lastTrashRequestAtRef = useRef(0);
+  const noopFolderTrashRefreshTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const noopFolderTrashRefreshWorkspaceIdRef = useRef<string | null>(null);
   const shareAccessProbeGenerationsRef = useRef(new Map<string, number>());
   const permissionRefreshRevisionRef = useRef(0);
 
@@ -485,6 +537,14 @@ export function useWorkspaceData() {
       prevOutline,
       prevLoadedIds
     );
+
+    // Full-replacement notifications can carry the complete outline even when
+    // nothing changed. Preserve both React and lazy-loading state identities so
+    // those payloads do not rerender the entire sidebar or invalidate expanded
+    // subtree bookkeeping.
+    if (isEqual(prevOutline, mergedOutline)) {
+      return prevOutline;
+    }
 
     stableOutlineRef.current = mergedOutline;
     loadedViewIdsRef.current = nextLoadedIds;
@@ -1303,6 +1363,8 @@ export function useWorkspaceData() {
     async (workspaceId: string, refresh: boolean, freshnessKey?: string | null) => {
       const requestSeq = ++trashRequestSeqRef.current;
 
+      lastTrashRequestAtRef.current = Date.now();
+
       try {
         const res = refresh
           ? await ViewService.refreshTrash(
@@ -1323,6 +1385,8 @@ export function useWorkspaceData() {
         if (requestSeq !== trashRequestSeqRef.current || currentWorkspaceIdRef.current !== workspaceId) {
           return false;
         }
+
+        lastTrashRequestAtRef.current = Date.now();
 
         const nextTrashList = sortBy(uniqBy(res, 'view_id') as unknown as View[], 'last_edited_time').reverse();
         const acceptedTrashList = isEqual(trashListRef.current, nextTrashList)
@@ -1432,6 +1496,54 @@ export function useWorkspaceData() {
     },
     [currentWorkspaceId, requestTrash, trashLoaderInstanceId]
   );
+
+  const scheduleNoopFolderTrashRefresh = useCallback(() => {
+    if (!currentWorkspaceId) return;
+
+    const workspaceId = currentWorkspaceId;
+
+    if (
+      noopFolderTrashRefreshTimerRef.current !== null &&
+      noopFolderTrashRefreshWorkspaceIdRef.current === workspaceId
+    ) {
+      return;
+    }
+
+    if (noopFolderTrashRefreshTimerRef.current !== null) {
+      clearTimeout(noopFolderTrashRefreshTimerRef.current);
+    }
+
+    noopFolderTrashRefreshWorkspaceIdRef.current = workspaceId;
+
+    const runWhenCooldownExpires = () => {
+      if (currentWorkspaceIdRef.current !== workspaceId) {
+        noopFolderTrashRefreshTimerRef.current = null;
+        noopFolderTrashRefreshWorkspaceIdRef.current = null;
+        return;
+      }
+
+      const remainingCooldown = Math.max(
+        0,
+        NOOP_FOLDER_TRASH_REFRESH_COOLDOWN_MS - (Date.now() - lastTrashRequestAtRef.current)
+      );
+
+      if (remainingCooldown > 0) {
+        noopFolderTrashRefreshTimerRef.current = setTimeout(runWhenCooldownExpires, remainingCooldown);
+        return;
+      }
+
+      noopFolderTrashRefreshTimerRef.current = null;
+      noopFolderTrashRefreshWorkspaceIdRef.current = null;
+      refreshTrashListInBackground();
+    };
+
+    const remainingCooldown = Math.max(
+      0,
+      NOOP_FOLDER_TRASH_REFRESH_COOLDOWN_MS - (Date.now() - lastTrashRequestAtRef.current)
+    );
+
+    noopFolderTrashRefreshTimerRef.current = setTimeout(runWhenCooldownExpires, remainingCooldown);
+  }, [currentWorkspaceId, refreshTrashListInBackground]);
 
   const revalidateSidebarOutline = useCallback(
     async (expandedViewIds: string[] = []): Promise<SidebarOutlineRevalidationResult> => {
@@ -1574,6 +1686,8 @@ export function useWorkspaceData() {
     const handleShareViewsChanged = (payload?: { emails?: string[] | null; viewId?: string | null }) => {
       if (!currentWorkspaceId) return;
 
+      ViewService.invalidateDatabaseCatalog?.(currentWorkspaceId);
+
       const changedViewId = payload?.viewId;
       const normalizedCurrentEmail = currentUserEmail?.toLowerCase();
       const affectsCurrentUser =
@@ -1656,6 +1770,8 @@ export function useWorkspaceData() {
 
     const handlePermissionChanged = () => {
       if (!currentWorkspaceId) return;
+
+      ViewService.invalidateDatabaseCatalog?.(currentWorkspaceId);
 
       // AppBusinessLayer handles the same event separately because it owns the
       // active route/modal IDs and can re-probe and purge either rendered view.
@@ -1767,6 +1883,7 @@ export function useWorkspaceData() {
 
       // If no diff JSON provided, fall back to full outline reload
       if (!payload?.outlineDiffJson) {
+        ViewService.invalidateDatabaseCatalog?.(currentWorkspaceId);
         Log.debug('[Outline] [FolderOutlineChanged] No diff JSON, reloading outline');
         refreshTrashListInBackground(payload.folderRid);
         refreshRequestedFavoriteViewsInBackground(currentWorkspaceId);
@@ -1777,9 +1894,9 @@ export function useWorkspaceData() {
       let patch: JsonPatchOperation[] | null = null;
 
       try {
-        Log.debug('[Outline] [FolderOutlineChanged] raw diff json', payload.outlineDiffJson);
         patch = JSON.parse(payload.outlineDiffJson) as JsonPatchOperation[];
       } catch (error) {
+        ViewService.invalidateDatabaseCatalog?.(currentWorkspaceId);
         Log.warn('[Outline] [FolderOutlineChanged] Failed to parse outline diff, reloading outline', error);
         refreshTrashListInBackground(payload.folderRid);
         void loadOutline(currentWorkspaceId, false);
@@ -1787,10 +1904,19 @@ export function useWorkspaceData() {
       }
 
       if (!patch || !Array.isArray(patch)) {
+        ViewService.invalidateDatabaseCatalog?.(currentWorkspaceId);
         refreshTrashListInBackground(payload.folderRid);
         void loadOutline(currentWorkspaceId, false);
         return;
       }
+
+      Log.debug('[Outline] [FolderOutlineChanged] parsed patch', {
+        folderRid: payload.folderRid ?? null,
+        byteLength: payload.outlineDiffJson.length,
+        operationCount: patch.length,
+        operations: patch.slice(0, 10).map(({ op, path }) => ({ op, path })),
+        operationsTruncated: patch.length > 10,
+      });
 
       const patchRid = parseFolderRid(payload.folderRid);
       const currentRid = lastFolderRidRef.current;
@@ -1807,13 +1933,6 @@ export function useWorkspaceData() {
         updateLastFolderRid(patchRid);
         return;
       }
-
-      refreshTrashListInBackground(payload.folderRid);
-      if (folderOutlinePatchMayAffectFavorites(patch)) {
-        refreshRequestedFavoriteViewsInBackground(currentWorkspaceId);
-      }
-
-      Log.debug('[Outline] [FolderOutlineChanged] parsed patch', patch);
 
       const baseOutline = stableOutlineRef.current.filter((view) => !view.extra?.is_hidden_space);
       const baseDocument = { outline: baseOutline };
@@ -1876,8 +1995,41 @@ export function useWorkspaceData() {
 
       const existingShareWithMe = stableOutlineRef.current.find((view) => view.extra?.is_hidden_space);
       const nextOutline = existingShareWithMe ? [...patchedOutline, existingShareWithMe] : patchedOutline;
+      const previousOutline = stableOutlineRef.current;
 
       const mergedOutline = replaceOutlinePreservingChildren(reconcilePendingFolderViewUpdates(nextOutline, patchRid));
+      const { addedIds, removedIds } = getOutlineMembershipChange(previousOutline, mergedOutline);
+
+      if (databaseCatalogMembershipChanged(previousOutline, mergedOutline)) {
+        ViewService.invalidateDatabaseCatalog?.(currentWorkspaceId);
+      }
+
+      if (mergedOutline !== previousOutline && folderOutlinePatchMayAffectFavorites(patch)) {
+        refreshRequestedFavoriteViewsInBackground(currentWorkspaceId);
+      }
+
+      const knownTrashIds = trashListRef.current
+        ? new Set(trashListRef.current.map((view) => view.view_id))
+        : undefined;
+      const mayRestoreKnownTrash =
+        knownTrashIds !== undefined && addedIds.some((viewId) => knownTrashIds.has(viewId));
+      const hasUnknownRestoreEvidence = addedIds.length > 0 && knownTrashIds === undefined;
+
+      if (removedIds.length > 0 || mayRestoreKnownTrash) {
+        // A view leaving the outline may have moved to trash. An added view is
+        // a restore only when it was previously known to be in trash; while the
+        // initial trash read is pending, refresh conservatively.
+        refreshTrashListInBackground(payload.folderRid);
+      } else if (hasUnknownRestoreEvidence || (!payload.folderRid && mergedOutline === previousOutline)) {
+        // Direct permanent-delete operations and unrelated PG-first writes both
+        // arrive as an indistinguishable no-RID, no-op full-outline replacement.
+        // An added view is similarly ambiguous while the initial trash read is
+        // unavailable. Keep these cases eventually correct, but cap the fallback
+        // at one request per 30 seconds. The workspace mount request starts the
+        // cooldown, preventing row registration bursts from producing one
+        // /trash request per notification.
+        scheduleNoopFolderTrashRefresh();
+      }
 
       if (usedRelaxedPatch) {
         updateLastFolderRid(patchRid);
@@ -1885,7 +2037,7 @@ export function useWorkspaceData() {
         updateAppliedRootOutlineSnapshot(patchRid, nextOutline);
       }
 
-      if (eventEmitter) {
+      if (eventEmitter && mergedOutline !== previousOutline) {
         eventEmitter.emit(APP_EVENTS.OUTLINE_LOADED, mergedOutline || []);
       }
     };
@@ -1907,6 +2059,7 @@ export function useWorkspaceData() {
     refreshTrashListInBackground,
     reconcilePendingFolderViewUpdates,
     replaceOutlinePreservingChildren,
+    scheduleNoopFolderTrashRefresh,
     stableOutlineRef,
     updateAppliedRootOutlineSnapshot,
     updateLastFolderRid,
@@ -1943,6 +2096,8 @@ export function useWorkspaceData() {
       const changeType = payload.changeType ?? 0;
       let nextOutline = stableOutlineRef.current;
       let shouldRefreshTrash = false;
+      let shouldScheduleNoopTrashRefresh = false;
+      let shouldInvalidateDatabaseCatalog = false;
 
       switch (changeType) {
         case FOLDER_VIEW_CHANGE_TYPE.VIEW_FIELDS_CHANGED: {
@@ -1950,6 +2105,11 @@ export function useWorkspaceData() {
           try {
             const updatedView = JSON.parse(payload.viewJson) as View;
             const previousView = findView(nextOutline, updatedView.view_id);
+
+            shouldInvalidateDatabaseCatalog =
+              isDatabaseCatalogView(previousView) !== isDatabaseCatalogView(updatedView) ||
+              previousView?.extra?.database_id !== updatedView.extra?.database_id ||
+              previousView?.extra?.is_database_container !== updatedView.extra?.is_database_container;
 
             if (previousView) {
               pendingFolderViewUpdatesRef.current.set(updatedView.view_id, {
@@ -1973,16 +2133,33 @@ export function useWorkspaceData() {
         }
 
         case FOLDER_VIEW_CHANGE_TYPE.VIEW_ADDED: {
-          shouldRefreshTrash = true;
+          if (!payload.viewJson || !payload.parentViewId) {
+            shouldScheduleNoopTrashRefresh = true;
+            break;
+          }
 
-          if (!payload.viewJson || !payload.parentViewId) break;
           try {
             const newView = JSON.parse(payload.viewJson) as View;
 
+            // VIEW_ADDED is used for both new pages/row-document registrations
+            // and restores. A known trash ID is definite restore evidence and
+            // refreshes immediately. If the initial trash request failed, the
+            // evidence is unknown; use the bounded retry lane so a burst of row
+            // registrations cannot retry /trash once per notification.
+            shouldRefreshTrash = Boolean(
+              trashListRef.current?.some((trashView) => trashView.view_id === newView.view_id)
+            );
+            shouldScheduleNoopTrashRefresh = trashListRef.current === undefined;
+
             // addViewToOutline already sets has_children: true on the parent
             nextOutline = addViewToOutline(nextOutline, payload.parentViewId, newView);
+            // A real database may be added below a parent whose children have
+            // not been loaded yet. Its parsed metadata is still authoritative
+            // catalog evidence even when the outline insertion is a no-op.
+            shouldInvalidateDatabaseCatalog = isDatabaseCatalogView(newView);
           } catch (error) {
             Log.warn('[Outline] [FolderViewChanged] Failed to parse view_json for view added', error);
+            scheduleNoopFolderTrashRefresh();
             void loadOutline(currentWorkspaceId, false);
             return;
           }
@@ -1991,20 +2168,40 @@ export function useWorkspaceData() {
         }
 
         case FOLDER_VIEW_CHANGE_TYPE.VIEW_REMOVED: {
-          shouldRefreshTrash = true;
-
           const parentId = payload.viewId;
           const childIds = payload.childViewIds ?? [];
+          const knownTrashIds = trashListRef.current
+            ? new Set(trashListRef.current.map((view) => view.view_id))
+            : undefined;
 
           if (parentId) {
+            const previousParent = findView(nextOutline, parentId);
+            const remainingChildIds = new Set(childIds);
+            const visiblyRemovedChildren =
+              previousParent?.children.filter((child) => !remainingChildIds.has(child.view_id)) ?? [];
+
+            shouldInvalidateDatabaseCatalog = Boolean(
+              visiblyRemovedChildren.some((child) => collectDatabaseCatalogViewIds([child]).size > 0)
+            );
+            const hasSemanticTrashEvidence =
+              visiblyRemovedChildren.length > 0 ||
+              Boolean(
+                knownTrashIds?.has(parentId) || childIds.some((childId) => knownTrashIds?.has(childId))
+              );
+
+            // A revisioned no-op can still be a remote permanent delete: the
+            // protocol sends remaining children and omits the deleted ID. The
+            // RID gives the request coordinator a safe deduplication key.
+            shouldRefreshTrash = hasSemanticTrashEvidence || Boolean(payload.folderRid);
+            shouldScheduleNoopTrashRefresh = !hasSemanticTrashEvidence && !payload.folderRid;
             nextOutline = removeViewFromOutline(nextOutline, parentId, childIds);
 
             // Clean removed children (and their subtrees) from loadedViewIdsRef
             // so that preserveLoadedChildren won't re-graft them on the next
             // FOLDER_OUTLINE_CHANGED shallow refresh.
-            for (const childId of childIds) {
-              loadedViewIdsRef.current.delete(childId);
-              pendingFolderViewUpdatesRef.current.delete(childId);
+            for (const removedChild of visiblyRemovedChildren) {
+              loadedViewIdsRef.current.delete(removedChild.view_id);
+              pendingFolderViewUpdatesRef.current.delete(removedChild.view_id);
             }
 
             // If the parent has no remaining children, remove it from loaded IDs
@@ -2014,6 +2211,8 @@ export function useWorkspaceData() {
             if (parentView && (!parentView.children || parentView.children.length === 0)) {
               loadedViewIdsRef.current.delete(parentId);
             }
+          } else {
+            shouldScheduleNoopTrashRefresh = !payload.folderRid;
           }
 
           break;
@@ -2041,6 +2240,17 @@ export function useWorkspaceData() {
 
       if (shouldRefreshTrash) {
         refreshTrashListInBackground(payload.folderRid);
+      } else if (shouldScheduleNoopTrashRefresh) {
+        // The granular payload carries the parent's remaining children, not the
+        // removed ID. Once the visible outline already reflects the removal, a
+        // duplicate no-RID frame is indistinguishable from legacy trash/purge
+        // notification traffic. Share the same bounded fallback as no-op full
+        // replacements instead of issuing one request per duplicate frame.
+        scheduleNoopFolderTrashRefresh();
+      }
+
+      if (shouldInvalidateDatabaseCatalog) {
+        ViewService.invalidateDatabaseCatalog?.(currentWorkspaceId);
       }
 
       if (folderRid) {
@@ -2075,6 +2285,7 @@ export function useWorkspaceData() {
     loadOutline,
     refreshRequestedFavoriteViewsInBackground,
     refreshTrashListInBackground,
+    scheduleNoopFolderTrashRefresh,
     stableOutlineRef,
     updateLastFolderRid,
   ]);
@@ -2244,6 +2455,13 @@ export function useWorkspaceData() {
   // Load data when workspace changes
   useEffect(() => {
     if (!currentWorkspaceId) return;
+    if (noopFolderTrashRefreshTimerRef.current !== null) {
+      clearTimeout(noopFolderTrashRefreshTimerRef.current);
+      noopFolderTrashRefreshTimerRef.current = null;
+    }
+
+    noopFolderTrashRefreshWorkspaceIdRef.current = null;
+    lastTrashRequestAtRef.current = 0;
     trashRequestSeqRef.current += 1;
     lastTrashRefreshRidRef.current = null;
     lastAcceptedTrashRefreshRidRef.current = null;
@@ -2278,6 +2496,12 @@ export function useWorkspaceData() {
     workspaceDatabasesRef.current = undefined;
     setWorkspaceDatabases(undefined);
     void loadOutline(currentWorkspaceId, true);
+    // Warm the shared user/workspace database catalog once. Relation cells,
+    // property menus, and linked-database pickers all reuse this same snapshot
+    // instead of independently requesting the workspace-wide list.
+    void ViewService.getDatabaseCatalog?.(currentWorkspaceId).catch((error) => {
+      Log.warn('[WorkspaceDatabaseCatalog] failed to warm the workspace catalog', error);
+    });
     void (async () => {
       try {
         // Always revalidate on workspace mount. The unkeyed refresh shares a
@@ -2288,6 +2512,15 @@ export function useWorkspaceData() {
         console.error(e);
       }
     })();
+
+    return () => {
+      if (noopFolderTrashRefreshTimerRef.current !== null) {
+        clearTimeout(noopFolderTrashRefreshTimerRef.current);
+        noopFolderTrashRefreshTimerRef.current = null;
+      }
+
+      noopFolderTrashRefreshWorkspaceIdRef.current = null;
+    };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [currentWorkspaceId]);
 

--- a/src/components/app/hooks/useWorkspaceData.ts
+++ b/src/components/app/hooks/useWorkspaceData.ts
@@ -83,25 +83,64 @@ function isDatabaseCatalogView(view: View | null | undefined): boolean {
   );
 }
 
-function collectDatabaseCatalogViewIds(views: View[]): Set<string> {
-  const ids = new Set<string>();
+interface DatabaseCatalogViewMetadata {
+  databaseId?: string;
+  embedded?: boolean;
+  icon: View['icon'];
+  isContainer?: boolean;
+  layout: ViewLayout;
+  name: string;
+  parentViewId?: string;
+}
+
+function getDatabaseCatalogViewMetadata(view: View | null | undefined): DatabaseCatalogViewMetadata | null {
+  if (!isDatabaseCatalogView(view)) return null;
+
+  return {
+    databaseId: view?.extra?.database_id,
+    embedded: view?.extra?.embedded,
+    icon: view?.icon ?? null,
+    isContainer: view?.extra?.is_database_container,
+    layout: view?.layout ?? ViewLayout.Document,
+    name: view?.name ?? '',
+    parentViewId: view?.parent_view_id,
+  };
+}
+
+function collectDatabaseCatalogViews(views: View[]): Map<string, DatabaseCatalogViewMetadata> {
+  const entries = new Map<string, DatabaseCatalogViewMetadata>();
 
   const walk = (items: View[]) => {
     for (const view of items) {
-      if (isDatabaseCatalogView(view)) ids.add(view.view_id);
+      const metadata = getDatabaseCatalogViewMetadata(view);
+
+      if (metadata) entries.set(view.view_id, metadata);
+
       if (view.children?.length) walk(view.children);
     }
   };
 
   walk(views);
-  return ids;
+  return entries;
 }
 
-function databaseCatalogMembershipChanged(previous: View[], next: View[]): boolean {
-  const previousIds = collectDatabaseCatalogViewIds(previous);
-  const nextIds = collectDatabaseCatalogViewIds(next);
+function databaseCatalogChanged(previous: View[], next: View[]): boolean {
+  const previousViews = collectDatabaseCatalogViews(previous);
+  const nextViews = collectDatabaseCatalogViews(next);
 
-  return previousIds.size !== nextIds.size || Array.from(previousIds).some((viewId) => !nextIds.has(viewId));
+  if (previousViews.size !== nextViews.size) return true;
+
+  for (const [viewId, previousMetadata] of previousViews) {
+    if (!isEqual(previousMetadata, nextViews.get(viewId))) return true;
+  }
+
+  return false;
+}
+
+function isOutlineSubtreeComplete(view: View, loadedViewIds: Set<string>): boolean {
+  if (view.has_children === true && !loadedViewIds.has(view.view_id)) return false;
+
+  return (view.children ?? []).every((child) => isOutlineSubtreeComplete(child, loadedViewIds));
 }
 
 function collectViewPath(root: View, targetViewId: string): View[] | null {
@@ -323,6 +362,15 @@ const ACCESS_REVOKED_PROBE_ERROR_CODES = new Set<number>([
 const PERMISSION_SUBTREE_REHYDRATE_MAX_ATTEMPTS = 2;
 const NOOP_FOLDER_TRASH_REFRESH_COOLDOWN_MS = 30_000;
 
+interface NoopFolderTrashRefreshBurst {
+  firstNotificationAt: number;
+  lastNotificationAt: number;
+  maxLatencyProbeCompleted: boolean;
+  maxLatencyProbeCoveredSeq: number;
+  notificationSeq: number;
+  workspaceId: string;
+}
+
 function getRefreshErrorCode(error: unknown): number | undefined {
   if (typeof error !== 'object' || error === null) return undefined;
 
@@ -503,6 +551,7 @@ export function useWorkspaceData() {
   const lastTrashRequestAtRef = useRef(0);
   const noopFolderTrashRefreshTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const noopFolderTrashRefreshWorkspaceIdRef = useRef<string | null>(null);
+  const noopFolderTrashRefreshBurstRef = useRef<NoopFolderTrashRefreshBurst | null>(null);
   const shareAccessProbeGenerationsRef = useRef(new Map<string, number>());
   const permissionRefreshRevisionRef = useRef(0);
 
@@ -1501,13 +1550,23 @@ export function useWorkspaceData() {
     if (!currentWorkspaceId) return;
 
     const workspaceId = currentWorkspaceId;
+    const now = Date.now();
+    const existingBurst = noopFolderTrashRefreshBurstRef.current;
+    const burst =
+      existingBurst?.workspaceId === workspaceId
+        ? existingBurst
+        : {
+            firstNotificationAt: now,
+            lastNotificationAt: now,
+            maxLatencyProbeCompleted: false,
+            maxLatencyProbeCoveredSeq: 0,
+            notificationSeq: 0,
+            workspaceId,
+          };
 
-    if (
-      noopFolderTrashRefreshTimerRef.current !== null &&
-      noopFolderTrashRefreshWorkspaceIdRef.current === workspaceId
-    ) {
-      return;
-    }
+    burst.lastNotificationAt = now;
+    burst.notificationSeq += 1;
+    noopFolderTrashRefreshBurstRef.current = burst;
 
     if (noopFolderTrashRefreshTimerRef.current !== null) {
       clearTimeout(noopFolderTrashRefreshTimerRef.current);
@@ -1515,34 +1574,92 @@ export function useWorkspaceData() {
 
     noopFolderTrashRefreshWorkspaceIdRef.current = workspaceId;
 
-    const runWhenCooldownExpires = () => {
-      if (currentWorkspaceIdRef.current !== workspaceId) {
+    const clearBurst = () => {
+      if (noopFolderTrashRefreshBurstRef.current?.workspaceId === workspaceId) {
+        noopFolderTrashRefreshBurstRef.current = null;
+      }
+
+      if (noopFolderTrashRefreshWorkspaceIdRef.current === workspaceId) {
         noopFolderTrashRefreshTimerRef.current = null;
         noopFolderTrashRefreshWorkspaceIdRef.current = null;
-        return;
       }
-
-      const remainingCooldown = Math.max(
-        0,
-        NOOP_FOLDER_TRASH_REFRESH_COOLDOWN_MS - (Date.now() - lastTrashRequestAtRef.current)
-      );
-
-      if (remainingCooldown > 0) {
-        noopFolderTrashRefreshTimerRef.current = setTimeout(runWhenCooldownExpires, remainingCooldown);
-        return;
-      }
-
-      noopFolderTrashRefreshTimerRef.current = null;
-      noopFolderTrashRefreshWorkspaceIdRef.current = null;
-      refreshTrashListInBackground();
     };
 
-    const remainingCooldown = Math.max(
-      0,
-      NOOP_FOLDER_TRASH_REFRESH_COOLDOWN_MS - (Date.now() - lastTrashRequestAtRef.current)
-    );
+    const runWhenReady = () => {
+      const activeBurst = noopFolderTrashRefreshBurstRef.current;
 
-    noopFolderTrashRefreshTimerRef.current = setTimeout(runWhenCooldownExpires, remainingCooldown);
+      if (currentWorkspaceIdRef.current !== workspaceId || activeBurst?.workspaceId !== workspaceId) {
+        clearBurst();
+        return;
+      }
+
+      const now = Date.now();
+
+      const remainingRequestCooldown = Math.max(
+        0,
+        NOOP_FOLDER_TRASH_REFRESH_COOLDOWN_MS - (now - lastTrashRequestAtRef.current)
+      );
+      const remainingQuietPeriod = Math.max(
+        0,
+        NOOP_FOLDER_TRASH_REFRESH_COOLDOWN_MS - (now - activeBurst.lastNotificationAt)
+      );
+      const remainingMaxLatency = activeBurst.maxLatencyProbeCompleted
+        ? Number.POSITIVE_INFINITY
+        : Math.max(0, NOOP_FOLDER_TRASH_REFRESH_COOLDOWN_MS - (now - activeBurst.firstNotificationAt));
+      const remainingPhaseDelay = activeBurst.maxLatencyProbeCompleted
+        ? remainingQuietPeriod
+        : Math.min(remainingQuietPeriod, remainingMaxLatency);
+      const remainingDelay = Math.max(remainingRequestCooldown, remainingPhaseDelay);
+
+      if (remainingDelay > 0) {
+        noopFolderTrashRefreshTimerRef.current = setTimeout(runWhenReady, remainingDelay);
+        return;
+      }
+
+      if (!activeBurst.maxLatencyProbeCompleted) {
+        // One bounded probe prevents a real permanent delete at the start of a
+        // long noisy burst from remaining stale forever. Further notifications
+        // only move the trailing quiet-period check; they never create polling.
+        activeBurst.maxLatencyProbeCompleted = true;
+        activeBurst.maxLatencyProbeCoveredSeq = activeBurst.notificationSeq;
+        refreshTrashListInBackground();
+
+        const postProbeQuietPeriod = Math.max(
+          0,
+          NOOP_FOLDER_TRASH_REFRESH_COOLDOWN_MS - (Date.now() - activeBurst.lastNotificationAt)
+        );
+
+        if (postProbeQuietPeriod > 0) {
+          noopFolderTrashRefreshTimerRef.current = setTimeout(runWhenReady, postProbeQuietPeriod);
+        } else {
+          clearBurst();
+        }
+
+        return;
+      }
+
+      const shouldRunTrailingProbe = activeBurst.notificationSeq > activeBurst.maxLatencyProbeCoveredSeq;
+
+      clearBurst();
+      if (shouldRunTrailingProbe) refreshTrashListInBackground();
+    };
+
+    const remainingRequestCooldown = Math.max(
+      0,
+      NOOP_FOLDER_TRASH_REFRESH_COOLDOWN_MS - (now - lastTrashRequestAtRef.current)
+    );
+    const remainingQuietPeriod = NOOP_FOLDER_TRASH_REFRESH_COOLDOWN_MS;
+    const remainingMaxLatency = burst.maxLatencyProbeCompleted
+      ? Number.POSITIVE_INFINITY
+      : Math.max(0, NOOP_FOLDER_TRASH_REFRESH_COOLDOWN_MS - (now - burst.firstNotificationAt));
+    const remainingPhaseDelay = burst.maxLatencyProbeCompleted
+      ? remainingQuietPeriod
+      : Math.min(remainingQuietPeriod, remainingMaxLatency);
+
+    noopFolderTrashRefreshTimerRef.current = setTimeout(
+      runWhenReady,
+      Math.max(remainingRequestCooldown, remainingPhaseDelay)
+    );
   }, [currentWorkspaceId, refreshTrashListInBackground]);
 
   const revalidateSidebarOutline = useCallback(
@@ -2000,7 +2117,7 @@ export function useWorkspaceData() {
       const mergedOutline = replaceOutlinePreservingChildren(reconcilePendingFolderViewUpdates(nextOutline, patchRid));
       const { addedIds, removedIds } = getOutlineMembershipChange(previousOutline, mergedOutline);
 
-      if (databaseCatalogMembershipChanged(previousOutline, mergedOutline)) {
+      if (databaseCatalogChanged(previousOutline, mergedOutline)) {
         ViewService.invalidateDatabaseCatalog?.(currentWorkspaceId);
       }
 
@@ -2024,10 +2141,9 @@ export function useWorkspaceData() {
         // Direct permanent-delete operations and unrelated PG-first writes both
         // arrive as an indistinguishable no-RID, no-op full-outline replacement.
         // An added view is similarly ambiguous while the initial trash read is
-        // unavailable. Keep these cases eventually correct, but cap the fallback
-        // at one request per 30 seconds. The workspace mount request starts the
-        // cooldown, preventing row registration bursts from producing one
-        // /trash request per notification.
+        // unavailable. Keep these cases eventually correct with one bounded
+        // max-latency probe and, when needed, one trailing quiet-period probe.
+        // Continuous row registration noise therefore never becomes polling.
         scheduleNoopFolderTrashRefresh();
       }
 
@@ -2106,10 +2222,13 @@ export function useWorkspaceData() {
             const updatedView = JSON.parse(payload.viewJson) as View;
             const previousView = findView(nextOutline, updatedView.view_id);
 
-            shouldInvalidateDatabaseCatalog =
-              isDatabaseCatalogView(previousView) !== isDatabaseCatalogView(updatedView) ||
-              previousView?.extra?.database_id !== updatedView.extra?.database_id ||
-              previousView?.extra?.is_database_container !== updatedView.extra?.is_database_container;
+            // Compare only fields represented by WorkspaceDatabaseViewItem.
+            // Favorite, publish, lock, and timestamp notifications must not
+            // evict the global catalog and trigger a later offset request.
+            shouldInvalidateDatabaseCatalog = !isEqual(
+              getDatabaseCatalogViewMetadata(previousView),
+              getDatabaseCatalogViewMetadata(updatedView)
+            );
 
             if (previousView) {
               pendingFolderViewUpdatesRef.current.set(updatedView.view_id, {
@@ -2174,15 +2293,34 @@ export function useWorkspaceData() {
             ? new Set(trashListRef.current.map((view) => view.view_id))
             : undefined;
 
+          // The payload contains the remaining children, not the removed ID.
+          // Invalidate even when the parent itself is absent from a lazy local
+          // outline. This is memory-only; the next catalog consumer performs
+          // the single shared refresh.
+          shouldInvalidateDatabaseCatalog = true;
+
           if (parentId) {
             const previousParent = findView(nextOutline, parentId);
             const remainingChildIds = new Set(childIds);
             const visiblyRemovedChildren =
               previousParent?.children.filter((child) => !remainingChildIds.has(child.view_id)) ?? [];
 
-            shouldInvalidateDatabaseCatalog = Boolean(
-              visiblyRemovedChildren.some((child) => collectDatabaseCatalogViewIds([child]).size > 0)
-            );
+            if (visiblyRemovedChildren.length > 0) {
+              // A visible removed subtree gives us enough metadata to avoid
+              // evicting the database catalog for complete document-only
+              // subtrees. A visible document may still hide lazy descendants,
+              // so preserve the conservative default until every removed
+              // branch is known complete.
+              const containsDatabase = visiblyRemovedChildren.some(
+                (child) => collectDatabaseCatalogViews([child]).size > 0
+              );
+              const removedSubtreesAreComplete = visiblyRemovedChildren.every((child) =>
+                isOutlineSubtreeComplete(child, loadedViewIdsRef.current)
+              );
+
+              shouldInvalidateDatabaseCatalog = containsDatabase || !removedSubtreesAreComplete;
+            }
+
             const hasSemanticTrashEvidence =
               visiblyRemovedChildren.length > 0 ||
               Boolean(
@@ -2244,8 +2382,8 @@ export function useWorkspaceData() {
         // The granular payload carries the parent's remaining children, not the
         // removed ID. Once the visible outline already reflects the removal, a
         // duplicate no-RID frame is indistinguishable from legacy trash/purge
-        // notification traffic. Share the same bounded fallback as no-op full
-        // replacements instead of issuing one request per duplicate frame.
+        // notification traffic. Share the same bounded burst fallback as no-op
+        // full replacements instead of issuing periodic requests.
         scheduleNoopFolderTrashRefresh();
       }
 
@@ -2461,6 +2599,7 @@ export function useWorkspaceData() {
     }
 
     noopFolderTrashRefreshWorkspaceIdRef.current = null;
+    noopFolderTrashRefreshBurstRef.current = null;
     lastTrashRequestAtRef.current = 0;
     trashRequestSeqRef.current += 1;
     lastTrashRefreshRidRef.current = null;
@@ -2520,6 +2659,7 @@ export function useWorkspaceData() {
       }
 
       noopFolderTrashRefreshWorkspaceIdRef.current = null;
+      noopFolderTrashRefreshBurstRef.current = null;
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [currentWorkspaceId]);

--- a/src/components/app/layers/AppBusinessLayer.tsx
+++ b/src/components/app/layers/AppBusinessLayer.tsx
@@ -243,6 +243,7 @@ export const AppBusinessLayer: FC<AppBusinessLayerProps> = ({ children }) => {
     syncAllToServer: syncContext.syncAllToServer,
     loadViewChildren,
     getDatabaseIdForViewId,
+    loadTrash,
   });
 
   // Check if current view has been deleted
@@ -756,13 +757,10 @@ export const AppBusinessLayer: FC<AppBusinessLayerProps> = ({ children }) => {
     [loadView, stableOutlineRef]
   );
 
-  // Enhanced deletePage with loadTrash
-  const enhancedDeletePage = useCallback(
-    async (viewId: string) => {
-      return rawDeletePage(viewId, loadTrash);
-    },
-    [rawDeletePage, loadTrash]
-  );
+  // usePageOperations owns the post-mutation trash refresh, so no wrapper is
+  // needed here. Keeping the original callback also avoids an extra promise
+  // and callback layer for every consumer.
+  const enhancedDeletePage = rawDeletePage;
 
   // Initialize database operations
   const {

--- a/src/components/database/Database.tsx
+++ b/src/components/database/Database.tsx
@@ -952,15 +952,25 @@ function Database(props: Database2Props) {
 
       const [rowKeyDatabaseId, rowId] = rowKey.split('_rows_');
       const currentDatabaseId = getDatabaseId();
+      const belongsToCurrentDatabase = rowKeyDatabaseId === currentDatabaseId;
 
-      const rowDoc = await createRow(rowKey);
+      // Database owns one sync registration per row key for its whole
+      // lifecycle. Relation, rollup, picker, and modal callers all share it,
+      // and the lifecycle cleanup releases it even if registration settles
+      // after unmount.
+      const rowDoc = await registerRowSync(rowKey);
+
+      if (!rowDoc) {
+        throw new Error('Failed to create row doc');
+      }
 
       // The row exists on the server either way, so still hand it back to the
-      // caller — only the local state writes belong to the old lifecycle.
+      // caller. Local state writes require both the active lifecycle and this
+      // database's ownership below.
       if (!isCurrentCreate()) return rowDoc;
 
       // Add the new row doc to rowMap so grouping logic can see it immediately
-      if (rowId && rowDoc) {
+      if (belongsToCurrentDatabase && rowId && rowDoc) {
         markLocallyCreatedRow(rowId);
         setRowMap((prev) => {
           if (prev[rowId]) return prev;
@@ -968,14 +978,14 @@ function Database(props: Database2Props) {
         });
       }
 
-      if (rowKeyDatabaseId && rowKeyDatabaseId === currentDatabaseId && !localCachePrimedRef.current) {
+      if (belongsToCurrentDatabase && !localCachePrimedRef.current) {
         localCachePrimedRef.current = true;
         void ensureBlobPrefetch();
       }
 
       return rowDoc;
     },
-    [createRow, databaseLifecycleIdentity, getDatabaseId, ensureBlobPrefetch, markLocallyCreatedRow]
+    [createRow, databaseLifecycleIdentity, getDatabaseId, ensureBlobPrefetch, markLocallyCreatedRow, registerRowSync]
   );
 
   // Self-healing for a lying delta watermark: the RID cursor lives in

--- a/src/components/database/__tests__/Database.prefetch-lifecycle.test.tsx
+++ b/src/components/database/__tests__/Database.prefetch-lifecycle.test.tsx
@@ -5,12 +5,14 @@ import * as Y from 'yjs';
 
 import { APP_EVENTS } from '@/application/constants';
 import { peekDatabaseRowDocSeed, prefetchDatabaseBlobDiff } from '@/application/database-blob';
+import type { DatabaseContextState } from '@/application/database-yjs';
 import { getCachedRowDoc, openRowDoc } from '@/application/services/js-services/cache';
 import { DatabaseViewLayout, UIVariant, YDoc, YjsDatabaseKey, YjsEditorKey } from '@/application/types';
 import Database, { Database2Props } from '@/components/database/Database';
 
 const mockSeedLoadPromises: Array<Promise<YDoc | undefined>> = [];
 const mockEnsureRowPromises: Array<Promise<YDoc | undefined> | void> = [];
+let mockDatabaseContext: DatabaseContextState | undefined;
 let mockLoadSeedOnLifecycleChange = false;
 
 jest.mock('@/application/database-blob', () => ({
@@ -59,7 +61,10 @@ jest.mock('@/components/database/DatabaseViews', () => {
   );
 
   return function MockDatabaseViews() {
-    const { bindRowSync, ensureRow, loadRowFromSeed, navigateToRow, rowMap } = useDatabaseContext();
+    const databaseContext = useDatabaseContext();
+    const { bindRowSync, ensureRow, loadRowFromSeed, navigateToRow, rowMap } = databaseContext;
+
+    mockDatabaseContext = databaseContext;
     const initialLoadRowFromSeed = React.useRef(loadRowFromSeed).current;
     const previousLoadRowFromSeed = React.useRef(loadRowFromSeed);
 
@@ -316,6 +321,7 @@ describe('Database blob prefetch lifecycle', () => {
     jest.clearAllMocks();
     mockSeedLoadPromises.length = 0;
     mockEnsureRowPromises.length = 0;
+    mockDatabaseContext = undefined;
     mockLoadSeedOnLifecycleChange = false;
     mockedPeekSeed.mockReset();
     mockedGetCachedRowDoc.mockReset();
@@ -348,6 +354,51 @@ describe('Database blob prefetch lifecycle', () => {
 
     unmount();
     doc.destroy();
+  });
+
+  it('keeps related-database rows out of the current row map and local mutation store', async () => {
+    const doc = createDatabaseDoc('database-id');
+    const relatedRowDoc = createHydratedRowDoc('related-row-doc');
+    const currentRowDoc = createHydratedRowDoc('current-row-doc');
+    const createRow = jest.fn(async (rowKey: string) =>
+      rowKey === 'database-b_rows_row-id' ? relatedRowDoc : currentRowDoc
+    );
+    const scheduleDeferredCleanup = jest.fn();
+    const { unmount } = render(
+      <Database
+        {...databaseProps(doc)}
+        createRow={createRow}
+        scheduleDeferredCleanup={scheduleDeferredCleanup}
+      />
+    );
+
+    try {
+      if (!mockDatabaseContext?.createRow) throw new Error('Database context did not expose createRow');
+
+      await act(async () => {
+        await mockDatabaseContext?.createRow?.('database-b_rows_row-id');
+      });
+
+      expect(createRow).toHaveBeenCalledWith('database-b_rows_row-id');
+      expect(mockDatabaseContext.rowMap?.['row-id']).toBeUndefined();
+      expect(mockDatabaseContext.hasCellLocalMutation?.('row-id', 'field-id')).toBe(false);
+
+      await act(async () => {
+        await mockDatabaseContext?.createRow?.('database-id_rows_row-id');
+      });
+
+      expect(createRow).toHaveBeenCalledWith('database-id_rows_row-id');
+      expect(mockDatabaseContext.rowMap?.['row-id']).toBe(currentRowDoc);
+      expect(mockDatabaseContext.hasCellLocalMutation?.('row-id', 'field-id')).toBe(true);
+    } finally {
+      unmount();
+      expect(scheduleDeferredCleanup).toHaveBeenCalledTimes(2);
+      expect(scheduleDeferredCleanup).toHaveBeenNthCalledWith(1, 'row-id');
+      expect(scheduleDeferredCleanup).toHaveBeenNthCalledWith(2, 'row-id');
+      doc.destroy();
+      relatedRowDoc.destroy();
+      currentRowDoc.destroy();
+    }
   });
 
   it('sequentially rebinds a visible remote row after its initial registration settles', async () => {

--- a/src/components/database/components/cell/relation/RelationCellMenu.tsx
+++ b/src/components/database/components/cell/relation/RelationCellMenu.tsx
@@ -52,7 +52,7 @@ function RelationCellMenu ({
     onUpdateDatabaseId,
     views,
     relatedDatabaseId,
-  } = useRelationData(fieldId, { enabled: hookEnabled });
+  } = useRelationData(fieldId, { enabled: hookEnabled, refreshCatalog: hookEnabled });
 
   const updateRelationCell = useUpdateRelationCell(rowId, fieldId);
 

--- a/src/components/database/components/cell/relation/RelationCellMenu.tsx
+++ b/src/components/database/components/cell/relation/RelationCellMenu.tsx
@@ -52,7 +52,7 @@ function RelationCellMenu ({
     onUpdateDatabaseId,
     views,
     relatedDatabaseId,
-  } = useRelationData(fieldId, { enabled: hookEnabled, refreshCatalog: hookEnabled });
+  } = useRelationData(fieldId, { enabled: hookEnabled });
 
   const updateRelationCell = useUpdateRelationCell(rowId, fieldId);
 

--- a/src/components/database/components/cell/relation/RelationCellMenuContent.tsx
+++ b/src/components/database/components/cell/relation/RelationCellMenuContent.tsx
@@ -12,7 +12,10 @@ import { ReactComponent as AddIcon } from '@/assets/icons/add_new_page.svg';
 import { ReactComponent as MinusIcon } from '@/assets/icons/minus.svg';
 import { ReactComponent as PlusIcon } from '@/assets/icons/plus.svg';
 import RelationRowItem from '@/components/database/components/cell/relation/RelationRowItem';
-import { getLiveRelationRowIds } from '@/components/database/components/cell/relation/relationRowOrders';
+import {
+  getLiveRelationRowIds,
+  getRelationRowOrders,
+} from '@/components/database/components/cell/relation/relationRowOrders';
 import { useNavigationKey } from '@/components/database/components/cell/relation/useNavigationKey';
 import { useCurrentUserOptional } from '@/components/main/app.hooks';
 import { Button } from '@/components/ui/button';
@@ -24,6 +27,7 @@ import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/comp
 import { cn } from '@/lib/utils';
 
 const recentRelationRowsByView = new Map<string, string[]>();
+const ROW_LOAD_CONCURRENCY = 8;
 
 function rememberRecentRelationRow(viewId: string | undefined, rowId: string) {
   if (!viewId) return;
@@ -54,43 +58,7 @@ function sortByRecentRows(rowIds: string[], viewId: string | undefined) {
   });
 }
 
-/**
- * The row list for the picker.
- *
- * Rows belong to the database, not to one of its views, so any view's `row_orders` names the same
- * set. The selected view is not always one of the registered inner views either — a relation can
- * point at the database's container page — and keying strictly off it left the picker rendering an
- * empty panel with no explanation.
- */
-function getRelationRowOrders(database: YDatabase, viewId: string) {
-  const views = database.get(YjsDatabaseKey.views);
-
-  if (!views) return null;
-
-  const named = views.get(viewId)?.get(YjsDatabaseKey.row_orders);
-
-  if (named) return named;
-
-  // `keys()`, not `Object.keys(views.toJSON())`: this runs on every change to the target database
-  // doc, and `toJSON` would deep-clone every view's row and field orders just to read the ids.
-  for (const id of views.keys()) {
-    const rowOrders = views.get(id)?.get(YjsDatabaseKey.row_orders);
-
-    if (rowOrders) return rowOrders;
-  }
-
-  return null;
-}
-
-function RelationCellMenuContent({
-  relationRowIds,
-  selectedView,
-  relatedDatabaseId,
-  onAddRelationRowId,
-  onRemoveRelationRowId,
-  loading,
-  onClose,
-}: {
+interface RelationCellMenuContentProps {
   loading?: boolean;
   relationRowIds?: string[];
   selectedView?: View;
@@ -98,7 +66,17 @@ function RelationCellMenuContent({
   onRemoveRelationRowId: (rowId: string) => void;
   relatedDatabaseId: string;
   onClose?: () => void;
-}) {
+}
+
+function RelationCellMenuContentForTarget({
+  relationRowIds,
+  selectedView,
+  relatedDatabaseId,
+  onAddRelationRowId,
+  onRemoveRelationRowId,
+  loading,
+  onClose,
+}: RelationCellMenuContentProps) {
   const { t } = useTranslation();
   const currentUser = useCurrentUserOptional();
   const actorUid = resolveUserAttributionUid(currentUser);
@@ -154,11 +132,20 @@ function RelationCellMenuContent({
   });
 
   useEffect(() => {
+    const rowDocs = rowDocsRef.current;
+
     // Switching target database starts the wait over — the previous database's rows say nothing
     // about this one.
     setRowIdsLoaded(false);
     setTargetDoc(null);
+    setGuid(null);
+    setPrimaryFieldId(null);
+    setPrimaryField(null);
+    setNoAccess(false);
+    setRowIds([]);
+    setRowContents(new Map());
     targetDocRef.current = null;
+    rowDocs.clear();
 
     let cancelled = false;
 
@@ -192,6 +179,7 @@ function RelationCellMenuContent({
 
     return () => {
       cancelled = true;
+      rowDocs.clear();
     };
   }, [loadView, relatedDatabaseId, selectedViewId]);
 
@@ -312,38 +300,56 @@ function RelationCellMenuContent({
     const cleanups: Array<() => void> = [];
 
     void (async () => {
-      for (const rowId of rowIds) {
-        // If the row document already exists, skip creating it
-        if (!rowDocsRef.current.has(rowId)) {
-          try {
-            const rowDoc = await createRow(getRowKey(guid, rowId));
+      let nextRowIndex = 0;
+      const loadNextRows = async () => {
+        while (!cancelled) {
+          const rowIndex = nextRowIndex;
 
-            rowDocsRef.current.set(rowId, rowDoc);
-          } catch (e) {
-            // Leave the doc missing, but still record the row below. Presence in `rowContents` is
-            // what ends the row's loading placeholder, so bailing out here — or skipping the
-            // write — would leave this row, and with a `continue` every row after it, pulsing
-            // forever. An unreadable row falls back to the "Untitled" wording instead.
-            // Deliberate: a failed row is retried only when `rowIds` or `guid` change (it stays
-            // absent from `rowDocsRef`, so the next run re-attempts createRow) — not on
-            // primary-field ticks, which no longer re-run this effect.
+          nextRowIndex += 1;
+          if (rowIndex >= rowIds.length) return;
+
+          const rowId = rowIds[rowIndex];
+
+          // If the row document already exists, skip creating it
+          if (!rowDocsRef.current.has(rowId)) {
+            try {
+              const rowDoc = await createRow(getRowKey(guid, rowId));
+
+              if (cancelled) return;
+
+              rowDocsRef.current.set(rowId, rowDoc);
+            } catch (e) {
+              // Leave the doc missing, but still record the row below. Presence in `rowContents` is
+              // what ends the row's loading placeholder, so bailing out here — or skipping the
+              // write — would leave this row, and with a `continue` every row after it, pulsing
+              // forever. An unreadable row falls back to the "Untitled" wording instead.
+              // Deliberate: a failed row is retried only when `rowIds` or `guid` change (it stays
+              // absent from `rowDocsRef`, so the next run re-attempts createRow) — not on
+              // primary-field ticks, which no longer re-run this effect.
+            }
+          }
+
+          if (cancelled) return;
+
+          // Store the content in the ref
+          recordContent(rowId);
+
+          // A row doc can resolve before its primary cell has synced; without an observer the row
+          // would stay on the "Untitled" fallback (and stay unmatchable by the search box) until
+          // the picker is closed and reopened.
+          const rowDoc = rowDocsRef.current.get(rowId);
+
+          if (rowDoc) {
+            cleanups.push(
+              subscribeSharedYjsDeep(rowDoc.getMap(YjsEditorKey.data_section), () => recordContent(rowId))
+            );
           }
         }
+      };
 
-        if (cancelled) return;
+      const workerCount = Math.min(ROW_LOAD_CONCURRENCY, rowIds.length);
 
-        // Store the content in the ref
-        recordContent(rowId);
-
-        // A row doc can resolve before its primary cell has synced; without an observer the row
-        // would stay on the "Untitled" fallback (and stay unmatchable by the search box) until
-        // the picker is closed and reopened.
-        const rowDoc = rowDocsRef.current.get(rowId);
-
-        if (rowDoc) {
-          cleanups.push(subscribeSharedYjsDeep(rowDoc.getMap(YjsEditorKey.data_section), () => recordContent(rowId)));
-        }
-      }
+      await Promise.all(Array.from({ length: workerCount }, loadNextRows));
     })();
 
     return () => {
@@ -649,6 +655,15 @@ function RelationCellMenuContent({
       </TooltipProvider>
     </div>
   );
+}
+
+function RelationCellMenuContent(props: RelationCellMenuContentProps) {
+  // All local docs, observers, and row state belong to one immutable target.
+  // Remounting the implementation prevents a passive-effect frame from
+  // combining database A's state with database B's identity.
+  const targetKey = `${props.relatedDatabaseId}:${props.selectedView?.view_id ?? ''}`;
+
+  return <RelationCellMenuContentForTarget key={targetKey} {...props} />;
 }
 
 export default RelationCellMenuContent;

--- a/src/components/database/components/cell/relation/RelationCellMenuContent.tsx
+++ b/src/components/database/components/cell/relation/RelationCellMenuContent.tsx
@@ -85,6 +85,7 @@ function getRelationRowOrders(database: YDatabase, viewId: string) {
 function RelationCellMenuContent({
   relationRowIds,
   selectedView,
+  relatedDatabaseId,
   onAddRelationRowId,
   onRemoveRelationRowId,
   loading,
@@ -171,7 +172,10 @@ function RelationCellMenuContent({
       }
 
       try {
-        const doc = await loadView(selectedViewId);
+        const doc = await loadView(selectedViewId, false, false, {
+          databaseId: relatedDatabaseId,
+          databaseMetadataOnly: true,
+        });
 
         if (cancelled) return;
 
@@ -189,7 +193,7 @@ function RelationCellMenuContent({
     return () => {
       cancelled = true;
     };
-  }, [loadView, selectedViewId]);
+  }, [loadView, relatedDatabaseId, selectedViewId]);
 
   // `loadView` hands back the target database doc as soon as it exists locally — its fields and
   // row_orders may still be empty while the first server sync lands. Reading it once left the

--- a/src/components/database/components/cell/relation/RelationItems.tsx
+++ b/src/components/database/components/cell/relation/RelationItems.tsx
@@ -12,10 +12,25 @@ import {
 import type { RelationCell, RelationCellData } from '@/application/database-yjs/cell.type';
 import { getRowKey } from '@/application/database-yjs/row_meta';
 import { subscribeSharedYjsDeep } from '@/application/database-yjs/shared-yjs-observer';
-import { type YDatabaseField, type YDoc, YjsDatabaseKey, YjsEditorKey } from '@/application/types';
+import {
+  type YDatabase,
+  type YDatabaseField,
+  type YDatabaseView,
+  type YDoc,
+  YjsDatabaseKey,
+  YjsEditorKey,
+} from '@/application/types';
 import { notify } from '@/components/_shared/notify';
 import { RelationPrimaryValue } from '@/components/database/components/cell/relation/RelationPrimaryValue';
+import { getLiveDatabaseRowIds } from '@/components/database/components/cell/relation/relationRowOrders';
 import { cn } from '@/lib/utils';
+
+function isRowStructurallyHydrated(rowDoc: YDoc): boolean {
+  const data = rowDoc.getMap(YjsEditorKey.data_section);
+  const row = data.get(YjsEditorKey.database_row);
+
+  return row instanceof Y.Map && row.get(YjsDatabaseKey.cells) instanceof Y.Map;
+}
 
 function RelationItemValue({
   field,
@@ -35,24 +50,25 @@ function RelationItemValue({
   return <RelationPrimaryValue field={field} fieldId={fieldId} onTextChange={handleTextChange} rowDoc={rowDoc} />;
 }
 
-function RelationItems({
-  style,
-  cell,
-  fieldId,
-  onTextChange,
-  wrap,
-}: {
+interface RelationItemsProps {
   cell: RelationCell;
   fieldId: string;
   onTextChange?: (text: string) => void;
   style?: CSSProperties;
   wrap: boolean;
-}) {
+}
+
+function RelationItemsForDatabase({
+  style,
+  cell,
+  onTextChange,
+  wrap,
+  relatedDatabaseId,
+}: RelationItemsProps & { relatedDatabaseId: string | undefined }) {
   const { t } = useTranslation();
   const context = useDatabaseContextOptional();
   // databasePageId: The main database page ID in the folder structure
   const viewId = context?.databasePageId;
-  const relatedDatabaseId = useDatabaseIdFromField(fieldId);
 
   const createRow = context?.createRow;
   const loadView = context?.loadView;
@@ -66,6 +82,10 @@ function RelationItems({
 
   const [databaseDoc, setDatabaseDoc] = useState<YDoc | null>(null);
   const [relatedField, setRelatedField] = useState<YDatabaseField | undefined>();
+  // null means the target database has not exposed authoritative row_orders
+  // yet. Once present, linked ids absent from this list are stale/deleted and
+  // their empty row docs must not keep the cell in a loading state forever.
+  const [liveRelatedRowIds, setLiveRelatedRowIds] = useState<string[] | null>(null);
   const docGuid = databaseDoc?.guid ?? null;
 
   const [rowIds, setRowIds] = useState<string[]>(() => {
@@ -112,6 +132,7 @@ function RelationItems({
     setDatabaseDoc(null);
     setRelatedFieldId(undefined);
     setRelatedField(undefined);
+    setLiveRelatedRowIds(null);
     setRows(undefined);
     setNoAccess(false);
 
@@ -189,14 +210,23 @@ function RelationItems({
     }
 
     let cancelled = false;
-    const rowObserverCleanups: Array<() => void> = [];
+    const rowObserverCleanups = new Map<string, () => void>();
+    const liveRelatedRowIdSet = liveRelatedRowIds === null ? null : new Set(liveRelatedRowIds);
+    const targetRowIds =
+      liveRelatedRowIdSet === null ? rowIds : rowIds.filter((rowId) => liveRelatedRowIdSet.has(rowId));
+
+    if (targetRowIds.length === 0) {
+      setRows({});
+      setLoading(false);
+      return;
+    }
 
     setLoading(true);
 
     void (async () => {
       // Load all rows in parallel instead of sequentially (async-parallel optimization)
       const rowResults = await Promise.allSettled(
-        rowIds.map(async (rowId) => {
+        targetRowIds.map(async (rowId) => {
           const rowDoc = await createRow(getRowKey(docGuid, rowId));
 
           return [rowId, rowDoc] as const;
@@ -216,33 +246,36 @@ function RelationItems({
       });
 
       const rows: Record<string, YDoc> = Object.fromEntries(rowEntries);
-      const updateLoadingState = () => {
-        if (cancelled) return;
-
-        const hasUnhydratedRow = rowEntries.some(([, rowDoc]) => {
-          const data = rowDoc.getMap(YjsEditorKey.data_section);
-          const row = data.get(YjsEditorKey.database_row);
-
-          return !(row instanceof Y.Map) || !(row.get(YjsDatabaseKey.cells) instanceof Y.Map);
-        });
-
-        setLoading(hasUnhydratedRow);
-      };
+      const pendingRowIds = new Set<string>();
 
       setRows(rows);
-      rowEntries.forEach(([, rowDoc]) => {
-        rowObserverCleanups.push(subscribeSharedYjsDeep(rowDoc.getMap(YjsEditorKey.data_section), updateLoadingState));
+      rowEntries.forEach(([rowId, rowDoc]) => {
+        if (isRowStructurallyHydrated(rowDoc)) return;
+
+        pendingRowIds.add(rowId);
+        const markReady = () => {
+          if (cancelled || !isRowStructurallyHydrated(rowDoc)) return;
+
+          pendingRowIds.delete(rowId);
+          rowObserverCleanups.get(rowId)?.();
+          rowObserverCleanups.delete(rowId);
+          if (pendingRowIds.size === 0) setLoading(false);
+        };
+
+        rowObserverCleanups.set(rowId, subscribeSharedYjsDeep(rowDoc.getMap(YjsEditorKey.data_section), markReady));
+        // Subscribe before reading so hydration cannot land between the final
+        // readiness check and observer installation.
+        markReady();
       });
-      // Subscribe before reading so hydration cannot land between the final
-      // readiness check and observer installation.
-      updateLoadingState();
+      setLoading(pendingRowIds.size > 0);
     })();
 
     return () => {
       cancelled = true;
       rowObserverCleanups.forEach((cleanup) => cleanup());
+      rowObserverCleanups.clear();
     };
-  }, [createRow, docGuid, hasRelatedRows, relatedFieldId, relatedViewId, rowIds]);
+  }, [createRow, docGuid, hasRelatedRows, liveRelatedRowIds, relatedFieldId, relatedViewId, rowIds]);
 
   useEffect(() => {
     handleUpdateRowIds();
@@ -259,31 +292,143 @@ function RelationItems({
   useEffect(() => {
     if (!databaseDoc) return;
     const sharedRoot = databaseDoc.getMap(YjsEditorKey.data_section);
+    let observedDatabase: YDatabase | undefined;
+    let cleanupFields: (() => void) | undefined;
+    let membershipCleanups: Array<() => void> = [];
 
-    const observerEvent = () => {
-      const database = sharedRoot.get(YjsEditorKey.database);
-
-      if (!database) {
+    const updatePrimaryField = () => {
+      if (!observedDatabase) {
         setRelatedFieldId(undefined);
         setRelatedField(undefined);
+        return;
+      }
+
+      const primaryFieldId = getPrimaryFieldId(observedDatabase);
+
+      setRelatedFieldId(primaryFieldId);
+      setRelatedField(primaryFieldId ? observedDatabase.get(YjsDatabaseKey.fields)?.get(primaryFieldId) : undefined);
+      setNoAccess(!primaryFieldId);
+      if (!primaryFieldId) setLoading(false);
+    };
+
+    const updateMembership = () => {
+      const databaseRowIds = observedDatabase ? getLiveDatabaseRowIds(observedDatabase) : null;
+      const databaseRowIdSet = databaseRowIds === null ? null : new Set(databaseRowIds);
+      const nextLiveRowIds =
+        databaseRowIdSet === null ? null : rowIds.filter((rowId) => databaseRowIdSet.has(rowId)).sort();
+
+      setLiveRelatedRowIds((current) => {
+        if (current === nextLiveRowIds) return current;
+        if (current === null || nextLiveRowIds === null) return nextLiveRowIds;
+        return current.length === nextLiveRowIds.length && current.every((id, index) => id === nextLiveRowIds[index])
+          ? current
+          : nextLiveRowIds;
+      });
+    };
+
+    const detachMembership = () => {
+      membershipCleanups.forEach((cleanup) => cleanup());
+      membershipCleanups = [];
+    };
+
+    const attachMembership = () => {
+      detachMembership();
+
+      const database = observedDatabase;
+      const views = database?.get(YjsDatabaseKey.views);
+      const metas = database?.get(YjsDatabaseKey.metas);
+
+      if (metas) {
+        const handleMetasChange = (event: Y.YMapEvent<unknown>) => {
+          if (event.keysChanged.has(YjsDatabaseKey.iid)) updateMembership();
+        };
+
+        metas.observe(handleMetasChange);
+        membershipCleanups.push(() => metas.unobserve(handleMetasChange));
+      }
+
+      if (views) {
+        const handleViewsChange = () => attachMembership();
+
+        views.observe(handleViewsChange);
+        membershipCleanups.push(() => views.unobserve(handleViewsChange));
+
+        views.forEach((view: YDatabaseView) => {
+          const handleViewChange = (event: Y.YMapEvent<unknown>) => {
+            if (event.keysChanged.has(YjsDatabaseKey.row_orders) || event.keysChanged.has(YjsDatabaseKey.is_inline)) {
+              attachMembership();
+            }
+          };
+
+          const rowOrders = view.get(YjsDatabaseKey.row_orders);
+
+          view.observe(handleViewChange);
+          membershipCleanups.push(() => view.unobserve(handleViewChange));
+
+          if (rowOrders) {
+            const handleRowOrdersChange = () => updateMembership();
+
+            rowOrders.observe(handleRowOrdersChange);
+            membershipCleanups.push(() => rowOrders.unobserve(handleRowOrdersChange));
+          }
+        });
+      }
+
+      updateMembership();
+    };
+
+    const attachFields = () => {
+      cleanupFields?.();
+      cleanupFields = undefined;
+
+      const fields = observedDatabase?.get(YjsDatabaseKey.fields);
+
+      if (fields) cleanupFields = subscribeSharedYjsDeep(fields, updatePrimaryField);
+      updatePrimaryField();
+    };
+
+    const handleDatabaseChange = (event: Y.YMapEvent<unknown>) => {
+      if (event.keysChanged.has(YjsDatabaseKey.fields)) attachFields();
+      if (event.keysChanged.has(YjsDatabaseKey.views) || event.keysChanged.has(YjsDatabaseKey.metas)) {
+        attachMembership();
+      }
+    };
+
+    const attachDatabase = () => {
+      observedDatabase?.unobserve(handleDatabaseChange);
+      cleanupFields?.();
+      cleanupFields = undefined;
+      detachMembership();
+
+      observedDatabase = sharedRoot.get(YjsEditorKey.database) as YDatabase | undefined;
+
+      if (!observedDatabase) {
+        setRelatedFieldId(undefined);
+        setRelatedField(undefined);
+        setLiveRelatedRowIds(null);
         setLoading(hasRelatedRows);
         return;
       }
 
-      const fieldId = getPrimaryFieldId(database);
-
-      setRelatedFieldId(fieldId);
-      setRelatedField(fieldId ? database?.get(YjsDatabaseKey.fields)?.get(fieldId) : undefined);
-      setNoAccess(!fieldId);
-      if (!fieldId) setLoading(false);
+      observedDatabase.observe(handleDatabaseChange);
+      attachFields();
+      attachMembership();
     };
 
-    observerEvent();
+    const handleSharedRootChange = (event: Y.YMapEvent<unknown>) => {
+      if (event.keysChanged.has(YjsEditorKey.database)) attachDatabase();
+    };
 
-    // The primary field can change type without replacing the database map.
-    // Share the deep observer across rendered relation cells for this database.
-    return subscribeSharedYjsDeep(sharedRoot, observerEvent);
-  }, [databaseDoc, hasRelatedRows]);
+    sharedRoot.observe(handleSharedRootChange);
+    attachDatabase();
+
+    return () => {
+      sharedRoot.unobserve(handleSharedRootChange);
+      observedDatabase?.unobserve(handleDatabaseChange);
+      cleanupFields?.();
+      detachMembership();
+    };
+  }, [databaseDoc, hasRelatedRows, rowIds]);
 
   return (
     <div
@@ -348,6 +493,15 @@ function RelationItems({
       )}
     </div>
   );
+}
+
+function RelationItems(props: RelationItemsProps) {
+  const relatedDatabaseId = useDatabaseIdFromField(props.fieldId);
+
+  // Every local doc and async row result belongs to one immutable relation
+  // target. A keyed implementation prevents a pending database-A load from
+  // committing rows after the field has switched to database B.
+  return <RelationItemsForDatabase key={relatedDatabaseId ?? ''} {...props} relatedDatabaseId={relatedDatabaseId} />;
 }
 
 export default RelationItems;

--- a/src/components/database/components/cell/relation/RelationItems.tsx
+++ b/src/components/database/components/cell/relation/RelationItems.tsx
@@ -1,16 +1,18 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import CircularProgress from '@mui/material/CircularProgress';
+import { useCallback, useEffect, useState, type CSSProperties } from 'react';
+import { useTranslation } from 'react-i18next';
 import * as Y from 'yjs';
 
 import {
-  DatabaseContextState,
+  type DatabaseContextState,
   getPrimaryFieldId,
   useDatabaseContextOptional,
   useDatabaseIdFromField,
 } from '@/application/database-yjs';
-import { RelationCell, RelationCellData } from '@/application/database-yjs/cell.type';
+import type { RelationCell, RelationCellData } from '@/application/database-yjs/cell.type';
 import { getRowKey } from '@/application/database-yjs/row_meta';
 import { subscribeSharedYjsDeep } from '@/application/database-yjs/shared-yjs-observer';
-import { YDatabaseField, YDoc, YjsDatabaseKey, YjsEditorKey } from '@/application/types';
+import { type YDatabaseField, type YDoc, YjsDatabaseKey, YjsEditorKey } from '@/application/types';
 import { notify } from '@/components/_shared/notify';
 import { RelationPrimaryValue } from '@/components/database/components/cell/relation/RelationPrimaryValue';
 import { cn } from '@/lib/utils';
@@ -43,9 +45,10 @@ function RelationItems({
   cell: RelationCell;
   fieldId: string;
   onTextChange?: (text: string) => void;
-  style?: React.CSSProperties;
+  style?: CSSProperties;
   wrap: boolean;
 }) {
+  const { t } = useTranslation();
   const context = useDatabaseContextOptional();
   // databasePageId: The main database page ID in the folder structure
   const viewId = context?.databasePageId;
@@ -61,12 +64,18 @@ function RelationItems({
   const [relatedFieldId, setRelatedFieldId] = useState<string | undefined>();
   const [relatedViewId, setRelatedViewId] = useState<string | null>(null);
 
-  const [docGuid, setDocGuid] = useState<string | null>(null);
   const [databaseDoc, setDatabaseDoc] = useState<YDoc | null>(null);
   const [relatedField, setRelatedField] = useState<YDatabaseField | undefined>();
+  const docGuid = databaseDoc?.guid ?? null;
 
-  const [rowIds, setRowIds] = useState([] as string[]);
+  const [rowIds, setRowIds] = useState<string[]>(() => {
+    const data = cell.data;
+
+    return data instanceof Y.Array ? (data.toJSON() as RelationCellData) ?? [] : [];
+  });
+  const [loading, setLoading] = useState(() => rowIds.length > 0);
   const [rowTexts, setRowTexts] = useState<Record<string, string>>({});
+  const hasRelatedRows = rowIds.length > 0;
 
   const navigateToView = context?.navigateToView;
 
@@ -93,12 +102,30 @@ function RelationItems({
 
     const ids = (data.toJSON() as RelationCellData) ?? [];
 
-    setRowIds(ids);
+    setRowIds((current) =>
+      current.length === ids.length && current.every((rowId, index) => rowId === ids[index]) ? current : ids
+    );
   }, [cell.data]);
 
   useEffect(() => {
-    if (!relatedDatabaseId) {
+    setRelatedViewId(null);
+    setDatabaseDoc(null);
+    setRelatedFieldId(undefined);
+    setRelatedField(undefined);
+    setRows(undefined);
+    setNoAccess(false);
+
+    if (!relatedDatabaseId || !hasRelatedRows) {
+      setLoading(false);
+      return;
+    }
+
+    setLoading(true);
+
+    if (!getViewIdFromDatabaseId || !loadView) {
       setRelatedViewId(null);
+      setNoAccess(true);
+      setLoading(false);
       return;
     }
 
@@ -106,77 +133,128 @@ function RelationItems({
 
     void (async () => {
       try {
-        const viewId = await getViewIdFromDatabaseId?.(relatedDatabaseId);
+        const viewId = await getViewIdFromDatabaseId(relatedDatabaseId);
 
         if (cancelled) return;
 
         if (!viewId) {
           setRelatedViewId(null);
           setNoAccess(true);
+          setLoading(false);
           return;
         }
 
         setNoAccess(false);
         setRelatedViewId(viewId);
+
+        const viewDoc = await loadView(viewId, false, false, {
+          databaseId: relatedDatabaseId,
+          databaseMetadataOnly: true,
+        });
+
+        if (cancelled) return;
+
+        if (!viewDoc) {
+          throw new Error('No access');
+        }
+
+        setDatabaseDoc(viewDoc);
       } catch (e) {
         if (cancelled) return;
         console.error(e);
         setRelatedViewId(null);
         setNoAccess(true);
+        setLoading(false);
       }
     })();
 
     return () => {
       cancelled = true;
     };
-  }, [getViewIdFromDatabaseId, relatedDatabaseId]);
+  }, [getViewIdFromDatabaseId, hasRelatedRows, loadView, relatedDatabaseId]);
 
   useEffect(() => {
-    if (!relatedViewId || !createRow || !docGuid) return;
+    if (!hasRelatedRows) {
+      setRows({});
+      setLoading(false);
+      return;
+    }
+
+    if (!relatedViewId || !docGuid || !relatedFieldId) return;
+
+    if (!createRow) {
+      setNoAccess(true);
+      setLoading(false);
+      return;
+    }
+
+    let cancelled = false;
+    const rowObserverCleanups: Array<() => void> = [];
+
+    setLoading(true);
+
     void (async () => {
-      try {
-        // Load all rows in parallel instead of sequentially (async-parallel optimization)
-        const rowEntries = await Promise.all(
-          rowIds.map(async (rowId) => {
-            const rowDoc = await createRow(getRowKey(docGuid, rowId));
+      // Load all rows in parallel instead of sequentially (async-parallel optimization)
+      const rowResults = await Promise.allSettled(
+        rowIds.map(async (rowId) => {
+          const rowDoc = await createRow(getRowKey(docGuid, rowId));
 
-            return [rowId, rowDoc] as const;
-          })
-        );
+          return [rowId, rowDoc] as const;
+        })
+      );
 
-        const rows: Record<string, YDoc> = Object.fromEntries(rowEntries);
+      if (cancelled) return;
 
-        setRows(rows);
-      } catch (e) {
-        console.error(e);
-      }
+      const rowEntries: Array<readonly [string, YDoc]> = [];
+
+      rowResults.forEach((result) => {
+        if (result.status === 'fulfilled') {
+          rowEntries.push(result.value);
+        } else {
+          console.error(result.reason);
+        }
+      });
+
+      const rows: Record<string, YDoc> = Object.fromEntries(rowEntries);
+      const updateLoadingState = () => {
+        if (cancelled) return;
+
+        const hasUnhydratedRow = rowEntries.some(([, rowDoc]) => {
+          const data = rowDoc.getMap(YjsEditorKey.data_section);
+          const row = data.get(YjsEditorKey.database_row);
+
+          return !(row instanceof Y.Map) || !(row.get(YjsDatabaseKey.cells) instanceof Y.Map);
+        });
+
+        setLoading(hasUnhydratedRow);
+      };
+
+      setRows(rows);
+      rowEntries.forEach(([, rowDoc]) => {
+        rowObserverCleanups.push(subscribeSharedYjsDeep(rowDoc.getMap(YjsEditorKey.data_section), updateLoadingState));
+      });
+      // Subscribe before reading so hydration cannot land between the final
+      // readiness check and observer installation.
+      updateLoadingState();
     })();
-  }, [createRow, relatedViewId, relatedFieldId, rowIds, docGuid]);
+
+    return () => {
+      cancelled = true;
+      rowObserverCleanups.forEach((cleanup) => cleanup());
+    };
+  }, [createRow, docGuid, hasRelatedRows, relatedFieldId, relatedViewId, rowIds]);
 
   useEffect(() => {
     handleUpdateRowIds();
-  }, [handleUpdateRowIds]);
+    const data = cell.data;
 
-  useEffect(() => {
-    if (!relatedViewId) return;
+    if (!(data instanceof Y.Array)) return;
 
-    void (async () => {
-      try {
-        const viewDoc = await loadView?.(relatedViewId);
-
-        if (!viewDoc) {
-          throw new Error('No access');
-        }
-
-        setDocGuid(viewDoc.guid);
-
-        setDatabaseDoc(viewDoc);
-      } catch (e) {
-        console.error(e);
-        setNoAccess(true);
-      }
-    })();
-  }, [loadView, relatedViewId]);
+    data.observe(handleUpdateRowIds);
+    return () => {
+      data.unobserve(handleUpdateRowIds);
+    };
+  }, [cell.data, handleUpdateRowIds]);
 
   useEffect(() => {
     if (!databaseDoc) return;
@@ -185,11 +263,19 @@ function RelationItems({
     const observerEvent = () => {
       const database = sharedRoot.get(YjsEditorKey.database);
 
+      if (!database) {
+        setRelatedFieldId(undefined);
+        setRelatedField(undefined);
+        setLoading(hasRelatedRows);
+        return;
+      }
+
       const fieldId = getPrimaryFieldId(database);
 
       setRelatedFieldId(fieldId);
       setRelatedField(fieldId ? database?.get(YjsDatabaseKey.fields)?.get(fieldId) : undefined);
       setNoAccess(!fieldId);
+      if (!fieldId) setLoading(false);
     };
 
     observerEvent();
@@ -197,7 +283,7 @@ function RelationItems({
     // The primary field can change type without replacing the database map.
     // Share the deep observer across rendered relation cells for this database.
     return subscribeSharedYjsDeep(sharedRoot, observerEvent);
-  }, [databaseDoc]);
+  }, [databaseDoc, hasRelatedRows]);
 
   return (
     <div
@@ -210,43 +296,55 @@ function RelationItems({
       {noAccess ? (
         <div className={'text-text-secondary'}>No access</div>
       ) : (
-        rowIds.map((rowId) => {
-          const rowDoc = rows?.[rowId];
+        <>
+          {rowIds.map((rowId) => {
+            const rowDoc = rows?.[rowId];
 
-          if (!rowDoc) return null;
-          return (
-            <div
-              key={rowId}
-              onClick={async (e) => {
-                if (!relatedViewId) return;
-                e.stopPropagation();
+            if (!rowDoc) return null;
+            return (
+              <div
+                key={rowId}
+                onClick={async (e) => {
+                  if (!relatedViewId) return;
+                  e.stopPropagation();
 
-                try {
-                  if (navigateToRow) {
-                    navigateToRow(rowId, relatedViewId !== viewId ? relatedViewId : undefined);
-                    return;
+                  try {
+                    if (navigateToRow) {
+                      navigateToRow(rowId, relatedViewId !== viewId ? relatedViewId : undefined);
+                      return;
+                    }
+
+                    await navigateToView?.(relatedViewId);
+                    // eslint-disable-next-line
+                  } catch (e: any) {
+                    notify.error(e.message);
                   }
-
-                  await navigateToView?.(relatedViewId);
-                  // eslint-disable-next-line
-                } catch (e: any) {
-                  notify.error(e.message);
-                }
-              }}
-              className={`min-w-fit overflow-hidden text-text-primary underline ${
-                relatedViewId ? 'cursor-pointer hover:text-text-action' : ''
-              }`}
-            >
-              <RelationItemValue
-                field={relatedField}
-                fieldId={relatedFieldId}
-                onTextChange={handleRowTextChange}
-                rowDoc={rowDoc}
-                rowId={rowId}
+                }}
+                className={`min-w-fit overflow-hidden text-text-primary underline ${
+                  relatedViewId ? 'cursor-pointer hover:text-text-action' : ''
+                }`}
+              >
+                <RelationItemValue
+                  field={relatedField}
+                  fieldId={relatedFieldId}
+                  onTextChange={handleRowTextChange}
+                  rowDoc={rowDoc}
+                  rowId={rowId}
+                />
+              </div>
+            );
+          })}
+          {loading ? (
+            <div aria-label={t('loading')} className='flex min-h-5 items-center' role='status'>
+              <CircularProgress
+                aria-hidden
+                className='text-icon-secondary'
+                data-testid='relation-cell-loading'
+                size={14}
               />
             </div>
-          );
-        })
+          ) : null}
+        </>
       )}
     </div>
   );

--- a/src/components/database/components/cell/relation/RelationPrimaryValue.test.tsx
+++ b/src/components/database/components/cell/relation/RelationPrimaryValue.test.tsx
@@ -3,6 +3,7 @@ import * as Y from 'yjs';
 
 import { FieldType, SelectOptionColor } from '@/application/database-yjs';
 import { createRowDoc } from '@/application/database-yjs/__tests__/test-helpers';
+import * as cellDecoder from '@/application/database-yjs/decode';
 import { YDatabaseField, YDatabaseRow, YDoc, YjsDatabaseKey, YjsEditorKey } from '@/application/types';
 import { RelationPrimaryValue } from '@/components/database/components/cell/relation/RelationPrimaryValue';
 
@@ -81,6 +82,39 @@ describe('RelationPrimaryValue', () => {
 
     await waitFor(() => expect(onTextChange).toHaveBeenLastCalledWith('Globex'));
     expect(screen.getByText('Globex')).toBeTruthy();
+  });
+
+  it('does not decode the primary cell again when an unrelated cell changes', async () => {
+    const fieldId = 'primary-field';
+    const otherFieldId = 'other-field';
+    const fieldDoc = new Y.Doc();
+    const field = fieldDoc.getMap('field') as YDatabaseField;
+    const rowDoc = createRowDoc('row-id', 'database-id', {
+      [fieldId]: { fieldType: FieldType.RichText, data: 'Acme' },
+      [otherFieldId]: { fieldType: FieldType.RichText, data: 'Unrelated' },
+    });
+    const row = rowDoc.getMap(YjsEditorKey.data_section).get(YjsEditorKey.database_row) as YDatabaseRow;
+    const cells = row.get(YjsDatabaseKey.cells);
+    const decodeSpy = jest.spyOn(cellDecoder, 'decodeCellToText');
+
+    field.set(YjsDatabaseKey.type, FieldType.RichText);
+    render(<RelationPrimaryValue field={field} fieldId={fieldId} rowDoc={rowDoc} />);
+
+    await waitFor(() => expect(screen.getByText('Acme')).toBeTruthy());
+    decodeSpy.mockClear();
+
+    act(() => {
+      cells.get(otherFieldId).set(YjsDatabaseKey.data, 'Changed elsewhere');
+    });
+
+    expect(decodeSpy).not.toHaveBeenCalled();
+
+    act(() => {
+      cells.get(fieldId).set(YjsDatabaseKey.data, 'Globex');
+    });
+
+    await waitFor(() => expect(decodeSpy).toHaveBeenCalledTimes(1));
+    decodeSpy.mockRestore();
   });
 
   it('renders a primary cell that arrives after the row structure', async () => {

--- a/src/components/database/components/cell/relation/RelationPrimaryValue.test.tsx
+++ b/src/components/database/components/cell/relation/RelationPrimaryValue.test.tsx
@@ -3,7 +3,7 @@ import * as Y from 'yjs';
 
 import { FieldType, SelectOptionColor } from '@/application/database-yjs';
 import { createRowDoc } from '@/application/database-yjs/__tests__/test-helpers';
-import { YDatabaseField, YDatabaseRow, YjsDatabaseKey, YjsEditorKey } from '@/application/types';
+import { YDatabaseField, YDatabaseRow, YDoc, YjsDatabaseKey, YjsEditorKey } from '@/application/types';
 import { RelationPrimaryValue } from '@/components/database/components/cell/relation/RelationPrimaryValue';
 
 jest.mock('@/utils/runtime-config', () => ({
@@ -81,5 +81,32 @@ describe('RelationPrimaryValue', () => {
 
     await waitFor(() => expect(onTextChange).toHaveBeenLastCalledWith('Globex'));
     expect(screen.getByText('Globex')).toBeTruthy();
+  });
+
+  it('renders a primary cell that arrives after the row structure', async () => {
+    const fieldId = 'primary-field';
+    const fieldDoc = new Y.Doc();
+    const field = fieldDoc.getMap('field') as YDatabaseField;
+    const rowDoc = new Y.Doc() as YDoc;
+    const row = new Y.Map() as YDatabaseRow;
+    const cells = new Y.Map();
+
+    field.set(YjsDatabaseKey.type, FieldType.RichText);
+    rowDoc.getMap(YjsEditorKey.data_section).set(YjsEditorKey.database_row, row);
+    row.set(YjsDatabaseKey.cells, cells);
+
+    const { container } = render(<RelationPrimaryValue field={field} fieldId={fieldId} rowDoc={rowDoc} />);
+
+    await waitFor(() => expect(container.textContent).toBe(''));
+
+    act(() => {
+      const cell = new Y.Map();
+
+      cells.set(fieldId, cell);
+      cell.set(YjsDatabaseKey.field_type, FieldType.RichText);
+      cell.set(YjsDatabaseKey.data, 'Late title');
+    });
+
+    await waitFor(() => expect(screen.getByText('Late title')).toBeTruthy());
   });
 });

--- a/src/components/database/components/cell/relation/RelationPrimaryValue.tsx
+++ b/src/components/database/components/cell/relation/RelationPrimaryValue.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import * as Y from 'yjs';
 
 import { FieldType } from '@/application/database-yjs';
 import { parseYDatabaseCellToCell } from '@/application/database-yjs/cell.parse';
@@ -7,6 +8,7 @@ import { subscribeSharedYjsDeep } from '@/application/database-yjs/shared-yjs-ob
 import {
   FieldId,
   YDatabaseCell,
+  YDatabaseCells,
   YDatabaseField,
   YDatabaseRow,
   YDoc,
@@ -29,43 +31,107 @@ export function RelationPrimaryValue({
 
   useEffect(() => {
     const data = rowDoc.getMap(YjsEditorKey.data_section);
+    let observedRow: YDatabaseRow | undefined;
+    let observedCells: YDatabaseCells | undefined;
+    let observedPrimaryCell: YDatabaseCell | undefined;
+    let cleanupPrimaryCell: (() => void) | undefined;
+    let cleanupStructuralHydration: (() => void) | undefined;
 
-    const observeHandler = () => {
-      const row = data.get(YjsEditorKey.database_row) as YDatabaseRow | undefined;
-      const cells = row?.get(YjsDatabaseKey.cells);
-      let primaryCell: YDatabaseCell | undefined;
-
-      if (fieldId) {
-        primaryCell = cells?.get(fieldId);
-      } else {
-        const richTextFieldId = Array.from(cells?.keys() ?? []).find((key) => {
-          const fieldType = cells?.get(key)?.get(YjsDatabaseKey.field_type);
-
-          if (fieldType === undefined || fieldType === null) return false;
-          return Number(fieldType) === FieldType.RichText;
-        });
-
-        if (richTextFieldId) {
-          primaryCell = cells?.get(richTextFieldId);
-        }
-      }
-
-      if (!primaryCell) {
+    const decodePrimaryCell = () => {
+      if (!observedPrimaryCell) {
         setText('');
         return;
       }
 
-      setText(field ? decodeCellToText(primaryCell, field) : String(parseYDatabaseCellToCell(primaryCell).data ?? ''));
+      const nextText = field
+        ? decodeCellToText(observedPrimaryCell, field)
+        : String(parseYDatabaseCellToCell(observedPrimaryCell).data ?? '');
+
+      setText((current) => (current === nextText ? current : nextText));
     };
 
-    observeHandler();
+    const resolvePrimaryCell = (): YDatabaseCell | undefined => {
+      if (fieldId) return observedCells?.get(fieldId);
 
-    const observerCleanups: Array<() => void> = [subscribeSharedYjsDeep(data, observeHandler)];
+      const richTextFieldId = Array.from(observedCells?.keys() ?? []).find((key) => {
+        const fieldType = observedCells?.get(key)?.get(YjsDatabaseKey.field_type);
 
-    if (field) observerCleanups.push(subscribeSharedYjsDeep(field, observeHandler));
+        if (fieldType === undefined || fieldType === null) return false;
+        return Number(fieldType) === FieldType.RichText;
+      });
+
+      return richTextFieldId ? observedCells?.get(richTextFieldId) : undefined;
+    };
+
+    const syncPrimaryCell = () => {
+      const nextPrimaryCell = resolvePrimaryCell();
+
+      if (nextPrimaryCell !== observedPrimaryCell) {
+        cleanupPrimaryCell?.();
+        cleanupPrimaryCell = undefined;
+        observedPrimaryCell = nextPrimaryCell;
+
+        if (observedPrimaryCell) {
+          cleanupPrimaryCell = subscribeSharedYjsDeep(observedPrimaryCell, decodePrimaryCell);
+        }
+      }
+
+      // Keep the broad observer only while the row structure is incomplete.
+      // Once the primary cell exists, shallow map observers detect structural
+      // replacement and the cell observer handles value changes.
+      if (observedPrimaryCell) {
+        cleanupStructuralHydration?.();
+        cleanupStructuralHydration = undefined;
+      } else if (!cleanupStructuralHydration) {
+        cleanupStructuralHydration = subscribeSharedYjsDeep(data, syncStructure);
+      }
+
+      decodePrimaryCell();
+    };
+
+    const handleCellsChange = (event: Y.YMapEvent<unknown>) => {
+      if (!fieldId || event.keysChanged.has(fieldId)) syncPrimaryCell();
+    };
+
+    const handleRowChange = (event: Y.YMapEvent<unknown>) => {
+      if (event.keysChanged.has(YjsDatabaseKey.cells)) syncStructure();
+    };
+
+    function syncStructure() {
+      const nextRow = data.get(YjsEditorKey.database_row) as YDatabaseRow | undefined;
+      const nextCells = nextRow?.get(YjsDatabaseKey.cells);
+
+      if (nextRow !== observedRow) {
+        observedRow?.unobserve(handleRowChange);
+        observedRow = nextRow;
+        observedRow?.observe(handleRowChange);
+      }
+
+      if (nextCells !== observedCells) {
+        observedCells?.unobserve(handleCellsChange);
+        observedCells = nextCells;
+        observedCells?.observe(handleCellsChange);
+      }
+
+      syncPrimaryCell();
+    }
+
+    const handleDataChange = (event: Y.YMapEvent<unknown>) => {
+      if (event.keysChanged.has(YjsEditorKey.database_row)) syncStructure();
+    };
+
+    data.observe(handleDataChange);
+    syncStructure();
+
+    const cleanupField = field ? subscribeSharedYjsDeep(field, decodePrimaryCell) : undefined;
 
     return () => {
-      observerCleanups.forEach((cleanup) => cleanup());
+      cleanupStructuralHydration?.();
+      cleanupPrimaryCell?.();
+      cleanupField?.();
+      observedCells?.unobserve(handleCellsChange);
+      observedRow?.unobserve(handleRowChange);
+      data.unobserve(handleDataChange);
     };
   }, [field, fieldId, rowDoc]);
 

--- a/src/components/database/components/cell/relation/RelationPrimaryValue.tsx
+++ b/src/components/database/components/cell/relation/RelationPrimaryValue.tsx
@@ -26,45 +26,30 @@ export function RelationPrimaryValue({
   onTextChange?: (text: string) => void;
 }) {
   const [text, setText] = useState<string | null>(null);
-  const [row, setRow] = useState<YDatabaseRow | null>(null);
 
   useEffect(() => {
     const data = rowDoc.getMap(YjsEditorKey.data_section);
 
-    const onRowChange = () => {
-      setRow(data?.get(YjsEditorKey.database_row) as YDatabaseRow);
-    };
-
-    onRowChange();
-    return subscribeSharedYjsDeep(data, onRowChange);
-  }, [rowDoc]);
-
-  useEffect(() => {
-    if (!row) {
-      setText('');
-      return;
-    }
-
-    const cells = row.get(YjsDatabaseKey.cells);
-
-    let primaryCell: YDatabaseCell | undefined;
-
-    if (fieldId) {
-      primaryCell = cells?.get(fieldId);
-    } else {
-      const fieldId = Array.from(cells?.keys() ?? []).find((key) => {
-        const fieldType = cells.get(key)?.get(YjsDatabaseKey.field_type);
-
-        if (fieldType === undefined || fieldType === null) return false;
-        return Number(fieldType) === FieldType.RichText;
-      });
+    const observeHandler = () => {
+      const row = data.get(YjsEditorKey.database_row) as YDatabaseRow | undefined;
+      const cells = row?.get(YjsDatabaseKey.cells);
+      let primaryCell: YDatabaseCell | undefined;
 
       if (fieldId) {
         primaryCell = cells?.get(fieldId);
-      }
-    }
+      } else {
+        const richTextFieldId = Array.from(cells?.keys() ?? []).find((key) => {
+          const fieldType = cells?.get(key)?.get(YjsDatabaseKey.field_type);
 
-    const observeHandler = () => {
+          if (fieldType === undefined || fieldType === null) return false;
+          return Number(fieldType) === FieldType.RichText;
+        });
+
+        if (richTextFieldId) {
+          primaryCell = cells?.get(richTextFieldId);
+        }
+      }
+
       if (!primaryCell) {
         setText('');
         return;
@@ -75,15 +60,14 @@ export function RelationPrimaryValue({
 
     observeHandler();
 
-    const observerCleanups: Array<() => void> = [];
+    const observerCleanups: Array<() => void> = [subscribeSharedYjsDeep(data, observeHandler)];
 
-    if (primaryCell) observerCleanups.push(subscribeSharedYjsDeep(primaryCell, observeHandler));
     if (field) observerCleanups.push(subscribeSharedYjsDeep(field, observeHandler));
 
     return () => {
       observerCleanups.forEach((cleanup) => cleanup());
     };
-  }, [row, fieldId, field]);
+  }, [field, fieldId, rowDoc]);
 
   useEffect(() => {
     onTextChange?.(text ?? '');

--- a/src/components/database/components/cell/relation/__tests__/RelationCellMenuContent.loading.test.tsx
+++ b/src/components/database/components/cell/relation/__tests__/RelationCellMenuContent.loading.test.tsx
@@ -150,6 +150,13 @@ describe('RelationCellMenuContent loading states', () => {
 
     renderPicker();
 
+    await waitFor(() => {
+      expect(mockDatabaseContext.loadView).toHaveBeenCalledWith(VIEW_ID, false, false, {
+        databaseId: DATABASE_ID,
+        databaseMetadataOnly: true,
+      });
+    });
+
     // Both rows are known the moment the row list lands; neither title has been fetched.
     await waitFor(() => expect(skeletons()).toHaveLength(2));
     expect(screen.queryByText(UNTITLED)).toBeNull();

--- a/src/components/database/components/cell/relation/__tests__/RelationCellMenuContent.loading.test.tsx
+++ b/src/components/database/components/cell/relation/__tests__/RelationCellMenuContent.loading.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { act, render, screen, waitFor } from '@testing-library/react';
 import * as Y from 'yjs';
 
 import { FieldType } from '@/application/database-yjs';
@@ -52,10 +52,10 @@ function deferred<T>() {
 }
 
 /** A target database doc shaped the way the picker reads it: primary field + view row orders. */
-function createTargetDoc(rowIds: string[]): YDoc {
+function createTargetDoc(rowIds: string[], viewId = VIEW_ID, databaseId = DATABASE_ID): YDoc {
   const doc = new Y.Doc() as YDoc;
 
-  doc.guid = VIEW_ID;
+  doc.guid = viewId;
 
   const database = new Y.Map() as YDatabase;
   const fields = new Y.Map();
@@ -76,9 +76,9 @@ function createTargetDoc(rowIds: string[]): YDoc {
 
   const views = new Y.Map();
 
-  views.set(VIEW_ID, view);
+  views.set(viewId, view);
 
-  database.set(YjsDatabaseKey.id, DATABASE_ID);
+  database.set(YjsDatabaseKey.id, databaseId);
   database.set(YjsDatabaseKey.fields, fields);
   database.set(YjsDatabaseKey.views, views);
   doc.getMap(YjsEditorKey.data_section).set(YjsEditorKey.database, database);
@@ -106,8 +106,8 @@ function syncDatabaseInto(doc: YDoc, rowIds: string[]) {
   });
 }
 
-function createTitledRowDoc(rowId: string, title: string): YDoc {
-  return createRowDoc(rowId, DATABASE_ID, {
+function createTitledRowDoc(rowId: string, title: string, databaseId = DATABASE_ID): YDoc {
+  return createRowDoc(rowId, databaseId, {
     [PRIMARY_FIELD_ID]: { fieldType: FieldType.RichText, data: title },
   });
 }
@@ -172,6 +172,77 @@ describe('RelationCellMenuContent loading states', () => {
     expect(skeletons()).toHaveLength(0);
   });
 
+  it('loads row documents in bounded parallel batches', async () => {
+    const rowIds = Array.from({ length: 10 }, (_, index) => `row-${index + 1}`);
+    const rowLoads = new Map(rowIds.map((rowId) => [rowId, deferred<YDoc>()]));
+
+    mockDatabaseContext.loadView.mockResolvedValue(createTargetDoc(rowIds));
+    mockDatabaseContext.createRow.mockImplementation((rowKey: string) => {
+      const rowId = rowIdFromKey(rowKey);
+
+      return rowLoads.get(rowId)!.promise;
+    });
+
+    const rendered = renderPicker();
+
+    await waitFor(() => expect(mockDatabaseContext.createRow).toHaveBeenCalledTimes(8));
+
+    await act(async () => {
+      rowLoads.get('row-1')?.resolve(createTitledRowDoc('row-1', 'TSK-001'));
+      await rowLoads.get('row-1')?.promise;
+    });
+
+    await waitFor(() => expect(mockDatabaseContext.createRow).toHaveBeenCalledTimes(9));
+    rendered.unmount();
+  });
+
+  it('never renders delayed rows from the previous keyed target', async () => {
+    const delayedARow = deferred<YDoc>();
+    const databaseADoc = createTargetDoc(['row-1'], 'view-a', 'database-a');
+    const databaseBDoc = createTargetDoc(['row-1'], 'view-b', 'database-b');
+    const rowADoc = createTitledRowDoc('row-1', 'Database A row', 'database-a');
+    const rowBDoc = createTitledRowDoc('row-1', 'Database B row', 'database-b');
+
+    mockDatabaseContext.loadView.mockImplementation((viewId: string) =>
+      Promise.resolve(viewId === 'view-a' ? databaseADoc : databaseBDoc)
+    );
+    mockDatabaseContext.createRow.mockImplementation((rowKey: string) =>
+      rowKey.startsWith('view-a_rows_') ? delayedARow.promise : Promise.resolve(rowBDoc)
+    );
+
+    const callbacks = {
+      onAddRelationRowId: jest.fn(),
+      onRemoveRelationRowId: jest.fn(),
+    };
+    const rendered = render(
+      <RelationCellMenuContent
+        {...callbacks}
+        relatedDatabaseId='database-a'
+        selectedView={{ view_id: 'view-a', name: 'Database A' } as View}
+      />
+    );
+
+    await waitFor(() => expect(mockDatabaseContext.createRow).toHaveBeenCalledWith('view-a_rows_row-1'));
+
+    rendered.rerender(
+      <RelationCellMenuContent
+        {...callbacks}
+        relatedDatabaseId='database-b'
+        selectedView={{ view_id: 'view-b', name: 'Database B' } as View}
+      />
+    );
+
+    await waitFor(() => expect(screen.getByText('Database B row')).toBeTruthy());
+
+    await act(async () => {
+      delayedARow.resolve(rowADoc);
+      await delayedARow.promise;
+    });
+
+    expect(screen.queryByText('Database A row')).toBeNull();
+    expect(screen.getByText('Database B row')).toBeTruthy();
+  });
+
   it('settles an unreadable row on the empty-name wording instead of pulsing forever', async () => {
     mockDatabaseContext.loadView.mockResolvedValue(createTargetDoc(['row-1', 'row-2']));
     mockDatabaseContext.createRow.mockImplementation((rowKey: string) =>
@@ -234,7 +305,9 @@ describe('RelationCellMenuContent loading states', () => {
     // Nothing has synced yet, so the picker may not conclude the database is empty.
     expect(screen.queryByText(NO_RESULT)).toBeNull();
 
-    syncDatabaseInto(doc, ['row-1']);
+    act(() => {
+      syncDatabaseInto(doc, ['row-1']);
+    });
 
     await waitFor(() => expect(screen.getByText('TSK-001')).toBeTruthy());
     expect(screen.queryByText(NO_RESULT)).toBeNull();
@@ -253,8 +326,10 @@ describe('RelationCellMenuContent loading states', () => {
 
     const row = rowDoc.getMap(YjsEditorKey.data_section).get(YjsEditorKey.database_row) as YDatabaseRow;
 
-    rowDoc.transact(() => {
-      row.get(YjsDatabaseKey.cells)?.get(PRIMARY_FIELD_ID)?.set(YjsDatabaseKey.data, 'TSK-001');
+    act(() => {
+      rowDoc.transact(() => {
+        row.get(YjsDatabaseKey.cells)?.get(PRIMARY_FIELD_ID)?.set(YjsDatabaseKey.data, 'TSK-001');
+      });
     });
 
     await waitFor(() => expect(screen.getByText('TSK-001')).toBeTruthy());

--- a/src/components/database/components/cell/relation/__tests__/RelationItems.loading.test.tsx
+++ b/src/components/database/components/cell/relation/__tests__/RelationItems.loading.test.tsx
@@ -18,11 +18,12 @@ const mockDatabaseContext = {
   navigateToRow: jest.fn(),
   navigateToView: jest.fn(),
 };
+let mockRelatedDatabaseId = 'related-database';
 
 jest.mock('@/application/database-yjs', () => ({
   ...jest.requireActual('@/application/database-yjs'),
   useDatabaseContextOptional: () => mockDatabaseContext,
-  useDatabaseIdFromField: () => 'related-database',
+  useDatabaseIdFromField: () => mockRelatedDatabaseId,
 }));
 
 jest.mock('react-i18next', () => ({
@@ -57,19 +58,30 @@ function createRelationCell(rowIds: string[]): RelationCell {
   };
 }
 
-function createRelatedDatabaseDoc(): YDoc {
+function createRelatedDatabaseDoc(rowIds?: string[], viewId = RELATED_VIEW_ID, databaseId = 'related-database'): YDoc {
   const doc = new Y.Doc() as YDoc;
   const database = new Y.Map() as YDatabase;
   const fields = new Y.Map();
   const primaryField = new Y.Map();
 
-  doc.guid = RELATED_VIEW_ID;
+  doc.guid = viewId;
   primaryField.set(YjsDatabaseKey.id, PRIMARY_FIELD_ID);
   primaryField.set(YjsDatabaseKey.is_primary, true);
   primaryField.set(YjsDatabaseKey.type, FieldType.RichText);
   fields.set(PRIMARY_FIELD_ID, primaryField);
-  database.set(YjsDatabaseKey.id, 'related-database');
+  database.set(YjsDatabaseKey.id, databaseId);
   database.set(YjsDatabaseKey.fields, fields);
+  if (rowIds) {
+    const rowOrders = new Y.Array();
+    const view = new Y.Map();
+    const views = new Y.Map();
+
+    rowOrders.push(rowIds.map((id) => ({ id })));
+    view.set(YjsDatabaseKey.row_orders, rowOrders);
+    views.set(viewId, view);
+    database.set(YjsDatabaseKey.views, views);
+  }
+
   doc.getMap(YjsEditorKey.data_section).set(YjsEditorKey.database, database);
 
   return doc;
@@ -84,6 +96,7 @@ describe('RelationItems loading state', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    mockRelatedDatabaseId = 'related-database';
     consoleError = jest.spyOn(console, 'error').mockImplementation(() => undefined);
     mockDatabaseContext.getViewIdFromDatabaseId.mockResolvedValue(RELATED_VIEW_ID);
   });
@@ -103,7 +116,7 @@ describe('RelationItems loading state', () => {
 
     expect(screen.getByRole('status', { name: 'loading' })).toBeTruthy();
 
-    view.resolve(createRelatedDatabaseDoc());
+    view.resolve(createRelatedDatabaseDoc(['row-1']));
 
     await waitFor(() => expect(mockDatabaseContext.createRow).toHaveBeenCalled());
     expect(mockDatabaseContext.loadView).toHaveBeenCalledWith(RELATED_VIEW_ID, false, false, {
@@ -159,11 +172,233 @@ describe('RelationItems loading state', () => {
   });
 
   it('stops the indicator when a linked row cannot be read', async () => {
-    mockDatabaseContext.loadView.mockResolvedValue(createRelatedDatabaseDoc());
+    mockDatabaseContext.loadView.mockResolvedValue(createRelatedDatabaseDoc(['row-1']));
     mockDatabaseContext.createRow.mockRejectedValue(new Error('row unavailable'));
 
     renderItems(['row-1']);
 
     await waitFor(() => expect(screen.queryByRole('status', { name: 'loading' })).toBeNull());
+  });
+
+  it('settles an empty row shell when authoritative row orders say the relation is deleted', async () => {
+    const databaseDoc = createRelatedDatabaseDoc();
+    const emptyRowDoc = new Y.Doc({ guid: 'related-database_rows_row-1' }) as YDoc;
+
+    mockDatabaseContext.loadView.mockResolvedValue(databaseDoc);
+    mockDatabaseContext.createRow.mockResolvedValue(emptyRowDoc);
+
+    renderItems(['row-1']);
+
+    await waitFor(() => expect(mockDatabaseContext.createRow).toHaveBeenCalledTimes(1));
+    expect(screen.getByRole('status', { name: 'loading' })).toBeTruthy();
+
+    act(() => {
+      const database = databaseDoc.getMap(YjsEditorKey.data_section).get(YjsEditorKey.database) as YDatabase;
+      const rowOrders = new Y.Array();
+      const view = new Y.Map();
+      const views = new Y.Map();
+
+      view.set(YjsDatabaseKey.row_orders, rowOrders);
+      views.set(RELATED_VIEW_ID, view);
+      database.set(YjsDatabaseKey.views, views);
+    });
+
+    await waitFor(() => expect(screen.queryByRole('status', { name: 'loading' })).toBeNull());
+  });
+
+  it('keeps a linked row that is live in another database view', async () => {
+    const databaseDoc = createRelatedDatabaseDoc(['row-visible-in-primary']);
+    const database = databaseDoc.getMap(YjsEditorKey.data_section).get(YjsEditorKey.database) as YDatabase;
+    const secondaryView = new Y.Map();
+    const secondaryRowOrders = new Y.Array();
+
+    secondaryRowOrders.push([{ id: 'row-1' }]);
+    secondaryView.set(YjsDatabaseKey.row_orders, secondaryRowOrders);
+    database.get(YjsDatabaseKey.views)?.set('secondary-view', secondaryView);
+
+    const rowDoc = new Y.Doc({ guid: 'related-database_rows_row-1' }) as YDoc;
+    const row = new Y.Map();
+    const cells = new Y.Map();
+    const primaryCell = new Y.Map();
+
+    primaryCell.set(YjsDatabaseKey.field_type, FieldType.RichText);
+    primaryCell.set(YjsDatabaseKey.data, 'Linked from another view');
+    cells.set(PRIMARY_FIELD_ID, primaryCell);
+    row.set(YjsDatabaseKey.cells, cells);
+    rowDoc.getMap(YjsEditorKey.data_section).set(YjsEditorKey.database_row, row);
+
+    mockDatabaseContext.loadView.mockResolvedValue(databaseDoc);
+    mockDatabaseContext.createRow.mockResolvedValue(rowDoc);
+
+    renderItems(['row-1']);
+
+    await waitFor(() => expect(screen.getByText('Linked from another view')).toBeTruthy());
+    expect(screen.queryByRole('status', { name: 'loading' })).toBeNull();
+  });
+
+  it('checks only the row that is still hydrating and releases observers after readiness', async () => {
+    mockDatabaseContext.loadView.mockResolvedValue(createRelatedDatabaseDoc(['row-1', 'row-2']));
+
+    const firstRowDoc = new Y.Doc({ guid: 'row-1' }) as YDoc;
+    const firstData = firstRowDoc.getMap(YjsEditorKey.data_section);
+    const firstRow = new Y.Map();
+    const firstCells = new Y.Map();
+    const firstPrimaryCell = new Y.Map();
+
+    firstData.set(YjsEditorKey.database_row, firstRow);
+    firstRow.set(YjsDatabaseKey.cells, firstCells);
+    firstCells.set(PRIMARY_FIELD_ID, firstPrimaryCell);
+    firstPrimaryCell.set(YjsDatabaseKey.field_type, FieldType.RichText);
+    firstPrimaryCell.set(YjsDatabaseKey.data, 'First');
+
+    const secondRowDoc = new Y.Doc({ guid: 'row-2' }) as YDoc;
+    const secondData = secondRowDoc.getMap(YjsEditorKey.data_section);
+
+    mockDatabaseContext.createRow.mockImplementation((rowKey: string) =>
+      Promise.resolve(rowKey.endsWith('row-1') ? firstRowDoc : secondRowDoc)
+    );
+
+    renderItems(['row-1', 'row-2']);
+
+    await waitFor(() => expect(screen.getByText('First')).toBeTruthy());
+    expect(screen.getByRole('status', { name: 'loading' })).toBeTruthy();
+
+    const secondDataGet = jest.spyOn(secondData, 'get');
+
+    secondDataGet.mockClear();
+    act(() => {
+      firstData.set('unrelated', true);
+    });
+    expect(secondDataGet).not.toHaveBeenCalled();
+
+    const secondRow = new Y.Map();
+    const secondCells = new Y.Map();
+    const secondPrimaryCell = new Y.Map();
+
+    act(() => {
+      secondData.set(YjsEditorKey.database_row, secondRow);
+      secondRow.set(YjsDatabaseKey.cells, secondCells);
+      secondCells.set(PRIMARY_FIELD_ID, secondPrimaryCell);
+      secondPrimaryCell.set(YjsDatabaseKey.field_type, FieldType.RichText);
+      secondPrimaryCell.set(YjsDatabaseKey.data, 'Second');
+    });
+
+    await waitFor(() => expect(screen.queryByRole('status', { name: 'loading' })).toBeNull());
+    secondDataGet.mockClear();
+    act(() => {
+      firstData.set('another-unrelated-key', true);
+    });
+    expect(secondDataGet).not.toHaveBeenCalled();
+  });
+
+  it('isolates row membership from unrelated database and row edits', async () => {
+    const databaseDoc = createRelatedDatabaseDoc(['row-1', 'row-2']);
+    const database = databaseDoc.getMap(YjsEditorKey.data_section).get(YjsEditorKey.database) as YDatabase;
+    const rowOrders = database.get(YjsDatabaseKey.views).get(RELATED_VIEW_ID).get(YjsDatabaseKey.row_orders);
+    const rowDoc = new Y.Doc({ guid: 'row-1' }) as YDoc;
+    const row = new Y.Map();
+    const cells = new Y.Map();
+    const primaryCell = new Y.Map();
+
+    primaryCell.set(YjsDatabaseKey.field_type, FieldType.RichText);
+    primaryCell.set(YjsDatabaseKey.data, 'Initial title');
+    cells.set(PRIMARY_FIELD_ID, primaryCell);
+    row.set(YjsDatabaseKey.cells, cells);
+    rowDoc.getMap(YjsEditorKey.data_section).set(YjsEditorKey.database_row, row);
+    mockDatabaseContext.loadView.mockResolvedValue(databaseDoc);
+    mockDatabaseContext.createRow.mockResolvedValue(rowDoc);
+
+    renderItems(['row-1']);
+
+    await waitFor(() => expect(screen.getByText('Initial title')).toBeTruthy());
+    expect(mockDatabaseContext.createRow).toHaveBeenCalledTimes(1);
+
+    const toArraySpy = jest.spyOn(rowOrders, 'toArray');
+
+    toArraySpy.mockClear();
+    act(() => {
+      database.set('unrelated-database-key', true);
+      primaryCell.set(YjsDatabaseKey.data, 'Edited title');
+    });
+
+    await waitFor(() => expect(screen.getByText('Edited title')).toBeTruthy());
+    expect(toArraySpy).not.toHaveBeenCalled();
+    expect(mockDatabaseContext.createRow).toHaveBeenCalledTimes(1);
+
+    toArraySpy.mockClear();
+    act(() => {
+      databaseDoc.transact(() => {
+        rowOrders.delete(0, rowOrders.length);
+        rowOrders.push([{ id: 'row-2' }, { id: 'row-1' }]);
+      });
+    });
+
+    expect(toArraySpy).toHaveBeenCalled();
+    expect(mockDatabaseContext.createRow).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      rowOrders.delete(1, 1);
+    });
+
+    await waitFor(() => expect(screen.queryByText('Edited title')).toBeNull());
+    expect(mockDatabaseContext.createRow).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      rowOrders.push([{ id: 'row-1' }]);
+    });
+
+    await waitFor(() => expect(screen.getByText('Edited title')).toBeTruthy());
+    expect(mockDatabaseContext.createRow).toHaveBeenCalledTimes(2);
+  });
+
+  it('never commits a delayed row result from the previous relation target', async () => {
+    const databaseADoc = createRelatedDatabaseDoc(['row-1'], 'view-a', 'database-a');
+    const databaseBDoc = createRelatedDatabaseDoc(['row-1'], 'view-b', 'database-b');
+    const delayedARow = deferred<YDoc>();
+    const rowADoc = new Y.Doc({ guid: 'view-a_rows_row-1' }) as YDoc;
+    const rowBDoc = new Y.Doc({ guid: 'view-b_rows_row-1' }) as YDoc;
+
+    const hydrateRow = (doc: YDoc, title: string) => {
+      const row = new Y.Map();
+      const cells = new Y.Map();
+      const primaryCell = new Y.Map();
+
+      primaryCell.set(YjsDatabaseKey.field_type, FieldType.RichText);
+      primaryCell.set(YjsDatabaseKey.data, title);
+      cells.set(PRIMARY_FIELD_ID, primaryCell);
+      row.set(YjsDatabaseKey.cells, cells);
+      doc.getMap(YjsEditorKey.data_section).set(YjsEditorKey.database_row, row);
+    };
+
+    hydrateRow(rowADoc, 'Database A row');
+    hydrateRow(rowBDoc, 'Database B row');
+    mockRelatedDatabaseId = 'database-a';
+    mockDatabaseContext.getViewIdFromDatabaseId.mockImplementation((databaseId: string) =>
+      Promise.resolve(databaseId === 'database-a' ? 'view-a' : 'view-b')
+    );
+    mockDatabaseContext.loadView.mockImplementation((viewId: string) =>
+      Promise.resolve(viewId === 'view-a' ? databaseADoc : databaseBDoc)
+    );
+    mockDatabaseContext.createRow.mockImplementation((rowKey: string) =>
+      rowKey.startsWith('view-a_rows_') ? delayedARow.promise : Promise.resolve(rowBDoc)
+    );
+
+    const cell = createRelationCell(['row-1']);
+    const rendered = render(<RelationItems cell={cell} fieldId='relation-field' wrap={false} />);
+
+    await waitFor(() => expect(mockDatabaseContext.createRow).toHaveBeenCalledWith('view-a_rows_row-1'));
+
+    mockRelatedDatabaseId = 'database-b';
+    rendered.rerender(<RelationItems cell={cell} fieldId='relation-field' wrap={false} />);
+
+    await waitFor(() => expect(screen.getByText('Database B row')).toBeTruthy());
+
+    await act(async () => {
+      delayedARow.resolve(rowADoc);
+      await delayedARow.promise;
+    });
+
+    expect(screen.queryByText('Database A row')).toBeNull();
+    expect(screen.getByText('Database B row')).toBeTruthy();
   });
 });

--- a/src/components/database/components/cell/relation/__tests__/RelationItems.loading.test.tsx
+++ b/src/components/database/components/cell/relation/__tests__/RelationItems.loading.test.tsx
@@ -1,0 +1,169 @@
+import { act, render, screen, waitFor } from '@testing-library/react';
+import * as Y from 'yjs';
+
+import { FieldType } from '@/application/database-yjs';
+import { RelationCell } from '@/application/database-yjs/cell.type';
+import { YDatabase, YDoc, YjsDatabaseKey, YjsEditorKey } from '@/application/types';
+import RelationItems from '@/components/database/components/cell/relation/RelationItems';
+
+jest.mock('@/utils/runtime-config', () => ({
+  getConfigValue: (_key: string, fallback: string) => fallback,
+}));
+
+const mockDatabaseContext = {
+  databasePageId: 'source-view',
+  createRow: jest.fn(),
+  getViewIdFromDatabaseId: jest.fn(),
+  loadView: jest.fn(),
+  navigateToRow: jest.fn(),
+  navigateToView: jest.fn(),
+};
+
+jest.mock('@/application/database-yjs', () => ({
+  ...jest.requireActual('@/application/database-yjs'),
+  useDatabaseContextOptional: () => mockDatabaseContext,
+  useDatabaseIdFromField: () => 'related-database',
+}));
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+const RELATED_VIEW_ID = 'related-view';
+const PRIMARY_FIELD_ID = 'primary-field';
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+
+  return { promise, reject, resolve };
+}
+
+function createRelationCell(rowIds: string[]): RelationCell {
+  const doc = new Y.Doc();
+  const data = doc.getArray<string>('relation');
+
+  data.push(rowIds);
+
+  return {
+    createdAt: 0,
+    data,
+    fieldType: FieldType.Relation,
+    lastModified: 0,
+  };
+}
+
+function createRelatedDatabaseDoc(): YDoc {
+  const doc = new Y.Doc() as YDoc;
+  const database = new Y.Map() as YDatabase;
+  const fields = new Y.Map();
+  const primaryField = new Y.Map();
+
+  doc.guid = RELATED_VIEW_ID;
+  primaryField.set(YjsDatabaseKey.id, PRIMARY_FIELD_ID);
+  primaryField.set(YjsDatabaseKey.is_primary, true);
+  primaryField.set(YjsDatabaseKey.type, FieldType.RichText);
+  fields.set(PRIMARY_FIELD_ID, primaryField);
+  database.set(YjsDatabaseKey.id, 'related-database');
+  database.set(YjsDatabaseKey.fields, fields);
+  doc.getMap(YjsEditorKey.data_section).set(YjsEditorKey.database, database);
+
+  return doc;
+}
+
+function renderItems(rowIds: string[]) {
+  return render(<RelationItems cell={createRelationCell(rowIds)} fieldId='relation-field' wrap={false} />);
+}
+
+describe('RelationItems loading state', () => {
+  let consoleError: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    consoleError = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+    mockDatabaseContext.getViewIdFromDatabaseId.mockResolvedValue(RELATED_VIEW_ID);
+  });
+
+  afterEach(() => {
+    consoleError.mockRestore();
+  });
+
+  it('shows an indicator until the related database and linked row are loaded', async () => {
+    const view = deferred<YDoc>();
+    const rowDoc = deferred<YDoc>();
+
+    mockDatabaseContext.loadView.mockReturnValue(view.promise);
+    mockDatabaseContext.createRow.mockReturnValue(rowDoc.promise);
+
+    renderItems(['row-1']);
+
+    expect(screen.getByRole('status', { name: 'loading' })).toBeTruthy();
+
+    view.resolve(createRelatedDatabaseDoc());
+
+    await waitFor(() => expect(mockDatabaseContext.createRow).toHaveBeenCalled());
+    expect(mockDatabaseContext.loadView).toHaveBeenCalledWith(RELATED_VIEW_ID, false, false, {
+      databaseId: 'related-database',
+      databaseMetadataOnly: true,
+    });
+    expect(screen.getByRole('status', { name: 'loading' })).toBeTruthy();
+
+    const emptyRowDoc = new Y.Doc({ guid: 'row-1' }) as YDoc;
+
+    emptyRowDoc.getMap(YjsEditorKey.data_section);
+    await act(async () => {
+      rowDoc.resolve(emptyRowDoc);
+      await rowDoc.promise;
+    });
+
+    // Registering realtime sync does not mean its initial row payload has
+    // arrived, so the cell must keep its indicator through this empty shell.
+    expect(screen.getByRole('status', { name: 'loading' })).toBeTruthy();
+
+    const row = new Y.Map();
+
+    act(() => {
+      emptyRowDoc.getMap(YjsEditorKey.data_section).set(YjsEditorKey.database_row, row);
+    });
+    expect(screen.getByRole('status', { name: 'loading' })).toBeTruthy();
+
+    const cells = new Y.Map();
+
+    act(() => {
+      row.set(YjsDatabaseKey.cells, cells);
+    });
+
+    await waitFor(() => expect(screen.queryByRole('status', { name: 'loading' })).toBeNull());
+
+    const primaryCell = new Y.Map();
+
+    act(() => {
+      cells.set(PRIMARY_FIELD_ID, primaryCell);
+      primaryCell.set(YjsDatabaseKey.field_type, FieldType.RichText);
+      primaryCell.set(YjsDatabaseKey.data, 'Design system');
+    });
+
+    await waitFor(() => expect(screen.getByText('Design system')).toBeTruthy());
+  });
+
+  it('does not load the related database for an empty relation cell', async () => {
+    renderItems([]);
+
+    await waitFor(() => expect(screen.queryByRole('status', { name: 'loading' })).toBeNull());
+    expect(mockDatabaseContext.getViewIdFromDatabaseId).not.toHaveBeenCalled();
+    expect(mockDatabaseContext.loadView).not.toHaveBeenCalled();
+  });
+
+  it('stops the indicator when a linked row cannot be read', async () => {
+    mockDatabaseContext.loadView.mockResolvedValue(createRelatedDatabaseDoc());
+    mockDatabaseContext.createRow.mockRejectedValue(new Error('row unavailable'));
+
+    renderItems(['row-1']);
+
+    await waitFor(() => expect(screen.queryByRole('status', { name: 'loading' })).toBeNull());
+  });
+});

--- a/src/components/database/components/cell/relation/__tests__/relationRowOrders.test.ts
+++ b/src/components/database/components/cell/relation/__tests__/relationRowOrders.test.ts
@@ -1,15 +1,84 @@
 import { describe, expect, it } from '@jest/globals';
+import * as Y from 'yjs';
 
-import { getLiveRelationRowIds } from '../relationRowOrders';
+import { YDatabase, YjsDatabaseKey, YjsEditorKey } from '@/application/types';
+
+import { getLiveDatabaseRowIds, getLiveRelationRowIds } from '../relationRowOrders';
 
 describe('getLiveRelationRowIds', () => {
   it('excludes tombstoned rows from relation picker candidates', () => {
     expect(
-      getLiveRelationRowIds([
-        { id: 'row-1' },
-        { id: 'row-2', is_deleted: true },
-        { id: 'row-3', is_deleted: false },
-      ])
+      getLiveRelationRowIds([{ id: 'row-1' }, { id: 'row-2', is_deleted: true }, { id: 'row-3', is_deleted: false }])
     ).toEqual(['row-1', 'row-3']);
+  });
+
+  it('unions live membership across database views', () => {
+    const doc = new Y.Doc();
+    const database = new Y.Map() as YDatabase;
+    const views = new Y.Map();
+    const firstView = new Y.Map();
+    const secondView = new Y.Map();
+    const firstRowOrders = new Y.Array<{ id: string; is_deleted?: boolean }>();
+    const secondRowOrders = new Y.Array<{ id: string; is_deleted?: boolean }>();
+
+    firstRowOrders.push([{ id: 'row-1' }, { id: 'row-2', is_deleted: true }]);
+    secondRowOrders.push([{ id: 'row-2' }, { id: 'row-3' }]);
+    firstView.set(YjsDatabaseKey.row_orders, firstRowOrders);
+    secondView.set(YjsDatabaseKey.row_orders, secondRowOrders);
+    views.set('view-1', firstView);
+    views.set('view-2', secondView);
+    database.set(YjsDatabaseKey.views, views);
+    doc.getMap(YjsEditorKey.data_section).set(YjsEditorKey.database, database);
+
+    expect(getLiveDatabaseRowIds(database)).toEqual(['row-1', 'row-2', 'row-3']);
+  });
+
+  it('uses inline tombstones canonically while retaining linked-only rows', () => {
+    const doc = new Y.Doc();
+    const database = new Y.Map() as YDatabase;
+    const views = new Y.Map();
+    const metas = new Y.Map();
+    const inlineView = new Y.Map();
+    const linkedView = new Y.Map();
+    const inlineRowOrders = new Y.Array<{ id: string; is_deleted?: boolean }>();
+    const linkedRowOrders = new Y.Array<{ id: string; is_deleted?: boolean }>();
+
+    inlineRowOrders.push([{ id: 'row-live' }, { id: 'row-canonically-deleted', is_deleted: true }]);
+    linkedRowOrders.push([
+      { id: 'row-linked-only' },
+      { id: 'row-canonically-deleted' },
+      { id: 'row-live', is_deleted: true },
+    ]);
+    inlineView.set(YjsDatabaseKey.row_orders, inlineRowOrders);
+    linkedView.set(YjsDatabaseKey.row_orders, linkedRowOrders);
+    views.set('inline-view', inlineView);
+    views.set('linked-view', linkedView);
+    metas.set(YjsDatabaseKey.iid, 'inline-view');
+    database.set(YjsDatabaseKey.metas, metas);
+    database.set(YjsDatabaseKey.views, views);
+    doc.getMap(YjsEditorKey.data_section).set(YjsEditorKey.database, database);
+
+    expect(getLiveDatabaseRowIds(database)).toEqual(['row-linked-only', 'row-live']);
+  });
+
+  it('returns stable sorted membership regardless of view and row order', () => {
+    const doc = new Y.Doc();
+    const database = new Y.Map() as YDatabase;
+    const views = new Y.Map();
+    const firstView = new Y.Map();
+    const secondView = new Y.Map();
+    const firstRowOrders = new Y.Array<{ id: string }>();
+    const secondRowOrders = new Y.Array<{ id: string }>();
+
+    firstRowOrders.push([{ id: 'row-z' }, { id: 'row-a' }]);
+    secondRowOrders.push([{ id: 'row-m' }, { id: 'row-a' }]);
+    firstView.set(YjsDatabaseKey.row_orders, firstRowOrders);
+    secondView.set(YjsDatabaseKey.row_orders, secondRowOrders);
+    views.set('view-z', firstView);
+    views.set('view-a', secondView);
+    database.set(YjsDatabaseKey.views, views);
+    doc.getMap(YjsEditorKey.data_section).set(YjsEditorKey.database, database);
+
+    expect(getLiveDatabaseRowIds(database)).toEqual(['row-a', 'row-m', 'row-z']);
   });
 });

--- a/src/components/database/components/cell/relation/relationRowOrders.ts
+++ b/src/components/database/components/cell/relation/relationRowOrders.ts
@@ -1,3 +1,6 @@
+import { getInlineViewRowOrders, materializeVisibleRowOrders } from '@/application/database-yjs/row-order-visibility';
+import { YDatabase, YDatabaseRowOrders, YjsDatabaseKey } from '@/application/types';
+
 interface RelationRowOrder {
   id: string;
   is_deleted?: boolean;
@@ -5,4 +8,54 @@ interface RelationRowOrder {
 
 export function getLiveRelationRowIds(rowOrders: readonly RelationRowOrder[]) {
   return rowOrders.filter((row) => !row.is_deleted).map((row) => row.id);
+}
+
+/**
+ * Database membership is the union of every view's live row orders. Filters,
+ * groups, and view-local visibility can omit a valid row from one view without
+ * deleting it from the database.
+ */
+export function getLiveDatabaseRowIds(database: YDatabase): string[] | null {
+  const views = database.get(YjsDatabaseKey.views);
+
+  if (!views) return null;
+
+  const canonicalRowOrders = getInlineViewRowOrders(database)?.toArray();
+  const rowIds = new Set<string>();
+  let foundRowOrders = false;
+
+  for (const viewId of views.keys()) {
+    const rowOrders = views.get(viewId)?.get(YjsDatabaseKey.row_orders);
+
+    if (!rowOrders) continue;
+    foundRowOrders = true;
+    const visibleRowOrders = materializeVisibleRowOrders(rowOrders.toArray(), canonicalRowOrders) ?? [];
+
+    visibleRowOrders.forEach(({ id }) => rowIds.add(id));
+  }
+
+  return foundRowOrders ? Array.from(rowIds).sort() : null;
+}
+
+/**
+ * Rows belong to a database, not to one specific view. Prefer the requested
+ * view when it is registered, then fall back to any view carrying row orders
+ * (relations can point at the database container rather than an inner view).
+ */
+export function getRelationRowOrders(database: YDatabase, viewId: string): YDatabaseRowOrders | null {
+  const views = database.get(YjsDatabaseKey.views);
+
+  if (!views) return null;
+
+  const named = views.get(viewId)?.get(YjsDatabaseKey.row_orders);
+
+  if (named) return named;
+
+  for (const id of views.keys()) {
+    const rowOrders = views.get(id)?.get(YjsDatabaseKey.row_orders);
+
+    if (rowOrders) return rowOrders;
+  }
+
+  return null;
 }

--- a/src/components/database/components/filters/advanced/FilterPanelRow.tsx
+++ b/src/components/database/components/filters/advanced/FilterPanelRow.tsx
@@ -504,7 +504,10 @@ function RelationValueInput({ filter, disabled }: { filter: Filter; disabled?: b
     ].includes(filter.condition);
   }, [filter.condition]);
   const selectedRowIds = useMemo(() => parseRelationFilterRowIds(filter.content), [filter.content]);
-  const { loading, selectedView, relatedDatabaseId } = useRelationData(filter.fieldId, { enabled: showInput && open });
+  const { loading, selectedView, relatedDatabaseId } = useRelationData(filter.fieldId, {
+    enabled: showInput && open,
+    refreshCatalog: showInput && open,
+  });
 
   const updateSelectedRowIds = useCallback(
     (rowIds: string[]) => {

--- a/src/components/database/components/filters/advanced/FilterPanelRow.tsx
+++ b/src/components/database/components/filters/advanced/FilterPanelRow.tsx
@@ -506,7 +506,6 @@ function RelationValueInput({ filter, disabled }: { filter: Filter; disabled?: b
   const selectedRowIds = useMemo(() => parseRelationFilterRowIds(filter.content), [filter.content]);
   const { loading, selectedView, relatedDatabaseId } = useRelationData(filter.fieldId, {
     enabled: showInput && open,
-    refreshCatalog: showInput && open,
   });
 
   const updateSelectedRowIds = useCallback(

--- a/src/components/database/components/filters/filter-menu/RelationFilterMenu.tsx
+++ b/src/components/database/components/filters/filter-menu/RelationFilterMenu.tsx
@@ -31,7 +31,10 @@ function RelationFilterMenu({ filter }: { filter: Filter }) {
     RelationFilterCondition.RelationDoesNotContain,
   ].includes(filter.condition);
   const selectedRowIds = useMemo(() => parseRelationFilterRowIds(filter.content), [filter.content]);
-  const { loading, selectedView, relatedDatabaseId } = useRelationData(filter.fieldId, { enabled: showPicker });
+  const { loading, selectedView, relatedDatabaseId } = useRelationData(filter.fieldId, {
+    enabled: showPicker,
+    refreshCatalog: showPicker,
+  });
 
   const updateSelectedRowIds = useCallback(
     (rowIds: string[]) => {

--- a/src/components/database/components/filters/filter-menu/RelationFilterMenu.tsx
+++ b/src/components/database/components/filters/filter-menu/RelationFilterMenu.tsx
@@ -33,7 +33,6 @@ function RelationFilterMenu({ filter }: { filter: Filter }) {
   const selectedRowIds = useMemo(() => parseRelationFilterRowIds(filter.content), [filter.content]);
   const { loading, selectedView, relatedDatabaseId } = useRelationData(filter.fieldId, {
     enabled: showPicker,
-    refreshCatalog: showPicker,
   });
 
   const updateSelectedRowIds = useCallback(

--- a/src/components/database/components/property/relation/RelationCreationDialog.test.tsx
+++ b/src/components/database/components/property/relation/RelationCreationDialog.test.tsx
@@ -3,7 +3,7 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import en from '@/@types/translations/en.json';
 import { useDatabaseContext } from '@/application/database-yjs';
 import { RelationLimit } from '@/application/database-yjs/fields/relation/relation.type';
-import { refreshWorkspaceDatabaseCatalog } from '@/application/services/domains/view';
+import { getWorkspaceDatabaseCatalog } from '@/application/services/domains/view';
 import { WorkspaceDatabaseWithViews } from '@/application/services/services.type';
 import { View, ViewLayout } from '@/application/types';
 import { RelationCreationDialog } from '@/components/database/components/property/relation/RelationCreationDialog';
@@ -40,7 +40,7 @@ jest.mock('@/application/services/domains/view', () => ({
 
       return container && primaryView ? [{ databaseId: database.database_id, container, primaryView }] : [];
     }),
-  refreshWorkspaceDatabaseCatalog: jest.fn(),
+  getWorkspaceDatabaseCatalog: jest.fn(),
 }));
 
 // Resolve against the real bundle so the assertions below read as the copy the
@@ -162,7 +162,7 @@ function mockViews(viewsById: Record<string, View>) {
     viewsByDatabaseId.set(databaseId, views);
   }
 
-  jest.mocked(refreshWorkspaceDatabaseCatalog).mockResolvedValue(
+  jest.mocked(getWorkspaceDatabaseCatalog).mockResolvedValue(
     Array.from(viewsByDatabaseId.entries()).map(([databaseId, views]) => ({
       database_id: databaseId,
       views: views.map((view) => ({
@@ -249,7 +249,7 @@ describe('RelationCreationDialog', () => {
     expect(currentCandidate.textContent).not.toContain('Grid');
     expect(relatedCandidate.textContent).not.toContain('Grid');
 
-    expect(refreshWorkspaceDatabaseCatalog).toHaveBeenCalledWith('workspace-1');
+    expect(getWorkspaceDatabaseCatalog).toHaveBeenCalledWith('workspace-1');
     expect(loadViewMeta).not.toHaveBeenCalled();
   });
 
@@ -346,7 +346,7 @@ describe('RelationCreationDialog', () => {
   });
 
   it('does not list a database view when the server has no container for it', async () => {
-    jest.mocked(refreshWorkspaceDatabaseCatalog).mockResolvedValue([
+    jest.mocked(getWorkspaceDatabaseCatalog).mockResolvedValue([
       {
         database_id: 'related-database',
         views: [

--- a/src/components/database/components/property/relation/RelationCreationDialog.tsx
+++ b/src/components/database/components/property/relation/RelationCreationDialog.tsx
@@ -227,6 +227,7 @@ export function RelationCreationDialog({
         const result = await loadRelationDatabaseCandidates({
           workspaceId,
           loadViews: loadViewsFn,
+          refreshCatalog: true,
         });
 
         if (cancelled) return;

--- a/src/components/database/components/property/relation/RelationCreationDialog.tsx
+++ b/src/components/database/components/property/relation/RelationCreationDialog.tsx
@@ -227,7 +227,6 @@ export function RelationCreationDialog({
         const result = await loadRelationDatabaseCandidates({
           workspaceId,
           loadViews: loadViewsFn,
-          refreshCatalog: true,
         });
 
         if (cancelled) return;

--- a/src/components/database/components/property/relation/RelationPropertyMenuContent.tsx
+++ b/src/components/database/components/property/relation/RelationPropertyMenuContent.tsx
@@ -57,7 +57,7 @@ function RelationPropertyMenuContent({ fieldId }: { fieldId: string }) {
     databaseCandidates,
     relationOption,
     relatedDatabaseId,
-  } = useRelationData(fieldId);
+  } = useRelationData(fieldId, { refreshCatalog: true });
   const [databaseQuery, setDatabaseQuery] = useState('');
   const filteredCandidates = useMemo(() => {
     const query = databaseQuery.trim().toLowerCase();

--- a/src/components/database/components/property/relation/RelationPropertyMenuContent.tsx
+++ b/src/components/database/components/property/relation/RelationPropertyMenuContent.tsx
@@ -57,7 +57,7 @@ function RelationPropertyMenuContent({ fieldId }: { fieldId: string }) {
     databaseCandidates,
     relationOption,
     relatedDatabaseId,
-  } = useRelationData(fieldId, { refreshCatalog: true });
+  } = useRelationData(fieldId);
   const [databaseQuery, setDatabaseQuery] = useState('');
   const filteredCandidates = useMemo(() => {
     const query = databaseQuery.trim().toLowerCase();

--- a/src/components/database/components/property/relation/relationDatabaseCandidates.test.ts
+++ b/src/components/database/components/property/relation/relationDatabaseCandidates.test.ts
@@ -1,4 +1,4 @@
-import { refreshWorkspaceDatabaseCatalog } from '@/application/services/domains/view';
+import { getWorkspaceDatabaseCatalog, refreshWorkspaceDatabaseCatalog } from '@/application/services/domains/view';
 import { WorkspaceDatabaseWithViews } from '@/application/services/services.type';
 import { View, ViewLayout } from '@/application/types';
 
@@ -30,6 +30,7 @@ jest.mock('@/application/services/domains/view', () => ({
 
       return container && primaryView ? [{ databaseId: database.database_id, container, primaryView }] : [];
     }),
+  getWorkspaceDatabaseCatalog: jest.fn(),
   refreshWorkspaceDatabaseCatalog: jest.fn(),
 }));
 
@@ -116,14 +117,14 @@ describe('loadRelationDatabaseCandidates', () => {
     });
     const space = makeView({ viewId: 'space-1', name: 'General', children: [container] });
 
-    jest.mocked(refreshWorkspaceDatabaseCatalog).mockResolvedValue([database]);
+    jest.mocked(getWorkspaceDatabaseCatalog).mockResolvedValue([database]);
 
     const result = await loadRelationDatabaseCandidates({
       workspaceId: 'workspace-1',
       loadViews: jest.fn().mockResolvedValue([space]),
     });
 
-    expect(refreshWorkspaceDatabaseCatalog).toHaveBeenCalledWith('workspace-1');
+    expect(getWorkspaceDatabaseCatalog).toHaveBeenCalledWith('workspace-1');
     expect(result.candidates).toEqual([
       expect.objectContaining({
         databaseId: 'database-1',
@@ -174,11 +175,22 @@ describe('loadRelationDatabaseCandidates', () => {
     );
   });
 
+  it('uses an explicit authoritative refresh for a user-opened picker', async () => {
+    const database = remoteDatabase('database-1', 'Projects');
+
+    jest.mocked(refreshWorkspaceDatabaseCatalog).mockResolvedValue([database]);
+
+    await loadRelationDatabaseCandidates({ workspaceId: 'workspace-1', refreshCatalog: true });
+
+    expect(refreshWorkspaceDatabaseCatalog).toHaveBeenCalledWith('workspace-1');
+    expect(getWorkspaceDatabaseCatalog).not.toHaveBeenCalled();
+  });
+
   it('does not expose databases without a container', async () => {
     const database = remoteDatabase('database-1', 'Projects');
 
     database.views = database.views.filter((view) => !view.is_container);
-    jest.mocked(refreshWorkspaceDatabaseCatalog).mockResolvedValue([database]);
+    jest.mocked(getWorkspaceDatabaseCatalog).mockResolvedValue([database]);
 
     const result = await loadRelationDatabaseCandidates({ workspaceId: 'workspace-1' });
 
@@ -194,7 +206,7 @@ describe('loadRelationDatabaseCandidates', () => {
       isContainer: true,
     });
 
-    jest.mocked(refreshWorkspaceDatabaseCatalog).mockResolvedValue([]);
+    jest.mocked(getWorkspaceDatabaseCatalog).mockResolvedValue([]);
 
     const result = await loadRelationDatabaseCandidates({
       workspaceId: 'workspace-1',
@@ -205,7 +217,7 @@ describe('loadRelationDatabaseCandidates', () => {
   });
 
   it('does not substitute folder data when the server catalog request fails', async () => {
-    jest.mocked(refreshWorkspaceDatabaseCatalog).mockRejectedValue(new Error('Unavailable'));
+    jest.mocked(getWorkspaceDatabaseCatalog).mockRejectedValue(new Error('Unavailable'));
 
     await expect(
       loadRelationDatabaseCandidates({

--- a/src/components/database/components/property/relation/relationDatabaseCandidates.test.ts
+++ b/src/components/database/components/property/relation/relationDatabaseCandidates.test.ts
@@ -1,4 +1,4 @@
-import { getWorkspaceDatabaseCatalog, refreshWorkspaceDatabaseCatalog } from '@/application/services/domains/view';
+import { getWorkspaceDatabaseCatalog } from '@/application/services/domains/view';
 import { WorkspaceDatabaseWithViews } from '@/application/services/services.type';
 import { View, ViewLayout } from '@/application/types';
 
@@ -31,7 +31,6 @@ jest.mock('@/application/services/domains/view', () => ({
       return container && primaryView ? [{ databaseId: database.database_id, container, primaryView }] : [];
     }),
   getWorkspaceDatabaseCatalog: jest.fn(),
-  refreshWorkspaceDatabaseCatalog: jest.fn(),
 }));
 
 function makeView({
@@ -175,15 +174,16 @@ describe('loadRelationDatabaseCandidates', () => {
     );
   });
 
-  it('uses an explicit authoritative refresh for a user-opened picker', async () => {
+  it('routes sequential picker loads through the shared workspace catalog', async () => {
     const database = remoteDatabase('database-1', 'Projects');
 
-    jest.mocked(refreshWorkspaceDatabaseCatalog).mockResolvedValue([database]);
+    jest.mocked(getWorkspaceDatabaseCatalog).mockResolvedValue([database]);
 
-    await loadRelationDatabaseCandidates({ workspaceId: 'workspace-1', refreshCatalog: true });
+    await loadRelationDatabaseCandidates({ workspaceId: 'workspace-1' });
+    await loadRelationDatabaseCandidates({ workspaceId: 'workspace-1' });
 
-    expect(refreshWorkspaceDatabaseCatalog).toHaveBeenCalledWith('workspace-1');
-    expect(getWorkspaceDatabaseCatalog).not.toHaveBeenCalled();
+    expect(getWorkspaceDatabaseCatalog).toHaveBeenNthCalledWith(1, 'workspace-1');
+    expect(getWorkspaceDatabaseCatalog).toHaveBeenNthCalledWith(2, 'workspace-1');
   });
 
   it('does not expose databases without a container', async () => {

--- a/src/components/database/components/property/relation/relationDatabaseCandidates.ts
+++ b/src/components/database/components/property/relation/relationDatabaseCandidates.ts
@@ -3,7 +3,6 @@ import {
   DatabaseContainerCatalogEntry,
   getDatabaseContainerEntries,
   getWorkspaceDatabaseCatalog,
-  refreshWorkspaceDatabaseCatalog,
 } from '@/application/services/domains/view';
 import { WorkspaceDatabaseWithViews } from '@/application/services/services.type';
 import { DatabaseRelations, View } from '@/application/types';
@@ -24,7 +23,6 @@ interface IndexedView {
 interface LoadRelationDatabaseCandidatesOptions {
   workspaceId: string;
   loadViews?: () => Promise<View[] | undefined>;
-  refreshCatalog?: boolean;
 }
 
 export interface RelationDatabaseCandidatesResult {
@@ -117,12 +115,9 @@ export function buildRelationDatabaseCandidates(
 export async function loadRelationDatabaseCandidates({
   workspaceId,
   loadViews,
-  refreshCatalog = false,
 }: LoadRelationDatabaseCandidatesOptions): Promise<RelationDatabaseCandidatesResult> {
   const outlinePromise = (loadViews?.() ?? Promise.resolve(undefined)).catch(() => undefined);
-  const catalogPromise = refreshCatalog
-    ? refreshWorkspaceDatabaseCatalog(workspaceId)
-    : getWorkspaceDatabaseCatalog(workspaceId);
+  const catalogPromise = getWorkspaceDatabaseCatalog(workspaceId);
   const [databases, loadedOutline] = await Promise.all([catalogPromise, outlinePromise]);
 
   return buildRelationDatabaseCandidates(databases, loadedOutline ?? []);

--- a/src/components/database/components/property/relation/relationDatabaseCandidates.ts
+++ b/src/components/database/components/property/relation/relationDatabaseCandidates.ts
@@ -2,6 +2,7 @@ import {
   databaseCatalogViewToView,
   DatabaseContainerCatalogEntry,
   getDatabaseContainerEntries,
+  getWorkspaceDatabaseCatalog,
   refreshWorkspaceDatabaseCatalog,
 } from '@/application/services/domains/view';
 import { WorkspaceDatabaseWithViews } from '@/application/services/services.type';
@@ -23,6 +24,7 @@ interface IndexedView {
 interface LoadRelationDatabaseCandidatesOptions {
   workspaceId: string;
   loadViews?: () => Promise<View[] | undefined>;
+  refreshCatalog?: boolean;
 }
 
 export interface RelationDatabaseCandidatesResult {
@@ -115,9 +117,13 @@ export function buildRelationDatabaseCandidates(
 export async function loadRelationDatabaseCandidates({
   workspaceId,
   loadViews,
+  refreshCatalog = false,
 }: LoadRelationDatabaseCandidatesOptions): Promise<RelationDatabaseCandidatesResult> {
   const outlinePromise = (loadViews?.() ?? Promise.resolve(undefined)).catch(() => undefined);
-  const [databases, loadedOutline] = await Promise.all([refreshWorkspaceDatabaseCatalog(workspaceId), outlinePromise]);
+  const catalogPromise = refreshCatalog
+    ? refreshWorkspaceDatabaseCatalog(workspaceId)
+    : getWorkspaceDatabaseCatalog(workspaceId);
+  const [databases, loadedOutline] = await Promise.all([catalogPromise, outlinePromise]);
 
   return buildRelationDatabaseCandidates(databases, loadedOutline ?? []);
 }

--- a/src/components/database/components/property/relation/useRelationData.test.tsx
+++ b/src/components/database/components/property/relation/useRelationData.test.tsx
@@ -1,10 +1,11 @@
 import { EventEmitter } from 'events';
 
 import { act, renderHook, waitFor } from '@testing-library/react';
+import { useLayoutEffect } from 'react';
 
 import { APP_EVENTS } from '@/application/constants';
 import { parseRelationTypeOption, useDatabaseContext, useFieldSelector } from '@/application/database-yjs';
-import { getWorkspaceDatabaseCatalog, refreshWorkspaceDatabaseCatalog } from '@/application/services/domains/view';
+import { getWorkspaceDatabaseCatalog } from '@/application/services/domains/view';
 import { WorkspaceDatabaseWithViews } from '@/application/services/services.type';
 import { ViewLayout } from '@/application/types';
 
@@ -49,7 +50,6 @@ jest.mock('@/application/services/domains/view', () => ({
       return container && primaryView ? [{ databaseId: database.database_id, container, primaryView }] : [];
     }),
   getWorkspaceDatabaseCatalog: jest.fn(),
-  refreshWorkspaceDatabaseCatalog: jest.fn(),
 }));
 
 describe('useRelationData', () => {
@@ -105,15 +105,20 @@ describe('useRelationData', () => {
     expect(result.current.selectedView?.name).toBe('Projects');
   });
 
-  it('uses an explicit refresh when mounted for a user-opened picker', async () => {
-    jest.mocked(refreshWorkspaceDatabaseCatalog).mockResolvedValue([]);
+  it('uses the shared catalog getter when a user-opened picker becomes enabled', async () => {
+    const { result, rerender } = renderHook(
+      ({ enabled }: { enabled: boolean }) => useRelationData('field-1', { enabled }),
+      { initialProps: { enabled: false } }
+    );
 
-    const { result } = renderHook(() => useRelationData('field-1', { refreshCatalog: true }));
+    expect(getWorkspaceDatabaseCatalog).not.toHaveBeenCalled();
+
+    rerender({ enabled: true });
 
     await waitFor(() => expect(result.current.loading).toBe(false));
 
-    expect(refreshWorkspaceDatabaseCatalog).toHaveBeenCalledWith('workspace-1');
-    expect(getWorkspaceDatabaseCatalog).not.toHaveBeenCalled();
+    expect(getWorkspaceDatabaseCatalog).toHaveBeenCalledTimes(1);
+    expect(getWorkspaceDatabaseCatalog).toHaveBeenCalledWith('workspace-1');
   });
 
   it('rebuilds candidate metadata from the outline event payload without refetching the catalog', async () => {
@@ -155,5 +160,80 @@ describe('useRelationData', () => {
       expect(result.current.selectedView?.name).toBe('Renamed Projects');
     });
     expect(getWorkspaceDatabaseCatalog).toHaveBeenCalledTimes(1);
+  });
+
+  it('never commits a selected view from the previous related database', async () => {
+    jest.mocked(getWorkspaceDatabaseCatalog).mockResolvedValue([
+      {
+        database_id: 'database-1',
+        views: [
+          {
+            view_id: 'container-1',
+            layout: ViewLayout.Grid,
+            is_container: true,
+            embedded: false,
+            name: 'Projects',
+            icon: null,
+            parent_view_id: null,
+          },
+          {
+            view_id: 'grid-1',
+            layout: ViewLayout.Grid,
+            is_container: false,
+            embedded: false,
+            name: 'Grid',
+            icon: null,
+            parent_view_id: 'container-1',
+          },
+        ],
+      },
+      {
+        database_id: 'database-2',
+        views: [
+          {
+            view_id: 'container-2',
+            layout: ViewLayout.Grid,
+            is_container: true,
+            embedded: false,
+            name: 'Customers',
+            icon: null,
+            parent_view_id: null,
+          },
+          {
+            view_id: 'grid-2',
+            layout: ViewLayout.Grid,
+            is_container: false,
+            embedded: false,
+            name: 'Grid',
+            icon: null,
+            parent_view_id: 'container-2',
+          },
+        ],
+      },
+    ]);
+
+    const committedSelections: Array<{ databaseId: string | null; viewName?: string }> = [];
+    const { result, rerender } = renderHook(() => {
+      const relationData = useRelationData('field-1');
+
+      useLayoutEffect(() => {
+        committedSelections.push({
+          databaseId: relationData.relatedDatabaseId,
+          viewName: relationData.selectedView?.name,
+        });
+      }, [relationData.relatedDatabaseId, relationData.selectedView]);
+
+      return relationData;
+    });
+
+    await waitFor(() => expect(result.current.selectedView?.name).toBe('Projects'));
+    committedSelections.length = 0;
+    jest.mocked(parseRelationTypeOption).mockReturnValue({ database_id: 'database-2' } as never);
+
+    rerender();
+
+    expect(result.current.relatedDatabaseId).toBe('database-2');
+    expect(result.current.selectedView?.name).toBe('Customers');
+    expect(committedSelections).not.toContainEqual({ databaseId: 'database-2', viewName: 'Projects' });
   });
 });

--- a/src/components/database/components/property/relation/useRelationData.test.tsx
+++ b/src/components/database/components/property/relation/useRelationData.test.tsx
@@ -4,7 +4,7 @@ import { act, renderHook, waitFor } from '@testing-library/react';
 
 import { APP_EVENTS } from '@/application/constants';
 import { parseRelationTypeOption, useDatabaseContext, useFieldSelector } from '@/application/database-yjs';
-import { refreshWorkspaceDatabaseCatalog } from '@/application/services/domains/view';
+import { getWorkspaceDatabaseCatalog, refreshWorkspaceDatabaseCatalog } from '@/application/services/domains/view';
 import { WorkspaceDatabaseWithViews } from '@/application/services/services.type';
 import { ViewLayout } from '@/application/types';
 
@@ -48,6 +48,7 @@ jest.mock('@/application/services/domains/view', () => ({
 
       return container && primaryView ? [{ databaseId: database.database_id, container, primaryView }] : [];
     }),
+  getWorkspaceDatabaseCatalog: jest.fn(),
   refreshWorkspaceDatabaseCatalog: jest.fn(),
 }));
 
@@ -61,7 +62,7 @@ describe('useRelationData', () => {
       workspaceId: 'workspace-1',
       loadViews: jest.fn().mockResolvedValue([]),
     } as never);
-    jest.mocked(refreshWorkspaceDatabaseCatalog).mockResolvedValue([
+    jest.mocked(getWorkspaceDatabaseCatalog).mockResolvedValue([
       {
         database_id: 'database-1',
         views: [
@@ -93,7 +94,7 @@ describe('useRelationData', () => {
 
     await waitFor(() => expect(result.current.loading).toBe(false));
 
-    expect(refreshWorkspaceDatabaseCatalog).toHaveBeenCalledWith('workspace-1');
+    expect(getWorkspaceDatabaseCatalog).toHaveBeenCalledWith('workspace-1');
     expect(result.current.databaseCandidates).toEqual([
       expect.objectContaining({
         databaseId: 'database-1',
@@ -102,6 +103,17 @@ describe('useRelationData', () => {
       }),
     ]);
     expect(result.current.selectedView?.name).toBe('Projects');
+  });
+
+  it('uses an explicit refresh when mounted for a user-opened picker', async () => {
+    jest.mocked(refreshWorkspaceDatabaseCatalog).mockResolvedValue([]);
+
+    const { result } = renderHook(() => useRelationData('field-1', { refreshCatalog: true }));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(refreshWorkspaceDatabaseCatalog).toHaveBeenCalledWith('workspace-1');
+    expect(getWorkspaceDatabaseCatalog).not.toHaveBeenCalled();
   });
 
   it('rebuilds candidate metadata from the outline event payload without refetching the catalog', async () => {
@@ -116,7 +128,7 @@ describe('useRelationData', () => {
     const { result } = renderHook(() => useRelationData('field-1'));
 
     await waitFor(() => expect(result.current.loading).toBe(false));
-    expect(refreshWorkspaceDatabaseCatalog).toHaveBeenCalledTimes(1);
+    expect(getWorkspaceDatabaseCatalog).toHaveBeenCalledTimes(1);
     expect(result.current.databaseCandidates[0]?.path).toEqual(['Projects']);
 
     const outline = [
@@ -142,6 +154,6 @@ describe('useRelationData', () => {
       expect(result.current.databaseCandidates[0]?.displayView.name).toBe('Renamed Projects');
       expect(result.current.selectedView?.name).toBe('Renamed Projects');
     });
-    expect(refreshWorkspaceDatabaseCatalog).toHaveBeenCalledTimes(1);
+    expect(getWorkspaceDatabaseCatalog).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/components/database/components/property/relation/useRelationData.ts
+++ b/src/components/database/components/property/relation/useRelationData.ts
@@ -58,10 +58,11 @@ function withLoading(workspaceId: string, loading: boolean) {
 
 export interface UseRelationDataOptions {
   enabled?: boolean;
+  refreshCatalog?: boolean;
 }
 
 export function useRelationData(fieldId: string, options: UseRelationDataOptions = {}) {
-  const { enabled = true } = options;
+  const { enabled = true, refreshCatalog = false } = options;
   const { eventEmitter, getViewIdFromDatabaseId, loadViewMeta, loadViews, workspaceId } = useDatabaseContext();
   const { field } = useFieldSelector(fieldId);
   const relationOption: RelationTypeOption | null = field ? parseRelationTypeOption(field) : null;
@@ -108,6 +109,7 @@ export function useRelationData(fieldId: string, options: UseRelationDataOptions
     void loadRelationDatabaseCandidates({
       workspaceId,
       loadViews: loadViewsRef.current,
+      refreshCatalog,
     })
       .then((nextResult) => {
         if (!cancelled) setCachedResult(workspaceId, nextResult);
@@ -120,7 +122,7 @@ export function useRelationData(fieldId: string, options: UseRelationDataOptions
     return () => {
       cancelled = true;
     };
-  }, [enabled, fieldId, workspaceId]);
+  }, [enabled, fieldId, refreshCatalog, workspaceId]);
 
   useEffect(() => {
     if (!enabled || !eventEmitter) return;

--- a/src/components/database/components/property/relation/useRelationData.ts
+++ b/src/components/database/components/property/relation/useRelationData.ts
@@ -58,11 +58,10 @@ function withLoading(workspaceId: string, loading: boolean) {
 
 export interface UseRelationDataOptions {
   enabled?: boolean;
-  refreshCatalog?: boolean;
 }
 
 export function useRelationData(fieldId: string, options: UseRelationDataOptions = {}) {
-  const { enabled = true, refreshCatalog = false } = options;
+  const { enabled = true } = options;
   const { eventEmitter, getViewIdFromDatabaseId, loadViewMeta, loadViews, workspaceId } = useDatabaseContext();
   const { field } = useFieldSelector(fieldId);
   const relationOption: RelationTypeOption | null = field ? parseRelationTypeOption(field) : null;
@@ -79,7 +78,10 @@ export function useRelationData(fieldId: string, options: UseRelationDataOptions
     setLoadingState({ workspaceId, loading: enabled && !getCachedResult(workspaceId) });
   }
 
-  const [fallbackRelatedViewId, setFallbackRelatedViewId] = useState<string | null>(null);
+  const [fallbackRelatedView, setFallbackRelatedView] = useState<{
+    databaseId: string;
+    viewId: string | null;
+  } | null>(null);
   const loadViewMetaRef = useRef(loadViewMeta);
   const loadViewsRef = useRef(loadViews);
   const onUpdateTypeOption = useUpdateRelationTypeOption(fieldId);
@@ -109,7 +111,6 @@ export function useRelationData(fieldId: string, options: UseRelationDataOptions
     void loadRelationDatabaseCandidates({
       workspaceId,
       loadViews: loadViewsRef.current,
-      refreshCatalog,
     })
       .then((nextResult) => {
         if (!cancelled) setCachedResult(workspaceId, nextResult);
@@ -122,7 +123,7 @@ export function useRelationData(fieldId: string, options: UseRelationDataOptions
     return () => {
       cancelled = true;
     };
-  }, [enabled, fieldId, refreshCatalog, workspaceId]);
+  }, [enabled, fieldId, workspaceId]);
 
   useEffect(() => {
     if (!enabled || !eventEmitter) return;
@@ -148,22 +149,25 @@ export function useRelationData(fieldId: string, options: UseRelationDataOptions
     };
   }, [enabled, eventEmitter, workspaceId]);
 
+  const fallbackRelatedViewId =
+    fallbackRelatedView?.databaseId === relatedDatabaseId ? fallbackRelatedView.viewId : null;
   const relatedViewId = relatedDatabaseId ? result.relations[relatedDatabaseId] || fallbackRelatedViewId : null;
 
   useEffect(() => {
     if (!enabled || !relatedDatabaseId || result.relations[relatedDatabaseId] || !getViewIdFromDatabaseId) {
-      setFallbackRelatedViewId(null);
+      setFallbackRelatedView(null);
       return;
     }
 
     let cancelled = false;
+    const requestedDatabaseId = relatedDatabaseId;
 
     void getViewIdFromDatabaseId(relatedDatabaseId)
       .then((viewId) => {
-        if (!cancelled) setFallbackRelatedViewId(viewId);
+        if (!cancelled) setFallbackRelatedView({ databaseId: requestedDatabaseId, viewId });
       })
       .catch(() => {
-        if (!cancelled) setFallbackRelatedViewId(null);
+        if (!cancelled) setFallbackRelatedView({ databaseId: requestedDatabaseId, viewId: null });
       });
 
     return () => {
@@ -176,24 +180,32 @@ export function useRelationData(fieldId: string, options: UseRelationDataOptions
     [relatedDatabaseId, result.candidates]
   );
 
-  // selectedView is writable state, not pure derived state — consumers set it
-  // optimistically when picking a candidate — so it is synced from the
-  // candidate list in an effect rather than derived during render. The lazy
-  // initializer still makes cache-hit mounts render the name immediately.
-  const [selectedView, setSelectedView] = useState<View | undefined>(() => selectedCandidate?.displayView);
+  type DatabaseViewState = { databaseId: string | null; view: View | undefined };
+  const [optimisticSelectedView, setOptimisticSelectedView] = useState<DatabaseViewState>({
+    databaseId: null,
+    view: undefined,
+  });
+  const [loadedSelectedView, setLoadedSelectedView] = useState<DatabaseViewState>({
+    databaseId: null,
+    view: undefined,
+  });
+
+  const setSelectedView = useCallback(
+    (view: View | undefined) => {
+      const candidateDatabaseId = view
+        ? result.candidates.find((candidate) => candidate.displayView.view_id === view.view_id)?.databaseId
+        : undefined;
+
+      setOptimisticSelectedView({ databaseId: candidateDatabaseId ?? relatedDatabaseId, view });
+    },
+    [relatedDatabaseId, result.candidates]
+  );
 
   useEffect(() => {
-    if (selectedCandidate) {
-      setSelectedView(selectedCandidate.displayView);
-      return;
-    }
-
-    if (!relatedViewId || !loadViewMetaRef.current) {
-      setSelectedView(undefined);
-      return;
-    }
+    if (selectedCandidate || !relatedDatabaseId || !relatedViewId || !loadViewMetaRef.current) return;
 
     let cancelled = false;
+    const requestedDatabaseId = relatedDatabaseId;
 
     void (async () => {
       try {
@@ -202,24 +214,38 @@ export function useRelationData(fieldId: string, options: UseRelationDataOptions
         if (!view || cancelled) return;
 
         if (!view.parent_view_id) {
-          setSelectedView(view);
+          setLoadedSelectedView({ databaseId: requestedDatabaseId, view });
           return;
         }
 
         const parent = await loadViewMetaRef.current?.(view.parent_view_id);
 
         if (!cancelled) {
-          setSelectedView(parent?.name ? { ...view, icon: parent.icon ?? view.icon, name: parent.name } : view);
+          setLoadedSelectedView({
+            databaseId: requestedDatabaseId,
+            view: parent?.name ? { ...view, icon: parent.icon ?? view.icon, name: parent.name } : view,
+          });
         }
       } catch {
-        if (!cancelled) setSelectedView(undefined);
+        if (!cancelled) setLoadedSelectedView({ databaseId: requestedDatabaseId, view: undefined });
       }
     })();
 
     return () => {
       cancelled = true;
     };
-  }, [relatedViewId, selectedCandidate]);
+  }, [relatedDatabaseId, relatedViewId, selectedCandidate]);
+
+  // Keep the view and database identity as one render-time value. Effect-
+  // syncing a bare View allowed one commit where database B was paired with
+  // the selected view left over from database A.
+  const selectedView = selectedCandidate
+    ? selectedCandidate.displayView
+    : optimisticSelectedView.databaseId === relatedDatabaseId
+      ? optimisticSelectedView.view
+      : loadedSelectedView.databaseId === relatedDatabaseId
+        ? loadedSelectedView.view
+        : undefined;
 
   const views = useMemo(() => result.candidates.map((candidate) => candidate.displayView), [result.candidates]);
 

--- a/src/components/editor/components/blocks/database/DatabaseBlock.tsx
+++ b/src/components/editor/components/blocks/database/DatabaseBlock.tsx
@@ -4,9 +4,7 @@ import { useTranslation } from 'react-i18next';
 import { Element, Transforms } from 'slate';
 import { ReactEditor, useReadOnly, useSlateStatic } from 'slate-react';
 
-import { APP_EVENTS } from '@/application/constants';
 import { DatabaseContextState } from '@/application/database-yjs';
-import { ViewService } from '@/application/services/domains';
 import { UIVariant, YjsEditorKey, YSharedRoot } from '@/application/types';
 import { useEmbeddedVisibleViewIds } from '@/components/database/hooks';
 import { DatabaseNode, EditorElementProps } from '@/components/editor/editor.type';
@@ -14,11 +12,12 @@ import { useEditorContext } from '@/components/editor/EditorContext';
 import { Log } from '@/utils/log';
 
 import { DatabaseContent } from './components/DatabaseContent';
+import { useDatabaseDeletionStatus } from './hooks/useDatabaseDeletionStatus';
 import { useDocumentLoader } from './hooks/useDocumentLoader';
 import { useResizePositioning } from './hooks/useResizePositioning';
 import { useViewMeta } from './hooks/useViewMeta';
 import { useViewSelection } from './hooks/useViewSelection';
-import { getViewIds, isDatabaseDuplicatePlaceholder, isViewGoneError, replaceViewIds } from './utils/databaseBlockUtils';
+import { getViewIds, isDatabaseDuplicatePlaceholder, replaceViewIds } from './utils/databaseBlockUtils';
 
 function DatabaseDuplicatePlaceholder() {
   const { t } = useTranslation();
@@ -54,9 +53,6 @@ function DatabaseBlockBody({ node, children, editor, forwardedRef, readOnly, ...
   const bindViewSync = context?.bindViewSync;
 
   const [hasDatabase, setHasDatabase] = useState(false);
-  const [deletionStatus, setDeletionStatus] = useState<'none' | 'inTrash' | 'deleted' | null>(null);
-  const effectiveDeletionStatus =
-    context.variant === UIVariant.Publish && deletionStatus === null ? 'none' : deletionStatus;
   const containerRef = useRef<HTMLDivElement | null>(null);
 
   // Compose focused hooks instead of one monolithic hook
@@ -88,130 +84,18 @@ function DatabaseBlockBody({ node, children, editor, forwardedRef, readOnly, ...
     onNotFound: () => setNotFound(true),
   });
 
-  // 5. Detect when the database page is deleted from (or restored to) the sidebar.
-  //    When OUTLINE_LOADED fires (after any folder change), fetch the fresh trash list
-  //    and check if our view is in it. This is reliable because:
-  //    - The server API (ViewService.get) returns trashed views as if they still exist
-  //    - The app's trashList state may not be updated yet due to async race conditions
-  //    - Fetching trash directly from the API gives an authoritative answer
-  const notFoundRef = useRef(notFound);
-
-  notFoundRef.current = notFound;
-
-  // Remember the database container (parent) id while the view is still reachable.
-  // Once the container is moved to trash, ViewService.get(viewId) returns 404 and
-  // viewMeta becomes null, so the response can no longer tell us the parent id. We
-  // still need it to recognize the deletion as "in trash" rather than "permanently
-  // deleted": the trash list only contains the container id, never the embedded
-  // child view id. Keyed by viewId so a stale parent is ignored if the block swaps views.
-  const lastKnownParentRef = useRef<{ viewId: string; parentId: string } | null>(null);
-
-  useEffect(() => {
-    const eventEmitter = context.eventEmitter;
-
-    if (!eventEmitter || !viewId || !hasDatabase || !workspaceId) return;
-
-    let cancelled = false;
-
-    // On mount, go through the short-lived view/trash caches so the fetch
-    // coalesces with useViewMeta's request (and with other embedded blocks on
-    // the same page). When OUTLINE_LOADED fires the folder just changed, so
-    // force fresh fetches — refresh() bypasses the TTL but still shares any
-    // in-flight request, keeping N blocks at one request per resource.
-    const checkView = async (refresh: boolean) => {
-      try {
-        // Fetch view metadata and trash list in parallel (async-parallel rule).
-        const [viewResult, trashResult] = await Promise.allSettled([
-          refresh ? ViewService.refresh(workspaceId, viewId) : ViewService.get(workspaceId, viewId),
-          refresh ? ViewService.refreshTrash(workspaceId) : ViewService.getTrashCached(workspaceId),
-        ]);
-
-        const viewMeta = viewResult.status === 'fulfilled' ? viewResult.value : null;
-        // Only a confirmed record-not-found/deleted response means the view is
-        // gone; transient network/server errors must not flip the block into
-        // the "deleted" state (the trash list may still resolve from cache).
-        const viewGone = viewResult.status === 'rejected' && isViewGoneError(viewResult.reason);
-        const trashItems = trashResult.status === 'fulfilled' ? trashResult.value : null;
-
-        // If both requests failed, optimistically allow rendering rather than
-        // blocking the user with an infinite spinner.
-        if (viewResult.status === 'rejected' && trashResult.status === 'rejected') {
-          if (cancelled) return;
-          setDeletionStatus('none');
-          return;
-        }
-
-        // Cache the parent id whenever the view is reachable, so we can still resolve
-        // the container after it is trashed (at which point viewMeta is null).
-        if (viewMeta?.parent_view_id) {
-          lastKnownParentRef.current = { viewId, parentId: viewMeta.parent_view_id };
-        }
-
-        // Build the set of IDs to check: the view itself and its parent (database
-        // container). When a database container is trashed, only the container ID
-        // appears in trash — not its child view IDs — so fall back to the last known
-        // parent id when the trashed view no longer reports its metadata.
-        const cachedParentId =
-          lastKnownParentRef.current?.viewId === viewId ? lastKnownParentRef.current.parentId : null;
-        const parentId = viewMeta?.parent_view_id ?? cachedParentId;
-        const idsToCheck = new Set<string>([viewId]);
-
-        if (parentId) {
-          idsToCheck.add(parentId);
-        }
-
-        // The view API omits trashed ancestors, so on a fresh mount the child view of
-        // a trashed container reports no parent and idsToCheck can't name the trashed
-        // container. The trash entries carry the container's DatabaseViewExtra, so also
-        // match by the block's database_id: if this database's container is in the
-        // trash, the block can't render regardless of which id was used to reach it.
-        const isInTrash = trashItems?.some(
-          (item) =>
-            idsToCheck.has(item.view_id) ||
-            (!!databaseId && item.extra?.is_database_container === true && item.extra?.database_id === databaseId)
-        );
-
-        if (cancelled) return;
-
-        if (isInTrash) {
-          // Database container is in the trash
-          setDeletionStatus('inTrash');
-
-          if (!notFoundRef.current) {
-            setNotFound(true);
-          }
-        } else if (viewGone && !viewMeta) {
-          // Not in trash AND API can't find the view — permanently deleted
-          setDeletionStatus('deleted');
-
-          if (!notFoundRef.current) {
-            setNotFound(true);
-          }
-        } else if (viewMeta) {
-          // View exists and is not in trash — confirmed alive (or restored)
-          setDeletionStatus('none');
-
-          if (notFoundRef.current) {
-            setNotFound(false);
-          }
-        }
-      } catch {
-        // Network error — do nothing, keep current state
-      }
-    };
-
-    // Check immediately on mount (covers navigating back to a page after deletion)
-    void checkView(false);
-
-    const handleOutlineLoaded = () => void checkView(true);
-
-    eventEmitter.on(APP_EVENTS.OUTLINE_LOADED, handleOutlineLoaded);
-    return () => {
-      cancelled = true;
-      eventEmitter.off(APP_EVENTS.OUTLINE_LOADED, handleOutlineLoaded);
-    };
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- node.data excluded to avoid re-subscribing on every block edit
-  }, [context.eventEmitter, viewId, workspaceId, hasDatabase, setNotFound]);
+  // 5. Detect when the database page is deleted from (or restored to) trash.
+  const deletionStatus = useDatabaseDeletionStatus({
+    workspaceId,
+    viewId,
+    databaseId,
+    hasDatabase,
+    eventEmitter: context.eventEmitter,
+    notFound,
+    setNotFound,
+  });
+  const effectiveDeletionStatus =
+    context.variant === UIVariant.Publish && deletionStatus === null ? 'none' : deletionStatus;
 
   // Combined callback when a view is added
   const onViewAdded = useCallback(

--- a/src/components/editor/components/blocks/database/hooks/__tests__/useDatabaseDeletionStatus.test.tsx
+++ b/src/components/editor/components/blocks/database/hooks/__tests__/useDatabaseDeletionStatus.test.tsx
@@ -1,0 +1,163 @@
+import EventEmitter from 'events';
+
+import { act, renderHook, waitFor } from '@testing-library/react';
+
+import { APP_EVENTS } from '@/application/constants';
+import { ViewService } from '@/application/services/domains';
+import { View, ViewLayout } from '@/application/types';
+
+import { useDatabaseDeletionStatus } from '../useDatabaseDeletionStatus';
+
+jest.mock('@/application/services/domains', () => ({
+  ViewService: {
+    get: jest.fn(),
+    getTrashCached: jest.fn(),
+    refresh: jest.fn(),
+  },
+}));
+
+function createDeferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+
+  return { promise, resolve, reject };
+}
+
+function createView(viewId: string, overrides: Partial<View> = {}): View {
+  return {
+    view_id: viewId,
+    name: viewId,
+    icon: null,
+    layout: ViewLayout.Document,
+    extra: null,
+    children: [],
+    is_published: false,
+    is_private: false,
+    ...overrides,
+  };
+}
+
+describe('useDatabaseDeletionStatus', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('ignores generic outline loads, consumes TRASH_UPDATED without fetching trash, and rejects a stale mount result', async () => {
+    const eventEmitter = new EventEmitter();
+    const setNotFound = jest.fn();
+    const mountViewRequest = createDeferred<View>();
+    const mountTrashRequest = createDeferred<View[]>();
+    const databaseView = createView('database-view', { parent_view_id: 'database-container' });
+    const trashedContainer = createView('database-container', {
+      extra: {
+        is_database_container: true,
+        database_id: 'database-id',
+      },
+    });
+    const trashItems = [trashedContainer];
+
+    (ViewService.get as jest.Mock).mockReturnValue(mountViewRequest.promise);
+    (ViewService.getTrashCached as jest.Mock).mockReturnValue(mountTrashRequest.promise);
+    (ViewService.refresh as jest.Mock).mockResolvedValue(databaseView);
+
+    const { result } = renderHook(() =>
+      useDatabaseDeletionStatus({
+        workspaceId: 'workspace-id',
+        viewId: 'database-view',
+        databaseId: 'database-id',
+        hasDatabase: true,
+        eventEmitter,
+        notFound: false,
+        setNotFound,
+      })
+    );
+
+    expect(ViewService.get).toHaveBeenCalledTimes(1);
+    expect(ViewService.getTrashCached).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      eventEmitter.emit(APP_EVENTS.OUTLINE_LOADED, []);
+    });
+
+    expect(ViewService.refresh).not.toHaveBeenCalled();
+    expect(ViewService.getTrashCached).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      eventEmitter.emit(APP_EVENTS.TRASH_UPDATED, {
+        workspaceId: 'different-workspace',
+        trashItems: [trashedContainer],
+      });
+    });
+
+    expect(ViewService.refresh).not.toHaveBeenCalled();
+
+    act(() => {
+      eventEmitter.emit(APP_EVENTS.TRASH_UPDATED, {
+        workspaceId: 'workspace-id',
+        trashItems,
+      });
+    });
+
+    await waitFor(() => {
+      expect(result.current).toBe('inTrash');
+    });
+
+    expect(ViewService.refresh).toHaveBeenCalledTimes(1);
+    expect(ViewService.getTrashCached).toHaveBeenCalledTimes(1);
+    expect(setNotFound).toHaveBeenCalledWith(true);
+
+    act(() => {
+      eventEmitter.emit(APP_EVENTS.TRASH_UPDATED, {
+        workspaceId: 'workspace-id',
+        trashItems,
+      });
+    });
+
+    expect(ViewService.refresh).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      mountViewRequest.resolve(databaseView);
+      mountTrashRequest.resolve([]);
+      await Promise.all([mountViewRequest.promise, mountTrashRequest.promise]);
+    });
+
+    expect(result.current).toBe('inTrash');
+    expect(setNotFound).not.toHaveBeenCalledWith(false);
+  });
+
+  it('shares one TRASH_UPDATED listener across embedded database hooks', async () => {
+    const eventEmitter = new EventEmitter();
+    const databaseView = createView('database-view', { parent_view_id: 'database-container' });
+
+    (ViewService.get as jest.Mock).mockResolvedValue(databaseView);
+    (ViewService.getTrashCached as jest.Mock).mockResolvedValue([]);
+
+    const props = {
+      workspaceId: 'workspace-id',
+      viewId: 'database-view',
+      databaseId: 'database-id',
+      hasDatabase: true,
+      eventEmitter,
+      notFound: false,
+      setNotFound: jest.fn(),
+    };
+    const first = renderHook(() => useDatabaseDeletionStatus(props));
+    const second = renderHook(() => useDatabaseDeletionStatus(props));
+
+    await waitFor(() => {
+      expect(first.result.current).toBe('none');
+      expect(second.result.current).toBe('none');
+    });
+    expect(eventEmitter.listenerCount(APP_EVENTS.TRASH_UPDATED)).toBe(1);
+
+    first.unmount();
+    expect(eventEmitter.listenerCount(APP_EVENTS.TRASH_UPDATED)).toBe(1);
+
+    second.unmount();
+    expect(eventEmitter.listenerCount(APP_EVENTS.TRASH_UPDATED)).toBe(0);
+  });
+});

--- a/src/components/editor/components/blocks/database/hooks/__tests__/useDatabaseDeletionStatus.test.tsx
+++ b/src/components/editor/components/blocks/database/hooks/__tests__/useDatabaseDeletionStatus.test.tsx
@@ -46,6 +46,130 @@ describe('useDatabaseDeletionStatus', () => {
     jest.clearAllMocks();
   });
 
+  it('settles an unconfirmed database as active when the initial view probe fails transiently', async () => {
+    const eventEmitter = new EventEmitter();
+    const setNotFound = jest.fn();
+
+    (ViewService.get as jest.Mock).mockRejectedValue({
+      code: 500,
+      httpStatus: 500,
+      message: 'Internal server error',
+    });
+    (ViewService.getTrashCached as jest.Mock).mockResolvedValue([]);
+
+    const { result } = renderHook(() =>
+      useDatabaseDeletionStatus({
+        workspaceId: 'workspace-id',
+        viewId: 'database-view',
+        databaseId: 'database-id',
+        hasDatabase: true,
+        eventEmitter,
+        notFound: false,
+        setNotFound,
+      })
+    );
+
+    await waitFor(() => {
+      expect(result.current).toBe('none');
+    });
+
+    expect(setNotFound).not.toHaveBeenCalled();
+  });
+
+  it('confirms deletion when the view is gone even if the trash lookup also fails', async () => {
+    const eventEmitter = new EventEmitter();
+    const setNotFound = jest.fn();
+
+    (ViewService.get as jest.Mock).mockRejectedValue({
+      code: -2,
+      httpStatus: 404,
+      message: 'Record not found',
+    });
+    (ViewService.getTrashCached as jest.Mock).mockRejectedValue(new Error('trash unavailable'));
+
+    const { result } = renderHook(() =>
+      useDatabaseDeletionStatus({
+        workspaceId: 'workspace-id',
+        viewId: 'database-view',
+        databaseId: 'database-id',
+        hasDatabase: true,
+        eventEmitter,
+        notFound: false,
+        setNotFound,
+      })
+    );
+
+    await waitFor(() => {
+      expect(result.current).toBe('deleted');
+    });
+    expect(setNotFound).toHaveBeenCalledWith(true);
+  });
+
+  it.each([
+    {
+      confirmedStatus: 'inTrash' as const,
+      initialViewResult: createView('database-view', { parent_view_id: 'database-container' }),
+      initialTrashItems: [
+        createView('database-container', {
+          extra: {
+            is_database_container: true,
+            database_id: 'database-id',
+          },
+        }),
+      ],
+    },
+    {
+      confirmedStatus: 'deleted' as const,
+      initialViewResult: { code: -2, httpStatus: 404, message: 'Record not found' },
+      initialTrashItems: [],
+    },
+  ])('preserves a confirmed $confirmedStatus state after a transient refresh failure', async (scenario) => {
+    const eventEmitter = new EventEmitter();
+    const setNotFound = jest.fn();
+
+    if (scenario.confirmedStatus === 'deleted') {
+      (ViewService.get as jest.Mock).mockRejectedValue(scenario.initialViewResult);
+    } else {
+      (ViewService.get as jest.Mock).mockResolvedValue(scenario.initialViewResult);
+    }
+
+    (ViewService.getTrashCached as jest.Mock).mockResolvedValue(scenario.initialTrashItems);
+    (ViewService.refresh as jest.Mock).mockRejectedValue({
+      code: 500,
+      httpStatus: 500,
+      message: 'Internal server error',
+    });
+
+    const { result } = renderHook(() =>
+      useDatabaseDeletionStatus({
+        workspaceId: 'workspace-id',
+        viewId: 'database-view',
+        databaseId: 'database-id',
+        hasDatabase: true,
+        eventEmitter,
+        notFound: false,
+        setNotFound,
+      })
+    );
+
+    await waitFor(() => {
+      expect(result.current).toBe(scenario.confirmedStatus);
+    });
+
+    await act(async () => {
+      eventEmitter.emit(APP_EVENTS.TRASH_UPDATED, {
+        workspaceId: 'workspace-id',
+        trashItems: [],
+      });
+      await Promise.resolve();
+    });
+
+    await waitFor(() => {
+      expect(ViewService.refresh).toHaveBeenCalledTimes(1);
+    });
+    expect(result.current).toBe(scenario.confirmedStatus);
+  });
+
   it('ignores generic outline loads, consumes TRASH_UPDATED without fetching trash, and rejects a stale mount result', async () => {
     const eventEmitter = new EventEmitter();
     const setNotFound = jest.fn();

--- a/src/components/editor/components/blocks/database/hooks/useDatabaseDeletionStatus.ts
+++ b/src/components/editor/components/blocks/database/hooks/useDatabaseDeletionStatus.ts
@@ -97,6 +97,11 @@ export function useDatabaseDeletionStatus({
       setDeletionStatus(status);
     };
 
+    const settleAsActiveIfUnconfirmed = () => {
+      if (deletionStatusRef.current !== null) return;
+      confirmDeletionStatus('none');
+    };
+
     const checkView = async (refreshView: boolean, freshTrashItems?: View[]) => {
       const requestSeq = ++checkRequestSeq;
 
@@ -119,8 +124,8 @@ export function useDatabaseDeletionStatus({
         }
 
         // Transient failure is not proof that the database was deleted.
-        if (viewResult.status === 'rejected' && trashResult.status === 'rejected') {
-          confirmDeletionStatus('none');
+        if (viewResult.status === 'rejected' && !viewGone && trashResult.status === 'rejected') {
+          settleAsActiveIfUnconfirmed();
           return;
         }
 
@@ -161,6 +166,11 @@ export function useDatabaseDeletionStatus({
           if (notFoundRef.current) {
             setNotFound(false);
           }
+        } else if (viewResult.status === 'rejected' && !viewGone && trashResult.status === 'fulfilled') {
+          // An empty authoritative trash result plus a transient metadata
+          // failure is enough to render an otherwise valid embedded database.
+          // Never overwrite a previously confirmed trash/deletion state.
+          settleAsActiveIfUnconfirmed();
         }
       } catch {
         // Network error — preserve the last confirmed state.

--- a/src/components/editor/components/blocks/database/hooks/useDatabaseDeletionStatus.ts
+++ b/src/components/editor/components/blocks/database/hooks/useDatabaseDeletionStatus.ts
@@ -1,0 +1,189 @@
+
+import { useEffect, useRef, useState } from 'react';
+
+import { APP_EVENTS } from '@/application/constants';
+import { ViewService } from '@/application/services/domains';
+import type { View } from '@/application/types';
+
+import { isViewGoneError } from '../utils/databaseBlockUtils';
+
+import type EventEmitter from 'events';
+
+export type DatabaseDeletionStatus = 'none' | 'inTrash' | 'deleted' | null;
+
+type TrashUpdatedPayload = { workspaceId?: string; trashItems?: View[] };
+type TrashUpdatedCallback = (payload: TrashUpdatedPayload) => void;
+type TrashUpdatedSubscription = {
+  callbacks: Set<TrashUpdatedCallback>;
+  handler: TrashUpdatedCallback;
+};
+
+const trashUpdatedSubscriptions = new WeakMap<EventEmitter, TrashUpdatedSubscription>();
+
+function subscribeTrashUpdated(eventEmitter: EventEmitter, callback: TrashUpdatedCallback) {
+  let subscription = trashUpdatedSubscriptions.get(eventEmitter);
+
+  if (!subscription) {
+    subscription = {
+      callbacks: new Set(),
+      handler: (payload) => {
+        subscription?.callbacks.forEach((subscriber) => subscriber(payload));
+      },
+    };
+    trashUpdatedSubscriptions.set(eventEmitter, subscription);
+    eventEmitter.on(APP_EVENTS.TRASH_UPDATED, subscription.handler);
+  }
+
+  subscription.callbacks.add(callback);
+
+  return () => {
+    const current = trashUpdatedSubscriptions.get(eventEmitter);
+
+    if (!current) return;
+    current.callbacks.delete(callback);
+
+    if (current.callbacks.size === 0) {
+      eventEmitter.off(APP_EVENTS.TRASH_UPDATED, current.handler);
+      trashUpdatedSubscriptions.delete(eventEmitter);
+    }
+  };
+}
+
+interface UseDatabaseDeletionStatusProps {
+  workspaceId: string;
+  viewId: string;
+  databaseId?: string;
+  hasDatabase: boolean;
+  eventEmitter?: EventEmitter;
+  notFound: boolean;
+  setNotFound: (notFound: boolean) => void;
+}
+
+/**
+ * Tracks whether an embedded database's container is in trash or permanently
+ * deleted. Mount probes share the workspace trash coordinator; later updates
+ * consume the app-level authoritative payload without starting another trash
+ * request for every embedded block.
+ */
+export function useDatabaseDeletionStatus({
+  workspaceId,
+  viewId,
+  databaseId,
+  hasDatabase,
+  eventEmitter,
+  notFound,
+  setNotFound,
+}: UseDatabaseDeletionStatusProps): DatabaseDeletionStatus {
+  const [deletionStatus, setDeletionStatus] = useState<DatabaseDeletionStatus>(null);
+  const deletionStatusRef = useRef<DatabaseDeletionStatus>(null);
+  const lastCheckedTrashItemsRef = useRef<View[] | null>(null);
+  const notFoundRef = useRef(notFound);
+  const lastKnownParentRef = useRef<{ viewId: string; parentId: string } | null>(null);
+
+  notFoundRef.current = notFound;
+
+  useEffect(() => {
+    if (!eventEmitter || !viewId || !hasDatabase || !workspaceId) return;
+
+    let cancelled = false;
+    let checkRequestSeq = 0;
+
+    deletionStatusRef.current = null;
+    lastCheckedTrashItemsRef.current = null;
+    setDeletionStatus((current) => (current === null ? current : null));
+
+    const confirmDeletionStatus = (status: Exclude<DatabaseDeletionStatus, null>) => {
+      deletionStatusRef.current = status;
+      setDeletionStatus(status);
+    };
+
+    const checkView = async (refreshView: boolean, freshTrashItems?: View[]) => {
+      const requestSeq = ++checkRequestSeq;
+
+      try {
+        const [viewResult, trashResult] = await Promise.allSettled([
+          refreshView ? ViewService.refresh(workspaceId, viewId) : ViewService.get(workspaceId, viewId),
+          freshTrashItems === undefined ? ViewService.getTrashCached(workspaceId) : Promise.resolve(freshTrashItems),
+        ]);
+
+        // A mount check may finish after a TRASH_UPDATED-driven check. Never
+        // let that older result restore stale deletion state or parent metadata.
+        if (cancelled || requestSeq !== checkRequestSeq) return;
+
+        const viewMeta = viewResult.status === 'fulfilled' ? viewResult.value : null;
+        const viewGone = viewResult.status === 'rejected' && isViewGoneError(viewResult.reason);
+        const trashItems = trashResult.status === 'fulfilled' ? trashResult.value : null;
+
+        if (trashItems) {
+          lastCheckedTrashItemsRef.current = trashItems;
+        }
+
+        // Transient failure is not proof that the database was deleted.
+        if (viewResult.status === 'rejected' && trashResult.status === 'rejected') {
+          confirmDeletionStatus('none');
+          return;
+        }
+
+        if (viewMeta?.parent_view_id) {
+          lastKnownParentRef.current = { viewId, parentId: viewMeta.parent_view_id };
+        }
+
+        const cachedParentId =
+          lastKnownParentRef.current?.viewId === viewId ? lastKnownParentRef.current.parentId : null;
+        const parentId = viewMeta?.parent_view_id ?? cachedParentId;
+        const idsToCheck = new Set<string>([viewId]);
+
+        if (parentId) {
+          idsToCheck.add(parentId);
+        }
+
+        const isInTrash = trashItems?.some(
+          (item) =>
+            idsToCheck.has(item.view_id) ||
+            (!!databaseId && item.extra?.is_database_container === true && item.extra?.database_id === databaseId)
+        );
+
+        if (isInTrash) {
+          confirmDeletionStatus('inTrash');
+
+          if (!notFoundRef.current) {
+            setNotFound(true);
+          }
+        } else if (viewGone && !viewMeta) {
+          confirmDeletionStatus('deleted');
+
+          if (!notFoundRef.current) {
+            setNotFound(true);
+          }
+        } else if (viewMeta) {
+          confirmDeletionStatus('none');
+
+          if (notFoundRef.current) {
+            setNotFound(false);
+          }
+        }
+      } catch {
+        // Network error — preserve the last confirmed state.
+      }
+    };
+
+    void checkView(false);
+
+    const handleTrashUpdated = (payload: TrashUpdatedPayload) => {
+      if (payload?.workspaceId !== workspaceId || !Array.isArray(payload.trashItems)) return;
+      if (deletionStatusRef.current !== null && lastCheckedTrashItemsRef.current === payload.trashItems) return;
+
+      void checkView(true, payload.trashItems);
+    };
+
+    const unsubscribeTrashUpdated = subscribeTrashUpdated(eventEmitter, handleTrashUpdated);
+
+    return () => {
+      cancelled = true;
+      checkRequestSeq += 1;
+      unsubscribeTrashUpdated();
+    };
+  }, [databaseId, eventEmitter, hasDatabase, setNotFound, viewId, workspaceId]);
+
+  return deletionStatus;
+}

--- a/src/components/editor/components/panels/slash-panel/SlashPanel.tsx
+++ b/src/components/editor/components/panels/slash-panel/SlashPanel.tsx
@@ -14,7 +14,7 @@ import { createDatabaseListPageViaGrid, createLinkedDatabaseListView } from '@/a
 import {
   databaseCatalogViewToView,
   getDatabaseContainerEntries,
-  refreshWorkspaceDatabaseCatalog,
+  getWorkspaceDatabaseCatalog,
 } from '@/application/services/domains/view';
 import { YjsEditor } from '@/application/slate-yjs';
 import { CustomEditor } from '@/application/slate-yjs/command';
@@ -579,7 +579,7 @@ export function SlashPanel({
     setDatabaseError(null);
 
     try {
-      const databases = await refreshWorkspaceDatabaseCatalog(workspaceId);
+      const databases = await getWorkspaceDatabaseCatalog(workspaceId);
       const options = getDatabaseContainerEntries(databases).map<DatabaseOption>(
         ({ databaseId, container, primaryView }) => ({
           databaseId,

--- a/src/pages/TrashPage.tsx
+++ b/src/pages/TrashPage.tsx
@@ -1,11 +1,14 @@
-import { Button, IconButton, TableContainer, Tooltip } from '@mui/material';
+import Button from '@mui/material/Button';
+import IconButton from '@mui/material/IconButton';
 import Table from '@mui/material/Table';
 import TableBody from '@mui/material/TableBody';
 import TableCell from '@mui/material/TableCell';
+import TableContainer from '@mui/material/TableContainer';
 import TableHead from '@mui/material/TableHead';
 import TableRow from '@mui/material/TableRow';
+import Tooltip from '@mui/material/Tooltip';
 import dayjs from 'dayjs';
-import React, { useCallback, useEffect, useMemo } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import {
@@ -20,13 +23,14 @@ import { NormalModal } from '@/components/_shared/modal';
 import { notify } from '@/components/_shared/notify';
 import TableSkeleton from '@/components/_shared/skeleton/TableSkeleton';
 import { useAppOperations, useAppTrash, useCurrentWorkspaceId } from '@/components/app/app.hooks';
+import { Log } from '@/utils/log';
 
 function TrashPage() {
   const { t } = useTranslation();
 
   const currentWorkspaceId = useCurrentWorkspaceId();
   const { trashList, loadTrash } = useAppTrash();
-  const [deleteViewId, setDeleteViewId] = React.useState<string | undefined>(undefined);
+  const [deleteViewId, setDeleteViewId] = useState<string | undefined>(undefined);
   const deleteView = useMemo(() => {
     return trashList?.find((view) => view.view_id === deleteViewId);
   }, [deleteViewId, trashList]);
@@ -80,7 +84,9 @@ function TrashPage() {
         }
 
         await restorePage?.(viewId);
-        void loadTrash?.(currentWorkspaceId);
+        void loadTrash?.(currentWorkspaceId, { ensureFreshAfterInFlight: true }).catch((error) => {
+          Log.warn('[Trash] Failed to refresh after restoring a page', error);
+        });
         // eslint-disable-next-line
       } catch (e: any) {
         notify.error(`Failed to restore page: ${e.message}`);
@@ -106,7 +112,9 @@ function TrashPage() {
 
         await deleteTrash?.(viewId);
         setDeleteViewId(undefined);
-        void loadTrash?.(currentWorkspaceId);
+        void loadTrash?.(currentWorkspaceId, { ensureFreshAfterInFlight: true }).catch((error) => {
+          Log.warn('[Trash] Failed to refresh after permanently deleting a page', error);
+        });
         // eslint-disable-next-line
       } catch (e: any) {
         notify.error(`Failed to delete page: ${e.message}`);


### PR DESCRIPTION
### **Description**

Fix relation cells that appeared blank while linked database metadata and rows were still hydrating, and eliminate repeated workspace `/trash` requests from embedded database blocks.

#### Relation loading

- Show an accessible loading indicator until each linked row has a hydrated `database_row.cells` map.
- Read relation database IDs synchronously and observe late primary-cell insertion so cached partial Yjs documents cannot produce a blank frame or stale label.
- Load the canonical related database collab from IndexedDB first and use a metadata-only collab fetch on cold/incomplete caches, avoiding the page-view response's unpaginated `row_data`.
- Open only the linked row IDs for a rendered relation cell; the relation picker still hydrates all candidate rows from the target view's row order for search/display.
- Keep foreign related rows out of the current database's `rowMap` and local mutation store, while balancing realtime row registrations with the owning database lifecycle.

#### Trash requests

- Replace split app/block fetch ownership with one user-and-workspace-scoped coordinator.
- Share concurrent reads, and queue at most one trailing refresh when a mutation/revision arrives during an older request.
- Coalesce paired folder notifications by folder RID (with same-tick fallback for legacy notifications).
- Publish accepted trash payloads through a dedicated `TRASH_UPDATED` event instead of making every embedded database refetch on generic `OUTLINE_LOADED` events.
- Preserve trash state identity for equivalent payloads and share one physical EventEmitter listener across embedded database hooks.
- Catch background refresh failures without turning a successful delete/restore mutation into a failed UI operation.

The repeated 204 entries seen in DevTools are CORS preflights paired with the duplicated XHR calls; removing the request fanout removes their corresponding preflight traffic as well.

#### Validation

- `pnpm lint`
- Full Jest suite: 336 suites / 3,206 tests passed
- Focused relation, rollup, trash, lifecycle, and partial-cache regressions
- `git diff --check`

---

### **Checklist**

#### **General**
- [x] I've included relevant documentation or comments for the changes introduced.
- [ ] I've tested the changes in multiple environments (e.g., different browsers, operating systems).

#### **Testing**
- [x] I've added or updated tests to validate the changes introduced for AppFlowy Web.

#### **Feature-Specific**
- [ ] For feature additions, I've added a preview (video, screenshot, or demo) in the "Feature Preview" section.
- [x] I've verified that this feature integrates seamlessly with existing functionality.

## Summary by Sourcery

Streamline relation metadata and row hydration while centralizing database catalog and trash refresh coordination to prevent blank relation cells, stale state, and duplicate network requests.

Bug Fixes:
- Prevent relation cells and labels from rendering blank while linked database metadata or row documents are still hydrating.
- Eliminate redundant workspace trash requests from embedded database blocks and preserve deletion state across refresh races.

Enhancements:
- Centralize workspace database catalog loading with shared, user-scoped snapshots and safe invalidation.
- Use canonical database metadata and targeted linked-row loading for relation and rollup consumers.
- Improve relation row lifecycle isolation, hydration tracking, and stale asynchronous result handling.
- Coordinate trash refreshes with request sharing, trailing mutation refreshes, revision deduplication, and dedicated update events.

Tests:
- Add regression coverage for partial database caches, relation and rollup hydration, row membership, trash request coalescing, catalog invalidation, and embedded database deletion state.