### PR TITLE
fix(database): open original page from linked views

### DIFF
--- a/playwright/bdd/features/database/linked-database-open-original.feature
+++ b/playwright/bdd/features/database/linked-database-open-original.feature
@@ -1,0 +1,12 @@
+Feature: Open a linked database's original page
+  A linked database embedded in a document keeps its own view ID, so both of
+  its open-original controls must resolve the database's primary source view.
+
+  Scenario: Header and toolbar actions open the source database
+    Given a document contains a linked Grid for open-original testing
+    Then the linked Grid shows an open-original header action
+    When I open the linked Grid from its header
+    Then the original Grid page is open
+    When I return to the linked Grid document
+    And I open the linked Grid from its toolbar
+    Then the original Grid page is open

--- a/playwright/bdd/steps/linked-database-open-original.steps.ts
+++ b/playwright/bdd/steps/linked-database-open-original.steps.ts
@@ -1,0 +1,92 @@
+import { expect, Page } from '@playwright/test';
+import { createBdd } from 'playwright-bdd';
+
+import { signUpAndLoginWithPasswordViaUi } from '../../support/auth-flow-helpers';
+import {
+  createNamedGridPage,
+  databaseBlocks,
+  editorForView,
+  insertLinkedGridViaSlash,
+} from '../../support/duplicate-test-helpers';
+import { createDocumentPageAndNavigate, currentViewIdFromUrl } from '../../support/page-utils';
+import { generateRandomEmail, setupPageErrorHandling } from '../../support/test-config';
+
+const { Given, When, Then } = createBdd();
+
+const PASSWORD = 'AppFlowy123!';
+const SOURCE_DATABASE_NAME = 'Open Original Source';
+
+type LinkedDatabaseState = {
+  documentUrl: string;
+  documentViewId: string;
+  sourceViewId: string;
+};
+
+const stateByPage = new WeakMap<Page, LinkedDatabaseState>();
+
+function requireState(page: Page): LinkedDatabaseState {
+  const state = stateByPage.get(page);
+
+  if (!state) throw new Error('Linked database open-original state was not initialized');
+
+  return state;
+}
+
+function linkedGrid(page: Page) {
+  const state = requireState(page);
+
+  return databaseBlocks(editorForView(page, state.documentViewId)).first();
+}
+
+async function expectSourceDatabase(page: Page, sourceViewId: string) {
+  await expect
+    .poll(() => currentViewIdFromUrl(page), {
+      message: 'Expected the linked database action to open the original database view',
+      timeout: 15_000,
+    })
+    .toBe(sourceViewId);
+  await expect(page.getByTestId('page-title-input').filter({ hasText: SOURCE_DATABASE_NAME })).toBeVisible({
+    timeout: 15_000,
+  });
+}
+
+Given('a document contains a linked Grid for open-original testing', async ({ page, request }) => {
+  setupPageErrorHandling(page);
+  await page.setViewportSize({ width: 1440, height: 900 });
+  await signUpAndLoginWithPasswordViaUi(page, request, generateRandomEmail(), PASSWORD);
+  await expect(page).toHaveURL(/\/app/, { timeout: 30_000 });
+
+  await createNamedGridPage(page, SOURCE_DATABASE_NAME);
+  const sourceViewId = currentViewIdFromUrl(page);
+  const documentViewId = await createDocumentPageAndNavigate(page);
+
+  await insertLinkedGridViaSlash(page, documentViewId, SOURCE_DATABASE_NAME);
+
+  const documentUrl = page.url();
+
+  stateByPage.set(page, { documentUrl, documentViewId, sourceViewId });
+  await expect(linkedGrid(page)).toBeVisible({ timeout: 30_000 });
+});
+
+Then('the linked Grid shows an open-original header action', async ({ page }) => {
+  await expect(linkedGrid(page).getByTestId('embedded-database-open-original')).toBeVisible({ timeout: 15_000 });
+});
+
+When('I open the linked Grid from its header', async ({ page }) => {
+  await linkedGrid(page).getByTestId('embedded-database-open-original').click();
+});
+
+Then('the original Grid page is open', async ({ page }) => {
+  await expectSourceDatabase(page, requireState(page).sourceViewId);
+});
+
+When('I return to the linked Grid document', async ({ page }) => {
+  const state = requireState(page);
+
+  await page.goto(state.documentUrl, { waitUntil: 'domcontentloaded' });
+  await expect(linkedGrid(page)).toBeVisible({ timeout: 30_000 });
+});
+
+When('I open the linked Grid from its toolbar', async ({ page }) => {
+  await linkedGrid(page).getByTestId('database-actions-open-as-page').click();
+});

