### PR TITLE
fix: show workspace groups to members

### DIFF
--- a/playwright/bdd/features/workspace/workspace-group-management.feature
+++ b/playwright/bdd/features/workspace/workspace-group-management.feature
@@ -1,6 +1,6 @@
 @workspace-group-management
 Feature: Workspace group management
-  Workspace owners can manage workspace groups from People settings.
+  Workspace owners can manage groups, while workspace members can view group summaries from People settings.
 
   Background:
     Given the seeded spm0622 space permission fixture exists
@@ -16,3 +16,15 @@ Feature: Workspace group management
     Then the temporary group does not show workspace member "spm0622-member-closed@appflowy.local"
     When I delete the temporary workspace group
     Then the temporary workspace group is not listed
+
+  Scenario: Workspace member sees an owner-created group without management controls
+    Given I sign in as the Nathan workspace owner
+    When I open the People settings groups tab
+    And I create a temporary workspace group
+    And I open the temporary workspace group
+    And I add workspace member "eva@appflowy.io" to the temporary group
+    Then the temporary group shows workspace member "eva@appflowy.io"
+    When I sign in as Eva and switch to the Nathan workspace
+    And I open the People settings groups tab as a workspace member
+    Then the temporary workspace group is listed with "1 member"
+    And workspace members cannot manage or open the temporary workspace group

--- a/playwright/bdd/steps/workspace-group-management.steps.ts
+++ b/playwright/bdd/steps/workspace-group-management.steps.ts
@@ -15,6 +15,7 @@ const { Given, When, Then, Before, After } = createBdd();
 
 const PASSWORD = 'AppFlowy!@123';
 const NATHAN_EMAIL = 'nathan@appflowy.io';
+const EVA_EMAIL = 'eva@appflowy.io';
 const TEMPORARY_GROUP_PREFIX = 'bdd group management';
 const SPM_GROUP_NAME = 'spm0622 Full Access Space Group';
 const SPM_GROUP_SPACE_NAME = 'spm0622 Group Full Access Space';
@@ -67,6 +68,7 @@ type ScenarioState = {
   groupDeleted: boolean;
   ownerToken?: string;
   workspaceId?: string;
+  workspaceName?: string;
   seededGroupCleanupEmails: Set<string>;
 };
 
