### PR TITLE
fix(database): match desktop rollup pill styling

### DIFF
--- a/src/components/database/components/cell/rollup/RollupCell.test.tsx
+++ b/src/components/database/components/cell/rollup/RollupCell.test.tsx
@@ -50,6 +50,10 @@ describe('RollupCell list navigation', () => {
     fireEvent.click(screen.getByRole('button', { name: 'EPC-013' }));
     fireEvent.click(screen.getByRole('button', { name: 'EPC-014' }));
 
+    const firstItem = screen.getByRole('button', { name: 'EPC-013' });
+
+    expect(firstItem.className).not.toContain('underline');
+    expect(firstItem.className).toContain('bg-fill-secondary');
     expect(mockNavigateToRow).toHaveBeenNthCalledWith(1, 'epic-row-13', 'epics-view');
     expect(mockNavigateToRow).toHaveBeenNthCalledWith(2, 'epic-row-14', 'epics-view');
     expect(onCellClick).not.toHaveBeenCalled();

--- a/src/components/database/components/cell/rollup/RollupCell.tsx
+++ b/src/components/database/components/cell/rollup/RollupCell.tsx
@@ -152,7 +152,10 @@ export function RollupCell({
 
           if (!itemRowId || !itemViewId || !navigateToRow) {
             return (
-              <div key={`${item.label}-${index}`} className={'min-w-fit max-w-[140px]'}>
+              <div
+                key={`${item.label}-${index}`}
+                className={'min-w-fit max-w-[140px] overflow-hidden rounded-[6px] bg-fill-secondary'}
+              >
                 {content}
               </div>
             );
@@ -163,7 +166,9 @@ export function RollupCell({
               key={`${itemViewId}-${itemRowId}-${index}`}
               type={'button'}
               data-testid={`rollup-list-item-${itemRowId}-${fieldId}-${index}`}
-              className={'min-w-fit max-w-[140px] cursor-pointer overflow-hidden underline hover:text-text-action'}
+              className={
+                'min-w-fit max-w-[140px] cursor-pointer overflow-hidden rounded-[6px] bg-fill-secondary'
+              }
               onClick={(event) => {
                 event.stopPropagation();
                 navigateToRow(itemRowId, itemViewId !== databasePageId ? itemViewId : undefined);


### PR DESCRIPTION
### **Description**

Match desktop rollup list-value styling in the web grid. Rollup values now use rounded secondary-fill pills instead of underlined link text, while preserving related-row navigation and the non-clickable legacy fallback.

### **Checklist**

#### **General**
- [x] No documentation changes are required for this UI parity fix.
- [ ] Tested in multiple browsers and operating systems.

#### **Testing**
- [x] Added regression assertions for the pill background and removal of the underline.
- [x] Ran TypeScript type-checking and ESLint.
- [x] Ran all 24 rollup component and property tests.

#### **Feature-Specific**
- [x] Verified the change preserves existing related-row navigation.
- [x] Not a feature addition; preview requirement does not apply.

## Summary by Sourcery

Align rollup list-value styling with the desktop experience without changing existing row navigation behavior.

Bug Fixes:
- Match web-grid rollup list values to desktop styling by replacing underlined link text with rounded secondary-fill pills while preserving navigation and legacy fallback behavior.

Tests:
- Add regression assertions covering the rollup pill background and removal of underlining.