### PR TITLE
fix: prevent breadcrumb refresh when expanding sidebar space

### DIFF
--- a/playwright/e2e/page/breadcrumb-navigation.spec.ts
+++ b/playwright/e2e/page/breadcrumb-navigation.spec.ts
@@ -495,7 +495,9 @@ test.describe('Breadcrumb Navigation Complete Tests', () => {
       const parentItem = page.locator(
         `[data-testid="page-item"]:has(> div:first-child [data-testid="page-name"]:text-is("${parentName}"))`
       ).first();
-      const addChildBtn = parentItem.getByTestId('inline-add-page');
+      const parentRow = parentItem.locator(':scope > [data-testid^="page-"]');
+      const addChildBtn = parentRow.getByTestId('inline-add-page');
+
       await expect(addChildBtn).toBeVisible({ timeout: 5000 });
       await addChildBtn.click({ force: true });
       await page.waitForTimeout(500);

--- a/src/components/_shared/outline/__tests__/mergeOutline.test.ts
+++ b/src/components/_shared/outline/__tests__/mergeOutline.test.ts
@@ -1,0 +1,68 @@
+import { View, ViewLayout } from '@/application/types';
+import { mergeShallowChildrenIntoOutline } from '@/components/_shared/outline/mergeOutline';
+
+const createView = (viewId: string, overrides: Partial<View> = {}): View => ({
+  view_id: viewId,
+  name: overrides.name ?? viewId,
+  icon: overrides.icon ?? null,
+  layout: overrides.layout ?? ViewLayout.Document,
+  extra: overrides.extra ?? null,
+  children: overrides.children ?? [],
+  has_children: overrides.has_children,
+  is_published: overrides.is_published ?? false,
+  is_private: overrides.is_private ?? false,
+  ...overrides,
+});
+
+describe('mergeShallowChildrenIntoOutline', () => {
+  it('updates direct children while preserving hydrated descendants beyond the response depth', () => {
+    const activeTab = createView('active-tab');
+    const databaseContainer = createView('database-container', {
+      children: [activeTab],
+      has_children: true,
+      name: 'Old database name',
+    });
+    const outline = [
+      createView('space', {
+        children: [databaseContainer, createView('removed-page')],
+        has_children: true,
+      }),
+    ];
+    const shallowChildren = [
+      createView('database-container', {
+        children: [],
+        has_children: true,
+        name: 'Updated database name',
+      }),
+      createView('new-page'),
+    ];
+
+    const result = mergeShallowChildrenIntoOutline(outline, 'space', shallowChildren, true);
+    const space = result[0];
+    const container = space?.children[0];
+
+    expect(space?.children.map((view) => view.view_id)).toEqual(['database-container', 'new-page']);
+    expect(container?.name).toBe('Updated database name');
+    expect(container?.children.map((view) => view.view_id)).toEqual(['active-tab']);
+  });
+
+  it('clears hydrated descendants when the response explicitly marks the child as empty', () => {
+    const outline = [
+      createView('space', {
+        children: [
+          createView('page', {
+            children: [createView('stale-child')],
+            has_children: true,
+          }),
+        ],
+        has_children: true,
+      }),
+    ];
+    const shallowChildren = [createView('page', { children: [], has_children: false })];
+
+    const result = mergeShallowChildrenIntoOutline(outline, 'space', shallowChildren, true);
+
+    expect(result[0]?.children[0]?.children).toEqual([]);
+    expect(result[0]?.children[0]?.has_children).toBe(false);
+  });
+});

--- a/src/components/_shared/outline/mergeOutline.ts
+++ b/src/components/_shared/outline/mergeOutline.ts
@@ -36,6 +36,84 @@ export function dedupeViewsByViewId(views: View[]): View[] {
 }
 
 /**
+ * A shallow view response is authoritative for its direct child list, but an
+ * empty `children` array at the response depth boundary does not mean that the
+ * child has no descendants. Preserve descendants already hydrated in the
+ * outline unless the response explicitly marks the child as empty.
+ */
+function preserveShallowDescendants(existingChildren: View[], incomingChildren: View[]): View[] {
+  if (existingChildren.length === 0 || incomingChildren.length === 0) return incomingChildren;
+
+  const existingById = new Map(existingChildren.map((view) => [view.view_id, view]));
+  let changed = false;
+
+  const nextChildren = incomingChildren.map((incoming) => {
+    const existing = existingById.get(incoming.view_id);
+
+    if (!existing) return incoming;
+
+    const incomingDescendants = incoming.children ?? [];
+    let nextDescendants = incomingDescendants;
+
+    if (incomingDescendants.length > 0) {
+      nextDescendants = preserveShallowDescendants(existing.children ?? [], incomingDescendants);
+    } else if (incoming.has_children !== false && existing.children?.length > 0) {
+      nextDescendants = existing.children;
+    }
+
+    if (nextDescendants === incomingDescendants) return incoming;
+
+    changed = true;
+    return { ...incoming, children: nextDescendants };
+  });
+
+  return changed ? nextChildren : incomingChildren;
+}
+
+function mergeChildrenIntoOutlineInternal(
+  outline: View[],
+  parentViewId: string,
+  children: View[],
+  hasChildrenOverride: boolean | undefined,
+  preserveDescendants: boolean
+): View[] {
+  let changed = false;
+  const dedupedChildren = dedupeViewsByViewId(children);
+
+  const next = outline.map((view) => {
+    if (view.view_id === parentViewId) {
+      const nextChildren = preserveDescendants
+        ? preserveShallowDescendants(view.children ?? [], dedupedChildren)
+        : dedupedChildren;
+      const nextHasChildren = hasChildrenOverride ?? (nextChildren.length > 0);
+
+      if (view.children === nextChildren && view.has_children === nextHasChildren) return view;
+      changed = true;
+      return { ...view, children: nextChildren, has_children: nextHasChildren };
+    }
+
+    if (view.children && view.children.length > 0) {
+      const nextChildren = mergeChildrenIntoOutlineInternal(
+        view.children,
+        parentViewId,
+        dedupedChildren,
+        hasChildrenOverride,
+        preserveDescendants
+      );
+
+      if (nextChildren !== view.children) {
+        changed = true;
+        return { ...view, children: nextChildren };
+      }
+    }
+
+    return view;
+  });
+
+  return changed ? next : outline;
+}
+
+/**
  * Immutably replaces a single view's children in the outline tree.
  * Returns the original array reference if the parentViewId is not found
  * (referential equality check to minimize re-renders).
@@ -49,32 +127,20 @@ export function mergeChildrenIntoOutline(
   children: View[],
   hasChildrenOverride?: boolean
 ): View[] {
-  let changed = false;
-  const dedupedChildren = dedupeViewsByViewId(children);
+  return mergeChildrenIntoOutlineInternal(outline, parentViewId, children, hasChildrenOverride, false);
+}
 
-  const next = outline.map((view) => {
-    if (view.view_id === parentViewId) {
-      const nextHasChildren = hasChildrenOverride ?? (dedupedChildren.length > 0);
-
-      // Only create a new object if children/has_children actually differ
-      if (view.children === dedupedChildren && view.has_children === nextHasChildren) return view;
-      changed = true;
-      return { ...view, children: dedupedChildren, has_children: nextHasChildren };
-    }
-
-    if (view.children && view.children.length > 0) {
-      const nextChildren = mergeChildrenIntoOutline(view.children, parentViewId, dedupedChildren, hasChildrenOverride);
-
-      if (nextChildren !== view.children) {
-        changed = true;
-        return { ...view, children: nextChildren };
-      }
-    }
-
-    return view;
-  });
-
-  return changed ? next : outline;
+/**
+ * Merge children returned by a bounded-depth request while retaining deeper
+ * descendants that are outside that request's authoritative depth.
+ */
+export function mergeShallowChildrenIntoOutline(
+  outline: View[],
+  parentViewId: string,
+  children: View[],
+  hasChildrenOverride?: boolean
+): View[] {
+  return mergeChildrenIntoOutlineInternal(outline, parentViewId, children, hasChildrenOverride, true);
 }
 
 export interface OutlineMerge {

--- a/src/components/app/hooks/__tests__/useWorkspaceData.sidebarRevalidation.test.tsx
+++ b/src/components/app/hooks/__tests__/useWorkspaceData.sidebarRevalidation.test.tsx
@@ -1110,6 +1110,50 @@ describe('useWorkspaceData sidebar outline revalidation', () => {
     expect(result.current.outline?.[0]?.children.map((view) => view.view_id)).toEqual(['refreshed-child-id']);
   });
 
+  it('keeps the active nested view when a parent refresh returns only direct children', async () => {
+    const eventEmitter = new EventEmitter();
+    const activeView = createView('active-view-id');
+    const databaseContainer = createView('database-container-id', {
+      children: [activeView],
+      has_children: true,
+      name: 'Original database name',
+    });
+    const root = createView('space-id', {
+      children: [databaseContainer],
+      has_children: true,
+    });
+    const refreshedRoot = createView('space-id', {
+      children: [
+        createView('database-container-id', {
+          children: [],
+          has_children: true,
+          name: 'Updated database name',
+        }),
+      ],
+      has_children: true,
+    });
+
+    (ViewService.getOutline as jest.Mock).mockResolvedValueOnce({ outline: [root], folderRid: '1-1' });
+    (ViewService.refresh as jest.Mock).mockResolvedValueOnce(refreshedRoot);
+
+    const { result } = renderHook(() => useWorkspaceData(), {
+      wrapper: createWrapper(eventEmitter),
+    });
+
+    await waitFor(() => {
+      expect(findView(result.current.outline ?? [], activeView.view_id)).not.toBeNull();
+    });
+
+    await act(async () => {
+      await result.current.loadViewChildren?.(root.view_id);
+    });
+
+    const refreshedContainer = findView(result.current.outline ?? [], databaseContainer.view_id);
+
+    expect(refreshedContainer?.name).toBe('Updated database name');
+    expect(findView(result.current.outline ?? [], activeView.view_id)).not.toBeNull();
+  });
+
   it('starts refresh immediately and shows disk cached children while the server request is pending', async () => {
     const eventEmitter = new EventEmitter();
     const root = createView('space-id', {

--- a/src/components/app/hooks/useWorkspaceData.ts
+++ b/src/components/app/hooks/useWorkspaceData.ts
@@ -23,6 +23,7 @@ import {
   addViewToOutline,
   deduplicateOutlineChildren,
   mergeChildrenIntoOutline,
+  mergeShallowChildrenIntoOutline,
   removeViewFromOutline,
   reorderChildrenInOutline,
   updateViewInOutline,
@@ -1044,7 +1045,12 @@ export function useWorkspaceData() {
       }
 
       const parentExists = Boolean(findView(stableOutlineRef.current, viewId));
-      const nextOutline = mergeChildrenIntoOutline(stableOutlineRef.current, viewId, children, viewData.has_children);
+      const nextOutline = mergeShallowChildrenIntoOutline(
+        stableOutlineRef.current,
+        viewId,
+        children,
+        viewData.has_children
+      );
 
       if (nextOutline !== stableOutlineRef.current) {
         stableOutlineRef.current = nextOutline;
@@ -1299,7 +1305,12 @@ export function useWorkspaceData() {
           if (!viewId) continue;
 
           const children = viewData.children ?? [];
-          const mergedOutline = mergeChildrenIntoOutline(nextOutline, viewId, children, viewData?.has_children);
+          const mergedOutline = mergeShallowChildrenIntoOutline(
+            nextOutline,
+            viewId,
+            children,
+            viewData?.has_children
+          );
 
           if (mergedOutline !== nextOutline) {
             nextOutline = mergedOutline;


### PR DESCRIPTION
### **Description**

Expanding a previously collapsed sidebar space reloads its subtree with `depth=1`. That response is authoritative for the direct child list, but the existing merge also replaced deeper hydrated descendants with empty arrays. When the active database tab was removed from the local outline, the breadcrumb briefly became empty and was unmounted until navigation hydration restored it.

This PR:

- Preserves hydrated descendants beyond a bounded-depth response while still applying direct child metadata, order, additions, and removals.
- Clears preserved descendants when the server explicitly reports `has_children: false`.
- Uses the depth-aware merge for both single and batch lazy subtree refreshes.
- Adds unit and hook-level regression coverage for the active nested view case.

### **Testing**

- [x] `pnpm exec jest src/components/_shared/outline/__tests__/mergeOutline.test.ts src/components/app/hooks/__tests__/useWorkspaceData.sidebarRevalidation.test.tsx --runInBand --no-coverage` — 50 tests passed.
- [x] `pnpm type-check`
- [x] Targeted ESLint for all changed TypeScript files.
- [x] Live Chrome verification on macOS: collapse and re-expand `Project Management`; breadcrumb stayed mounted, URL stayed unchanged, and no console errors were emitted.

---

### **Checklist**

#### **General**
- [x] Relevant behavior is documented in code comments.
- [ ] Tested in multiple browser/OS environments; live verification was performed in Chrome on macOS.

#### **Testing**
- [x] Added tests validating shallow-merge preservation and authoritative clearing.

#### **Feature-Specific**
- [x] Not applicable; this is a bug fix.
- [x] Verified integration with the existing lazy outline refresh flow.

## Summary by Sourcery

Prevent shallow sidebar revalidation from removing hydrated descendants and disrupting active breadcrumbs.

Bug Fixes:
- Preserve hydrated nested outline views during shallow sidebar refreshes so active breadcrumbs remain mounted and navigation state is retained.
- Clear previously hydrated descendants when refreshed data explicitly indicates that a view has no children.

Enhancements:
- Apply depth-aware outline merging consistently to single-view and batch lazy refreshes while retaining authoritative direct-child metadata, ordering, additions, and removals.

Tests:
- Add unit and hook-level regression coverage for descendant preservation and authoritative empty-child responses.
- Adjust breadcrumb navigation E2E element targeting for reliable inline child-page actions.