### PR TITLE
fix(space): show creation progress and clear member search

### DIFF
--- a/playwright/bdd/features/workspace/space-custom-permissions.feature
+++ b/playwright/bdd/features/workspace/space-custom-permissions.feature
@@ -36,7 +36,7 @@ Feature: Seeded Public, Private and Custom space permissions
     When I open the seeded scp0822 "public space" manage space panel
     And I click Switch to Custom in the Public access card
     Then the Manage Space confirmation asks "Change this Space to Custom?" with the action "Change to Custom"
-    And the Manage Space confirmation explains "All current Workspace members will remain in this Space. Space owners will keep Full access, and other members will remain Space members with Can edit access. You can customize their access after switching. You can change these permissions after switching."
+    And the Manage Space confirmation explains "All current Workspace members will remain in this Space. Space owners will keep Full access, and other members will remain Space members with Can edit access. You can customize their access after switching."
     When I confirm the Manage Space dialog
     Then the Manage Space general tab shows the Custom permissions card
     And the Custom permissions card shows Space members "Can edit" and everyone else "Can view"

--- a/src/@types/translations/en.json
+++ b/src/@types/translations/en.json
@@ -223,6 +223,7 @@
     "invite": "Invite",
     "inviteSuccess": "Invite sent successfully",
     "changeAccessSuccess": "Access level changed successfully for {{email}}",
+    "databaseRowPagePermissionChangeDisabled": "Unable to change database row page permission.",
     "changeGroupAccessSuccess": "Access level changed successfully for {{group}}",
     "groupAccessInheritedStronger": "{{group}} still has stronger access inherited from a parent page",
     "changeAccessError": "Failed to change access level",

