### PR TITLE
fix: support nesting sidebar pages with drag and drop

### DIFF
--- a/playwright/bdd/features/app/sidebar-drop-indicator.feature
+++ b/playwright/bdd/features/app/sidebar-drop-indicator.feature
@@ -27,3 +27,14 @@ Feature: Sidebar drop indicator marks the real landing spot
     And the drop indicator sits at the bottom of the "Solo Target" name row
     When the drag is released
     Then the sidebar lists "Solo Target, Solo Drag" in that order
+
+  Scenario: Dropping on the center of a document makes the page its child
+    Given a page "Drag Me Into Parent" in the sidebar
+    And a page "Drop Parent" in the sidebar with the child "Existing Child"
+    And "Drop Parent" is expanded
+    When "Drag Me Into Parent" is dragged into the center of "Drop Parent" without dropping
+    Then "Drop Parent" is the active child drop target
+    When the drag is released
+    Then "Drag Me Into Parent" is a direct child of "Drop Parent"
+    When the sidebar drag app is reloaded
+    Then "Drag Me Into Parent" is a direct child of "Drop Parent"

--- a/playwright/bdd/steps/sidebar-drop-indicator.steps.ts
+++ b/playwright/bdd/steps/sidebar-drop-indicator.steps.ts
@@ -8,10 +8,11 @@ import {
   readDropIndicatorGeometry,
   readDropIndicatorTargetName,
   readSidebarPageNames,
+  startOutlineDragInto,
   startOutlineDragOver,
 } from '../../support/outline-drag-helpers';
 import { expandPageByName } from '../../support/page/flows';
-import { PageSelectors } from '../../support/selectors';
+import { itemDirectChildPageItems, PageSelectors } from '../../support/selectors';
 import { generateRandomEmail, setupPageErrorHandling } from '../../support/test-config';
 
 const { Given, Then, When } = createBdd();
@@ -60,6 +61,19 @@ When(
   }
 );
 
+When(
+  '{string} is dragged into the center of {string} without dropping',
+  async ({ page }, sourceName: string, targetName: string) => {
+    await startOutlineDragInto(page, sourceName, targetName);
+  }
+);
+
+Then('{string} is the active child drop target', async ({ page }, targetName: string) => {
+  const targetRow = PageSelectors.itemByName(page, targetName).locator(':scope > [data-testid^="page-"]').first();
+
+  await expect(targetRow).toHaveAttribute('data-drop-instruction', 'make-child');
+});
+
 Then('the drop indicator is attached to {string}', async ({ page }, targetName: string) => {
   expect(await readDropIndicatorTargetName(page)).toBe(targetName);
 });
@@ -74,19 +88,16 @@ Then('the drop indicator sits below the expanded children of {string}', async ({
   ).not.toBeNull();
   // Dropping here lands the page after the whole subtree, so the line has to be
   // below the last child's row — not tucked between the parent and that child.
-  expect(geometry.indicatorBottom).toBeGreaterThanOrEqual(
-    (geometry.lastDescendantBottom as number) - EDGE_TOLERANCE_PX
-  );
+  expect(geometry.indicatorBottom).toBeGreaterThanOrEqual((geometry.lastDescendantBottom as number) - EDGE_TOLERANCE_PX);
   expect(geometry.indicatorBottom).toBeGreaterThanOrEqual(geometry.subtreeBottom - EDGE_TOLERANCE_PX);
 });
 
 Then('the drop indicator does not sit at the bottom of the {string} name row', async ({ page }, targetName: string) => {
   const geometry = await readDropIndicatorGeometry(page);
 
-  expect(
-    geometry.indicatorBottom,
-    `the indicator is still pinned to the "${targetName}" name row`
-  ).toBeGreaterThan(geometry.rowBottom + EDGE_TOLERANCE_PX);
+  expect(geometry.indicatorBottom, `the indicator is still pinned to the "${targetName}" name row`).toBeGreaterThan(
+    geometry.rowBottom + EDGE_TOLERANCE_PX
+  );
 });
 
 Then('the drop indicator sits at the bottom of the {string} name row', async ({ page }, targetName: string) => {
@@ -114,4 +125,21 @@ Then('the sidebar lists {string} in that order', async ({ page }, expected: stri
       message: `Waiting for the sidebar order ${expected}`,
     })
     .toEqual(names);
+});
+
+Then('{string} is a direct child of {string}', async ({ page }, childName: string, parentName: string) => {
+  const directChildNames = PageSelectors.itemByName(page, parentName).locator(
+    `${itemDirectChildPageItems()} > [data-testid^="page-"] [data-testid="page-name"]`
+  );
+
+  await expect
+    .poll(() => directChildNames.allTextContents(), {
+      timeout: 30000,
+      message: `Waiting for "${childName}" to become a direct child of "${parentName}"`,
+    })
+    .toContain(childName);
+});
+
+When('the sidebar drag app is reloaded', async ({ page }) => {
+  await page.reload({ waitUntil: 'domcontentloaded' });
 });

