### PR TITLE
fix: prevent first-login failure after logout

### DIFF
--- a/src/application/session/__tests__/sign_in.test.ts
+++ b/src/application/session/__tests__/sign_in.test.ts
@@ -1,4 +1,4 @@
-import { afterAuth, buildLoginUrl, getSafeRedirectUrl, isSafeRedirectUrl, saveRedirectTo } from '../sign_in';
+import { afterAuth, buildLoginUrl, getSafeRedirectUrl, isAuthPath, isSafeRedirectUrl, saveRedirectTo } from '../sign_in';
 
 // Mock localStorage
 const localStorageMock = (() => {
@@ -133,6 +133,22 @@ describe('getSafeRedirectUrl', () => {
   });
 });
 
+describe('isAuthPath', () => {
+  it.each(['/login', '/login/', '/LOGIN', '/%6Cogin', '/auth/callback', '/auth/%63allback'])(
+    'matches a router-equivalent authentication path: %s',
+    (pathname) => {
+      expect(isAuthPath(pathname)).toBe(true);
+    }
+  );
+
+  it.each(['/login/foo', '/loginish', '/login%2F', '/auth/callback-other'])(
+    'does not match a non-authentication path: %s',
+    (pathname) => {
+      expect(isAuthPath(pathname)).toBe(false);
+    }
+  );
+});
+
 describe('saveRedirectTo', () => {
   it('stores a safe redirect without changing its encoding', () => {
     const redirectTo = '/settings?next=%2Fapp';
@@ -237,6 +253,33 @@ describe('afterAuth', () => {
     afterAuth();
     expect(window.location.href).toBe('/app');
   });
+
+  it.each([
+    '/login?force=true',
+    'http://localhost/login?force=true',
+    '/LOGIN?force=true',
+    '/%6Cogin?force=true',
+    '/auth/callback#access_token=example',
+    '/auth/%63allback#access_token=example',
+  ])('redirects to /app instead of returning to an authentication route: %s', (redirectTo) => {
+    localStorage.setItem('redirectTo', redirectTo);
+
+    afterAuth();
+
+    expect(window.location.href).toBe('/app');
+    expect(localStorage.getItem('redirectTo')).toBeNull();
+  });
+
+  it.each(['/login/foo', '/loginish', '/auth/callback-other'])(
+    'preserves a safe non-authentication destination: %s',
+    (redirectTo) => {
+      localStorage.setItem('redirectTo', redirectTo);
+
+      afterAuth();
+
+      expect(window.location.href).toBe(redirectTo);
+    }
+  );
 
   it('follows a safe relative path', () => {
     localStorage.setItem('redirectTo', '/settings');

--- a/src/application/session/sign_in.ts
+++ b/src/application/session/sign_in.ts
@@ -21,6 +21,25 @@ export function clearRedirectTo() {
 export const AUTH_CALLBACK_PATH = '/auth/callback';
 export const AUTH_CALLBACK_URL = `${window.location.origin}${AUTH_CALLBACK_PATH}`;
 
+export function isAuthPath(pathname: string): boolean {
+  let decodedPathname: string;
+
+  try {
+    // Match React Router's segment decoding while preserving encoded slashes,
+    // which are data inside a segment rather than route separators.
+    decodedPathname = pathname
+      .split('/')
+      .map((segment) => decodeURIComponent(segment).replace(/\//g, '%2F'))
+      .join('/');
+  } catch {
+    return false;
+  }
+
+  const normalizedPathname = decodedPathname.replace(/\/+$/, '').toLowerCase();
+
+  return normalizedPathname === '/login' || normalizedPathname === AUTH_CALLBACK_PATH;
+}
+
 const MAX_REDIRECT_VALIDATION_DECODES = 5;
 const ABSOLUTE_URL_PATTERN = /^[a-z][a-z\d+.-]*:/i;
 const AUTHORITY_RELATIVE_URL_PATTERN = /^[\\/]{2}/;
@@ -149,7 +168,13 @@ export function afterAuth() {
     // Pattern matches /app/{uuid}/{uuid} or /app/{uuid}
     const hasUserSpecificIds = /\/app\/[a-f0-9-]{36}/i.test(pathname);
 
-    if (hasUserSpecificIds) {
+    if (isAuthPath(pathname)) {
+      // Authentication pages are transitional destinations. Sending a newly
+      // authenticated user back to one can strand them on the login screen and
+      // require a second sign-in attempt.
+      Log.info('[Auth] afterAuth: blocking authentication-route redirect, going to /app', { pathname });
+      window.location.href = '/app';
+    } else if (hasUserSpecificIds) {
       // Don't redirect to user-specific pages from previous sessions
       Log.info('[Auth] afterAuth: blocking user-specific redirect, going to /app', { pathname });
       window.location.href = '/app';

--- a/src/components/app/layers/AppAuthLayer.tsx
+++ b/src/components/app/layers/AppAuthLayer.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useContext, useEffect, useMemo, useRef, useState } 
 import { useLocation, useNavigate, useParams } from 'react-router-dom';
 
 import { AuthService, UserService, WorkspaceService } from '@/application/services/domains';
-import { buildLoginUrl } from '@/application/session/sign_in';
+import { buildLoginUrl, isAuthPath } from '@/application/session/sign_in';
 import { invalidToken } from '@/application/session/token';
 import { UserWorkspaceInfo } from '@/application/types';
 import { determineErrorType, ErrorType } from '@/application/utils/error-utils';
@@ -175,7 +175,11 @@ export const AppAuthLayer: React.FC<AppAuthLayerProps> = ({ children }) => {
   // so this layer does not need timer-based token polling or a second auth source.
   useEffect(() => {
     if (!hasConfigContext || isAuthenticated) return;
-    if (location.pathname === '/login' || location.pathname.startsWith('/auth/callback')) return;
+
+    // An explicit sign-out invalidates the session before React Router commits
+    // its navigation. Read the browser URL as well so this stale render cannot
+    // replace `/login?force=true` with a login URL that redirects back to login.
+    if (isAuthPath(location.pathname) || isAuthPath(window.location.pathname)) return;
 
     logout();
   }, [hasConfigContext, isAuthenticated, location.pathname, logout]);

--- a/src/components/app/layers/__tests__/AppAuthLayer.test.tsx
+++ b/src/components/app/layers/__tests__/AppAuthLayer.test.tsx
@@ -73,6 +73,7 @@ describe('AppAuthLayer workspace info loading', () => {
     jest.clearAllMocks();
     mockWorkspaceId = undefined;
     mockPathname = '/login';
+    window.history.replaceState({}, '', '/');
     mockGetServerInfo.mockResolvedValue({
       enable_page_history: true,
       ai_enabled: true,
@@ -99,6 +100,35 @@ describe('AppAuthLayer workspace info loading', () => {
 
     await waitFor(() => expect(mockInvalidToken).toHaveBeenCalledTimes(1));
     expect(mockNavigate).toHaveBeenCalledWith(`/login?redirectTo=${encodeURIComponent(window.location.href)}`);
+    expect(mockGetWorkspaceInfo).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    '/login?force=true',
+    '/LOGIN?force=true',
+    '/%6Cogin?force=true',
+    '/auth/callback?type=oauth',
+    '/auth/%63allback?type=oauth',
+  ])('does not overwrite an explicit auth navigation when the router location is stale: %s', (liveUrl) => {
+    mockPathname = '/app/workspace-old';
+    window.history.replaceState({}, '', liveUrl);
+
+    render(
+      <AFConfigContext.Provider
+        value={{
+          isAuthenticated: false,
+          updateCurrentUser: jest.fn(),
+          openLoginModal: jest.fn(),
+        }}
+      >
+        <AppAuthLayer>
+          <div />
+        </AppAuthLayer>
+      </AFConfigContext.Provider>
+    );
+
+    expect(mockInvalidToken).not.toHaveBeenCalled();
+    expect(mockNavigate).not.toHaveBeenCalled();
     expect(mockGetWorkspaceInfo).not.toHaveBeenCalled();
   });
 


### PR DESCRIPTION
### **Description**

Fix the logout-to-OAuth race that made the first third-party login appear to fail.

An explicit logout invalidates the session before React Router commits its navigation to `/login?force=true`. The unauthenticated app-layer effect could therefore observe the stale `/app/...` router pathname while the browser was already on the login page, run its fallback logout, and save the forced-login URL as the next post-auth destination. OAuth succeeded, but `afterAuth` sent the user back to the forced login page.

The fix:

- treats the live browser location as authoritative while an explicit auth navigation is settling;
- prevents login and OAuth callback routes from becoming post-auth destinations;
- matches React Router's case, percent-decoding, encoded-slash, and trailing-slash semantics without misclassifying published paths such as `/login/foo`.

### Reported regression

| Bug | Evidence | Actual | Expected |
| --- | --- | --- | --- |
| First third-party login fails after logout | User-supplied 35.5-second recording: logout at ~10s, first OAuth return at ~20s, second attempt reaches the app at ~30s | The first OAuth completion returned to `/login?force=true` | The first OAuth completion should open `/app` |

### Root cause and provenance

| Bug | Root cause | Introducing change |
| --- | --- | --- |
| First third-party login fails after logout | `SESSION_INVALID` synchronously changed auth state; `AppAuthLayer` then ran with a stale router pathname and nested the already-current login URL in `redirectTo`; `afterAuth` accepted that same-origin auth route and returned there | Original behavior change: `1ad8233f3a44eb34be1036c1f586721f785143d4` (`fix: harden authentication startup flows`), authored by Nathan `<nathan@appflowy.io>` on 2026-08-21. Its parent used delayed 50ms/100ms auth checks; this commit replaced them with the immediate fallback effect. It shipped to `main` in squash merge `ceb8f7937601e510b6657c3edfe87ee8b66437ac` via [#494](https://github.com/AppFlowy-IO/AppFlowy-Web/pull/494). |

### Fixes and commit

| Bug | Fix | Regression coverage | Commit |
| --- | --- | --- | --- |
| First third-party login fails after logout | Guard fallback logout with both router and live browser auth paths; reject auth routes in `afterAuth` | `src/components/app/layers/__tests__/AppAuthLayer.test.tsx` and `src/application/session/__tests__/sign_in.test.ts` | `0b2a1be2e051f3de542dc916e8418c7e4b7e1c0e` |

### Test integrity

- Production-fix revert: the focused command failed with 11 intended assertions (stale live login/callback locations and auth-route post-login destinations).
- Restored fix: `pnpm exec jest src/application/session/__tests__/sign_in.test.ts src/components/app/layers/__tests__/AppAuthLayer.test.tsx --runInBand --no-coverage` — 74/74 passed.
- Full unit suite: `pnpm exec jest --runInBand --no-coverage` — 358/358 suites and 3,526/3,526 tests passed.
- `pnpm lint` — passed (includes TypeScript type-check and ESLint).
- `pnpm build` — passed.
- Live Chrome verification on the fixed build:
  - logout settled on `/login?force=true` with no token and no saved redirect;
  - one OAuth-style callback using the production `loginAuth` path, with the formerly poisoned redirect deliberately seeded, reached `/app` with a valid token and cleared redirect state.

---

### **Checklist**

#### **General**
- [x] I've included relevant documentation or comments for the changes introduced.
- [ ] I've tested the changes in multiple environments (verified in Chrome on macOS).

#### **Testing**
- [x] I've added or updated tests to validate the changes introduced for AppFlowy Web.

#### **Feature-Specific**
- [x] Not applicable — this is a regression fix, not a feature addition.
- [x] I've verified that this fix integrates with the existing logout and post-auth flows.

## Summary by Sourcery

Prevent logout-to-OAuth race conditions from trapping newly authenticated users on the login page.

Bug Fixes:
- Prevent the first OAuth login after logout from redirecting back to the login page by ignoring stale router locations during auth navigation and blocking authentication routes as post-login destinations.

Enhancements:
- Align authentication-path detection with React Router semantics while preserving similarly prefixed published paths as valid destinations.

Tests:
- Add regression coverage for stale router locations, encoded and case-variant authentication paths, and safe post-auth redirect handling.