### PR TITLE
fix: harden database row mention sync coverage

### DIFF
--- a/.github/workflows/playwright-test.yml
+++ b/.github/workflows/playwright-test.yml
@@ -99,12 +99,13 @@ jobs:
           - name: 'gallery-bdd'
             spec: >-
               playwright/.features-gen/playwright/bdd/features/auth/auth-regressions.feature.spec.js
+              playwright/.features-gen/playwright/bdd/features/app/sidebar-drop-indicator.feature.spec.js
               playwright/.features-gen/playwright/bdd/features/editor/database-row-page-mention.feature.spec.js
               playwright/.features-gen/playwright/bdd/features/database/gallery-readonly.feature.spec.js
               playwright/.features-gen/playwright/bdd/features/database/gallery-relation-prefill.feature.spec.js
               playwright/.features-gen/playwright/bdd/features/database/gallery-row-detail-no-stacking.feature.spec.js
             shard: ''
-            description: 'Authentication, database-row mention, and migrated Gallery behavior scenarios'
+            description: 'Authentication, sidebar, database-row mention, and migrated Gallery behavior scenarios'
             bdd: true
           - name: 'space-permissions-bdd'
             spec: >-

--- a/playwright/bdd/features/editor/database-row-page-mention.feature
+++ b/playwright/bdd/features/editor/database-row-page-mention.feature
@@ -1,9 +1,9 @@
 @database-row-page-mention @row-page-lifecycle
-Feature: Paste database row page links as mentions
+Feature: Render database row page mentions
 
-  Scenario: A row-page link becomes a styled database-row mention
+  Scenario: A web-created row-page mention keeps the row title
     Given I am signed in with a new account
-    And I have created a grid page named "Row Mention Grid"
+    And I have created a grid page named "Portfolio"
     When I set the first grid cell to "PRJ-001"
     And I open the grid row named "PRJ-001" as a full row page
     And I remember the current database row page link
@@ -12,4 +12,19 @@ Feature: Paste database row page links as mentions
     And I paste the remembered database row page link
     Then the Paste as menu is visible
     When I choose Mention from the Paste as menu
-    Then the pasted database row mention is styled and labeled "PRJ-001"
+    Then the database row mention is styled and labeled "PRJ-001"
+    And the database row mention is not labeled "Portfolio"
+    And the stored database row mention includes its database id
+
+  Scenario: A desktop-synced row-page mention keeps the row title
+    Given I am signed in with a new account
+    And I have created a grid page named "By Status"
+    When I set the first grid cell to "EPC-001"
+    And I open the grid row named "EPC-001" as a full row page
+    And I remember the current database row page link
+    And I have created and opened a document page named "Desktop Row Mention Target"
+    And I type "Inside an Epic page (example: " in the editor
+    And the document receives a desktop-authored database row mention labeled "EPC-001"
+    Then the database row mention is styled and labeled "EPC-001"
+    And the database row mention is not labeled "By Status"
+    And the stored database row mention omits its database id

--- a/playwright/bdd/steps/database-row-page-mention.steps.ts
+++ b/playwright/bdd/steps/database-row-page-mention.steps.ts
@@ -10,20 +10,28 @@ type DatabaseRowMentionState = {
   databaseViewId: string;
 };
 
