### PR TITLE
fix: preserve management for space creators

### DIFF
--- a/playwright/bdd/features/workspace/create-space-draft.feature
+++ b/playwright/bdd/features/workspace/create-space-draft.feature
@@ -5,9 +5,9 @@ Feature: Create Space keeps a local draft until confirmation
 
   Background:
     Given the seeded scp0822 space permission fixture exists
-    And I sign in as seeded scp0822 "owner"
 
   Scenario: Cancelling a renamed Custom draft sends no mutations
+    Given I sign in as seeded scp0822 "owner"
     When I start recording create-space draft mutations
     And I open the create-space draft panel
     And I rename the create-space draft to "Draft that must not persist"
@@ -21,6 +21,7 @@ Feature: Create Space keeps a local draft until confirmation
     Then the create-space draft has sent no mutations
 
   Scenario: Create persists one renamed Custom space before its queued member
+    Given I sign in as seeded scp0822 "owner"
     When I start recording create-space draft mutations
     And I open the create-space draft panel
     And I rename the create-space draft to "BDD Deferred Custom Space"
@@ -32,4 +33,15 @@ Feature: Create Space keeps a local draft until confirmation
     When I confirm the create-space draft
     Then one renamed Custom space and initial page are created before the queued member
     And the created create-space draft is visible as "BDD Deferred Custom Space"
+    And the created space owner menu shows Manage Space and Duplicate Space
+
+  Scenario: Eva can manage a default Public space she creates in the Nathan workspace
+    Given I sign in as Eva and open the Nathan workspace for space creation
+    When I start recording create-space draft mutations
+    And I open the create-space draft panel
+    And I rename the create-space draft to "BDD Member Public Space"
+    And I confirm the create-space draft
+    Then one default Public space and initial page are created through structured APIs
+    And the created Public space grants Eva creator ownership via the API
+    And the created create-space draft is visible as "BDD Member Public Space"
     And the created space owner menu shows Manage Space and Duplicate Space

--- a/playwright/bdd/features/workspace/create-space-draft.feature
+++ b/playwright/bdd/features/workspace/create-space-draft.feature
@@ -34,14 +34,3 @@ Feature: Create Space keeps a local draft until confirmation
     Then one renamed Custom space and initial page are created before the queued member
     And the created create-space draft is visible as "BDD Deferred Custom Space"
     And the created space owner menu shows Manage Space and Duplicate Space
-
-  Scenario: Eva can manage a default Public space she creates in the Nathan workspace
-    Given I sign in as Eva and open the Nathan workspace for space creation
-    When I start recording create-space draft mutations
-    And I open the create-space draft panel
-    And I rename the create-space draft to "BDD Member Public Space"
-    And I confirm the create-space draft
-    Then one default Public space and initial page are created through structured APIs
-    And the created Public space grants Eva creator ownership via the API
-    And the created create-space draft is visible as "BDD Member Public Space"
-    And the created space owner menu shows Manage Space and Duplicate Space

--- a/playwright/bdd/features/workspace/space-creator-management.feature
+++ b/playwright/bdd/features/workspace/space-creator-management.feature
@@ -1,0 +1,14 @@
+@space-creator-management @create-space-draft @mode:serial
+Feature: A workspace member retains management of a space they create
+  A workspace member who creates a space is its owner and can manage it.
+
+  Scenario: Eva can manage a default Public space she creates in the Nathan workspace
+    Given I sign in as Eva and open the Nathan workspace for space creation
+    When I start recording create-space draft mutations
+    And I open the create-space draft panel
+    And I rename the create-space draft to "BDD Member Public Space"
+    And I confirm the create-space draft
+    Then one default Public space and initial page are created through structured APIs
+    And the created create-space draft is visible as "BDD Member Public Space"
+    And the created space owner menu shows Manage Space and Duplicate Space
+    And the created Public space grants Eva creator ownership via the API

