### PR TITLE
fix: remove public access table header

### DIFF
--- a/playwright/bdd/steps/space-custom-permissions.steps.ts
+++ b/playwright/bdd/steps/space-custom-permissions.steps.ts
@@ -299,8 +299,8 @@ Then('the Manage Space general tab shows the Public access card', async ({ page 
       exact: true,
     })
   ).toBeVisible();
-  await expect(card.getByText('Who', { exact: true })).toBeVisible();
-  await expect(card.getByText('Access', { exact: true })).toBeVisible();
+  await expect(card.getByText('Who', { exact: true })).toHaveCount(0);
+  await expect(card.getByText('Access', { exact: true })).toHaveCount(0);
   await expect(card.getByText('Need different access levels?', { exact: true })).toBeVisible();
   await expect(
     card.getByText(

--- a/src/@types/translations/en.json
+++ b/src/@types/translations/en.json
@@ -3380,8 +3380,6 @@
       "everyoneElseDescription": "Access for other workspace members",
       "publicAccessTitle": "Public access",
       "publicAccessDescription": "This space is public. Everyone in the workspace can access with the permissions below.",
-      "who": "Who",
-      "access": "Access",
       "workspaceOwners": "Workspace owners",
       "workspaceOwnersDescription": "You and other workspace owners",
       "workspaceMembers": "Workspace members",

--- a/src/components/app/view-actions/ManageSpace.tsx
+++ b/src/components/app/view-actions/ManageSpace.tsx
@@ -1792,13 +1792,6 @@ function PublicAccessCard({
           <div className='font-medium text-text-primary'>{t('space.permissionManager.publicAccessTitle')}</div>
           <div className='text-sm text-text-secondary'>{t('space.permissionManager.publicAccessDescription')}</div>
         </div>
-        <div
-          className='grid items-center gap-3 border-b border-border-primary px-4 py-2 text-xs font-medium text-text-tertiary'
-          style={{ gridTemplateColumns: 'minmax(0, 1fr) 160px' }}
-        >
-          <span>{t('space.permissionManager.who')}</span>
-          <span className='text-right'>{t('space.permissionManager.access')}</span>
-        </div>
         <PermissionPrincipalRow
           icon={<Shield className='h-5 w-5 text-icon-primary' />}
           title={t('space.permissionManager.workspaceOwners')}

--- a/src/components/app/view-actions/__tests__/ManageSpace.test.tsx
+++ b/src/components/app/view-actions/__tests__/ManageSpace.test.tsx
@@ -719,7 +719,7 @@ describe('ManageSpace ACL management', () => {
   });
 
   describe('public access card', () => {
-    it('renders the Who / Access table with the design copy and an editable members level', async () => {
+    it('renders the access rows without a redundant table header', async () => {
       mockGetSpacePermission.mockResolvedValue(permissionResponse({ permission: publicPermission }));
       render(<ManageSpace open onClose={jest.fn()} viewId='space-1' />);
 
@@ -728,8 +728,8 @@ describe('ManageSpace ACL management', () => {
 
       expect(card.textContent).toContain('space.permissionManager.publicAccessTitle');
       expect(card.textContent).toContain('space.permissionManager.publicAccessDescription');
-      expect(card.textContent).toContain('space.permissionManager.who');
-      expect(card.textContent).toContain('space.permissionManager.access');
+      expect(card.textContent).not.toContain('space.permissionManager.who');
+      expect(card.textContent).not.toContain('space.permissionManager.access');
       expect(screen.getByTestId('manage-space-workspace-owners-row').textContent).toContain(
         'space.permissionManager.workspaceOwnersDescription'
       );


### PR DESCRIPTION
## Summary

- Remove the redundant Who / Access header from the Manage Space Public access card.
- Remove the unused translation keys.
- Update unit and BDD regression expectations for the simplified layout.

## Validation

- pnpm exec jest --runInBand src/components/app/view-actions/__tests__/ManageSpace.test.tsx
- pnpm type-check
- pnpm exec eslint --quiet --ext .ts,.tsx src/components/app/view-actions/ManageSpace.tsx src/components/app/view-actions/__tests__/ManageSpace.test.tsx
- pnpm exec bddgen test -c playwright.bdd.config.ts

## Summary by Sourcery

Simplify the Manage Space public access card by removing its redundant table header.

Bug Fixes:
- Remove the redundant Who / Access header from the Manage Space public access card.

Tests:
- Update unit and BDD expectations to verify the simplified public access card layout.

Chores:
- Remove unused public access header translation keys.