-type TestSlateNode = {
-  children?: TestSlateNode[];
-  mention?: {
-    type?: string;
-    page_id?: string;
-    row_id?: string;
-    database_id?: string;
-    database_view_id?: string;
-    database_row_id?: string;
+type TestMention = {
+  type?: string;
+  page_id?: string;
+  block_id?: string;
+  row_id?: string;
+  database_id?: string;
+  database_view_id?: string;
+  database_row_id?: string;
+  data?: {
+    title?: string;
   };
+};
+
+type TestSlateNode = {
+  text?: string;
+  children?: TestSlateNode[];
+  mention?: TestMention;
 };
 
 type TestSlateEditor = {
   children: TestSlateNode[];
+  insertNode?: (node: TestSlateNode) => void;
 };
 
 const stateByPage = new WeakMap<Page, DatabaseRowMentionState>();
@@ -33,6 +41,38 @@ function requireState(page: Page): DatabaseRowMentionState {
 
   if (!state) throw new Error('Database row mention state was not initialized');
   return state;
+}
+
+async function getStoredMention(page: Page, rowId: string): Promise<TestMention | null> {
+  return page.evaluate((expectedRowId) => {
+    const testWindow = window as Window & {
+      __TEST_EDITOR__?: TestSlateEditor;
+      __TEST_EDITORS__?: Record<string, TestSlateEditor | undefined>;
+    };
+    const editors = [testWindow.__TEST_EDITOR__, ...Object.values(testWindow.__TEST_EDITORS__ ?? {})].filter(
+      (editor): editor is TestSlateEditor => Boolean(editor)
+    );
+
+    const findMention = (nodes: TestSlateNode[]): TestMention | null => {
+      for (const node of nodes) {
+        if (node.mention?.row_id === expectedRowId) return node.mention;
+
+        const nested = node.children ? findMention(node.children) : null;
+
+        if (nested) return nested;
+      }
+
+      return null;
+    };
+
+    for (const editor of editors) {
+      const found = findMention(editor.children);
+
+      if (found) return found;
+    }
+
+    return null;
+  }, rowId);
 }
 
 Before({ tags: '@database-row-page-mention' }, async ({ page }) => {
@@ -65,7 +105,42 @@ When('I choose Mention from the Paste as menu', async ({ page }) => {
   await page.getByTestId('paste-as-mention').click({ force: true });
 });
 
-Then('the pasted database row mention is styled and labeled {string}', async ({ page }, title: string) => {
+When(
+  'the document receives a desktop-authored database row mention labeled {string}',
+  async ({ page }, title: string) => {
+    const { databaseViewId, rowId } = requireState(page);
+
+    await page.evaluate(
+      ({ databaseViewId, rowId, title }) => {
+        const testWindow = window as Window & {
+          __TEST_EDITOR__?: TestSlateEditor;
+        };
+        const editor = testWindow.__TEST_EDITOR__;
+
+        if (!editor?.insertNode) {
+          throw new Error('No active test editor with insertNode() found');
+        }
+
+        // This is the exact legacy desktop wire shape that exposed the bug:
+        // it identifies the database view through page_id and carries the row
+        // title, but it does not include database_id.
+        editor.insertNode({
+          text: '$',
+          mention: {
+            type: 'page',
+            page_id: databaseViewId,
+            block_id: rowId,
+            row_id: rowId,
+            data: { title },
+          },
+        });
+      },
+      { databaseViewId, rowId, title }
+    );
+  }
+);
+
+Then('the database row mention is styled and labeled {string}', async ({ page }, title: string) => {
   const { databaseViewId, rowId, rowPageUrl } = requireState(page);
   const mention = page.locator(`.mention-inline[data-mention-id="${rowId}"]`);
 
@@ -75,42 +150,38 @@ Then('the pasted database row mention is styled and labeled {string}', async ({ 
   await expect(mention).toHaveCSS('text-decoration-line', /underline/);
   await expect(page.locator('[data-slate-editor="true"]').first()).not.toContainText(rowPageUrl);
 
-  const slateMention = await page.evaluate((expectedRowId) => {
-    const testWindow = window as Window & {
-      __TEST_EDITOR__?: TestSlateEditor;
-      __TEST_EDITORS__?: Record<string, TestSlateEditor | undefined>;
-    };
-    const editors = [testWindow.__TEST_EDITOR__, ...Object.values(testWindow.__TEST_EDITORS__ ?? {})].filter(
-      (editor): editor is TestSlateEditor => Boolean(editor)
-    );
-
-    const findMention = (nodes: TestSlateNode[]): TestSlateNode['mention'] | null => {
-      for (const node of nodes) {
-        if (node.mention?.row_id === expectedRowId) return node.mention;
-
-        const nested = node.children ? findMention(node.children) : null;
-
-        if (nested) return nested;
-      }
-
-      return null;
-    };
-
-    for (const editor of editors) {
-      const found = findMention(editor.children);
-
-      if (found) return found;
-    }
-
-    return null;
-  }, rowId);
+  const slateMention = await getStoredMention(page, rowId);
 
   expect(slateMention).toMatchObject({
     type: 'page',
     page_id: databaseViewId,
     row_id: rowId,
+  });
+  expect(slateMention?.data?.title).toBe(title);
+});
+
+Then('the database row mention is not labeled {string}', async ({ page }, parentTitle: string) => {
+  const { rowId } = requireState(page);
+  const mentionContent = page.locator(`.mention-inline[data-mention-id="${rowId}"] .mention-content`);
+
+  await expect(mentionContent).not.toHaveText(parentTitle);
+});
+
+Then('the stored database row mention includes its database id', async ({ page }) => {
+  const { databaseViewId, rowId } = requireState(page);
+  const slateMention = await getStoredMention(page, rowId);
+
+  expect(slateMention).toMatchObject({
     database_view_id: databaseViewId,
     database_row_id: rowId,
   });
   expect(slateMention?.database_id).toBeTruthy();
+});
+
+Then('the stored database row mention omits its database id', async ({ page }) => {
+  const { rowId } = requireState(page);
+  const slateMention = await getStoredMention(page, rowId);
+
+  expect(slateMention).not.toBeNull();
+  expect(slateMention?.database_id).toBeUndefined();
 });

--- a/playwright/bdd/steps/database-row-page-mention.steps.ts
+++ b/playwright/bdd/steps/database-row-page-mention.steps.ts
@@ -173,9 +173,15 @@ When(
       .poll(
         () =>
           peerPage.evaluate(() => {
-            const testWindow = window as Window & { __TEST_EDITOR__?: TestSlateEditor };
+            const testWindow = window as Window & {
+              __TEST_EDITOR__?: TestSlateEditor;
+              __TEST_EDITORS__?: Record<string, TestSlateEditor | undefined>;
+            };
+            const editor =
+              testWindow.__TEST_EDITOR__ ??
+              Object.values(testWindow.__TEST_EDITORS__ ?? {}).find((candidate) => candidate?.insertNode);
 
-            return Boolean(testWindow.__TEST_EDITOR__?.insertNode);
+            return Boolean(editor?.insertNode);
           }),
         { timeout: 30000 }
       )
@@ -185,8 +191,11 @@ When(
       ({ routeViewId, rowId, title }) => {
         const testWindow = window as Window & {
           __TEST_EDITOR__?: TestSlateEditor;
+          __TEST_EDITORS__?: Record<string, TestSlateEditor | undefined>;
         };
-        const editor = testWindow.__TEST_EDITOR__;
+        const editor =
+          testWindow.__TEST_EDITOR__ ??
+          Object.values(testWindow.__TEST_EDITORS__ ?? {}).find((candidate) => candidate?.insertNode);
 
         if (!editor?.insertNode) {
           throw new Error('No active test editor with insertNode() found');

--- a/playwright/bdd/steps/database-row-page-mention.steps.ts
+++ b/playwright/bdd/steps/database-row-page-mention.steps.ts
@@ -1,13 +1,18 @@
-import { expect, Page } from '@playwright/test';
+import { expect, type BrowserContext, type Page } from '@playwright/test';
 import { createBdd } from 'playwright-bdd';
 
-const { When, Then, Before } = createBdd();
+import { setupPageErrorHandling } from '../../support/test-config';
+
+const { When, Then, Before, After } = createBdd();
 const modKey = process.platform === 'darwin' ? 'Meta' : 'Control';
 
 type DatabaseRowMentionState = {
   rowPageUrl: string;
   rowId: string;
+  routeViewId: string;
   databaseViewId: string;
+  expectedMentionPageId: string;
+  peerContext?: BrowserContext;
 };
 
 type TestMention = {
@@ -31,6 +36,10 @@ type TestSlateNode = {
 
 type TestSlateEditor = {
   children: TestSlateNode[];
+  selection?: {
+    anchor: { path: number[]; offset: number };
+    focus: { path: number[]; offset: number };
+  } | null;
   insertNode?: (node: TestSlateNode) => void;
 };
 
@@ -75,7 +84,31 @@ async function getStoredMention(page: Page, rowId: string): Promise<TestMention 
   }, rowId);
 }
 
+async function flushPendingSync(page: Page): Promise<void> {
+  await expect
+    .poll(
+      () =>
+        page.evaluate(async () => {
+          const flush = (window as typeof window & { __TEST_FLUSH_ALL_SYNC__?: () => Promise<boolean> })
+            .__TEST_FLUSH_ALL_SYNC__;
+
+          return flush ? flush() : false;
+        }),
+      {
+        message: 'the document client should flush its collaboration updates',
+        timeout: 30000,
+        intervals: [250, 500, 1000],
+      }
+    )
+    .toBe(true);
+}
+
 Before({ tags: '@database-row-page-mention' }, async ({ page }) => {
+  stateByPage.delete(page);
+});
+
+After({ tags: '@database-row-page-mention' }, async ({ page }) => {
+  await stateByPage.get(page)?.peerContext?.close();
   stateByPage.delete(page);
 });
 
@@ -83,10 +116,20 @@ When('I remember the current database row page link', async ({ page }) => {
   const rowPageUrl = page.url();
   const url = new URL(rowPageUrl);
   const rowId = url.searchParams.get('r');
-  const databaseViewId = url.searchParams.get('v') || url.pathname.split('/').filter(Boolean).at(-1);
+  const routeViewId = url.pathname.split('/').filter(Boolean).at(-1);
+  const databaseViewId = url.searchParams.get('v') || routeViewId;
 
-  if (!rowId || !databaseViewId) throw new Error(`Expected a database row page URL, got ${rowPageUrl}`);
-  stateByPage.set(page, { rowPageUrl, rowId, databaseViewId });
+  if (!rowId || !routeViewId || !databaseViewId) {
+    throw new Error(`Expected a database row page URL, got ${rowPageUrl}`);
+  }
+
+  stateByPage.set(page, {
+    rowPageUrl,
+    rowId,
+    routeViewId,
+    databaseViewId,
+    expectedMentionPageId: databaseViewId,
+  });
 });
 
 When('I paste the remembered database row page link', async ({ page }) => {
@@ -107,11 +150,39 @@ When('I choose Mention from the Paste as menu', async ({ page }) => {
 
 When(
   'the document receives a desktop-authored database row mention labeled {string}',
-  async ({ page }, title: string) => {
-    const { databaseViewId, rowId } = requireState(page);
+  async ({ page, browser }, title: string) => {
+    const state = requireState(page);
+    const { routeViewId, rowId } = state;
 
-    await page.evaluate(
-      ({ databaseViewId, rowId, title }) => {
+    await flushPendingSync(page);
+
+    const peerContext = await browser.newContext({
+      baseURL: new URL(page.url()).origin,
+      storageState: await page.context().storageState({ indexedDB: true }),
+      viewport: { width: 1440, height: 900 },
+    });
+    const peerPage = await peerContext.newPage();
+
+    state.peerContext = peerContext;
+    state.expectedMentionPageId = routeViewId;
+    setupPageErrorHandling(peerPage);
+
+    await peerPage.goto(page.url(), { waitUntil: 'domcontentloaded' });
+    await expect(peerPage.locator('[data-slate-editor="true"]').first()).toBeVisible({ timeout: 30000 });
+    await expect
+      .poll(
+        () =>
+          peerPage.evaluate(() => {
+            const testWindow = window as Window & { __TEST_EDITOR__?: TestSlateEditor };
+
+            return Boolean(testWindow.__TEST_EDITOR__?.insertNode);
+          }),
+        { timeout: 30000 }
+      )
+      .toBe(true);
+
+    await peerPage.evaluate(
+      ({ routeViewId, rowId, title }) => {
         const testWindow = window as Window & {
           __TEST_EDITOR__?: TestSlateEditor;
         };
@@ -121,27 +192,62 @@ When(
           throw new Error('No active test editor with insertNode() found');
         }
 
-        // This is the exact legacy desktop wire shape that exposed the bug:
-        // it identifies the database view through page_id and carries the row
-        // title, but it does not include database_id.
+        const findLastTextPoint = (
+          nodes: TestSlateNode[],
+          parentPath: number[] = []
+        ): { path: number[]; offset: number } | null => {
+          for (let index = nodes.length - 1; index >= 0; index -= 1) {
+            const node = nodes[index];
+            const path = [...parentPath, index];
+
+            if (typeof node.text === 'string') return { path, offset: node.text.length };
+
+            const nested = node.children ? findLastTextPoint(node.children, path) : null;
+
+            if (nested) return nested;
+          }
+
+          return null;
+        };
+        const insertAt = findLastTextPoint(editor.children);
+
+        if (!insertAt) throw new Error('No text position found in the peer editor');
+
+        editor.selection = { anchor: insertAt, focus: insertAt };
+
+        // Match the current desktop producer: row references use the route view
+        // as both page_id and database_view_id and include database_row_id, but
+        // intentionally have no database_id.
         editor.insertNode({
           text: '$',
           mention: {
             type: 'page',
-            page_id: databaseViewId,
+            page_id: routeViewId,
             block_id: rowId,
             row_id: rowId,
+            database_view_id: routeViewId,
+            database_row_id: rowId,
             data: { title },
           },
         });
       },
-      { databaseViewId, rowId, title }
+      { routeViewId, rowId, title }
     );
+
+    await flushPendingSync(peerPage);
+    await expect(page.locator(`.mention-inline[data-mention-id="${rowId}"] .mention-content`)).toHaveText(title, {
+      timeout: 30000,
+    });
+
+    // Recreate the renderer from persisted collaboration state. This prevents
+    // a locally inserted JavaScript object from masquerading as a sync test.
+    await page.reload({ waitUntil: 'domcontentloaded' });
+    await expect(page.locator('[data-slate-editor="true"]').first()).toBeVisible({ timeout: 30000 });
   }
 );
 
 Then('the database row mention is styled and labeled {string}', async ({ page }, title: string) => {
-  const { databaseViewId, rowId, rowPageUrl } = requireState(page);
+  const { expectedMentionPageId, rowId, rowPageUrl } = requireState(page);
   const mention = page.locator(`.mention-inline[data-mention-id="${rowId}"]`);
 
   await expect(mention).toBeVisible({ timeout: 15000 });
@@ -154,7 +260,7 @@ Then('the database row mention is styled and labeled {string}', async ({ page },
 
   expect(slateMention).toMatchObject({
     type: 'page',
-    page_id: databaseViewId,
+    page_id: expectedMentionPageId,
     row_id: rowId,
   });
   expect(slateMention?.data?.title).toBe(title);

--- a/playwright/bdd/steps/database-row-page-mention.steps.ts
+++ b/playwright/bdd/steps/database-row-page-mention.steps.ts
@@ -161,6 +161,13 @@ When(
       storageState: await page.context().storageState({ indexedDB: true }),
       viewport: { width: 1440, height: 900 },
     });
+
+    // The normal sign-in helper installs this context-level flag before the
+    // production build boots. A manually created peer context must do the same
+    // so CollaborativeEditor exposes its E2E editor registry.
+    await peerContext.addInitScript(() => {
+      (window as Window & { Cypress?: boolean }).Cypress = true;
+    });
     const peerPage = await peerContext.newPage();
 
     state.peerContext = peerContext;

--- a/src/components/editor/components/panels/paste-as-panel/PasteAsPanel.tsx
+++ b/src/components/editor/components/panels/paste-as-panel/PasteAsPanel.tsx
@@ -2,7 +2,7 @@ import { Button } from '@mui/material';
 import { PopoverOrigin } from '@mui/material/Popover/Popover';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Editor, Transforms } from 'slate';
+import { Editor, Range, Transforms } from 'slate';
 import { ReactEditor, useSlateStatic } from 'slate-react';
 
 import { YjsEditor } from '@/application/slate-yjs';
@@ -132,17 +132,17 @@ export function PasteAsPanel() {
       const url = processUrl(payload.url) || payload.url;
 
       if (type === PasteAsMenuType.Mention) {
+        // Keep following the pasted URL while the row metadata resolves. A
+        // plain Range becomes stale when local or remote edits happen before
+        // the URL during the request.
+        const pasteRangeRef = Editor.rangeRef(editor, payload.range, { affinity: 'inward' });
         let mention: Mention = {
           type: MentionType.externalLink,
           url,
         };
         const appFlowyLink = parseAppFlowyPageLink(url, window.location.hostname);
 
-        if (
-          loadView &&
-          appFlowyLink?.rowId &&
-          appFlowyLink.workspaceId.toLowerCase() === workspaceId.toLowerCase()
-        ) {
+        if (loadView && appFlowyLink?.rowId && appFlowyLink.workspaceId.toLowerCase() === workspaceId.toLowerCase()) {
           try {
             mention = (await resolveDatabaseRowPageMention(workspaceId, appFlowyLink, loadView)) ?? mention;
           } catch {
@@ -151,22 +151,38 @@ export function PasteAsPanel() {
           }
         }
 
-        if (!mountedRef.current || operationId !== pasteOperationRef.current) return;
+        const pasteRange = pasteRangeRef.unref();
+
+        if (!mountedRef.current || operationId !== pasteOperationRef.current || !pasteRange) return;
 
         // Resolution is asynchronous. Confirm the original pasted URL still
-        // occupies the tracked range before replacing any user content.
-        if (!selectPasteRange(payload)) return;
+        // occupies the tracked range before replacing any user content. Do not
+        // re-focus or re-select it here: the user may have continued editing
+        // elsewhere while the request was pending.
+        if (
+          !Editor.hasPath(editor, pasteRange.anchor.path) ||
+          !Editor.hasPath(editor, pasteRange.focus.path) ||
+          editor.string(pasteRange) !== payload.url
+        ) {
+          return;
+        }
 
-        Transforms.delete(editor);
+        const shouldSelectMention = Boolean(editor.selection && Range.equals(editor.selection, pasteRange));
+        const insertAt = Range.start(pasteRange);
+
+        Transforms.delete(editor, { at: pasteRange });
         Transforms.insertNodes(
           editor,
           {
             text: '@',
             mention,
           },
-          { select: true, voids: false }
+          { at: insertAt, select: shouldSelectMention, voids: false }
         );
-        Transforms.collapse(editor, { edge: 'end' });
+        if (shouldSelectMention) {
+          Transforms.collapse(editor, { edge: 'end' });
+        }
+
         return;
       }
 
@@ -269,9 +285,7 @@ export function PasteAsPanel() {
           e.stopPropagation();
 
           const nextIndex =
-            e.key === 'ArrowDown'
-              ? (index + 1) % options.length
-              : (index - 1 + options.length) % options.length;
+            e.key === 'ArrowDown' ? (index + 1) % options.length : (index - 1 + options.length) % options.length;
 
           setSelectedType(options[nextIndex].type);
           break;

--- a/src/components/editor/components/panels/paste-as-panel/PasteAsPanel.tsx
+++ b/src/components/editor/components/panels/paste-as-panel/PasteAsPanel.tsx
@@ -168,20 +168,38 @@ export function PasteAsPanel() {
         }
 
         const shouldSelectMention = Boolean(editor.selection && Range.equals(editor.selection, pasteRange));
-        const insertAt = Range.start(pasteRange);
+        const liveSelectionRef =
+          !shouldSelectMention && editor.selection
+            ? Editor.rangeRef(editor, editor.selection, { affinity: 'forward' })
+            : null;
 
-        Transforms.delete(editor, { at: pasteRange });
-        Transforms.insertNodes(
-          editor,
-          {
-            text: '@',
-            mention,
-          },
-          { at: insertAt, select: shouldSelectMention, voids: false }
-        );
-        if (shouldSelectMention) {
+        // An auto-linked URL can occupy a leaf that disappears when deleted.
+        // Use Slate's transformed selection as the insertion point, then put a
+        // user who moved elsewhere back at their tracked selection. The whole
+        // swap is synchronous and never moves DOM focus.
+        Editor.withoutNormalizing(editor, () => {
+          Transforms.select(editor, pasteRange);
+          Transforms.delete(editor);
+          Transforms.insertNodes(
+            editor,
+            {
+              text: '@',
+              mention,
+            },
+            { select: true, voids: false }
+          );
           Transforms.collapse(editor, { edge: 'end' });
-        }
+
+          if (!shouldSelectMention) {
+            const liveSelection = liveSelectionRef?.unref();
+
+            if (liveSelection) {
+              Transforms.select(editor, liveSelection);
+            } else {
+              Transforms.deselect(editor);
+            }
+          }
+        });
 
         return;
       }

--- a/src/components/editor/components/panels/paste-as-panel/__tests__/PasteAsPanel.test.tsx
+++ b/src/components/editor/components/panels/paste-as-panel/__tests__/PasteAsPanel.test.tsx
@@ -1,5 +1,5 @@
 import { act, fireEvent, render, screen } from '@testing-library/react';
-import { createEditor, Transforms } from 'slate';
+import { createEditor, Editor, Transforms } from 'slate';
 
 import { YjsEditor } from '@/application/slate-yjs';
 import { BlockType, Mention, MentionType } from '@/application/types';
@@ -55,8 +55,7 @@ jest.mock('@mui/material', () => ({
 
 jest.mock('@/components/_shared/popover', () => ({
   calculateOptimalOrigins: () => ({ transformOrigin: { horizontal: 'left', vertical: 'top' } }),
-  Popover: ({ children, open }: { children: React.ReactNode; open: boolean }) =>
-    open ? <div>{children}</div> : null,
+  Popover: ({ children, open }: { children: React.ReactNode; open: boolean }) => (open ? <div>{children}</div> : null),
 }));
 
 jest.mock('@/components/editor/EditorContext', () => ({
@@ -144,5 +143,49 @@ describe('PasteAsPanel async mention resolution', () => {
     expect(deleteSpy).not.toHaveBeenCalled();
     expect(insertNodesSpy).not.toHaveBeenCalled();
     expect(mockEditor.string([])).toBe(rowPageUrl);
+  });
+
+  it('replaces the tracked URL without moving a selection the user made while resolving', async () => {
+    const resolution = deferred<Mention | null>();
+
+    mockEditor.children = [
+      {
+        type: BlockType.Paragraph,
+        blockId: 'paragraph-1',
+        children: [{ text: rowPageUrl, href: rowPageUrl }, { text: ' keep editing' }],
+      },
+    ];
+    mockResolveDatabaseRowPageMention.mockReturnValue(resolution.promise);
+
+    render(<PasteAsPanel />);
+
+    fireEvent.click(screen.getByTestId(`paste-as-${PasteAsMenuType.Mention}`));
+
+    const liveSelection = {
+      anchor: { path: [0, 1], offset: 6 },
+      focus: { path: [0, 1], offset: 6 },
+    };
+
+    Transforms.select(mockEditor, liveSelection);
+    const expectedSelectionRef = Editor.rangeRef(mockEditor, liveSelection);
+
+    await act(async () => {
+      resolution.resolve({
+        type: MentionType.PageRef,
+        page_id: databaseViewId,
+        row_id: rowId,
+        data: { title: 'PRJ-001' },
+      });
+      await resolution.promise;
+    });
+
+    expect(mockFocus).toHaveBeenCalledTimes(1);
+    expect(mockEditor.selection).toEqual(expectedSelectionRef.unref());
+    expect(mockEditor.string([])).toBe('@ keep editing');
+    expect((mockEditor.children[0].children[0] as { mention?: Mention }).mention).toMatchObject({
+      type: MentionType.PageRef,
+      row_id: rowId,
+      data: { title: 'PRJ-001' },
+    });
   });
 });

--- a/src/components/editor/components/panels/paste-as-panel/__tests__/PasteAsPanel.test.tsx
+++ b/src/components/editor/components/panels/paste-as-panel/__tests__/PasteAsPanel.test.tsx
@@ -147,14 +147,22 @@ describe('PasteAsPanel async mention resolution', () => {
 
   it('replaces the tracked URL without moving a selection the user made while resolving', async () => {
     const resolution = deferred<Mention | null>();
+    const prefix = 'Inside a Project page (example: ';
 
     mockEditor.children = [
       {
         type: BlockType.Paragraph,
         blockId: 'paragraph-1',
-        children: [{ text: rowPageUrl, href: rowPageUrl }, { text: ' keep editing' }],
+        children: [{ text: prefix }, { text: rowPageUrl, href: rowPageUrl }, { text: ' keep editing' }],
       },
     ];
+    const pasteRange = {
+      anchor: { path: [0, 1], offset: 0 },
+      focus: { path: [0, 1], offset: rowPageUrl.length },
+    };
+
+    mockEditor.selection = pasteRange;
+    mockGetPasteAsPayload.mockReturnValue({ range: pasteRange, url: rowPageUrl });
     mockResolveDatabaseRowPageMention.mockReturnValue(resolution.promise);
 
     render(<PasteAsPanel />);
@@ -162,8 +170,8 @@ describe('PasteAsPanel async mention resolution', () => {
     fireEvent.click(screen.getByTestId(`paste-as-${PasteAsMenuType.Mention}`));
 
     const liveSelection = {
-      anchor: { path: [0, 1], offset: 6 },
-      focus: { path: [0, 1], offset: 6 },
+      anchor: { path: [0, 2], offset: 6 },
+      focus: { path: [0, 2], offset: 6 },
     };
 
     Transforms.select(mockEditor, liveSelection);
@@ -181,8 +189,13 @@ describe('PasteAsPanel async mention resolution', () => {
 
     expect(mockFocus).toHaveBeenCalledTimes(1);
     expect(mockEditor.selection).toEqual(expectedSelectionRef.unref());
-    expect(mockEditor.string([])).toBe('@ keep editing');
-    expect((mockEditor.children[0].children[0] as { mention?: Mention }).mention).toMatchObject({
+    expect(mockEditor.string([])).toBe(`${prefix}@ keep editing`);
+    const mentionNode = Editor.nodes(mockEditor, {
+      at: [],
+      match: (node) => 'mention' in node,
+    }).next().value?.[0] as { mention?: Mention } | undefined;
+
+    expect(mentionNode?.mention).toMatchObject({
       type: MentionType.PageRef,
       row_id: rowId,
       data: { title: 'PRJ-001' },

--- a/src/components/editor/components/panels/paste-as-panel/__tests__/databaseRowMention.test.ts
+++ b/src/components/editor/components/panels/paste-as-panel/__tests__/databaseRowMention.test.ts
@@ -15,15 +15,22 @@ import {
   YjsEditorKey,
 } from '@/application/types';
 
-import {
-  DatabaseRowMentionResolverDependencies,
-  resolveDatabaseRowPageMention,
-} from '../databaseRowMention';
+import { DatabaseRowMentionResolverDependencies, resolveDatabaseRowPageMention } from '../databaseRowMention';
 
 const workspaceId = '3df0c6bb-417f-4f81-939a-c6114f160f9a';
 const databaseId = '1cd808b6-7f36-45e5-b520-42ebd6f620f4';
+const databaseContainerViewId = '72541d40-50d8-41b5-bc29-cb1de45f51c2';
 const databaseViewId = 'b709de16-f480-43cb-a175-03b1808449cf';
 const rowId = '439bd5d7-6b22-4117-8465-539dcc6c55d9';
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((promiseResolve) => {
+    resolve = promiseResolve;
+  });
+
+  return { promise, resolve };
+}
 
 function createDatabaseDoc(): YDoc {
   const doc = new Y.Doc({ guid: databaseId }) as YDoc;
@@ -84,12 +91,7 @@ describe('resolveDatabaseRowPageMention', () => {
     const loadView = jest.fn(async () => databaseDoc);
 
     await expect(
-      resolveDatabaseRowPageMention(
-        workspaceId,
-        { workspaceId, viewId: databaseViewId, rowId },
-        loadView,
-        dependencies
-      )
+      resolveDatabaseRowPageMention(workspaceId, { workspaceId, viewId: databaseViewId, rowId }, loadView, dependencies)
     ).resolves.toEqual({
       type: MentionType.PageRef,
       page_id: databaseViewId,
@@ -135,12 +137,50 @@ describe('resolveDatabaseRowPageMention', () => {
     expect(dependencies.getRowCollab).toHaveBeenCalledWith(workspaceId, rowId);
   });
 
+  it('resolves route and selected database views in parallel', async () => {
+    const databaseDoc = createDatabaseDoc();
+    const rowDoc = createRowDoc('PRJ-003');
+    const dependencies = resolverDependencies(rowDoc);
+    const routeLookup = deferred<string | null>();
+    const selectedLookup = deferred<string | null>();
+
+    dependencies.getDatabaseId = jest.fn((_workspaceId, viewId) =>
+      viewId === databaseContainerViewId ? routeLookup.promise : selectedLookup.promise
+    );
+
+    const mentionPromise = resolveDatabaseRowPageMention(
+      workspaceId,
+      {
+        workspaceId,
+        viewId: databaseContainerViewId,
+        databaseViewId,
+        rowId,
+      },
+      async () => databaseDoc,
+      dependencies
+    );
+
+    await Promise.resolve();
+
+    expect(dependencies.getDatabaseId).toHaveBeenCalledTimes(2);
+    expect(dependencies.getDatabaseId).toHaveBeenCalledWith(workspaceId, databaseContainerViewId);
+    expect(dependencies.getDatabaseId).toHaveBeenCalledWith(workspaceId, databaseViewId);
+
+    routeLookup.resolve(databaseId);
+    selectedLookup.resolve(databaseId);
+
+    await expect(mentionPromise).resolves.toMatchObject({
+      database_id: databaseId,
+      database_view_id: databaseViewId,
+      row_id: rowId,
+      data: { title: 'PRJ-003' },
+    });
+  });
+
   it('rejects a cached row that belongs to another database', async () => {
     const databaseDoc = createDatabaseDoc();
     const wrongRowDoc = createRowDoc('Wrong database');
-    const wrongRow = wrongRowDoc
-      .getMap(YjsEditorKey.data_section)
-      .get(YjsEditorKey.database_row) as YDatabaseRow;
+    const wrongRow = wrongRowDoc.getMap(YjsEditorKey.data_section).get(YjsEditorKey.database_row) as YDatabaseRow;
 
     wrongRow.set(YjsDatabaseKey.database_id, 'another-database');
     const dependencies = resolverDependencies(wrongRowDoc);

--- a/src/components/editor/components/panels/paste-as-panel/databaseRowMention.ts
+++ b/src/components/editor/components/panels/paste-as-panel/databaseRowMention.ts
@@ -53,12 +53,16 @@ async function resolveDatabaseTarget(
   link: AppFlowyPageLink,
   getDatabaseId: DatabaseRowMentionResolverDependencies['getDatabaseId']
 ) {
-  const routeDatabaseId = await getDatabaseId(workspaceId, link.viewId);
+  if (!link.databaseViewId || link.databaseViewId === link.viewId) {
+    const databaseId = await getDatabaseId(workspaceId, link.viewId);
 
-  if (!routeDatabaseId) return null;
-  if (!link.databaseViewId) return { databaseId: routeDatabaseId, databaseViewId: link.viewId };
+    return databaseId ? { databaseId, databaseViewId: link.databaseViewId || link.viewId } : null;
+  }
 
-  const selectedDatabaseId = await getDatabaseId(workspaceId, link.databaseViewId);
+  const [routeDatabaseId, selectedDatabaseId] = await Promise.all([
+    getDatabaseId(workspaceId, link.viewId),
+    getDatabaseId(workspaceId, link.databaseViewId),
+  ]);
 
   if (!selectedDatabaseId || selectedDatabaseId !== routeDatabaseId) return null;
 


### PR DESCRIPTION
### Description\n\nHardens the database-row mention fix and its regression coverage:\n\n- preserves the live caret while Paste as Mention resolves row metadata asynchronously\n- safely transforms the pasted URL range before deleting an auto-linked URL leaf, avoiding stale Slate paths\n- resolves independent route and selected-view database catalog lookups in parallel\n- sends the current desktop-shaped payload from a separate authenticated browser context, flushes collaboration sync, and reloads the receiving Web client before asserting EPC-001 instead of By Status\n- keeps the Web-created PRJ-001 case with its full database payload\n- assigns the recently changed sidebar-drop BDD feature to the CI BDD runner; all BDD features touched in the latest five commits are represented in the workflow matrix\n\n### Testing\n\n- [x] 21 focused Jest tests\n- [x] pnpm run type-check\n- [x] focused ESLint checks\n- [x] pnpm run build\n- [x] Playwright BDD generation\n- [x] CI gallery-bdd: 12 selected scenarios passed, including both row-mention cases and the sidebar scenarios\n- [x] CI assignment audit: all 7 BDD features touched by the latest five commits are assigned\n- [x] git diff --check\n\n## Summary by Sourcery\n\nHarden database row mention resolution and end-to-end synchronization coverage across web and desktop-authored content.\n\nBug Fixes:\n- Preserve the user’s live caret and selection while asynchronously converting pasted database row URLs into mentions.\n- Validate database row mentions against both route and selected-view database metadata, resolving independent lookups in parallel.\n\nEnhancements:\n- Expand row-mention regression coverage to verify web-created and desktop-synced payloads, persisted metadata, display titles, collaboration flushing, and reload behavior.\n\nCI:\n- Assign the sidebar-drop BDD feature to the Playwright CI matrix alongside the existing authentication and database scenarios.\n\nTests:\n- Add focused Jest and Playwright BDD coverage for asynchronous mention replacement and database row mention synchronization.