--- a/playwright/bdd/steps/create-space-draft.steps.ts
+++ b/playwright/bdd/steps/create-space-draft.steps.ts
@@ -1,10 +1,15 @@
 import { expect, Page, Request } from '@playwright/test';
 import { createBdd } from 'playwright-bdd';
 
+import { signInWithPasswordViaUi } from '../../support/auth-flow-helpers';
 import { PageSelectors, SpaceSelectors, ModalSelectors } from '../../support/selectors';
 import { TestConfig } from '../../support/test-config';
 
-const { When, Then, After } = createBdd();
+const { Given, When, Then, After } = createBdd();
+
+const EVA_EMAIL = 'eva@appflowy.io';
+const FIXTURE_PASSWORD = 'AppFlowy!@123';
+const NATHAN_WORKSPACE_NAME = /nathan.*workspace/i;
 
 type DraftMutationKind = 'create-space' | 'initial-page' | 'space-update' | 'member' | 'group';
 
@@ -25,7 +30,72 @@ type DraftScenarioState = {
   expectedMemberUid?: string;
 };
 
+type ApiResponse<T> = {
+  code?: number;
+  message?: string;
+  data?: T;
+};
+
+type SpacePermissionResponse = {
+  permission?: { visibility?: string };
+  current_user_access_level?: number | null;
+  explicit_member_count?: number;
+  can_manage_space?: boolean;
+};
+
+type SpaceMember = {
+  email?: string | null;
+  role?: string;
+  access_level?: number;
+  source?: string;
+};
+
+type SpaceMembersResponse = {
+  members?: SpaceMember[];
+};
+
+type WorkspaceSummary = {
+  workspace_id?: string;
+  workspace_name?: string;
+  role?: string;
+};
+
+type UserWorkspaceInfoResponse = {
+  visiting_workspace?: WorkspaceSummary;
+  workspaces?: WorkspaceSummary[];
+};
+
 const stateByPage = new WeakMap<Page, DraftScenarioState>();
