### PR TITLE
fix: render database row page links as mentions

### DIFF
--- a/.github/workflows/playwright-test.yml
+++ b/.github/workflows/playwright-test.yml
@@ -99,11 +99,12 @@ jobs:
           - name: 'gallery-bdd'
             spec: >-
               playwright/.features-gen/playwright/bdd/features/auth/auth-regressions.feature.spec.js
+              playwright/.features-gen/playwright/bdd/features/editor/database-row-page-mention.feature.spec.js
               playwright/.features-gen/playwright/bdd/features/database/gallery-readonly.feature.spec.js
               playwright/.features-gen/playwright/bdd/features/database/gallery-relation-prefill.feature.spec.js
               playwright/.features-gen/playwright/bdd/features/database/gallery-row-detail-no-stacking.feature.spec.js
             shard: ''
-            description: 'Authentication regressions and migrated Gallery behavior scenarios'
+            description: 'Authentication, database-row mention, and migrated Gallery behavior scenarios'
             bdd: true
           - name: 'space-permissions-bdd'
             spec: >-

--- a/playwright/bdd/features/editor/database-row-page-mention.feature
+++ b/playwright/bdd/features/editor/database-row-page-mention.feature
@@ -1,0 +1,15 @@
+@database-row-page-mention @row-page-lifecycle
+Feature: Paste database row page links as mentions
+
+  Scenario: A row-page link becomes a styled database-row mention
+    Given I am signed in with a new account
+    And I have created a grid page named "Row Mention Grid"
+    When I set the first grid cell to "PRJ-001"
+    And I open the grid row named "PRJ-001" as a full row page
+    And I remember the current database row page link
+    And I have created and opened a document page named "Row Mention Target"
+    And I type "Inside a Project page (example: " in the editor
+    And I paste the remembered database row page link
+    Then the Paste as menu is visible
+    When I choose Mention from the Paste as menu
+    Then the pasted database row mention is styled and labeled "PRJ-001"

--- a/playwright/bdd/steps/database-row-page-mention.steps.ts
+++ b/playwright/bdd/steps/database-row-page-mention.steps.ts
@@ -1,0 +1,116 @@
+import { expect, Page } from '@playwright/test';
+import { createBdd } from 'playwright-bdd';
+
+const { When, Then, Before } = createBdd();
+const modKey = process.platform === 'darwin' ? 'Meta' : 'Control';
+
+type DatabaseRowMentionState = {
+  rowPageUrl: string;
+  rowId: string;
+  databaseViewId: string;
+};
+
+type TestSlateNode = {
+  children?: TestSlateNode[];
+  mention?: {
+    type?: string;
+    page_id?: string;
+    row_id?: string;
+    database_id?: string;
+    database_view_id?: string;
+    database_row_id?: string;
+  };
+};
+
+type TestSlateEditor = {
+  children: TestSlateNode[];
+};
+
+const stateByPage = new WeakMap<Page, DatabaseRowMentionState>();
+
+function requireState(page: Page): DatabaseRowMentionState {
+  const state = stateByPage.get(page);
+
+  if (!state) throw new Error('Database row mention state was not initialized');
+  return state;
+}
+
+Before({ tags: '@database-row-page-mention' }, async ({ page }) => {
+  stateByPage.delete(page);
+});
+
+When('I remember the current database row page link', async ({ page }) => {
+  const rowPageUrl = page.url();
+  const url = new URL(rowPageUrl);
+  const rowId = url.searchParams.get('r');
+  const databaseViewId = url.searchParams.get('v') || url.pathname.split('/').filter(Boolean).at(-1);
+
+  if (!rowId || !databaseViewId) throw new Error(`Expected a database row page URL, got ${rowPageUrl}`);
+  stateByPage.set(page, { rowPageUrl, rowId, databaseViewId });
+});
+
+When('I paste the remembered database row page link', async ({ page }) => {
+  const { rowPageUrl } = requireState(page);
+
+  await page.context().grantPermissions(['clipboard-read', 'clipboard-write']);
+  await page.evaluate(async (url) => navigator.clipboard.writeText(url), rowPageUrl);
+  await page.keyboard.press(`${modKey}+V`);
+});
+
+Then('the Paste as menu is visible', async ({ page }) => {
+  await expect(page.getByTestId('paste-as-panel')).toBeVisible({ timeout: 15000 });
+});
+
+When('I choose Mention from the Paste as menu', async ({ page }) => {
+  await page.getByTestId('paste-as-mention').click({ force: true });
+});
+
+Then('the pasted database row mention is styled and labeled {string}', async ({ page }, title: string) => {
+  const { databaseViewId, rowId, rowPageUrl } = requireState(page);
+  const mention = page.locator(`.mention-inline[data-mention-id="${rowId}"]`);
+
+  await expect(mention).toBeVisible({ timeout: 15000 });
+  await expect(mention.locator('.mention-content')).toHaveText(title, { timeout: 15000 });
+  await expect(mention.locator('.mention-icon svg')).toBeVisible();
+  await expect(mention).toHaveCSS('text-decoration-line', /underline/);
+  await expect(page.locator('[data-slate-editor="true"]').first()).not.toContainText(rowPageUrl);
+
+  const slateMention = await page.evaluate((expectedRowId) => {
+    const testWindow = window as Window & {
+      __TEST_EDITOR__?: TestSlateEditor;
+      __TEST_EDITORS__?: Record<string, TestSlateEditor | undefined>;
+    };
+    const editors = [testWindow.__TEST_EDITOR__, ...Object.values(testWindow.__TEST_EDITORS__ ?? {})].filter(
+      (editor): editor is TestSlateEditor => Boolean(editor)
+    );
+
+    const findMention = (nodes: TestSlateNode[]): TestSlateNode['mention'] | null => {
+      for (const node of nodes) {
+        if (node.mention?.row_id === expectedRowId) return node.mention;
+
+        const nested = node.children ? findMention(node.children) : null;
+
+        if (nested) return nested;
+      }
+
+      return null;
+    };
+
+    for (const editor of editors) {
+      const found = findMention(editor.children);
+
+      if (found) return found;
+    }
+
+    return null;
+  }, rowId);
+
+  expect(slateMention).toMatchObject({
+    type: 'page',
+    page_id: databaseViewId,
+    row_id: rowId,
+    database_view_id: databaseViewId,
+    database_row_id: rowId,
+  });
+  expect(slateMention?.database_id).toBeTruthy();
+});

