### PR TITLE
fix(space): show Delete for workspace owners

### DIFF
--- a/src/components/app/view-actions/MoreSpaceActions.tsx
+++ b/src/components/app/view-actions/MoreSpaceActions.tsx
@@ -76,7 +76,7 @@ function MoreSpaceActions({
           {t('loading')}
         </DropdownMenuItem>
       )}
-      {canManageActions && (
+      {(canManageActions || canOpenManageActions) && (
         <>
           <DropdownMenuSeparator className={'w-full'} />
           <DropdownMenuItem

--- a/src/components/app/view-actions/__tests__/actionPermissionGates.test.tsx
+++ b/src/components/app/view-actions/__tests__/actionPermissionGates.test.tsx
@@ -189,7 +189,7 @@ describe('view action permission gates', () => {
     expect(screen.queryByTestId('space-action-delete')).toBeNull();
   });
 
-  it('shows Manage and Duplicate together when canonical space-management authority is granted', () => {
+  it('shows Manage, Duplicate, and Delete when canonical space-management authority is granted', () => {
     render(
       <MoreSpaceActions
         view={mockSpaceView}
@@ -202,7 +202,7 @@ describe('view action permission gates', () => {
 
     expect(screen.getByTestId('space-action-manage')).toBeTruthy();
     expect(screen.getByTestId('space-action-duplicate')).toBeTruthy();
-    expect(screen.queryByTestId('space-action-delete')).toBeNull();
+    expect(screen.getByTestId('space-action-delete')).toBeTruthy();
   });
 
   it('hides the space more trigger when no menu action is permitted while keeping Add independent', () => {
@@ -276,7 +276,7 @@ describe('view action permission gates', () => {
     }
   );
 
-  it('shows Manage and Duplicate for canonical owners even without generic create/delete permission', () => {
+  it('shows owner actions for canonical owners even without generic view-management permission', () => {
     mockUseViewActionPermissions.mockReturnValue({
       canCreateViewActions: false,
       canManageViewActions: false,
@@ -302,7 +302,7 @@ describe('view action permission gates', () => {
 
     expect(screen.getByTestId('space-action-manage')).toBeTruthy();
     expect(screen.getByTestId('space-action-duplicate')).toBeTruthy();
-    expect(screen.queryByTestId('space-action-delete')).toBeNull();
+    expect(screen.getByTestId('space-action-delete')).toBeTruthy();
   });
 
   it('keeps Delete available for delegated Full Access without structured space management', () => {


### PR DESCRIPTION
### **Description**

Show **Delete** when a user has either generic object share authority or canonical structured-space management authority.

`Manage members` and `Duplicate` already used the server-provided `can_manage_space` capability, but `Delete` was gated only by the generic object-level `can_share` capability. That hid Delete from workspace Owners for Custom spaces created by other members, even though the server's delete path explicitly authorizes workspace Owners.

The existing delegated-Full-Access behavior is preserved, and focused tests now cover canonical managers whose generic share flag is false.

Related backend roster and permission repair: https://github.com/AppFlowy-IO/AppFlowy-Cloud-Premium/pull/1061

#### Validation

- focused Jest suite — 14 passed
- `tsc --noEmit --project tsconfig.web.json`
- targeted ESLint for the changed component and test
- negative test-integrity check: reverting only the production gate makes the two new manager/owner assertions fail because Delete is absent

---

### **Checklist**

#### **General**

- [x] No documentation or public API changes are needed for this permission-gate correction.
- [ ] Tested in multiple browser/OS environments; validation is component-level because the local server was intentionally not restarted.

#### **Testing**

- [x] I've updated tests to validate the change.

#### **Feature-Specific**

- [x] This is a bug fix, not a feature addition requiring a preview.
- [x] TypeScript, lint, focused tests, and a negative test-integrity check passed.

## Summary by Sourcery

Show the workspace Delete action for all server-authorized space managers.

Bug Fixes:
- Allow workspace owners and other canonical space managers to see the Delete action even when generic share permissions are absent, while preserving delegated Full Access behavior.

Tests:
- Update permission-gate tests to verify Delete is shown for canonical managers and owners without generic management permissions.