@@ -110,7 +112,7 @@ Given('the seeded spm0622 space permission fixture exists', async () => {
 });
 
 Given('I sign in as the Nathan workspace owner', async ({ page, request }) => {
-  await signInAsWorkspaceOwner(page, request, NATHAN_EMAIL);
+  await signInAsNathanWorkspaceOwner(page, request);
 });
 
 Given('I sign in as seeded spm0622 {string}', async ({ page, request }, accountAliasValue: string) => {
@@ -127,18 +129,25 @@ When(
 );
 
 When('I open the People settings groups tab', async ({ page }) => {
-  await expect(WorkspaceSelectors.dropdownTrigger(page)).toBeVisible({ timeout: 30000 });
-  await WorkspaceSelectors.dropdownTrigger(page).click();
-  await expect(WorkspaceSelectors.dropdownContent(page)).toBeVisible({ timeout: 15000 });
+  const dialog = await openPeopleSettingsGroupsTab(page);
 
-  await AccountSelectors.settingsButton(page).click();
-
-  const dialog = settingsDialog(page);
-
-  await expect(dialog).toBeVisible({ timeout: 15000 });
-  await dialog.getByTestId('settings-menu-members').click();
-  await dialog.getByRole('tab', { name: /^Groups/ }).click();
   await expect(dialog.getByTestId('people-create-group-button')).toBeVisible({ timeout: 15000 });
+});
+
+When('I sign in as Eva and switch to the Nathan workspace', async ({ page }) => {
+  const workspaceName = requireWorkspaceName(page);
+
+  await resetBrowserSession(page);
+  await signInWithPasswordViaUi(page, EVA_EMAIL, PASSWORD, 2000);
+  await expect(page).toHaveURL(/\/app/, { timeout: 30000 });
+  await expect(WorkspaceSelectors.dropdownTrigger(page)).toBeVisible({ timeout: 30000 });
+  await switchWorkspace(page, workspaceName);
+});
+
+When('I open the People settings groups tab as a workspace member', async ({ page }) => {
+  const dialog = await openPeopleSettingsGroupsTab(page);
+
+  await expect(dialog.getByTestId('people-create-group-button')).toHaveCount(0);
 });
 
 When('I create a temporary workspace group', async ({ page }) => {
@@ -247,6 +256,50 @@ Then('the temporary workspace group is not listed', async ({ page }) => {
   await expect(groupRow(page, requireGroupName(page))).toHaveCount(0, { timeout: 15000 });
 });
 
+Then('the temporary workspace group is listed with {string}', async ({ page, request }, memberCount: string) => {
+  const groupName = requireGroupName(page);
+  const workspaceId = requireWorkspaceId(page);
+  const evaToken = await getAuthToken(page);
+
+  if (!evaToken) {
+    throw new Error(`No auth token found after signing in as ${EVA_EMAIL}`);
+  }
+
+  const visibleGroups = await getApi<WorkspaceGroupsPayload>(request, evaToken, `/api/workspace/${workspaceId}/groups`);
+  const temporaryGroup = visibleGroups.groups.find((group) => group.name === groupName);
+
+  if (!temporaryGroup) {
+    throw new Error(`Eva's group list does not contain the temporary workspace group: ${groupName}`);
+  }
+
+  expect(temporaryGroup.member_count).toBe(1);
+
+  const dialog = settingsDialog(page);
+  const row = dialog.getByTestId(`group-row-${temporaryGroup.group_id}`);
+
+  await expect(dialog.getByRole('tab', { name: `Groups ${visibleGroups.groups.length}`, exact: true })).toBeVisible({
+    timeout: 15000,
+  });
+  await expect(row).toBeVisible({ timeout: 15000 });
+  await expect(row.getByText(groupName, { exact: true })).toBeVisible();
+  await expect(row.getByText(memberCount, { exact: true })).toBeVisible();
+});
+
+Then('workspace members cannot manage or open the temporary workspace group', async ({ page }) => {
+  const groupName = requireGroupName(page);
+  const dialog = settingsDialog(page);
+  const row = groupRow(page, groupName);
+
+  await expect(dialog.getByTestId('people-create-group-button')).toHaveCount(0);
+  await expect(row.locator('[data-testid^="group-edit-"]')).toHaveCount(0);
+  await expect(row.getByRole('button')).toHaveCount(0);
+
+  await row.click();
+  await expect(groupDetailModal(page)).toHaveCount(0);
+  await expect(page.getByTestId('rename-group-modal')).toHaveCount(0);
+  await expect(page.getByTestId('delete-group-confirmation')).toHaveCount(0);
+});
+
 Then(
   'seeded spm0622 {string} cannot open the seeded group Full Access page',
   async ({ page }, accountAliasValue: string) => {
@@ -302,6 +355,26 @@ async function signInAsWorkspaceOwner(page: Page, request: APIRequestContext, em
   state.workspaceId = await getCurrentWorkspaceId(request, ownerToken);
 }
 
+async function signInAsNathanWorkspaceOwner(page: Page, request: APIRequestContext) {
+  await resetBrowserSession(page);
+  await signInWithPasswordViaUi(page, NATHAN_EMAIL, PASSWORD, 2000);
+  await expect(page).toHaveURL(/\/app/, { timeout: 30000 });
+  await expect(WorkspaceSelectors.dropdownTrigger(page)).toBeVisible({ timeout: 30000 });
+
+  const workspaceName = await switchWorkspaceMatching(page, /nathan.*workspace/i);
+  const ownerToken = await getAuthToken(page);
+
+  if (!ownerToken) {
+    throw new Error(`No auth token found after signing in as ${NATHAN_EMAIL}`);
+  }
+
+  const state = requireState(page);
+
+  state.ownerToken = ownerToken;
+  state.workspaceId = await getCurrentWorkspaceId(request, ownerToken);
+  state.workspaceName = workspaceName;
+}
+
 async function signInSeededAccountForAccessCheck(page: Page, accountAliasValue: string) {
   await resetBrowserSession(page);
   await signInWithPasswordViaUi(page, spmAccountEmail(accountAliasValue), PASSWORD, 2000);
@@ -329,6 +402,26 @@ function requireGroupName(page: Page): string {
   return groupName;
 }
 
+function requireWorkspaceName(page: Page): string {
+  const workspaceName = requireState(page).workspaceName;
+
+  if (!workspaceName) {
+    throw new Error("Nathan's workspace name has not been captured for this scenario");
+  }
+
+  return workspaceName;
+}
+
+function requireWorkspaceId(page: Page): string {
+  const workspaceId = requireState(page).workspaceId;
+
+  if (!workspaceId) {
+    throw new Error("Nathan's workspace id has not been captured for this scenario");
+  }
+
+  return workspaceId;
+}
+
 function settingsDialog(page: Page) {
   return AccountSelectors.settingsDialog(page);
 }
@@ -347,6 +440,46 @@ function groupRow(page: Page, groupName: string) {
 
 function groupMemberRow(page: Page, email: string) {
   return groupDetailModal(page).locator('[data-testid^="group-member-row-"]').filter({ hasText: email }).first();
+}
+
+async function openPeopleSettingsGroupsTab(page: Page) {
+  await expect(WorkspaceSelectors.dropdownTrigger(page)).toBeVisible({ timeout: 30000 });
+  await WorkspaceSelectors.dropdownTrigger(page).click();
+  await expect(WorkspaceSelectors.dropdownContent(page)).toBeVisible({ timeout: 15000 });
+  await AccountSelectors.settingsButton(page).click();
+
+  const dialog = settingsDialog(page);
+
+  await expect(dialog).toBeVisible({ timeout: 15000 });
+  await dialog.getByTestId('settings-menu-members').click();
+  await dialog.getByRole('tab', { name: /^Groups/ }).click();
+  return dialog;
+}
+
+async function switchWorkspace(page: Page, workspaceName: string): Promise<void> {
+  const currentWorkspaceName = page.getByTestId('current-workspace-name');
+
+  if ((await currentWorkspaceName.textContent())?.trim() === workspaceName) return;
+
+  await WorkspaceSelectors.dropdownTrigger(page).click();
+  await expect(WorkspaceSelectors.dropdownContent(page)).toBeVisible({ timeout: 15000 });
+  await WorkspaceSelectors.item(page).filter({ hasText: workspaceName }).first().click();
+  await expect(currentWorkspaceName).toHaveText(workspaceName, { timeout: 30000 });
+}
+
+async function switchWorkspaceMatching(page: Page, workspaceName: RegExp): Promise<string> {
+  const currentWorkspaceName = page.getByTestId('current-workspace-name');
+  const currentName = (await currentWorkspaceName.textContent())?.trim();
+
+  if (currentName && workspaceName.test(currentName)) return currentName;
+
+  await WorkspaceSelectors.dropdownTrigger(page).click();
+  await expect(WorkspaceSelectors.dropdownContent(page)).toBeVisible({ timeout: 15000 });
+  const workspace = WorkspaceSelectors.item(page).filter({ hasText: workspaceName }).first();
+
+  await workspace.click();
+  await expect(currentWorkspaceName).toHaveText(workspaceName, { timeout: 30000 });
+  return (await currentWorkspaceName.textContent())?.trim() || 'Nathan workspace';
 }
 
 async function openWorkspaceGroup(page: Page, groupName: string) {

--- a/src/components/app/settings/MembersPanel.tsx
+++ b/src/components/app/settings/MembersPanel.tsx
@@ -292,6 +292,18 @@ function MembersPanelForWorkspace({
     };
   }, [currentWorkspaceId, isOwner]);
 
+  // Owner-only dialogs are gated on `isOwner` below; also clear their state so a
+  // stale dialog cannot reappear if ownership is later regained.
+  useEffect(() => {
+    if (isOwner) return;
+
+    setSelectedGroup(null);
+    setShowCreateGroup(false);
+    setRenamingGroup(null);
+    setRenamingGroupName('');
+    setDeleteConfirmationGroup(null);
+  }, [isOwner]);
+
   useEffect(() => {
     if (!showGroupSearch) return;
 
@@ -775,46 +787,46 @@ function MembersPanelForWorkspace({
                                 {groupMemberCountLabel(group.member_count, t)}
                               </span>
                               {isOwner && (
-                                <button
-                                  type='button'
-                                  data-testid={`group-edit-${group.group_id}`}
-                                  className='flex h-7 w-7 items-center justify-center rounded-300 text-icon-secondary hover:bg-fill-content-hover focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-border-theme-thick'
-                                  aria-label={`${t('button.edit')} ${group.name}`}
-                                  onClick={() => setSelectedGroup(group)}
-                                >
-                                  <EditIcon aria-hidden='true' className='h-5 w-5' />
-                                </button>
-                              )}
-                              {isOwner && (
-                                <div>
-                                  {isScimManaged ? (
-                                    <span className='block h-7 w-7' aria-hidden='true' />
-                                  ) : (
-                                    <DropdownMenu>
-                                      <DropdownMenuTrigger asChild>
-                                        <button
-                                          type='button'
-                                          disabled={deletingGroupId === group.group_id}
-                                          className='flex h-7 w-7 items-center justify-center rounded-300 text-icon-secondary hover:bg-fill-content-hover focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-border-theme-thick disabled:opacity-50'
-                                          aria-label={`${t('settings.appearance.people.groupActions')} ${group.name}`}
-                                        >
-                                          <MoreIcon aria-hidden='true' className='h-4 w-4' />
-                                        </button>
-                                      </DropdownMenuTrigger>
-                                      <DropdownMenuContent align='end' className='w-[180px] min-w-[180px]'>
-                                        <DropdownMenuItem onSelect={() => startRenameGroup(group)}>
-                                          {t('settings.appearance.people.renameGroup')}
-                                        </DropdownMenuItem>
-                                        <DropdownMenuItem
-                                          variant='destructive'
-                                          onSelect={() => requestDeleteGroup(group)}
-                                        >
-                                          {t('settings.appearance.people.deleteGroup')}
-                                        </DropdownMenuItem>
-                                      </DropdownMenuContent>
-                                    </DropdownMenu>
-                                  )}
-                                </div>
+                                <>
+                                  <button
+                                    type='button'
+                                    data-testid={`group-edit-${group.group_id}`}
+                                    className='flex h-7 w-7 items-center justify-center rounded-300 text-icon-secondary hover:bg-fill-content-hover focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-border-theme-thick'
+                                    aria-label={`${t('button.edit')} ${group.name}`}
+                                    onClick={() => setSelectedGroup(group)}
+                                  >
+                                    <EditIcon aria-hidden='true' className='h-5 w-5' />
+                                  </button>
+                                  <div>
+                                    {isScimManaged ? (
+                                      <span className='block h-7 w-7' aria-hidden='true' />
+                                    ) : (
+                                      <DropdownMenu>
+                                        <DropdownMenuTrigger asChild>
+                                          <button
+                                            type='button'
+                                            disabled={deletingGroupId === group.group_id}
+                                            className='flex h-7 w-7 items-center justify-center rounded-300 text-icon-secondary hover:bg-fill-content-hover focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-border-theme-thick disabled:opacity-50'
+                                            aria-label={`${t('settings.appearance.people.groupActions')} ${group.name}`}
+                                          >
+                                            <MoreIcon aria-hidden='true' className='h-4 w-4' />
+                                          </button>
+                                        </DropdownMenuTrigger>
+                                        <DropdownMenuContent align='end' className='w-[180px] min-w-[180px]'>
+                                          <DropdownMenuItem onSelect={() => startRenameGroup(group)}>
+                                            {t('settings.appearance.people.renameGroup')}
+                                          </DropdownMenuItem>
+                                          <DropdownMenuItem
+                                            variant='destructive'
+                                            onSelect={() => requestDeleteGroup(group)}
+                                          >
+                                            {t('settings.appearance.people.deleteGroup')}
+                                          </DropdownMenuItem>
+                                        </DropdownMenuContent>
+                                      </DropdownMenu>
+                                    )}
+                                  </div>
+                                </>
                               )}
                             </div>
                           );

--- a/src/components/app/settings/MembersPanel.tsx
+++ b/src/components/app/settings/MembersPanel.tsx
@@ -56,6 +56,11 @@ type GroupDetailTab = 'general' | 'members';
 const GROUP_EXCLUDED_WORKSPACE_ROLES = [Role.Guest];
 const PEOPLE_GUIDE_URL = 'https://appflowy.com/guide/getting-started-with-appflowy';
 const SCIM_GROUP_SOURCE = 'scim';
+const MEMBERS_TABLE_GRID_COLUMNS = 'grid-cols-[minmax(0,2fr)_minmax(120px,1fr)_minmax(0,2fr)_32px]';
+const PEOPLE_TABLE_HEADER_CLASS_NAME =
+  'grid gap-4 border-b border-border-primary pb-2 text-xs font-medium text-text-secondary';
+const PEOPLE_TABLE_ROW_CLASS_NAME = 'grid min-h-[60px] items-center gap-4 border-b border-border-primary py-3 text-sm';
+const PEOPLE_TABLE_STATUS_CLASS_NAME = 'py-6 text-center text-sm text-text-secondary';
 
 function parseInviteEmails(value: string): string[] {
   return Array.from(
@@ -580,18 +585,21 @@ function MembersPanelForWorkspace({
                 )}
 
                 <div className='flex flex-col'>
-                  <div className='grid grid-cols-[minmax(0,2fr)_minmax(120px,1fr)_minmax(0,2fr)_32px] gap-4 border-b border-border-primary pb-2 text-xs font-medium text-text-secondary'>
+                  <div
+                    data-testid='members-table-header'
+                    className={cn(PEOPLE_TABLE_HEADER_CLASS_NAME, MEMBERS_TABLE_GRID_COLUMNS)}
+                  >
                     <span>{t('settings.appearance.members.user')}</span>
                     <span>{t('settings.appearance.members.role')}</span>
                     <span>{t('settings.appearance.members.email')}</span>
                     <span className='w-6' aria-hidden='true' />
                   </div>
                   {loadingMembers && members.length === 0 ? (
-                    <div className='py-6 text-center text-sm text-text-secondary'>
+                    <div data-testid='members-table-status' className={PEOPLE_TABLE_STATUS_CLASS_NAME}>
                       <Progress />
                     </div>
                   ) : members.length === 0 ? (
-                    <div className='py-6 text-center text-sm text-text-secondary'>
+                    <div data-testid='members-table-status' className={PEOPLE_TABLE_STATUS_CLASS_NAME}>
                       {t('settings.appearance.members.noMembers')}
                     </div>
                   ) : (
@@ -605,7 +613,7 @@ function MembersPanelForWorkspace({
                         <div
                           key={m.email || `member-${idx}`}
                           data-testid={`members-row-${m.email || idx}`}
-                          className='grid grid-cols-[minmax(0,2fr)_minmax(120px,1fr)_minmax(0,2fr)_32px] items-center gap-4 border-b border-border-primary py-3 text-sm'
+                          className={cn(PEOPLE_TABLE_ROW_CLASS_NAME, MEMBERS_TABLE_GRID_COLUMNS)}
                         >
                           <div className='flex min-w-0 items-center gap-3'>
                             <Avatar size='md'>
@@ -734,21 +742,19 @@ function MembersPanelForWorkspace({
 
                     <div className='flex flex-col'>
                       <div
-                        className={cn(
-                          'grid gap-4 border-b border-border-primary pb-2 text-xs font-medium leading-[18px] text-text-secondary',
-                          groupGridColumns
-                        )}
+                        data-testid='groups-table-header'
+                        className={cn(PEOPLE_TABLE_HEADER_CLASS_NAME, groupGridColumns)}
                       >
                         <span>{t('settings.appearance.people.groupsTab')}</span>
                         <span>{t('settings.appearance.people.membersTab')}</span>
                         {isOwner && <span className='col-span-2 w-16' aria-hidden='true' />}
                       </div>
                       {loadingGroups && groups.length === 0 ? (
-                        <div className='py-5 text-center text-sm text-text-secondary'>
+                        <div data-testid='groups-table-status' className={PEOPLE_TABLE_STATUS_CLASS_NAME}>
                           <Progress />
                         </div>
                       ) : visibleGroups.length === 0 ? (
-                        <div className='py-5 text-center text-sm text-text-secondary'>
+                        <div data-testid='groups-table-status' className={PEOPLE_TABLE_STATUS_CLASS_NAME}>
                           {t('settings.appearance.people.noGroups')}
                         </div>
                       ) : (
@@ -759,10 +765,7 @@ function MembersPanelForWorkspace({
                             <div
                               key={group.group_id}
                               data-testid={`group-row-${group.group_id}`}
-                              className={cn(
-                                'grid items-center gap-4 border-b border-border-primary py-3 text-sm',
-                                groupGridColumns
-                              )}
+                              className={cn(PEOPLE_TABLE_ROW_CLASS_NAME, groupGridColumns)}
                             >
                               <div className='flex min-w-0 items-center gap-3'>
                                 <WorkspaceGroupIcon variant='settings-row' />

--- a/src/components/app/settings/MembersPanel.tsx
+++ b/src/components/app/settings/MembersPanel.tsx
@@ -186,11 +186,17 @@ function MembersPanelForWorkspace({
   const groupSearchInputRef = useRef<HTMLInputElement | null>(null);
   const removingRef = useRef(false);
 
-  const isOwner = useMemo(() => {
-    const workspace = userWorkspaceInfo?.workspaces.find((w) => w.id === currentWorkspaceId);
-
-    return workspace?.role === Role.Owner || isSameUserUid(workspace?.owner?.uid, currentUser?.uid);
-  }, [userWorkspaceInfo?.workspaces, currentWorkspaceId, currentUser?.uid]);
+  const currentWorkspace = useMemo(
+    () => userWorkspaceInfo?.workspaces.find((workspace) => workspace.id === currentWorkspaceId),
+    [userWorkspaceInfo?.workspaces, currentWorkspaceId]
+  );
+  const isOwner = currentWorkspace?.role === Role.Owner || isSameUserUid(currentWorkspace?.owner?.uid, currentUser?.uid);
+  // The list endpoint exposes summaries to Members, but group rosters and all
+  // mutations remain Owner-only.
+  const canViewGroups = isOwner || currentWorkspace?.role === Role.Member;
+  const groupGridColumns = isOwner
+    ? 'grid-cols-[minmax(0,2fr)_minmax(120px,1fr)_32px_32px]'
+    : 'grid-cols-[minmax(0,2fr)_minmax(120px,1fr)]';
 
   useEffect(() => {
     if (!currentWorkspaceId) return;
@@ -226,8 +232,9 @@ function MembersPanelForWorkspace({
   }, []);
 
   useEffect(() => {
-    if (!currentWorkspaceId || !isOwner) {
+    if (!currentWorkspaceId || !canViewGroups) {
       applyGroups([]);
+      setLoadingGroups(false);
       return;
     }
 
@@ -249,7 +256,7 @@ function MembersPanelForWorkspace({
     return () => {
       cancelled = true;
     };
-  }, [applyGroups, currentWorkspaceId, isOwner, t]);
+  }, [applyGroups, canViewGroups, currentWorkspaceId, t]);
 
   useEffect(() => {
     if (!currentWorkspaceId || !isOwner) {
@@ -658,7 +665,7 @@ function MembersPanelForWorkspace({
 
             <TabsContent value='groups' className='outline-none'>
               <div className='flex flex-col gap-5'>
-                {!isOwner ? (
+                {!canViewGroups ? (
                   <div className='rounded-400 border border-border-primary px-4 py-6 text-sm text-text-secondary'>
                     {t('settings.appearance.people.groupsOwnerOnly')}
                   </div>
@@ -712,22 +719,29 @@ function MembersPanelForWorkspace({
                           )}
                         </div>
                       )}
-                      <Button
-                        type='button'
-                        size='lg'
-                        onClick={() => setShowCreateGroup(true)}
-                        data-testid='people-create-group-button'
-                        className='focus-visible:ring-1 focus-visible:ring-border-theme-thick'
-                      >
-                        {t('settings.appearance.people.createGroup')}
-                      </Button>
+                      {isOwner && (
+                        <Button
+                          type='button'
+                          size='lg'
+                          onClick={() => setShowCreateGroup(true)}
+                          data-testid='people-create-group-button'
+                          className='focus-visible:ring-1 focus-visible:ring-border-theme-thick'
+                        >
+                          {t('settings.appearance.people.createGroup')}
+                        </Button>
+                      )}
                     </div>
 
                     <div className='flex flex-col'>
-                      <div className='grid grid-cols-[minmax(0,2fr)_minmax(120px,1fr)_32px_32px] gap-4 border-b border-border-primary pb-2 text-xs font-medium leading-[18px] text-text-secondary'>
+                      <div
+                        className={cn(
+                          'grid gap-4 border-b border-border-primary pb-2 text-xs font-medium leading-[18px] text-text-secondary',
+                          groupGridColumns
+                        )}
+                      >
                         <span>{t('settings.appearance.people.groupsTab')}</span>
                         <span>{t('settings.appearance.people.membersTab')}</span>
-                        <span className='col-span-2 w-16' aria-hidden='true' />
+                        {isOwner && <span className='col-span-2 w-16' aria-hidden='true' />}
                       </div>
                       {loadingGroups && groups.length === 0 ? (
                         <div className='py-5 text-center text-sm text-text-secondary'>
@@ -745,7 +759,10 @@ function MembersPanelForWorkspace({
                             <div
                               key={group.group_id}
                               data-testid={`group-row-${group.group_id}`}
-                              className='grid grid-cols-[minmax(0,2fr)_minmax(120px,1fr)_32px_32px] items-center gap-4 border-b border-border-primary py-3 text-sm'
+                              className={cn(
+                                'grid items-center gap-4 border-b border-border-primary py-3 text-sm',
+                                groupGridColumns
+                              )}
                             >
                               <div className='flex min-w-0 items-center gap-3'>
                                 <WorkspaceGroupIcon variant='settings-row' />
@@ -754,41 +771,48 @@ function MembersPanelForWorkspace({
                               <span className='truncate text-text-secondary'>
                                 {groupMemberCountLabel(group.member_count, t)}
                               </span>
-                              <button
-                                type='button'
-                                data-testid={`group-edit-${group.group_id}`}
-                                className='flex h-7 w-7 items-center justify-center rounded-300 text-icon-secondary hover:bg-fill-content-hover focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-border-theme-thick'
-                                aria-label={`${t('button.edit')} ${group.name}`}
-                                onClick={() => setSelectedGroup(group)}
-                              >
-                                <EditIcon aria-hidden='true' className='h-5 w-5' />
-                              </button>
-                              <div>
-                                {isScimManaged ? (
-                                  <span className='block h-7 w-7' aria-hidden='true' />
-                                ) : (
-                                  <DropdownMenu>
-                                    <DropdownMenuTrigger asChild>
-                                      <button
-                                        type='button'
-                                        disabled={deletingGroupId === group.group_id}
-                                        className='flex h-7 w-7 items-center justify-center rounded-300 text-icon-secondary hover:bg-fill-content-hover focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-border-theme-thick disabled:opacity-50'
-                                        aria-label={`${t('settings.appearance.people.groupActions')} ${group.name}`}
-                                      >
-                                        <MoreIcon aria-hidden='true' className='h-4 w-4' />
-                                      </button>
-                                    </DropdownMenuTrigger>
-                                    <DropdownMenuContent align='end' className='w-[180px] min-w-[180px]'>
-                                      <DropdownMenuItem onSelect={() => startRenameGroup(group)}>
-                                        {t('settings.appearance.people.renameGroup')}
-                                      </DropdownMenuItem>
-                                      <DropdownMenuItem variant='destructive' onSelect={() => requestDeleteGroup(group)}>
-                                        {t('settings.appearance.people.deleteGroup')}
-                                      </DropdownMenuItem>
-                                    </DropdownMenuContent>
-                                  </DropdownMenu>
-                                )}
-                              </div>
+                              {isOwner && (
+                                <button
+                                  type='button'
+                                  data-testid={`group-edit-${group.group_id}`}
+                                  className='flex h-7 w-7 items-center justify-center rounded-300 text-icon-secondary hover:bg-fill-content-hover focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-border-theme-thick'
+                                  aria-label={`${t('button.edit')} ${group.name}`}
+                                  onClick={() => setSelectedGroup(group)}
+                                >
+                                  <EditIcon aria-hidden='true' className='h-5 w-5' />
+                                </button>
+                              )}
+                              {isOwner && (
+                                <div>
+                                  {isScimManaged ? (
+                                    <span className='block h-7 w-7' aria-hidden='true' />
+                                  ) : (
+                                    <DropdownMenu>
+                                      <DropdownMenuTrigger asChild>
+                                        <button
+                                          type='button'
+                                          disabled={deletingGroupId === group.group_id}
+                                          className='flex h-7 w-7 items-center justify-center rounded-300 text-icon-secondary hover:bg-fill-content-hover focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-border-theme-thick disabled:opacity-50'
+                                          aria-label={`${t('settings.appearance.people.groupActions')} ${group.name}`}
+                                        >
+                                          <MoreIcon aria-hidden='true' className='h-4 w-4' />
+                                        </button>
+                                      </DropdownMenuTrigger>
+                                      <DropdownMenuContent align='end' className='w-[180px] min-w-[180px]'>
+                                        <DropdownMenuItem onSelect={() => startRenameGroup(group)}>
+                                          {t('settings.appearance.people.renameGroup')}
+                                        </DropdownMenuItem>
+                                        <DropdownMenuItem
+                                          variant='destructive'
+                                          onSelect={() => requestDeleteGroup(group)}
+                                        >
+                                          {t('settings.appearance.people.deleteGroup')}
+                                        </DropdownMenuItem>
+                                      </DropdownMenuContent>
+                                    </DropdownMenu>
+                                  )}
+                                </div>
+                              )}
                             </div>
                           );
                         })
@@ -801,7 +825,7 @@ function MembersPanelForWorkspace({
           </Tabs>
         </div>
       </div>
-      {selectedGroupForPanel && currentWorkspaceId && (
+      {isOwner && selectedGroupForPanel && currentWorkspaceId && (
         <GroupDetailModal
           open
           workspaceId={currentWorkspaceId}
@@ -812,7 +836,7 @@ function MembersPanelForWorkspace({
           workspaceMembers={members}
         />
       )}
-      {showCreateGroup && currentWorkspaceId && (
+      {isOwner && showCreateGroup && currentWorkspaceId && (
         <CreateGroupModal
           open
           workspaceId={currentWorkspaceId}
@@ -821,7 +845,7 @@ function MembersPanelForWorkspace({
           onCreated={refreshGroups}
         />
       )}
-      {renamingGroup && (
+      {isOwner && renamingGroup && (
         <Dialog
           open
           onOpenChange={(isOpen) => {
@@ -893,7 +917,7 @@ function MembersPanelForWorkspace({
           </DialogContent>
         </Dialog>
       )}
-      {deleteConfirmationGroup && (
+      {isOwner && deleteConfirmationGroup && (
         <AlertDialog
           open
           onOpenChange={(isOpen) => {

--- a/src/components/app/settings/__tests__/MembersPanel.groups.test.tsx
+++ b/src/components/app/settings/__tests__/MembersPanel.groups.test.tsx
@@ -163,6 +163,63 @@ describe('MembersPanel workspace group parity', () => {
     expect(learnMore.getAttribute('target')).toBe('_blank');
   });
 
+  it('uses the Members table typography and spacing for group summaries', async () => {
+    render(<MembersPanel />);
+    await waitFor(() => expect(mockGetWorkspaceGroups).toHaveBeenCalled());
+
+    const memberHeader = screen.getByTestId('members-table-header');
+    const memberRow = screen.getByTestId(`members-row-${workspaceMember.email}`);
+
+    fireEvent.click(screen.getByRole('tab', { name: /settings\.appearance\.people\.groupsTab/ }));
+
+    const groupHeader = screen.getByTestId('groups-table-header');
+    const row = groupRow();
+    const sharedHeaderClasses = [
+      'grid',
+      'gap-4',
+      'border-b',
+      'border-border-primary',
+      'pb-2',
+      'text-xs',
+      'font-medium',
+      'text-text-secondary',
+    ];
+    const sharedRowClasses = [
+      'grid',
+      'min-h-[60px]',
+      'items-center',
+      'gap-4',
+      'border-b',
+      'border-border-primary',
+      'py-3',
+      'text-sm',
+    ];
+
+    sharedHeaderClasses.forEach((className) => {
+      expect(memberHeader.classList.contains(className)).toBe(true);
+      expect(groupHeader.classList.contains(className)).toBe(true);
+    });
+    sharedRowClasses.forEach((className) => {
+      expect(memberRow.classList.contains(className)).toBe(true);
+      expect(row.classList.contains(className)).toBe(true);
+    });
+    expect(groupHeader.className).not.toContain('leading-[');
+  });
+
+  it('uses the Members table spacing for the empty Groups state', async () => {
+    mockGetMembers.mockResolvedValueOnce([]);
+    mockGetWorkspaceGroups.mockResolvedValueOnce({ groups: [] });
+
+    render(<MembersPanel />);
+    await waitFor(() => expect(screen.getByTestId('members-table-status')).toBeTruthy());
+    const memberStatusClassName = screen.getByTestId('members-table-status').className;
+
+    fireEvent.click(screen.getByRole('tab', { name: /settings\.appearance\.people\.groupsTab/ }));
+
+    expect(screen.getByTestId('groups-table-status').className).toBe(memberStatusClassName);
+    expect(screen.getByTestId('groups-table-status').classList.contains('py-6')).toBe(true);
+  });
+
   it('shows workspace group summaries without management controls to members', async () => {
     const memberVisibleGroup = { ...group, member_count: 1 };
 

--- a/src/components/app/settings/__tests__/MembersPanel.groups.test.tsx
+++ b/src/components/app/settings/__tests__/MembersPanel.groups.test.tsx
@@ -15,6 +15,7 @@ const mockAddWorkspaceGroupMember = jest.fn();
 const mockRemoveWorkspaceGroupMember = jest.fn();
 const mockTranslate = (key: string, values?: { count?: number }) => values?.count ?? key;
 let mockCurrentWorkspaceId = 'workspace-1';
+let mockWorkspaceRole = Role.Owner;
 
 jest.mock('react-i18next', () => ({
   useTranslation: () => ({ t: mockTranslate }),
@@ -51,12 +52,12 @@ jest.mock('@/components/app/app.hooks', () => ({
     workspaces: [
       {
         id: 'workspace-1',
-        role: Role.Owner,
+        role: mockWorkspaceRole,
         owner: { uid: 9007199254740991 },
       },
       {
         id: 'workspace-2',
-        role: Role.Owner,
+        role: mockWorkspaceRole,
         owner: { uid: 9007199254740991 },
       },
     ],
@@ -142,6 +143,7 @@ describe('MembersPanel workspace group parity', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockCurrentWorkspaceId = 'workspace-1';
+    mockWorkspaceRole = Role.Owner;
     mockGetMembers.mockResolvedValue([workspaceMember]);
     mockGetWorkspaceGroups.mockResolvedValue({ groups: [group] });
     mockCreateWorkspaceGroup.mockResolvedValue(group);
@@ -159,6 +161,51 @@ describe('MembersPanel workspace group parity', () => {
 
     expect(learnMore.getAttribute('href')).toBe('https://appflowy.com/guide/getting-started-with-appflowy');
     expect(learnMore.getAttribute('target')).toBe('_blank');
+  });
+
+  it('shows workspace group summaries without management controls to members', async () => {
+    const memberVisibleGroup = { ...group, member_count: 1 };
+
+    mockWorkspaceRole = Role.Member;
+    mockGetWorkspaceGroups.mockResolvedValueOnce({ groups: [memberVisibleGroup] });
+
+    await renderGroupsPanel();
+
+    expect(mockGetWorkspaceGroups).toHaveBeenCalledWith('workspace-1');
+    expect(screen.getByRole('tab', { name: 'settings.appearance.people.groupsTab 1' })).toBeTruthy();
+
+    const row = screen.getByTestId(`group-row-${memberVisibleGroup.group_id}`);
+
+    expect(within(row).getByText(memberVisibleGroup.name)).toBeTruthy();
+    expect(within(row).getByText('1')).toBeTruthy();
+    expect(screen.queryByTestId('people-create-group-button')).toBeNull();
+    expect(screen.queryByTestId(`group-edit-${memberVisibleGroup.group_id}`)).toBeNull();
+    expect(
+      within(row).queryByRole('button', {
+        name: `settings.appearance.people.groupActions ${memberVisibleGroup.name}`,
+      })
+    ).toBeNull();
+
+    fireEvent.click(row);
+
+    expect(screen.queryByTestId('group-detail-modal')).toBeNull();
+    expect(mockGetWorkspaceGroupMembers).not.toHaveBeenCalled();
+    expect(mockCreateWorkspaceGroup).not.toHaveBeenCalled();
+    expect(mockUpdateWorkspaceGroup).not.toHaveBeenCalled();
+    expect(mockRemoveWorkspaceGroup).not.toHaveBeenCalled();
+  });
+
+  it('does not request workspace group summaries for guests', async () => {
+    mockWorkspaceRole = Role.Guest;
+
+    render(<MembersPanel />);
+    await waitFor(() => expect(mockGetMembers).toHaveBeenCalledWith('workspace-1', false));
+    fireEvent.click(screen.getByRole('tab', { name: 'settings.appearance.people.groupsTab 0' }));
+
+    expect(mockGetWorkspaceGroups).not.toHaveBeenCalled();
+    expect(screen.getByText('settings.appearance.people.groupsOwnerOnly')).toBeTruthy();
+    expect(screen.queryByTestId(`group-row-${group.group_id}`)).toBeNull();
+    expect(screen.queryByTestId('people-create-group-button')).toBeNull();
   });
 
   it('renames a group through a modal instead of inline editing', async () => {

--- a/src/components/app/share/GroupAccessLevelDropdown.tsx
+++ b/src/components/app/share/GroupAccessLevelDropdown.tsx
@@ -112,7 +112,7 @@ export function GroupAccessLevelDropdown({
   return (
     <DropdownMenu open={open} onOpenChange={setOpen}>
       <DropdownMenuTrigger asChild>
-        <Button variant='ghost' className='flex items-center justify-center gap-1.5' disabled={!canModify}>
+        <Button variant='ghost' className='flex items-center justify-center gap-1.5'>
           {getAccessLevelText(group.access_level)}
           <ArrowDownIcon className='text-icon-secondary' />
         </Button>

--- a/src/components/app/share/GroupAccessLevelDropdown.tsx
+++ b/src/components/app/share/GroupAccessLevelDropdown.tsx
@@ -101,7 +101,7 @@ export function GroupAccessLevelDropdown({
     }
   }, [canManageFullAccess, group.access_level, group.group_id, group.name, onRemoveAccess, t]);
 
-  if (group.access_level === AccessLevel.FullAccess && (!canModify || !canManageFullAccess)) {
+  if (!canModify || (group.access_level === AccessLevel.FullAccess && !canManageFullAccess)) {
     return (
       <div className='mr-2 flex min-w-fit items-center justify-center whitespace-nowrap px-3 py-1.5 text-sm text-text-secondary'>
         {getAccessLevelText(group.access_level)}

--- a/src/components/app/share/InviteGuest.tsx
+++ b/src/components/app/share/InviteGuest.tsx
@@ -8,7 +8,6 @@ import {
   IPeopleWithAccessType,
   MentionablePerson,
   MentionPersonRole,
-  Role,
   SubscriptionInterval,
   SubscriptionPlan,
   WorkspaceGroup,
@@ -20,7 +19,7 @@ import { ReactComponent as EditIcon } from '@/assets/icons/edit.svg';
 import { ReactComponent as ViewIcon } from '@/assets/icons/show.svg';
 import { notify } from '@/components/_shared/notify';
 import { AccessService, BillingService, WorkspaceService } from '@/application/services/domains';
-import { useCurrentWorkspaceId, useUserWorkspaceInfo } from '@/components/app/app.hooks';
+import { useCurrentWorkspaceId } from '@/components/app/app.hooks';
 import { Button } from '@/components/ui/button';
 import {
   Dialog,
@@ -55,6 +54,7 @@ interface InviteGuestProps {
   hasFullAccess: boolean;
   canGrantFullAccess: boolean;
   canManageGroupAccess: boolean;
+  isWorkspaceOwner: boolean;
 }
 
 interface InviteSubmission {
@@ -75,6 +75,7 @@ export function InviteGuest({
   hasFullAccess,
   canGrantFullAccess,
   canManageGroupAccess,
+  isWorkspaceOwner,
 }: InviteGuestProps) {
   const { t } = useTranslation();
   const [searchValue, setSearchValue] = useState<string>('');
@@ -105,8 +106,6 @@ export function InviteGuest({
   // Combined loading state: show loading when people, mentionable, or group data is loading
   const isLoading = isLoadingPeople || isLoadingMentionable || isLoadingGroups;
   const [upgradeLoading, setUpgradeLoading] = useState(false);
-  const userWorkspaceInfo = useUserWorkspaceInfo();
-  const isOwner = userWorkspaceInfo?.selectedWorkspace?.role === Role.Owner;
 
   useEffect(() => {
     latestInviteTargetRef.current = { workspaceId: currentWorkspaceId, viewId };
@@ -130,13 +129,19 @@ export function InviteGuest({
     };
   }, [currentWorkspaceId, viewId]);
 
+  // Group selections made while authority was held must not survive losing it.
+  useEffect(() => {
+    if (canManageGroupAccess) return;
+
+    setEmailTags((currentTags) =>
+      currentTags.some((tag) => tag.kind === 'group') ? currentTags.filter((tag) => tag.kind !== 'group') : currentTags
+    );
+  }, [canManageGroupAccess]);
+
   useEffect(() => {
     if (!currentWorkspaceId || !canManageGroupAccess) {
       setWorkspaceGroups([]);
       setIsLoadingGroups(false);
-      setEmailTags((currentTags) =>
-        currentTags.some((tag) => tag.kind === 'group') ? currentTags.filter((tag) => tag.kind !== 'group') : currentTags
-      );
       return;
     }
 
@@ -545,7 +550,7 @@ export function InviteGuest({
     const workspaceId = currentWorkspaceId;
 
     if (!workspaceId) return;
-    if (!isOwner) {
+    if (!isWorkspaceOwner) {
       toast.error('Please ask the workspace owner to upgrade to Pro to unlock guest editors.');
       return;
     }
@@ -570,7 +575,7 @@ export function InviteGuest({
     } finally {
       setUpgradeLoading(false);
     }
-  }, [currentWorkspaceId, isOwner]);
+  }, [currentWorkspaceId, isWorkspaceOwner]);
 
   const handleSendInvites = useCallback(async () => {
     if (!currentWorkspaceId) return;

--- a/src/components/app/share/InviteGuest.tsx
+++ b/src/components/app/share/InviteGuest.tsx
@@ -54,6 +54,7 @@ interface InviteGuestProps {
   viewId: string;
   hasFullAccess: boolean;
   canGrantFullAccess: boolean;
+  canManageGroupAccess: boolean;
 }
 
 interface InviteSubmission {
@@ -73,6 +74,7 @@ export function InviteGuest({
   viewId,
   hasFullAccess,
   canGrantFullAccess,
+  canManageGroupAccess,
 }: InviteGuestProps) {
   const { t } = useTranslation();
   const [searchValue, setSearchValue] = useState<string>('');
@@ -129,8 +131,12 @@ export function InviteGuest({
   }, [currentWorkspaceId, viewId]);
 
   useEffect(() => {
-    if (!currentWorkspaceId || canNotInvite) {
+    if (!currentWorkspaceId || !canManageGroupAccess) {
       setWorkspaceGroups([]);
+      setIsLoadingGroups(false);
+      setEmailTags((currentTags) =>
+        currentTags.some((tag) => tag.kind === 'group') ? currentTags.filter((tag) => tag.kind !== 'group') : currentTags
+      );
       return;
     }
 
@@ -156,7 +162,7 @@ export function InviteGuest({
     return () => {
       cancelled = true;
     };
-  }, [canNotInvite, currentWorkspaceId]);
+  }, [canManageGroupAccess, currentWorkspaceId]);
 
   // Clamp during render: a selection made before permissions resolved must
   // never let a user submit a level they cannot grant.
@@ -378,48 +384,55 @@ export function InviteGuest({
     [isDataLoadingComplete, hasSuggestionData, isOpen]
   );
 
-  const handleInvite = useCallback((emailOrUserOrGroup: string | MentionablePerson | WorkspaceGroup) => {
-    if (typeof emailOrUserOrGroup !== 'string' && 'group_id' in emailOrUserOrGroup) {
-      const group = emailOrUserOrGroup;
+  const handleInvite = useCallback(
+    (emailOrUserOrGroup: string | MentionablePerson | WorkspaceGroup) => {
+      if (typeof emailOrUserOrGroup !== 'string' && 'group_id' in emailOrUserOrGroup) {
+        if (!canManageGroupAccess) return;
+
+        const group = emailOrUserOrGroup;
+        const newTag: EmailTag = {
+          id: `group:${group.group_id}`,
+          email: group.name,
+          avatar: '',
+          name: group.name,
+          kind: 'group',
+          groupId: group.group_id,
+          memberCount: group.member_count,
+        };
+
+        setEmailTags((prev) =>
+          prev.some((tag) => tag.kind === 'group' && tag.groupId === group.group_id) ? prev : [...prev, newTag]
+        );
+        setSearchValue('');
+        setIsOpen(false);
+        return;
+      }
+
+      const emailOrUser = emailOrUserOrGroup;
+      const isNew = typeof emailOrUser === 'string';
+      const email = typeof emailOrUser === 'string' ? emailOrUser : emailOrUser.email;
+      const isGuest = typeof emailOrUser === 'string' ? true : emailOrUser.role === MentionPersonRole.Guest;
+
+      // Add email to tags instead of immediately inviting
       const newTag: EmailTag = {
-        id: `group:${group.group_id}`,
-        email: group.name,
-        avatar: '',
-        name: group.name,
-        kind: 'group',
-        groupId: group.group_id,
-        memberCount: group.member_count,
+        id: `user:${email}`,
+        email: email,
+        new: isNew,
+        isGuest: isGuest,
+        avatar: typeof emailOrUser === 'string' ? '' : emailOrUser.avatar_url || '',
+        name: typeof emailOrUser === 'string' ? undefined : emailOrUser.name, // Include name if from mentionable list
+        kind: 'user',
       };
 
       setEmailTags((prev) =>
-        prev.some((tag) => tag.kind === 'group' && tag.groupId === group.group_id) ? prev : [...prev, newTag]
+        prev.some((tag) => tag.kind !== 'group' && tag.email === email) ? prev : [...prev, newTag]
       );
+
       setSearchValue('');
       setIsOpen(false);
-      return;
-    }
-
-    const emailOrUser = emailOrUserOrGroup;
-    const isNew = typeof emailOrUser === 'string';
-    const email = typeof emailOrUser === 'string' ? emailOrUser : emailOrUser.email;
-    const isGuest = typeof emailOrUser === 'string' ? true : emailOrUser.role === MentionPersonRole.Guest;
-
-    // Add email to tags instead of immediately inviting
-    const newTag: EmailTag = {
-      id: `user:${email}`,
-      email: email,
-      new: isNew,
-      isGuest: isGuest,
-      avatar: typeof emailOrUser === 'string' ? '' : emailOrUser.avatar_url || '',
-      name: typeof emailOrUser === 'string' ? undefined : emailOrUser.name, // Include name if from mentionable list
-      kind: 'user',
-    };
-
-    setEmailTags((prev) => (prev.some((tag) => tag.kind !== 'group' && tag.email === email) ? prev : [...prev, newTag]));
-
-    setSearchValue('');
-    setIsOpen(false);
-  }, []);
+    },
+    [canManageGroupAccess]
+  );
 
   const handleEmailTagsChange = useCallback((newTags: EmailTag[]) => {
     setEmailTags(newTags);
@@ -569,7 +582,9 @@ export function InviteGuest({
       return;
     }
 
-    const pendingInvites = emailTags.filter((tag) => tag.kind !== 'group' || Boolean(tag.groupId));
+    const pendingInvites = emailTags.filter(
+      (tag) => tag.kind !== 'group' || (canManageGroupAccess && Boolean(tag.groupId))
+    );
 
     if (pendingInvites.length === 0) return;
 
@@ -652,7 +667,7 @@ export function InviteGuest({
         setInviteLoading(false);
       }
     }
-  }, [currentWorkspaceId, emailTags, onInviteSuccess, viewId, t, effectiveAccessLevel]);
+  }, [canManageGroupAccess, currentWorkspaceId, emailTags, onInviteSuccess, viewId, t, effectiveAccessLevel]);
 
   const commitCurrentSearchValue = useCallback(
     (preferSuggestion: boolean) => {

--- a/src/components/app/share/PeopleWithAccess.tsx
+++ b/src/components/app/share/PeopleWithAccess.tsx
@@ -27,6 +27,7 @@ interface PeopleWithAccessProps {
   onPersonRemoved: (email: string) => void;
   updateGroupInAccessList: (groupId: string, accessLevel: AccessLevel | null) => void;
   hasFullAccess: boolean;
+  canManageGroupAccess: boolean;
   canManageFullAccess: boolean;
   canGrantFullAccess: boolean;
   sectionType: ShareSectionType;
@@ -42,6 +43,7 @@ export function PeopleWithAccess({
   updateGroupInAccessList,
   isLoading,
   hasFullAccess,
+  canManageGroupAccess,
   canManageFullAccess,
   canGrantFullAccess,
   sectionType,
@@ -122,7 +124,7 @@ export function PeopleWithAccess({
 
   const handleGroupAccessLevelChange = useCallback(
     async (groupId: string, newAccessLevel: AccessLevel) => {
-      if (!currentWorkspaceId) return;
+      if (!currentWorkspaceId || !canManageGroupAccess) return;
       await AccessService.sharePageToGroup(currentWorkspaceId, viewId, groupId, newAccessLevel);
       updateGroupInAccessList(groupId, newAccessLevel);
       const refreshResult = await onPeopleChange();
@@ -130,12 +132,12 @@ export function PeopleWithAccess({
       if (!refreshResult) return undefined;
       return refreshResult.effectiveGroups.find((group) => group.group_id === groupId)?.access_level ?? null;
     },
-    [currentWorkspaceId, onPeopleChange, updateGroupInAccessList, viewId]
+    [canManageGroupAccess, currentWorkspaceId, onPeopleChange, updateGroupInAccessList, viewId]
   );
 
   const handleRemoveGroupAccess = useCallback(
     async (groupId: string) => {
-      if (!currentWorkspaceId) return;
+      if (!currentWorkspaceId || !canManageGroupAccess) return;
       await AccessService.revokeGroupAccess(currentWorkspaceId, viewId, groupId);
       updateGroupInAccessList(groupId, null);
       const refreshResult = await onPeopleChange();
@@ -143,7 +145,7 @@ export function PeopleWithAccess({
       if (!refreshResult) return undefined;
       return refreshResult.effectiveGroups.find((group) => group.group_id === groupId)?.access_level ?? null;
     },
-    [currentWorkspaceId, onPeopleChange, updateGroupInAccessList, viewId]
+    [canManageGroupAccess, currentWorkspaceId, onPeopleChange, updateGroupInAccessList, viewId]
   );
 
   const currentUserRole = people.find((p) => p.email === currentUser?.email)?.role;
@@ -195,7 +197,7 @@ export function PeopleWithAccess({
             </div>
             <GroupAccessLevelDropdown
               group={group}
-              canModify={hasFullAccess && editableGroupIds.has(group.group_id)}
+              canModify={canManageGroupAccess && editableGroupIds.has(group.group_id)}
               currentUserHasFullAccess={hasFullAccess}
               canManageFullAccess={canManageFullAccess}
               onAccessLevelChange={handleGroupAccessLevelChange}

--- a/src/components/app/share/SharePanel.tsx
+++ b/src/components/app/share/SharePanel.tsx
@@ -8,6 +8,7 @@ import {
   SubscriptionPlan,
   WorkspaceGroupViewPermission,
 } from '@/application/types';
+import { isSameUserUid } from '@/application/user-uid';
 import { notify } from '@/components/_shared/notify';
 import { useLoadMentionableUsers, useGetSubscriptions, useUserWorkspaceInfo } from '@/components/app/app.hooks';
 import { CopyLink } from '@/components/app/share/CopyLink';
@@ -16,6 +17,7 @@ import { InviteGuest } from '@/components/app/share/InviteGuest';
 import { PeopleWithAccess } from '@/components/app/share/PeopleWithAccess';
 import { ShareSectionType } from '@/components/app/share/shareSectionType';
 import { UpgradeBanner } from '@/components/app/share/UpgradeBanner';
+import { useCurrentUser } from '@/components/main/app.hooks';
 import { getProAccessPlanFromSubscriptions, isAppFlowyHosted } from '@/utils/subscription';
 
 import type { ShareAccessRefreshResult } from './useShareAccessDetails';
@@ -48,15 +50,18 @@ function SharePanel({
   sectionType: ShareSectionType;
 }) {
   const userWorkspaceInfo = useUserWorkspaceInfo();
+  const currentUser = useCurrentUser();
   const selectedWorkspace = userWorkspaceInfo?.selectedWorkspace;
   const role = selectedWorkspace?.role;
   const loadMentionableUsers = useLoadMentionableUsers();
   const [mentionable, setMentionable] = useState<MentionablePerson[]>([]);
   const [isLoadingMentionable, setIsLoadingMentionable] = useState(false);
   const [mentionableError, setMentionableError] = useState<string | null>(null);
-  const isOwner = role === Role.Owner;
+  const isOwner = role === Role.Owner || isSameUserUid(selectedWorkspace?.owner?.uid, currentUser?.uid);
   const isMember = role === Role.Member;
   const showInviteControls = currentUserAccessLevel !== undefined && currentUserAccessLevel !== AccessLevel.ReadOnly;
+  // Page Full Access does not make a Guest part of the workspace group boundary.
+  const canManageGroupAccess = hasFullAccess && (isOwner || isMember);
 
   // Load mentionable users
   const loadMentionableData = useCallback(async () => {
@@ -151,6 +156,7 @@ function SharePanel({
               }}
               hasFullAccess={hasFullAccess}
               canGrantFullAccess={canManageFullAccess}
+              canManageGroupAccess={canManageGroupAccess}
             />
             {isHosted && <UpgradeBanner activeSubscriptionPlan={activeSubscriptionPlan} />}
           </>
@@ -165,6 +171,7 @@ function SharePanel({
           onPersonRemoved={onPersonRemoved}
           updateGroupInAccessList={updateGroupInAccessList}
           hasFullAccess={hasFullAccess}
+          canManageGroupAccess={canManageGroupAccess}
           canManageFullAccess={canManageFullAccess}
           canGrantFullAccess={canManageFullAccess}
           sectionType={sectionType}

--- a/src/components/app/share/SharePanel.tsx
+++ b/src/components/app/share/SharePanel.tsx
@@ -157,6 +157,7 @@ function SharePanel({
               hasFullAccess={hasFullAccess}
               canGrantFullAccess={canManageFullAccess}
               canManageGroupAccess={canManageGroupAccess}
+              isWorkspaceOwner={isOwner}
             />
             {isHosted && <UpgradeBanner activeSubscriptionPlan={activeSubscriptionPlan} />}
           </>

--- a/src/components/app/share/WorkspaceGroupIcon.tsx
+++ b/src/components/app/share/WorkspaceGroupIcon.tsx
@@ -31,7 +31,7 @@ export function WorkspaceGroupIcon({ variant, className }: WorkspaceGroupIconPro
 
   const containerClassName: Record<Exclude<WorkspaceGroupIconVariant, 'chip' | 'hero'>, string> = {
     row: 'h-8 w-8 rounded-300',
-    'settings-row': 'h-9 w-9 rounded-full',
+    'settings-row': 'h-8 w-8 rounded-full',
     name: 'h-12 w-12 rounded-400 border border-border-primary',
     detail: 'h-16 w-16 rounded-full',
   };

--- a/src/components/app/share/__tests__/GroupAccessLevelDropdown.test.tsx
+++ b/src/components/app/share/__tests__/GroupAccessLevelDropdown.test.tsx
@@ -200,6 +200,23 @@ describe('GroupAccessLevelDropdown', () => {
     expect(onRemoveAccess).not.toHaveBeenCalled();
   });
 
+  it('renders access as plain text when group mutations are not allowed', () => {
+    render(
+      <GroupAccessLevelDropdown
+        group={group}
+        canModify={false}
+        currentUserHasFullAccess
+        canManageFullAccess={false}
+        onAccessLevelChange={jest.fn(async () => AccessLevel.ReadOnly)}
+        onRemoveAccess={jest.fn(async () => null)}
+      />
+    );
+
+    expect(screen.getByText('shareAction.readAndWrite')).toBeTruthy();
+    expect(screen.queryByRole('button')).toBeNull();
+    expect(screen.queryByText('shareAction.removeAccess')).toBeNull();
+  });
+
   it('offers Full Access assignment to an owner-tier manager', () => {
     render(
       <GroupAccessLevelDropdown

--- a/src/components/app/share/__tests__/InviteGuest.test.tsx
+++ b/src/components/app/share/__tests__/InviteGuest.test.tsx
@@ -61,6 +61,12 @@ jest.mock('@/components/ui/popover', () => ({
   PopoverTrigger: ({ children }: { children: ReactNode }) => <>{children}</>,
 }));
 
+jest.mock('@/components/ui/tooltip', () => ({
+  Tooltip: ({ children }: { children: ReactNode }) => <>{children}</>,
+  TooltipContent: ({ children }: { children: ReactNode }) => <>{children}</>,
+  TooltipTrigger: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+
 jest.mock('../InviteInput', () => ({
   InviteInput: ({
     afterExtra,
@@ -145,6 +151,7 @@ function inviteGuestProps(overrides: Partial<ComponentProps<typeof InviteGuest>>
     viewId: 'view-1',
     hasFullAccess: true,
     canGrantFullAccess: true,
+    canManageGroupAccess: true,
     ...overrides,
   };
 }
@@ -164,6 +171,65 @@ describe('InviteGuest group sharing', () => {
     mockSharePageToGroups.mockReset();
     mockNotifyError.mockReset();
     mockNotifySuccess.mockReset();
+  });
+
+  it('loads group summaries for a workspace member with page Full Access', async () => {
+    renderInviteGuest();
+
+    expect(await screen.findByTestId(`suggestion-group:${successfulGroup.group_id}`)).toBeTruthy();
+    expect(mockGetWorkspaceGroups).toHaveBeenCalledWith('workspace-1');
+  });
+
+  it('does not load group summaries for a workspace member without page Full Access', async () => {
+    renderInviteGuest({ hasFullAccess: false, canManageGroupAccess: false });
+
+    await waitFor(() => expect(mockGetWorkspaceGroups).not.toHaveBeenCalled());
+    expect(screen.queryByTestId(`suggestion-group:${successfulGroup.group_id}`)).toBeNull();
+    expect(screen.getByLabelText('invite-input').readOnly).toBe(true);
+  });
+
+  it('keeps person sharing available to a Full Access guest without loading or mutating groups', async () => {
+    renderInviteGuest({ canManageGroupAccess: false });
+
+    await waitFor(() => expect(mockGetWorkspaceGroups).not.toHaveBeenCalled());
+    expect(screen.queryByTestId(`suggestion-group:${successfulGroup.group_id}`)).toBeNull();
+
+    const input = screen.getByLabelText('invite-input');
+
+    expect(input.readOnly).toBe(false);
+    fireEvent.change(input, { target: { value: 'person@example.com' } });
+    fireEvent.click(await screen.findByTestId('suggestion-email:person@example.com'));
+    fireEvent.click(screen.getByRole('button', { name: 'shareAction.invite' }));
+
+    await waitFor(() =>
+      expect(mockSharePageTo).toHaveBeenCalledWith('workspace-1', 'view-1', ['person@example.com'], AccessLevel.ReadOnly)
+    );
+    expect(mockSharePageToGroup).not.toHaveBeenCalled();
+  });
+
+  it('drops selected groups when group authority is lost but still submits selected people', async () => {
+    const { rerender } = render(<InviteGuest {...inviteGuestProps()} />);
+
+    fireEvent.click(await screen.findByTestId(`suggestion-group:${successfulGroup.group_id}`));
+    const input = screen.getByLabelText('invite-input');
+
+    fireEvent.change(input, { target: { value: 'person@example.com' } });
+    fireEvent.click(await screen.findByTestId('suggestion-email:person@example.com'));
+    expect(screen.getByTestId(`tag-group:${successfulGroup.group_id}`)).toBeTruthy();
+    expect(screen.getByTestId('tag-user:person@example.com')).toBeTruthy();
+
+    rerender(<InviteGuest {...inviteGuestProps({ canManageGroupAccess: false })} />);
+
+    await waitFor(() => expect(screen.queryByTestId(`tag-group:${successfulGroup.group_id}`)).toBeNull());
+    expect(screen.queryByTestId(`suggestion-group:${successfulGroup.group_id}`)).toBeNull();
+    expect(screen.getByTestId('tag-user:person@example.com')).toBeTruthy();
+
+    fireEvent.click(screen.getByRole('button', { name: 'shareAction.invite' }));
+
+    await waitFor(() =>
+      expect(mockSharePageTo).toHaveBeenCalledWith('workspace-1', 'view-1', ['person@example.com'], AccessLevel.ReadOnly)
+    );
+    expect(mockSharePageToGroup).not.toHaveBeenCalled();
   });
 
   it('keeps only failed recipients selected and allows retry after a partially successful send', async () => {

--- a/src/components/app/share/__tests__/InviteGuest.test.tsx
+++ b/src/components/app/share/__tests__/InviteGuest.test.tsx
@@ -48,7 +48,6 @@ jest.mock('@/components/_shared/notify', () => ({
 
 jest.mock('@/components/app/app.hooks', () => ({
   useCurrentWorkspaceId: () => 'workspace-1',
-  useUserWorkspaceInfo: () => ({ selectedWorkspace: { role: 'Owner' } }),
 }));
 
 jest.mock('@/utils/subscription', () => ({
@@ -152,6 +151,7 @@ function inviteGuestProps(overrides: Partial<ComponentProps<typeof InviteGuest>>
     hasFullAccess: true,
     canGrantFullAccess: true,
     canManageGroupAccess: true,
+    isWorkspaceOwner: true,
     ...overrides,
   };
 }

--- a/src/components/app/share/__tests__/PeopleWithAccess.test.tsx
+++ b/src/components/app/share/__tests__/PeopleWithAccess.test.tsx
@@ -63,20 +63,22 @@ jest.mock('@/components/app/share/GroupAccessLevelDropdown', () => ({
     canManageFullAccess: boolean;
     onAccessLevelChange: (groupId: string, accessLevel: AccessLevel) => Promise<AccessLevel | null | undefined>;
     onRemoveAccess: (groupId: string) => Promise<AccessLevel | null | undefined>;
-  }) => (
-    <>
-      <button
-        disabled={!canModify}
-        data-can-manage-full-access={String(canManageFullAccess)}
-        onClick={() => void onAccessLevelChange(group.group_id, group.access_level).then(mockGroupMutationResult)}
-      >
-        update:{group.group_id}
-      </button>
-      <button disabled={!canModify} onClick={() => void onRemoveAccess(group.group_id).then(mockGroupMutationResult)}>
-        remove:{group.group_id}
-      </button>
-    </>
-  ),
+  }) =>
+    canModify ? (
+      <>
+        <button
+          data-can-manage-full-access={String(canManageFullAccess)}
+          onClick={() => void onAccessLevelChange(group.group_id, group.access_level).then(mockGroupMutationResult)}
+        >
+          update:{group.group_id}
+        </button>
+        <button onClick={() => void onRemoveAccess(group.group_id).then(mockGroupMutationResult)}>
+          remove:{group.group_id}
+        </button>
+      </>
+    ) : (
+      <span data-testid={`group-access-readonly:${group.group_id}`}>{group.access_level}</span>
+    ),
 }));
 
 const removedPerson: IPeopleWithAccessType = {
@@ -123,6 +125,7 @@ describe('PeopleWithAccess', () => {
         onPersonRemoved={onPersonRemoved}
         updateGroupInAccessList={jest.fn()}
         hasFullAccess
+        canManageGroupAccess
         canManageFullAccess
         canGrantFullAccess
         sectionType={ShareSectionType.Shared}
@@ -152,6 +155,7 @@ describe('PeopleWithAccess', () => {
         onPersonRemoved={jest.fn()}
         updateGroupInAccessList={updateGroupInAccessList}
         hasFullAccess
+        canManageGroupAccess
         canManageFullAccess
         canGrantFullAccess
         sectionType={ShareSectionType.Shared}
@@ -189,6 +193,7 @@ describe('PeopleWithAccess', () => {
         onPersonRemoved={jest.fn()}
         updateGroupInAccessList={updateGroupInAccessList}
         hasFullAccess
+        canManageGroupAccess
         canManageFullAccess
         canGrantFullAccess
         sectionType={ShareSectionType.Shared}
@@ -206,6 +211,36 @@ describe('PeopleWithAccess', () => {
     expect(updateGroupInAccessList.mock.invocationCallOrder[0]).toBeLessThan(onPeopleChange.mock.invocationCallOrder[0]);
   });
 
+  it('does not expose group mutation controls without workspace-member group authority', () => {
+    const updateGroupInAccessList = jest.fn();
+
+    render(
+      <PeopleWithAccess
+        viewId='view-1'
+        people={[]}
+        groups={[sharedGroup]}
+        editableGroupIds={new Set([sharedGroup.group_id])}
+        isLoading={false}
+        onPeopleChange={async () => undefined}
+        onPersonRemoved={jest.fn()}
+        updateGroupInAccessList={updateGroupInAccessList}
+        hasFullAccess
+        canManageGroupAccess={false}
+        canManageFullAccess={false}
+        canGrantFullAccess={false}
+        sectionType={ShareSectionType.Shared}
+      />
+    );
+
+    expect(screen.getByText(sharedGroup.name)).toBeTruthy();
+    expect(screen.getByTestId(`group-access-readonly:${sharedGroup.group_id}`)).toBeTruthy();
+    expect(screen.queryByRole('button', { name: `update:${sharedGroup.group_id}` })).toBeNull();
+    expect(screen.queryByRole('button', { name: `remove:${sharedGroup.group_id}` })).toBeNull();
+    expect(mockSharePageToGroup).not.toHaveBeenCalled();
+    expect(mockRevokeGroupAccess).not.toHaveBeenCalled();
+    expect(updateGroupInAccessList).not.toHaveBeenCalled();
+  });
+
   it('keeps inherited or stronger-effective group rows visible but disabled', () => {
     const { container } = render(
       <PeopleWithAccess
@@ -218,6 +253,7 @@ describe('PeopleWithAccess', () => {
         onPersonRemoved={jest.fn()}
         updateGroupInAccessList={jest.fn()}
         hasFullAccess
+        canManageGroupAccess
         canManageFullAccess
         canGrantFullAccess
         sectionType={ShareSectionType.Shared}
@@ -227,8 +263,9 @@ describe('PeopleWithAccess', () => {
     expect(screen.getByText(sharedGroup.name)).toBeTruthy();
     expect(container.querySelector("[data-slot='workspace-group-icon']")).not.toBeNull();
     expect(container.querySelector("[data-slot='workspace-group-icon-container']")).not.toBeNull();
-    expect(screen.getByRole('button', { name: `update:${sharedGroup.group_id}` }).disabled).toBe(true);
-    expect(screen.getByRole('button', { name: `remove:${sharedGroup.group_id}` }).disabled).toBe(true);
+    expect(screen.getByTestId(`group-access-readonly:${sharedGroup.group_id}`)).toBeTruthy();
+    expect(screen.queryByRole('button', { name: `update:${sharedGroup.group_id}` })).toBeNull();
+    expect(screen.queryByRole('button', { name: `remove:${sharedGroup.group_id}` })).toBeNull();
   });
 
   it('passes the narrower Full Access management capability to group rows', () => {
@@ -243,6 +280,7 @@ describe('PeopleWithAccess', () => {
         onPersonRemoved={jest.fn()}
         updateGroupInAccessList={jest.fn()}
         hasFullAccess
+        canManageGroupAccess
         canManageFullAccess={false}
         canGrantFullAccess
         sectionType={ShareSectionType.Shared}
@@ -273,6 +311,7 @@ describe('PeopleWithAccess', () => {
         onPersonRemoved={jest.fn()}
         updateGroupInAccessList={jest.fn()}
         hasFullAccess
+        canManageGroupAccess
         canManageFullAccess
         canGrantFullAccess
         sectionType={ShareSectionType.Shared}
@@ -296,6 +335,7 @@ describe('PeopleWithAccess', () => {
         onPersonRemoved={jest.fn()}
         updateGroupInAccessList={jest.fn()}
         hasFullAccess
+        canManageGroupAccess
         canManageFullAccess
         canGrantFullAccess
         sectionType={ShareSectionType.Shared}
@@ -326,6 +366,7 @@ describe('PeopleWithAccess', () => {
         onPersonRemoved={jest.fn()}
         updateGroupInAccessList={jest.fn()}
         hasFullAccess
+        canManageGroupAccess
         canManageFullAccess
         canGrantFullAccess
         sectionType={ShareSectionType.Shared}

--- a/src/components/app/share/__tests__/SharePanel.test.tsx
+++ b/src/components/app/share/__tests__/SharePanel.test.tsx
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 import { render, screen, waitFor } from '@testing-library/react';
 
-import { AccessLevel } from '@/application/types';
+import { AccessLevel, Role } from '@/application/types';
 
 import SharePanel from '../SharePanel';
 import { ShareSectionType } from '../shareSectionType';
@@ -11,15 +11,23 @@ const mockLoadMentionableUsers = jest.fn(async () => []);
 const mockInviteGuestProps = jest.fn();
 const mockPeopleWithAccessProps = jest.fn();
 let mockIsHosted = false;
+let mockWorkspaceRole: Role | undefined = Role.Member;
+let mockWorkspaceOwnerUid: string | number = '101';
+let mockCurrentUserUid: string | number = '202';
 
 jest.mock('@/components/app/app.hooks', () => ({
   useGetSubscriptions: () => mockGetSubscriptions,
   useLoadMentionableUsers: () => mockLoadMentionableUsers,
   useUserWorkspaceInfo: () => ({
     selectedWorkspace: {
-      role: 'Member',
+      role: mockWorkspaceRole,
+      owner: { uid: mockWorkspaceOwnerUid },
     },
   }),
+}));
+
+jest.mock('@/components/main/app.hooks', () => ({
+  useCurrentUser: () => ({ uid: mockCurrentUserUid }),
 }));
 
 jest.mock('@/components/_shared/notify', () => ({
@@ -85,6 +93,9 @@ describe('SharePanel', () => {
     mockInviteGuestProps.mockClear();
     mockPeopleWithAccessProps.mockClear();
     mockIsHosted = false;
+    mockWorkspaceRole = Role.Member;
+    mockWorkspaceOwnerUid = '101';
+    mockCurrentUserUid = '202';
   });
 
   it('hides invite controls for read-only users while keeping the access list visible', () => {
@@ -124,12 +135,55 @@ describe('SharePanel', () => {
   });
 
   it('uses owner-tier authority for Full Access invite and row controls', async () => {
+    mockWorkspaceRole = Role.Owner;
     renderSharePanel(AccessLevel.FullAccess, jest.fn(), false);
 
     await waitFor(() => expect(mockLoadMentionableUsers).toHaveBeenCalledTimes(1));
     expect(mockInviteGuestProps).toHaveBeenCalledWith(expect.objectContaining({ canGrantFullAccess: false }));
     expect(mockPeopleWithAccessProps).toHaveBeenCalledWith(
       expect.objectContaining({ canGrantFullAccess: false, canManageFullAccess: false, hasFullAccess: true })
+    );
+  });
+
+  it('allows a workspace member with page Full Access to manage group grants', async () => {
+    renderSharePanel(AccessLevel.FullAccess);
+
+    await waitFor(() => expect(mockLoadMentionableUsers).toHaveBeenCalledTimes(1));
+    expect(mockInviteGuestProps).toHaveBeenCalledWith(expect.objectContaining({ canManageGroupAccess: true }));
+    expect(mockPeopleWithAccessProps).toHaveBeenCalledWith(expect.objectContaining({ canManageGroupAccess: true }));
+  });
+
+  it('recognizes the workspace owner by UID when the role projection is missing', async () => {
+    mockWorkspaceRole = undefined;
+    mockWorkspaceOwnerUid = '9007199254740993';
+    mockCurrentUserUid = '9007199254740993';
+
+    renderSharePanel(AccessLevel.FullAccess);
+
+    await waitFor(() => expect(mockLoadMentionableUsers).toHaveBeenCalledTimes(1));
+    expect(mockInviteGuestProps).toHaveBeenCalledWith(expect.objectContaining({ canManageGroupAccess: true }));
+    expect(mockPeopleWithAccessProps).toHaveBeenCalledWith(expect.objectContaining({ canManageGroupAccess: true }));
+  });
+
+  it('does not allow a workspace member without page Full Access to manage group grants', async () => {
+    renderSharePanel(AccessLevel.ReadAndWrite);
+
+    await waitFor(() => expect(mockLoadMentionableUsers).toHaveBeenCalledTimes(1));
+    expect(mockInviteGuestProps).toHaveBeenCalledWith(expect.objectContaining({ canManageGroupAccess: false }));
+    expect(mockPeopleWithAccessProps).toHaveBeenCalledWith(expect.objectContaining({ canManageGroupAccess: false }));
+  });
+
+  it('keeps person sharing available to a Full Access guest without exposing group management', async () => {
+    mockWorkspaceRole = Role.Guest;
+    renderSharePanel(AccessLevel.FullAccess);
+
+    expect(screen.getByTestId('invite-guest')).toBeTruthy();
+    await waitFor(() => expect(mockLoadMentionableUsers).toHaveBeenCalledTimes(1));
+    expect(mockInviteGuestProps).toHaveBeenCalledWith(
+      expect.objectContaining({ hasFullAccess: true, canManageGroupAccess: false })
+    );
+    expect(mockPeopleWithAccessProps).toHaveBeenCalledWith(
+      expect.objectContaining({ hasFullAccess: true, canManageGroupAccess: false })
     );
   });
 });

--- a/src/components/app/share/__tests__/SharePanel.test.tsx
+++ b/src/components/app/share/__tests__/SharePanel.test.tsx
@@ -149,7 +149,9 @@ describe('SharePanel', () => {
     renderSharePanel(AccessLevel.FullAccess);
 
     await waitFor(() => expect(mockLoadMentionableUsers).toHaveBeenCalledTimes(1));
-    expect(mockInviteGuestProps).toHaveBeenCalledWith(expect.objectContaining({ canManageGroupAccess: true }));
+    expect(mockInviteGuestProps).toHaveBeenCalledWith(
+      expect.objectContaining({ canManageGroupAccess: true, isWorkspaceOwner: false })
+    );
     expect(mockPeopleWithAccessProps).toHaveBeenCalledWith(expect.objectContaining({ canManageGroupAccess: true }));
   });
 
@@ -161,7 +163,9 @@ describe('SharePanel', () => {
     renderSharePanel(AccessLevel.FullAccess);
 
     await waitFor(() => expect(mockLoadMentionableUsers).toHaveBeenCalledTimes(1));
-    expect(mockInviteGuestProps).toHaveBeenCalledWith(expect.objectContaining({ canManageGroupAccess: true }));
+    expect(mockInviteGuestProps).toHaveBeenCalledWith(
+      expect.objectContaining({ canManageGroupAccess: true, isWorkspaceOwner: true })
+    );
     expect(mockPeopleWithAccessProps).toHaveBeenCalledWith(expect.objectContaining({ canManageGroupAccess: true }));
   });
 

--- a/src/components/app/share/__tests__/WorkspaceGroupIcon.test.tsx
+++ b/src/components/app/share/__tests__/WorkspaceGroupIcon.test.tsx
@@ -3,6 +3,7 @@ import { render, screen } from '@testing-library/react';
 import { WorkspaceGroup } from '@/application/types';
 import { InviteInput } from '@/components/app/share/InviteInput';
 import { PersonSuggestionItem } from '@/components/app/share/PersonSuggestionItem';
+import { WorkspaceGroupIcon } from '@/components/app/share/WorkspaceGroupIcon';
 
 jest.mock('react-i18next', () => ({
   useTranslation: () => ({ t: (key: string) => key }),
@@ -25,6 +26,17 @@ function getGroupIcon(container: HTMLElement): SVGSVGElement {
 }
 
 describe('page-share workspace group icons', () => {
+  it('matches the medium member avatar footprint in settings rows', () => {
+    render(<WorkspaceGroupIcon variant='settings-row' />);
+
+    const iconContainer = screen.getByTestId('workspace-group-icon-settings-row');
+
+    expect(iconContainer.classList.contains('h-8')).toBe(true);
+    expect(iconContainer.classList.contains('w-8')).toBe(true);
+    expect(iconContainer.classList.contains('h-9')).toBe(false);
+    expect(iconContainer.classList.contains('w-9')).toBe(false);
+  });
+
   it('uses the canonical row icon in group suggestions', () => {
     const { container } = render(
       <PersonSuggestionItem


### PR DESCRIPTION
### Description

Workspace Members could not see owner-created group summaries because the Web client only loaded them for Owners. This change:

- shows group names, member counts, and the Groups tab count to Owners and Members
- keeps group creation, rename, deletion, details, rosters, and membership management Owner-only
- allows only Owners or Members with page Full Access to enumerate selectable groups and add, update, or remove page-group grants
- keeps existing effective group rows visible read-only and preserves ordinary person sharing for Full Access Guests
- clears stale selected group tags and blocks stale group submissions when role or page access changes
- includes the Nathan and Eva BDD regression for Member group visibility

Backend dependency: https://github.com/AppFlowy-IO/AppFlowy-Cloud-Premium/pull/1047

Companion Flutter change: https://github.com/AppFlowy-IO/AppFlowy-Premium/pull/1265

---

### Testing

- [x] Share Jest suites: 11 passed, 86 tests passed
- [x] `pnpm lint`
- [x] Prettier and `git diff --check`
- [x] `pnpm build`
- [x] BDD generation and Playwright discovery
- [ ] Live Nathan and Eva BDD pass: localhost is still running the older Cloud binary with Owner-only group listing

### Permission boundary

- Owners and Members can view workspace group summaries.
- Only Owners manage group entities and rosters.
- Only Owners or Members with page Full Access modify page-group grants.
- Guests can keep person-sharing capability and see informational existing group rows, but cannot enumerate selectable groups or mutate group grants.

## Summary by Sourcery

Expose workspace group summaries to Members while restricting group administration and page-group grant changes to authorized users.

New Features:
- Allow workspace Members to view group summaries, including group names, member counts, and the Groups tab count, without management controls.
- Allow Owners and Members with page Full Access to manage page-group sharing grants while preserving person-sharing for Full Access Guests.

Bug Fixes:
- Prevent unauthorized or stale group selections from being enumerated or submitted after workspace roles or page access change.
- Keep existing group access rows visible as read-only when group grant mutations are unavailable.

Enhancements:
- Refine workspace group and page-sharing permission boundaries across settings and sharing panels.
- Align group summary tables and icons with the existing Members panel styling.

Tests:
- Add unit, integration, and BDD coverage for Member group visibility and restricted group management.