--- a/src/components/editor/components/leaf/mention/MentionLeaf.tsx
+++ b/src/components/editor/components/leaf/mention/MentionLeaf.tsx
@@ -34,6 +34,10 @@ export function MentionLeaf({ mention, text, children }: { mention: Mention; tex
   const rawDatabaseTitle = mention.data?.title;
   const databaseTitle =
     typeof rawDatabaseTitle === 'string' && rawDatabaseTitle.length > 0 ? rawDatabaseTitle : undefined;
+  const isDatabaseReference =
+    type === MentionType.PageRef &&
+    ((Boolean(databaseRowId) && Boolean(database_id || database_view_id || page_id)) ||
+      (Boolean(database_id) && Boolean(databaseTitle)));
 
   const reminder = useMemo(() => {
     return reminder_id ? { id: reminder_id ?? '', option: reminder_option ?? '' } : undefined;
@@ -43,7 +47,7 @@ export function MentionLeaf({ mention, text, children }: { mention: Mention; tex
     // New database mentions include their selected display title. Keep legacy
     // title-less database references on MentionPage so they can still resolve
     // their label from the outline.
-    if (type === MentionType.PageRef && database_id && (databaseRowId || databaseTitle)) {
+    if (isDatabaseReference) {
       return (
         <MentionDatabase
           databaseId={database_id}
@@ -86,6 +90,7 @@ export function MentionLeaf({ mention, text, children }: { mention: Mention; tex
     databaseRowId,
     row_document_id,
     databaseTitle,
+    isDatabaseReference,
   ]);
 
   // check if the mention is selected

--- a/src/components/editor/components/leaf/mention/__tests__/MentionLeaf.test.tsx
+++ b/src/components/editor/components/leaf/mention/__tests__/MentionLeaf.test.tsx
@@ -2,7 +2,7 @@ import { render, screen } from '@testing-library/react';
 
 import { MentionType } from '@/application/types';
 
-import MentionLeaf from '../MentionLeaf';
+import { MentionLeaf } from '../MentionLeaf';
 
 const mockMentionDatabase = jest.fn(({ title }: { title?: string }) => (
   <span data-testid='mention-database'>{title}</span>
@@ -74,5 +74,24 @@ describe('MentionLeaf database references', () => {
 
     expect(screen.getByTestId('mention-page')).toBeTruthy();
     expect(screen.queryByTestId('mention-database')).toBeNull();
+  });
+
+  it('renders a desktop-authored database row reference without a database id', () => {
+    render(
+      <MentionLeaf
+        mention={{
+          type: MentionType.PageRef,
+          page_id: 'database-view-id',
+          row_id: 'row-id',
+          data: { title: 'PRJ-001' },
+        }}
+        text={{ text: '' }}
+      >
+        {' '}
+      </MentionLeaf>
+    );
+
+    expect(screen.getByTestId('mention-database').textContent).toBe('PRJ-001');
+    expect(screen.queryByTestId('mention-page')).toBeNull();
   });
 });

--- a/src/components/editor/components/panels/paste-as-panel/PasteAsPanel.tsx
+++ b/src/components/editor/components/panels/paste-as-panel/PasteAsPanel.tsx
@@ -14,6 +14,7 @@ import {
   BlockType,
   LinkPreviewBlockData,
   LinkPreviewType,
+  Mention,
   MentionType,
   VideoBlockData,
   VideoType,
@@ -25,10 +26,13 @@ import { ReactComponent as VideoIcon } from '@/assets/icons/video.svg';
 import { calculateOptimalOrigins, Popover } from '@/components/_shared/popover';
 import { usePanelContext } from '@/components/editor/components/panels/Panels.hooks';
 import { PanelType } from '@/components/editor/components/panels/PanelsContext';
-import { processUrl } from '@/utils/url';
+import { useEditorContext } from '@/components/editor/EditorContext';
+import { parseAppFlowyPageLink, processUrl } from '@/utils/url';
 import { isValidVideoUrl, videoTypeData } from '@/utils/video-url';
 
 import { PasteAsMenuType } from './constants';
+import { resolveDatabaseRowPageMention } from './databaseRowMention';
+
 import type { PasteAsMenuPayload } from './constants';
 
 const PASTE_AS_PANEL_WIDTH = 260;
@@ -60,10 +64,13 @@ function isValidPasteRange(editor: YjsEditor, payload: PasteAsMenuPayload) {
 export function PasteAsPanel() {
   const { closePanel, getPasteAsPayload, isPanelOpen, panelPosition } = usePanelContext();
   const editor = useSlateStatic() as YjsEditor;
+  const { loadView, workspaceId } = useEditorContext();
   const { t } = useTranslation();
   const open = isPanelOpen(PanelType.PasteAs);
   const [selectedType, setSelectedType] = useState<PasteAsMenuType>(PasteAsMenuType.Mention);
   const selectedTypeRef = useRef<PasteAsMenuType>(PasteAsMenuType.Mention);
+  const pasteOperationRef = useRef(0);
+  const mountedRef = useRef(true);
   const [transformOrigin, setTransformOrigin] = useState<PopoverOrigin | undefined>(undefined);
 
   const turnIntoBlock = useCallback(
@@ -109,7 +116,8 @@ export function PasteAsPanel() {
   );
 
   const handleSelect = useCallback(
-    (type: PasteAsMenuType) => {
+    async (type: PasteAsMenuType) => {
+      const operationId = ++pasteOperationRef.current;
       const payload = getPasteAsPayload();
 
       closePanel();
@@ -123,23 +131,46 @@ export function PasteAsPanel() {
 
       const url = processUrl(payload.url) || payload.url;
 
-      Transforms.delete(editor);
-
       if (type === PasteAsMenuType.Mention) {
+        let mention: Mention = {
+          type: MentionType.externalLink,
+          url,
+        };
+        const appFlowyLink = parseAppFlowyPageLink(url, window.location.hostname);
+
+        if (
+          loadView &&
+          appFlowyLink?.rowId &&
+          appFlowyLink.workspaceId.toLowerCase() === workspaceId.toLowerCase()
+        ) {
+          try {
+            mention = (await resolveDatabaseRowPageMention(workspaceId, appFlowyLink, loadView)) ?? mention;
+          } catch {
+            // Preserve the existing external-link mention fallback when the
+            // database or row cannot be resolved with the current permission.
+          }
+        }
+
+        if (!mountedRef.current || operationId !== pasteOperationRef.current) return;
+
+        // Resolution is asynchronous. Confirm the original pasted URL still
+        // occupies the tracked range before replacing any user content.
+        if (!selectPasteRange(payload)) return;
+
+        Transforms.delete(editor);
         Transforms.insertNodes(
           editor,
           {
             text: '@',
-            mention: {
-              type: MentionType.externalLink,
-              url,
-            },
+            mention,
           },
           { select: true, voids: false }
         );
         Transforms.collapse(editor, { edge: 'end' });
         return;
       }
+
+      Transforms.delete(editor);
 
       if (type === PasteAsMenuType.Embed && isValidVideoUrl(url)) {
         turnIntoBlock(BlockType.VideoBlock, {
@@ -155,7 +186,7 @@ export function PasteAsPanel() {
         preview_type: type === PasteAsMenuType.Embed ? LinkPreviewType.Embed : LinkPreviewType.Bookmark,
       } as LinkPreviewBlockData);
     },
-    [closePanel, editor, getPasteAsPayload, selectPasteRange, turnIntoBlock]
+    [closePanel, editor, getPasteAsPayload, loadView, selectPasteRange, turnIntoBlock, workspaceId]
   );
 
   const options = useMemo(
@@ -189,7 +220,19 @@ export function PasteAsPanel() {
   }, [selectedType]);
 
   useEffect(() => {
+    mountedRef.current = true;
+
+    return () => {
+      mountedRef.current = false;
+      pasteOperationRef.current += 1;
+    };
+  }, []);
+
+  useEffect(() => {
     if (open) {
+      // Reopening the panel means a newer URL was pasted. Invalidate any row
+      // lookup still running for the previous paste operation.
+      pasteOperationRef.current += 1;
       setSelectedType(PasteAsMenuType.Mention);
     }
   }, [open]);
@@ -218,7 +261,7 @@ export function PasteAsPanel() {
         case 'Enter':
           e.preventDefault();
           e.stopPropagation();
-          handleSelect(selectedTypeRef.current);
+          void handleSelect(selectedTypeRef.current);
           break;
         case 'ArrowUp':
         case 'ArrowDown': {
@@ -270,7 +313,7 @@ export function PasteAsPanel() {
             color={'inherit'}
             data-testid={`paste-as-${option.type}`}
             key={option.type}
-            onClick={() => handleSelect(option.type)}
+            onClick={() => void handleSelect(option.type)}
             onMouseEnter={() => setSelectedType(option.type)}
             size={'small'}
             startIcon={option.icon}

--- a/src/components/editor/components/panels/paste-as-panel/__tests__/PasteAsPanel.test.tsx
+++ b/src/components/editor/components/panels/paste-as-panel/__tests__/PasteAsPanel.test.tsx
@@ -1,0 +1,148 @@
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { createEditor, Transforms } from 'slate';
+
+import { YjsEditor } from '@/application/slate-yjs';
+import { BlockType, Mention, MentionType } from '@/application/types';
+
+import { PasteAsMenuType } from '../constants';
+import { PasteAsPanel } from '../PasteAsPanel';
+
+const workspaceId = '3df0c6bb-417f-4f81-939a-c6114f160f9a';
+const databaseViewId = 'b709de16-f480-43cb-a175-03b1808449cf';
+const rowId = '439bd5d7-6b22-4117-8465-539dcc6c55d9';
+const rowPageUrl = `http://localhost/app/${workspaceId}/${databaseViewId}?r=${rowId}`;
+
+let mockEditor: YjsEditor;
+const mockClosePanel = jest.fn();
+const mockFocus = jest.fn();
+const mockGetPasteAsPayload = jest.fn();
+const mockLoadView = jest.fn();
+const mockResolveDatabaseRowPageMention = jest.fn();
+const mockSlateDom = document.createElement('div');
+const mockPanelPosition = { left: 0, top: 0 };
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (_key: string, options?: { defaultValue?: string }) => options?.defaultValue ?? '',
+  }),
+}));
+
+jest.mock('slate-react', () => ({
+  ReactEditor: {
+    focus: (...args: unknown[]) => mockFocus(...args),
+    toDOMNode: () => mockSlateDom,
+  },
+  useSlateStatic: () => mockEditor,
+}));
+
+jest.mock('@mui/material', () => ({
+  Button: ({
+    children,
+    onClick,
+    onMouseEnter,
+    'data-testid': testId,
+  }: {
+    children: React.ReactNode;
+    onClick?: () => void;
+    onMouseEnter?: () => void;
+    'data-testid'?: string;
+  }) => (
+    <button data-testid={testId} onClick={onClick} onMouseEnter={onMouseEnter}>
+      {children}
+    </button>
+  ),
+}));
+
+jest.mock('@/components/_shared/popover', () => ({
+  calculateOptimalOrigins: () => ({ transformOrigin: { horizontal: 'left', vertical: 'top' } }),
+  Popover: ({ children, open }: { children: React.ReactNode; open: boolean }) =>
+    open ? <div>{children}</div> : null,
+}));
+
+jest.mock('@/components/editor/EditorContext', () => ({
+  useEditorContext: () => ({
+    loadView: mockLoadView,
+    workspaceId,
+  }),
+}));
+
+jest.mock('@/components/editor/components/panels/Panels.hooks', () => ({
+  usePanelContext: () => ({
+    closePanel: mockClosePanel,
+    getPasteAsPayload: mockGetPasteAsPayload,
+    isPanelOpen: () => true,
+    panelPosition: mockPanelPosition,
+  }),
+}));
+
+jest.mock('../databaseRowMention', () => ({
+  resolveDatabaseRowPageMention: (...args: unknown[]) => mockResolveDatabaseRowPageMention(...args),
+}));
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((promiseResolve) => {
+    resolve = promiseResolve;
+  });
+
+  return { promise, resolve };
+}
+
+describe('PasteAsPanel async mention resolution', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockEditor = createEditor() as YjsEditor;
+    mockEditor.children = [
+      {
+        type: BlockType.Paragraph,
+        blockId: 'paragraph-1',
+        children: [{ text: rowPageUrl, href: rowPageUrl }],
+      },
+    ];
+
+    const range = {
+      anchor: { path: [0, 0], offset: 0 },
+      focus: { path: [0, 0], offset: rowPageUrl.length },
+    };
+
+    mockEditor.selection = range;
+    mockGetPasteAsPayload.mockReturnValue({ range, url: rowPageUrl });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('does not mutate or refocus a detached editor after row resolution completes', async () => {
+    const resolution = deferred<Mention | null>();
+    const deleteSpy = jest.spyOn(Transforms, 'delete');
+    const insertNodesSpy = jest.spyOn(Transforms, 'insertNodes');
+
+    mockResolveDatabaseRowPageMention.mockReturnValue(resolution.promise);
+
+    const { unmount } = render(<PasteAsPanel />);
+
+    fireEvent.click(screen.getByTestId(`paste-as-${PasteAsMenuType.Mention}`));
+
+    expect(mockResolveDatabaseRowPageMention).toHaveBeenCalledTimes(1);
+    expect(mockClosePanel).toHaveBeenCalledTimes(1);
+    expect(mockFocus).toHaveBeenCalledTimes(1);
+
+    unmount();
+
+    await act(async () => {
+      resolution.resolve({
+        type: MentionType.PageRef,
+        page_id: databaseViewId,
+        row_id: rowId,
+        data: { title: 'PRJ-001' },
+      });
+      await resolution.promise;
+    });
+
+    expect(mockFocus).toHaveBeenCalledTimes(1);
+    expect(deleteSpy).not.toHaveBeenCalled();
+    expect(insertNodesSpy).not.toHaveBeenCalled();
+    expect(mockEditor.string([])).toBe(rowPageUrl);
+  });
+});

--- a/src/components/editor/components/panels/paste-as-panel/__tests__/databaseRowMention.test.ts
+++ b/src/components/editor/components/panels/paste-as-panel/__tests__/databaseRowMention.test.ts
@@ -1,0 +1,159 @@
+import * as Y from 'yjs';
+
+import { FieldType } from '@/application/database-yjs/database.type';
+import { initialDatabaseRow } from '@/application/database-yjs/row';
+import { rowDocumentIdFromRowId } from '@/application/row-document/lifecycle';
+import {
+  MentionType,
+  YDatabase,
+  YDatabaseCell,
+  YDatabaseField,
+  YDatabaseFields,
+  YDatabaseRow,
+  YDoc,
+  YjsDatabaseKey,
+  YjsEditorKey,
+} from '@/application/types';
+
+import {
+  DatabaseRowMentionResolverDependencies,
+  resolveDatabaseRowPageMention,
+} from '../databaseRowMention';
+
+const workspaceId = '3df0c6bb-417f-4f81-939a-c6114f160f9a';
+const databaseId = '1cd808b6-7f36-45e5-b520-42ebd6f620f4';
+const databaseViewId = 'b709de16-f480-43cb-a175-03b1808449cf';
+const rowId = '439bd5d7-6b22-4117-8465-539dcc6c55d9';
+
+function createDatabaseDoc(): YDoc {
+  const doc = new Y.Doc({ guid: databaseId }) as YDoc;
+  const database = new Y.Map() as YDatabase;
+  const fields = new Y.Map() as YDatabaseFields;
+  const primaryField = new Y.Map() as YDatabaseField;
+  const views = new Y.Map();
+  const inlineView = new Y.Map();
+  const rowOrders = new Y.Array<{ id: string; is_deleted?: boolean }>();
+  const metas = new Y.Map();
+
+  primaryField.set(YjsDatabaseKey.id, 'primary-field');
+  primaryField.set(YjsDatabaseKey.name, 'Name');
+  primaryField.set(YjsDatabaseKey.type, FieldType.RichText);
+  primaryField.set(YjsDatabaseKey.is_primary, true);
+  fields.set('primary-field', primaryField);
+  rowOrders.push([{ id: rowId }]);
+  inlineView.set(YjsDatabaseKey.is_inline, true);
+  inlineView.set(YjsDatabaseKey.row_orders, rowOrders);
+  views.set(databaseViewId, inlineView);
+  metas.set(YjsDatabaseKey.iid, databaseViewId);
+  database.set(YjsDatabaseKey.id, databaseId);
+  database.set(YjsDatabaseKey.fields, fields);
+  database.set(YjsDatabaseKey.views, views);
+  database.set(YjsDatabaseKey.metas, metas);
+  doc.getMap(YjsEditorKey.data_section).set(YjsEditorKey.database, database);
+  return doc;
+}
+
+function createRowDoc(title: string): YDoc {
+  const doc = new Y.Doc({ guid: rowId }) as YDoc;
+
+  initialDatabaseRow(rowId, databaseId, doc);
+  const row = doc.getMap(YjsEditorKey.data_section).get(YjsEditorKey.database_row) as YDatabaseRow;
+  const cell = new Y.Map() as YDatabaseCell;
+
+  cell.set(YjsDatabaseKey.field_type, FieldType.RichText);
+  cell.set(YjsDatabaseKey.data, title);
+  row.get(YjsDatabaseKey.cells).set('primary-field', cell);
+  return doc;
+}
+
+function resolverDependencies(rowDoc: YDoc): DatabaseRowMentionResolverDependencies {
+  return {
+    getDatabaseId: jest.fn(async () => databaseId),
+    getCachedRow: jest.fn(() => rowDoc),
+    getRowCollab: jest.fn(async () => ({ data: new Uint8Array() })),
+    createRowDoc: jest.fn(() => new Y.Doc() as YDoc),
+    applyRowUpdate: jest.fn(),
+  };
+}
+
+describe('resolveDatabaseRowPageMention', () => {
+  it('builds a titled database-row PageRef from the cached row', async () => {
+    const databaseDoc = createDatabaseDoc();
+    const rowDoc = createRowDoc('PRJ-001');
+    const dependencies = resolverDependencies(rowDoc);
+    const loadView = jest.fn(async () => databaseDoc);
+
+    await expect(
+      resolveDatabaseRowPageMention(
+        workspaceId,
+        { workspaceId, viewId: databaseViewId, rowId },
+        loadView,
+        dependencies
+      )
+    ).resolves.toEqual({
+      type: MentionType.PageRef,
+      page_id: databaseViewId,
+      block_id: rowId,
+      row_id: rowId,
+      database_id: databaseId,
+      database_view_id: databaseViewId,
+      database_row_id: rowId,
+      row_document_id: rowDocumentIdFromRowId(rowId),
+      data: { title: 'PRJ-001' },
+    });
+
+    expect(loadView).toHaveBeenCalledWith(databaseViewId, false, false, {
+      databaseId,
+      databaseMetadataOnly: true,
+    });
+    expect(dependencies.getRowCollab).not.toHaveBeenCalled();
+  });
+
+  it('fetches only the target row when it is not cached', async () => {
+    const databaseDoc = createDatabaseDoc();
+    const sourceRowDoc = createRowDoc('PRJ-002');
+    const dependencies = resolverDependencies(sourceRowDoc);
+
+    dependencies.getCachedRow = jest.fn(() => undefined);
+    dependencies.getRowCollab = jest.fn(async () => ({ data: Y.encodeStateAsUpdate(sourceRowDoc) }));
+    dependencies.createRowDoc = jest.fn(() => new Y.Doc({ guid: rowId }) as YDoc);
+    dependencies.applyRowUpdate = jest.fn((doc, update) => Y.applyUpdate(doc, update));
+
+    await expect(
+      resolveDatabaseRowPageMention(
+        workspaceId,
+        { workspaceId, viewId: databaseViewId, rowId },
+        async () => databaseDoc,
+        dependencies
+      )
+    ).resolves.toMatchObject({
+      type: MentionType.PageRef,
+      row_id: rowId,
+      data: { title: 'PRJ-002' },
+    });
+
+    expect(dependencies.getRowCollab).toHaveBeenCalledWith(workspaceId, rowId);
+  });
+
+  it('rejects a cached row that belongs to another database', async () => {
+    const databaseDoc = createDatabaseDoc();
+    const wrongRowDoc = createRowDoc('Wrong database');
+    const wrongRow = wrongRowDoc
+      .getMap(YjsEditorKey.data_section)
+      .get(YjsEditorKey.database_row) as YDatabaseRow;
+
+    wrongRow.set(YjsDatabaseKey.database_id, 'another-database');
+    const dependencies = resolverDependencies(wrongRowDoc);
+
+    dependencies.getRowCollab = jest.fn(async () => ({ data: new Uint8Array() }));
+
+    await expect(
+      resolveDatabaseRowPageMention(
+        workspaceId,
+        { workspaceId, viewId: databaseViewId, rowId },
+        async () => databaseDoc,
+        dependencies
+      )
+    ).resolves.toBeNull();
+  });
+});

--- a/src/components/editor/components/panels/paste-as-panel/databaseRowMention.ts
+++ b/src/components/editor/components/panels/paste-as-panel/databaseRowMention.ts
@@ -1,0 +1,133 @@
+import * as Y from 'yjs';
+
+import { waitForDatabaseHydration } from '@/application/database-yjs/database.hydration';
+import { decodeCellToText } from '@/application/database-yjs/decode';
+import { getInlineViewRowOrders } from '@/application/database-yjs/row-order-visibility';
+import { getRowKey } from '@/application/database-yjs/row_meta';
+import { getPrimaryFieldId } from '@/application/database-yjs/selector';
+import { rowDocumentIdFromRowId } from '@/application/row-document/lifecycle';
+import { CollabService } from '@/application/services/domains';
+import { getCachedRowDoc } from '@/application/services/js-services/cache';
+import { getDatabaseIdFromWorkspaceCatalog } from '@/application/services/js-services/workspace-database-catalog';
+import {
+  LoadView,
+  Mention,
+  MentionType,
+  Types,
+  YDatabaseRow,
+  YDoc,
+  YjsDatabaseKey,
+  YjsEditorKey,
+} from '@/application/types';
+import { applyYDoc } from '@/application/ydoc/apply';
+import { AppFlowyPageLink } from '@/utils/url';
+
+export interface DatabaseRowMentionResolverDependencies {
+  getDatabaseId: (workspaceId: string, viewId: string) => Promise<string | null>;
+  getCachedRow: (rowKey: string) => YDoc | undefined;
+  getRowCollab: (workspaceId: string, rowId: string) => Promise<{ data: Uint8Array }>;
+  createRowDoc: (rowId: string) => YDoc;
+  applyRowUpdate: (doc: YDoc, update: Uint8Array) => void;
+}
+
+const defaultDependencies: DatabaseRowMentionResolverDependencies = {
+  getDatabaseId: getDatabaseIdFromWorkspaceCatalog,
+  getCachedRow: getCachedRowDoc,
+  getRowCollab: (workspaceId, rowId) => CollabService.get(workspaceId, rowId, Types.DatabaseRow),
+  createRowDoc: (rowId) => new Y.Doc({ guid: rowId }) as YDoc,
+  applyRowUpdate: applyYDoc,
+};
+
+function getValidatedRow(rowDoc: YDoc, rowId: string, databaseId: string): YDatabaseRow | null {
+  const row = rowDoc.getMap(YjsEditorKey.data_section).get(YjsEditorKey.database_row) as YDatabaseRow | undefined;
+
+  if (!row) return null;
+  if (row.get(YjsDatabaseKey.id) !== rowId) return null;
+  if (row.get(YjsDatabaseKey.database_id) !== databaseId) return null;
+
+  return row;
+}
+
+async function resolveDatabaseTarget(
+  workspaceId: string,
+  link: AppFlowyPageLink,
+  getDatabaseId: DatabaseRowMentionResolverDependencies['getDatabaseId']
+) {
+  const routeDatabaseId = await getDatabaseId(workspaceId, link.viewId);
+
+  if (!routeDatabaseId) return null;
+  if (!link.databaseViewId) return { databaseId: routeDatabaseId, databaseViewId: link.viewId };
+
+  const selectedDatabaseId = await getDatabaseId(workspaceId, link.databaseViewId);
+
+  if (!selectedDatabaseId || selectedDatabaseId !== routeDatabaseId) return null;
+
+  return { databaseId: selectedDatabaseId, databaseViewId: link.databaseViewId };
+}
+
+export async function resolveDatabaseRowPageMention(
+  workspaceId: string,
+  link: AppFlowyPageLink,
+  loadView: LoadView,
+  dependencies: DatabaseRowMentionResolverDependencies = defaultDependencies
+): Promise<Mention | null> {
+  if (!link.rowId) return null;
+
+  const target = await resolveDatabaseTarget(workspaceId, link, dependencies.getDatabaseId);
+
+  if (!target) return null;
+
+  const rowKey = getRowKey(target.databaseId, link.rowId);
+  const cachedRowDoc = dependencies.getCachedRow(rowKey);
+  let row = cachedRowDoc ? getValidatedRow(cachedRowDoc, link.rowId, target.databaseId) : null;
+  const databasePromise = loadView(target.databaseViewId, false, false, {
+    databaseId: target.databaseId,
+    databaseMetadataOnly: true,
+  }).then(waitForDatabaseHydration);
+  const rowUpdatePromise = row
+    ? Promise.resolve<Uint8Array | null>(null)
+    : dependencies.getRowCollab(workspaceId, link.rowId).then(({ data }) => data);
+  const [database, rowUpdate] = await Promise.all([databasePromise, rowUpdatePromise]);
+
+  if (!database || database.get(YjsDatabaseKey.id) !== target.databaseId) return null;
+
+  const rowOrder = getInlineViewRowOrders(database)
+    ?.toArray()
+    .find(({ id }) => id === link.rowId);
+
+  if (!rowOrder || rowOrder.is_deleted) return null;
+
+  const primaryFieldId = getPrimaryFieldId(database);
+  const primaryField = primaryFieldId ? database.get(YjsDatabaseKey.fields).get(primaryFieldId) : undefined;
+
+  if (!primaryFieldId || !primaryField) return null;
+
+  let transientRowDoc: YDoc | undefined;
+
+  try {
+    if (!row && rowUpdate) {
+      transientRowDoc = dependencies.createRowDoc(link.rowId);
+      dependencies.applyRowUpdate(transientRowDoc, rowUpdate);
+      row = getValidatedRow(transientRowDoc, link.rowId, target.databaseId);
+    }
+
+    if (!row) return null;
+
+    const cell = row.get(YjsDatabaseKey.cells).get(primaryFieldId);
+    const title = cell ? decodeCellToText(cell, primaryField).trim() : '';
+
+    return {
+      type: MentionType.PageRef,
+      page_id: target.databaseViewId,
+      block_id: link.rowId,
+      row_id: link.rowId,
+      database_id: target.databaseId,
+      database_view_id: target.databaseViewId,
+      database_row_id: link.rowId,
+      row_document_id: rowDocumentIdFromRowId(link.rowId),
+      data: { title: title || 'Untitled' },
+    };
+  } finally {
+    transientRowDoc?.destroy();
+  }
+}

--- a/src/components/editor/plugins/__tests__/withPasted.test.ts
+++ b/src/components/editor/plugins/__tests__/withPasted.test.ts
@@ -3,6 +3,7 @@ import { ReactEditor, withReact } from 'slate-react';
 
 import { BlockType, MentionType } from '@/application/types';
 import { withPasted } from '@/components/editor/plugins/withPasted';
+import { PASTE_AS_MENU_EVENT } from '@/components/editor/components/panels/paste-as-panel/constants';
 
 jest.mock('@/components/editor/parsers/html-parser', () => ({
   parseHTML: jest.fn(),
@@ -20,6 +21,7 @@ jest.mock('@/application/slate-yjs/utils/editor', () => ({
 const workspaceId = '3df0c6bb-417f-4f81-939a-c6114f160f9a';
 const otherWorkspaceId = '8a412c3f-2b6d-49e0-9c11-52c1d86ffb01';
 const databaseViewId = '5d62b705-fee1-43c5-bd20-75a40aef254d';
+const databaseRowId = '439bd5d7-6b22-4117-8465-539dcc6c55d9';
 const currentDocumentViewId = '0f1a2b3c-4d5e-4f60-8172-93a4b5c6d7e8';
 
 function createPasteData(text: string): DataTransfer {
@@ -41,6 +43,24 @@ function createEditorWithEmptyParagraph(): ReactEditor {
   editor.selection = {
     anchor: { path: [0, 0], offset: 0 },
     focus: { path: [0, 0], offset: 0 },
+  };
+
+  return editor;
+}
+
+function createEditorWithParagraph(text: string): ReactEditor {
+  const editor = createEditorWithEmptyParagraph();
+
+  editor.children = [
+    {
+      type: BlockType.Paragraph,
+      blockId: 'paragraph-1',
+      children: [{ text }],
+    } as Element,
+  ];
+  editor.selection = {
+    anchor: { path: [0, 0], offset: text.length },
+    focus: { path: [0, 0], offset: text.length },
   };
 
   return editor;
@@ -73,7 +93,7 @@ describe('withPasted', () => {
 
   it('keeps a row deep link as a plain link so the row target is not dropped', () => {
     const editor = createEditorWithEmptyParagraph();
-    const url = `http://localhost:3000/app/${workspaceId}/${databaseViewId}?r=row-1`;
+    const url = `http://localhost:3000/app/${workspaceId}/${databaseViewId}?r=${databaseRowId}`;
 
     const handled = editor.insertTextData(createPasteData(url));
 
@@ -82,6 +102,29 @@ describe('withPasted', () => {
 
     expect(leaves.some((leaf) => 'mention' in leaf)).toBe(false);
     expect(leaves).toContainEqual({ text: url, href: url });
+  });
+
+  it('keeps the Paste as range attached to a URL inserted after existing text', () => {
+    jest.useFakeTimers();
+    const editor = createEditorWithParagraph('Inside a Project page (example: ');
+    const url = `http://localhost:3000/app/${workspaceId}/${databaseViewId}?r=${databaseRowId}`;
+    const dispatchEvent = jest.fn();
+    const toDOMNode = jest.spyOn(ReactEditor, 'toDOMNode').mockReturnValue({ dispatchEvent } as unknown as HTMLElement);
+
+    try {
+      editor.insertTextData(createPasteData(url));
+      jest.runOnlyPendingTimers();
+
+      const event = dispatchEvent.mock.calls
+        .map(([value]) => value as CustomEvent)
+        .find((value) => value.type === PASTE_AS_MENU_EVENT);
+
+      expect(event).toBeDefined();
+      expect(editor.string(event?.detail.range)).toBe(url);
+    } finally {
+      toDOMNode.mockRestore();
+      jest.useRealTimers();
+    }
   });
 
   it('keeps a link into another workspace as a plain link instead of an unresolvable mention', () => {

--- a/src/components/editor/plugins/withPasted.ts
+++ b/src/components/editor/plugins/withPasted.ts
@@ -2,8 +2,8 @@ import { BasePoint, Editor, Element, Range, Text, Transforms } from 'slate';
 import { ReactEditor } from 'slate-react';
 
 import { YjsEditor } from '@/application/slate-yjs';
-import { EditorMarkFormat } from '@/application/slate-yjs/types';
 import { SOFT_BREAK_TYPES } from '@/application/slate-yjs/command/const';
+import { EditorMarkFormat } from '@/application/slate-yjs/types';
 import { slateContentInsertToYData } from '@/application/slate-yjs/utils/convert';
 import {
   getBlockEntry,
@@ -13,14 +13,14 @@ import {
 } from '@/application/slate-yjs/utils/editor';
 import { assertDocExists, getBlock, getChildrenArray, getText } from '@/application/slate-yjs/utils/yjs';
 import { BlockType, MentionType, YjsEditorKey } from '@/application/types';
+import { PASTE_AS_MENU_EVENT } from '@/components/editor/components/panels/paste-as-panel/constants';
+import type { PasteAsMenuPayload } from '@/components/editor/components/panels/paste-as-panel/constants';
+import { getRangeRect } from '@/components/editor/components/toolbar/selection-toolbar/utils';
 import { parseHTML } from '@/components/editor/parsers/html-parser';
 import { parseMarkdown } from '@/components/editor/parsers/markdown-parser';
 import { parsePlainTextFragments } from '@/components/editor/parsers/paste-fragment-detectors';
 import { parseTSVTable } from '@/components/editor/parsers/table-parser';
 import { ParsedBlock } from '@/components/editor/parsers/types';
-import { PASTE_AS_MENU_EVENT } from '@/components/editor/components/panels/paste-as-panel/constants';
-import type { PasteAsMenuPayload } from '@/components/editor/components/panels/paste-as-panel/constants';
-import { getRangeRect } from '@/components/editor/components/toolbar/selection-toolbar/utils';
 import { insertBlocksAtCaret } from '@/components/editor/utils/insert-blocks-at-caret';
 import { detectMarkdown, detectTSV } from '@/components/editor/utils/markdown-detector';
 import { isSingleURLText, parseAppFlowyPageLink, processUrl, workspaceIdFromAppPathname } from '@/utils/url';
@@ -392,9 +392,10 @@ function handleMarkdownPaste(editor: ReactEditor, markdown: string): boolean {
  * Page links into the current workspace are inserted as page-reference
  * mentions so they retain the exact view identity and follow live metadata
  * updates. Every other URL — external sites, other workspaces (whose views a
- * mention could not resolve here), or links carrying row/tab targets — is
- * pasted as an inline link and the "Paste as" menu (Mention / URL / Bookmark /
- * Embed) is shown so the user can choose how to render it.
+ * mention could not resolve here), or database-row links that need their row
+ * title resolved — is pasted as an inline link and the "Paste as" menu
+ * (Mention / URL / Bookmark / Embed) is shown so the user can choose how to
+ * render it.
  */
 function handleURLPaste(editor: ReactEditor, url: string): boolean {
   const appFlowyPageLink = parseAppFlowyPageLink(url, window.location.hostname);
@@ -402,6 +403,7 @@ function handleURLPaste(editor: ReactEditor, url: string): boolean {
 
   if (
     appFlowyPageLink &&
+    !appFlowyPageLink.rowId &&
     currentWorkspaceId &&
     appFlowyPageLink.workspaceId.toLowerCase() === currentWorkspaceId.toLowerCase()
   ) {
@@ -516,11 +518,21 @@ function insertLinkedURLTextAndShowPasteAsMenu(editor: ReactEditor, url: string)
   const insertedRange = getInsertedURLRange(editor, url, point);
 
   if (insertedRange) {
+    // Adding the href mark splits a URL pasted after existing text into a new
+    // Slate leaf. Track the range through that split so Paste as actions still
+    // target the URL instead of silently failing validation against a stale
+    // path.
+    const insertedRangeRef = Editor.rangeRef(editor, insertedRange, { affinity: 'inward' });
+
     Transforms.select(editor, insertedRange);
     editor.addMark(EditorMarkFormat.Href, href);
-    Transforms.select(editor, insertedRange);
-    Transforms.collapse(editor, { edge: 'end' });
-    dispatchPasteAsMenuEvent(editor, { url, range: insertedRange });
+    const linkedRange = insertedRangeRef.unref();
+
+    if (linkedRange) {
+      Transforms.select(editor, linkedRange);
+      Transforms.collapse(editor, { edge: 'end' });
+      dispatchPasteAsMenuEvent(editor, { url, range: linkedRange });
+    }
   }
 
   return true;

--- a/src/utils/__tests__/url.test.ts
+++ b/src/utils/__tests__/url.test.ts
@@ -2,6 +2,8 @@ import { parseAppFlowyPageLink, workspaceIdFromAppPathname } from '@/utils/url';
 
 const workspaceId = '3df0c6bb-417f-4f81-939a-c6114f160f9a';
 const viewId = '5d62b705-fee1-43c5-bd20-75a40aef254d';
+const rowId = '439bd5d7-6b22-4117-8465-539dcc6c55d9';
+const databaseViewId = 'b709de16-f480-43cb-a175-03b1808449cf';
 
 describe('parseAppFlowyPageLink', () => {
   it('resolves a database page on the current AppFlowy host', () => {
@@ -30,10 +32,18 @@ describe('parseAppFlowyPageLink', () => {
     ).toBeUndefined();
   });
 
-  it('rejects a link with a row target that a page mention cannot represent', () => {
+  it('preserves a database row target for a row-page mention', () => {
     expect(
-      parseAppFlowyPageLink(`http://localhost:3000/app/${workspaceId}/${viewId}?r=row-1`, 'localhost')
-    ).toBeUndefined();
+      parseAppFlowyPageLink(
+        `http://localhost:3000/app/${workspaceId}/${viewId}?v=${databaseViewId}&r=${rowId}`,
+        'localhost'
+      )
+    ).toEqual({
+      workspaceId,
+      viewId,
+      databaseViewId,
+      rowId,
+    });
   });
 
   it('rejects a link with a database tab selection that a page mention cannot represent', () => {

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -25,6 +25,7 @@ export function isSingleURLText(input: string) {
 }
 
 const UUID_PATTERN = '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}';
+const UUID_VALUE = new RegExp(`^${UUID_PATTERN}$`, 'i');
 const APPFLOWY_PAGE_PATH = new RegExp(`^/app/(${UUID_PATTERN})/(${UUID_PATTERN})/?$`, 'i');
 const APPFLOWY_WORKSPACE_PATH = new RegExp(`^/app/(${UUID_PATTERN})(?:/|$)`, 'i');
 
@@ -32,6 +33,8 @@ export interface AppFlowyPageLink {
   workspaceId: string;
   viewId: string;
   blockId?: string;
+  rowId?: string;
+  databaseViewId?: string;
 }
 
 /** Workspace id segment of an /app route pathname, if present. */
@@ -46,9 +49,10 @@ export function workspaceIdFromAppPathname(pathname: string): string | undefined
  * live folder metadata (including database tab renames) instead of freezing
  * the database container's HTML title into an external-link preview.
  *
- * Only URLs a page mention can fully represent qualify: query params other
- * than blockId (e.g. `r` row targets, `v` database tab selection) carry
- * targeting a mention would silently drop, so those URLs stay plain links.
+ * Database-row routes keep their row and selected database-view targets so
+ * Paste as → Mention can resolve the row title and build a database-row
+ * reference. A `v` tab target without a row still cannot be represented by a
+ * page mention and remains a plain link.
  */
 export function parseAppFlowyPageLink(input: string, appHostname: string): AppFlowyPageLink | undefined {
   const normalized = processUrl(input);
@@ -64,11 +68,31 @@ export function parseAppFlowyPageLink(input: string, appHostname: string): AppFl
 
     if (!match) return;
 
+    const blockId = url.searchParams.get('blockId')?.trim();
+    const rowId = url.searchParams.get('r')?.trim();
+    const databaseViewId = url.searchParams.get('v')?.trim();
+
+    if (rowId) {
+      if (blockId) return;
+      if (!UUID_VALUE.test(rowId)) return;
+
+      for (const key of url.searchParams.keys()) {
+        if (key !== 'r' && key !== 'v') return;
+      }
+
+      if (databaseViewId && !UUID_VALUE.test(databaseViewId)) return;
+
+      return {
+        workspaceId: match[1],
+        viewId: match[2],
+        rowId,
+        ...(databaseViewId ? { databaseViewId } : {}),
+      };
+    }
+
     for (const key of url.searchParams.keys()) {
       if (key !== 'blockId') return;
     }
-
-    const blockId = url.searchParams.get('blockId')?.trim();
 
     return {
       workspaceId: match[1],


### PR DESCRIPTION
### Description

Fix database-row page URLs pasted into a document with **Paste as → Mention** so they render as database-row references (reference-page icon plus the underlined primary-field title) instead of remaining a raw URL or becoming a generic external link.

The fix:

- preserves the pasted Slate range when applying the URL mark splits the text leaf;
- parses and validates AppFlowy `?r=` and optional `?v=` row routes;
- resolves the exact row title and builds the cross-client-compatible database-row PageRef;
- validates view/database/row membership and safely falls back to an external-link mention when the target cannot be trusted;
- ignores stale asynchronous lookups after a newer paste or editor unmount;
- accepts Desktop-authored row PageRefs that omit `database_id`;
- adds the exact Playwright BDD regression to the CI allowlist.

### Root cause

The Paste As payload retained a Slate path captured before `addMark` split a non-empty text leaf. The resulting stale range failed validation, so selecting Mention silently did nothing. Row-target URLs were also deliberately excluded from internal-page parsing, while the Mention action only constructed generic external-link mentions.

Regression history: the stale range originated with Paste As URL layouts in `a26a5758`; the regular document paste path exposed it in `ca72c3f6`; row query targets remained plain links after `048599b7`.

### Validation

- `pnpm exec bddgen test -c playwright.bdd.config.ts`
- Focused Playwright BDD: **1 passed**
  - creates a grid and row titled `PRJ-001`;
  - opens and remembers the real row-page URL;
  - pastes it mid-sentence through the clipboard;
  - chooses Mention;
  - verifies the icon, underline, title, exact row/view PageRef metadata, and removal of the raw URL.
- Focused Jest: **5 suites, 19 tests passed**
- `pnpm run type-check`
- ESLint on changed source files
- `git diff --check`

### Checklist

- [x] I have included relevant comments for the changes introduced.
- [ ] I have tested the changes in multiple browsers/operating systems.
- [x] I have added or updated tests to validate the changes.
- [x] I have verified the fix integrates with existing page and external-link mentions.

## Summary by Sourcery

Render trusted AppFlowy database-row links pasted as mentions as validated database-row references while preserving safe fallbacks and editor state.

New Features:
- Render valid AppFlowy database-row URLs pasted through Paste as → Mention as styled database-row references with the row’s primary-field title.

Bug Fixes:
- Preserve pasted URL ranges through Slate leaf splitting so Paste as actions continue to target the correct text.
- Fall back safely to external-link mentions when database, view, row, or workspace validation fails.
- Prevent stale asynchronous row lookups from mutating an unmounted editor or replacing newer pasted content.
- Support database-row PageRefs authored by Desktop clients without a database ID.

Enhancements:
- Resolve and validate database-row, view, and row membership before creating cross-client-compatible PageRefs.

CI:
- Add the database-row mention Playwright BDD regression to the CI allowlist.

Tests:
- Add unit coverage for row-route parsing, row mention resolution, Slate range preservation, asynchronous paste cancellation, and Desktop-authored references.
- Add an end-to-end regression covering pasting a database row link mid-sentence and converting it to a styled mention.