--- a/playwright/support/outline-drag-helpers.ts
+++ b/playwright/support/outline-drag-helpers.ts
@@ -62,12 +62,35 @@ export async function startOutlineDragOver(
   await page.waitForTimeout(150);
   await page.mouse.move(
     targetBox.x + targetBox.width / 2,
-    targetBox.y + targetBox.height * (edge === 'top' ? 0.15 : 0.85),
+    edge === 'top' ? targetBox.y + 1 : targetBox.y + targetBox.height - 1,
     { steps: 12 }
   );
   await page.waitForTimeout(400);
 
   await expect(page.getByTestId('drop-row-line')).toHaveCount(1, { timeout: 10000 });
+}
+
+/**
+ * Holds `sourceName` over the center of `targetName`, the desktop-parity
+ * gesture for making the source a child of the target document.
+ */
+export async function startOutlineDragInto(page: Page, sourceName: string, targetName: string): Promise<void> {
+  const sourceRow = pageItemByName(page, sourceName).locator(':scope > [data-testid^="page-"]').first();
+  const targetRow = pageItemByName(page, targetName).locator(':scope > [data-testid^="page-"]').first();
+
+  await expect(sourceRow).toBeVisible({ timeout: 15000 });
+  await expect(targetRow).toBeVisible({ timeout: 15000 });
+
+  const sourceBox = await boxOf(sourceRow);
+  const targetBox = await boxOf(targetRow);
+
+  await page.mouse.move(sourceBox.x + sourceBox.width / 2, sourceBox.y + sourceBox.height / 2);
+  await page.mouse.down();
+  await page.waitForTimeout(150);
+  await page.mouse.move(targetBox.x + targetBox.width / 2, targetBox.y + targetBox.height / 2, { steps: 12 });
+  await page.waitForTimeout(400);
+
+  await expect(targetRow).toHaveAttribute('data-drop-instruction', 'make-child', { timeout: 10000 });
 }
 
 export async function finishOutlineDrag(page: Page): Promise<void> {

--- a/src/components/_shared/reorder/__tests__/treeItem.test.ts
+++ b/src/components/_shared/reorder/__tests__/treeItem.test.ts
@@ -1,0 +1,56 @@
+import {
+  moveIdAfterPrevious,
+  resolveTreeMoveDestination,
+  type ActionableTreeInstruction,
+} from '@/components/_shared/reorder/treeItem';
+
+function instruction(type: ActionableTreeInstruction['type']): ActionableTreeInstruction {
+  return { type, currentLevel: 0, indentPerLevel: 16 };
+}
+
+describe('sidebar tree move resolution', () => {
+  it('appends a page to the target document while excluding the source itself', () => {
+    expect(
+      resolveTreeMoveDestination({
+        instruction: instruction('make-child'),
+        sourceId: 'source',
+        targetId: 'parent',
+        targetParentId: 'space',
+        targetSiblingIds: ['source', 'parent'],
+        targetChildIds: ['existing-child', 'source'],
+      })
+    ).toEqual({ parentId: 'parent', prevId: 'existing-child' });
+  });
+
+  it('resolves drops above and below a sibling to API previous-view semantics', () => {
+    const common = {
+      sourceId: 'source',
+      targetId: 'target',
+      targetParentId: 'destination-parent',
+      targetSiblingIds: ['first', 'target', 'last'],
+      targetChildIds: [],
+    };
+
+    expect(resolveTreeMoveDestination({ ...common, instruction: instruction('reorder-above') })).toEqual({
+      parentId: 'destination-parent',
+      prevId: 'first',
+    });
+    expect(resolveTreeMoveDestination({ ...common, instruction: instruction('reorder-below') })).toEqual({
+      parentId: 'destination-parent',
+      prevId: 'target',
+    });
+  });
+
+  it('reorders a sibling after the resolved previous view', () => {
+    expect(moveIdAfterPrevious(['first', 'source', 'target', 'last'], 'source', 'target')).toEqual({
+      nextIds: ['first', 'target', 'source', 'last'],
+      fromIndex: 1,
+      toIndex: 2,
+    });
+    expect(moveIdAfterPrevious(['first', 'source'], 'source', null)).toEqual({
+      nextIds: ['source', 'first'],
+      fromIndex: 1,
+      toIndex: 0,
+    });
+  });
+});

--- a/src/components/_shared/reorder/treeItem.ts
+++ b/src/components/_shared/reorder/treeItem.ts
@@ -1,0 +1,123 @@
+import type { Instruction } from '@atlaskit/pragmatic-drag-and-drop-hitbox/tree-item';
+
+const treeItemDataKey = Symbol('reorderable-tree-item-data');
+
+export type ActionableTreeInstruction = Extract<Instruction, { type: 'reorder-above' | 'reorder-below' | 'make-child' }>;
+
+/**
+ * Extra metadata used when a reorderable item participates in a tree.
+ *
+ * `instanceId` still identifies one sibling list. `scopeId` identifies the
+ * whole tree, allowing a draggable item to cross sibling-list boundaries while
+ * keeping unrelated trees (database tabs, move popovers, etc.) isolated.
+ */
+export interface ReorderableTreeItemData {
+  scopeId: symbol;
+  parentId: string;
+  currentLevel: number;
+  indentPerLevel: number;
+  canMoveAcrossParents: boolean;
+  canAcceptChildren: boolean;
+  canAcceptMovedSiblings: boolean;
+  ancestorIds: readonly string[];
+  siblingIds: readonly string[];
+  childIds: readonly string[];
+}
+
+export interface TreeMoveDestination {
+  parentId: string;
+  prevId: string | null;
+}
+
+export interface OrderedMoveResult {
+  nextIds: string[];
+  fromIndex: number;
+  toIndex: number;
+}
+
+export function attachReorderableTreeItemData(
+  data: Record<string | symbol, unknown>,
+  treeItem: ReorderableTreeItemData
+): Record<string | symbol, unknown> {
+  return {
+    ...data,
+    [treeItemDataKey]: treeItem,
+  };
+}
+
+export function extractReorderableTreeItemData(data: Record<string | symbol, unknown>): ReorderableTreeItemData | null {
+  const value = data[treeItemDataKey];
+
+  if (!value || typeof value !== 'object') return null;
+  return value as ReorderableTreeItemData;
+}
+
+/** Resolve the API parent/previous-sibling pair for a tree drop. */
+export function resolveTreeMoveDestination({
+  instruction,
+  sourceId,
+  targetId,
+  targetParentId,
+  targetSiblingIds,
+  targetChildIds,
+}: {
+  instruction: ActionableTreeInstruction;
+  sourceId: string;
+  targetId: string;
+  targetParentId: string;
+  targetSiblingIds: readonly string[];
+  targetChildIds: readonly string[];
+}): TreeMoveDestination | null {
+  if (instruction.type === 'make-child') {
+    let prevId: string | null = null;
+
+    for (let index = targetChildIds.length - 1; index >= 0; index -= 1) {
+      const childId = targetChildIds[index];
+
+      if (childId && childId !== sourceId) {
+        prevId = childId;
+        break;
+      }
+    }
+
+    return { parentId: targetId, prevId };
+  }
+
+  const siblingsWithoutSource = targetSiblingIds.filter((id) => id !== sourceId);
+  const targetIndex = siblingsWithoutSource.indexOf(targetId);
+
+  if (targetIndex < 0) return null;
+
+  if (instruction.type === 'reorder-below') {
+    return { parentId: targetParentId, prevId: targetId };
+  }
+
+  return {
+    parentId: targetParentId,
+    prevId: targetIndex > 0 ? siblingsWithoutSource[targetIndex - 1] ?? null : null,
+  };
+}
+
+/** Apply the API's `prev_view_id` insertion semantics to one sibling order. */
+export function moveIdAfterPrevious(
+  orderedIds: readonly string[],
+  movedId: string,
+  prevId: string | null
+): OrderedMoveResult | null {
+  const fromIndex = orderedIds.indexOf(movedId);
+
+  if (fromIndex < 0 || prevId === movedId) return null;
+
+  const nextIds = orderedIds.filter((id) => id !== movedId);
+  const insertionIndex = prevId === null ? 0 : nextIds.indexOf(prevId) + 1;
+
+  if (insertionIndex < 0 || (prevId !== null && insertionIndex === 0)) return null;
+
+  nextIds.splice(insertionIndex, 0, movedId);
+
+  return {
+    nextIds,
+    fromIndex,
+    toIndex: insertionIndex,
+  };
+}

--- a/src/components/_shared/reorder/useReorderMonitor.ts
+++ b/src/components/_shared/reorder/useReorderMonitor.ts
@@ -4,7 +4,14 @@ import { reorder } from '@atlaskit/pragmatic-drag-and-drop/reorder';
 import { autoScrollForElements } from '@atlaskit/pragmatic-drag-and-drop-auto-scroll/element';
 import { extractClosestEdge } from '@atlaskit/pragmatic-drag-and-drop-hitbox/closest-edge';
 import { getReorderDestinationIndex } from '@atlaskit/pragmatic-drag-and-drop-hitbox/util/get-reorder-destination-index';
+import { extractInstruction } from '@atlaskit/pragmatic-drag-and-drop-hitbox/tree-item';
 import React, { useEffect, useRef } from 'react';
+
+import {
+  extractReorderableTreeItemData,
+  moveIdAfterPrevious,
+  resolveTreeMoveDestination,
+} from '@/components/_shared/reorder/treeItem';
 
 const SCROLLABLE_OVERFLOW = /(auto|scroll|overlay)/;
 
@@ -100,6 +107,48 @@ export function useReorderMonitor({
           const targetId = String(target.data.id ?? '');
 
           if (!sourceId || !targetId || sourceId === targetId) return;
+
+          const sourceTreeItem = extractReorderableTreeItemData(source.data);
+          const targetTreeItem = extractReorderableTreeItemData(target.data);
+
+          if (sourceTreeItem && targetTreeItem?.scopeId === sourceTreeItem.scopeId) {
+            // This monitor owns only the source sibling list. A single monitor
+            // at the outline root persists cross-parent and make-child drops.
+            if (target.data.instanceId !== instanceId) return;
+
+            const instruction = extractInstruction(target.data);
+
+            if (!instruction || instruction.type === 'instruction-blocked' || instruction.type === 'reparent') {
+              return;
+            }
+
+            const orderedIds = getOrderedIdsRef.current();
+            const destination = resolveTreeMoveDestination({
+              instruction,
+              sourceId,
+              targetId,
+              targetParentId: targetTreeItem.parentId,
+              targetSiblingIds: orderedIds,
+              targetChildIds: targetTreeItem.childIds,
+            });
+
+            if (!destination) return;
+
+            if (instruction.type === 'make-child' || destination.parentId !== sourceTreeItem.parentId) return;
+
+            const orderedMove = moveIdAfterPrevious(orderedIds, sourceId, destination.prevId);
+
+            if (!orderedMove || orderedMove.fromIndex === orderedMove.toIndex) return;
+
+            onReorderRef.current({
+              movedId: sourceId,
+              prevId: destination.prevId,
+              nextIds: orderedMove.nextIds,
+              fromIndex: orderedMove.fromIndex,
+              toIndex: orderedMove.toIndex,
+            });
+            return;
+          }
 
           const orderedIds = getOrderedIdsRef.current();
           const startIndex = orderedIds.indexOf(sourceId);

--- a/src/components/_shared/reorder/useReorderableItem.ts
+++ b/src/components/_shared/reorder/useReorderableItem.ts
@@ -1,7 +1,18 @@
 import { combine } from '@atlaskit/pragmatic-drag-and-drop/combine';
 import { draggable, dropTargetForElements } from '@atlaskit/pragmatic-drag-and-drop/element/adapter';
 import { attachClosestEdge, extractClosestEdge, type Edge } from '@atlaskit/pragmatic-drag-and-drop-hitbox/closest-edge';
+import {
+  attachInstruction,
+  extractInstruction,
+  type Instruction,
+} from '@atlaskit/pragmatic-drag-and-drop-hitbox/tree-item';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
+
+import {
+  attachReorderableTreeItemData,
+  extractReorderableTreeItemData,
+  type ReorderableTreeItemData,
+} from '@/components/_shared/reorder/treeItem';
 
 /**
  * Drag state for a single reorderable item (sidebar row, database tab, …).
@@ -15,7 +26,7 @@ import React, { useCallback, useEffect, useRef, useState } from 'react';
 export type ReorderableItemDragState =
   | { type: 'idle' }
   | { type: 'dragging' }
-  | { type: 'over'; closestEdge: Edge | null };
+  | { type: 'over'; closestEdge: Edge | null; instruction: Instruction | null };
 
 const idleState: ReorderableItemDragState = { type: 'idle' };
 
@@ -44,6 +55,8 @@ interface UseReorderableItemParams {
    * vertical lists (default) and `['left', 'right']` for horizontal ones.
    */
   allowedEdges?: Edge[];
+  /** Optional metadata that lets this item move across lists in one tree. */
+  treeItem?: ReorderableTreeItemData;
 }
 
 interface UseReorderableItemResult {
@@ -70,6 +83,7 @@ export function useReorderableItem({
   instanceId,
   canDrag,
   allowedEdges = VERTICAL_EDGES,
+  treeItem,
 }: UseReorderableItemParams): UseReorderableItemResult {
   const [dragState, setDragState] = useState<ReorderableItemDragState>(idleState);
   const suppressClickRef = useRef(false);
@@ -104,11 +118,12 @@ export function useReorderableItem({
 
     if (!instanceId || !element) return;
 
-    const data = {
+    const baseData = {
       type: dragType,
       instanceId,
       id,
     };
+    const data = treeItem ? attachReorderableTreeItemData(baseData, treeItem) : baseData;
     const edges = allowedEdgesKey.split(',') as Edge[];
 
     const cleanups: Array<() => void> = [];
@@ -142,10 +157,49 @@ export function useReorderableItem({
     cleanups.push(
       dropTargetForElements({
         element,
-        canDrop: ({ source }) =>
-          source.data.type === dragType && source.data.instanceId === instanceId && source.data.id !== id,
+        canDrop: ({ source }) => {
+          if (source.data.type !== dragType || source.data.id === id) return false;
+
+          const sameList = source.data.instanceId === instanceId;
+          const sourceTreeItem = extractReorderableTreeItemData(source.data);
+
+          if (!treeItem || !sourceTreeItem || sourceTreeItem.scopeId !== treeItem.scopeId) {
+            return sameList;
+          }
+
+          const sourceId = String(source.data.id ?? '');
+
+          // Moving an ancestor beside or inside one of its descendants would
+          // create a cycle. The rendered target already knows its full path.
+          if (treeItem.ancestorIds.includes(sourceId)) return false;
+
+          if (!sameList && (!sourceTreeItem.canMoveAcrossParents || !treeItem.canAcceptMovedSiblings)) {
+            return false;
+          }
+
+          return true;
+        },
         getIsSticky: () => true,
-        getData({ input }) {
+        getData({ input, source }) {
+          const sourceTreeItem = extractReorderableTreeItemData(source.data);
+
+          if (treeItem && sourceTreeItem?.scopeId === treeItem.scopeId) {
+            const block: Instruction['type'][] = [];
+
+            if (!sourceTreeItem.canMoveAcrossParents || !treeItem.canAcceptChildren) {
+              block.push('make-child');
+            }
+
+            return attachInstruction(data, {
+              element,
+              input,
+              currentLevel: treeItem.currentLevel,
+              indentPerLevel: treeItem.indentPerLevel,
+              mode: 'standard',
+              block,
+            });
+          }
+
           return attachClosestEdge(data, {
             element,
             input,
@@ -153,11 +207,23 @@ export function useReorderableItem({
           });
         },
         onDrag({ self }) {
+          const instruction = extractInstruction(self.data);
           const closestEdge = extractClosestEdge(self.data);
+          const instructionEdge =
+            instruction?.type === 'reorder-above' ? 'top' : instruction?.type === 'reorder-below' ? 'bottom' : null;
 
           setDragState((current) => {
-            if (current.type === 'over' && current.closestEdge === closestEdge) return current;
-            return { type: 'over', closestEdge };
+            const nextClosestEdge = instruction ? instructionEdge : closestEdge;
+
+            if (
+              current.type === 'over' &&
+              current.closestEdge === nextClosestEdge &&
+              current.instruction === instruction
+            ) {
+              return current;
+            }
+
+            return { type: 'over', closestEdge: nextClosestEdge, instruction };
           });
         },
         onDragLeave() {
@@ -170,7 +236,7 @@ export function useReorderableItem({
     );
 
     return combine(...cleanups);
-  }, [allowedEdgesKey, canDrag, dragType, elementRef, id, instanceId]);
+  }, [allowedEdgesKey, canDrag, dragType, elementRef, id, instanceId, treeItem]);
 
   return { dragState, shouldSuppressClick };
 }

--- a/src/components/app/outline/Outline.tsx
+++ b/src/components/app/outline/Outline.tsx
@@ -25,6 +25,7 @@ import {
 } from '@/components/app/app.hooks';
 import { Favorite } from '@/components/app/favorite';
 import { useReorderableSidebarList } from '@/components/app/outline/reorder/useReorderableSidebarList';
+import { useSidebarTreeMonitor } from '@/components/app/outline/reorder/useSidebarTreeMonitor';
 import {
   createSidebarOutlineRevalidationScheduleState,
   floorSidebarOutlineRevalidationStateForOpenWebSocket,
@@ -82,6 +83,10 @@ export function Outline({ width }: { width: number }) {
   const userWorkspaceInfo = useUserWorkspaceInfo();
   const canReorderSpaces = userWorkspaceInfo?.selectedWorkspace.role === Role.Owner;
   const spaceListRef = useRef<HTMLDivElement>(null);
+  const [pageTreeScopeId] = useState(() => Symbol('sidebar-page-tree-scope'));
+
+  useSidebarTreeMonitor({ scopeId: pageTreeScopeId, workspaceId: currentWorkspaceId });
+
   const visibleSpacesFromOutline = useMemo(
     () => outline?.filter((view) => isSpaceView(view) && !view.extra?.is_hidden_space) ?? [],
     [outline]
@@ -674,6 +679,7 @@ export function Outline({ width }: { width: number }) {
               loadedViewIds={loadedViewIds}
               canReorder={canReorderSpaces && visibleSpaces.length > 1}
               dragInstanceId={spaceDragInstanceId}
+              pageTreeScopeId={pageTreeScopeId}
             />
           ))
         )}

--- a/src/components/app/outline/SpaceItem.tsx
+++ b/src/components/app/outline/SpaceItem.tsx
@@ -28,6 +28,7 @@ function SpaceItem({
   loadedViewIds,
   canReorder,
   dragInstanceId,
+  pageTreeScopeId,
 }: {
   view: View;
   width: number;
@@ -40,6 +41,8 @@ function SpaceItem({
   loadedViewIds?: Set<string>;
   canReorder?: boolean;
   dragInstanceId?: symbol;
+  /** Shared scope for page reparenting in the workspace sidebar. */
+  pageTreeScopeId?: symbol;
 }) {
   const [hovered, setHovered] = React.useState<boolean>(false);
   const rowRef = useRef<HTMLDivElement>(null);
@@ -57,12 +60,14 @@ function SpaceItem({
 
   // The space's direct children can be reordered within the space.
   const spaceChildren = useMemo(() => view?.children ?? [], [view?.children]);
+  const childAncestorIds = useMemo(() => [view.view_id], [view.view_id]);
+  const childReorderEnabled = pageTreeScopeId ? spaceChildren.length > 0 : spaceChildren.length > 1;
   const { orderedItems: orderedChildren, instanceId: childDragInstanceId } = useReorderableSidebarList({
     items: spaceChildren,
     parentId: view.view_id,
     workspaceId,
     dragType: 'sidebar-view',
-    enabled: spaceChildren.length > 1,
+    enabled: childReorderEnabled,
     errorMessage: 'Failed to reorder pages',
   });
 
@@ -130,6 +135,7 @@ function SpaceItem({
   // Gate the open animation on actual child presence (not a loading flag) so the
   // Collapse opens against real content and animates on the first expand.
   const childrenPresent = orderedChildren.length > 0;
+  const orderedChildIds = useMemo(() => orderedChildren.map((child) => child.view_id), [orderedChildren]);
 
   const renderChildren = useMemo(() => {
     // No loading shimmer here: a fixed-height placeholder spikes then collapses
@@ -153,6 +159,9 @@ function SpaceItem({
               reorderChildren
               reorderInstanceId={childDragInstanceId}
               canReorder={canReorderWithinParent(child, view)}
+              pageTreeScopeId={pageTreeScopeId}
+              ancestorIds={childAncestorIds}
+              siblingIds={orderedChildIds}
             />
           ))}
         </div>
@@ -164,6 +173,9 @@ function SpaceItem({
     childrenPresent,
     orderedChildren,
     childDragInstanceId,
+    pageTreeScopeId,
+    childAncestorIds,
+    orderedChildIds,
     view,
     width,
     renderExtra,

--- a/src/components/app/outline/ViewItem.tsx
+++ b/src/components/app/outline/ViewItem.tsx
@@ -4,6 +4,7 @@ import { toast } from 'sonner';
 
 import { View, ViewIconType, ViewLayout } from '@/application/types';
 import {
+  canBeMoved,
   canReorderWithinParent,
   getFirstChildView,
   isDatabaseContainer,
@@ -26,6 +27,9 @@ import { useReorderableSidebarList } from '@/components/app/outline/reorder/useR
 import DropRowLine from '@/components/database/components/drag-and-drop/DropRowLine';
 import { cn } from '@/lib/utils';
 
+const EMPTY_ANCESTOR_IDS: readonly string[] = [];
+const SIDEBAR_INDENT_PER_LEVEL = 16;
+
 function ViewItem({
   view,
   width,
@@ -40,6 +44,9 @@ function ViewItem({
   reorderInstanceId,
   canReorder,
   reorderChildren,
+  pageTreeScopeId,
+  ancestorIds = EMPTY_ANCESTOR_IDS,
+  siblingIds = EMPTY_ANCESTOR_IDS,
 }: {
   view: View;
   width: number;
@@ -62,6 +69,12 @@ function ViewItem({
    * reordered (e.g. the Shared-with-me section).
    */
   reorderChildren?: boolean;
+  /** Shared scope for moving pages between parents in the real sidebar tree. */
+  pageTreeScopeId?: symbol;
+  /** IDs above this view, used to reject drops that would create a cycle. */
+  ancestorIds?: readonly string[];
+  /** Current display order of the sibling list containing this view. */
+  siblingIds?: readonly string[];
 }) {
   const { t } = useTranslation();
   const selectedViewId = useSidebarSelectedViewId();
@@ -82,6 +95,23 @@ function ViewItem({
 
   const rowRef = useRef<HTMLDivElement>(null);
   const workspaceId = useCurrentWorkspaceIdOptional();
+  const childIds = useMemo(() => view.children?.map((child) => child.view_id) ?? [], [view.children]);
+  const treeItem = useMemo(() => {
+    if (!pageTreeScopeId || !parentView) return undefined;
+
+    return {
+      scopeId: pageTreeScopeId,
+      parentId: parentView.view_id,
+      currentLevel: level,
+      indentPerLevel: SIDEBAR_INDENT_PER_LEVEL,
+      canMoveAcrossParents: canBeMoved(view, parentView),
+      canAcceptChildren: view.layout === ViewLayout.Document,
+      canAcceptMovedSiblings: parentView.layout === ViewLayout.Document && !isDatabaseContainer(parentView),
+      ancestorIds,
+      siblingIds,
+      childIds,
+    };
+  }, [ancestorIds, childIds, level, pageTreeScopeId, parentView, siblingIds, view]);
 
   // This row can be dragged to reorder within the group its parent owns.
   const { dragState, shouldSuppressClick } = useReorderableItem({
@@ -90,16 +120,20 @@ function ViewItem({
     dragType: 'sidebar-view',
     instanceId: reorderInstanceId,
     canDrag: Boolean(canReorder),
+    treeItem,
   });
 
   // This view's own children form a reorderable sibling group (database-container
   // views or nested pages), reordered within this view as their parent.
+  const childReorderEnabled =
+    Boolean(reorderChildren) &&
+    (pageTreeScopeId ? (visibleChildren?.length ?? 0) > 0 : (visibleChildren?.length ?? 0) > 1);
   const { orderedItems: orderedChildren, instanceId: childReorderInstanceId } = useReorderableSidebarList({
     items: visibleChildren ?? [],
     parentId: viewId,
     workspaceId,
     dragType: 'sidebar-view',
-    enabled: Boolean(reorderChildren) && (visibleChildren?.length ?? 0) > 1,
+    enabled: childReorderEnabled,
     errorMessage: 'Failed to reorder pages',
   });
 
@@ -168,6 +202,11 @@ function ViewItem({
   // Calculate left padding based on icon presence
   const showLeftIcon = isRefDatabaseView || hasChildren;
   const leftPadding = showLeftIcon ? level * 16 : level * 16 + 24;
+  const dropInstruction =
+    dragState.type === 'over' && dragState.instruction?.type !== 'instruction-blocked'
+      ? dragState.instruction?.type
+      : undefined;
+  const isMakeChildTarget = dropInstruction === 'make-child';
 
   const renderItem = useMemo(() => {
     if (!view) return null;
@@ -193,6 +232,7 @@ function ViewItem({
         ref={rowRef}
         data-testid={`page-${view.view_id}`}
         data-selected={selected}
+        data-drop-instruction={dropInstruction}
         style={{
           backgroundColor: selected ? 'var(--fill-content-hover)' : undefined,
           cursor: 'pointer',
@@ -211,7 +251,8 @@ function ViewItem({
         }}
         className={cn(
           'relative my-[1px] flex min-h-[30px] w-full cursor-pointer select-none items-center gap-1 rounded-[8px] px-0.5 py-0.5 text-sm hover:bg-fill-content-hover focus:outline-none',
-          dragState.type === 'dragging' && 'opacity-40'
+          dragState.type === 'dragging' && 'opacity-40',
+          isMakeChildTarget && 'bg-fill-content-hover ring-1 ring-inset ring-border-theme-thick'
         )}
       >
         {renderLeftIcon()}
@@ -278,6 +319,8 @@ function ViewItem({
     viewId,
     handleChangeIcon,
     dragState.type,
+    dropInstruction,
+    isMakeChildTarget,
     shouldSuppressClick,
   ]);
 
@@ -285,6 +328,8 @@ function ViewItem({
   // Gate the open animation on actual presence (not a loading flag) so the
   // Collapse opens against real content and animates on the first expand.
   const childrenPresent = orderedChildren.length > 0;
+  const childAncestorIds = useMemo(() => [...ancestorIds, viewId], [ancestorIds, viewId]);
+  const orderedChildIds = useMemo(() => orderedChildren.map((child) => child.view_id), [orderedChildren]);
 
   const renderChildren = useMemo(() => {
     if (!aiEnabled && view.layout === ViewLayout.AIChat) return null;
@@ -317,6 +362,9 @@ function ViewItem({
               reorderChildren={reorderChildren}
               reorderInstanceId={childReorderInstanceId}
               canReorder={canReorderWithinParent(child, view)}
+              pageTreeScopeId={pageTreeScopeId}
+              ancestorIds={childAncestorIds}
+              siblingIds={orderedChildIds}
             />
           ))}
         </div>
@@ -335,6 +383,9 @@ function ViewItem({
     orderedChildren,
     reorderChildren,
     childReorderInstanceId,
+    pageTreeScopeId,
+    childAncestorIds,
+    orderedChildIds,
     width,
     loadingViewIds,
     loadedViewIds,

--- a/src/components/app/outline/__tests__/Outline.navigationContext.test.tsx
+++ b/src/components/app/outline/__tests__/Outline.navigationContext.test.tsx
@@ -36,6 +36,7 @@ jest.mock('@/components/app/app.hooks', () => ({
   useLoadViewChildren: () => jest.fn().mockResolvedValue([]),
   useLoadViewChildrenBatch: () => jest.fn().mockResolvedValue([]),
   useMarkViewChildrenStale: () => jest.fn(),
+  useRefreshOutline: () => jest.fn().mockResolvedValue(undefined),
   useRevalidateSidebarOutline: () => undefined,
   useSidebarHighlightedViewIds: () =>
     global.__outlineNavigationTestSelectedViewId ? [global.__outlineNavigationTestSelectedViewId] : [],

--- a/src/components/app/outline/reorder/useSidebarTreeMonitor.ts
+++ b/src/components/app/outline/reorder/useSidebarTreeMonitor.ts
@@ -1,0 +1,100 @@
+import { monitorForElements } from '@atlaskit/pragmatic-drag-and-drop/element/adapter';
+import { extractInstruction } from '@atlaskit/pragmatic-drag-and-drop-hitbox/tree-item';
+import { useEffect, useRef } from 'react';
+import { toast } from 'sonner';
+
+import { PageService, ViewService } from '@/application/services/domains';
+import { extractReorderableTreeItemData, resolveTreeMoveDestination } from '@/components/_shared/reorder/treeItem';
+import { useRefreshOutline } from '@/components/app/app.hooks';
+import { Log } from '@/utils/log';
+
+const SIDEBAR_VIEW_DRAG_TYPE = 'sidebar-view';
+
+/**
+ * Persists the tree-level part of sidebar drag-and-drop exactly once.
+ *
+ * Individual sibling lists retain their existing monitors for optimistic
+ * top/bottom reordering. This root monitor handles only make-child and
+ * cross-parent drops, avoiding one global cross-tree listener per nested list.
+ */
+export function useSidebarTreeMonitor({
+  scopeId,
+  workspaceId,
+}: {
+  scopeId: symbol;
+  workspaceId: string | undefined;
+}): void {
+  const refreshOutline = useRefreshOutline();
+  const refreshOutlineRef = useRef(refreshOutline);
+
+  useEffect(() => {
+    refreshOutlineRef.current = refreshOutline;
+  }, [refreshOutline]);
+
+  useEffect(() => {
+    if (!workspaceId) return;
+
+    return monitorForElements({
+      canMonitor({ source }) {
+        const sourceTreeItem = extractReorderableTreeItemData(source.data);
+
+        return source.data.type === SIDEBAR_VIEW_DRAG_TYPE && sourceTreeItem?.scopeId === scopeId;
+      },
+      onDrop({ location, source }) {
+        const target = location.current.dropTargets[0];
+
+        if (!target) return;
+
+        const sourceId = String(source.data.id ?? '');
+        const targetId = String(target.data.id ?? '');
+        const sourceTreeItem = extractReorderableTreeItemData(source.data);
+        const targetTreeItem = extractReorderableTreeItemData(target.data);
+
+        if (
+          !sourceId ||
+          !targetId ||
+          sourceId === targetId ||
+          sourceTreeItem?.scopeId !== scopeId ||
+          targetTreeItem?.scopeId !== scopeId
+        ) {
+          return;
+        }
+
+        const instruction = extractInstruction(target.data);
+
+        if (!instruction || instruction.type === 'instruction-blocked' || instruction.type === 'reparent') return;
+
+        const destination = resolveTreeMoveDestination({
+          instruction,
+          sourceId,
+          targetId,
+          targetParentId: targetTreeItem.parentId,
+          targetSiblingIds: targetTreeItem.siblingIds,
+          targetChildIds: targetTreeItem.childIds,
+        });
+
+        if (!destination) return;
+
+        // Same-parent edge drops are owned by the list monitor so they retain
+        // its optimistic ordering and cannot be persisted twice.
+        if (instruction.type !== 'make-child' && destination.parentId === sourceTreeItem.parentId) return;
+
+        void (async () => {
+          try {
+            await PageService.moveTo(workspaceId, sourceId, destination.parentId, destination.prevId);
+
+            ViewService.invalidateCache(workspaceId, sourceTreeItem.parentId);
+            if (destination.parentId !== sourceTreeItem.parentId) {
+              ViewService.invalidateCache(workspaceId, destination.parentId);
+            }
+
+            await refreshOutlineRef.current?.();
+          } catch (error) {
+            toast.error('Failed to move page');
+            Log.error('[Sidebar tree] Failed to move page', error);
+          }
+        })();
+      },
+    });
+  }, [scopeId, workspaceId]);
+}


### PR DESCRIPTION
### **Description**

Fixes sidebar page drag-and-drop so a page can be moved under a parent page by dropping it on the center of the parent row.

- Mirrors the desktop top, center, and bottom tree-drop behavior.
- Rejects invalid descendant moves and database-managed page moves while preserving existing sibling reorder behavior.
- Uses one outline-level monitor for cross-parent persistence and refreshes both affected view caches.
- Adds Playwright BDD coverage for the child-drop affordance, persisted parent relationship, and reload behavior.

### **Testing**

- [x] pnpm exec tsc --noEmit --project tsconfig.web.json --pretty false
- [x] Focused ESLint and Prettier checks for changed TypeScript files
- [x] 24 focused Jest unit and regression tests
- [x] 3 Chromium Playwright BDD sidebar drag scenarios

### **Checklist**

#### **General**
- [x] Relevant implementation comments are included.
- [ ] Multiple browser environments were not run; Chromium is covered by the BDD suite.

#### **Testing**
- [x] Tests were added and updated for the change.

#### **Feature-Specific**
- [x] A feature preview is not applicable because this is a bug fix.
- [x] Existing sibling reorder and database behavior were covered by regression tests.

## Summary by Sourcery

Support nesting sidebar pages through center-row drag-and-drop while preserving existing reorder behavior and validating tree moves.

Bug Fixes:
- Enable sidebar pages to be moved into a parent by dropping them on the center of its row.
- Prevent invalid descendant and unsupported database-managed page moves while preserving sibling reordering.

Enhancements:
- Centralize sidebar tree drag handling for cross-parent persistence and refresh affected outline caches.

Tests:
- Add unit coverage for tree move destination resolution and sibling ordering.
- Add Playwright coverage for the child-drop affordance, persistence, and reload behavior.