### PR TITLE
fix: smooth image upload status and preview

### DIFF
--- a/src/components/editor/components/block-popover/ImageBlockPopoverContent.tsx
+++ b/src/components/editor/components/block-popover/ImageBlockPopoverContent.tsx
@@ -96,11 +96,35 @@ function ImageBlockPopoverContent({ blockId, onClose }: { blockId: string; onClo
     await fileHandler.cleanup(retryLocalUrl).catch(() => undefined);
   }, []);
 
+  const getMatchingPendingData = useCallback(
+    (targetBlockId: string, pendingUploadId?: string) => {
+      if (!pendingUploadId) return;
+
+      try {
+        const entry = findSlateEntryByBlockId(editor, targetBlockId);
+        const currentData = entry ? (entry[0] as { data?: ImageBlockData }).data ?? undefined : undefined;
+
+        if (!currentData || currentData.url || currentData.pending_upload_id !== pendingUploadId) return;
+
+        return currentData;
+      } catch {
+        return;
+      }
+    },
+    [editor]
+  );
+
   const uploadIntoImageBlock = useCallback(
     async (targetBlockId: string, file: File, pendingData: ImageBlockData) => {
       const url = await uploadFileRemote(file);
 
       if (!url) {
+        if (getMatchingPendingData(targetBlockId, pendingData.pending_upload_id)) {
+          CustomEditor.setBlockData(editor, targetBlockId, {
+            pending_upload_id: '',
+          } as ImageBlockData);
+        }
+
         return;
       }
 
@@ -109,19 +133,7 @@ function ImageBlockPopoverContent({ blockId, onClose }: { blockId: string; onClo
       // Popover closes before the upload settles, so the user may have
       // deleted/edited/replaced the block. Skip the write if the placeholder
       // we created is no longer there.
-      let currentData: ImageBlockData | undefined;
-
-      try {
-        const entry = findSlateEntryByBlockId(editor, targetBlockId);
-
-        currentData = entry ? (entry[0] as { data?: ImageBlockData }).data ?? undefined : undefined;
-      } catch {
-        return;
-      }
-
-      if (!currentData) return;
-      if (currentData.url) return;
-      if (!pendingData.pending_upload_id || currentData.pending_upload_id !== pendingData.pending_upload_id) return;
+      if (!getMatchingPendingData(targetBlockId, pendingData.pending_upload_id)) return;
 
       CustomEditor.setBlockData(editor, targetBlockId, {
         url,
@@ -130,7 +142,7 @@ function ImageBlockPopoverContent({ blockId, onClose }: { blockId: string; onClo
         pending_upload_id: '',
       } as ImageBlockData);
     },
-    [cleanupLocalFile, editor, uploadFileRemote]
+    [cleanupLocalFile, editor, getMatchingPendingData, uploadFileRemote]
   );
 
   const handleChangeUploadFiles = useCallback(

--- a/src/components/editor/components/blocks/image/ImageBlock.tsx
+++ b/src/components/editor/components/blocks/image/ImageBlock.tsx
@@ -26,15 +26,17 @@ export const ImageBlock = memo(
     const retry_local_url = data?.retry_local_url;
     const { uploadFile, workspaceId, viewId } = useEditorContext();
     const editor = useSlateStatic() as YjsEditor;
-    const [needRetry, setNeedRetry] = useState(false);
     const [localUrl, setLocalUrl] = useState<string | undefined>(undefined);
     const [loading, setLoading] = useState(false);
 
     const fileHandler = useMemo(() => new FileHandler(), []);
     const readOnly = useReadOnly() || editor.isElementReadOnly(node as unknown as Element);
     const selected = useSelected();
-    const { url: dataUrl, align } = useMemo(() => data || {}, [data]);
+    const { url: dataUrl, align, pending_upload_id } = useMemo(() => data || {}, [data]);
     const url = useMemo(() => constructFileUrl(dataUrl, workspaceId, viewId), [dataUrl, workspaceId, viewId]);
+    const isUploading = Boolean(pending_upload_id && !dataUrl);
+    const hasImage = Boolean(url || localUrl);
+    const needRetry = Boolean(retry_local_url && localUrl && !dataUrl && !isUploading);
 
     const containerRef = useRef<HTMLDivElement>(null);
     const onFocusNode = useCallback(() => {
@@ -68,7 +70,7 @@ export const ImageBlock = memo(
 
     const handleClick = useCallback(async () => {
       try {
-        if (!url && !needRetry) {
+        if (!hasImage && !isUploading && !needRetry) {
           if (containerRef.current && !readOnly) {
             openPopover(blockId, BlockType.ImageBlock, containerRef.current);
           }
@@ -80,21 +82,30 @@ export const ImageBlock = memo(
       } catch (e: any) {
         notify.error(e.message);
       }
-    }, [needRetry, url, readOnly, openPopover, blockId]);
+    }, [blockId, hasImage, isUploading, needRetry, openPopover, readOnly]);
 
     useEffect(() => {
       if (readOnly) return;
-      void (async () => {
-        if (retry_local_url) {
-          const fileData = await fileHandler.getStoredFile(retry_local_url);
 
+      let cancelled = false;
+
+      if (!retry_local_url || dataUrl) {
+        setLocalUrl(undefined);
+        return;
+      }
+
+      void (async () => {
+        const fileData = await fileHandler.getStoredFile(retry_local_url);
+
+        if (!cancelled) {
           setLocalUrl(fileData?.url);
-          setNeedRetry(!!fileData);
-        } else {
-          setNeedRetry(false);
         }
       })();
-    }, [readOnly, retry_local_url, fileHandler]);
+
+      return () => {
+        cancelled = true;
+      };
+    }, [dataUrl, fileHandler, readOnly, retry_local_url]);
 
     const uploadFileRemote = useCallback(
       async (file: File) => {
@@ -158,11 +169,9 @@ export const ImageBlock = memo(
       >
         <div
           contentEditable={false}
-          className={`embed-block relative ${alignCss} ${
-            url || needRetry ? '!rounded-none !border-none !bg-transparent' : 'p-4'
-          }`}
+          className={`embed-block relative ${alignCss} ${hasImage ? '!rounded-none !border-none !bg-transparent' : 'p-4'}`}
         >
-          {url || needRetry ? (
+          {hasImage ? (
             <ImageRender
               showToolbar={showToolbar}
               selected={selected}
@@ -187,6 +196,15 @@ export const ImageBlock = memo(
               onEscape={onFocusNode}
               containerRef={containerRef}
             />
+          )}
+          {isUploading && (
+            <div
+              data-testid='image-upload-pending'
+              className={'absolute bottom-2 right-4 flex items-center gap-2 text-text-secondary'}
+            >
+              <CircularProgress size={16} />
+              <div className={'font-normal'}>{t('fileDropzone.uploading')}</div>
+            </div>
           )}
           {needRetry && (
             <div className={'absolute bottom-2 right-4 flex items-center gap-2'}>

--- a/src/components/editor/components/blocks/image/ImageBlock.tsx
+++ b/src/components/editor/components/blocks/image/ImageBlock.tsx
@@ -34,8 +34,18 @@ export const ImageBlock = memo(
     const selected = useSelected();
     const { url: dataUrl, align, pending_upload_id } = useMemo(() => data || {}, [data]);
     const url = useMemo(() => constructFileUrl(dataUrl, workspaceId, viewId), [dataUrl, workspaceId, viewId]);
+    const localFileIdRef = useRef<string>();
+    const previewRemoteUrlRef = useRef<string>();
+    const previousPendingUploadIdRef = useRef(pending_upload_id);
+    const uploadJustSucceeded = Boolean(
+      dataUrl && localUrl && previousPendingUploadIdRef.current && !pending_upload_id
+    );
+    const shouldUseLocalPreview = Boolean(
+      localUrl && (!dataUrl || uploadJustSucceeded || previewRemoteUrlRef.current === dataUrl)
+    );
+    const renderedLocalUrl = shouldUseLocalPreview ? localUrl : undefined;
     const isUploading = Boolean(pending_upload_id && !dataUrl);
-    const hasImage = Boolean(url || localUrl);
+    const hasImage = Boolean(url || renderedLocalUrl);
     const needRetry = Boolean(retry_local_url && localUrl && !dataUrl && !isUploading);
 
     const containerRef = useRef<HTMLDivElement>(null);
@@ -85,27 +95,72 @@ export const ImageBlock = memo(
     }, [blockId, hasImage, isUploading, needRetry, openPopover, readOnly]);
 
     useEffect(() => {
-      if (readOnly) return;
+      if (uploadJustSucceeded && dataUrl) {
+        previewRemoteUrlRef.current = dataUrl;
+      }
+
+      previousPendingUploadIdRef.current = pending_upload_id;
+    }, [dataUrl, pending_upload_id, uploadJustSucceeded]);
+
+    useEffect(() => {
+      if (readOnly || !retry_local_url) return;
 
       let cancelled = false;
+      const previousFileId = localFileIdRef.current;
 
-      if (!retry_local_url || dataUrl) {
+      if (previousFileId && previousFileId !== retry_local_url) {
+        localFileIdRef.current = undefined;
+        previewRemoteUrlRef.current = undefined;
         setLocalUrl(undefined);
-        return;
+        void fileHandler.cleanup(previousFileId).catch(() => undefined);
       }
 
       void (async () => {
-        const fileData = await fileHandler.getStoredFile(retry_local_url);
+        try {
+          const fileData = await fileHandler.getStoredFile(retry_local_url);
 
-        if (!cancelled) {
-          setLocalUrl(fileData?.url);
+          if (!cancelled) {
+            localFileIdRef.current = retry_local_url;
+            previewRemoteUrlRef.current = undefined;
+            setLocalUrl(fileData?.url);
+          }
+        } catch {
+          // The remote upload can still finish even if the local preview is unavailable.
         }
       })();
 
       return () => {
         cancelled = true;
       };
-    }, [dataUrl, fileHandler, readOnly, retry_local_url]);
+    }, [fileHandler, readOnly, retry_local_url]);
+
+    useEffect(() => {
+      if (!localUrl || !dataUrl || shouldUseLocalPreview) return;
+
+      const localFileId = localFileIdRef.current;
+
+      localFileIdRef.current = undefined;
+      previewRemoteUrlRef.current = undefined;
+      setLocalUrl(undefined);
+
+      if (localFileId) {
+        void fileHandler.cleanup(localFileId).catch(() => undefined);
+      }
+    }, [dataUrl, fileHandler, localUrl, shouldUseLocalPreview]);
+
+    useEffect(() => {
+      return () => {
+        const localFileId = localFileIdRef.current;
+
+        if (!localFileId) return;
+
+        if (previewRemoteUrlRef.current) {
+          void fileHandler.cleanup(localFileId).catch(() => undefined);
+        } else {
+          fileHandler.releaseUrl(localFileId);
+        }
+      };
+    }, [fileHandler]);
 
     const uploadFileRemote = useCallback(
       async (file: File) => {
@@ -125,20 +180,19 @@ export const ImageBlock = memo(
       async (e: React.MouseEvent) => {
         e.stopPropagation();
         if (!retry_local_url) return;
-        const fileData = await fileHandler.getStoredFile(retry_local_url);
-        const file = fileData?.file;
-
-        if (!file) return;
-
-        const url = await uploadFileRemote(file);
-
-        if (!url) {
-          return;
-        }
 
         setLoading(true);
         try {
-          await fileHandler.cleanup(retry_local_url);
+          const fileData = await fileHandler.getStoredFile(retry_local_url);
+          const file = fileData?.file;
+
+          if (!file) return;
+
+          const url = await uploadFileRemote(file);
+
+          if (!url) return;
+
+          previewRemoteUrlRef.current = url;
           CustomEditor.setBlockData(editor, blockId, {
             url,
             image_type: ImageType.External,
@@ -146,7 +200,7 @@ export const ImageBlock = memo(
             pending_upload_id: '',
           } as ImageBlockData);
         } catch (e) {
-          // do noting
+          // do nothing
         } finally {
           setLoading(false);
         }
@@ -182,7 +236,7 @@ export const ImageBlock = memo(
                   url,
                 },
               }}
-              localUrl={localUrl}
+              localUrl={renderedLocalUrl}
             />
           ) : (
             <ImageEmpty

--- a/src/components/editor/components/blocks/image/ImageRender.tsx
+++ b/src/components/editor/components/blocks/image/ImageRender.tsx
@@ -30,7 +30,7 @@ function ImageRender({
   const [rendered, setRendered] = useState(false);
 
   const { width: imageWidth } = useMemo(() => node.data || {}, [node.data]);
-  const url = node.data.url || localUrl;
+  const url = localUrl || node.data.url;
 
   Log.debug('[ImageRender] url', { url, localUrl, node: node.data });
   const [initialWidth, setInitialWidth] = useState<number | null>(null);

--- a/src/components/editor/components/blocks/image/__tests__/ImageBlock.test.tsx
+++ b/src/components/editor/components/blocks/image/__tests__/ImageBlock.test.tsx
@@ -5,6 +5,8 @@ import { ImageBlock } from '@/components/editor/components/blocks/image/ImageBlo
 import { ImageBlockNode } from '@/components/editor/editor.type';
 
 const mockGetStoredFile = jest.fn();
+const mockCleanup = jest.fn();
+const mockReleaseUrl = jest.fn();
 
 jest.mock('react-i18next', () => ({
   useTranslation: () => ({ t: (key: string) => key }),
@@ -42,15 +44,21 @@ jest.mock('@/components/editor/utils/file-url', () => ({
 
 jest.mock('@/utils/file', () => ({
   FileHandler: jest.fn().mockImplementation(() => ({
-    cleanup: jest.fn(),
+    cleanup: mockCleanup,
     getStoredFile: mockGetStoredFile,
+    releaseUrl: mockReleaseUrl,
   })),
 }));
 
 jest.mock('@/components/editor/components/blocks/image/ImageRender', () => ({
   __esModule: true,
   default: ({ localUrl, node }: { localUrl?: string; node: ImageBlockNode }) => (
-    <div data-testid='image-render' data-local-url={localUrl} data-url={node.data.url} />
+    <div
+      data-testid='image-render'
+      data-display-url={localUrl || node.data.url}
+      data-local-url={localUrl}
+      data-url={node.data.url}
+    />
   ),
 }));
 
@@ -71,7 +79,62 @@ function imageNode(data: ImageBlockData): ImageBlockNode {
 describe('ImageBlock upload status', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockCleanup.mockResolvedValue(undefined);
     mockGetStoredFile.mockResolvedValue({ url: 'blob:local-preview' });
+  });
+
+  it('keeps the rendered local preview when the pending upload succeeds', async () => {
+    const retryLocalUrl = 'stored-file-id';
+    const { rerender } = render(
+      <ImageBlock
+        node={imageNode({
+          pending_upload_id: 'pending-upload-id',
+          retry_local_url: retryLocalUrl,
+          url: '',
+        })}
+      >
+        <span />
+      </ImageBlock>
+    );
+
+    expect((await screen.findByTestId('image-render')).getAttribute('data-display-url')).toBe('blob:local-preview');
+
+    rerender(
+      <ImageBlock
+        node={imageNode({
+          pending_upload_id: '',
+          retry_local_url: '',
+          url: 'https://example.com/uploaded-image.png',
+        })}
+      >
+        <span />
+      </ImageBlock>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('image-render').getAttribute('data-display-url')).toBe('blob:local-preview');
+    });
+    expect(screen.queryByTestId('image-upload-pending')).toBeNull();
+    expect(screen.queryByText('button.uploadFailed')).toBeNull();
+
+    rerender(
+      <ImageBlock
+        node={imageNode({
+          pending_upload_id: '',
+          retry_local_url: '',
+          url: 'https://example.com/replacement-image.png',
+        })}
+      >
+        <span />
+      </ImageBlock>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('image-render').getAttribute('data-display-url')).toBe(
+        'https://example.com/replacement-image.png'
+      );
+    });
+    expect(mockCleanup).toHaveBeenCalledWith(retryLocalUrl);
   });
 
   it('shows uploading instead of a false failure while the remote upload is pending', async () => {
@@ -106,5 +169,26 @@ describe('ImageBlock upload status', () => {
 
     await waitFor(() => expect(screen.getByText('button.uploadFailed')).toBeTruthy());
     expect(screen.queryByTestId('image-upload-pending')).toBeNull();
+  });
+
+  it('releases the preview without deleting retry data when a failed block unmounts', async () => {
+    const retryLocalUrl = 'stored-file-id';
+    const { unmount } = render(
+      <ImageBlock
+        node={imageNode({
+          pending_upload_id: '',
+          retry_local_url: retryLocalUrl,
+          url: '',
+        })}
+      >
+        <span />
+      </ImageBlock>
+    );
+
+    await screen.findByTestId('image-render');
+    unmount();
+
+    expect(mockReleaseUrl).toHaveBeenCalledWith(retryLocalUrl);
+    expect(mockCleanup).not.toHaveBeenCalled();
   });
 });

--- a/src/components/editor/components/blocks/image/__tests__/ImageBlock.test.tsx
+++ b/src/components/editor/components/blocks/image/__tests__/ImageBlock.test.tsx
@@ -1,0 +1,110 @@
+import { render, screen, waitFor } from '@testing-library/react';
+
+import { BlockType, ImageBlockData } from '@/application/types';
+import { ImageBlock } from '@/components/editor/components/blocks/image/ImageBlock';
+import { ImageBlockNode } from '@/components/editor/editor.type';
+
+const mockGetStoredFile = jest.fn();
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+jest.mock('slate-react', () => ({
+  ReactEditor: {
+    findPath: jest.fn(),
+    focus: jest.fn(),
+  },
+  useReadOnly: () => false,
+  useSelected: () => false,
+  useSlateStatic: () => ({
+    isElementReadOnly: () => false,
+    select: jest.fn(),
+    start: jest.fn(),
+  }),
+}));
+
+jest.mock('@/components/editor/EditorContext', () => ({
+  useEditorContext: () => ({
+    uploadFile: jest.fn(),
+    viewId: 'view-id',
+    workspaceId: 'workspace-id',
+  }),
+}));
+
+jest.mock('@/components/editor/components/block-popover/BlockPopoverContext', () => ({
+  usePopoverContext: () => ({ openPopover: jest.fn() }),
+}));
+
+jest.mock('@/components/editor/utils/file-url', () => ({
+  constructFileUrl: (url?: string) => url || '',
+}));
+
+jest.mock('@/utils/file', () => ({
+  FileHandler: jest.fn().mockImplementation(() => ({
+    cleanup: jest.fn(),
+    getStoredFile: mockGetStoredFile,
+  })),
+}));
+
+jest.mock('@/components/editor/components/blocks/image/ImageRender', () => ({
+  __esModule: true,
+  default: ({ localUrl, node }: { localUrl?: string; node: ImageBlockNode }) => (
+    <div data-testid='image-render' data-local-url={localUrl} data-url={node.data.url} />
+  ),
+}));
+
+jest.mock('@/components/editor/components/blocks/image/ImageEmpty', () => ({
+  __esModule: true,
+  default: () => <div data-testid='image-empty' />,
+}));
+
+function imageNode(data: ImageBlockData): ImageBlockNode {
+  return {
+    blockId: 'image-block-id',
+    children: [{ text: '' }],
+    data,
+    type: BlockType.ImageBlock,
+  };
+}
+
+describe('ImageBlock upload status', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetStoredFile.mockResolvedValue({ url: 'blob:local-preview' });
+  });
+
+  it('shows uploading instead of a false failure while the remote upload is pending', async () => {
+    const retryLocalUrl = 'stored-file-id';
+    const { rerender } = render(
+      <ImageBlock
+        node={imageNode({
+          pending_upload_id: 'pending-upload-id',
+          retry_local_url: retryLocalUrl,
+          url: '',
+        })}
+      >
+        <span />
+      </ImageBlock>
+    );
+
+    expect((await screen.findByTestId('image-render')).getAttribute('data-local-url')).toBe('blob:local-preview');
+    expect(screen.getByTestId('image-upload-pending').textContent).toContain('fileDropzone.uploading');
+    expect(screen.queryByText('button.uploadFailed')).toBeNull();
+
+    rerender(
+      <ImageBlock
+        node={imageNode({
+          pending_upload_id: '',
+          retry_local_url: retryLocalUrl,
+          url: '',
+        })}
+      >
+        <span />
+      </ImageBlock>
+    );
+
+    await waitFor(() => expect(screen.getByText('button.uploadFailed')).toBeTruthy());
+    expect(screen.queryByTestId('image-upload-pending')).toBeNull();
+  });
+});

--- a/src/components/editor/components/blocks/image/__tests__/ImageRender.test.tsx
+++ b/src/components/editor/components/blocks/image/__tests__/ImageRender.test.tsx
@@ -1,0 +1,40 @@
+import { render, screen } from '@testing-library/react';
+
+import { BlockType } from '@/application/types';
+import ImageRender from '@/components/editor/components/blocks/image/ImageRender';
+import { ImageBlockNode } from '@/components/editor/editor.type';
+
+jest.mock('slate-react', () => ({
+  useReadOnly: () => false,
+  useSlateStatic: () => ({ isElementReadOnly: () => false }),
+}));
+
+jest.mock('@/components/editor/components/blocks/image/Img', () => ({
+  __esModule: true,
+  default: ({ url }: { url: string }) => <div data-testid='image-source' data-url={url} />,
+}));
+
+jest.mock('@/components/editor/components/blocks/image/ImageResizer', () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+jest.mock('@/components/editor/components/blocks/image/ImageToolbar', () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+describe('ImageRender', () => {
+  it('prefers an existing local preview over the newly uploaded remote URL', () => {
+    const node: ImageBlockNode = {
+      blockId: 'image-block-id',
+      children: [{ text: '' }],
+      data: { url: 'https://example.com/uploaded-image.png' },
+      type: BlockType.ImageBlock,
+    };
+
+    render(<ImageRender localUrl='blob:local-preview' node={node} selected={false} />);
+
+    expect(screen.getByTestId('image-source').getAttribute('data-url')).toBe('blob:local-preview');
+  });
+});

--- a/src/utils/file.ts
+++ b/src/utils/file.ts
@@ -201,13 +201,19 @@ export class FileHandler {
     }
   }
 
+  // Release an in-memory preview without deleting the persisted retry file.
+  releaseUrl(id: string): void {
+    const url = this.fileUrls.get(id);
+
+    if (!url) return;
+
+    URL.revokeObjectURL(url);
+    this.fileUrls.delete(id);
+  }
+
   // Clean up single file and its resources
   async cleanup(id: string): Promise<void> {
-    if (this.fileUrls.has(id)) {
-      URL.revokeObjectURL(this.fileUrls.get(id)!);
-      this.fileUrls.delete(id);
-    }
-
+    this.releaseUrl(id);
     await this.storage.deleteFile(id);
   }
 


### PR DESCRIPTION
### **Description**

Image blocks previously treated the optimistic local preview as proof that an upload had failed. They also replaced the already-rendered `blob:` preview with the remote URL as soon as the upload completed, causing an unnecessary fetch/decode repaint and a visible refresh.

This PR:
- derives uploading and retry states from `pending_upload_id`
- displays **Uploading...** while the remote request is active
- clears the pending token on genuine upload failure so Retry remains available
- keeps the existing local preview rendered after a successful upload for a smooth transition
- saves the remote URL for future mounts and reloads without swapping the current image source
- releases preview object URLs without deleting failed-upload retry data
- ignores stale upload completions when the block was replaced or deleted
- adds regression coverage for pending, failure, success, replacement, and cleanup transitions

---

### **Checklist**

#### **General**
- [x] Reviewed against the React best-practices guidance.
- [x] The behavior and state transitions are documented in code and tests.
- [ ] Tested in multiple browser and operating-system environments.

#### **Testing**
- [x] Added focused image upload status and stable-preview regression tests.
- [x] `pnpm exec jest --runInBand --no-coverage` (341 suites, 3,325 tests)
- [x] `pnpm type-check`
- [x] Targeted ESLint checks

#### **Feature-Specific**
- [x] Not applicable; this is a bug fix.