### PR TITLE
fix: stabilize board loading and chart rendering

### DIFF
--- a/src/components/_shared/skeleton/KanbanSkeleton.tsx
+++ b/src/components/_shared/skeleton/KanbanSkeleton.tsx
@@ -7,6 +7,7 @@ function KanbanSkeleton({ includeTitle = true, includeTabs = true }: { includeTi
 
   return (
     <div
+      data-testid='kanban-skeleton'
       className={`appflowy-custom-scroller w-full overflow-x-auto py-${
         includeTitle ? '2' : '0'
       }  min-w-0 max-w-full px-24 max-sm:px-6`}

--- a/src/components/database/chart/widgets/BarChart.tsx
+++ b/src/components/database/chart/widgets/BarChart.tsx
@@ -67,7 +67,7 @@ function BarChartWidgetImpl({ data, onBarClick }: BarChartWidgetProps) {
   };
 
   return (
-    <div className="w-full relative" style={{ height: '400px' }}>
+    <div data-testid='bar-chart-widget' className='relative w-full' style={{ height: '400px' }}>
       <ResponsiveContainer width="100%" height="100%">
         <RechartsBarChart
           data={data}

--- a/src/components/database/chart/widgets/__tests__/BarChart.test.tsx
+++ b/src/components/database/chart/widgets/__tests__/BarChart.test.tsx
@@ -1,0 +1,75 @@
+import { render, screen } from '@testing-library/react';
+
+import BarChartWidget from '@/components/database/chart/widgets/BarChart';
+
+class ResizeObserverMock implements ResizeObserver {
+  constructor(private readonly callback: ResizeObserverCallback) {}
+
+  disconnect() {
+    // The test has no persistent observation lifecycle to clean up.
+  }
+
+  observe(target: Element) {
+    this.callback(
+      [
+        {
+          borderBoxSize: [],
+          contentBoxSize: [],
+          contentRect: {
+            bottom: 400,
+            height: 400,
+            left: 0,
+            right: 800,
+            top: 0,
+            width: 800,
+            x: 0,
+            y: 0,
+            toJSON: () => ({}),
+          },
+          devicePixelContentBoxSize: [],
+          target,
+        },
+      ],
+      this
+    );
+  }
+
+  unobserve() {
+    // Recharts only needs the initial measurement in this test.
+  }
+}
+
+describe('BarChartWidget', () => {
+  const originalResizeObserver = globalThis.ResizeObserver;
+
+  beforeAll(() => {
+    globalThis.ResizeObserver = ResizeObserverMock;
+  });
+
+  afterAll(() => {
+    globalThis.ResizeObserver = originalResizeObserver;
+  });
+
+  it('renders the real Recharts component without an invalid hook call', () => {
+    let container: HTMLElement | undefined;
+
+    expect(() =>
+      ({ container } = render(
+        <BarChartWidget
+          data={[
+            {
+              color: '#5B8FF9',
+              label: 'In Progress',
+              rowIds: ['row-1'],
+              value: 1,
+            },
+          ]}
+        />
+      ))
+    ).not.toThrow();
+
+    expect(screen.getByTestId('bar-chart-widget')).toBeTruthy();
+    expect(container?.querySelector('.recharts-wrapper')).not.toBeNull();
+    expect(container?.querySelector('.recharts-bar-rectangle')).not.toBeNull();
+  });
+});

--- a/src/components/database/components/board/group/Group.tsx
+++ b/src/components/database/components/board/group/Group.tsx
@@ -2,8 +2,16 @@ import { autoScrollForElements } from '@atlaskit/pragmatic-drag-and-drop-auto-sc
 import React, { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import { PADDING_END, useDatabaseContext, useReadOnly, useRowsByGroup } from '@/application/database-yjs';
+import {
+  GroupColumn,
+  PADDING_END,
+  Row,
+  useDatabaseContext,
+  useReadOnly,
+  useRowsByGroup,
+} from '@/application/database-yjs';
 import { useNewRowDispatch } from '@/application/database-yjs/dispatch';
+import KanbanSkeleton from '@/components/_shared/skeleton/KanbanSkeleton';
 import { useBoardActions } from '@/components/database/board/BoardProvider';
 import { BoardDragContext } from '@/components/database/components/board/drag-and-drop/board-context';
 import { useColumnsDrag } from '@/components/database/components/board/drag-and-drop/useColumnsDrag';
@@ -24,6 +32,41 @@ export interface GroupProps {
 export const Group = ({ groupId }: GroupProps) => {
   const { columns, groupResult, fieldId, groupRowsReady, notFound } = useRowsByGroup(groupId);
   const { t } = useTranslation();
+
+  if (notFound) {
+    return (
+      <div className={'mt-[10%] flex h-full w-full flex-col items-center gap-2 text-text-secondary'}>
+        <div className={'text-sm font-medium'}>{t('board.noGroup')}</div>
+        <div className={'text-xs'}>{t('board.noGroupDesc')}</div>
+      </div>
+    );
+  }
+
+  if (!fieldId) return null;
+
+  if (!groupRowsReady) {
+    return <KanbanSkeleton includeTitle={false} includeTabs={false} />;
+  }
+
+  return (
+    <HydratedGroup
+      groupId={groupId}
+      columns={columns}
+      groupResult={groupResult}
+      fieldId={fieldId}
+      groupRowsReady={groupRowsReady}
+    />
+  );
+};
+
+interface HydratedGroupProps extends GroupProps {
+  columns: GroupColumn[];
+  groupResult: Map<string, Row[]>;
+  fieldId: string;
+  groupRowsReady: boolean;
+}
+
+const HydratedGroup = ({ groupId, columns, groupResult, fieldId, groupRowsReady }: HydratedGroupProps) => {
   const context = useDatabaseContext();
   const { paddingStart, paddingEnd, navigateToRow } = context;
 
@@ -214,16 +257,6 @@ export const Group = ({ groupId }: GroupProps) => {
     };
   }, [ref, verticalScrollContainer]);
 
-  if (notFound) {
-    return (
-      <div className={'mt-[10%] flex h-full w-full flex-col items-center gap-2 text-text-secondary'}>
-        <div className={'text-sm font-medium'}>{t('board.noGroup')}</div>
-        <div className={'text-xs'}>{t('board.noGroupDesc')}</div>
-      </div>
-    );
-  }
-
-  if (!fieldId) return null;
   if (readOnly && columns.length === 0) return null;
 
   return (

--- a/src/components/database/components/board/group/__tests__/Group.loading.test.tsx
+++ b/src/components/database/components/board/group/__tests__/Group.loading.test.tsx
@@ -1,0 +1,92 @@
+import { render, screen } from '@testing-library/react';
+
+import { useRowsByGroup } from '@/application/database-yjs';
+import { Group } from '@/components/database/components/board/group/Group';
+
+jest.mock('@/application/database-yjs', () => ({
+  PADDING_END: 100,
+  useDatabaseContext: () => ({ navigateToRow: jest.fn(), paddingEnd: 0, paddingStart: 0 }),
+  useReadOnly: () => false,
+  useRowsByGroup: jest.fn(),
+}));
+
+jest.mock('@/application/database-yjs/dispatch', () => ({
+  useNewRowDispatch: () => jest.fn(),
+}));
+jest.mock('@/components/database/board/BoardProvider', () => ({
+  useBoardActions: () => ({ setEditingCardId: jest.fn(), setSelectedCardIds: jest.fn() }),
+}));
+jest.mock('@/components/database/components/board/drag-and-drop/useColumnsDrag', () => ({
+  useColumnsDrag: () => ({ contextValue: { instanceId: 'test-board' }, scrollableRef: { current: null } }),
+}));
+jest.mock('@/components/database/components/board/group/Columns', () => {
+  const React = jest.requireActual('react') as typeof import('react');
+
+  return {
+    __esModule: true,
+    default: React.forwardRef<HTMLDivElement>(() => <div data-testid='board-columns'>Hydrated board</div>),
+  };
+});
+jest.mock('@/components/database/components/board/group/GroupStickyHeader', () => {
+  const React = jest.requireActual('react') as typeof import('react');
+
+  return {
+    __esModule: true,
+    default: React.forwardRef<HTMLDivElement>(() => null),
+  };
+});
+jest.mock('@/components/database/components/board/group/useNavigationKey', () => ({
+  useNavigationKey: jest.fn(),
+}));
+jest.mock('@/components/database/components/sticky-overlay/DatabaseStickyBottomOverlay', () => ({
+  __esModule: true,
+  default: ({ children }: { children: React.ReactNode }) => children,
+}));
+jest.mock('@/components/database/components/sticky-overlay/DatabaseStickyHorizontalScrollbar', () => {
+  const React = jest.requireActual('react') as typeof import('react');
+
+  return {
+    __esModule: true,
+    default: React.forwardRef<HTMLDivElement>(() => null),
+  };
+});
+jest.mock('@/components/database/components/sticky-overlay/DatabaseStickyTopOverlay', () => ({
+  __esModule: true,
+  default: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+const mockUseRowsByGroup = useRowsByGroup as jest.MockedFunction<typeof useRowsByGroup>;
+const loadingResult = {
+  columns: [],
+  fieldId: 'status-field-id',
+  groupResult: new Map(),
+  groupRowsReady: false,
+  hideEmptyGroups: false,
+  notFound: false,
+};
+
+describe('Board group loading state', () => {
+  afterEach(() => {
+    mockUseRowsByGroup.mockReset();
+  });
+
+  it('replaces the non-interactive Kanban skeleton after the first row grouping is hydrated', () => {
+    mockUseRowsByGroup.mockReturnValue(loadingResult);
+
+    const { rerender } = render(<Group groupId='status-group-id' />);
+
+    expect(screen.getByTestId('kanban-skeleton')).toBeTruthy();
+    expect(screen.queryByTestId('board-columns')).toBeNull();
+    expect(screen.queryByText('New')).toBeNull();
+
+    mockUseRowsByGroup.mockReturnValue({ ...loadingResult, groupRowsReady: true });
+    rerender(<Group groupId='status-group-id' />);
+
+    expect(screen.queryByTestId('kanban-skeleton')).toBeNull();
+    expect(screen.getByTestId('board-columns').textContent).toBe('Hydrated board');
+  });
+});

--- a/src/config/vite-dependencies.test.ts
+++ b/src/config/vite-dependencies.test.ts
@@ -1,0 +1,30 @@
+/** @jest-environment node */
+
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+
+const execFileAsync = promisify(execFile);
+
+describe('Vite React dependency graph', () => {
+  it('applies React deduplication and lazy chart pre-bundling to the resolved Vite configuration', async () => {
+    const script = `
+      import { loadConfigFromFile } from 'vite';
+      import path from 'node:path';
+      const loaded = await loadConfigFromFile(
+        { command: 'serve', mode: 'test' },
+        path.resolve('vite.config.ts')
+      );
+      console.log(JSON.stringify({
+        dedupe: loaded?.config.resolve?.dedupe,
+        include: loaded?.config.optimizeDeps?.include,
+      }));
+    `;
+    const { stdout } = await execFileAsync(process.execPath, ['--input-type=module', '--eval', script], {
+      cwd: process.cwd(),
+    });
+    const resolvedConfig = JSON.parse(stdout) as { dedupe?: string[]; include?: string[] };
+
+    expect(resolvedConfig.dedupe).toEqual(expect.arrayContaining(['react', 'react-dom']));
+    expect(resolvedConfig.include).toEqual(expect.arrayContaining(['react', 'react-dom', 'recharts']));
+  });
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,6 +7,7 @@ import istanbul from 'vite-plugin-istanbul';
 import svgr from 'vite-plugin-svgr';
 import { totalBundleSize } from 'vite-plugin-total-bundle-size';
 import { stripTestIdPlugin } from './vite-plugin-strip-testid';
+import { VITE_DEDUPED_DEPENDENCIES, VITE_OPTIMIZED_DEPENDENCIES } from './vite.dependencies';
 
 const resourcesPath = path.resolve(__dirname, '../resources');
 const isDev = process.env.NODE_ENV ? process.env.NODE_ENV === 'development' : true;
@@ -245,6 +246,7 @@ export default defineConfig({
       : {},
   },
   resolve: {
+    dedupe: [...VITE_DEDUPED_DEPENDENCIES],
     alias: [
       { find: '@protobufjs/inquire', replacement: path.resolve(__dirname, 'src/shims/protobufjs-inquire.cjs') },
       { find: 'src/', replacement: `${__dirname}/src/` },
@@ -253,17 +255,7 @@ export default defineConfig({
   },
 
   optimizeDeps: {
-    include: [
-      'react',
-      'react-dom',
-      'react-katex',
-      '@appflowyinc/editor',
-      'react-colorful',
-      'i18next',
-      'i18next-browser-languagedetector',
-      'i18next-resources-to-backend',
-      'react-i18next'
-    ],
+    include: [...VITE_OPTIMIZED_DEPENDENCIES],
   },
   css: {
     preprocessorOptions: {

--- a/vite.dependencies.ts
+++ b/vite.dependencies.ts
@@ -1,0 +1,24 @@
+/**
+ * Dependencies that must resolve to one runtime instance. A second React
+ * module has its own hook dispatcher and cannot be rendered by the app's
+ * ReactDOM instance.
+ */
+export const VITE_DEDUPED_DEPENDENCIES = ['react', 'react-dom'] as const;
+
+/**
+ * Lazy views are not guaranteed to be found by Vite's startup dependency
+ * scan. Pre-bundle Recharts with React so opening the first Chart view cannot
+ * trigger a mid-session dependency re-optimization and split the React graph.
+ */
+export const VITE_OPTIMIZED_DEPENDENCIES = [
+  'react',
+  'react-dom',
+  'recharts',
+  'react-katex',
+  '@appflowyinc/editor',
+  'react-colorful',
+  'i18next',
+  'i18next-browser-languagedetector',
+  'i18next-resources-to-backend',
+  'react-i18next',
+] as const;


### PR DESCRIPTION
## Summary

- show a Kanban skeleton until the initial board row grouping is hydrated
- keep drag and scroll hooks behind the hydrated board boundary
- deduplicate React and pre-bundle lazy Recharts dependencies in Vite
- add regression coverage for board hydration, resolved Vite configuration, and real Recharts rendering

## Root cause

The board rendered its interactive empty state before the first complete grouping of row documents. Separately, opening the lazy chart view could trigger Vite dependency re-optimization mid-session, loading Recharts against a query-distinct React runtime and causing the invalid hook and useRef crash.

## Test plan

- `pnpm exec jest src/config/vite-dependencies.test.ts src/components/database/components/board/group/__tests__/Group.loading.test.tsx src/components/database/chart/widgets/__tests__/BarChart.test.tsx src/application/database-yjs/__tests__/useRowsByGroup.test.tsx src/application/database-yjs/__tests__/board-visibility.test.ts src/components/database/chart/hooks/useChartData.test.tsx --runInBand --coverage=false`
- `pnpm type-check`
- targeted ESLint for all changed files
- `pnpm build`
- clean browser reload of Project Tracker: chart rendered with no invalid-hook warning, useRef crash, or error boundary

## Summary by Sourcery

Stabilize initial Kanban loading and lazy chart rendering by gating board interactivity on hydration and ensuring charts share the application’s React runtime.

Bug Fixes:
- Prevent the board from exposing interactive content before its initial row grouping has hydrated.
- Prevent lazy chart loading from causing duplicate React runtimes, invalid hook calls, and Recharts rendering crashes.

Enhancements:
- Isolate hydrated board interactions behind the loading boundary and provide regression coverage for board hydration, Vite dependency resolution, and real chart rendering.

Build:
- Centralize Vite dependency configuration with React deduplication and pre-bundling for Recharts and related dependencies.

Tests:
- Add regression tests covering the Kanban loading transition, resolved Vite dependency settings, and successful Recharts rendering.