### PR TITLE
fix(publish): recognize Desktop-published database children

### DIFF
--- a/src/application/database-yjs/__tests__/useNewRowTemplateDispatch.test.tsx
+++ b/src/application/database-yjs/__tests__/useNewRowTemplateDispatch.test.tsx
@@ -644,6 +644,52 @@ describe('useNewRowDispatch database templates', () => {
     });
   });
 
+  it('restores non-empty row metadata after async template duplication is accepted', async () => {
+    const { doc, database } = createDatabaseDoc();
+    const template = addTemplate(database, { empty: false });
+    const sourceDocument = new Y.Doc({ guid: template.docViewId }) as YDoc;
+    const createdRows = new Map<string, YDoc>();
+
+    sourceDocument.getMap(YjsEditorKey.data_section).set(YjsEditorKey.document, new Y.Map());
+    const duplicateRowDocument: NonNullable<DatabaseContextState['duplicateRowDocument']> = jest.fn(
+      async (_databaseId, _sourceId, targetRowId) => {
+        const targetRowDoc = createdRows.get(getRowKey(databaseDocId, targetRowId)) as YDoc;
+        const meta = targetRowDoc.getMap(YjsEditorKey.data_section).get(YjsEditorKey.meta) as Y.Map<unknown>;
+
+        // The server accepts duplication as a background task. While the request
+        // is pending, canonical hydration can replace the optimistic metadata.
+        meta.set(getMetaIdMap(targetRowId).get(RowMetaKey.IsDocumentEmpty) as string, true);
+      }
+    );
+    const context: DatabaseContextState = {
+      readOnly: false,
+      databaseDoc: doc,
+      databasePageId: viewId,
+      activeViewId: viewId,
+      rowMap: {},
+      workspaceId: 'workspace-id',
+      createRow: async (key) => {
+        const rowDoc = new Y.Doc({ guid: key }) as YDoc;
+
+        createdRows.set(key, rowDoc);
+        return rowDoc;
+      },
+      loadRowDocument: async () => sourceDocument,
+      duplicateRowDocument,
+    };
+    const { result } = renderHook(() => useNewRowDispatch(), { wrapper: createWrapper(context) });
+    let rowId = '';
+
+    await act(async () => {
+      rowId = (await result.current({ templateId: template.templateId, openAfterCreate: true })) as string;
+    });
+
+    const rowDoc = createdRows.get(getRowKey(databaseDocId, rowId)) as YDoc;
+    const meta = rowDoc.getMap(YjsEditorKey.data_section).get(YjsEditorKey.meta) as Y.Map<unknown>;
+
+    expect(meta.get(getMetaIdMap(rowId).get(RowMetaKey.IsDocumentEmpty) as string)).toBe(false);
+  });
+
   it('uses a non-empty default template through the same document materialization path', async () => {
     const { doc, database } = createDatabaseDoc();
     const template = addTemplate(database, { empty: false, makeDefault: true });

--- a/src/application/database-yjs/dispatch/row.ts
+++ b/src/application/database-yjs/dispatch/row.ts
@@ -538,6 +538,17 @@ function markRowDocumentEmpty(rowDoc: YDoc, rowId: string) {
   }, 'database-row-template-fallback');
 }
 
+function markRowDocumentNonEmpty(rowDoc: YDoc, rowId: string) {
+  rowDoc.transact(() => {
+    const materializedMeta = generateRowMeta(rowId, {
+      [RowMetaKey.IsDocumentEmpty]: false,
+    });
+    const meta = rowDoc.getMap(YjsEditorKey.data_section).get(YjsEditorKey.meta) as Y.Map<unknown>;
+
+    Object.entries(materializedMeta).forEach(([key, value]) => meta.set(key, value));
+  }, 'database-row-template-materialized');
+}
+
 export function useNewRowDispatch() {
   const database = useDatabase();
   const sharedRoot = useSharedRoot();
@@ -913,6 +924,10 @@ export function useNewRowDispatch() {
                 row_id: selectedTemplate.templateId,
               });
             });