+
+Given('I sign in as Eva and open the Nathan workspace for space creation', async ({ page, request }) => {
+  await signInWithPasswordViaUi(page, EVA_EMAIL, FIXTURE_PASSWORD, 2000);
+  const token = await getAuthToken(page);
+
+  if (!token) throw new Error('The Eva session has no auth token');
+  const response = await request.get(`${TestConfig.apiUrl}/api/user/workspace`, {
+    headers: { Authorization: `Bearer ${token}` },
+    failOnStatusCode: false,
+  });
+  const responseText = await response.text();
+  const responseBody = parseJsonObject(responseText) as ApiResponse<UserWorkspaceInfoResponse>;
+  const workspaces = [
+    ...(responseBody.data?.workspaces ?? []),
+    ...(responseBody.data?.visiting_workspace ? [responseBody.data.visiting_workspace] : []),
+  ];
+  const nathanWorkspace = workspaces.find(({ workspace_name }) => NATHAN_WORKSPACE_NAME.test(workspace_name ?? ''));
+
+  if (!response.ok() || responseBody.code !== 0) {
+    throw new Error(`Eva workspace lookup failed: HTTP ${response.status()} ${responseText}`);
+  }
+  if (!nathanWorkspace?.workspace_id) {
+    throw new Error(`Eva cannot find a workspace matching ${NATHAN_WORKSPACE_NAME}`);
+  }
+  expect(nathanWorkspace.role?.toLowerCase()).toBe('member');
+
+  await page.goto(`/app/${nathanWorkspace.workspace_id}`, { waitUntil: 'domcontentloaded' });
+  await expect(page.getByTestId('current-workspace-name')).toHaveText(NATHAN_WORKSPACE_NAME, { timeout: 30000 });
+  await expect(PageSelectors.newPageButton(page)).toBeVisible({ timeout: 30000 });
+});
 
 After({ tags: '@create-space-draft' }, async ({ page, request }) => {
   const state = stateByPage.get(page);
@@ -216,6 +286,75 @@ Then('one renamed Custom space and initial page are created before the queued me
   state.workspaceId = workspaceIdFromMutation(state.mutations[0].url);
 });
 
+Then('one default Public space and initial page are created through structured APIs', async ({ page }) => {
+  const state = requireState(page);
+
+  await expect
+    .poll(() => state.mutations.length, {
+      message: 'expected structured space and initial-page mutations',
+      timeout: 30000,
+    })
+    .toBe(2);
+
+  expect(state.mutations.map(({ kind }) => kind)).toEqual(['create-space', 'initial-page']);
+  const [createMutation, initialPageMutation] = state.mutations;
+  const createBody = parseJsonObject(createMutation.body);
+  const initialPageBody = parseJsonObject(initialPageMutation.body);
+  const permission = createBody.permission as { visibility?: string } | undefined;
+
+  expect(new URL(createMutation.url).pathname).toMatch(/\/api\/workspace\/[^/]+\/spaces$/);
+  expect(new URL(createMutation.url).pathname).not.toMatch(/\/v2\/space$/);
+  expect(createBody.name).toBe(state.draftName);
+  expect(permission?.visibility).toBe('public');
+  expect(typeof createBody.view_id).toBe('string');
+  expect(initialPageBody.parent_view_id).toBe(createBody.view_id);
+  expect(initialPageBody.view_id).toBeTruthy();
+  expect(initialPageBody.collab_id).toBe(initialPageBody.view_id);
+
+  state.createdSpaceId = String(createBody.view_id);
+  state.createdInitialPageId = String(initialPageBody.view_id);
+  state.workspaceId = workspaceIdFromMutation(createMutation.url);
+});
+
+Then('the created Public space grants Eva creator ownership via the API', async ({ page, request }) => {
+  const state = requireState(page);
+
+  if (!state.workspaceId || !state.createdSpaceId) throw new Error('The created Public space IDs are unavailable');
+  const token = await getAuthToken(page);
+
+  if (!token) throw new Error('The seeded Member session has no auth token');
+  const headers = { Authorization: `Bearer ${token}` };
+  const permissionPath = `/api/workspace/${state.workspaceId}/spaces/${state.createdSpaceId}/permission`;
+  const permissionResponse = await request.get(`${TestConfig.apiUrl}${permissionPath}`, {
+    headers,
+    failOnStatusCode: false,
+  });
+  const permissionBody = (await permissionResponse.json()) as ApiResponse<SpacePermissionResponse>;
+
+  expect(permissionResponse.ok(), await permissionResponse.text()).toBe(true);
+  expect(permissionBody.code).toBe(0);
+  expect(permissionBody.data?.permission?.visibility).toBe('public');
+  expect(permissionBody.data?.current_user_access_level).toBe(ACCESS_LEVEL_FULL_ACCESS);
+  expect(permissionBody.data?.can_manage_space).toBe(true);
+  expect(permissionBody.data?.explicit_member_count).toBeGreaterThanOrEqual(1);
+
+  const membersPath = `/api/workspace/${state.workspaceId}/spaces/${state.createdSpaceId}/members`;
+  const membersResponse = await request.get(`${TestConfig.apiUrl}${membersPath}`, {
+    headers,
+    failOnStatusCode: false,
+  });
+  const membersBody = (await membersResponse.json()) as ApiResponse<SpaceMembersResponse>;
+  const creator = membersBody.data?.members?.find(({ email }) => email === EVA_EMAIL);
+
+  expect(membersResponse.ok(), await membersResponse.text()).toBe(true);
+  expect(membersBody.code).toBe(0);
+  expect(creator).toMatchObject({
+    role: 'owner',
+    access_level: ACCESS_LEVEL_FULL_ACCESS,
+    source: 'creator',
+  });
+});
+
 Then('the created create-space draft is visible as {string}', async ({ page }, _requestedName: string) => {
   const state = requireState(page);
 
@@ -256,6 +395,7 @@ const SpaceMemberRoleValue = {
   Member: 'member',
 } as const;
 const ACCESS_LEVEL_READ_AND_WRITE = 30;
+const ACCESS_LEVEL_FULL_ACCESS = 50;
 
 function classifyDraftMutation(request: Request): DraftMutationKind | null {
   if (!['POST', 'PATCH', 'PUT', 'DELETE'].includes(request.method())) return null;

--- a/src/application/services/js-services/http/__tests__/page-api.test.ts
+++ b/src/application/services/js-services/http/__tests__/page-api.test.ts
@@ -489,15 +489,16 @@ describe('createSpaceWithInitialPage', () => {
   });
 
   it.each([
-    [SpaceVisibility.Public, SpacePermission.Public],
-    [SpaceVisibility.Private, SpacePermission.Private],
-  ])('uses the atomic V2 endpoint for a lossless %s permission draft', async (visibility, expectedLegacy) => {
-    const response = {
-      space: { view_id: 'space-id' },
-      page: { view_id: 'page-id' },
-    };
+    [SpaceVisibility.Public, SpacePermission.Private],
+    [SpaceVisibility.Private, SpacePermission.Public],
+  ])('uses structured endpoints for a default %s permission draft', async (visibility, staleLegacyPermission) => {
+    const permission = { ...privatePermission, visibility };
 
-    post.mockResolvedValue(apiResponse(response));
+    post.mockImplementation(async (url: string) => {
+      if (url === '/api/workspace/workspace-id/spaces') return apiResponse({ view_id: 'space-id' });
+      if (url === '/api/workspace/workspace-id/page-view') return apiResponse({ view_id: 'page-id' });
+      throw new Error(`Unexpected URL: ${url}`);
+    });
 
     await expect(
       createSpaceWithInitialPage('workspace-id', {
@@ -506,25 +507,34 @@ describe('createSpaceWithInitialPage', () => {
         space_icon_color: '',
         view_id: 'space-id',
         client_generated_view_id: true,
-        permission: { ...privatePermission, visibility },
+        permission,
         // The structured visibility is authoritative when both forms are
-        // present, so a stale compatibility field cannot select the wrong
-        // binary space type.
-        space_permission:
-          expectedLegacy === SpacePermission.Private ? SpacePermission.Public : SpacePermission.Private,
+        // present, so a stale compatibility field cannot select a legacy path.
+        space_permission: staleLegacyPermission,
         initial_page: { layout: ViewLayout.Document, view_id: 'page-id' },
       })
-    ).resolves.toEqual(response);
+    ).resolves.toEqual({
+      space: { view_id: 'space-id' },
+      page: { view_id: 'page-id' },
+    });
 
-    expect(post).toHaveBeenCalledTimes(1);
-    expect(post).toHaveBeenCalledWith('/api/workspace/workspace-id/v2/space', {
+    expect(post).toHaveBeenNthCalledWith(1, '/api/workspace/workspace-id/spaces', {
       name: 'Default space',
       space_icon: '',
       space_icon_color: '',
       view_id: 'space-id',
-      space_permission: expectedLegacy,
-      initial_page: { layout: ViewLayout.Document, view_id: 'page-id' },
+      permission,
     });
+    expect(post).toHaveBeenNthCalledWith(2, '/api/workspace/workspace-id/page-view', {
+      parent_view_id: 'space-id',
+      layout: ViewLayout.Document,
+      name: undefined,
+      page_data: undefined,
+      view_id: 'page-id',
+      collab_id: 'page-id',
+      prev_view_id: undefined,
+    });
+    expect(post.mock.calls.map(([url]) => url)).not.toContain('/api/workspace/workspace-id/v2/space');
     expect(deleteRequest).not.toHaveBeenCalled();
   });
 });

--- a/src/application/services/js-services/http/page-api.ts
+++ b/src/application/services/js-services/http/page-api.ts
@@ -322,10 +322,12 @@ export async function createSpace(workspaceId: string, payload: CreateSpacePaylo
 }
 
 export async function createSpaceWithInitialPage(workspaceId: string, payload: CreateSpaceWithInitialPagePayload) {
-  if (payload.permission && !isLosslessLegacyPermission(payload.permission)) {
-    // The legacy /v2/space endpoint only understands binary public/private
-    // permissions. Compose the structured endpoints instead so richer ACLs are
-    // never silently downgraded. This is compensating, not server-transactional.
+  if (payload.permission) {
+    // The legacy /v2/space endpoint neither persists the structured ACL nor
+    // records the creator as a space owner, even when the requested settings
+    // have a binary public/private representation. Compose the structured
+    // endpoints for every permission-aware draft. This is compensating, not
+    // server-transactional.
     const clientGeneratedViewId = payload.client_generated_view_id === true;
     const ownsSpaceId = payload.view_id === undefined || clientGeneratedViewId;
     const requestedSpaceId = payload.view_id ?? uuidv4();
@@ -381,13 +383,13 @@ export async function createSpaceWithInitialPage(workspaceId: string, payload: C
   const url = `/api/workspace/${workspaceId}/v2/space`;
   const {
     client_generated_view_id: clientGeneratedViewId,
-    permission,
+    permission: _structuredPermission,
     space_permission: requestedLegacyPermission,
     ...legacyPayload
   } = payload;
   const requestPayload = {
     ...legacyPayload,
-    space_permission: permission ? legacySpacePermission(permission.visibility) : requestedLegacyPermission,
+    space_permission: requestedLegacyPermission,
   };
 
   try {

--- a/src/application/services/js-services/http/page-api.ts
+++ b/src/application/services/js-services/http/page-api.ts
@@ -323,10 +323,10 @@ export async function createSpace(workspaceId: string, payload: CreateSpacePaylo
 
 export async function createSpaceWithInitialPage(workspaceId: string, payload: CreateSpaceWithInitialPagePayload) {
   if (payload.permission) {
-    // The legacy /v2/space endpoint neither persists the structured ACL nor
-    // records the creator as a space owner, even when the requested settings
-    // have a binary public/private representation. Compose the structured
-    // endpoints for every permission-aware draft. This is compensating, not
+    // The atomic /v2/space endpoint accepts only the binary permission model;
+    // it does not persist a structured ACL or a creator-owner row. Compose the
+    // structured endpoints for every permission-aware draft so the requested
+    // ownership contract is retained. This is compensating, not
     // server-transactional.
     const clientGeneratedViewId = payload.client_generated_view_id === true;
     const ownsSpaceId = payload.view_id === undefined || clientGeneratedViewId;


### PR DESCRIPTION
## Summary
- route every permission-aware Create Space draft through POST /spaces, then create its first page with POST /page-view
- keep POST /v2/space for callers that provide only the binary permission model; the endpoint is active and atomic, but does not persist a structured ACL or creator-owner row
- add unit coverage for default Public and Private drafts
- add an isolated Playwright BDD scenario where Eva, a workspace Member, creates a default Public space in the Nathan workspace and receives creator ownership plus Manage Space and Duplicate Space actions

## Baseline comparison
- clean origin/main used one POST /v2/space request for the Eva scenario and did not expose the creator management actions in the isolated run
- this branch used POST /spaces plus POST /page-view, returned can_manage_space=true with Eva as the creator owner, and exposed both actions

## Validation
- pnpm type-check
- focused page-api Jest suite: 33 passed
- create-space draft and creator-management Playwright BDD features: 3 passed
- isolated Eva/Nathan creator-management scenario: passed against the branch

## Summary by Sourcery

Preserve space creator management by using structured APIs for every permission-aware space draft.

Bug Fixes:
- Preserve creator ownership and management permissions by routing permission-aware space creation through structured APIs instead of the binary-only atomic endpoint.

Tests:
- Add unit coverage for default Public and Private permission drafts.
- Add isolated Playwright BDD coverage verifying that a workspace member creating a Public space receives creator ownership and management actions.