--- a/src/components/database/components/conditions/DatabaseActions.tsx
+++ b/src/components/database/components/conditions/DatabaseActions.tsx
@@ -13,6 +13,7 @@ import FiltersButton from '@/components/database/components/conditions/FiltersBu
 import SortsButton from '@/components/database/components/conditions/SortsButton';
 import Settings from '@/components/database/components/settings/Settings';
 import { DatabaseTemplateButton } from '@/components/database/components/template';
+import { useOpenDatabaseAsPage } from '@/components/database/hooks';
 import { Button } from '@/components/ui/button';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 
@@ -109,7 +110,8 @@ export function DatabaseActions() {
   const layout = useDatabaseViewLayout() as DatabaseViewLayout;
   const readOnly = useReadOnly();
   const conditionsContext = useConditionsContext();
-  const { activeViewId, isDocumentBlock, navigateToView, databasePageId } = useDatabaseContext();
+  const { activeViewId, isDocumentBlock, databasePageId } = useDatabaseContext();
+  const { canOpen, isOpening, openDatabaseAsPage } = useOpenDatabaseAsPage({ fallbackViewId: databasePageId });
 
   const showSorts = [DatabaseViewLayout.Grid, DatabaseViewLayout.List, DatabaseViewLayout.Gallery].includes(layout);
   const showSearch = layout === DatabaseViewLayout.Gallery;
@@ -148,10 +150,9 @@ export function DatabaseActions() {
             <Button
               aria-label={t('tooltip.openAsPage')}
               data-testid='database-actions-open-as-page'
-              onClick={() => {
-                if (!databasePageId) return;
-                void navigateToView?.(databasePageId);
-              }}
+              disabled={!canOpen}
+              loading={isOpening}
+              onClick={() => void openDatabaseAsPage()}
               size={showSearch ? 'icon-sm' : 'icon'}
               type='button'
               variant='ghost'

--- a/src/components/database/components/conditions/__tests__/DatabaseActions.test.tsx
+++ b/src/components/database/components/conditions/__tests__/DatabaseActions.test.tsx
@@ -1,6 +1,6 @@
-import { act, fireEvent, render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 
-import { useDatabaseContext, useDatabaseViewLayout, useReadOnly } from '@/application/database-yjs';
+import { useDatabase, useDatabaseContext, useDatabaseViewLayout, useReadOnly } from '@/application/database-yjs';
 import { DatabaseViewLayout } from '@/application/types';
 import {
   DatabaseSearchProvider,
@@ -10,6 +10,7 @@ import {
 import { DatabaseActions } from '../DatabaseActions';
 
 jest.mock('@/application/database-yjs', () => ({
+  useDatabase: jest.fn(),
   useDatabaseContext: jest.fn(),
   useDatabaseViewLayout: jest.fn(),
   useReadOnly: jest.fn(),
@@ -67,6 +68,7 @@ jest.mock('@/components/ui/tooltip', () => ({
   TooltipTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
 }));
 
+const mockUseDatabase = useDatabase as jest.MockedFunction<typeof useDatabase>;
 const mockUseDatabaseContext = useDatabaseContext as jest.MockedFunction<typeof useDatabaseContext>;
 const mockUseDatabaseViewLayout = useDatabaseViewLayout as jest.MockedFunction<typeof useDatabaseViewLayout>;
 const mockUseReadOnly = useReadOnly as jest.MockedFunction<typeof useReadOnly>;
@@ -84,6 +86,7 @@ describe('DatabaseActions template support', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    mockUseDatabase.mockReturnValue(undefined);
     mockUseDatabaseContext.mockReturnValue({
       activeViewId: 'view-1',
       isDocumentBlock: false,
@@ -200,6 +203,33 @@ describe('DatabaseActions template support', () => {
     expect(screen.queryByTestId('sorts-button')).toBeNull();
     expect(screen.queryByTestId('database-actions-settings')).toBeNull();
     expect(screen.queryByTestId('database-template-button')).toBeNull();
+  });
+
+  it('resolves the source view before opening a linked database as a page', async () => {
+    const getViewIdFromDatabaseId = jest.fn().mockResolvedValue('source-database-view');
+    const navigateToView = jest.fn().mockResolvedValue(undefined);
+
+    mockUseDatabaseViewLayout.mockReturnValue(DatabaseViewLayout.Grid);
+    mockUseDatabase.mockReturnValue({
+      get: jest.fn().mockReturnValue('source-database-id'),
+    } as ReturnType<typeof useDatabase>);
+    mockUseDatabaseContext.mockReturnValue({
+      activeViewId: 'linked-view',
+      databasePageId: 'embedded-linked-view',
+      getViewIdFromDatabaseId,
+      isDocumentBlock: true,
+      navigateToView,
+    } as ReturnType<typeof useDatabaseContext>);
+
+    render(<DatabaseActions />);
+
+    fireEvent.click(screen.getByTestId('database-actions-open-as-page'));
+
+    await waitFor(() => {
+      expect(getViewIdFromDatabaseId).toHaveBeenCalledWith('source-database-id');
+      expect(navigateToView).toHaveBeenCalledWith('source-database-view');
+    });
+    expect(navigateToView).not.toHaveBeenCalledWith('embedded-linked-view');
   });
 
   it('updates the shared trimmed query after the desktop debounce and clears it with Escape', () => {

--- a/src/components/database/components/tabs/DatabaseTabs.tsx
+++ b/src/components/database/components/tabs/DatabaseTabs.tsx
@@ -6,13 +6,21 @@ import { APP_EVENTS } from '@/application/constants';
 import { useDatabase, useDatabaseContext } from '@/application/database-yjs';
 import { useDuplicateDatabaseView, useUpdateDatabaseView } from '@/application/database-yjs/dispatch';
 import { View, YjsDatabaseKey } from '@/application/types';
-import { isDatabaseContainer } from '@/application/view-utils';
+import {
+  getDatabaseIdFromExtra,
+  isDatabaseContainer,
+  isEmbeddedDatabaseViewWithoutChildren,
+} from '@/application/view-utils';
+import { ReactComponent as RelationIcon } from '@/assets/icons/relation.svg';
 import { findView } from '@/components/_shared/outline/utils';
 import { type ReorderResult } from '@/components/_shared/reorder/useReorderMonitor';
 import RenameModal from '@/components/app/view-actions/RenameModal';
 import { DatabaseActions } from '@/components/database/components/conditions';
 import { DatabaseViewTabs } from '@/components/database/components/tabs/DatabaseViewTabs';
 import DeleteViewConfirm from '@/components/database/components/tabs/DeleteViewConfirm';
+import { useOpenDatabaseAsPage } from '@/components/database/hooks';
+import { Button } from '@/components/ui/button';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 
 const TAB_BAR_CLASS_NAME =
   '-mb-[0.5px] flex items-center  text-text-primary flex-col  max-sm:!px-6 min-w-0 overflow-hidden';
@@ -67,7 +75,8 @@ export const DatabaseTabs = forwardRef<HTMLDivElement, DatabaseTabBarProps>(
     ref
   ) => {
     const { t } = useTranslation();
-    const views = useDatabase()?.get(YjsDatabaseKey.views);
+    const database = useDatabase();
+    const views = database?.get(YjsDatabaseKey.views);
     const context = useDatabaseContext();
     const {
       loadViewMeta,
@@ -80,7 +89,7 @@ export const DatabaseTabs = forwardRef<HTMLDivElement, DatabaseTabBarProps>(
     const updateDatabaseView = useUpdateDatabaseView();
     const duplicateView = useDuplicateDatabaseView();
     const [meta, setMeta] = useState<View | null>(null);
-    const [pendingContainerName, setPendingContainerName] = useState<{ viewId: string; name: string } | null>(null);
+    const [pendingEmbeddedName, setPendingEmbeddedName] = useState<{ viewId: string; name: string } | null>(null);
     const scrollLeftPadding = context.paddingStart;
     const [deleteConfirmOpen, setDeleteConfirmOpen] = useState<string | null>(null);
     const [renameTarget, setRenameTarget] = useState<RenameTarget | null>(null);
@@ -245,7 +254,7 @@ export const DatabaseTabs = forwardRef<HTMLDivElement, DatabaseTabBarProps>(
     const viewNameById = useMemo(() => {
       if (!meta) return undefined;
 
-      if (isDatabaseContainer(meta)) {
+      if (isDatabaseContainer(meta) && !isEmbeddedDatabaseViewWithoutChildren(meta)) {
         const mapping: Record<string, string> = {};
 
         for (const child of meta.children ?? []) {
@@ -264,16 +273,16 @@ export const DatabaseTabs = forwardRef<HTMLDivElement, DatabaseTabBarProps>(
 
     useEffect(() => {
       if (
-        pendingContainerName &&
-        meta?.view_id === pendingContainerName.viewId &&
-        meta.name === pendingContainerName.name
+        pendingEmbeddedName &&
+        meta?.view_id === pendingEmbeddedName.viewId &&
+        meta.name === pendingEmbeddedName.name
       ) {
-        setPendingContainerName(null);
+        setPendingEmbeddedName(null);
       }
-    }, [meta, pendingContainerName]);
+    }, [meta, pendingEmbeddedName]);
 
     useEffect(() => {
-      setPendingContainerName(null);
+      setPendingEmbeddedName(null);
     }, [databasePageId]);
 
     useEffect(() => {
@@ -293,15 +302,35 @@ export const DatabaseTabs = forwardRef<HTMLDivElement, DatabaseTabBarProps>(
       };
     }, [menuViewId]);
 
-    const embeddedDatabaseMeta = context.isDocumentBlock && isDatabaseContainer(meta) ? meta : null;
-    const embeddedDatabaseRawName = embeddedDatabaseMeta
-      ? pendingContainerName?.viewId === embeddedDatabaseMeta.view_id
-        ? pendingContainerName.name
-        : embeddedDatabaseMeta.name
+    // An inline database owns an embedded container with child views. A linked
+    // database is the embedded leaf itself (including legacy Web metadata that
+    // incorrectly marks that leaf as a container).
+    const embeddedReferenceMeta =
+      context.isDocumentBlock && meta?.view_id === databasePageId && isEmbeddedDatabaseViewWithoutChildren(meta)
+        ? meta
+        : null;
+    const embeddedDatabaseMeta =
+      context.isDocumentBlock && isDatabaseContainer(meta) && !embeddedReferenceMeta ? meta : null;
+    const embeddedTitleMeta = embeddedReferenceMeta ?? embeddedDatabaseMeta;
+    const embeddedDatabaseRawName = embeddedTitleMeta
+      ? pendingEmbeddedName?.viewId === embeddedTitleMeta.view_id
+        ? pendingEmbeddedName.name
+        : embeddedTitleMeta.name
       : '';
     const embeddedDatabaseName = embeddedDatabaseRawName.trim() || t('untitled');
-    const embeddedDatabaseViewId = embeddedDatabaseMeta?.view_id;
-    const canRenameEmbeddedTitle = Boolean(embeddedDatabaseMeta && !readOnly && updateContainerPage);
+    const embeddedDatabaseViewId = embeddedTitleMeta?.view_id;
+    const canRenameEmbeddedTitle = Boolean(embeddedTitleMeta && !readOnly && updateContainerPage);
+    const embeddedReferenceDatabaseId = embeddedReferenceMeta
+      ? getDatabaseIdFromExtra(embeddedReferenceMeta) ?? database?.get(YjsDatabaseKey.id)
+      : undefined;
+    const {
+      canOpen: canOpenOriginalDatabase,
+      isOpening: isOpeningOriginalDatabase,
+      openDatabaseAsPage: openOriginalDatabase,
+    } = useOpenDatabaseAsPage({
+      databaseId: embeddedReferenceDatabaseId,
+      fallbackViewId: embeddedReferenceMeta?.view_id,
+    });
 
     const startEditingTitle = useCallback(() => {
       setTitleDraft(embeddedDatabaseRawName);
@@ -326,7 +355,7 @@ export const DatabaseTabs = forwardRef<HTMLDivElement, DatabaseTabBarProps>(
 
       try {
         await updateContainerPage(embeddedDatabaseViewId, { name: nextName });
-        setPendingContainerName({ viewId: embeddedDatabaseViewId, name: nextName });
+        setPendingEmbeddedName({ viewId: embeddedDatabaseViewId, name: nextName });
       } catch (e) {
         toast.error(e instanceof Error ? e.message : String(e));
       }
@@ -443,49 +472,75 @@ export const DatabaseTabs = forwardRef<HTMLDivElement, DatabaseTabBarProps>(
           paddingRight: scrollLeftPadding === undefined ? 96 : scrollLeftPadding,
         }}
       >
-        {embeddedDatabaseMeta ? (
-          <h3 data-testid='embedded-database-title' className='w-full pb-3 text-xl font-semibold text-text-primary'>
-            {canRenameEmbeddedTitle ? (
-              editingTitle ? (
-                <input
-                  ref={titleInputRef}
-                  data-testid='embedded-database-title-input'
-                  className='w-full bg-transparent text-xl font-semibold text-text-primary outline-none'
-                  value={titleDraft}
-                  placeholder={t('untitled')}
-                  onChange={(e) => setTitleDraft(e.target.value)}
-                  onBlur={() => void commitTitle()}
-                  // The title lives inside the document editor; keep its keys and
-                  // pointer events from reaching the surrounding Slate editor.
-                  onMouseDown={(e) => e.stopPropagation()}
-                  onKeyDown={(e) => {
-                    e.stopPropagation();
+        {embeddedTitleMeta ? (
+          <h3
+            data-testid='embedded-database-title'
+            className='flex w-full items-center pb-3 text-xl font-semibold text-text-primary'
+          >
+            {embeddedReferenceMeta ? (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    aria-label={t('tooltip.viewDataBase')}
+                    className='mr-1.5 h-6 w-6'
+                    data-testid='embedded-database-open-original'
+                    disabled={!canOpenOriginalDatabase}
+                    loading={isOpeningOriginalDatabase}
+                    onClick={() => void openOriginalDatabase()}
+                    onMouseDown={(event) => event.stopPropagation()}
+                    size='icon-sm'
+                    type='button'
+                    variant='ghost'
+                  >
+                    <RelationIcon aria-hidden='true' className='h-5 w-5' />
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>{t('tooltip.viewDataBase')}</TooltipContent>
+              </Tooltip>
+            ) : null}
+            <div className='min-w-0 flex-1'>
+              {canRenameEmbeddedTitle ? (
+                editingTitle ? (
+                  <input
+                    ref={titleInputRef}
+                    data-testid='embedded-database-title-input'
+                    className='w-full bg-transparent text-xl font-semibold text-text-primary outline-none'
+                    value={titleDraft}
+                    placeholder={t('untitled')}
+                    onChange={(e) => setTitleDraft(e.target.value)}
+                    onBlur={() => void commitTitle()}
+                    // The title lives inside the document editor; keep its keys and
+                    // pointer events from reaching the surrounding Slate editor.
+                    onMouseDown={(e) => e.stopPropagation()}
+                    onKeyDown={(e) => {
+                      e.stopPropagation();
 
-                    if (e.key === 'Enter') {
-                      e.preventDefault();
-                      void commitTitle();
-                      return;
-                    }
+                      if (e.key === 'Enter') {
+                        e.preventDefault();
+                        void commitTitle();
+                        return;
+                      }
 
-                    if (e.key === 'Escape') {
-                      e.preventDefault();
-                      cancelEditingTitle();
-                    }
-                  }}
-                />
+                      if (e.key === 'Escape') {
+                        e.preventDefault();
+                        cancelEditingTitle();
+                      }
+                    }}
+                  />
+                ) : (
+                  <button
+                    type='button'
+                    data-testid='embedded-database-title-rename'
+                    className='w-full cursor-text rounded-200 text-left hover:bg-fill-list-hover'
+                    onClick={startEditingTitle}
+                  >
+                    {embeddedDatabaseName}
+                  </button>
+                )
               ) : (
-                <button
-                  type='button'
-                  data-testid='embedded-database-title-rename'
-                  className='w-full cursor-text rounded-200 text-left hover:bg-fill-list-hover'
-                  onClick={startEditingTitle}
-                >
-                  {embeddedDatabaseName}
-                </button>
-              )
-            ) : (
-              embeddedDatabaseName
-            )}
+                embeddedDatabaseName
+              )}
+            </div>
           </h3>
         ) : null}
         <div className={`database-tabs flex w-full items-center gap-1.5 overflow-hidden border-b border-border-primary`}>
@@ -536,7 +591,7 @@ export const DatabaseTabs = forwardRef<HTMLDivElement, DatabaseTabBarProps>(
 
                 await updateContainerPage(viewId, payload);
                 if (payload.name) {
-                  setPendingContainerName({ viewId, name: payload.name });
+                  setPendingEmbeddedName({ viewId, name: payload.name });
                 }
 
                 return;

--- a/src/components/database/components/tabs/__tests__/DatabaseTabs.containerRename.test.tsx
+++ b/src/components/database/components/tabs/__tests__/DatabaseTabs.containerRename.test.tsx
@@ -71,6 +71,13 @@ const databaseContainer: View = {
   is_private: false,
 };
 
+const linkedDatabaseView: View = {
+  ...databaseView,
+  view_id: 'linked-database-view-id',
+  parent_view_id: 'document-id',
+  name: 'Project has employee relation',
+};
+
 function setupContext({
   container = databaseContainer,
   updateContainerPage,
@@ -135,6 +142,7 @@ describe('DatabaseTabs embedded database title rename', () => {
 
     expect(input.value).toBe('New Database');
     expect(screen.queryByTestId('rename-modal')).toBeNull();
+    expect(screen.queryByTestId('embedded-database-open-original')).toBeNull();
 
     fireEvent.change(input, { target: { value: 'Renamed Database' } });
     fireEvent.keyDown(input, { key: 'Enter' });
@@ -270,6 +278,106 @@ describe('DatabaseTabs embedded database title rename', () => {
 
     await waitFor(() => {
       expect(updateContainerPage).toHaveBeenCalledWith(untitledContainer.view_id, { name: 'Named At Last' });
+    });
+  });
+
+  it('opens the original database from a linked database header', async () => {
+    const getViewIdFromDatabaseId = jest.fn().mockResolvedValue('original-database-view-id');
+    const navigateToView = jest.fn().mockResolvedValue(undefined);
+
+    (useDatabaseContext as jest.Mock).mockReturnValue({
+      getViewIdFromDatabaseId,
+      isDocumentBlock: true,
+      loadViewMeta: jest.fn(async (viewId: string) =>
+        viewId === linkedDatabaseView.view_id ? linkedDatabaseView : null
+      ),
+      navigateToView,
+      readOnly: false,
+      showActions: true,
+      updatePage: jest.fn().mockResolvedValue(undefined),
+    } as DatabaseContextState);
+
+    render(
+      <DatabaseTabs
+        databasePageId={linkedDatabaseView.view_id}
+        selectedViewId={linkedDatabaseView.view_id}
+        viewIds={[linkedDatabaseView.view_id]}
+      />
+    );
+
+    const openOriginal = await screen.findByTestId('embedded-database-open-original');
+
+    expect(screen.getByTestId('embedded-database-title').textContent).toContain(linkedDatabaseView.name);
+
+    fireEvent.click(openOriginal);
+
+    await waitFor(() => {
+      expect(getViewIdFromDatabaseId).toHaveBeenCalledWith('database-id');
+      expect(navigateToView).toHaveBeenCalledWith('original-database-view-id');
+    });
+  });
+
+  it('recognizes legacy linked views that were incorrectly marked as containers', async () => {
+    const legacyLinkedDatabaseView: View = {
+      ...linkedDatabaseView,
+      extra: {
+        ...linkedDatabaseView.extra,
+        is_database_container: true,
+      },
+    };
+
+    (useDatabaseContext as jest.Mock).mockReturnValue({
+      getViewIdFromDatabaseId: jest.fn().mockResolvedValue('original-database-view-id'),
+      isDocumentBlock: true,
+      loadViewMeta: jest.fn(async () => legacyLinkedDatabaseView),
+      navigateToView: jest.fn().mockResolvedValue(undefined),
+      readOnly: true,
+      showActions: true,
+    } as DatabaseContextState);
+
+    render(
+      <DatabaseTabs
+        databasePageId={legacyLinkedDatabaseView.view_id}
+        selectedViewId={legacyLinkedDatabaseView.view_id}
+        viewIds={[legacyLinkedDatabaseView.view_id]}
+      />
+    );
+
+    expect((await screen.findByTestId('embedded-database-open-original')).hasAttribute('disabled')).toBe(false);
+    expect(screen.getByTestId('embedded-database-title').textContent).toContain(legacyLinkedDatabaseView.name);
+  });
+
+  it('renames a linked database title without renaming its source database', async () => {
+    const updatePage = jest.fn().mockResolvedValue(undefined);
+
+    (useDatabaseContext as jest.Mock).mockReturnValue({
+      getViewIdFromDatabaseId: jest.fn().mockResolvedValue('original-database-view-id'),
+      isDocumentBlock: true,
+      loadViewMeta: jest.fn(async () => linkedDatabaseView),
+      navigateToView: jest.fn().mockResolvedValue(undefined),
+      readOnly: false,
+      showActions: true,
+      updatePage,
+    } as DatabaseContextState);
+
+    render(
+      <DatabaseTabs
+        databasePageId={linkedDatabaseView.view_id}
+        selectedViewId={linkedDatabaseView.view_id}
+        viewIds={[linkedDatabaseView.view_id]}
+      />
+    );
+
+    const title = await screen.findByTestId('embedded-database-title-rename');
+
+    fireEvent.click(title);
+    fireEvent.change(screen.getByTestId('embedded-database-title-input'), {
+      target: { value: 'Renamed linked view' },
+    });
+    fireEvent.keyDown(screen.getByTestId('embedded-database-title-input'), { key: 'Enter' });
+
+    await waitFor(() => {
+      expect(updatePage).toHaveBeenCalledWith(linkedDatabaseView.view_id, { name: 'Renamed linked view' });
     });
   });
 });

--- a/src/components/database/hooks/index.ts
+++ b/src/components/database/hooks/index.ts
@@ -1,4 +1,5 @@
 export * from './visibleViewIds';
+export { useOpenDatabaseAsPage } from './useOpenDatabaseAsPage';
 
 // Row document sync hook
 export { useBindViewSync } from './useBindViewSync';

--- a/src/components/database/hooks/useOpenDatabaseAsPage.ts
+++ b/src/components/database/hooks/useOpenDatabaseAsPage.ts
@@ -1,0 +1,56 @@
+import { useCallback, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { toast } from 'sonner';
+
+import { useDatabase, useDatabaseContext } from '@/application/database-yjs';
+import { YjsDatabaseKey } from '@/application/types';
+
+interface UseOpenDatabaseAsPageOptions {
+  databaseId?: string;
+  fallbackViewId?: string;
+}
+
+/**
+ * Opens the primary page for the mounted database.
+ *
+ * Linked database blocks have their own embedded view ID. Resolving through
+ * the shared database ID first prevents their header and toolbar actions from
+ * navigating to that embedded view instead of the source database page.
+ */
+export function useOpenDatabaseAsPage({ databaseId, fallbackViewId }: UseOpenDatabaseAsPageOptions = {}) {
+  const { t } = useTranslation();
+  const database = useDatabase();
+  const { getViewIdFromDatabaseId, navigateToView } = useDatabaseContext();
+  const [isOpening, setIsOpening] = useState(false);
+  const mountedDatabaseId = databaseId ?? database?.get(YjsDatabaseKey.id);
+  const canOpen = Boolean(navigateToView && ((mountedDatabaseId && getViewIdFromDatabaseId) || fallbackViewId));
+
+  const openDatabaseAsPage = useCallback(async () => {
+    if (isOpening || !navigateToView) return;
+
+    setIsOpening(true);
+
+    try {
+      let targetViewId: string | null | undefined;
+
+      if (mountedDatabaseId && getViewIdFromDatabaseId) {
+        targetViewId = await getViewIdFromDatabaseId(mountedDatabaseId);
+      }
+
+      targetViewId ??= fallbackViewId;
+
+      if (!targetViewId) {
+        throw new Error('Database view not found');
+      }
+
+      await navigateToView(targetViewId);
+    } catch (error) {
+      console.error('[useOpenDatabaseAsPage] Failed to open database:', error);
+      toast.error(t('chat.openPagePreviewFailedToast'));
+    } finally {
+      setIsOpening(false);
+    }
+  }, [fallbackViewId, getViewIdFromDatabaseId, isOpening, mountedDatabaseId, navigateToView, t]);
+
+  return { canOpen, isOpening, openDatabaseAsPage };
+}


### PR DESCRIPTION
### **Description**

Bring linked databases embedded in documents to desktop parity:

- show the linked database title header with the relation/open-original icon
- resolve the shared database ID to its primary source view from both the header and existing toolbar action
- preserve the existing inline-database header without a linked-source icon
- support legacy linked views that were incorrectly marked as database containers

The toolbar previously navigated directly to the embedded `databasePageId`, and the tab header only recognized inline database containers. Both entry points now share one source-view resolver, with the embedded view retained as a compatibility fallback.

### **Testing**

- Added a focused Playwright BDD scenario covering header and toolbar navigation to the recorded source view ID.
- Verified the BDD fails against the pre-fix production behavior, passes with the fix, and fails again after a production-only revert.
- Added component coverage for source resolution, linked/legacy headers, linked title rename, and inline icon absence.
- `pnpm exec jest src/components/database/components/tabs/__tests__ src/components/database/components/conditions/__tests__/DatabaseActions.test.tsx --runInBand --no-coverage` (34 passed)
- `pnpm lint`
- `pnpm build`

### **Feature Preview**

Automated browser proof was captured from the passing BDD run and will be attached in a PR comment.

---

### **Checklist**

#### **General**
- [x] I've included relevant documentation or comments for the changes introduced.
- [ ] I've tested the changes in multiple environments (e.g., different browsers, operating systems).

#### **Testing**
- [x] I've added or updated tests to validate the changes introduced for AppFlowy Web.

#### **Feature-Specific**
- [ ] For feature additions, I've added a preview (video, screenshot, or demo) in the "Feature Preview" section.
- [x] I've verified that this feature integrates seamlessly with existing functionality.

## Summary by Sourcery

Open linked databases on their original source page from both embedded controls while preserving inline database behavior.

New Features:
- Add linked database header controls that open the database’s original source page.
- Resolve linked database navigation consistently from both header and toolbar actions.

Bug Fixes:
- Prevent linked and legacy embedded views from opening their embedded view instead of the primary database page.
- Preserve inline database headers without an open-original icon.

Enhancements:
- Support linked database title display and renaming independently from the source database.

Tests:
- Add browser coverage for opening linked databases from header and toolbar controls.
- Add component coverage for source resolution, linked and legacy headers, title renaming, and inline icon behavior.