--- a/src/components/app/share/AccessLevelDropdown.tsx
+++ b/src/components/app/share/AccessLevelDropdown.tsx
@@ -18,12 +18,15 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 import { Progress } from '@/components/ui/progress';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+import { cn } from '@/lib/utils';
 
 interface AccessLevelDropdownProps {
   person: IPeopleWithAccessType;
   canModify: boolean;
   currentUserHasFullAccess: boolean;
   currentUserCanGrantFullAccess?: boolean;
+  disabledReason?: string;
   isYou: boolean;
   onAccessLevelChange: (email: string, accessLevel: AccessLevel) => Promise<void>;
   onRemoveAccess: (email: string) => Promise<void>;
@@ -34,6 +37,7 @@ export function AccessLevelDropdown({
   canModify,
   currentUserHasFullAccess,
   currentUserCanGrantFullAccess = false,
+  disabledReason,
   isYou,
   onAccessLevelChange,
   onRemoveAccess,
@@ -92,11 +96,28 @@ export function AccessLevelDropdown({
     );
   }, [loading, isYou, handleRemoveAccess, t]);
 
-  if (!canModify) {
-    return (
-      <div className='mr-2 flex min-w-fit items-center justify-center whitespace-nowrap px-3 py-1.5 text-sm text-text-secondary'>
+  if (!canModify || disabledReason) {
+    const accessLabel = (
+      <div
+        aria-disabled={disabledReason ? true : undefined}
+        className={cn(
+          'mr-2 flex min-w-fit items-center justify-center whitespace-nowrap px-3 py-1.5 text-sm text-text-secondary',
+          disabledReason && 'cursor-not-allowed'
+        )}
+        data-testid={disabledReason ? 'access-level-change-disabled' : undefined}
+        tabIndex={disabledReason ? 0 : undefined}
+      >
         {getAccessLevelText(person.access_level)}
       </div>
+    );
+
+    if (!disabledReason) return accessLabel;
+
+    return (
+      <Tooltip disableHoverableContent>
+        <TooltipTrigger asChild>{accessLabel}</TooltipTrigger>
+        <TooltipContent side='top'>{disabledReason}</TooltipContent>
+      </Tooltip>
     );
   }
 

--- a/src/components/app/share/PeopleWithAccess.tsx
+++ b/src/components/app/share/PeopleWithAccess.tsx
@@ -30,6 +30,7 @@ interface PeopleWithAccessProps {
   canManageGroupAccess: boolean;
   canManageFullAccess: boolean;
   canGrantFullAccess: boolean;
+  disablePersonAccessChanges?: boolean;
   sectionType: ShareSectionType;
 }
 
@@ -46,6 +47,7 @@ export function PeopleWithAccess({
   canManageGroupAccess,
   canManageFullAccess,
   canGrantFullAccess,
+  disablePersonAccessChanges = false,
   sectionType,
 }: PeopleWithAccessProps) {
   const { t } = useTranslation();
@@ -150,6 +152,9 @@ export function PeopleWithAccess({
 
   const currentUserRole = people.find((p) => p.email === currentUser?.email)?.role;
   const currentUserIsOwner = currentUserRole === Role.Owner;
+  const permissionChangeDisabledReason = disablePersonAccessChanges
+    ? t('shareAction.databaseRowPagePermissionChangeDisabled')
+    : undefined;
 
   return (
     <div className='w-full px-2 pt-4'>
@@ -170,6 +175,7 @@ export function PeopleWithAccess({
               currentUserHasFullAccess={hasFullAccess}
               currentUserIsOwner={currentUserIsOwner}
               currentUserCanGrantFullAccess={canGrantFullAccess}
+              permissionChangeDisabledReason={permissionChangeDisabledReason}
               onAccessLevelChange={handleAccessLevelChange}
               onRemoveAccess={handleRemoveAccess}
               onTurnIntoMember={handleTurnIntoMember}

--- a/src/components/app/share/PersonItem.tsx
+++ b/src/components/app/share/PersonItem.tsx
@@ -19,6 +19,7 @@ interface PersonItemProps {
   currentUserHasFullAccess: boolean;
   currentUserIsOwner: boolean;
   currentUserCanGrantFullAccess: boolean;
+  permissionChangeDisabledReason?: string;
   onAccessLevelChange: (email: string, accessLevel: AccessLevel) => Promise<void>;
   onRemoveAccess: (email: string) => Promise<void>;
   onTurnIntoMember?: (email: string) => Promise<void>;
@@ -31,12 +32,14 @@ export function PersonItem({
   currentUserHasFullAccess,
   currentUserIsOwner,
   currentUserCanGrantFullAccess,
+  permissionChangeDisabledReason,
   onAccessLevelChange,
   onRemoveAccess,
   onTurnIntoMember,
 }: PersonItemProps) {
   const { t } = useTranslation();
   const canModifyThisPerson =
+    !permissionChangeDisabledReason &&
     !isInheritedWorkspaceAccess &&
     currentUserHasFullAccess &&
     !isYou &&
@@ -126,6 +129,7 @@ export function PersonItem({
         canModify={canModifyThisPerson}
         currentUserHasFullAccess={currentUserHasFullAccess}
         currentUserCanGrantFullAccess={currentUserCanGrantFullAccess}
+        disabledReason={permissionChangeDisabledReason}
         isYou={isYou}
         onAccessLevelChange={onAccessLevelChange}
         onRemoveAccess={onRemoveAccess}

--- a/src/components/app/share/SharePanel.tsx
+++ b/src/components/app/share/SharePanel.tsx
@@ -33,6 +33,7 @@ function SharePanel({
   updateGroupInAccessList,
   hasFullAccess,
   canManageFullAccess,
+  disablePersonAccessChanges,
   currentUserAccessLevel,
   generalAccessLevel,
   sectionType,
@@ -47,6 +48,7 @@ function SharePanel({
   updateGroupInAccessList: (groupId: string, accessLevel: AccessLevel | null) => void;
   hasFullAccess: boolean;
   canManageFullAccess: boolean;
+  disablePersonAccessChanges: boolean;
   currentUserAccessLevel?: AccessLevel;
   generalAccessLevel?: AccessLevel | null;
   sectionType: ShareSectionType;
@@ -177,6 +179,7 @@ function SharePanel({
           canManageGroupAccess={canManageGroupAccess}
           canManageFullAccess={canManageFullAccess}
           canGrantFullAccess={canManageFullAccess}
+          disablePersonAccessChanges={disablePersonAccessChanges}
           sectionType={sectionType}
         />
         <GeneralAccess sectionType={sectionType} accessLevel={generalAccessLevel} />

--- a/src/components/app/share/ShareTabs.tsx
+++ b/src/components/app/share/ShareTabs.tsx
@@ -40,6 +40,9 @@ function ShareTabs({
   const view = useAppView(viewId);
   const [value, setValue] = React.useState<TabKey>(TabKey.SHARE);
   const activeValue = hidePublish && value === TabKey.PUBLISH ? TabKey.SHARE : value;
+  // RightMenu uses hidePublish for full-page database rows. Their access list
+  // comes from the containing database and must not be mutated from the row.
+  const disablePersonAccessChanges = hidePublish;
   const currentUser = useCurrentUser();
   const {
     people,
@@ -139,6 +142,7 @@ function ShareTabs({
                 updateGroupInAccessList={updateGroupInAccessList}
                 hasFullAccess={canShare}
                 canManageFullAccess={canShare && canManageFullAccess}
+                disablePersonAccessChanges={disablePersonAccessChanges}
                 currentUserAccessLevel={currentUserAccessLevel}
                 generalAccessLevel={generalAccessLevel}
                 sectionType={sectionType}

--- a/src/components/app/share/__tests__/AccessLevelDropdown.test.tsx
+++ b/src/components/app/share/__tests__/AccessLevelDropdown.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it, jest } from '@jest/globals';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 
 import { AccessLevel, IPeopleWithAccessType, Role } from '@/application/types';
 
@@ -149,5 +149,23 @@ describe('AccessLevelDropdown', () => {
     expect(screen.queryByRole('button', { name: 'Can view' })).toBeNull();
     expect(screen.getByText('Can view')).toBeTruthy();
     expect(screen.queryByText('Remove access')).toBeNull();
+  });
+
+  it('shows why database row-page permission changes are disabled', async () => {
+    const disabledReason = 'Unable to change database row page permission.';
+
+    renderAccessLevelDropdown({
+      disabledReason,
+      person: createPerson({ access_level: AccessLevel.ReadAndWrite }),
+    });
+
+    const disabledAccess = screen.getByTestId('access-level-change-disabled');
+
+    expect(disabledAccess.getAttribute('aria-disabled')).toBe('true');
+    expect(screen.queryByRole('button', { name: 'Can edit' })).toBeNull();
+    expect(screen.queryByText('Remove access')).toBeNull();
+
+    fireEvent.pointerMove(disabledAccess, { pointerType: 'mouse' });
+    await waitFor(() => expect(screen.getByRole('tooltip').textContent).toBe(disabledReason));
   });
 });

--- a/src/components/app/share/__tests__/PeopleWithAccess.test.tsx
+++ b/src/components/app/share/__tests__/PeopleWithAccess.test.tsx
@@ -44,10 +44,19 @@ jest.mock('@/components/app/share/PersonItem', () => ({
   PersonItem: ({
     person,
     onRemoveAccess,
+    permissionChangeDisabledReason,
   }: {
     person: IPeopleWithAccessType;
     onRemoveAccess: (email: string) => Promise<void>;
-  }) => <button onClick={() => void onRemoveAccess(person.email)}>{person.email}</button>,
+    permissionChangeDisabledReason?: string;
+  }) => (
+    <button
+      data-permission-change-disabled-reason={permissionChangeDisabledReason}
+      onClick={() => void onRemoveAccess(person.email)}
+    >
+      {person.email}
+    </button>
+  ),
 }));
 
 jest.mock('@/components/app/share/GroupAccessLevelDropdown', () => ({
@@ -108,6 +117,31 @@ describe('PeopleWithAccess', () => {
     mockRevokeGroupAccess.mockResolvedValue(undefined);
     mockNavigate.mockReset();
     mockGroupMutationResult.mockReset();
+  });
+
+  it('disables person access changes for a database row page', () => {
+    render(
+      <PeopleWithAccess
+        viewId='view-1'
+        people={[removedPerson]}
+        groups={[]}
+        editableGroupIds={new Set()}
+        isLoading={false}
+        onPeopleChange={async () => undefined}
+        onPersonRemoved={jest.fn()}
+        updateGroupInAccessList={jest.fn()}
+        hasFullAccess
+        canManageGroupAccess
+        canManageFullAccess
+        canGrantFullAccess
+        disablePersonAccessChanges
+        sectionType={ShareSectionType.Shared}
+      />
+    );
+
+    expect(screen.getByText(removedPerson.email).dataset.permissionChangeDisabledReason).toBe(
+      'shareAction.databaseRowPagePermissionChangeDisabled'
+    );
   });
 
   it('optimistically removes a successfully revoked row before revalidation', async () => {

--- a/src/components/app/share/__tests__/PersonItem.test.tsx
+++ b/src/components/app/share/__tests__/PersonItem.test.tsx
@@ -31,15 +31,18 @@ jest.mock('../AccessLevelDropdown', () => ({
     person,
     canModify,
     currentUserCanGrantFullAccess,
+    disabledReason,
   }: {
     person: IPeopleWithAccessType;
     canModify: boolean;
     currentUserCanGrantFullAccess: boolean;
+    disabledReason?: string;
   }) => (
     <div
       data-testid={`access-level-${person.email}`}
       data-can-grant-full-access={String(currentUserCanGrantFullAccess)}
       data-can-modify={String(canModify)}
+      data-disabled-reason={disabledReason}
     >
       {person.access_level}
     </div>
@@ -96,6 +99,25 @@ describe('PersonItem', () => {
 
     expect(memberAccess.dataset.canGrantFullAccess).toBe('true');
     expect(memberAccess.dataset.canModify).toBe('true');
+  });
+
+  it('keeps database row-page person permissions disabled with a reason', () => {
+    const disabledReason = 'Unable to change database row page permission.';
+
+    renderPersonItem({
+      permissionChangeDisabledReason: disabledReason,
+      person: createPerson({
+        access_level: AccessLevel.ReadAndWrite,
+        email: 'member@appflowy.local',
+        name: 'Member',
+        role: Role.Member,
+      }),
+    });
+
+    const memberAccess = screen.getByTestId('access-level-member@appflowy.local');
+
+    expect(memberAccess.dataset.canModify).toBe('false');
+    expect(memberAccess.dataset.disabledReason).toBe(disabledReason);
   });
 
   it('keeps Full Access recipients immutable for delegated share managers', () => {

--- a/src/components/app/share/__tests__/SharePanel.test.tsx
+++ b/src/components/app/share/__tests__/SharePanel.test.tsx
@@ -72,7 +72,8 @@ function renderSharePanel(
   updateGroupInAccessList = jest.fn(),
   canManageFullAccess = false,
   hasFullAccess = currentUserAccessLevel === AccessLevel.FullAccess,
-  generalAccessLevel: AccessLevel | null = null
+  generalAccessLevel: AccessLevel | null = null,
+  disablePersonAccessChanges = false
 ) {
   return render(
     <SharePanel
@@ -86,6 +87,7 @@ function renderSharePanel(
       updateGroupInAccessList={updateGroupInAccessList}
       hasFullAccess={hasFullAccess}
       canManageFullAccess={canManageFullAccess}
+      disablePersonAccessChanges={disablePersonAccessChanges}
       currentUserAccessLevel={currentUserAccessLevel}
       generalAccessLevel={generalAccessLevel}
       sectionType={ShareSectionType.Private}
@@ -148,6 +150,14 @@ describe('SharePanel', () => {
 
     expect(mockPeopleWithAccessProps).toHaveBeenCalledWith(
       expect.objectContaining({ updateGroupInAccessList, canManageFullAccess: true })
+    );
+  });
+
+  it('forwards the database row-page person access restriction', () => {
+    renderSharePanel(AccessLevel.ReadOnly, jest.fn(), true, true, null, true);
+
+    expect(mockPeopleWithAccessProps).toHaveBeenCalledWith(
+      expect.objectContaining({ disablePersonAccessChanges: true })
     );
   });
 

--- a/src/components/app/share/__tests__/ShareTabs.test.tsx
+++ b/src/components/app/share/__tests__/ShareTabs.test.tsx
@@ -99,6 +99,9 @@ describe('ShareTabs publish availability', () => {
     expect(screen.getByRole('tab', { name: 'shareAction.shareTab' })).toBeTruthy();
     expect(screen.queryByTestId('publish-tab')).toBeNull();
     expect(screen.getByTestId('share-panel')).toBeTruthy();
+    expect(mockSharePanelProps).toHaveBeenCalledWith(
+      expect.objectContaining({ disablePersonAccessChanges: true })
+    );
   });
 
   it('keeps Publish available by default', () => {

--- a/src/components/app/view-actions/CreateSpaceModal.tsx
+++ b/src/components/app/view-actions/CreateSpaceModal.tsx
@@ -711,6 +711,16 @@ function CreateSpaceModal({
       primaryActionLoading={loading}
       primaryActionDisabled={loading || !spaceName.trim()}
       onPrimaryAction={() => void handleCreate()}
+      overlay={
+        loading ? (
+          <div
+            className='bg-surface-primary/80 absolute inset-0 z-10 flex items-center justify-center rounded-400 backdrop-blur-sm'
+            data-testid='create-space-loading-indicator'
+          >
+            <Progress aria-label={t('loading')} role='status' variant='primary' />
+          </div>
+        ) : null
+      }
     />
   );
 }

--- a/src/components/app/view-actions/ManageSpace.tsx
+++ b/src/components/app/view-actions/ManageSpace.tsx
@@ -1091,6 +1091,7 @@ function ManageSpace({ open, onClose, viewId }: { open: boolean; onClose: () => 
 
       const requestGeneration = spaceRequestRef.current.generation;
 
+      setMemberSearch('');
       setAddingUid(uid);
       try {
         await WorkspaceService.addSpaceMember(workspaceId, viewId, {
@@ -1129,6 +1130,7 @@ function ManageSpace({ open, onClose, viewId }: { open: boolean; onClose: () => 
       if (membersReadOnly || !permissionLoaded || permissionLoadFailed || !canManageMembers || !workspaceId) return;
       const requestGeneration = spaceRequestRef.current.generation;
 
+      setMemberSearch('');
       setAddingGroupId(group.group_id);
       try {
         const granted = await WorkspaceService.addSpaceGroupPermission(workspaceId, viewId, group.group_id, {

--- a/src/components/app/view-actions/SpaceSettingsPanel.tsx
+++ b/src/components/app/view-actions/SpaceSettingsPanel.tsx
@@ -561,6 +561,7 @@ function SpaceSettingsPanel({
       <Tabs
         value={activeTab}
         onValueChange={(value) => onTabChange(value as SpaceSettingsTab)}
+        aria-busy={primaryActionLoading || undefined}
         className='min-h-0 max-w-full'
         style={{ width: CONTENT_WIDTH }}
         data-testid='space-settings-panel'

--- a/src/components/app/view-actions/__tests__/CreateSpaceModal.test.tsx
+++ b/src/components/app/view-actions/__tests__/CreateSpaceModal.test.tsx
@@ -239,7 +239,9 @@ jest.mock('@/components/ui/dropdown-menu', () => ({
 }));
 
 jest.mock('@/components/ui/progress', () => ({
-  Progress: () => <span data-testid='progress' />,
+  Progress: ({ variant: _variant, ...props }: { variant?: string; role?: string; 'aria-label'?: string }) => (
+    <span data-testid='progress' {...props} />
+  ),
 }));
 
 jest.mock('@/components/ui/tabs', () => {
@@ -259,7 +261,7 @@ jest.mock('@/components/ui/tabs', () => {
       'data-testid'?: string;
     }) => (
       <TabsContext.Provider value={{ value, onValueChange: onValueChange ?? (() => undefined) }}>
-        <div data-testid={props['data-testid']}>{children}</div>
+        <div {...props}>{children}</div>
       </TabsContext.Provider>
     ),
     TabsContent: ({ children, value }: { children: ReactNode; value: string }) => {
@@ -536,6 +538,27 @@ describe('CreateSpaceModal draft controller', () => {
     creation.resolve('space-id');
     await waitFor(() => expect(submit.getAttribute('disabled')).not.toBeNull());
     expect(screen.getByTestId('space-name-input').value).toBe('');
+  });
+
+  it('shows an in-panel loading indicator while creation is in flight', async () => {
+    const creation = deferred<string>();
+
+    mockCreateSpace.mockReturnValue(creation.promise);
+    render(<CreateSpaceModal open onClose={jest.fn()} />);
+    enterSpaceName();
+
+    fireEvent.click(screen.getByTestId('create-space-submit'));
+
+    const panel = screen.getByTestId('space-settings-panel');
+    const loadingIndicator = within(screen.getByTestId('create-space-modal')).getByTestId(
+      'create-space-loading-indicator'
+    );
+
+    expect(panel.getAttribute('aria-busy')).toBe('true');
+    expect(within(loadingIndicator).getByRole('status').getAttribute('aria-label')).toBe('loading');
+
+    creation.resolve('space-id');
+    await waitFor(() => expect(screen.queryByTestId('create-space-loading-indicator')).toBeNull());
   });
 
   it('keeps an ambiguous create draft open, frozen, and retries with the same client-owned ID', async () => {

--- a/src/components/app/view-actions/__tests__/ManageSpace.test.tsx
+++ b/src/components/app/view-actions/__tests__/ManageSpace.test.tsx
@@ -1633,7 +1633,10 @@ describe('ManageSpace ACL management', () => {
 
       expect(mockGetMembers).toHaveBeenCalledWith('workspace-1');
       expect(mockUseAddableWorkspaceMembers).toHaveBeenLastCalledWith(expect.objectContaining({ excludePending: true }));
+      fireEvent.change(screen.getByTestId('inline-member-search'), { target: { value: 'Candidate' } });
       fireEvent.click(screen.getByTestId('inline-member-add'));
+
+      expect(screen.getByTestId('inline-member-search').value).toBe('');
 
       await waitFor(() =>
         expect(mockAddSpaceMember).toHaveBeenCalledWith(
@@ -1668,6 +1671,8 @@ describe('ManageSpace ACL management', () => {
 
       expect(result.textContent).toContain('space.permissionManager.groupInfo:{"count":12}');
       fireEvent.click(within(result).getByTestId('space-group-inline-search-result-add'));
+
+      expect(screen.getByTestId('inline-member-search').value).toBe('');
 
       await waitFor(() =>
         expect(mockAddSpaceGroupPermission).toHaveBeenCalledWith('workspace-1', 'space-1', 'group-engineering', {


### PR DESCRIPTION
### **Description**

- Show an accessible in-panel loading overlay while Create Space is in flight.
- Mark the space settings panel busy during creation.
- Clear the Manage Space people-or-groups query immediately after selecting a person or group.
- Add regression coverage for the loading state and both search reset paths.

---

### **Checklist**

#### **General**
- [x] The change is scoped to existing space interactions.
- [x] The behavior integrates with the existing permission and member flows.

#### **Testing**
- [x] Added or updated tests for the changes.
- [x] `pnpm exec jest src/components/app/view-actions/__tests__/CreateSpaceModal.test.tsx src/components/app/view-actions/__tests__/ManageSpace.test.tsx --runInBand --coverage=false`
- [x] `pnpm type-check`
- [x] ESLint on all changed files.

## Summary by Sourcery

Improve space creation feedback and prevent unsupported member permission changes while keeping Manage Space searches clear after selections.

New Features:
- Show an accessible loading overlay and busy state while creating a space.
- Explain when person-level permission changes are unavailable for database row pages.

Bug Fixes:
- Clear the Manage Space member search immediately after selecting a person or group.
- Remove outdated wording from the custom-permissions confirmation message.

Enhancements:
- Propagate database row-page permission restrictions through sharing controls and present them with an explanatory tooltip.

Tests:
- Add regression coverage for space creation loading state, search reset behavior, and disabled row-page permission controls.