### PR TITLE
fix: show inline comment submission progress

### DIFF
--- a/src/components/inline-comment/InlineCommentComposer.tsx
+++ b/src/components/inline-comment/InlineCommentComposer.tsx
@@ -103,6 +103,7 @@ export function InlineCommentComposer() {
         />
         <button
           aria-label={t('inlineComment.addComment')}
+          aria-busy={submitting}
           data-testid={'inline-comment-submit'}
           disabled={!content.trim() || submitting}
           onClick={submit}
@@ -110,10 +111,24 @@ export function InlineCommentComposer() {
             'mb-0.5 flex shrink-0 items-center justify-center p-1 transition-colors',
             // Desktop keeps the send glyph in its brand color while it can be
             // submitted and greys it out otherwise.
-            content.trim() && !submitting ? 'text-brand-skyline hover:opacity-90' : 'text-icon-tertiary'
+            submitting
+              ? 'text-brand-skyline'
+              : content.trim()
+              ? 'text-brand-skyline hover:opacity-90'
+              : 'text-icon-tertiary'
           )}
         >
-          <SendCommentIcon className={'h-5 w-5'} />
+          {submitting ? (
+            <span
+              aria-hidden={'true'}
+              data-testid={'inline-comment-submit-loading'}
+              className={
+                'h-5 w-5 animate-spin rounded-full border-2 border-current border-t-transparent motion-reduce:animate-none'
+              }
+            />
+          ) : (
+            <SendCommentIcon className={'h-5 w-5'} />
+          )}
         </button>
       </div>
     </Portal>

--- a/src/components/inline-comment/InlineCommentSidebar.tsx
+++ b/src/components/inline-comment/InlineCommentSidebar.tsx
@@ -539,9 +539,10 @@ function ReplyInput({ parentCommentId, onClose }: { parentCommentId: string; onC
 
   return (
     <div className={'px-4 pb-3 pt-1'}>
-      <div className={'rounded-lg border border-border-primary bg-background-primary px-2 py-1'}>
+      <div className={'relative rounded-lg border border-border-primary bg-background-primary px-2 py-1'}>
         <TextareaAutosize
           autoFocus
+          aria-busy={submitting}
           // The bordered shell around it is the field frame, as on desktop.
           variant={'ghost'}
           data-testid={'inline-comment-reply-input'}
@@ -561,8 +562,17 @@ function ReplyInput({ parentCommentId, onClose }: { parentCommentId: string; onC
               void submit();
             }
           }}
-          className={'w-full bg-transparent py-1 text-sm'}
+          className={cn('w-full bg-transparent py-1 text-sm', submitting && 'pr-7')}
         />
+        {submitting ? (
+          <span
+            aria-hidden={'true'}
+            data-testid={'inline-comment-reply-loading'}
+            className={
+              'absolute right-2 top-1/2 h-4 w-4 -translate-y-1/2 animate-spin rounded-full border-2 border-current border-t-transparent text-brand-skyline motion-reduce:animate-none'
+            }
+          />
+        ) : null}
       </div>
     </div>
   );

--- a/src/components/inline-comment/__tests__/InlineCommentComposer.test.tsx
+++ b/src/components/inline-comment/__tests__/InlineCommentComposer.test.tsx
@@ -16,9 +16,10 @@ jest.mock('react-i18next', () => ({
 
 const cancelPendingComment = jest.fn();
 const submitPendingComment = jest.fn().mockResolvedValue(undefined);
+let mockMutatingCommentIds = new Set<string>();
 
 jest.mock('../InlineCommentContext', () => ({
-  useInlineCommentStatus: () => ({ mutatingCommentIds: new Set() }),
+  useInlineCommentStatus: () => ({ mutatingCommentIds: mockMutatingCommentIds }),
   useInlineCommentCompose: () => ({
     cancelPendingComment,
     pendingComment: {
@@ -39,6 +40,7 @@ jest.mock('../InlineCommentContext', () => ({
 describe('InlineCommentComposer', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockMutatingCommentIds = new Set();
   });
 
   it('renders the compact desktop compose menu', () => {
@@ -61,6 +63,17 @@ describe('InlineCommentComposer', () => {
 
     fireEvent.keyDown(input, { key: 'Enter' });
     expect(submitPendingComment).toHaveBeenCalledWith('Review this');
+  });
+
+  it('shows a loading indicator while the comment is being submitted', () => {
+    mockMutatingCommentIds = new Set(['new']);
+    render(<InlineCommentComposer />);
+
+    const submitButton = screen.getByTestId('inline-comment-submit');
+
+    expect(submitButton.getAttribute('aria-busy')).toBe('true');
+    expect(submitButton.disabled).toBe(true);
+    expect(screen.queryByTestId('inline-comment-submit-loading')).not.toBeNull();
   });
 
   it('dismisses with Escape or an outside pointer press', () => {

--- a/src/components/inline-comment/__tests__/InlineCommentSidebar.test.tsx
+++ b/src/components/inline-comment/__tests__/InlineCommentSidebar.test.tsx
@@ -206,6 +206,19 @@ describe('InlineCommentSidebar', () => {
     expect(createReply).toHaveBeenCalledWith('open-comment', 'Sounds good');
   });
 
+  it('shows a loading indicator while a reply is being submitted', () => {
+    setContext({ mutatingCommentIds: new Set(['open-comment']) });
+    render(<InlineCommentSidebar />);
+
+    fireEvent.click(screen.getByTestId('inline-comment-reply-button'));
+
+    const input = screen.getByTestId('inline-comment-reply-input');
+
+    expect(input.getAttribute('aria-busy')).toBe('true');
+    expect(input.disabled).toBe(true);
+    expect(screen.queryByTestId('inline-comment-reply-loading')).not.toBeNull();
+  });
+
   it('deletes a thread through the action menu and its confirmation', async () => {
     render(<InlineCommentSidebar />);
 


### PR DESCRIPTION
## Summary

- replace the inline comment send icon with a spinner while creation is pending
- show the same spinner inside the reply field while a reply is pending
- expose aria-busy state and keep submission controls disabled to prevent duplicate requests
- respect reduced-motion preferences

## Root cause

The mutation state already existed, but the comment composer only dimmed its send icon and the reply field rendered no progress indicator. During the create and reload round trips, successful submissions therefore appeared unresponsive.

## Testing

- pnpm exec jest src/components/inline-comment/__tests__/InlineCommentSidebar.test.tsx src/components/inline-comment/__tests__/InlineCommentComposer.test.tsx --runInBand --coverage=false
- pnpm type-check
- pnpm exec eslint --quiet src/components/inline-comment/InlineCommentSidebar.tsx src/components/inline-comment/InlineCommentComposer.tsx src/components/inline-comment/__tests__/InlineCommentSidebar.test.tsx src/components/inline-comment/__tests__/InlineCommentComposer.test.tsx
- live Chrome verification with delayed comment and reply requests

## Summary by Sourcery

Provide clear, accessible progress feedback for inline comment and reply submissions.

New Features:
- Show loading indicators while inline comments and replies are being submitted.

Bug Fixes:
- Improve submission feedback so pending comment and reply requests no longer appear unresponsive.

Enhancements:
- Expose busy states, preserve disabled submission controls, and respect reduced-motion preferences during submission.

Tests:
- Add coverage for comment and reply submission loading states, accessibility attributes, and disabled controls.