+            // Cloud returns after queueing duplication, not after writing the
+            // target. Reassert this after the request so row hydration received
+            // while awaiting it cannot make the target open as an empty document.
+            markRowDocumentNonEmpty(rowDoc, rowId);
           } catch (error) {
             // Cell defaults must remain usable if document materialization is
             // temporarily unavailable; this is also Desktop's graceful fallback.

--- a/src/components/app/header/RightMenu.tsx
+++ b/src/components/app/header/RightMenu.tsx
@@ -62,7 +62,10 @@ function RightMenu() {
   return (
     <div className={'flex items-center gap-2'}>
       <Users viewId={routeViewId} />
-      {actionViewId ? <ShareButton viewId={actionViewId} hidePublish={hasRowPageRoute} /> : null}
+      {/* Access control belongs to the database container, but Desktop publishes the active child view. */}
+      {actionViewId ? (
+        <ShareButton viewId={actionViewId} publishViewId={routeViewId} hidePublish={hasRowPageRoute} />
+      ) : null}
       <InlineCommentToggleButton />
       {favoriteViewId && (
         <FavoriteButton viewId={favoriteViewId} beforeToggle={rowPage ? prepareRowDocumentForFavorite : undefined} />

--- a/src/components/app/header/__tests__/RightMenu.rowFavorite.test.tsx
+++ b/src/components/app/header/__tests__/RightMenu.rowFavorite.test.tsx
@@ -2,9 +2,13 @@ import { render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 
 import type { ActiveRowPageInfo } from '@/application/row-document/row-page-state';
+import { ViewLayout } from '@/application/types';
 import RightMenu from '@/components/app/header/RightMenu';
 
 let mockActiveRowPage: ActiveRowPageInfo | null = null;
+let mockRouteViewId = 'database-container';
+let mockRouteView = { view_id: mockRouteViewId };
+let mockOutline: Array<Record<string, unknown>> = [];
 
 jest.mock('react-i18next', () => ({
   useTranslation: () => ({ t: (key: string) => key }),
@@ -20,16 +24,29 @@ jest.mock('@/application/row-document/row-page-state', () => ({
 }));
 
 jest.mock('@/components/app/app.hooks', () => ({
-  useAppOutline: () => [],
-  useAppView: () => ({ view_id: 'database-container' }),
-  useAppViewId: () => 'database-container',
+  useAppOutline: () => mockOutline,
+  useAppView: () => mockRouteView,
+  useAppViewId: () => mockRouteViewId,
   useCurrentWorkspaceId: () => 'workspace-1',
 }));
 
 jest.mock('src/components/app/share/ShareButton', () => ({
   __esModule: true,
-  default: ({ hidePublish = false }: { hidePublish?: boolean }) => (
-    <div data-testid='share-button' data-publish-hidden={String(hidePublish)} />
+  default: ({
+    viewId,
+    publishViewId,
+    hidePublish = false,
+  }: {
+    viewId: string;
+    publishViewId?: string;
+    hidePublish?: boolean;
+  }) => (
+    <div
+      data-testid='share-button'
+      data-view-id={viewId}
+      data-publish-view-id={publishViewId}
+      data-publish-hidden={String(hidePublish)}
+    />
   ),
 }));
 
@@ -50,6 +67,9 @@ jest.mock('@/components/app/header/Users', () => ({
 describe('RightMenu row-page actions', () => {
   beforeEach(() => {
     mockActiveRowPage = null;
+    mockRouteViewId = 'database-container';
+    mockRouteView = { view_id: mockRouteViewId };
+    mockOutline = [];
   });
 
   it('hides the favorite action while the requested row page state is not ready', () => {
@@ -132,5 +152,38 @@ describe('RightMenu row-page actions', () => {
 
     expect(screen.getByTestId('favorite-button').getAttribute('data-view-id')).toBe('database-container');
     expect(screen.getByTestId('share-button').getAttribute('data-publish-hidden')).toBe('false');
+  });
+
+  it('keeps database sharing on the container while publishing the active child', () => {
+    const containerViewId = 'database-container';
+
+    mockRouteViewId = 'board-view';
+    mockRouteView = {
+      view_id: mockRouteViewId,
+      parent_view_id: containerViewId,
+    };
+    mockOutline = [
+      {
+        view_id: containerViewId,
+        name: 'Database',
+        layout: ViewLayout.Grid,
+        extra: { is_database_container: true },
+        children: [mockRouteView],
+      },
+    ];
+
+    render(
+      <MemoryRouter
+        initialEntries={['/app/workspace-1/board-view']}
+        future={{ v7_relativeSplatPath: true, v7_startTransition: true }}
+      >
+        <RightMenu />
+      </MemoryRouter>
+    );
+
+    const shareButton = screen.getByTestId('share-button');
+
+    expect(shareButton.getAttribute('data-view-id')).toBe(containerViewId);
+    expect(shareButton.getAttribute('data-publish-view-id')).toBe(mockRouteViewId);
   });
 });

--- a/src/components/app/share/PublishPanel.tsx
+++ b/src/components/app/share/PublishPanel.tsx
@@ -11,6 +11,7 @@ import PublishLinkPreview from '@/components/app/share/PublishLinkPreview';
 
 function PublishPanel({
   viewId,
+  fallbackViewId,
   opened,
   onClose,
   onOpenPublishManage,
@@ -18,6 +19,7 @@ function PublishPanel({
   shareDetailsLoading,
 }: {
   viewId: string;
+  fallbackViewId?: string;
   onClose: () => void;
   opened: boolean;
   onOpenPublishManage?: () => void;
@@ -36,7 +38,7 @@ function PublishPanel({
     isOwner,
     isPublisher,
     updatePublishConfig,
-  } = useLoadPublishInfo(viewId);
+  } = useLoadPublishInfo(viewId, fallbackViewId);
   const [unpublishLoading, setUnpublishLoading] = React.useState<boolean>(false);
   const [publishLoading, setPublishLoading] = React.useState<boolean>(false);
   // Track publish/unpublish actions locally so the panel updates immediately,
@@ -48,7 +50,7 @@ function PublishPanel({
   // Reset session-local overrides when the target view changes
   useEffect(() => {
     setPublishedOverride(undefined);
-  }, [viewId]);
+  }, [publishInfoViewId]);
 
   useEffect(() => {
     if (opened) {
@@ -57,11 +59,11 @@ function PublishPanel({
   }, [loadPublishInfo, opened]);
 
   useEffect(() => {
-    if (opened && publishInfo && publishInfoViewId === viewId) {
+    if (opened && publishInfo) {
       setCommentEnabled(publishInfo.commentEnabled);
       setDuplicateEnabled(publishInfo.duplicateEnabled);
     }
-  }, [opened, publishInfo, publishInfoViewId, viewId]);
+  }, [opened, publishInfo]);
 
   const handlePublish = useCallback(
     async (publishName?: string) => {
@@ -95,7 +97,7 @@ function PublishPanel({
     setUnpublishLoading(true);
 
     try {
-      await unpublish(viewId);
+      await unpublish(publishInfoViewId);
       setPublishedOverride(false);
       await loadPublishInfo();
       notify.success(t('publish.unpublishSuccessfully'));
@@ -105,16 +107,16 @@ function PublishPanel({
     } finally {
       setUnpublishLoading(false);
     }
-  }, [isOwner, isPublisher, loadPublishInfo, t, unpublish, view, viewId]);
+  }, [isOwner, isPublisher, loadPublishInfo, publishInfoViewId, t, unpublish, view]);
 
-  const scopedPublishInfo = publishInfoViewId === viewId ? publishInfo : undefined;
+  const scopedPublishInfo = publishInfo;
 
   const renderPublished = useCallback(() => {
     if (!scopedPublishInfo || !view) return null;
     return (
       <div className={'flex flex-col gap-5'}>
         <PublishLinkPreview
-          viewId={viewId}
+          viewId={publishInfoViewId}
           publishInfo={scopedPublishInfo}
           url={url}
           updatePublishConfig={updatePublishConfig}
@@ -155,7 +157,7 @@ function PublishPanel({
               checked={commentEnabled !== false}
               onChange={(e) => {
                 setCommentEnabled(e.target.checked);
-                void updatePublishConfig({ comments_enabled: e.target.checked, view_id: viewId });
+                void updatePublishConfig({ comments_enabled: e.target.checked, view_id: publishInfoViewId });
               }}
               size={'small'}
               inputProps={{ 'data-testid': 'publish-comments-switch' } as React.InputHTMLAttributes<HTMLInputElement>}
@@ -167,7 +169,7 @@ function PublishPanel({
               checked={duplicateEnabled !== false}
               onChange={(e) => {
                 setDuplicateEnabled(e.target.checked);
-                void updatePublishConfig({ duplicate_enabled: e.target.checked, view_id: viewId });
+                void updatePublishConfig({ duplicate_enabled: e.target.checked, view_id: publishInfoViewId });
               }}
               size={'small'}
             />
@@ -188,7 +190,7 @@ function PublishPanel({
     commentEnabled,
     duplicateEnabled,
     updatePublishConfig,
-    viewId,
+    publishInfoViewId,
     onOpenPublishManage,
   ]);
 
@@ -222,10 +224,7 @@ function PublishPanel({
 
     return (
       <div className={'flex w-full flex-col gap-4'}>
-        <Tooltip
-          disableHoverListener={canShare}
-          title={!canShare ? t('shareAction.readOnlyPublishTooltip') : ''}
-        >
+        <Tooltip disableHoverListener={canShare} title={!canShare ? t('shareAction.readOnlyPublishTooltip') : ''}>
           <span className={'w-full'}>{publishButton}</span>
         </Tooltip>
       </div>

--- a/src/components/app/share/ShareButton.tsx
+++ b/src/components/app/share/ShareButton.tsx
@@ -9,7 +9,15 @@ import ShareTabs from '@/components/app/share/ShareTabs';
 import { Button } from '@/components/ui/button';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 
-export function ShareButton({ viewId, hidePublish = false }: { viewId: string; hidePublish?: boolean }) {
+export function ShareButton({
+  viewId,
+  publishViewId = viewId,
+  hidePublish = false,
+}: {
+  viewId: string;
+  publishViewId?: string;
+  hidePublish?: boolean;
+}) {
   const { t } = useTranslation();
 
   const view = useAppView(viewId);
@@ -39,6 +47,7 @@ export function ShareButton({ viewId, hidePublish = false }: { viewId: string; h
           <ShareTabs
             opened={opened}
             viewId={viewId}
+            publishViewId={publishViewId}
             hidePublish={hidePublish}
             onClose={() => setOpened(false)}
             onOpenPublishManage={() => {

--- a/src/components/app/share/ShareTabs.tsx
+++ b/src/components/app/share/ShareTabs.tsx
@@ -26,12 +26,14 @@ enum TabKey {
 function ShareTabs({
   opened,
   viewId,
+  publishViewId = viewId,
   hidePublish = false,
   onClose,
   onOpenPublishManage,
 }: {
   opened: boolean;
   viewId: string;
+  publishViewId?: string;
   hidePublish?: boolean;
   onClose: () => void;
   onOpenPublishManage?: () => void;
@@ -149,7 +151,8 @@ function ShareTabs({
               />
             ) : option.value === TabKey.PUBLISH ? (
               <PublishPanel
-                viewId={viewId}
+                viewId={publishViewId}
+                fallbackViewId={publishViewId === viewId ? undefined : viewId}
                 onClose={onClose}
                 opened={opened}
                 onOpenPublishManage={onOpenPublishManage}

--- a/src/components/app/share/__tests__/ShareTabs.test.tsx
+++ b/src/components/app/share/__tests__/ShareTabs.test.tsx
@@ -99,9 +99,7 @@ describe('ShareTabs publish availability', () => {
     expect(screen.getByRole('tab', { name: 'shareAction.shareTab' })).toBeTruthy();
     expect(screen.queryByTestId('publish-tab')).toBeNull();
     expect(screen.getByTestId('share-panel')).toBeTruthy();
-    expect(mockSharePanelProps).toHaveBeenCalledWith(
-      expect.objectContaining({ disablePersonAccessChanges: true })
-    );
+    expect(mockSharePanelProps).toHaveBeenCalledWith(expect.objectContaining({ disablePersonAccessChanges: true }));
   });
 
   it('keeps Publish available by default', () => {
@@ -112,6 +110,24 @@ describe('ShareTabs publish availability', () => {
       expect.objectContaining({ view_id: 'database-view' }),
       true,
       'database-view'
+    );
+  });
+
+  it('keeps access on the container while publishing the active database child', () => {
+    render(<ShareTabs opened viewId='database-container' publishViewId='board-view' onClose={() => undefined} />);
+
+    expect(mockUseViewActionPermissions).toHaveBeenCalledWith(
+      expect.objectContaining({ view_id: 'database-container' }),
+      true,
+      'database-container'
+    );
+
+    fireEvent.mouseDown(screen.getByTestId('publish-tab'), { button: 0, ctrlKey: false });
+    expect(mockPublishPanelProps).toHaveBeenCalledWith(
+      expect.objectContaining({
+        viewId: 'board-view',
+        fallbackViewId: 'database-container',
+      })
     );
   });
 

--- a/src/components/app/share/__tests__/publish.hooks.test.tsx
+++ b/src/components/app/share/__tests__/publish.hooks.test.tsx
@@ -1,0 +1,121 @@
+import { renderHook, waitFor } from '@testing-library/react';
+
+import { View, ViewLayout } from '@/application/types';
+import { useLoadPublishInfo } from '@/components/app/share/publish.hooks';
+
+const mockGetPublishInfo = jest.fn();
+const mockGetView = jest.fn();
+
+const childView: View = {
+  view_id: 'board-view',
+  name: 'Board',
+  icon: null,
+  layout: ViewLayout.Board,
+  extra: { database_id: 'database-id' },
+  children: [],
+  is_published: true,
+  is_private: false,
+  parent_view_id: 'database-container',
+};
+
+const containerView: View = {
+  view_id: 'database-container',
+  name: 'Database',
+  icon: null,
+  layout: ViewLayout.Grid,
+  extra: { database_id: 'database-id', is_database_container: true },
+  children: [childView],
+  is_published: false,
+  is_private: false,
+};
+
+const views = new Map([
+  [childView.view_id, childView],
+  [containerView.view_id, containerView],
+]);
+
+jest.mock('@/application/services/domains', () => ({
+  PublishService: {
+    getViewInfo: (...args: unknown[]) => mockGetPublishInfo(...args),
+    updateConfig: jest.fn(),
+  },
+  ViewService: {
+    get: (...args: unknown[]) => mockGetView(...args),
+  },
+}));
+
+jest.mock('@/components/app/app.hooks', () => ({
+  useAppView: (viewId?: string) => (viewId ? views.get(viewId) : undefined),
+  useUserWorkspaceInfo: () => ({
+    selectedWorkspace: {
+      id: 'workspace-id',
+      owner: { uid: 'owner-id' },
+    },
+  }),
+}));
+
+jest.mock('@/components/main/app.hooks', () => ({
+  useCurrentUser: () => ({ uid: 'owner-id', email: 'owner@appflowy.io' }),
+}));
+
+const childPublishInfo = {
+  namespace: 'workspace-namespace',
+  publishName: 'Board-board-view',
+  publisherEmail: 'owner@appflowy.io',
+  commentEnabled: true,
+  duplicateEnabled: true,
+};
+
+const containerPublishInfo = {
+  ...childPublishInfo,
+  publishName: 'Database-database-container',
+};
+
+describe('useLoadPublishInfo database publication identity', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('recognizes a Desktop publication keyed by the active database child', async () => {
+    mockGetPublishInfo.mockImplementation((viewId: string) =>
+      viewId === childView.view_id ? Promise.resolve(childPublishInfo) : Promise.reject(new Error('Record not found'))
+    );
+
+    const { result } = renderHook(() => useLoadPublishInfo(childView.view_id, containerView.view_id));
+
+    await waitFor(() => expect(result.current.publishInfo).toEqual(childPublishInfo));
+
+    expect(mockGetPublishInfo).toHaveBeenNthCalledWith(1, childView.view_id);
+    expect(mockGetPublishInfo).toHaveBeenNthCalledWith(2, containerView.view_id);
+    expect(result.current.publishInfoViewId).toBe(childView.view_id);
+    expect(result.current.view?.view_id).toBe(childView.view_id);
+  });
+
+  it('keeps an existing Web publication keyed by the database container manageable', async () => {
+    mockGetPublishInfo.mockImplementation((viewId: string) =>
+      viewId === containerView.view_id
+        ? Promise.resolve(containerPublishInfo)
+        : Promise.reject(new Error('Record not found'))
+    );
+
+    const { result } = renderHook(() => useLoadPublishInfo(childView.view_id, containerView.view_id));
+
+    await waitFor(() => expect(result.current.publishInfo).toEqual(containerPublishInfo));
+
+    expect(result.current.publishInfoViewId).toBe(containerView.view_id);
+    expect(result.current.view?.view_id).toBe(containerView.view_id);
+  });
+
+  it('defaults new database publications to the active child', async () => {
+    mockGetPublishInfo.mockRejectedValue(new Error('Record not found'));
+
+    const { result } = renderHook(() => useLoadPublishInfo(childView.view_id, containerView.view_id));
+
+    await waitFor(() => expect(mockGetPublishInfo).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.publishInfo).toBeUndefined();
+    expect(result.current.publishInfoViewId).toBe(childView.view_id);
+    expect(result.current.view?.view_id).toBe(childView.view_id);
+  });
+});

--- a/src/components/app/share/publish.hooks.ts
+++ b/src/components/app/share/publish.hooks.ts
@@ -7,18 +7,22 @@ import { useAppView, useUserWorkspaceInfo } from '@/components/app/app.hooks';
 import { ViewService, PublishService } from '@/application/services/domains';
 import { useCurrentUser } from '@/components/main/app.hooks';
 
-export function useLoadPublishInfo(viewId: string) {
-  const outlineView = useAppView(viewId);
-  const userWorkspaceInfo = useUserWorkspaceInfo();
-  const workspaceId = userWorkspaceInfo?.selectedWorkspace?.id;
+type PublishInfo = {
+  namespace: string;
+  publishName: string;
+  publisherEmail: string;
+  commentEnabled: boolean;
+  duplicateEnabled: boolean;
+};
 
-  // Fallback view fetched from server when not in outline (e.g. lazy-loaded children)
-  const [fallbackView, setFallbackView] = React.useState<View | null>(null);
+function usePublishView(viewId: string | undefined, workspaceId: string | undefined) {
+  const outlineView = useAppView(viewId);
+  const [fetchedView, setFetchedView] = React.useState<View | null>(null);
 
   useEffect(() => {
     if (outlineView || !viewId || !workspaceId) {
       if (outlineView) {
-        setFallbackView((prev) => (prev?.view_id === viewId ? null : prev));
+        setFetchedView((previousView) => (previousView?.view_id === viewId ? null : previousView));
       }
 
       return;
@@ -27,13 +31,13 @@ export function useLoadPublishInfo(viewId: string) {
     let cancelled = false;
 
     ViewService.get(workspaceId, viewId)
-      .then((fetchedView) => {
-        if (!cancelled && fetchedView) {
-          setFallbackView(fetchedView);
+      .then((view) => {
+        if (!cancelled && view) {
+          setFetchedView(view);
         }
       })
       .catch(() => {
-        // View not found - ignore
+        // The publish-info request remains useful even when folder metadata is unavailable.
       });
 
     return () => {
@@ -41,81 +45,114 @@ export function useLoadPublishInfo(viewId: string) {
     };
   }, [outlineView, viewId, workspaceId]);
 
-  const view = outlineView ?? (fallbackView?.view_id === viewId ? fallbackView : null) ?? undefined;
+  return outlineView ?? (fetchedView?.view_id === viewId ? fetchedView : undefined);
+}
 
-  const [publishInfo, setPublishInfo] = React.useState<{
-    namespace: string,
-    publishName: string,
-    publisherEmail: string,
-    commentEnabled: boolean,
-    duplicateEnabled: boolean,
+export function useLoadPublishInfo(viewId: string, fallbackViewId?: string) {
+  const userWorkspaceInfo = useUserWorkspaceInfo();
+  const workspaceId = userWorkspaceInfo?.selectedWorkspace?.id;
+  const primaryView = usePublishView(viewId, workspaceId);
+  const fallbackView = usePublishView(fallbackViewId, workspaceId);
+  // Desktop publications are keyed by the active database child. Older Web
+  // publications can be keyed by the container, so probe both without a waterfall.
+  const candidateViewIds = useMemo(
+    () => (fallbackViewId && fallbackViewId !== viewId ? [viewId, fallbackViewId] : [viewId]),
+    [fallbackViewId, viewId]
+  );
+  const requestKey = candidateViewIds.join(':');
+  const [publishState, setPublishState] = React.useState<{
+    requestKey: string;
+    viewId: string;
+    publishInfo?: PublishInfo;
   }>();
-  const [publishInfoViewId, setPublishInfoViewId] = React.useState<string | null>(null);
   const publishInfoRequestSeqRef = React.useRef(0);
   const [loading, setLoading] = React.useState<boolean>(false);
 
+  const currentPublishState = publishState?.requestKey === requestKey ? publishState : undefined;
+  const publishInfoViewId = currentPublishState?.viewId ?? viewId;
+  const publishInfo = currentPublishState?.publishInfo;
+  const view = publishInfoViewId === fallbackViewId ? fallbackView : primaryView;
   const currentUser = useCurrentUser();
   const isOwner = isSameUserUid(userWorkspaceInfo?.selectedWorkspace?.owner?.uid, currentUser?.uid);
-  const currentViewPublishInfo = publishInfoViewId === viewId ? publishInfo : undefined;
-  const isPublisher = currentViewPublishInfo?.publisherEmail === currentUser?.email;
+  const isPublisher = publishInfo?.publisherEmail === currentUser?.email;
 
-  const loadPublishInfo = useCallback(async() => {
+  const loadPublishInfo = useCallback(async () => {
     const requestSeq = publishInfoRequestSeqRef.current + 1;
 
     publishInfoRequestSeqRef.current = requestSeq;
 
     setLoading(true);
     try {
-      const res = await PublishService.getViewInfo(viewId);
+      const results = await Promise.allSettled(
+        candidateViewIds.map((candidateViewId) => PublishService.getViewInfo(candidateViewId))
+      );
 
       if (publishInfoRequestSeqRef.current !== requestSeq) return;
-      setPublishInfo(res);
-      setPublishInfoViewId(viewId);
 
-      // eslint-disable-next-line
-    } catch(e: any) {
-      if (publishInfoRequestSeqRef.current !== requestSeq) return;
-      // Not published or fetch failed - clear stale publish info
-      setPublishInfo(undefined);
-      setPublishInfoViewId(viewId);
+      const publishedResultIndex = results.findIndex((result) => result.status === 'fulfilled');
+
+      if (publishedResultIndex === -1) {
+        setPublishState({ requestKey, viewId });
+      } else {
+        const publishedResult = results[publishedResultIndex];
+
+        if (publishedResult.status === 'fulfilled') {
+          setPublishState({
+            requestKey,
+            viewId: candidateViewIds[publishedResultIndex],
+            publishInfo: publishedResult.value,
+          });
+        }
+      }
     } finally {
       if (publishInfoRequestSeqRef.current === requestSeq) {
         setLoading(false);
       }
     }
-  }, [viewId]);
+  }, [candidateViewIds, requestKey, viewId]);
 
   useEffect(() => {
     void loadPublishInfo();
   }, [loadPublishInfo]);
 
-  const updatePublishConfig = useCallback(async(payload: UpdatePublishConfigPayload) => {
-    if(!workspaceId) return;
-    try {
-      await PublishService.updateConfig(workspaceId, payload);
-      setPublishInfo(prev => {
-        if(!prev) return prev;
-        return {
-          publishName: payload.publish_name || prev.publishName,
-          namespace: prev.namespace,
-          publisherEmail: prev.publisherEmail,
-          commentEnabled: payload.comments_enabled === undefined ? prev.commentEnabled : payload.comments_enabled,
-          duplicateEnabled: payload.duplicate_enabled === undefined ? prev.duplicateEnabled : payload.duplicate_enabled,
-        };
-      });
-      // eslint-disable-next-line
-    } catch(e: any) {
-      notify.error(e.message);
-    }
-
-  }, [workspaceId]);
+  const updatePublishConfig = useCallback(
+    async (payload: UpdatePublishConfigPayload) => {
+      if (!workspaceId) return;
+      try {
+        await PublishService.updateConfig(workspaceId, payload);
+        setPublishState((previousState) => {
+          if (!previousState?.publishInfo || previousState.requestKey !== requestKey) return previousState;
+          return {
+            ...previousState,
+            publishInfo: {
+              publishName: payload.publish_name || previousState.publishInfo.publishName,
+              namespace: previousState.publishInfo.namespace,
+              publisherEmail: previousState.publishInfo.publisherEmail,
+              commentEnabled:
+                payload.comments_enabled === undefined
+                  ? previousState.publishInfo.commentEnabled
+                  : payload.comments_enabled,
+              duplicateEnabled:
+                payload.duplicate_enabled === undefined
+                  ? previousState.publishInfo.duplicateEnabled
+                  : payload.duplicate_enabled,
+            },
+          };
+        });
+        // eslint-disable-next-line
+      } catch (e: any) {
+        notify.error(e.message);
+      }
+    },
+    [requestKey, workspaceId]
+  );
 
   const url = useMemo(() => {
-    return `${window.origin}/${currentViewPublishInfo?.namespace}/${currentViewPublishInfo?.publishName}`;
-  }, [currentViewPublishInfo]);
+    return `${window.origin}/${publishInfo?.namespace}/${publishInfo?.publishName}`;
+  }, [publishInfo]);
 
   return {
-    publishInfo: currentViewPublishInfo,
+    publishInfo,
     publishInfoViewId,
     url,
     loadPublishInfo,


### PR DESCRIPTION
### **Description**

Fix the Share > Publish state for database pages published from AppFlowy Desktop, and stabilize non-empty row templates after the server accepts their asynchronous document-copy task.

Web keeps page-level sharing and permissions on the database container, but now gives the Publish flow the active database child as a separate identity. Publish state is resolved in parallel against the active child first and the container second, so:

- Desktop child-keyed publications are recognized and managed correctly.
- Existing Web container-keyed publications remain manageable.
- New database publications use the active child, matching Desktop.
- Private sharing, export, favorite, and other page-level actions remain scoped to the container.

For template-created rows, Web now reasserts the known non-empty document state after the duplication request returns. This preserves the row document icon and makes row opening use the existing bounded worker-lag fetch path instead of creating an empty target ahead of the background copy.

### Reported regression

| Bug | Evidence | Actual | Expected |
| --- | --- | --- | --- |
| Desktop-published Board appears unpublished on Web | Production data export and API responses for private view `68154112-2410-4e04-b9be-a23c6bd7c4de`, container `65dfb70f-329f-462a-acd5-42d7fb6fe708`, and the working [public Board](https://appflowy.com/5fca8c8a-8126-428e-bb5e-0efeef22ab56/Board-68154112-2410-4e04-b9be-a23c6bd7c4de) | The public page loads, but Web Share > Publish renders the unpublished state because it requests the container ID, whose publish record does not exist. | Web recognizes the active child publication and uses that ID for unpublish/configuration actions. |
| Template-created rows lose their document icon | PR #519 `database-3` [attempt 1](https://github.com/AppFlowy-IO/AppFlowy-Web/actions/runs/33317176602/job/99272791150) and [attempt 2](https://github.com/AppFlowy-IO/AppFlowy-Web/actions/runs/33317176602/job/99277220735), including Playwright traces/screenshots for the default-template and inline-restore scenarios | The row and template title appear, but `row-document-icon-*` never appears; opening can materialize an empty document even though duplication returned HTTP 200. | The target remains marked non-empty while its independent copy finishes, so the icon appears and opening waits for the copy. |

Publication reproduction:

1. Publish a database Board from Desktop.
2. Open the same active Board route in Web.
3. Open Share, then Publish.
4. Before this fix, Web shows the Publish button instead of the published URL and Unpublish controls.

Template-race reproduction:

1. Create a non-empty row template and make it the default.
2. Create a row from the shared top-right New action, or deep-copy an inline database containing that template.
3. Let canonical row hydration arrive while the duplication request is waiting for the background task acknowledgement.
4. Before this fix, the row finishes with `is_document_empty=true`, so its document icon is absent and opening takes the empty-document path.

### Root cause and provenance

| Bug | Root cause | Introducing change |
| --- | --- | --- |
| Desktop-published database child appears unpublished | Desktop passes the active database child to its publish service. Web resolved that child to the database container in `RightMenu` and sent only the container through `ShareButton`/`ShareTabs` to `PublishPanel`. The child has an active publish row; the container returns record-not-found. | Introduced by `52740c38df4e5223fa90ce5de0d6a23d22b43c97` (`fix: duplicate page`), authored by Nathan `<nathan@appflowy.io>` on 2026-04-12. Its parent passed the route child directly; this commit changed all header actions to the resolved container. The change entered `main` through [PR #309](https://github.com/AppFlowy-IO/AppFlowy-Web/pull/309) as `2205f3552a038c49dd30dc3373809e44c37cd73e`. |
| Template-created rows lose their document icon | The duplication endpoint acknowledges a queued background task. Canonical row hydration can restore `is_document_empty=true` while Web awaits that response. The success path did not write the known non-empty state again, so the row could open as empty before the worker materialized its target. | Introduced by `7e1db3dbbcf4b701ae1f223cb74a9a0d466724a8` (`feat(database): add Desktop-compatible row templates (#470)`), authored by Nathan.fooo `<86001920+appflowy@users.noreply.github.com>` on 2026-08-13. `git log -S`/`-G`, blame, and its parent diff show that this commit introduced the asynchronous duplication path without a post-acknowledgement metadata write. |

### Fixes and commits

| Bug | Fix | Regression coverage | Commit |
| --- | --- | --- | --- |
| Desktop-published database child appears unpublished | Split container access identity from publication identity; probe child/container publish info concurrently and route all publish management actions to the resolved owner. | `src/components/app/header/__tests__/RightMenu.rowFavorite.test.tsx`, `src/components/app/share/__tests__/ShareTabs.test.tsx`, `src/components/app/share/__tests__/publish.hooks.test.tsx` | `6632af9667ec575aba78f61dcbdd7c677d4443fb` |
| Template-created rows lose their document icon | Reassert `is_document_empty=false` on the target row after the duplication task is accepted and before opening the row; retain the existing empty fallback when duplication fails or is unavailable. | `src/application/database-yjs/__tests__/useNewRowTemplateDispatch.test.tsx` | `cea2dc1e71cbf9f850a9aa28bc8e5908449db636` |

### Test integrity

- Pre-fix: `pnpm exec jest src/components/app/header/__tests__/RightMenu.rowFavorite.test.tsx --runInBand --no-coverage` failed at the intended regression assertion: expected `data-publish-view-id="board-view"`, received `null`.
- Post-fix: the focused command below passes 5 suites / 19 tests, including Desktop child-keyed, existing Web container-keyed, and new-publication behavior.
- Revert check: temporarily removing the causal `publishViewId={routeViewId}` production prop while retaining the test made the same focused test fail at the same intended assertion; restoring it passes.
- Template-race pre-fix: the new focused dispatch test failed at its intended assertion with expected `false`, received `true` after simulated canonical hydration during the asynchronous duplication request.
- Template-race post-fix: all 25 template-dispatch tests pass. Five affected suites covering dispatch, row icons, row detail, template actions, and worker-lag fetching pass 61 tests.
- Template-race revert check: temporarily removing only the post-acknowledgement write made the same regression fail with expected `false`, received `true`; restoring it passes.
- Replacement CI: [Playwright run 33346243956](https://github.com/AppFlowy-IO/AppFlowy-Web/actions/runs/33346243956) passed all 13 jobs. Its formerly failing [`database-3` shard](https://github.com/AppFlowy-IO/AppFlowy-Web/actions/runs/33346243956/job/99350996958) passed 73 tests with 4 skipped; both the top-right default-template scenario and inline deep-copy scenario passed. Web-CI and code coverage also passed.

```bash
pnpm exec jest \
  src/components/app/header/__tests__/RightMenu.rowFavorite.test.tsx \
  src/components/app/share/__tests__/ShareButton.test.tsx \
  src/components/app/share/__tests__/ShareTabs.test.tsx \
  src/components/app/share/__tests__/PublishPanel.permission.test.tsx \
  src/components/app/share/__tests__/publish.hooks.test.tsx \
  --runInBand --no-coverage
```

Additional validation:

- `pnpm lint` — passed.
- `pnpm exec jest --no-coverage --silent` — 381 suites / 3,770 tests passed.
- `pnpm build` — passed (existing Browserslist age and chunk-size warnings only).
- `pnpm exec prettier --check` for both changed template-dispatch files — passed.
- `git diff --check` — passed.

### Proof video

Pending: no in-app/connected browser session was available in this run, so no UI recording or attachment is claimed here. The two failed CI attempts retain Playwright traces and screenshots for the template race.

---

### **Checklist**

#### **General**
- [x] I've included relevant documentation or comments for the changes introduced.
- [ ] I've tested the changes in multiple environments (e.g., different browsers, operating systems).

#### **Testing**
- [x] I've added or updated tests to validate the changes introduced for AppFlowy Web.

#### **Feature-Specific**
- [ ] For feature additions, I've added a preview (video, screenshot, or demo) in the "Feature Preview" section. (Not a feature addition.)
- [x] I've verified that this fix preserves existing container-keyed Web publications and container-level sharing.
