### PR TITLE
fix: close relation metadata cache races

### DIFF
--- a/src/components/app/hooks/__tests__/useWorkspaceData.sidebarRevalidation.test.tsx
+++ b/src/components/app/hooks/__tests__/useWorkspaceData.sidebarRevalidation.test.tsx
@@ -53,6 +53,7 @@ jest.mock('@/application/services/domains', () => ({
     getOutline: jest.fn(),
     getTrashCached: jest.fn(),
     invalidateCache: jest.fn(),
+    invalidateWorkspaceMemoryCache: jest.fn(),
     refresh: jest.fn(),
     refreshTrash: jest.fn(),
   },
@@ -187,6 +188,7 @@ describe('useWorkspaceData sidebar outline revalidation', () => {
     (ViewService.getFavorites as jest.Mock).mockResolvedValue([]);
     (ViewService.getMultiple as jest.Mock).mockResolvedValue([]);
     (ViewService.getNavigation as jest.Mock).mockResolvedValue(createView('navigation-root'));
+    (ViewService.invalidateWorkspaceMemoryCache as jest.Mock).mockImplementation(() => undefined);
     (ViewService.refresh as jest.Mock).mockImplementation((activeWorkspaceId: string, viewId: string) =>
       ViewService.get(activeWorkspaceId, viewId)
     );
@@ -727,6 +729,53 @@ describe('useWorkspaceData sidebar outline revalidation', () => {
     expect(ViewService.getCachedFromDisk).toHaveBeenCalledWith(workspaceId, databaseView.view_id);
     expect(ViewService.invalidateCache).toHaveBeenCalledWith(workspaceId, databaseView.view_id);
     expect(revokedListener).toHaveBeenCalledWith({ viewId: databaseView.view_id });
+  });
+
+  it('captures an off-outline database identity before share invalidation clears memory', async () => {
+    const eventEmitter = new EventEmitter();
+    const databaseView = createView('memory-only-database-view-id', {
+      layout: ViewLayout.Grid,
+      extra: {
+        database_id: 'memory-only-database-collab-id',
+        is_database_container: true,
+        is_space: false,
+      },
+    });
+    const shallowOutline = [createView('space-id', { extra: { is_space: true } })];
+    let memoryNavigation: View | undefined = databaseView;
+
+    (ViewService.getOutline as jest.Mock).mockResolvedValue({ outline: shallowOutline, folderRid: '1-1' });
+    (ViewService.getCached as jest.Mock).mockImplementation(
+      (_activeWorkspaceId: string, viewId: string) =>
+        (viewId === databaseView.view_id ? memoryNavigation : undefined)
+    );
+    (ViewService.invalidateWorkspaceMemoryCache as jest.Mock).mockImplementation(() => {
+      memoryNavigation = undefined;
+    });
+    (ViewService.getNavigation as jest.Mock).mockRejectedValueOnce({
+      code: ERROR_CODE.NOT_HAS_PERMISSION,
+      message: 'no permission',
+    });
+
+    const { result } = renderHook(() => useWorkspaceData(), {
+      wrapper: createWrapper(eventEmitter),
+    });
+
+    await waitFor(() => expect(result.current.outline).toEqual(shallowOutline));
+
+    act(() => {
+      eventEmitter.emit(APP_EVENTS.SHARE_VIEWS_CHANGED, {
+        viewId: databaseView.view_id,
+        emails: ['current-user@appflowy.io'],
+      });
+    });
+
+    await waitFor(() => {
+      expect(deleteCollabDB).toHaveBeenCalledWith(databaseView.view_id, { destroyDoc: true });
+      expect(deleteCollabDB).toHaveBeenCalledWith('memory-only-database-collab-id', { destroyDoc: true });
+    });
+    expect(ViewService.invalidateWorkspaceMemoryCache).toHaveBeenCalledWith(workspaceId);
+    expect(ViewService.getCachedFromDisk).not.toHaveBeenCalled();
   });
 
   it('announces restored access after a successful share-change probe', async () => {

--- a/src/components/app/hooks/useWorkspaceData.ts
+++ b/src/components/app/hooks/useWorkspaceData.ts
@@ -1911,15 +1911,6 @@ export function useWorkspaceData() {
       const accessMayAffectCurrentUser =
         !normalizedCurrentEmail || !hasOnlyValidEmails || Boolean(affectsCurrentUser);
 
-      if (accessMayAffectCurrentUser) {
-        // Fence root/lazy responses that started before this share event.
-        // Sharing an ancestor can alter inherited descendant access.
-        permissionRefreshRevisionRef.current += 1;
-        ViewService.invalidateDatabaseCatalog?.(currentWorkspaceId);
-        ViewService.invalidateWorkspaceMemoryCache?.(currentWorkspaceId);
-        markWorkspaceViewMetadataOutlineUntrusted(currentWorkspaceId);
-      }
-
       const shouldProbeAccess = Boolean(changedViewId && affectsCurrentUser);
       const cachedNavigation =
         shouldProbeAccess && changedViewId ? ViewService.getCached(currentWorkspaceId, changedViewId) : undefined;
@@ -1931,7 +1922,7 @@ export function useWorkspaceData() {
 
       // A lazy/depth-truncated outline may not contain the route metadata, and
       // its memory cache may already have expired. Start the disk lookup before
-      // loadOutline can replace or invalidate anything; only await it if a
+      // any permission-derived cache invalidation; only await it if a
       // definitive denial requires local collab eviction.
       const diskCachedNavigationPromise =
         shouldProbeAccess && changedViewId && !changedView
@@ -1947,8 +1938,18 @@ export function useWorkspaceData() {
 
       // Database folder/view UUIDs are metadata identifiers. Their Y.Doc and
       // IndexedDB collab are stored under the backing database UUID instead.
-      // Capture it before loadOutline can remove a newly revoked view.
+      // Capture it before the workspace-wide memory invalidation can discard
+      // the only available identity for an off-outline view.
       const cachedDatabaseId = changedView?.extra?.database_id;
+
+      if (accessMayAffectCurrentUser) {
+        // Fence root/lazy responses that started before this share event.
+        // Sharing an ancestor can alter inherited descendant access.
+        permissionRefreshRevisionRef.current += 1;
+        ViewService.invalidateDatabaseCatalog?.(currentWorkspaceId);
+        ViewService.invalidateWorkspaceMemoryCache?.(currentWorkspaceId);
+        markWorkspaceViewMetadataOutlineUntrusted(currentWorkspaceId);
+      }
 
       if (accessMayAffectCurrentUser) evictAccessDerivedSubtrees();
       refreshPermissionDerivedState();

--- a/src/components/database/components/property/relation/useRelationData.test.tsx
+++ b/src/components/database/components/property/relation/useRelationData.test.tsx
@@ -567,6 +567,65 @@ describe('useRelationData', () => {
     expect(getDatabaseContainerEntries).toHaveBeenCalledTimes(2);
   });
 
+  it('starts a replacement request when invalidation leaves no catalog snapshot while the outline is pending', async () => {
+    const initialCatalog = deferred<WorkspaceDatabaseWithViews[]>();
+    const initialOutline = deferred<View[]>();
+    const replacementCatalog = deferred<WorkspaceDatabaseWithViews[]>();
+    const replacement = workspaceCatalog.map((database) => ({
+      ...database,
+      views: database.views.map((view) =>
+        view.is_container ? { ...view, name: 'Replacement Projects' } : view
+      ),
+    }));
+    const loadViews = jest.fn<Promise<View[]>, []>().mockReturnValueOnce(initialOutline.promise).mockResolvedValue([]);
+
+    jest.mocked(getCachedWorkspaceDatabaseCatalog).mockReturnValue(undefined);
+    jest
+      .mocked(getWorkspaceDatabaseCatalog)
+      .mockReturnValueOnce(initialCatalog.promise)
+      .mockReturnValueOnce(replacementCatalog.promise);
+    jest.mocked(useDatabaseContext).mockReturnValue({
+      workspaceId: 'workspace-1',
+      loadViews,
+    } as never);
+
+    const { result } = renderHook(() => useRelationData('field-1'));
+
+    await waitFor(() => {
+      expect(getWorkspaceDatabaseCatalog).toHaveBeenCalledTimes(1);
+      expect(loadViews).toHaveBeenCalledTimes(1);
+    });
+
+    await act(async () => {
+      publishMockWorkspaceCatalog(workspaceCatalog);
+      initialCatalog.resolve(workspaceCatalog);
+      await initialCatalog.promise;
+    });
+
+    act(() => {
+      publishMockWorkspaceCatalog(undefined);
+    });
+
+    expect(getWorkspaceDatabaseCatalog).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      initialOutline.resolve([]);
+      await initialOutline.promise;
+    });
+
+    await waitFor(() => expect(getWorkspaceDatabaseCatalog).toHaveBeenCalledTimes(2));
+    expect(result.current.loading).toBe(true);
+
+    await act(async () => {
+      publishMockWorkspaceCatalog(replacement);
+      replacementCatalog.resolve(replacement);
+      await replacementCatalog.promise;
+    });
+
+    await waitFor(() => expect(result.current.selectedView?.name).toBe('Replacement Projects'));
+    expect(getWorkspaceDatabaseCatalog).toHaveBeenCalledTimes(2);
+  });
+
   it('checks the current outline once when cached headers remount after a listener gap', async () => {
     const eventEmitter = new EventEmitter();
     const initialOutline: View[] = [
@@ -1159,6 +1218,120 @@ describe('useRelationData', () => {
     unmount();
     expect(eventEmitter.listenerCount(APP_EVENTS.VIEW_ACCESS_REVOKED)).toBe(0);
     expect(eventEmitter.listenerCount(APP_EVENTS.VIEW_ACCESS_RESTORED)).toBe(0);
+  });
+
+  it('retires fallback metadata while disabled before reopening after an unobserved revoke', async () => {
+    const eventEmitter = new EventEmitter();
+    const primaryView: View = {
+      view_id: 'grid-1',
+      name: 'Tasks',
+      icon: null,
+      layout: ViewLayout.Grid,
+      children: [],
+      extra: {
+        database_id: 'database-1',
+        is_database_container: false,
+        is_space: false,
+      },
+      is_published: false,
+      is_private: false,
+    };
+    let revoked = false;
+    const loadViewMeta = jest.fn(async () => {
+      if (revoked) throw new Error('Access revoked while the relation menu was closed');
+      return primaryView;
+    });
+
+    mockWorkspaceCatalog([]);
+    jest.mocked(useDatabaseContext).mockReturnValue({
+      workspaceId: 'workspace-1',
+      loadViews: jest.fn().mockResolvedValue([]),
+      getViewIdFromDatabaseId: jest.fn().mockResolvedValue(primaryView.view_id),
+      loadViewMeta,
+      eventEmitter,
+    } as never);
+
+    const { result, rerender } = renderHook(
+      ({ enabled }: { enabled: boolean }) => useRelationData('field-1', { enabled }),
+      { initialProps: { enabled: true } }
+    );
+
+    await waitFor(() => expect(result.current.selectedView?.name).toBe('Tasks'));
+
+    rerender({ enabled: false });
+
+    await waitFor(() => {
+      expect(result.current.selectedView).toBeUndefined();
+      expect(eventEmitter.listenerCount(APP_EVENTS.VIEW_ACCESS_REVOKED)).toBe(0);
+    });
+
+    revoked = true;
+    act(() => {
+      eventEmitter.emit(APP_EVENTS.VIEW_ACCESS_REVOKED, { viewId: primaryView.view_id });
+    });
+
+    rerender({ enabled: true });
+
+    await waitFor(() => expect(loadViewMeta).toHaveBeenCalledTimes(2));
+    expect(result.current.selectedView).toBeUndefined();
+  });
+
+  it('revalidates after a suspended fallback misses its restore event while disabled', async () => {
+    const eventEmitter = new EventEmitter();
+    const primaryView: View = {
+      view_id: 'grid-1',
+      name: 'Tasks',
+      icon: null,
+      layout: ViewLayout.Grid,
+      children: [],
+      extra: {
+        database_id: 'database-1',
+        is_database_container: false,
+        is_space: false,
+      },
+      is_published: false,
+      is_private: false,
+    };
+    let revoked = false;
+    const loadViewMeta = jest.fn(async () => {
+      if (revoked) throw new Error('Access revoked');
+      return primaryView;
+    });
+
+    mockWorkspaceCatalog([]);
+    jest.mocked(useDatabaseContext).mockReturnValue({
+      workspaceId: 'workspace-1',
+      loadViews: jest.fn().mockResolvedValue([]),
+      getViewIdFromDatabaseId: jest.fn().mockResolvedValue(primaryView.view_id),
+      loadViewMeta,
+      eventEmitter,
+    } as never);
+
+    const { result, rerender } = renderHook(
+      ({ enabled }: { enabled: boolean }) => useRelationData('field-1', { enabled }),
+      { initialProps: { enabled: true } }
+    );
+
+    await waitFor(() => expect(result.current.selectedView?.name).toBe('Tasks'));
+
+    revoked = true;
+    act(() => {
+      eventEmitter.emit(APP_EVENTS.VIEW_ACCESS_REVOKED, { viewId: primaryView.view_id });
+    });
+    expect(result.current.selectedView).toBeUndefined();
+
+    rerender({ enabled: false });
+    expect(eventEmitter.listenerCount(APP_EVENTS.VIEW_ACCESS_RESTORED)).toBe(0);
+
+    revoked = false;
+    act(() => {
+      eventEmitter.emit(APP_EVENTS.VIEW_ACCESS_RESTORED, { viewId: primaryView.view_id });
+    });
+
+    rerender({ enabled: true });
+
+    await waitFor(() => expect(result.current.selectedView?.name).toBe('Tasks'));
+    expect(loadViewMeta).toHaveBeenCalledTimes(2);
   });
 
   it('never commits a selected view from the previous related database', async () => {

--- a/src/components/database/components/property/relation/useRelationData.ts
+++ b/src/components/database/components/property/relation/useRelationData.ts
@@ -573,6 +573,43 @@ export function useRelationData(fieldId: string, options: UseRelationDataOptions
   }, [fallbackSelectedView]);
 
   useEffect(() => {
+    if (enabled) return;
+
+    // RelationCellMenu disables this hook while it is closed, which also
+    // removes its access-event subscriber. Retire the last fallback so an
+    // unobserved revoke cannot expose that metadata when the menu reopens and
+    // its fresh lookup fails.
+    fallbackAccessGenerationRef.current += 1;
+    authoritativeFallbackRef.current = null;
+    fallbackAccessRef.current = {
+      databaseId: relatedDatabaseId,
+      allowOutlineRestore: false,
+      suspension: null,
+    };
+    setFallbackAccess((access) =>
+      access.databaseId === relatedDatabaseId && access.suspension === null
+        ? access
+        : { databaseId: relatedDatabaseId, suspension: null }
+    );
+    const retiredFallback: DatabaseViewState = {
+      databaseId: null,
+      parentViewId: null,
+      viewId: null,
+      view: undefined,
+    };
+
+    fallbackSelectedViewRef.current = retiredFallback;
+    setFallbackSelectedView((fallback) =>
+      fallback.databaseId === null &&
+      fallback.parentViewId === null &&
+      fallback.viewId === null &&
+      fallback.view === undefined
+        ? fallback
+        : retiredFallback
+    );
+  }, [enabled, relatedDatabaseId, workspaceId]);
+
+  useEffect(() => {
     const access = fallbackAccessRef.current;
 
     if (access.databaseId === relatedDatabaseId) return;
@@ -629,7 +666,6 @@ export function useRelationData(fieldId: string, options: UseRelationDataOptions
         // The accepted catalog snapshot changed while this request was in
         // flight. Retry against that snapshot; concurrent headers join the
         // same replacement request through getCandidateRequest.
-        if (!getCachedWorkspaceDatabaseCatalog(workspaceId)) return;
         request = getCandidateRequest(workspaceId);
       }
     })()


### PR DESCRIPTION
## Summary

- capture an off-outline database identity before share-change cache invalidation so access revocation purges both the view and backing database collab
- retire and fence relation fallback metadata while a picker is disabled, including revoke/restore events missed while unsubscribed
- restart the shared relation-catalog request when invalidation supersedes a request before its outline load completes

## Validation

- `pnpm exec jest` — 6 focused suites, 146 tests
- `pnpm lint`
- `pnpm build`
- `git diff --check`

Follow-up to #491.

## Summary by Sourcery

Harden workspace share invalidation and relation metadata revalidation to prevent stale or inaccessible relation data from resurfacing.

Bug Fixes:
- Prevent share-change cache invalidation from losing the backing database identity needed to purge revoked database collaborations.
- Prevent relation metadata from resurfacing after access changes occur while the relation picker is disabled.
- Retry shared relation-catalog loading when invalidation supersedes an in-flight request.

Enhancements:
- Harden relation metadata lifecycle and access revalidation across picker suspension and listener gaps.

Tests:
- Add coverage for off-outline database eviction, superseded catalog requests, and missed revoke/restore events while relation metadata is disabled.