### PR TITLE
feat: match desktop exact and range number grouping on web

### DIFF
--- a/playwright/bdd/features/database/number-grouping.feature
+++ b/playwright/bdd/features/database/number-grouping.feature
@@ -1,0 +1,172 @@
+Feature: Number grouping matches Desktop
+  Numbers can be grouped by their exact numeric value or by configured ranges.
+  A range includes its lower bound, and only the final range includes its upper bound.
+
+  Scenario: Default ranges separate zero, boundaries, outliers, and missing values
+    Given a Grid contains the following numbers for number grouping
+      | value   |
+      | -1      |
+      | 0       |
+      | 10      |
+      | 90      |
+      | 100     |
+      | 101     |
+      | <empty> |
+    When I group the Grid by its number field
+    Then number grouping uses Range with Start "0", End "100", and Interval "10"
+    And the number groups contain these row counts
+      | bucket    | rows |
+      | empty     | 1    |
+      | < 0       | 1    |
+      | [0, 10)   | 1    |
+      | [10, 20)  | 1    |
+      | [90, 100] | 2    |
+      | > 100     | 1    |
+    When I show empty number groups
+    Then the number groups contain these row counts
+      | bucket   | rows |
+      | [20, 30) | 0    |
+      | [30, 40) | 0    |
+      | [40, 50) | 0    |
+      | [50, 60) | 0    |
+      | [60, 70) | 0    |
+      | [70, 80) | 0    |
+      | [80, 90) | 0    |
+    When I reload the number-grouped Grid
+    Then number grouping uses Range with Start "0", End "100", and Interval "10"
+    And the number groups contain these row counts
+      | bucket    | rows |
+      | [20, 30)  | 0    |
+      | [90, 100] | 2    |
+      | > 100     | 1    |
+    When I hide empty number groups
+    Then the number group "[20, 30)" is not displayed
+    And the number groups contain these row counts
+      | bucket  | rows |
+      | empty   | 1    |
+      | [0, 10) | 1    |
+
+  Scenario: Exact values merge decimal spellings and sort numerically after reopening
+    Given a Grid contains the following numbers for number grouping
+      | value   |
+      | 1       |
+      | 1.0     |
+      | 1.00    |
+      | 2       |
+      | 10      |
+      | -2      |
+      | 0       |
+      | <empty> |
+    When I group the Grid by its number field
+    And I select Exact value number grouping
+    Then the number groups contain these row counts
+      | bucket | rows |
+      | empty  | 1    |
+      | = -2   | 1    |
+      | = 0    | 1    |
+      | = 1    | 3    |
+      | = 2    | 1    |
+      | = 10   | 1    |
+    And the displayed number groups are ordered as follows
+      | bucket |
+      | empty  |
+      | = -2   |
+      | = 0    |
+      | = 1    |
+      | = 2    |
+      | = 10   |
+    When I sort number groups descending
+    And I reload the number-grouped Grid
+    Then Exact value number grouping is selected
+    And the displayed number groups are ordered as follows
+      | bucket |
+      | empty  |
+      | = 10   |
+      | = 2    |
+      | = 1    |
+      | = 0    |
+      | = -2   |
+    When I sort number groups ascending
+    Then the displayed number groups are ordered as follows
+      | bucket |
+      | empty  |
+      | = -2   |
+      | = 0    |
+      | = 1    |
+      | = 2    |
+      | = 10   |
+
+  Scenario: Signed decimal ranges use exact boundaries and a shortened final bucket
+    Given a Grid contains the following numbers for number grouping
+      | value   |
+      | -0.6    |
+      | -0.5    |
+      | -0.3    |
+      | 0       |
+      | 0.5     |
+      | 0.6     |
+      | 0.7     |
+      | <empty> |
+    When I group the Grid by its number field
+    And I apply number ranges with Start "-0.5", End "0.6", and Interval "0.2"
+    And I show empty number groups
+    Then the number groups contain these row counts
+      | bucket       | rows |
+      | empty        | 1    |
+      | < -0.5       | 1    |
+      | [-0.5, -0.3) | 1    |
+      | [-0.3, -0.1) | 1    |
+      | [-0.1, 0.1)  | 1    |
+      | [0.1, 0.3)   | 0    |
+      | [0.3, 0.5)   | 0    |
+      | [0.5, 0.6]   | 2    |
+      | > 0.6        | 1    |
+    When I reload the number-grouped Grid
+    Then number grouping uses Range with Start "-0.5", End "0.6", and Interval "0.2"
+    And the number groups contain these row counts
+      | bucket       | rows |
+      | [-0.3, -0.1) | 1    |
+      | [0.5, 0.6]   | 2    |
+      | > 0.6        | 1    |
+
+  Scenario: Invalid range drafts cannot replace the saved configuration
+    Given a Grid contains the following numbers for number grouping
+      | value |
+      | -1    |
+      | 1     |
+      | 11    |
+    When I group the Grid by its number field
+    Then these invalid range drafts cannot be applied or saved
+      | start | end  | interval |
+      | 0     | 100  | 0        |
+      | 0     | 100  | -1       |
+      | 0     | 0    | 10       |
+      | 100   | 0    | 10       |
+      | nope  | 100  | 10       |
+      | 0     | 1001 | 1        |
+    When I reload the number-grouped Grid
+    Then number grouping uses Range with Start "0", End "100", and Interval "10"
+    And the number groups contain these row counts
+      | bucket   | rows |
+      | < 0      | 1    |
+      | [0, 10)  | 1    |
+      | [10, 20) | 1    |
+
+  Scenario: Adding a row inside a range prefills that range's lower bound
+    Given a Grid contains the following numbers for number grouping
+      | value   |
+      | 1       |
+      | 11      |
+      | <empty> |
+    When I group the Grid by its number field
+    And I add a row to number group "[10, 20)"
+    Then the number groups contain these row counts
+      | bucket   | rows |
+      | [10, 20) | 2    |
+    When I select Exact value number grouping
+    Then the number groups contain these row counts
+      | bucket | rows |
+      | empty  | 1    |
+      | = 1    | 1    |
+      | = 10   | 1    |
+      | = 11   | 1    |

--- a/playwright/bdd/steps/number-grouping.steps.ts
+++ b/playwright/bdd/steps/number-grouping.steps.ts
@@ -1,0 +1,215 @@
+import { expect, Page } from '@playwright/test';
+import { createBdd, DataTable } from 'playwright-bdd';
+
+import { waitForGridReady } from '../../support/database-ui-helpers';
+import { addFieldWithType, addRows, loginAndCreateGrid, typeTextIntoCell } from '../../support/field-type-helpers';
+import { DatabaseGridSelectors, FieldType } from '../../support/selectors';
+import { generateRandomEmail, setupPageErrorHandling } from '../../support/test-config';
+
+const { Given, When, Then } = createBdd();
+const numberFieldIds = new WeakMap<Page, string>();
+const groupHeaders = (page: Page) => page.locator('[data-testid^="grid-group-header-"]');
+const numberControl = (page: Page, name: string) => page.getByTestId(`grid-number-group-${name}`);
+
+function numberFieldId(page: Page): string {
+  const fieldId = numberFieldIds.get(page);
+
+  if (!fieldId) throw new Error('The number grouping field has not been created');
+  return fieldId;
+}
+
+// Bucket notation states the boundary contract without depending on translated labels.
+function bucketId(page: Page, bucket: string): string {
+  if (bucket === 'empty') return numberFieldId(page);
+
+  const value = /^([=<>])\s*(.+)$/.exec(bucket);
+
+  if (value) {
+    const prefix = value[1] === '=' ? 'value' : value[1] === '<' ? 'below' : 'above';
+
+    return `number_${prefix}_${value[2]}`;
+  }
+
+  const range = /^\[([^,]+),\s*([^,]+)(\)|\])$/.exec(bucket);
+
+  if (!range) throw new Error(`Unsupported number bucket: ${bucket}`);
+  return `number_interval_${range[3] === ']' ? 'closed_' : ''}${range[1].trim()}_${range[2].trim()}`;
+}
+
+async function openNumberGroupSettings(page: Page) {
+  const menu = page.getByTestId('grid-group-settings-menu');
+
+  if (await menu.isVisible()) return;
+
+  const trigger = page.getByTestId('grid-group-settings-trigger');
+
+  if (!(await trigger.isVisible())) await page.getByTestId('database-actions-settings').click();
+  await trigger.click();
+  await expect(menu).toBeVisible();
+}
+
+async function closeNumberGroupSettings(page: Page) {
+  await page.keyboard.press('Escape');
+  await page.keyboard.press('Escape');
+  await expect(page.getByTestId('grid-group-settings-menu')).toBeHidden();
+}
+
+async function fillRange(page: Page, start: string, end: string, interval: string) {
+  await numberControl(page, 'start').fill(start);
+  await numberControl(page, 'end').fill(end);
+  await numberControl(page, 'interval').fill(interval);
+}
+
+async function expectSavedRange(page: Page, start: string, end: string, interval: string) {
+  await openNumberGroupSettings(page);
+  await expect(numberControl(page, 'mode-range')).toHaveAttribute('aria-checked', 'true');
+  await expect(numberControl(page, 'start')).toHaveValue(start);
+  await expect(numberControl(page, 'end')).toHaveValue(end);
+  await expect(numberControl(page, 'interval')).toHaveValue(interval);
+  await closeNumberGroupSettings(page);
+}
+
+async function setHideEmpty(page: Page, hide: boolean) {
+  await openNumberGroupSettings(page);
+  const toggle = page.getByTestId('grid-hide-empty-groups-toggle');
+
+  if ((await toggle.getAttribute('aria-checked')) !== String(hide)) await toggle.click();
+  await closeNumberGroupSettings(page);
+  await openNumberGroupSettings(page);
+  await expect(toggle).toHaveAttribute('aria-checked', String(hide));
+  await closeNumberGroupSettings(page);
+}
+
+Given('a Grid contains the following numbers for number grouping', async ({ page, request }, table: DataTable) => {
+  setupPageErrorHandling(page);
+  // Keep every configured default bucket mounted so DOM assertions cover the whole order.
+  await page.setViewportSize({ width: 1600, height: 3200 });
+  await loginAndCreateGrid(page, request, generateRandomEmail());
+
+  const values = table.hashes().map((row) => row.value);
+  const fieldId = await addFieldWithType(page, FieldType.Number);
+
+  expect(fieldId).not.toBe('');
+  numberFieldIds.set(page, fieldId);
+  const initialRows = await DatabaseGridSelectors.dataRows(page).count();
+
+  expect(values.length).toBeGreaterThanOrEqual(initialRows);
+  await addRows(page, values.length - initialRows);
+  await expect(DatabaseGridSelectors.dataRows(page)).toHaveCount(values.length);
+
+  for (const [index, value] of values.entries()) {
+    if (value !== '<empty>') await typeTextIntoCell(page, fieldId, index, value);
+  }
+});
+
+When('I group the Grid by its number field', async ({ page }) => {
+  await openNumberGroupSettings(page);
+  await page.getByTestId(`grid-group-by-field-${numberFieldId(page)}`).click();
+  await closeNumberGroupSettings(page);
+  await expect(groupHeaders(page).first()).toBeVisible();
+});
+
+Then(
+  'number grouping uses Range with Start {string}, End {string}, and Interval {string}',
+  async ({ page }, start: string, end: string, interval: string) => {
+    await expectSavedRange(page, start, end, interval);
+  }
+);
+
+When('I select Exact value number grouping', async ({ page }) => {
+  await openNumberGroupSettings(page);
+  await numberControl(page, 'mode-exact').click();
+  await closeNumberGroupSettings(page);
+  await openNumberGroupSettings(page);
+  await expect(numberControl(page, 'mode-exact')).toHaveAttribute('aria-checked', 'true');
+  await closeNumberGroupSettings(page);
+});
+
+Then('Exact value number grouping is selected', async ({ page }) => {
+  await openNumberGroupSettings(page);
+  await expect(numberControl(page, 'mode-exact')).toHaveAttribute('aria-checked', 'true');
+  await closeNumberGroupSettings(page);
+});
+
+When(
+  'I apply number ranges with Start {string}, End {string}, and Interval {string}',
+  async ({ page }, start: string, end: string, interval: string) => {
+    await openNumberGroupSettings(page);
+    await fillRange(page, start, end, interval);
+    await expect(numberControl(page, 'apply')).toBeEnabled();
+    await numberControl(page, 'apply').click();
+    await closeNumberGroupSettings(page);
+    await expectSavedRange(page, start, end, interval);
+  }
+);
+
+When('I show empty number groups', async ({ page }) => {
+  await setHideEmpty(page, false);
+});
+
+When('I hide empty number groups', async ({ page }) => {
+  await setHideEmpty(page, true);
+});
+
+Then('the number groups contain these row counts', async ({ page }, table: DataTable) => {
+  for (const { bucket, rows } of table.hashes()) {
+    const header = page.getByTestId(`grid-group-header-${bucketId(page, bucket)}`);
+
+    await expect(header, `Expected one displayed number group ${bucket}`).toHaveCount(1);
+    await expect(header).toBeVisible();
+    await expect(header.getByTestId('grid-group-row-count')).toHaveText(rows);
+  }
+});
+
+Then('the number group {string} is not displayed', async ({ page }, bucket: string) => {
+  await expect(page.getByTestId(`grid-group-header-${bucketId(page, bucket)}`)).toHaveCount(0);
+});
+
+Then('the displayed number groups are ordered as follows', async ({ page }, table: DataTable) => {
+  const expected = table.hashes().map(({ bucket }) => bucketId(page, bucket));
+
+  await expect
+    .poll(() => groupHeaders(page).evaluateAll((headers) => headers.map((header) => header.dataset.groupId)))
+    .toEqual(expected);
+});
+
+When('I sort number groups {word}', async ({ page }, direction: string) => {
+  expect(['ascending', 'descending']).toContain(direction);
+  await openNumberGroupSettings(page);
+  await numberControl(page, `sort-${direction}`).click();
+  await closeNumberGroupSettings(page);
+  await openNumberGroupSettings(page);
+  await expect(numberControl(page, `sort-${direction}`)).toHaveAttribute('aria-checked', 'true');
+  await closeNumberGroupSettings(page);
+});
+
+When('I reload the number-grouped Grid', async ({ page }) => {
+  await page.reload({ waitUntil: 'domcontentloaded' });
+  await waitForGridReady(page);
+  await expect(groupHeaders(page).first()).toBeVisible({ timeout: 30000 });
+});
+
+Then('these invalid range drafts cannot be applied or saved', async ({ page }, table: DataTable) => {
+  const savedGroupIds = await groupHeaders(page).evaluateAll((headers) =>
+    headers.map((header) => header.dataset.groupId)
+  );
+
+  for (const { start, end, interval } of table.hashes()) {
+    await openNumberGroupSettings(page);
+    await fillRange(page, start, end, interval);
+    await numberControl(page, 'apply').click();
+    await expect(numberControl(page, 'validation')).toBeVisible();
+    await closeNumberGroupSettings(page);
+    await expectSavedRange(page, '0', '100', '10');
+    await expect
+      .poll(() => groupHeaders(page).evaluateAll((headers) => headers.map((header) => header.dataset.groupId)))
+      .toEqual(savedGroupIds);
+  }
+});
+
+When('I add a row to number group {string}', async ({ page }, bucket: string) => {
+  const header = page.getByTestId(`grid-group-header-${bucketId(page, bucket)}`);
+
+  await header.hover();
+  await header.getByTestId('grid-group-new-row').click();
+});

--- a/playwright/e2e/database/database-grid-grouping.spec.ts
+++ b/playwright/e2e/database/database-grid-grouping.spec.ts
@@ -2,9 +2,9 @@
  * Grid grouping desktop-parity integration coverage.
  *
  * Migrated from the Desktop Grid grouping, grouping/filter/sort, all-field,
- * visibility, number, text, hide-empty, and sort-with-group suites. Exact
- * date/number boundaries and high-volume derivation stay in the colocated Jest
- * suites; this file exercises every Web-supported grouping field through UI.
+ * visibility, number, text, hide-empty, and sort-with-group suites. Number
+ * configuration and boundaries also have Playwright BDD coverage. High-volume
+ * derivation stays in Jest; this file exercises each supported grouping field through UI.
  *
  * Desktop sources audited:
  * - database_grid_group_test.dart
@@ -447,25 +447,26 @@ test.describe('Database Grid grouping', () => {
     await typeTextIntoCell(page, urlFieldId, 2, 'https://appflowy.io');
 
     await groupGridByField(page, numberFieldId);
-    await expect(page.getByTestId('grid-group-header-number_range_0_100')).toBeVisible();
-    await expect(page.getByTestId('grid-group-header-number_range_0_100')).toContainText('0 to 100');
     await expect(
-      page.getByTestId('grid-group-header-number_range_0_100').getByTestId('grid-group-row-count')
-    ).toHaveText('2');
-    await expect(
-      page.getByTestId('grid-group-header-number_range_100_200').getByTestId('grid-group-row-count')
+      page.getByTestId('grid-group-header-number_interval_50_60').getByTestId('grid-group-row-count')
     ).toHaveText('1');
+    await expect(
+      page.getByTestId('grid-group-header-number_interval_70_80').getByTestId('grid-group-row-count')
+    ).toHaveText('1');
+    await expect(page.getByTestId('grid-group-header-number_above_100').getByTestId('grid-group-row-count')).toHaveText(
+      '1'
+    );
 
     await typeTextIntoCell(page, numberFieldId, 0, '250');
     await expect(
-      page.getByTestId('grid-group-header-number_range_0_100').getByTestId('grid-group-row-count')
+      page.getByTestId('grid-group-header-number_interval_70_80').getByTestId('grid-group-row-count')
     ).toHaveText('1');
-    await expect(
-      page.getByTestId('grid-group-header-number_range_200_300').getByTestId('grid-group-row-count')
-    ).toHaveText('1');
+    await expect(page.getByTestId('grid-group-header-number_above_100').getByTestId('grid-group-row-count')).toHaveText(
+      '2'
+    );
     await expect
       .poll(() => gridGroupHeaders(page).evaluateAll((headers) => headers.map((header) => header.dataset.groupId)))
-      .toEqual(['number_range_0_100', 'number_range_100_200', 'number_range_200_300']);
+      .toEqual(['number_interval_70_80', 'number_above_100']);
 
     await openGridGroupSettings(page);
     await page.getByTestId(`grid-group-by-field-${urlFieldId}`).click();

--- a/src/@types/translations/en.json
+++ b/src/@types/translations/en.json
@@ -2804,6 +2804,21 @@
     "ungroupedItemsTitle": "Click to add to the board",
     "groupBy": "Group by",
     "groupCondition": "Group condition",
+    "numberGrouping": {
+      "title": "Group numbers by",
+      "exact": "Exact value",
+      "range": "Range",
+      "legacy": "Automatic ranges of 100",
+      "start": "Start",
+      "end": "End",
+      "interval": "Interval",
+      "sort": "Sort groups",
+      "invalidNumber": "Enter valid decimal numbers.",
+      "invalidBounds": "End must be greater than Start.",
+      "invalidInterval": "Interval must be greater than zero.",
+      "tooManyRanges": "Use a larger interval to create at most 1,000 ranges.",
+      "precisionExceeded": "These values exceed the supported decimal precision."
+    },
     "referencedBoardPrefix": "View of",
     "notesTooltip": "Notes inside",
     "mobile": {

--- a/src/application/database-yjs/__tests__/group-row.test.ts
+++ b/src/application/database-yjs/__tests__/group-row.test.ts
@@ -1,0 +1,64 @@
+import * as Y from 'yjs';
+
+import { FieldType } from '@/application/database-yjs/database.type';
+import { getGroupRowCellsData } from '@/application/database-yjs/group-row';
+import { YjsDatabaseKey } from '@/application/types';
+import type {
+  YDatabaseField,
+  YDatabaseFields,
+  YDatabaseGroup,
+  YDatabaseGroups,
+  YDatabaseView,
+} from '@/application/types';
+
+function createFixture() {
+  const doc = new Y.Doc();
+  const fields = doc.getMap('fields') as YDatabaseFields;
+  const field = new Y.Map() as YDatabaseField;
+  const view = doc.getMap('view') as YDatabaseView;
+  const group = new Y.Map() as YDatabaseGroup;
+  const groups = new Y.Array<YDatabaseGroup>() as YDatabaseGroups;
+
+  field.set(YjsDatabaseKey.id, 'amount');
+  field.set(YjsDatabaseKey.type, FieldType.Number);
+  fields.set('amount', field);
+  group.set(YjsDatabaseKey.field_id, 'amount');
+  groups.push([group]);
+  view.set(YjsDatabaseKey.groups, groups);
+
+  const configure = (interval: string, mode = 2) =>
+    group.set(
+      YjsDatabaseKey.content,
+      JSON.stringify({ mode, range_start: '-1', range_end: '1', range_interval: interval })
+    );
+
+  configure('0.5');
+  return { fields, view, configure };
+}
+
+describe('grouped row insertion', () => {
+  it('uses decimal boundaries and reads changed overflow intervals at insertion time', () => {
+    const { fields, view, configure } = createFixture();
+    const prefill = (id: string) => getGroupRowCellsData(fields, 'amount', id, view);
+
+    expect(prefill('number_interval_-0.5_0')).toEqual({ amount: '-0.5' });
+    expect(prefill('number_interval_closed_0.5_1')).toEqual({ amount: '0.5' });
+    expect(prefill('number_below_-1')).toEqual({ amount: '-1.5' });
+    expect(prefill('number_above_1')).toEqual({ amount: '1.5' });
+
+    configure('0.25');
+    expect(prefill('number_below_-1')).toEqual({ amount: '-1.25' });
+    expect(prefill('number_above_1')).toEqual({ amount: '1.25' });
+    expect(prefill('number_interval_-0.5_0')).toBeUndefined();
+  });
+
+  it('prefills exact zero separately from missing and rejects stale range groups after a mode change', () => {
+    const { fields, view, configure } = createFixture();
+
+    configure('0.5', 1);
+    expect(getGroupRowCellsData(fields, 'amount', 'number_value_0', view)).toEqual({ amount: '0' });
+    expect(getGroupRowCellsData(fields, 'amount', 'number_value_1.25', view)).toEqual({ amount: '1.25' });
+    expect(getGroupRowCellsData(fields, 'amount', 'amount', view)).toEqual({ amount: '' });
+    expect(getGroupRowCellsData(fields, 'amount', 'number_below_-1', view)).toBeUndefined();
+  });
+});

--- a/src/application/database-yjs/__tests__/group.test.ts
+++ b/src/application/database-yjs/__tests__/group.test.ts
@@ -23,7 +23,8 @@ import {
   normalizeGroupIdentifiers,
 } from '@/application/database-yjs/group';
 import { DateGroupCondition, FieldType, FilterType } from '@/application/database-yjs/database.type';
-import { CheckboxFilterCondition, SelectOptionFilterCondition } from '@/application/database-yjs/fields';
+import { CheckboxFilterCondition, NumberFormat, SelectOptionFilterCondition } from '@/application/database-yjs/fields';
+import { defaultNumberGroupConfiguration, NumberGroupMode } from '@/application/database-yjs/number-grouping';
 import { Row } from '@/application/database-yjs/selector';
 import {
   RowId,
@@ -369,7 +370,7 @@ describe('desktop Grid dynamic grouping parity', () => {
       '0',
       '99.9',
       '100',
-      '1,250',
+      '1250',
       '',
     ]);
     const result = groupByNumber(rows, rowMetas, field);
@@ -384,6 +385,31 @@ describe('desktop Grid dynamic grouping parity', () => {
     ]);
     expect(result.get('number_range_0_100')?.map(({ id }) => id)).toEqual(['row-3', 'row-4']);
     expect(result.get('amount')?.map(({ id }) => id)).toEqual(['row-7']);
+  });
+
+  it.each([NumberFormat.Num, NumberFormat.Percent, NumberFormat.USD])('groups raw stored numbers independently of display format %s', (format) => {
+    const field = createField('amount', FieldType.Number, { format, scale: 2 });
+    const { rowMetas, rows } = createRows('amount', FieldType.Number, ['0.5', '1.234', '1,250', '', '0']);
+    const content = JSON.stringify(defaultNumberGroupConfiguration(NumberGroupMode.Exact));
+    const result = groupByField(rows, rowMetas, field, undefined, content);
+
+    expect([...result!.keys()]).toEqual(['amount', 'number_value_0', 'number_value_0.5', 'number_value_1', 'number_value_1.234']);
+    expect(result?.get('number_value_0.5')?.map(({ id }) => id)).toEqual(['row-0']);
+    expect(result?.get('amount')?.map(({ id }) => id)).toEqual(['row-3']);
+  });
+
+  it('removes emptied exact groups after edits and deletions and retains configured empty ranges', () => {
+    const field = createField('amount', FieldType.Number);
+    const { rowMetas, rows } = createRows('amount', FieldType.Number, ['1', '2']);
+    const exact = JSON.stringify(defaultNumberGroupConfiguration(NumberGroupMode.Exact));
+
+    updateCell(rowMetas['row-0'], 'amount', '2.0');
+    expect([...groupByNumber(rows, rowMetas, field, exact).keys()]).toEqual(['amount', 'number_value_2']);
+    expect([...groupByNumber([], rowMetas, field, exact).keys()]).toEqual(['amount']);
+    const range = JSON.stringify(defaultNumberGroupConfiguration(NumberGroupMode.Range));
+
+    expect(groupByNumber([], rowMetas, field, range).size).toBe(13);
+    expect(getGroupCellData('number_above_100', field, range)).toBe('110');
   });
 
   it('moves a row when the RichText grouping cell changes', () => {
@@ -482,7 +508,7 @@ describe('desktop Grid dynamic grouping parity', () => {
     const relationField = createField('project', FieldType.Relation);
 
     expect(getGroupLabel('number_range_-100_0', numberField)).toBe('-100 to 0');
-    expect(getGroupLabel('amount', numberField)).toBe('No Amount');
+    expect(getGroupLabel('amount', numberField)).toBe('No Number');
     expect(getGroupLabel('todo', selectField)).toBe('To do');
     expect(getGroupCellData('number_range_200_300', numberField)).toBe('200');
     expect(getGroupCellData('status', selectField)).toBeUndefined();

--- a/src/application/database-yjs/__tests__/number-grouping.test.ts
+++ b/src/application/database-yjs/__tests__/number-grouping.test.ts
@@ -1,0 +1,105 @@
+import {
+  createNumberGroupingPolicy,
+  defaultNumberGroupConfiguration,
+  getNumberGroupLabel,
+  NumberGroupMode,
+  parseNumberGroupCell,
+  parseNumberGroupConfiguration,
+  validateNumberGroupConfiguration,
+} from '../number-grouping';
+
+const content = (overrides = {}) => JSON.stringify({ ...defaultNumberGroupConfiguration(NumberGroupMode.Range), ...overrides });
+
+describe('desktop numeric grouping compatibility', () => {
+  it('keeps old hide-only settings in Legacy mode and normalizes explicit decimal configuration', () => {
+    expect(parseNumberGroupConfiguration('{"hide_empty":true}')).toEqual({ ...defaultNumberGroupConfiguration(), hide_empty: true });
+    expect(parseNumberGroupConfiguration(content({ range_start: '-0.00', range_end: '+100.00', range_interval: '10.0' })))
+      .toEqual(defaultNumberGroupConfiguration(NumberGroupMode.Range));
+    expect(parseNumberGroupConfiguration(content({ mode: 99 }))).toEqual(defaultNumberGroupConfiguration());
+  });
+
+  it.each([
+    ['0', 'number_interval_0_10'], ['9.999', 'number_interval_0_10'],
+    ['10', 'number_interval_10_20'], ['99.99', 'number_interval_closed_90_100'],
+    ['100', 'number_interval_closed_90_100'], ['-0.001', 'number_below_0'],
+    ['100.001', 'number_above_100'], ['', null], ['invalid', null],
+  ])('groups %s using lower-inclusive intervals and an inclusive final end', (value, id) => {
+    expect(createNumberGroupingPolicy(content()).groupIdForCell(value)).toBe(id);
+  });
+
+  it('keeps empty intervals and both overflow groups with decimal, nondivisible bounds', () => {
+    const policy = createNumberGroupingPolicy(content({ range_start: '-0.5', range_end: '0.6', range_interval: '0.5' }));
+
+    expect(policy.configuredGroupIds()).toEqual([
+      'number_below_-0.5', 'number_interval_-0.5_0', 'number_interval_0_0.5',
+      'number_interval_closed_0.5_0.6', 'number_above_0.6',
+    ]);
+    expect(policy.groupIdForCell('0.6')).toBe('number_interval_closed_0.5_0.6');
+    expect(policy.groupIdForCell('-0.0000000000000000000000000001')).toBe('number_interval_-0.5_0');
+    expect(policy.retainsEmptyGroups).toBe(true);
+    expect(policy.configuredGroupIds().map((id) => policy.valueForGroup(id))).toEqual(['-1', '-0.5', '0', '0.5', '1.1']);
+    policy.configuredGroupIds().forEach((id) => expect(policy.groupIdForCell(policy.valueForGroup(id))).toBe(id));
+  });
+
+  it('normalizes numeric equality and sorts exact groups beyond JS integer precision', () => {
+    const policy = createNumberGroupingPolicy(content({ mode: NumberGroupMode.Exact, sort_descending: true }));
+
+    expect(['1', '1.00', '01.0'].map(policy.groupIdForCell)).toEqual(Array(3).fill('number_value_1'));
+    expect(policy.groupIdForCell('-0.0')).toBe('number_value_0');
+    expect(policy.groupIdForCell('')).toBeNull();
+    expect(['number_value_2', 'number_value_9007199254740993', 'number_value_10', 'number_value_9007199254740992', 'number_value_-2']
+      .sort(policy.compareGroupIds)).toEqual(['number_value_9007199254740993', 'number_value_9007199254740992', 'number_value_10', 'number_value_2', 'number_value_-2']);
+    expect(policy.configuredGroupIds()).toEqual([]);
+    expect(policy.valueForGroup('number_value_1.00')).toBeUndefined();
+    expect(policy.valueForGroup('number_value_-0.5')).toBe('-0.5');
+    expect(policy.valueForGroup('number_interval_0_10')).toBeUndefined();
+  });
+
+  it('preserves legacy fixed-100 identities, including the smallest negative decimal', () => {
+    const policy = createNumberGroupingPolicy();
+
+    expect(policy.groupIdForCell('-0.0000000000000000000000000001')).toBe('number_range_-100_0');
+    expect(policy.groupIdForCell('100')).toBe('number_range_100_200');
+    expect(policy.valueForGroup('number_range_-100_0')).toBe('-100');
+    expect(policy.isValidGroupId('number_range_5_105')).toBe(false);
+  });
+
+  it.each([
+    [{ range_start: '' }, 'invalidNumber'], [{ range_start: ' 0' }, 'invalidNumber'],
+    [{ range_end: '1e2' }, 'invalidNumber'], [{ range_end: '1_000' }, 'invalidNumber'],
+    [{ range_interval: '0.00000000000000000000000000001' }, 'invalidNumber'],
+    [{ range_start: '100' }, 'invalidBounds'], [{ range_interval: '0' }, 'invalidInterval'],
+    [{ range_interval: '-1' }, 'invalidInterval'], [{ range_interval: '0.01' }, 'tooManyRanges'],
+    [{ range_start: '79228162514264337593543950333', range_end: '79228162514264337593543950335', range_interval: '1' }, 'precisionExceeded'],
+    [{ range_start: '7922816251426433759354395032', range_end: '7922816251426433759354395033', range_interval: '0.01' }, 'precisionExceeded'],
+  ])('rejects invalid configuration %j with a stable error', (overrides, error) => {
+    expect(validateNumberGroupConfiguration({ ...defaultNumberGroupConfiguration(NumberGroupMode.Range), ...overrides }))
+      .toEqual({ valid: false, error });
+  });
+
+  it('allows exactly 1000 intervals and retains the range settings in Exact mode', () => {
+    const configuration = { ...defaultNumberGroupConfiguration(NumberGroupMode.Exact), range_interval: '0.1' };
+
+    expect(validateNumberGroupConfiguration(configuration)).toEqual({ valid: true, configuration });
+    expect(createNumberGroupingPolicy(content({ range_interval: '0.1' })).configuredGroupIds()).toHaveLength(1002);
+  });
+
+  it.each([
+    ['number_value_-0.5', '-0.5'], ['number_interval_-0.5_0', '-0.5–<0'],
+    ['number_interval_closed_90_100', '90–100'], ['number_below_0', 'Below 0'],
+    ['number_above_100', 'Above 100'], ['number_range_-100_0', '-100 to 0'],
+  ])('labels %s without rounding', (id, label) => expect(getNumberGroupLabel(id)).toBe(label));
+
+  it.each([
+    ['1e3', '1000'], ['1E3', '1'], ['12abc', '12'], ['1,000', '1'],
+    ['-.2', '2'], ['.2', '0.2'], ['-$0.2', '0.2'], ['0.5%', '0.5'],
+    ['$1.234', '1.234'], ['prefix1e3', null], ['1e-29', null], ['0e29', null],
+    ['1.0000000000000000000000000000e-1', null],
+    ['0.00000000000000000000000000005', '0.0000000000000000000000000001'],
+    ['79228162514264337593543950335', '79228162514264337593543950335'],
+    ['79228162514264337593543950335.4', '79228162514264337593543950335'],
+    ['79228162514264337593543950335.5', null],
+    ['79228162514264337593543950336', null],
+    [1, null], [null, null], [undefined, null],
+  ])('matches desktop raw-cell parsing for %j', (raw, expected) => expect(parseNumberGroupCell(raw)).toBe(expected));
+});

--- a/src/application/database-yjs/__tests__/useGridGroupingSelector.test.tsx
+++ b/src/application/database-yjs/__tests__/useGridGroupingSelector.test.tsx
@@ -1,4 +1,5 @@
 import { act, renderHook, waitFor } from '@testing-library/react';
+import { StrictMode, type ReactNode, useLayoutEffect, useState } from 'react';
 import * as Y from 'yjs';
 
 import {
@@ -16,8 +17,10 @@ import {
   useUpdateCellDispatch,
   useUpdateDateGroupConditionDispatch,
   useUpdateGroupContentDispatch,
+  useUpdateNumberGroupConfigurationDispatch,
 } from '@/application/database-yjs';
 import { createYDatabaseGroupColumn } from '@/application/database-yjs/group-column';
+import { defaultNumberGroupConfiguration, NumberGroupMode, parseNumberGroupConfiguration } from '@/application/database-yjs/number-grouping';
 import {
   DatabaseViewLayout,
   YDatabase,
@@ -44,7 +47,6 @@ import { useSyncGridGroupingMetadata } from '@/components/database/grid/GridGrou
 
 import { createCell, createRowDoc } from './test-helpers';
 
-import { StrictMode, type ReactNode, useLayoutEffect, useState } from 'react';
 
 jest.mock('@/utils/runtime-config', () => ({
   getConfigValue: (_key: string, fallback: string) => fallback,
@@ -188,6 +190,135 @@ describe('useGridGroupingSelector refresh behavior', () => {
     useSyncGridGroupingMetadata(grouping);
     return grouping;
   };
+
+  it('starts new numeric grouping in Range and preserves settings and column metadata on reselection', async () => {
+    const fixture = createGridGroupingFixture({ fieldType: FieldType.Number, rowAValue: '10', rowBValue: '100' });
+
+    fixture.groups.delete(0, fixture.groups.length);
+    fixture.gridLayoutSetting.set(YjsDatabaseKey.hide_empty_groups, false);
+    const { result, unmount } = renderHook(() => ({
+      grouping: useGroupingWithMetadataSync(),
+      groupBy: useGroupByFieldDispatch(),
+      update: useUpdateNumberGroupConfigurationDispatch(),
+    }), { wrapper: fixture.wrapper });
+
+    act(() => result.current.groupBy(fixture.fieldId));
+    await waitFor(() => expect(result.current.grouping.visibleGroups).toHaveLength(13));
+    expect(parseNumberGroupConfiguration(result.current.grouping.content).mode).toBe(NumberGroupMode.Range);
+    const group = fixture.groups.get(0);
+    const columns = group.get(YjsDatabaseKey.groups);
+    const final = columns.toArray().find((column) => column.get(YjsDatabaseKey.id) === 'number_interval_closed_90_100')!;
+
+    act(() => {
+      final.set(YjsDatabaseKey.visible, false);
+      final.set(YjsDatabaseKey.group_color, 'appflowy_tint5');
+      group.get(YjsDatabaseKey.collapsed_group_ids).push(['number_interval_closed_90_100']);
+      result.current.groupBy(fixture.fieldId);
+      result.current.update({ ...defaultNumberGroupConfiguration(NumberGroupMode.Range), range_start: '-0.0', sort_descending: true });
+    });
+    await waitFor(() => expect(result.current.grouping.activeGroupIds.slice(0, 3))
+      .toEqual(['name', 'number_above_100', 'number_interval_closed_90_100']));
+    expect(fixture.groups.get(0)).toBe(group);
+    expect(result.current.grouping.groups.find(({ id }) => id === 'number_interval_closed_90_100'))
+      .toMatchObject({ hidden: true, collapsed: true });
+    const canonicalColumns = columns.toArray();
+
+    act(() => result.current.update(parseNumberGroupConfiguration(result.current.grouping.content)));
+    expect(columns.toArray()).toEqual(canonicalColumns);
+    expect(columns.toJSON()).toContainEqual({ id: 'number_interval_closed_90_100', visible: false, group_color: 'appflowy_tint5' });
+    unmount();
+    fixture.rowA.destroy(); fixture.rowB.destroy(); fixture.databaseDoc.destroy();
+  });
+
+  it('switches numeric modes atomically and never shows stale exact headers after editing', async () => {
+    const fixture = createGridGroupingFixture({ fieldType: FieldType.Number, rowAValue: '1', rowBValue: '2' });
+    const { result, unmount } = renderHook(() => ({
+      grouping: useGroupingWithMetadataSync(), update: useUpdateNumberGroupConfigurationDispatch(),
+    }), { wrapper: fixture.wrapper });
+
+    act(() => result.current.update(defaultNumberGroupConfiguration(NumberGroupMode.Exact)));
+    await waitFor(() => expect(result.current.grouping.visibleGroups.map(({ id }) => id)).toEqual(['number_value_1', 'number_value_2']));
+    act(() => fixture.updateCell(fixture.rowA, fixture.fieldId, '2.0'));
+    await waitFor(() => expect(result.current.grouping.visibleGroups.map(({ id }) => id)).toEqual(['number_value_2']));
+    act(() => { fixture.gridLayoutSetting.set(YjsDatabaseKey.hide_empty_groups, false); });
+    await waitFor(() => expect(result.current.grouping.visibleGroups.map(({ id }) => id)).toEqual(['name', 'number_value_2']));
+    act(() => result.current.update({ ...defaultNumberGroupConfiguration(NumberGroupMode.Range), range_start: '-0.5', range_end: '0.6', range_interval: '0.5' }));
+    await waitFor(() => expect(result.current.grouping.visibleGroups).toHaveLength(6));
+    expect(fixture.columns.toJSON().some(({ id }: { id: string }) => id.startsWith('number_value'))).toBe(false);
+    expect(result.current.grouping.groups.find(({ id }) => id === 'number_above_0.6')?.rows).toHaveLength(2);
+    const before = fixture.group.toJSON();
+
+    expect(() => result.current.update({ ...defaultNumberGroupConfiguration(NumberGroupMode.Range), range_interval: '0' })).toThrow(RangeError);
+    expect(fixture.group.toJSON()).toEqual(before);
+    unmount();
+    const reopened = renderHook(useGroupingWithMetadataSync, { wrapper: fixture.wrapper });
+
+    await waitFor(() => expect(reopened.result.current.visibleGroups).toHaveLength(6));
+    expect(parseNumberGroupConfiguration(reopened.result.current.content).range_interval).toBe('0.5');
+    reopened.unmount();
+    fixture.rowA.destroy(); fixture.rowB.destroy(); fixture.databaseDoc.destroy();
+  });
+
+  it('preserves unhydrated valid numeric group metadata while discarding IDs from another mode', async () => {
+    const fixture = createGridGroupingFixture({ fieldType: FieldType.Number, rowAValue: '2', rowBValue: '10' });
+
+    fixture.group.set(YjsDatabaseKey.content, JSON.stringify({ ...defaultNumberGroupConfiguration(NumberGroupMode.Exact), sort_descending: true }));
+    fixture.columns.push([
+      createYDatabaseGroupColumn({ id: 'number_value_9007199254740993', visible: false, groupColor: 'appflowy_tint5' }),
+      createYDatabaseGroupColumn({ id: 'number_range_0_100' }),
+    ]);
+    fixture.rowOrders.push([{ id: 'not-hydrated', height: 36 }]);
+    const { result, unmount } = renderHook(useGroupingWithMetadataSync, { wrapper: fixture.wrapper });
+
+    await waitFor(() => expect(result.current.activeGroupIds).toEqual(['name', 'number_value_9007199254740993', 'number_value_10', 'number_value_2']));
+    expect(result.current.ready).toBe(false);
+    expect(fixture.columns.toJSON()).toContainEqual({ id: 'number_value_9007199254740993', visible: false, group_color: 'appflowy_tint5' });
+    expect(result.current.metadataGroupIds).toContain('number_value_9007199254740993');
+    unmount();
+    fixture.rowA.destroy(); fixture.rowB.destroy(); fixture.databaseDoc.destroy();
+  });
+
+  it('uses the current field type when a grouped schema changes in either direction', async () => {
+    const fixture = createGridGroupingFixture({ fieldType: FieldType.Number, rowAValue: '2', rowBValue: '10' });
+    const field = fixture.databaseDoc.getMap(YjsEditorKey.data_section).get(YjsEditorKey.database)
+      ?.get(YjsDatabaseKey.fields).get(fixture.fieldId) as YDatabaseField;
+    const { result, unmount } = renderHook(useGroupingWithMetadataSync, { wrapper: fixture.wrapper });
+
+    await waitFor(() => expect(result.current.visibleGroups.map(({ id }) => id)).toEqual(['number_range_0_100']));
+    act(() => {
+      field.set(YjsDatabaseKey.type, FieldType.RichText);
+      [fixture.rowA, fixture.rowB].forEach((doc) => {
+        const row = doc.getMap(YjsEditorKey.data_section).get(YjsEditorKey.database_row) as YDatabaseRow;
+
+        row.get(YjsDatabaseKey.cells).get(fixture.fieldId).set(YjsDatabaseKey.field_type, FieldType.RichText);
+      });
+      fixture.updateCell(fixture.rowA, fixture.fieldId, 'Alpha');
+      fixture.updateCell(fixture.rowB, fixture.fieldId, 'Beta');
+    });
+    await waitFor(() => expect(fixture.columns.toJSON().map(({ id }: { id: string }) => id)).toContain('Alpha'));
+    const alpha = fixture.columns.toArray().find((column) => column.get(YjsDatabaseKey.id) === 'Alpha')!;
+
+    act(() => {
+      alpha.set(YjsDatabaseKey.visible, false);
+      alpha.set(YjsDatabaseKey.group_color, 'appflowy_tint5');
+      fixture.updateCell(fixture.rowB, fixture.fieldId, 'Gamma');
+    });
+    await waitFor(() => expect(result.current.visibleGroups.map(({ id }) => id)).toEqual(['Gamma']));
+    expect(fixture.columns.toJSON()).toContainEqual({ id: 'Alpha', visible: false, group_color: 'appflowy_tint5' });
+    act(() => {
+      // Imported schema snapshots can retain the old group type too.
+      fixture.group.set(YjsDatabaseKey.type, FieldType.RichText);
+      fixture.group.set(YjsDatabaseKey.content, JSON.stringify({ ...defaultNumberGroupConfiguration(NumberGroupMode.Exact), sort_descending: true }));
+      field.set(YjsDatabaseKey.type, FieldType.Number);
+      fixture.updateCell(fixture.rowA, fixture.fieldId, '2');
+      fixture.updateCell(fixture.rowB, fixture.fieldId, '10');
+    });
+    await waitFor(() => expect(fixture.columns.toJSON().map(({ id }: { id: string }) => id))
+      .toEqual(['name', 'number_value_10', 'number_value_2']));
+    expect(result.current.visibleGroups.map(({ id }) => id)).toEqual(['number_value_10', 'number_value_2']);
+    unmount();
+    fixture.rowA.destroy(); fixture.rowB.destroy(); fixture.databaseDoc.destroy();
+  });
 
   it('uses List layout slot 4 through the generic selector and List alias', async () => {
     const fixture = createGridGroupingFixture();

--- a/src/application/database-yjs/__tests__/useGroup.test.tsx
+++ b/src/application/database-yjs/__tests__/useGroup.test.tsx
@@ -120,7 +120,12 @@ describe('useGroup', () => {
 
   it.each<[FieldType, string[]]>([
     [FieldType.RichText, ['field-id']],
-    [FieldType.Number, ['field-id']],
+    [FieldType.Number, [
+      'field-id', 'number_below_0', 'number_interval_0_10', 'number_interval_10_20',
+      'number_interval_20_30', 'number_interval_30_40', 'number_interval_40_50',
+      'number_interval_50_60', 'number_interval_60_70', 'number_interval_70_80',
+      'number_interval_80_90', 'number_interval_closed_90_100', 'number_above_100',
+    ]],
     [FieldType.URL, ['field-id']],
     [FieldType.Checkbox, ['Yes', 'No']],
     [FieldType.SingleSelect, ['field-id']],
@@ -153,7 +158,8 @@ describe('useGroup', () => {
     ).toBe(true);
     expect(group?.get(YjsDatabaseKey.collapsed_group_ids)?.toArray()).toEqual([]);
     expect(group?.get(YjsDatabaseKey.content)).toBe(
-      fieldType === FieldType.DateTime ? JSON.stringify({ hide_empty: false, condition: 0 }) : ''
+      fieldType === FieldType.DateTime ? JSON.stringify({ hide_empty: false, condition: 0 }) :
+        fieldType === FieldType.Number ? JSON.stringify({ hide_empty: false, mode: 2, range_start: '0', range_end: '100', range_interval: '10', sort_descending: false }) : ''
     );
     expect(view?.get(YjsDatabaseKey.layout_settings)?.get('0')?.get(YjsDatabaseKey.hide_empty_groups)).toBe(true);
   });

--- a/src/application/database-yjs/__tests__/useMoveCardDispatch.test.tsx
+++ b/src/application/database-yjs/__tests__/useMoveCardDispatch.test.tsx
@@ -1,13 +1,15 @@
 import { act, renderHook } from '@testing-library/react';
-import type React from 'react';
 import * as Y from 'yjs';
 
 import { DatabaseContext, DatabaseContextState, FieldType } from '@/application/database-yjs';
 import { useMoveCardDispatch } from '@/application/database-yjs/dispatch';
+import { defaultNumberGroupConfiguration, NumberGroupMode } from '@/application/database-yjs/number-grouping';
 import {
   YDatabase,
   YDatabaseField,
   YDatabaseFields,
+  YDatabaseGroup,
+  YDatabaseGroups,
   YDatabaseRow,
   YDatabaseView,
   YDatabaseViews,
@@ -16,13 +18,75 @@ import {
   YjsEditorKey,
 } from '@/application/types';
 
-import { createRowDoc } from './test-helpers';
+import { createCell, createRowDoc } from './test-helpers';
+
+import type { ReactNode } from 'react';
 
 jest.mock('@/utils/runtime-config', () => ({
   getConfigValue: (_key: string, fallback: string) => fallback,
 }));
 
 describe('useMoveCardDispatch', () => {
+  it.each([
+    [NumberGroupMode.Range, 'number_interval_0_10', 'number_interval_10_20', '10'],
+    [NumberGroupMode.Range, 'number_interval_0_10', 'number_below_0', '-10'],
+    [NumberGroupMode.Range, 'number_interval_0_10', 'number_above_100', '110'],
+    [NumberGroupMode.Exact, 'number_value_1.25', 'number_value_-0.5', '-0.5'],
+    [NumberGroupMode.Legacy, 'number_range_0_100', 'number_range_-100_0', '-100'],
+  ])('writes the numeric representative in mode %s and preserves same-group values', (mode, start, finish, value) => {
+    const databaseId = 'numeric-database';
+    const viewId = 'numeric-view';
+    const fieldId = 'amount';
+    const rowId = 'numeric-row';
+    const databaseDoc = new Y.Doc({ guid: databaseId }) as YDoc;
+    const database = new Y.Map() as YDatabase;
+    const fields = new Y.Map() as YDatabaseFields;
+    const field = new Y.Map() as YDatabaseField;
+    const views = new Y.Map() as YDatabaseViews;
+    const view = new Y.Map() as YDatabaseView;
+    const groups = new Y.Array() as YDatabaseGroups;
+    const group = new Y.Map() as YDatabaseGroup;
+
+    field.set(YjsDatabaseKey.id, fieldId);
+    field.set(YjsDatabaseKey.type, FieldType.Number);
+    fields.set(fieldId, field);
+    group.set(YjsDatabaseKey.field_id, fieldId);
+    group.set(YjsDatabaseKey.content, JSON.stringify(defaultNumberGroupConfiguration(mode as NumberGroupMode)));
+    groups.push([group]);
+    view.set(YjsDatabaseKey.groups, groups);
+    view.set(YjsDatabaseKey.row_orders, Y.Array.from([{ id: rowId, height: 36 }]));
+    views.set(viewId, view);
+    database.set(YjsDatabaseKey.id, databaseId);
+    database.set(YjsDatabaseKey.fields, fields);
+    database.set(YjsDatabaseKey.views, views);
+    databaseDoc.getMap(YjsEditorKey.data_section).set(YjsEditorKey.database, database);
+    const rowDoc = createRowDoc(rowId, databaseId, { [fieldId]: createCell(FieldType.Number, '1.25') });
+    const row = rowDoc.getMap(YjsEditorKey.data_section).get(YjsEditorKey.database_row) as YDatabaseRow;
+    const cell = row.get(YjsDatabaseKey.cells).get(fieldId);
+    const contextValue = {
+      readOnly: false, databaseDoc, databasePageId: viewId, activeViewId: viewId,
+      rowMap: { [rowId]: rowDoc }, workspaceId: 'workspace-id',
+    } as DatabaseContextState;
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <DatabaseContext.Provider value={contextValue}>{children}</DatabaseContext.Provider>
+    );
+    const { result, unmount } = renderHook(useMoveCardDispatch, { wrapper });
+    const before = cell.toJSON();
+
+    act(() => result.current({ rowId, fieldId, startColumnId: start as string, finishColumnId: start as string }));
+    expect(cell.toJSON()).toEqual(before);
+    act(() => result.current({ rowId, fieldId, startColumnId: start as string, finishColumnId: finish as string }));
+    expect(cell.get(YjsDatabaseKey.data)).toBe(value);
+    expect(cell.get(YjsDatabaseKey.field_type)).toBe(FieldType.Number);
+    act(() => result.current({ rowId, fieldId, startColumnId: finish as string, finishColumnId: fieldId }));
+    expect(cell.get(YjsDatabaseKey.data)).toBe('');
+    act(() => row.get(YjsDatabaseKey.cells).delete(fieldId));
+    act(() => result.current({ rowId, fieldId, startColumnId: fieldId, finishColumnId: finish as string }));
+    expect(row.get(YjsDatabaseKey.cells).get(fieldId).get(YjsDatabaseKey.data)).toBe(value);
+    unmount();
+    rowDoc.destroy(); databaseDoc.destroy();
+  });
+
   it('transforms a lazy cell before writing the new board group value', () => {
     const databaseId = 'database-id';
     const viewId = 'view-id';
@@ -74,7 +138,7 @@ describe('useMoveCardDispatch', () => {
       rowMap: { [rowId]: rowDoc },
       workspaceId: 'workspace-id',
     } as DatabaseContextState;
-    const wrapper = ({ children }: { children: React.ReactNode }) => (
+    const wrapper = ({ children }: { children: ReactNode }) => (
       <DatabaseContext.Provider value={contextValue}>{children}</DatabaseContext.Provider>
     );
     const { result } = renderHook(() => useMoveCardDispatch(), { wrapper });

--- a/src/application/database-yjs/dispatch.ts
+++ b/src/application/database-yjs/dispatch.ts
@@ -6,7 +6,7 @@ import * as Y from 'yjs';
 import { resolveUserAttributionUid, touchRowAttribution } from '@/application/database-yjs/attribution';
 import { calculateFieldValue } from '@/application/database-yjs/calculation';
 import { cloneDatabaseCell } from '@/application/database-yjs/cell.clone';
-import { normalizeLegacyCellFieldType, setCellStoredType } from '@/application/database-yjs/cell.field-type';
+import { normalizeLegacyCellFieldType } from '@/application/database-yjs/cell.field-type';
 import { parseYDatabaseCellToCell } from '@/application/database-yjs/cell.parse';
 import { DEFAULT_FIELD_WRAP } from '@/application/database-yjs/const';
 import {
@@ -43,12 +43,10 @@ import {
   SelectOptionColor,
   SelectTypeOption,
 } from '@/application/database-yjs/fields';
-import { createCheckboxCell } from '@/application/database-yjs/fields/checkbox/utils';
 import { parseRelationTypeOption } from '@/application/database-yjs/fields/relation/parse';
 import { createRelationField } from '@/application/database-yjs/fields/relation/utils';
 import { RollupShowAsType } from '@/application/database-yjs/fields/rollup/rollup.type';
 import { createRollupField } from '@/application/database-yjs/fields/rollup/utils';
-import { createSelectOptionCell } from '@/application/database-yjs/fields/select-option/utils';
 import { createDateTimeField } from '@/application/database-yjs/fields/text/utils';
 import { getDefaultFilterCondition, resolveRollupFilterTargetFieldType } from '@/application/database-yjs/filter';
 import { isFormQuestionFieldType } from '@/application/database-yjs/form-field-types';
@@ -83,6 +81,14 @@ import {
   normalizeCreatedDatabaseListView,
   removeCreatedDatabaseView,
 } from '@/application/database-yjs/list-layout';
+import {
+  createNumberGroupingPolicy,
+  defaultNumberGroupConfiguration,
+  NumberGroupConfiguration,
+  NumberGroupMode,
+  parseNumberGroupConfiguration,
+  validateNumberGroupConfiguration,
+} from '@/application/database-yjs/number-grouping';
 import { getInlineViewRowOrders, materializeVisibleRowOrders } from '@/application/database-yjs/row-order-visibility';
 import { waitForDatabaseRowHydration } from '@/application/database-yjs/row.hydration';
 import { useCalendarLayoutSetting, useFieldType } from '@/application/database-yjs/selector';
@@ -269,8 +275,15 @@ function generateGroupByField(field: YDatabaseField) {
 
       columns.push([createYDatabaseGroupColumn({ id: fieldId })]);
       break;
+    case FieldType.Number: {
+      const content = JSON.stringify(defaultNumberGroupConfiguration(NumberGroupMode.Range));
+
+      group.set(YjsDatabaseKey.content, content);
+      columns.push((getGroupColumns(field, content) ?? []).map(createYDatabaseGroupColumn));
+      break;
+    }
+
     case FieldType.RichText:
-    case FieldType.Number:
     case FieldType.URL:
     case FieldType.Relation:
     case FieldType.Person:
@@ -415,6 +428,76 @@ export function useUpdateGroupContentDispatch() {
     },
     [sharedRoot, view]
   );
+}
+
+export function useUpdateNumberGroupConfigurationDispatch() {
+  const view = useDatabaseView();
+  const database = useDatabase();
+  const sharedRoot = useSharedRoot();
+
+  return useCallback((configuration: NumberGroupConfiguration) => {
+    const validated = validateNumberGroupConfiguration(configuration);
+
+    if (!validated.valid) throw new RangeError(validated.error);
+    const next = validated.configuration;
+
+    executeOperations(sharedRoot, [() => {
+      const group = view?.get(YjsDatabaseKey.groups)?.toArray()[0];
+      const fieldId = group?.get(YjsDatabaseKey.field_id);
+      const field = fieldId ? database.get(YjsDatabaseKey.fields)?.get(fieldId) : undefined;
+
+      if (!group || !field || Number(field.get(YjsDatabaseKey.type)) !== FieldType.Number) {
+        throw new Error('Number group not found');
+      }
+
+      const previous = parseNumberGroupConfiguration(group.get(YjsDatabaseKey.content));
+      const content = JSON.stringify(next);
+
+      if (JSON.stringify(previous) === content) return;
+      const membershipChanged = previous.mode !== next.mode ||
+        (next.mode === NumberGroupMode.Range && (
+          previous.range_start !== next.range_start || previous.range_end !== next.range_end ||
+          previous.range_interval !== next.range_interval
+        ));
+
+      // Retain the group map and surviving column/collapse metadata. Only IDs
+      // invalid under the new policy can be discarded without hydrating rows.
+      group.set(YjsDatabaseKey.content, content);
+      if (membershipChanged) {
+        const policy = createNumberGroupingPolicy(content);
+        const isValid = (id: string) => id === fieldId || policy.isValidGroupId(id);
+        const columns = group.get(YjsDatabaseKey.groups);
+
+        if (columns) {
+          for (let index = columns.length - 1; index >= 0; index--) {
+            if (!isValid(getDatabaseGroupColumnId(columns.get(index)) ?? '')) columns.delete(index);
+          }
+        }
+
+        const collapsed = group.get(YjsDatabaseKey.collapsed_group_ids);
+
+        if (collapsed instanceof Y.Array) {
+          for (let index = collapsed.length - 1; index >= 0; index--) {
+            if (!isValid(collapsed.get(index))) collapsed.delete(index);
+          }
+        } else if (Array.isArray(collapsed)) {
+          group.set(YjsDatabaseKey.collapsed_group_ids, Y.Array.from(collapsed.filter(isValid)));
+        }
+
+        const currentIds = new Set(columns?.toArray().map(getDatabaseGroupColumnId));
+        const additions = [fieldId, ...policy.configuredGroupIds()]
+          .filter((id): id is string => Boolean(id && !currentIds.has(id)))
+          .map((id) => createYDatabaseGroupColumn({ id }));
+
+        if (columns && additions.length) columns.push(additions);
+        const layout = Number(view?.get(YjsDatabaseKey.layout)) as DatabaseViewLayout;
+
+        if (layout === DatabaseViewLayout.Grid || layout === DatabaseViewLayout.List) {
+          markLocalDatabaseGroupInitialization(group);
+        }
+      }
+    }], 'updateNumberGroupConfiguration');
+  }, [database, sharedRoot, view]);
 }
 
 export function useUpdateDateGroupConditionDispatch() {
@@ -650,7 +733,7 @@ function setGroupColumnsHidden({
 
   if (missingRequestedColumnIds.length > 0) {
     const field = fields?.get(fieldId);
-    const fallbackColumns = field ? getGroupColumns(field) ?? [] : [];
+    const fallbackColumns = field ? getGroupColumns(field, group.get(YjsDatabaseKey.content)) ?? [] : [];
     const fallbackColumnIds = new Set(fallbackColumns.map((column) => column.id));
 
     if (!allowDynamicColumn) {
@@ -712,13 +795,13 @@ function setGroupColumnHidden({
 
 export function useSyncDatabaseGroupColumnsDispatch(groupId?: string) {
   const view = useDatabaseView();
+  const database = useDatabase();
   const sharedRoot = useSharedRoot();
 
   return useCallback(
     (activeGroupIds: readonly string[]) => {
       if (!view || !groupId) return;
 
-      const uniqueGroupIds = [...new Set(activeGroupIds.filter(Boolean))];
       const group = view
         .get(YjsDatabaseKey.groups)
         ?.toArray()
@@ -726,6 +809,14 @@ export function useSyncDatabaseGroupColumnsDispatch(groupId?: string) {
       const columns = group?.get(YjsDatabaseKey.groups);
 
       if (!columns) return;
+      const defaultGroupId = group?.get(YjsDatabaseKey.field_id);
+      const groupingField = defaultGroupId ? database.get(YjsDatabaseKey.fields)?.get(defaultGroupId) : undefined;
+      // A schema conversion updates the field before the saved group type.
+      // Match the selector's current field type when validating metadata.
+      const isNumberGroup = Number(groupingField?.get(YjsDatabaseKey.type)) === FieldType.Number;
+      const numberPolicy = isNumberGroup ? createNumberGroupingPolicy(group?.get(YjsDatabaseKey.content)) : undefined;
+      const isValidGroupId = (id: string) => !numberPolicy || id === defaultGroupId || numberPolicy.isValidGroupId(id);
+      const uniqueGroupIds = [...new Set(activeGroupIds.filter((id) => Boolean(id) && isValidGroupId(id)))];
 
       const currentColumns = columns.toArray();
       const currentGroupIds = new Set<string>();
@@ -735,7 +826,7 @@ export function useSyncDatabaseGroupColumnsDispatch(groupId?: string) {
       currentColumns.forEach((column) => {
         const id = getDatabaseGroupColumnId(column);
 
-        if (!id || currentGroupIds.has(id)) {
+        if (!id || !isValidGroupId(id) || currentGroupIds.has(id)) {
           hasDuplicateOrInvalidColumns = true;
           return;
         }
@@ -747,7 +838,6 @@ export function useSyncDatabaseGroupColumnsDispatch(groupId?: string) {
       const legacyColumns = currentColumns.filter(
         (column) => !(column instanceof Y.Map) || !column.has(YjsDatabaseKey.visible)
       );
-      const isNumberGroup = Number(group?.get(YjsDatabaseKey.type)) === FieldType.Number;
       const hasCanonicalNumberOrder =
         !isNumberGroup || uniqueGroupIds.every((id, index) => currentGroupIdOrder[index] === id);
       const alreadyCanonical =
@@ -776,7 +866,7 @@ export function useSyncDatabaseGroupColumnsDispatch(groupId?: string) {
             latestColumns.toArray().forEach((column, index) => {
               const id = getDatabaseGroupColumnId(column);
 
-              if (!id || seenColumnIds.has(id)) {
+              if (!id || !isValidGroupId(id) || seenColumnIds.has(id)) {
                 redundantColumnIndexes.push(index);
                 return;
               }
@@ -799,7 +889,7 @@ export function useSyncDatabaseGroupColumnsDispatch(groupId?: string) {
                 }),
               ]);
             });
-            if (Number(latestGroup?.get(YjsDatabaseKey.type)) === FieldType.Number) {
+            if (isNumberGroup) {
               // Desktop keeps the default Number group first and inserts dynamic
               // ranges by their numeric start. The selector supplies that desired
               // order; reconcile it without replacing columns already in place so
@@ -834,7 +924,7 @@ export function useSyncDatabaseGroupColumnsDispatch(groupId?: string) {
         { type: 'database.sync-group-columns', policy: 'skip' }
       );
     },
-    [groupId, sharedRoot, view]
+    [database, groupId, sharedRoot, view]
   );
 }
 
@@ -1262,129 +1352,8 @@ export function useReorderRowDispatch() {
   );
 }
 
-export function useMoveCardDispatch() {
-  const view = useDatabaseView();
-  const sharedRoot = useSharedRoot();
-  const rowMap = useRowMap();
-  const database = useDatabase();
-  const { databaseDoc } = useDatabaseContext();
-  const currentUser = useCurrentUserOptional();
-  const actorUid = resolveUserAttributionUid(currentUser);
-
-  return useCallback(
-    ({
-      rowId,
-      beforeRowId,
-      fieldId,
-      startColumnId,
-      finishColumnId,
-    }: {
-      rowId: string;
-      beforeRowId?: string;
-      fieldId: string;
-      startColumnId: string;
-      finishColumnId: string;
-    }) => {
-      if (!view) {
-        throw new Error(`Unable to reorder card`);
-      }
-
-      const field = database.get(YjsDatabaseKey.fields)?.get(fieldId);
-
-      if (!field) {
-        throw new Error(`Field not found`);
-      }
-
-      const fieldType = Number(field.get(YjsDatabaseKey.type));
-
-      if (isAttributionFieldType(fieldType)) {
-        executeOperations(
-          sharedRoot,
-          [
-            () => {
-              if (startColumnId === finishColumnId) {
-                reorderRow(rowId, beforeRowId, view);
-              }
-            },
-          ],
-          'reorderCard',
-          { type: 'database.reorder-card', rowId, fieldId, fieldType }
-        );
-        return;
-      }
-
-      const rowDoc = rowMap?.[rowId];
-
-      if (!rowDoc) {
-        throw new Error(`Unable to reorder card`);
-      }
-
-      const historyGroup = createDatabaseHistoryGroup();
-
-      getOrCreateDatabaseHistoryManager(databaseDoc).registerRowDoc(rowId, rowDoc);
-      executeOperations(
-        sharedRoot,
-        [
-          () => {
-            runDatabaseRowAction(rowDoc, { type: 'row.move-card-cell', rowId, fieldId, fieldType, historyGroup }, () => {
-              const row = rowDoc.getMap(YjsEditorKey.data_section).get(YjsEditorKey.database_row) as YDatabaseRow;
-              const cells = row.get(YjsDatabaseKey.cells);
-              const isSelectOptionField = [FieldType.SingleSelect, FieldType.MultiSelect].includes(fieldType);
-              let cellChanged = false;
-              let cell = cells.get(fieldId);
-
-              if (!cell) {
-                // if the cell is empty, create a new cell and set data to finishColumnId
-                if (isSelectOptionField) {
-                  cell = createSelectOptionCell(fieldId, fieldType, finishColumnId);
-                } else if (fieldType === FieldType.Checkbox) {
-                  cell = createCheckboxCell(fieldId, finishColumnId);
-                }
-
-                if (cell) {
-                  cells.set(fieldId, cell);
-                  cellChanged = true;
-                }
-              } else {
-                const cellData = parseYDatabaseCellToCell(cell, field).data;
-                let newCellData = cellData;
-
-                if (isSelectOptionField) {
-                  const selectedIds = (cellData as string)?.split(',') ?? [];
-                  const index = selectedIds.findIndex((id) => id === startColumnId);
-
-                  if (selectedIds.includes(finishColumnId)) {
-                    selectedIds.splice(index, 1);
-                  } else {
-                    selectedIds.splice(index, 1, finishColumnId);
-                  }
-
-                  newCellData = selectedIds.join(',');
-                } else if (fieldType === FieldType.Checkbox) {
-                  newCellData = finishColumnId;
-                }
-
-                cell.set(YjsDatabaseKey.data, newCellData);
-                setCellStoredType(cell, fieldType);
-                cell.set(YjsDatabaseKey.last_modified, String(dayjs().unix()));
-                cellChanged = newCellData !== cellData;
-              }
-
-              if (cellChanged) {
-                touchRowAttribution(row, actorUid);
-              }
-            });
-
-            reorderRow(rowId, beforeRowId, view);
-          },
-        ],
-        'reorderCard',
-        { type: 'database.reorder-card', rowId, fieldId, fieldType, historyGroup }
-      );
-    },
-    [actorUid, database, databaseDoc, rowMap, sharedRoot, view]
-  );
-}
+// Keep the public and modular dispatch entry points on the same mutation path.
+export { useMoveCardDispatch } from '@/application/database-yjs/dispatch/row';
 
 export function useDeleteRowDispatch() {
   const database = useDatabase();

--- a/src/application/database-yjs/dispatch/row.ts
+++ b/src/application/database-yjs/dispatch/row.ts
@@ -50,6 +50,7 @@ import {
   registerDatabaseHistoryRowDoc,
   runDatabaseRowAction,
 } from '@/application/database-yjs/history';
+import { createNumberGroupingPolicy } from '@/application/database-yjs/number-grouping';
 import { initialDatabaseRow } from '@/application/database-yjs/row';
 import { generateRowMeta, getMetaIdMap, getMetaJSON, getRowKey } from '@/application/database-yjs/row_meta';
 import { getPrimaryFieldId, useCalendarLayoutSetting, useDatabaseViewLayout } from '@/application/database-yjs/selector';
@@ -251,6 +252,30 @@ export function useMoveCardDispatch() {
                 const isSelectOptionField = [FieldType.SingleSelect, FieldType.MultiSelect].includes(fieldType);
                 let cellChanged = false;
                 let cell = cells.get(fieldId);
+
+                if (fieldType === FieldType.Number) {
+                  const group = view.get(YjsDatabaseKey.groups)?.toArray()
+                    .find((candidate) => candidate.get(YjsDatabaseKey.field_id) === fieldId);
+                  const policy = createNumberGroupingPolicy(group?.get(YjsDatabaseKey.content));
+                  const currentGroupId = policy.groupIdForCell(cell?.get(YjsDatabaseKey.data)) ?? fieldId;
+
+                  // Reordering within a numeric bucket must preserve its actual
+                  // value, including values away from the bucket's lower bound.
+                  if (startColumnId === finishColumnId || currentGroupId === finishColumnId) return;
+                  const value = finishColumnId === fieldId ? '' : policy.valueForGroup(finishColumnId);
+
+                  if (value === undefined) throw new RangeError('Invalid number group');
+                  if (!cell) {
+                    cell = new Y.Map() as YDatabaseCell;
+                    cells.set(fieldId, cell);
+                  }
+
+                  cell.set(YjsDatabaseKey.data, value);
+                  setCellStoredType(cell, fieldType);
+                  cell.set(YjsDatabaseKey.last_modified, String(dayjs().unix()));
+                  touchRowAttribution(row, actorUid);
+                  return;
+                }
 
                 if (!cell) {
                   // if the cell is empty, create a new cell and set data to finishColumnId

--- a/src/application/database-yjs/group-row.ts
+++ b/src/application/database-yjs/group-row.ts
@@ -1,0 +1,30 @@
+import { getGroupCellData } from '@/application/database-yjs/group';
+import { YjsDatabaseKey } from '@/application/types';
+import type { FieldId, YDatabaseFields, YDatabaseView } from '@/application/types';
+
+export function getGroupRowCellsData(
+  fields?: YDatabaseFields,
+  groupFieldId?: string,
+  groupId?: string,
+  view?: YDatabaseView
+): Record<FieldId, string> | undefined {
+  const field = groupFieldId ? fields?.get(groupFieldId) : undefined;
+
+  if (!groupFieldId || !field || !groupId) return undefined;
+
+  if (groupId === field.get(YjsDatabaseKey.id)) {
+    // An explicit missing-value group must override same-field filter prefills.
+    return { [groupFieldId]: '' };
+  }
+
+  // Read configuration at insertion time: overflow groups use the current
+  // interval, which may have changed since the row action was rendered.
+  const content = view
+    ?.get(YjsDatabaseKey.groups)
+    ?.toArray()
+    .find((group) => group.get(YjsDatabaseKey.field_id) === groupFieldId)
+    ?.get(YjsDatabaseKey.content);
+  const value = getGroupCellData(groupId, field, content);
+
+  return value === undefined ? undefined : { [groupFieldId]: value };
+}

--- a/src/application/database-yjs/group.ts
+++ b/src/application/database-yjs/group.ts
@@ -11,12 +11,11 @@ import {
 } from '@/application/database-yjs/fields';
 import { parseCheckboxValue } from '@/application/database-yjs/fields/text/utils';
 import { checkboxFilterCheck, selectOptionFilterCheck } from '@/application/database-yjs/filter';
+import { createNumberGroupingPolicy, getNumberGroupLabel } from '@/application/database-yjs/number-grouping';
 import { getRelationRowIdsFromCell } from '@/application/database-yjs/relation/cell';
 import type { Row } from '@/application/database-yjs/selector';
 import { RowId, YDatabaseField, YDatabaseFilter, YDoc, YjsDatabaseKey } from '@/application/types';
 import { canonicalizeUserUid } from '@/application/user-uid';
-
-const NUMBER_GROUP_INTERVAL = 100;
 
 export const DATABASE_GROUPABLE_FIELD_TYPES: readonly FieldType[] = [
   FieldType.RichText,
@@ -110,7 +109,7 @@ export function groupByField(
   }
 
   if (fieldType === FieldType.Number) {
-    return groupByNumber(rows, rowMetas, field);
+    return groupByNumber(rows, rowMetas, field, groupContent);
   }
 
   if (fieldType === FieldType.DateTime) {
@@ -124,7 +123,7 @@ export function groupByField(
   return;
 }
 
-export function getGroupColumns(field: YDatabaseField) {
+export function getGroupColumns(field: YDatabaseField, groupContent?: string) {
   const fieldType = Number(field.get(YjsDatabaseKey.type));
   const isSelectOptionField = [FieldType.SingleSelect, FieldType.MultiSelect].includes(fieldType);
 
@@ -146,6 +145,11 @@ export function getGroupColumns(field: YDatabaseField) {
 
   if (fieldType === FieldType.Checkbox) {
     return [{ id: 'Yes' }, { id: 'No' }];
+  }
+
+  if (fieldType === FieldType.Number) {
+    return [field.get(YjsDatabaseKey.id), ...createNumberGroupingPolicy(groupContent).configuredGroupIds()]
+      .map((id) => ({ id }));
   }
 
   if (isDatabaseGroupableFieldType(fieldType)) {
@@ -269,35 +273,22 @@ export function groupByText(rows: Row[], rowMetas: Record<RowId, YDoc>, field: Y
   return result;
 }
 
-export function getNumberGroupId(value: unknown): string | null {
-  if (value === null || value === undefined || String(value).trim() === '') return null;
-
-  const parsed = Number(String(value).replaceAll(',', ''));
-
-  if (!Number.isFinite(parsed)) return null;
-
-  const start = Math.floor(parsed / NUMBER_GROUP_INTERVAL) * NUMBER_GROUP_INTERVAL;
-
-  return `number_range_${start}_${start + NUMBER_GROUP_INTERVAL}`;
+export function getNumberGroupId(value: unknown, groupContent?: string): string | null {
+  return createNumberGroupingPolicy(groupContent).groupIdForCell(value);
 }
 
-function getNumberGroupStart(groupId: string): number {
-  if (!groupId.startsWith('number_range_')) return Number.NEGATIVE_INFINITY;
-
-  const match = /^number_range_(-?\d+(?:\.\d+)?)_/.exec(groupId);
-
-  return match ? Number(match[1]) : Number.NEGATIVE_INFINITY;
-}
-
-export function groupByNumber(rows: Row[], rowMetas: Record<RowId, YDoc>, field: YDatabaseField) {
+export function groupByNumber(rows: Row[], rowMetas: Record<RowId, YDoc>, field: YDatabaseField, groupContent?: string) {
   const fieldId = field.get(YjsDatabaseKey.id);
-  const dynamicGroups = new Map<string, Row[]>();
+  const policy = createNumberGroupingPolicy(groupContent);
+  const dynamicGroups = new Map<string, Row[]>(policy.configuredGroupIds().map((id) => [id, []]));
   const ungroupedRows: Row[] = [];
 
   rows.forEach((row) => {
     if (!hasRowConditionData(rowMetas[row.id])) return;
 
-    const groupId = getNumberGroupId(getGroupingCellData(row.id, rowMetas, field));
+    // Formatting a Percent or Currency cell changes its apparent numeric value.
+    // Desktop groups its raw stored string independently of the field format.
+    const groupId = policy.groupIdForCell(getCell(row.id, fieldId, rowMetas)?.get(YjsDatabaseKey.data));
 
     if (!groupId) {
       ungroupedRows.push(row);
@@ -313,7 +304,7 @@ export function groupByNumber(rows: Row[], rowMetas: Record<RowId, YDoc>, field:
   const result = new Map<string, Row[]>([[fieldId, ungroupedRows]]);
 
   [...dynamicGroups.entries()]
-    .sort(([left], [right]) => getNumberGroupStart(left) - getNumberGroupStart(right))
+    .sort(([left], [right]) => policy.compareGroupIds(left, right))
     .forEach(([groupId, groupRows]) => result.set(groupId, groupRows));
 
   return result;
@@ -466,9 +457,9 @@ export function getGroupLabel(
   const fieldId = field.get(YjsDatabaseKey.id);
   const fieldName = field.get(YjsDatabaseKey.name) || '';
 
-  if (groupId === fieldId) return `No ${fieldName}`.trim();
-
   const fieldType = Number(field.get(YjsDatabaseKey.type)) as FieldType;
+
+  if (groupId === fieldId) return fieldType === FieldType.Number ? 'No Number' : `No ${fieldName}`.trim();
 
   if ([FieldType.Relation, FieldType.Person, FieldType.CreatedBy, FieldType.LastEditedBy].includes(fieldType)) {
     const resolved = identifierLabels?.get(groupId)?.trim();
@@ -491,9 +482,7 @@ export function getGroupLabel(
   }
 
   if (fieldType === FieldType.Number) {
-    const match = /^number_range_(-?\d+(?:\.\d+)?)_(-?\d+(?:\.\d+)?)$/.exec(groupId);
-
-    return match ? `${match[1]} to ${match[2]}` : groupId;
+    return getNumberGroupLabel(groupId) ?? groupId;
   }
 
   if (fieldType === FieldType.DateTime) {
@@ -536,7 +525,7 @@ export function getGroupLabel(
   return groupId;
 }
 
-export function getGroupCellData(groupId: string, field: YDatabaseField): string | undefined {
+export function getGroupCellData(groupId: string, field: YDatabaseField, groupContent?: string): string | undefined {
   const fieldId = field.get(YjsDatabaseKey.id);
 
   if (groupId === fieldId) return undefined;
@@ -544,9 +533,7 @@ export function getGroupCellData(groupId: string, field: YDatabaseField): string
   const fieldType = Number(field.get(YjsDatabaseKey.type)) as FieldType;
 
   if (fieldType === FieldType.Number) {
-    const match = /^number_range_(-?\d+(?:\.\d+)?)_/.exec(groupId);
-
-    return match?.[1];
+    return createNumberGroupingPolicy(groupContent).valueForGroup(groupId);
   }
 
   if (fieldType === FieldType.DateTime) {

--- a/src/application/database-yjs/number-grouping.ts
+++ b/src/application/database-yjs/number-grouping.ts
@@ -1,0 +1,336 @@
+/** Desktop-compatible numeric identity, validation, ordering and group prefills. */
+export enum NumberGroupMode {
+  Legacy = 0,
+  Exact = 1,
+  Range = 2,
+}
+
+export interface NumberGroupConfiguration {
+  hide_empty: boolean;
+  mode: NumberGroupMode;
+  range_start: string;
+  range_end: string;
+  range_interval: string;
+  sort_descending: boolean;
+}
+
+export type NumberGroupValidationError =
+  | 'invalidNumber'
+  | 'invalidBounds'
+  | 'invalidInterval'
+  | 'tooManyRanges'
+  | 'precisionExceeded';
+
+export type NumberGroupValidationResult =
+  | { valid: true; configuration: NumberGroupConfiguration }
+  | { valid: false; error: NumberGroupValidationError };
+
+const SCALE = 28;
+const TEN = BigInt(10);
+const ZERO = BigInt(0);
+const ONE = BigInt(1);
+const UNIT = TEN ** BigInt(SCALE);
+const MAX_COEFFICIENT = (ONE << BigInt(96)) - ONE;
+
+export const MAX_NUMBER_GROUP_BUCKETS = 1000;
+
+interface Decimal {
+  coefficient: bigint;
+  scale: number;
+}
+
+interface NumberGroupDefinition {
+  id: string;
+  value: bigint;
+  kind: 'exact' | 'legacy' | 'interval' | 'closed' | 'below' | 'above';
+  end?: bigint;
+}
+
+export function defaultNumberGroupConfiguration(mode = NumberGroupMode.Legacy): NumberGroupConfiguration {
+  return {
+    hide_empty: false,
+    mode,
+    range_start: '0',
+    range_end: '100',
+    range_interval: '10',
+    sort_descending: false,
+  };
+}
+
+function scaled(decimal: Decimal): bigint {
+  return decimal.coefficient * TEN ** BigInt(SCALE - decimal.scale);
+}
+
+function isRepresentable(scaledValue: bigint): boolean {
+  let value = scaledValue;
+
+  for (let scale = SCALE; scale > 0 && value % TEN === ZERO; scale--) value /= TEN;
+  return (value < ZERO ? -value : value) <= MAX_COEFFICIENT;
+}
+
+function canonical(value: bigint): string {
+  if (value === ZERO) return '0';
+  const negative = value < ZERO;
+  const digits = (negative ? -value : value).toString().padStart(SCALE + 1, '0');
+  const fraction = digits.slice(-SCALE).replace(/0+$/, '');
+  const integer = digits.slice(0, -SCALE);
+
+  return `${negative ? '-' : ''}${integer}${fraction ? `.${fraction}` : ''}`;
+}
+
+/** Rust's normal decimal parser rounds discarded fractional digits; its exact parser rejects them. */
+function parseDecimal(input: string, exact: boolean): Decimal | null {
+  const match = /^([+-]?)(\d*)(?:\.(\d*))?$/.exec(input);
+
+  if (!match || (!match[2] && !match[3])) return null;
+  const integer = (match[2] || '0').replace(/^0+(?=\d)/, '');
+  const fraction = match[3] || '';
+
+  if (integer.length > 29 || BigInt(integer) > MAX_COEFFICIENT) return null;
+  let scale = Math.min(fraction.length, SCALE);
+  let coefficient = BigInt(`${integer}${fraction.slice(0, scale)}`);
+
+  if (exact && (fraction.length > SCALE || coefficient > MAX_COEFFICIENT)) return null;
+  while (coefficient > MAX_COEFFICIENT && scale > 0) {
+    coefficient /= TEN;
+    scale--;
+  }
+
+  if (coefficient > MAX_COEFFICIENT) return null;
+  if (!exact && fraction.length > scale && fraction.charAt(scale) >= '5') {
+    coefficient++;
+    if (coefficient > MAX_COEFFICIENT) {
+      if (scale === 0) return null;
+      coefficient = (coefficient + BigInt(4)) / TEN;
+      scale--;
+    }
+  }
+
+  return { coefficient: match[1] === '-' ? -coefficient : coefficient, scale };
+}
+
+function parseConfigurationDecimal(value: unknown): bigint | null {
+  if (typeof value !== 'string' || value.length > 64 || /[eE_]/.test(value)) return null;
+  const decimal = parseDecimal(value, true);
+
+  return decimal ? scaled(decimal) : null;
+}
+
+/**
+ * Group raw stored cell strings using NumberTypeOption::default(), never the
+ * formatted Percent/Currency display value. Preserve its legacy extraction
+ * and lowercase-scientific detection; cell writes normalize input separately.
+ */
+export function parseNumberGroupCell(value: unknown): string | null {
+  const parsed = parseStoredNumber(value);
+
+  return parsed === null ? null : canonical(parsed);
+}
+
+function parseStoredNumber(value: unknown): bigint | null {
+  if (typeof value !== 'string' || !value) return null;
+  if (/([+-]?\d*\.?\d+)e([+-]?\d+)/.test(value)) {
+    const match = /^([+-]?(?:\d[\d_]*(?:\.[\d_]*)?|\.\d[\d_]*))[eE]([+-]?\d+)$/.exec(value);
+
+    if (!match) return null;
+    const base = parseDecimal(match[1].replaceAll('_', ''), false);
+    const exponentText = match[2].replace(/^[+-]?0*/, '');
+
+    if (!base || exponentText.length > 2) return null;
+    const exponent = Number(match[2]);
+
+    if (Math.abs(exponent) > SCALE || (exponent < 0 && base.scale - exponent > SCALE)) return null;
+    const result = exponent < 0
+      ? scaled(base) / TEN ** BigInt(-exponent)
+      : scaled(base) * TEN ** BigInt(exponent);
+
+    return isRepresentable(result) ? result : null;
+  }
+
+  const leadingFraction = /^\.\d+/.exec(value)?.[0];
+  const token = leadingFraction ? `0${leadingFraction}` : /-?\d+(\.\d+)?/.exec(value)?.[0];
+  const decimal = token ? parseDecimal(token, false) : null;
+
+  return decimal ? scaled(decimal) : null;
+}
+
+function parseGroupDefinition(id: string): NumberGroupDefinition | null {
+  const single = /^number_(value|below|above)_(.+)$/.exec(id);
+
+  if (single) {
+    const value = parseConfigurationDecimal(single[2]);
+
+    if (value === null) return null;
+    return { id, value, kind: single[1] === 'value' ? 'exact' : single[1] as 'below' | 'above' };
+  }
+
+  const pair = /^number_(range|interval|interval_closed)_([^_]+)_([^_]+)$/.exec(id);
+
+  if (!pair) return null;
+  const value = parseConfigurationDecimal(pair[2]);
+  const end = parseConfigurationDecimal(pair[3]);
+
+  if (value === null || end === null || value >= end) return null;
+  return { id, value, end, kind: pair[1] === 'range' ? 'legacy' : pair[1] === 'interval' ? 'interval' : 'closed' };
+}
+
+function compareValues(left: bigint, right: bigint): number {
+  return left < right ? -1 : left > right ? 1 : 0;
+}
+
+export interface NumberGroupingPolicy {
+  readonly configuration: NumberGroupConfiguration;
+  readonly retainsEmptyGroups: boolean;
+  configuredGroupIds(): string[];
+  groupIdForCell(value: unknown): string | null;
+  compareGroupIds(left: string, right: string): number;
+  valueForGroup(groupId: string): string | undefined;
+  isValidGroupId(groupId: string): boolean;
+}
+
+function makePolicy(
+  configuration: NumberGroupConfiguration,
+  start: bigint,
+  end: bigint,
+  interval: bigint,
+  rangeIds: string[]
+): NumberGroupingPolicy {
+  const belowId = `number_below_${canonical(start)}`;
+  const aboveId = `number_above_${canonical(end)}`;
+  const range = configuration.mode === NumberGroupMode.Range;
+  const groupForValue = (value: bigint): string | null => {
+    if (configuration.mode === NumberGroupMode.Exact) return `number_value_${canonical(value)}`;
+    if (range) {
+      if (value < start) return belowId;
+      if (value > end) return aboveId;
+      if (value === end) return rangeIds[rangeIds.length - 1];
+      return rangeIds[Number((value - start) / interval)];
+    }
+
+    const width = BigInt(100) * UNIT;
+    const quotient = value / width - (value < ZERO && value % width !== ZERO ? ONE : ZERO);
+    const lower = quotient * width;
+    const upper = lower + width;
+
+    return isRepresentable(lower) && isRepresentable(upper)
+      ? `number_range_${canonical(lower)}_${canonical(upper)}`
+      : null;
+  };
+
+  const valueForGroup = (id: string): string | undefined => {
+    const group = parseGroupDefinition(id);
+
+    if (!group) return undefined;
+    const value = group.kind === 'below' ? start - interval : group.kind === 'above' ? end + interval : group.value;
+
+    return groupForValue(value) === id ? canonical(value) : undefined;
+  };
+
+  return {
+    configuration,
+    retainsEmptyGroups: range,
+    configuredGroupIds: () => range ? [belowId, ...rangeIds, aboveId] : [],
+    groupIdForCell: (value) => {
+      const parsed = parseStoredNumber(value);
+
+      return parsed === null ? null : groupForValue(parsed);
+    },
+    compareGroupIds: (left, right) => {
+      const a = parseGroupDefinition(left);
+      const b = parseGroupDefinition(right);
+      const rank = (group: NumberGroupDefinition) => group.kind === 'below' ? 0 : group.kind === 'above' ? 2 : 1;
+      const order = a && b
+        ? rank(a) - rank(b) || compareValues(a.value, b.value)
+        : a ? 1 : b ? -1 : 0;
+
+      return configuration.sort_descending ? -order : order;
+    },
+    valueForGroup,
+    isValidGroupId: (id) => valueForGroup(id) !== undefined,
+  };
+}
+
+type PolicyValidation = { valid: true; policy: NumberGroupingPolicy } | { valid: false; error: NumberGroupValidationError };
+
+function validatePolicy(configuration: NumberGroupConfiguration): PolicyValidation {
+  if (!configuration || ![0, 1, 2].includes(configuration.mode) ||
+    typeof configuration.hide_empty !== 'boolean' || typeof configuration.sort_descending !== 'boolean') {
+    return { valid: false, error: 'invalidNumber' };
+  }
+
+  const start = parseConfigurationDecimal(configuration.range_start);
+  const end = parseConfigurationDecimal(configuration.range_end);
+  const interval = parseConfigurationDecimal(configuration.range_interval);
+
+  if (start === null || end === null || interval === null) return { valid: false, error: 'invalidNumber' };
+  if (start >= end) return { valid: false, error: 'invalidBounds' };
+  if (interval <= ZERO) return { valid: false, error: 'invalidInterval' };
+  if (end - start > interval * BigInt(MAX_NUMBER_GROUP_BUCKETS)) return { valid: false, error: 'tooManyRanges' };
+  if (!isRepresentable(start - interval) || !isRepresentable(end + interval)) {
+    return { valid: false, error: 'precisionExceeded' };
+  }
+
+  const rangeIds: string[] = [];
+
+  for (let lower = start; lower < end;) {
+    const next = lower + interval;
+
+    if (!isRepresentable(next)) return { valid: false, error: 'precisionExceeded' };
+    const upper: bigint = next < end ? next : end;
+
+    rangeIds.push(`number_interval_${upper === end ? 'closed_' : ''}${canonical(lower)}_${canonical(upper)}`);
+    lower = upper;
+  }
+
+  return {
+    valid: true,
+    policy: makePolicy({
+      ...configuration,
+      range_start: canonical(start),
+      range_end: canonical(end),
+      range_interval: canonical(interval),
+    }, start, end, interval, rangeIds),
+  };
+}
+
+export function validateNumberGroupConfiguration(configuration: NumberGroupConfiguration): NumberGroupValidationResult {
+  const result = validatePolicy(configuration);
+
+  return result.valid ? { valid: true, configuration: result.policy.configuration } : result;
+}
+
+const LEGACY_POLICY = makePolicy(defaultNumberGroupConfiguration(), ZERO, BigInt(100) * UNIT, BigInt(10) * UNIT, []);
+
+export function createNumberGroupingPolicy(content?: string): NumberGroupingPolicy {
+  if (!content) return LEGACY_POLICY;
+  try {
+    const parsed: unknown = JSON.parse(content);
+
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return LEGACY_POLICY;
+    const result = validatePolicy({ ...defaultNumberGroupConfiguration(), ...parsed });
+
+    return result.valid ? result.policy : LEGACY_POLICY;
+  } catch {
+    return LEGACY_POLICY;
+  }
+}
+
+export function parseNumberGroupConfiguration(content?: string): NumberGroupConfiguration {
+  return { ...createNumberGroupingPolicy(content).configuration };
+}
+
+export function getNumberGroupLabel(id: string): string | null {
+  const group = parseGroupDefinition(id);
+
+  if (!group) return null;
+  const value = canonical(group.value);
+
+  switch (group.kind) {
+    case 'exact': return value;
+    case 'below': return `Below ${value}`;
+    case 'above': return `Above ${value}`;
+    case 'legacy': return `${value} to ${canonical(group.end as bigint)}`;
+    case 'interval': return `${value}–<${canonical(group.end as bigint)}`;
+    case 'closed': return `${value}–${canonical(group.end as bigint)}`;
+  }
+}

--- a/src/application/database-yjs/selector.ts
+++ b/src/application/database-yjs/selector.ts
@@ -53,7 +53,6 @@ import {
   isDatabaseGroupableFieldType,
   isDynamicDatabaseGroupFieldType,
 } from '@/application/database-yjs/group';
-import { canonicalizeUserUid } from '@/application/user-uid';
 import {
   hasPendingLocalDatabaseGroupInitialization,
   normalizeDatabaseGroupColumn,
@@ -65,6 +64,7 @@ import {
   useBackgroundRowDocLoader,
   useRollupFieldObservers,
 } from '@/application/database-yjs/hooks';
+import { createNumberGroupingPolicy, NumberGroupingPolicy } from '@/application/database-yjs/number-grouping';
 import {
   ensureRelationGroupLabel,
   getRelationGroupLabelRevision,
@@ -113,6 +113,7 @@ import {
   YSharedRoot,
 } from '@/application/types';
 import { MetadataKey } from '@/application/user-metadata';
+import { canonicalizeUserUid } from '@/application/user-uid';
 import { useMentionableUsersWithAutoFetch } from '@/components/database/components/cell/person/useMentionableUsers';
 import { useCurrentUser } from '@/components/main/app.hooks';
 import { getDateFormat, getTimeFormat, renderDate } from '@/utils/time';
@@ -1100,10 +1101,10 @@ export function useGroupsSelector() {
 
 export type GroupColumn = DatabaseGroupColumn;
 
-function getFallbackGroupColumns(field?: YDatabaseField): GroupColumn[] {
+function getFallbackGroupColumns(field?: YDatabaseField, content?: string): GroupColumn[] {
   if (!field) return [];
 
-  return (getGroupColumns(field) ?? []).map((column) => ({
+  return (getGroupColumns(field, content) ?? []).map((column) => ({
     id: column.id,
     visible: true,
     visibleExplicit: false,
@@ -1476,23 +1477,12 @@ const EMPTY_DATABASE_GROUPING: DatabaseGrouping = {
   metadataSyncKey: '',
 };
 
-function getNumberGroupStart(groupId: string) {
-  const match = /^number_range_(-?\d+(?:\.\d+)?)_/.exec(groupId);
-
-  return match ? Number(match[1]) : undefined;
-}
-
-function orderNumberGroupIds(groupIds: string[], defaultGroupId: string) {
+function orderNumberGroupIds(groupIds: string[], defaultGroupId: string, policy: NumberGroupingPolicy) {
   return [...groupIds].sort((left, right) => {
     if (left === defaultGroupId) return -1;
     if (right === defaultGroupId) return 1;
 
-    const leftStart = getNumberGroupStart(left);
-    const rightStart = getNumberGroupStart(right);
-
-    if (leftStart === undefined) return rightStart === undefined ? 0 : 1;
-    if (rightStart === undefined) return -1;
-    return leftStart - rightStart;
+    return policy.compareGroupIds(left, right);
   });
 }
 
@@ -1947,6 +1937,7 @@ export function useDatabaseGroupingSelector(layout: DatabaseViewLayout): Databas
 
     const groupingFieldId = field.get(YjsDatabaseKey.id);
     const content = group.get(YjsDatabaseKey.content);
+    const numberPolicy = fieldType === FieldType.Number ? createNumberGroupingPolicy(content) : undefined;
     const result = rowOrders ? groupByField(rowOrders, groupingRows, field, undefined, content) : undefined;
     const metadataResult = haveSameRowOrder(rowOrders, allRowOrders)
       ? result
@@ -1962,8 +1953,12 @@ export function useDatabaseGroupingSelector(layout: DatabaseViewLayout): Databas
     const ready = rowsHydrated;
     const initializesLocalGroup = ready && hasPendingLocalDatabaseGroupInitialization(group);
     const rawColumns = group.get(YjsDatabaseKey.groups)?.toArray() ?? [];
-    const persistedColumns = normalizeUniqueDatabaseGroupColumns(rawColumns);
-    const fallbackColumns = getFallbackGroupColumns(field);
+    // Configuration changes can invalidate old numeric IDs without proving
+    // anything about unloaded rows. Keep every still-valid persisted ID.
+    const persistedColumns = normalizeUniqueDatabaseGroupColumns(rawColumns).filter(
+      (column) => !numberPolicy || column.id === groupingFieldId || numberPolicy.isValidGroupId(column.id)
+    );
+    const fallbackColumns = getFallbackGroupColumns(field, content);
     const derivedMetadataGroupIds = metadataResult
       ? [...metadataResult.keys()]
       : fallbackColumns.map((column) => column.id);
@@ -1983,8 +1978,8 @@ export function useDatabaseGroupingSelector(layout: DatabaseViewLayout): Databas
       }
     });
     const orderedIds =
-      fieldType === FieldType.Number
-        ? orderNumberGroupIds(persistedAndDerivedIds, groupingFieldId)
+      numberPolicy
+        ? orderNumberGroupIds(persistedAndDerivedIds, groupingFieldId, numberPolicy)
         : persistedAndDerivedIds;
 
     // Seed-only docs may lag a Desktop edit indefinitely because background
@@ -2012,7 +2007,7 @@ export function useDatabaseGroupingSelector(layout: DatabaseViewLayout): Databas
       }
     });
     const orderedMetadataGroupIds =
-      fieldType === FieldType.Number ? orderNumberGroupIds(metadataGroupIds, groupingFieldId) : metadataGroupIds;
+      numberPolicy ? orderNumberGroupIds(metadataGroupIds, groupingFieldId, numberPolicy) : metadataGroupIds;
 
     const collapsedValue = group.get(YjsDatabaseKey.collapsed_group_ids) as unknown;
     const collapsedIds = new Set(
@@ -2039,7 +2034,7 @@ export function useDatabaseGroupingSelector(layout: DatabaseViewLayout): Databas
         ? (Number(primarySort.get(YjsDatabaseKey.condition)) as SortCondition)
         : undefined;
     const displayIds =
-      primarySortCondition === undefined
+      primarySortCondition === undefined || numberPolicy
         ? orderedIds
         : orderDatabaseGroupsForPrimarySort(orderedIds, result, rowOrders, primarySortCondition);
     const identifierLabels = new Map<string, string>();
@@ -2085,7 +2080,7 @@ export function useDatabaseGroupingSelector(layout: DatabaseViewLayout): Databas
       const automaticallyHidden =
         ready &&
         groupRows.length === 0 &&
-        (hideEmptyGroups || (id !== currentFieldId && isDynamicDatabaseGroupFieldType(fieldType)));
+        (hideEmptyGroups || (id !== currentFieldId && isDynamicDatabaseGroupFieldType(fieldType) && !numberPolicy?.retainsEmptyGroups));
 
       return {
         id,

--- a/src/components/database/components/cell/number/__tests__/NumberCellEditing.test.tsx
+++ b/src/components/database/components/cell/number/__tests__/NumberCellEditing.test.tsx
@@ -1,0 +1,63 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { useState } from 'react';
+
+import { useUpdateCellDispatch } from '@/application/database-yjs/dispatch';
+import NumberCellEditing from '@/components/database/components/cell/number/NumberCellEditing';
+
+jest.mock('@/application/database-yjs/dispatch', () => ({ useUpdateCellDispatch: jest.fn() }));
+jest.mock('@/utils/runtime-config', () => ({ getConfigValue: (_key: string, fallback: string) => fallback }));
+
+describe('NumberCellEditing', () => {
+  const updateCell = jest.fn();
+
+  beforeEach(() => {
+    updateCell.mockReset();
+    (useUpdateCellDispatch as jest.Mock).mockReturnValue(updateCell);
+  });
+
+  it('keeps partial input and the caret local until blur despite a remote refresh', () => {
+    const onExit = jest.fn();
+    const { rerender } = render(<NumberCellEditing defaultValue='1' fieldId='number' onExit={onExit} rowId='row' />);
+    const input = screen.getByRole('textbox');
+
+    fireEvent.change(input, { target: { value: '2.' } });
+    expect(updateCell).not.toHaveBeenCalled();
+    fireEvent.change(input, { target: { value: '2.5' } });
+    input.setSelectionRange(1, 1);
+    rerender(<NumberCellEditing defaultValue='9' fieldId='number' onExit={onExit} rowId='row' />);
+    expect(input.value).toBe('2.5');
+    expect(input.selectionStart).toBe(1);
+    expect(updateCell).not.toHaveBeenCalled();
+
+    fireEvent.blur(input);
+    expect(updateCell).toHaveBeenCalledTimes(1);
+    expect(updateCell).toHaveBeenCalledWith('2.5');
+    expect(onExit).toHaveBeenCalledTimes(1);
+  });
+
+  it('commits once when Enter closes the number editor', () => {
+    function EditingCell() {
+      const [editing, setEditing] = useState(true);
+
+      return editing ? (
+        <NumberCellEditing defaultValue='1' fieldId='number' onExit={() => setEditing(false)} rowId='row' />
+      ) : (
+        <span>Committed</span>
+      );
+    }
+
+    render(<EditingCell />);
+    fireEvent.change(screen.getByRole('textbox'), { target: { value: '2.0' } });
+    fireEvent.keyDown(screen.getByRole('textbox'), { key: 'Enter', keyCode: 13, which: 13 });
+    expect(updateCell).toHaveBeenCalledTimes(1);
+    expect(updateCell).toHaveBeenCalledWith('2');
+    expect(screen.queryByRole('textbox')).toBeNull();
+  });
+
+  it.each(['0', ''])('commits %p without conflating zero and missing', (value) => {
+    render(<NumberCellEditing defaultValue='1' fieldId='number' rowId='row' />);
+    fireEvent.change(screen.getByRole('textbox'), { target: { value } });
+    fireEvent.blur(screen.getByRole('textbox'));
+    expect(updateCell).toHaveBeenCalledWith(value);
+  });
+});

--- a/src/components/database/components/grid/controls/HoverControls.hooks.ts
+++ b/src/components/database/components/grid/controls/HoverControls.hooks.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 
-import { useDatabaseFields } from '@/application/database-yjs';
+import { useDatabaseFields, useDatabaseView } from '@/application/database-yjs';
 import { useDuplicateRowDispatch, useNewRowDispatch } from '@/application/database-yjs/dispatch';
 import { getGridGroupCellsData } from '@/components/database/components/grid/grid-row/GridNewRow';
 import { useGridContext, useIsGridRowHovered } from '@/components/database/grid/useGridContext';
@@ -53,9 +53,10 @@ export function useHoverControlsActions(rowId: string, groupFieldId?: string, gr
   const onNewRow = useNewRowDispatch();
   const duplicateRow = useDuplicateRowDispatch();
   const fields = useDatabaseFields();
+  const view = useDatabaseView();
   const getCellsData = useCallback(
-    () => getGridGroupCellsData(fields, groupFieldId, groupId),
-    [fields, groupFieldId, groupId]
+    () => getGridGroupCellsData(fields, groupFieldId, groupId, view),
+    [fields, groupFieldId, groupId, view]
   );
 
   const onAddRowBelow = useCallback(async () => {

--- a/src/components/database/components/grid/grid-row/GridNewRow.tsx
+++ b/src/components/database/components/grid/grid-row/GridNewRow.tsx
@@ -1,40 +1,23 @@
 import { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import { useDatabaseContext, useDatabaseFields } from '@/application/database-yjs';
+import { useDatabaseContext, useDatabaseFields, useDatabaseView } from '@/application/database-yjs';
 import { useNewRowDispatch } from '@/application/database-yjs/dispatch';
-import { getGroupCellData } from '@/application/database-yjs/group';
-import { YjsDatabaseKey } from '@/application/types';
-import type { FieldId, YDatabaseFields } from '@/application/types';
+import { getGroupRowCellsData } from '@/application/database-yjs/group-row';
 import { ReactComponent as PlusIcon } from '@/assets/icons/plus.svg';
 import { useGridContext } from '@/components/database/grid/useGridContext';
 
-export function getGridGroupCellsData(
-  fields?: YDatabaseFields,
-  groupFieldId?: string,
-  groupId?: string
-): Record<FieldId, string> | undefined {
-  const groupField = groupFieldId ? fields?.get(groupFieldId) : undefined;
-
-  if (groupFieldId && groupField && groupId === groupField.get(YjsDatabaseKey.id)) {
-    // Explicitly overwrite same-field filter prefills when a row is inserted
-    // into Desktop's default/ungrouped column.
-    return { [groupFieldId]: '' };
-  }
-
-  const groupCellData = groupField && groupId ? getGroupCellData(groupId, groupField) : undefined;
-
-  return groupFieldId && groupCellData !== undefined ? { [groupFieldId]: groupCellData } : undefined;
-}
+export const getGridGroupCellsData = getGroupRowCellsData;
 
 export function useCreateGridGroupRow(groupFieldId?: string, groupId?: string) {
   const onNewRow = useNewRowDispatch();
   const { isDocumentBlock } = useDatabaseContext();
   const { lastVisibleRowId, revealCreatedRow } = useGridContext();
   const fields = useDatabaseFields();
+  const view = useDatabaseView();
 
   return useCallback(async () => {
-    const cellsData = getGridGroupCellsData(fields, groupFieldId, groupId);
+    const cellsData = getGridGroupCellsData(fields, groupFieldId, groupId, view);
 
     await onNewRow(
       isDocumentBlock
@@ -46,7 +29,7 @@ export function useCreateGridGroupRow(groupFieldId?: string, groupId?: string) {
         : { cellsData, tailing: true }
     );
     revealCreatedRow();
-  }, [fields, groupFieldId, groupId, isDocumentBlock, lastVisibleRowId, onNewRow, revealCreatedRow]);
+  }, [fields, groupFieldId, groupId, isDocumentBlock, lastVisibleRowId, onNewRow, revealCreatedRow, view]);
 }
 
 function GridNewRow({ groupFieldId, groupId }: { groupFieldId?: string; groupId?: string }) {

--- a/src/components/database/components/settings/GridSettingGroup.tsx
+++ b/src/components/database/components/settings/GridSettingGroup.tsx
@@ -10,16 +10,23 @@ import {
   useSetGridGroupVisibilityDispatch,
   useToggleGridHideEmptyGroups,
   useUpdateDateGroupConditionDispatch,
+  useUpdateNumberGroupConfigurationDispatch,
 } from '@/application/database-yjs/dispatch';
 import {
   DATABASE_GROUPABLE_FIELD_TYPES,
   isDynamicDatabaseGroupFieldType,
   parseDateGroupConfiguration,
 } from '@/application/database-yjs/group';
+import {
+  NumberGroupMode,
+  type NumberGroupConfiguration,
+  parseNumberGroupConfiguration,
+} from '@/application/database-yjs/number-grouping';
 import { ReactComponent as GroupIcon } from '@/assets/icons/group.svg';
 import { Tag } from '@/components/_shared/tag';
 import { SelectOptionColorMap, SelectOptionFgColorMap } from '@/components/database/components/cell/cell.const';
 import { FieldDisplay } from '@/components/database/components/field';
+import { NumberGroupSettings } from '@/components/database/components/settings/NumberGroupSettings';
 import { useGridGrouping } from '@/components/database/grid/GridGroupingContext';
 import {
   DropdownMenuItem,
@@ -43,8 +50,10 @@ const DATE_CONDITIONS = [
 
 export const GRID_GROUP_VISIBILITY_LIMIT = 40;
 
-export function getGridGroupVisibilityGroups(groups: GridGroup[], fieldType?: FieldType): GridGroup[] {
+export function getGridGroupVisibilityGroups(groups: GridGroup[], fieldType?: FieldType, content?: string): GridGroup[] {
   if (fieldType === undefined || !isDynamicDatabaseGroupFieldType(fieldType)) return groups;
+  if (fieldType === FieldType.Number && parseNumberGroupConfiguration(content).mode === NumberGroupMode.Range)
+    return groups;
 
   return groups.filter((group) => group.isDefault || group.rows.length > 0);
 }
@@ -229,6 +238,7 @@ interface DatabaseSettingGroupProps {
   setVisibility: (groupId: string, visible: boolean) => void;
   setAllVisibility: (groupIds: string[], visible: boolean) => void;
   updateDateCondition: (condition: DateGroupCondition) => void;
+  updateNumberConfiguration: (configuration: NumberGroupConfiguration) => void;
   testIdPrefix: 'grid' | 'list';
 }
 
@@ -240,6 +250,7 @@ export function DatabaseSettingGroup({
   setVisibility,
   setAllVisibility,
   updateDateCondition,
+  updateNumberConfiguration,
   testIdPrefix,
 }: DatabaseSettingGroupProps) {
   const { t } = useTranslation();
@@ -249,8 +260,8 @@ export function DatabaseSettingGroup({
     [allProperties]
   );
   const visibilityGroups = useMemo(
-    () => getGridGroupVisibilityGroups(grouping.groups, grouping.fieldType),
-    [grouping.fieldType, grouping.groups]
+    () => getGridGroupVisibilityGroups(grouping.groups, grouping.fieldType, grouping.content),
+    [grouping.fieldType, grouping.groups, grouping.content]
   );
   const currentDateCondition = parseDateGroupConfiguration(grouping.content).condition;
 
@@ -305,6 +316,15 @@ export function DatabaseSettingGroup({
                   ))}
                 </>
               )}
+
+              {grouping.fieldType === FieldType.Number ? (
+                <NumberGroupSettings
+                  configuration={parseNumberGroupConfiguration(grouping.content)}
+                  key={grouping.fieldId}
+                  onChange={updateNumberConfiguration}
+                  testIdPrefix={testIdPrefix}
+                />
+              ) : null}
 
               {visibilityGroups.length > 0 && (
                 <>
@@ -374,6 +394,7 @@ function GridSettingGroup() {
   const setVisibility = useSetGridGroupVisibilityDispatch(grouping.groupId, grouping.fieldId);
   const setAllVisibility = useSetAllGridGroupsVisibilityDispatch(grouping.groupId, grouping.fieldId);
   const updateDateCondition = useUpdateDateGroupConditionDispatch();
+  const updateNumberConfiguration = useUpdateNumberGroupConfigurationDispatch();
 
   return (
     <DatabaseSettingGroup
@@ -385,6 +406,7 @@ function GridSettingGroup() {
       testIdPrefix='grid'
       toggleHideEmpty={toggleHideEmpty}
       updateDateCondition={updateDateCondition}
+      updateNumberConfiguration={updateNumberConfiguration}
     />
   );
 }

--- a/src/components/database/components/settings/ListSettingGroup.tsx
+++ b/src/components/database/components/settings/ListSettingGroup.tsx
@@ -6,6 +6,7 @@ import {
   useToggleListHideEmptyGroups,
   useUpdateDateGroupConditionDispatch,
 } from '@/application/database-yjs';
+import { useUpdateNumberGroupConfigurationDispatch } from '@/application/database-yjs/dispatch';
 import { DatabaseSettingGroup } from '@/components/database/components/settings/GridSettingGroup';
 import { useListGrouping } from '@/components/database/list/ListGroupingContext';
 
@@ -17,6 +18,7 @@ function ListSettingGroup() {
   const setVisibility = useSetListGroupVisibilityDispatch(grouping.groupId, grouping.fieldId);
   const setAllVisibility = useSetAllListGroupsVisibilityDispatch(grouping.groupId, grouping.fieldId);
   const updateDateCondition = useUpdateDateGroupConditionDispatch();
+  const updateNumberConfiguration = useUpdateNumberGroupConfigurationDispatch();
 
   return (
     <DatabaseSettingGroup
@@ -28,6 +30,7 @@ function ListSettingGroup() {
       testIdPrefix='list'
       toggleHideEmpty={toggleHideEmpty}
       updateDateCondition={updateDateCondition}
+      updateNumberConfiguration={updateNumberConfiguration}
     />
   );
 }

--- a/src/components/database/components/settings/NumberGroupSettings.tsx
+++ b/src/components/database/components/settings/NumberGroupSettings.tsx
@@ -1,0 +1,215 @@
+import { type KeyboardEvent, useId, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import {
+  NumberGroupMode,
+  type NumberGroupConfiguration,
+  type NumberGroupValidationError,
+  validateNumberGroupConfiguration,
+} from '@/application/database-yjs/number-grouping';
+import { Button } from '@/components/ui/button';
+import { DropdownMenuItem, DropdownMenuItemTick, DropdownMenuLabel } from '@/components/ui/dropdown-menu';
+import { Input } from '@/components/ui/input';
+
+type RangeDraft = Pick<NumberGroupConfiguration, 'range_start' | 'range_end' | 'range_interval'>;
+
+const RANGE_FIELDS = [
+  { key: 'range_start', name: 'start', label: 'Start' },
+  { key: 'range_end', name: 'end', label: 'End' },
+  { key: 'range_interval', name: 'interval', label: 'Interval' },
+] as const;
+
+const ERROR_MESSAGES: Record<NumberGroupValidationError, string> = {
+  invalidNumber: 'Enter valid decimal numbers.',
+  invalidBounds: 'End must be greater than Start.',
+  invalidInterval: 'Interval must be greater than zero.',
+  tooManyRanges: 'Use a larger interval to create at most 1,000 ranges.',
+  precisionExceeded: 'These values exceed the supported decimal precision.',
+};
+
+function rangeDraft(configuration: NumberGroupConfiguration): RangeDraft {
+  return {
+    range_start: configuration.range_start,
+    range_end: configuration.range_end,
+    range_interval: configuration.range_interval,
+  };
+}
+
+function sameRange(left: RangeDraft, right: RangeDraft) {
+  return RANGE_FIELDS.every(({ key }) => left[key] === right[key]);
+}
+
+export function NumberGroupSettings({
+  configuration,
+  onChange,
+  testIdPrefix = 'grid',
+}: {
+  configuration: NumberGroupConfiguration;
+  onChange: (configuration: NumberGroupConfiguration) => void;
+  testIdPrefix?: string;
+}) {
+  const { t } = useTranslation();
+  const id = useId();
+  const [appliedRange, setAppliedRange] = useState(() => rangeDraft(configuration));
+  const [draft, setDraft] = useState(() => rangeDraft(configuration));
+  const [error, setError] = useState<NumberGroupValidationError | null>(null);
+  const hasEdits = !sameRange(draft, appliedRange);
+
+  // Yjs group metadata refreshes often while rows move. Only adopt a changed
+  // saved range, and retain an unfinished draft and its input selection.
+  if (!sameRange(configuration, appliedRange)) {
+    const incoming = rangeDraft(configuration);
+
+    setAppliedRange(incoming);
+    if (!hasEdits) setDraft(incoming);
+  }
+
+  const selectMode = (mode: NumberGroupMode) => {
+    if (configuration.mode === mode) return;
+
+    setDraft(rangeDraft(configuration));
+    setError(null);
+    onChange({ ...configuration, mode });
+  };
+
+  const applyRange = () => {
+    const result = validateNumberGroupConfiguration({ ...configuration, ...draft });
+
+    if (!result.valid) {
+      setError(result.error);
+      return;
+    }
+
+    setDraft(rangeDraft(result.configuration));
+    setError(null);
+    onChange(result.configuration);
+  };
+
+  const updateDraft = (key: keyof RangeDraft, value: string) => {
+    setDraft((previous) => ({ ...previous, [key]: value }));
+    setError(null);
+  };
+
+  const handleInputKeyDown = (event: KeyboardEvent<HTMLInputElement>, key: keyof RangeDraft) => {
+    if (event.key === 'Enter') {
+      event.preventDefault();
+      event.stopPropagation();
+      applyRange();
+      return;
+    }
+
+    if (['Escape', 'Tab', 'ArrowUp', 'ArrowDown'].includes(event.key)) return;
+
+    // Keep editing and caret keys out of Radix's menu typeahead/submenu logic.
+    event.stopPropagation();
+    if (event.key !== ' ') return;
+
+    event.preventDefault();
+    const input = event.currentTarget;
+    const start = input.selectionStart ?? input.value.length;
+    const end = input.selectionEnd ?? start;
+
+    updateDraft(key, `${input.value.slice(0, start)} ${input.value.slice(end)}`);
+    window.setTimeout(() => input.setSelectionRange(start + 1, start + 1));
+  };
+
+  return (
+    <>
+      <DropdownMenuLabel>{t('board.numberGrouping.title', 'Group numbers by')}</DropdownMenuLabel>
+      {configuration.mode === NumberGroupMode.Legacy ? (
+        <p className='px-3 py-1 text-xs text-text-secondary' data-testid={`${testIdPrefix}-number-group-legacy`}>
+          {t('board.numberGrouping.legacy', 'Automatic ranges of 100')}
+        </p>
+      ) : null}
+      {[
+        { mode: NumberGroupMode.Exact, name: 'exact', label: 'Exact value' },
+        { mode: NumberGroupMode.Range, name: 'range', label: 'Range' },
+      ].map(({ mode, name, label }) => (
+        <DropdownMenuItem
+          aria-checked={configuration.mode === mode}
+          data-testid={`${testIdPrefix}-number-group-mode-${name}`}
+          key={name}
+          onSelect={(event) => {
+            event.preventDefault();
+            selectMode(mode);
+          }}
+          role='menuitemradio'
+        >
+          {t(`board.numberGrouping.${name}`, label)}
+          {configuration.mode === mode ? <DropdownMenuItemTick /> : null}
+        </DropdownMenuItem>
+      ))}
+      {configuration.mode === NumberGroupMode.Range ? (
+        <div className='space-y-2 px-3 py-2'>
+          {RANGE_FIELDS.map(({ key, name, label }) => (
+            <label className='flex items-center gap-3 text-sm text-text-primary' htmlFor={`${id}-${name}`} key={key}>
+              <span className='min-w-[52px]'>{t(`board.numberGrouping.${name}`, label)}</span>
+              <DropdownMenuItem asChild onSelect={(event) => event.preventDefault()}>
+                <Input
+                  aria-describedby={error ? `${id}-error` : undefined}
+                  aria-invalid={error !== null}
+                  className='w-full cursor-text'
+                  data-testid={`${testIdPrefix}-number-group-${name}`}
+                  id={`${id}-${name}`}
+                  inputMode='decimal'
+                  onChange={(event) => updateDraft(key, event.target.value)}
+                  onKeyDown={(event) => handleInputKeyDown(event, key)}
+                  role='textbox'
+                  type='text'
+                  value={draft[key]}
+                />
+              </DropdownMenuItem>
+            </label>
+          ))}
+          {error ? (
+            <p
+              className='text-xs text-text-error'
+              data-testid={`${testIdPrefix}-number-group-validation`}
+              id={`${id}-error`}
+              role='alert'
+            >
+              {t(`board.numberGrouping.${error}`, ERROR_MESSAGES[error])}
+            </p>
+          ) : null}
+          <DropdownMenuItem
+            asChild
+            disabled={!hasEdits}
+            onSelect={(event) => {
+              event.preventDefault();
+              applyRange();
+            }}
+          >
+            <Button
+              className='w-full'
+              data-testid={`${testIdPrefix}-number-group-apply`}
+              disabled={!hasEdits}
+              role='button'
+              size='sm'
+              type='button'
+            >
+              {t('button.apply', 'Apply')}
+            </Button>
+          </DropdownMenuItem>
+        </div>
+      ) : null}
+      <DropdownMenuLabel>{t('board.numberGrouping.sort', 'Sort groups')}</DropdownMenuLabel>
+      {[false, true].map((descending) => (
+        <DropdownMenuItem
+          aria-checked={configuration.sort_descending === descending}
+          data-testid={`${testIdPrefix}-number-group-sort-${descending ? 'descending' : 'ascending'}`}
+          key={String(descending)}
+          onSelect={(event) => {
+            event.preventDefault();
+            if (configuration.sort_descending !== descending) {
+              onChange({ ...configuration, sort_descending: descending });
+            }
+          }}
+          role='menuitemradio'
+        >
+          {descending ? t('grid.sort.descending', 'Descending') : t('grid.sort.ascending', 'Ascending')}
+          {configuration.sort_descending === descending ? <DropdownMenuItemTick /> : null}
+        </DropdownMenuItem>
+      ))}
+    </>
+  );
+}

--- a/src/components/database/components/settings/__tests__/GridSettingGroup.test.tsx
+++ b/src/components/database/components/settings/__tests__/GridSettingGroup.test.tsx
@@ -5,6 +5,7 @@ import { DatabaseContext, FieldType, SelectOptionColor } from '@/application/dat
 import type { DatabaseContextState, GridGroup } from '@/application/database-yjs';
 import { createCell, createRowDoc } from '@/application/database-yjs/__tests__/test-helpers';
 import { createYDatabaseGroupColumn } from '@/application/database-yjs/group-column';
+import { defaultNumberGroupConfiguration, NumberGroupMode } from '@/application/database-yjs/number-grouping';
 import { YjsDatabaseKey, YjsEditorKey } from '@/application/types';
 import type {
   YDatabase,
@@ -215,6 +216,31 @@ describe('GridGroupVisibilityList', () => {
       'current-value',
     ]);
     expect(getGridGroupVisibilityGroups(groups, FieldType.SingleSelect)).toBe(groups);
+  });
+
+  it('exposes empty configured ranges but omits empty derived numeric groups', () => {
+    const groups = [
+      { ...createGroup(0), id: 'number', isDefault: true },
+      { ...createGroup(1), id: 'occupied', rows: [{ height: 36, id: 'row-a' }] },
+      { ...createGroup(2), id: 'empty' },
+    ];
+
+    expect(
+      getGridGroupVisibilityGroups(
+        groups,
+        FieldType.Number,
+        JSON.stringify(defaultNumberGroupConfiguration(NumberGroupMode.Range))
+      )
+    ).toBe(groups);
+    for (const mode of [NumberGroupMode.Legacy, NumberGroupMode.Exact]) {
+      expect(
+        getGridGroupVisibilityGroups(
+          groups,
+          FieldType.Number,
+          JSON.stringify(defaultNumberGroupConfiguration(mode))
+        ).map((group) => group.id)
+      ).toEqual(['number', 'occupied']);
+    }
   });
 
   it('renders select-option groups with the same semantic tag colors while retaining checkbox semantics', async () => {

--- a/src/components/database/components/settings/__tests__/ListSettingGroup.test.tsx
+++ b/src/components/database/components/settings/__tests__/ListSettingGroup.test.tsx
@@ -35,6 +35,11 @@ jest.mock('@/application/database-yjs', () => ({
   useUpdateDateGroupConditionDispatch: () => jest.fn(),
 }));
 
+jest.mock('@/application/database-yjs/dispatch', () => ({
+  ...jest.requireActual('@/application/database-yjs/dispatch'),
+  useUpdateNumberGroupConfigurationDispatch: () => jest.fn(),
+}));
+
 jest.mock('@/components/database/list/ListGroupingContext', () => ({
   useListGrouping: () => mockGrouping,
 }));

--- a/src/components/database/components/settings/__tests__/NumberGroupSettings.test.tsx
+++ b/src/components/database/components/settings/__tests__/NumberGroupSettings.test.tsx
@@ -1,0 +1,156 @@
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { useState } from 'react';
+
+import {
+  defaultNumberGroupConfiguration,
+  NumberGroupMode,
+  type NumberGroupConfiguration,
+} from '@/application/database-yjs/number-grouping';
+import { NumberGroupSettings } from '@/components/database/components/settings/NumberGroupSettings';
+import { DropdownMenu, DropdownMenuContent, DropdownMenuTrigger } from '@/components/ui/dropdown-menu';
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string, fallback?: string) => fallback ?? key }),
+}));
+
+function SettingsMenu({
+  configuration,
+  onChange,
+}: {
+  configuration: NumberGroupConfiguration;
+  onChange: (configuration: NumberGroupConfiguration) => void;
+}) {
+  return (
+    <DropdownMenu open>
+      <DropdownMenuTrigger>Grouping</DropdownMenuTrigger>
+      <DropdownMenuContent>
+        <NumberGroupSettings configuration={configuration} onChange={onChange} />
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
+function LiveSettingsMenu({
+  initial = defaultNumberGroupConfiguration(NumberGroupMode.Range),
+  onChange,
+}: {
+  initial?: NumberGroupConfiguration;
+  onChange: (configuration: NumberGroupConfiguration) => void;
+}) {
+  const [configuration, setConfiguration] = useState(initial);
+
+  return (
+    <SettingsMenu
+      configuration={configuration}
+      onChange={(next) => {
+        setConfiguration(next);
+        onChange(next);
+      }}
+    />
+  );
+}
+
+function input(name: 'Start' | 'End' | 'Interval') {
+  return screen.getByRole('textbox', { name });
+}
+
+function changeRange(start: string, end: string, interval: string) {
+  fireEvent.change(input('Start'), { target: { value: start } });
+  fireEvent.change(input('End'), { target: { value: end } });
+  fireEvent.change(input('Interval'), { target: { value: interval } });
+}
+
+describe('NumberGroupSettings', () => {
+  it('preserves legacy grouping until an explicit mode selection', () => {
+    const onChange = jest.fn();
+
+    render(<LiveSettingsMenu initial={defaultNumberGroupConfiguration()} onChange={onChange} />);
+    expect(screen.getByText('Automatic ranges of 100')).toBeTruthy();
+    expect(screen.getByRole('menuitemradio', { name: 'Exact value' }).getAttribute('aria-checked')).toBe('false');
+    expect(screen.getByRole('menuitemradio', { name: 'Range' }).getAttribute('aria-checked')).toBe('false');
+    expect(screen.queryByRole('textbox')).toBeNull();
+    expect(onChange).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole('menuitemradio', { name: 'Range' }));
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenLastCalledWith(defaultNumberGroupConfiguration(NumberGroupMode.Range));
+    expect(input('Start').value).toBe('0');
+    expect(input('End').value).toBe('100');
+    expect(input('Interval').value).toBe('10');
+  });
+
+  it('validates and applies signed decimal ranges atomically', () => {
+    const onChange = jest.fn();
+
+    render(<LiveSettingsMenu onChange={onChange} />);
+    changeRange('-0.50', '0.50', '0');
+    expect(onChange).not.toHaveBeenCalled();
+    fireEvent.click(screen.getByRole('button', { name: 'Apply' }));
+    expect(screen.getByRole('alert').textContent).toBe('Interval must be greater than zero.');
+    expect(onChange).not.toHaveBeenCalled();
+
+    fireEvent.change(input('Interval'), { target: { value: '0.25' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Apply' }));
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        range_start: '-0.5',
+        range_end: '0.5',
+        range_interval: '0.25',
+      })
+    );
+    expect(input('Start').value).toBe('-0.5');
+    expect(screen.queryByRole('alert')).toBeNull();
+    expect(screen.getByRole('button', { name: 'Apply' }).disabled).toBe(true);
+  });
+
+  it('retains the last valid range and sorting across mode switches', () => {
+    const onChange = jest.fn();
+
+    render(<LiveSettingsMenu onChange={onChange} />);
+    changeRange('-1', '1', '0.25');
+    fireEvent.click(screen.getByRole('button', { name: 'Apply' }));
+    fireEvent.change(input('Start'), { target: { value: '-' } });
+    fireEvent.click(screen.getByRole('menuitemradio', { name: 'Descending' }));
+    expect(input('Start').value).toBe('-');
+    expect(onChange).toHaveBeenLastCalledWith(expect.objectContaining({ range_start: '-1', sort_descending: true }));
+
+    fireEvent.click(screen.getByRole('menuitemradio', { name: 'Exact value' }));
+    expect(screen.queryByRole('textbox')).toBeNull();
+    fireEvent.click(screen.getByRole('menuitemradio', { name: 'Range' }));
+    expect(input('Start').value).toBe('-1');
+    expect(input('Interval').value).toBe('0.25');
+    expect(screen.getByRole('menuitemradio', { name: 'Descending' }).getAttribute('aria-checked')).toBe('true');
+  });
+
+  it('preserves unfinished input and caret when saved metadata refreshes', () => {
+    const onChange = jest.fn();
+    const configuration = defaultNumberGroupConfiguration(NumberGroupMode.Range);
+    const { rerender } = render(<SettingsMenu configuration={configuration} onChange={onChange} />);
+
+    fireEvent.change(input('Start'), { target: { value: '-0.' } });
+    act(() => input('Start').focus());
+    input('Start').setSelectionRange(2, 2);
+    rerender(<SettingsMenu configuration={{ ...configuration, sort_descending: true }} onChange={onChange} />);
+    expect(input('Start').value).toBe('-0.');
+    expect(input('Start').selectionStart).toBe(2);
+
+    rerender(<SettingsMenu configuration={{ ...configuration, range_start: '-10' }} onChange={onChange} />);
+    expect(input('Start').value).toBe('-0.');
+    expect(input('Start').selectionStart).toBe(2);
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('handles Enter inside a range field without Radix selecting a different option', () => {
+    const onChange = jest.fn();
+
+    render(<LiveSettingsMenu onChange={onChange} />);
+    changeRange('-1', '1', '0.5');
+    act(() => input('Interval').focus());
+    fireEvent.keyDown(input('Interval'), { key: 'Enter' });
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenLastCalledWith(expect.objectContaining({ range_interval: '0.5' }));
+    expect(screen.getByRole('menuitemradio', { name: 'Range' }).getAttribute('aria-checked')).toBe('true');
+    expect(input('Interval').value).toBe('0.5');
+  });
+});

--- a/src/components/database/list/ListGroup.tsx
+++ b/src/components/database/list/ListGroup.tsx
@@ -1,7 +1,7 @@
 import { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import { FieldType, useDatabaseFields, useReadOnly } from '@/application/database-yjs';
+import { FieldType, useDatabaseFields, useDatabaseView, useReadOnly } from '@/application/database-yjs';
 import type { GridGroup } from '@/application/database-yjs';
 import {
   useClearGroupByFieldDispatch,
@@ -23,15 +23,16 @@ import { getListGroupCellsData } from './ListRowActions';
 
 function useCreateListGroupRow(groupFieldId?: string, groupId?: string, openAfterCreate = false) {
   const fields = useDatabaseFields();
+  const view = useDatabaseView();
   const createRow = useNewRowDispatch();
 
   return useCallback(async () => {
     await createRow({
-      cellsData: getListGroupCellsData(fields, groupFieldId, groupId),
+      cellsData: getListGroupCellsData(fields, groupFieldId, groupId, view),
       openAfterCreate,
       tailing: true,
     });
-  }, [createRow, fields, groupFieldId, groupId, openAfterCreate]);
+  }, [createRow, fields, groupFieldId, groupId, openAfterCreate, view]);
 }
 
 export function ListGroupHeader({

--- a/src/components/database/list/ListRowActions.tsx
+++ b/src/components/database/list/ListRowActions.tsx
@@ -1,12 +1,10 @@
 import { useCallback, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import { useDatabaseFields } from '@/application/database-yjs';
+import { useDatabaseFields, useDatabaseView } from '@/application/database-yjs';
 import type { Row } from '@/application/database-yjs';
 import { useDuplicateRowDispatch, useNewRowDispatch } from '@/application/database-yjs/dispatch';
-import { getGroupCellData } from '@/application/database-yjs/group';
-import { YjsDatabaseKey } from '@/application/types';
-import type { FieldId, YDatabaseFields } from '@/application/types';
+import { getGroupRowCellsData } from '@/application/database-yjs/group-row';
 import { ReactComponent as UpIcon } from '@/assets/icons/arrow_up.svg';
 import { ReactComponent as DeleteIcon } from '@/assets/icons/delete.svg';
 import { ReactComponent as DragIcon } from '@/assets/icons/drag.svg';
@@ -26,21 +24,7 @@ import { Progress } from '@/components/ui/progress';
 
 import { useListHasSorts } from './ListSortState';
 
-export function getListGroupCellsData(
-  fields?: YDatabaseFields,
-  groupFieldId?: string,
-  groupId?: string
-): Record<FieldId, string> | undefined {
-  const groupField = groupFieldId ? fields?.get(groupFieldId) : undefined;
-
-  if (groupFieldId && groupField && groupId === groupField.get(YjsDatabaseKey.id)) {
-    return { [groupFieldId]: '' };
-  }
-
-  const groupCellData = groupField && groupId ? getGroupCellData(groupId, groupField) : undefined;
-
-  return groupFieldId && groupCellData !== undefined ? { [groupFieldId]: groupCellData } : undefined;
-}
+export const getListGroupCellsData = getGroupRowCellsData;
 
 function useListRowActions({
   groupFieldId,
@@ -54,19 +38,19 @@ function useListRowActions({
   rowOrders: Row[];
 }) {
   const fields = useDatabaseFields();
+  const view = useDatabaseView();
   const createRow = useNewRowDispatch();
   const duplicateRow = useDuplicateRowDispatch();
   const [loadingAction, setLoadingAction] = useState<'above' | 'below' | 'duplicate' | null>(null);
-  const cellsData = useMemo(() => getListGroupCellsData(fields, groupFieldId, groupId), [fields, groupFieldId, groupId]);
 
   const addBelow = useCallback(async () => {
     setLoadingAction('below');
     try {
-      await createRow({ beforeRowId: rowId, cellsData });
+      await createRow({ beforeRowId: rowId, cellsData: getListGroupCellsData(fields, groupFieldId, groupId, view) });
     } finally {
       setLoadingAction(null);
     }
-  }, [cellsData, createRow, rowId]);
+  }, [createRow, fields, groupFieldId, groupId, rowId, view]);
 
   const addAbove = useCallback(async () => {
     const rowIndex = rowOrders.findIndex((row) => row.id === rowId);
@@ -74,11 +58,14 @@ function useListRowActions({
 
     setLoadingAction('above');
     try {
-      await createRow({ beforeRowId: previousRowId, cellsData });
+      await createRow({
+        beforeRowId: previousRowId,
+        cellsData: getListGroupCellsData(fields, groupFieldId, groupId, view),
+      });
     } finally {
       setLoadingAction(null);
     }
-  }, [cellsData, createRow, rowId, rowOrders]);
+  }, [createRow, fields, groupFieldId, groupId, rowId, rowOrders, view]);
 
   const duplicate = useCallback(async () => {
     setLoadingAction('duplicate');

--- a/src/components/database/list/__tests__/ListGroup.test.tsx
+++ b/src/components/database/list/__tests__/ListGroup.test.tsx
@@ -14,6 +14,7 @@ import { getListGroupCellsData } from '../ListRowActions';
 jest.mock('@/application/database-yjs', () => ({
   FieldType: { Checkbox: 5, RichText: 0 },
   useDatabaseFields: jest.fn(),
+  useDatabaseView: jest.fn(),
   useReadOnly: jest.fn(),
 }));
 

--- a/src/components/database/list/__tests__/ListRowActions.test.tsx
+++ b/src/components/database/list/__tests__/ListRowActions.test.tsx
@@ -1,10 +1,16 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import * as Y from 'yjs';
 
-import { FieldType, useDatabaseFields } from '@/application/database-yjs';
+import { FieldType, useDatabaseFields, useDatabaseView } from '@/application/database-yjs';
 import { useDuplicateRowDispatch, useNewRowDispatch } from '@/application/database-yjs/dispatch';
 import { YjsDatabaseKey } from '@/application/types';
-import type { YDatabaseField, YDatabaseFields } from '@/application/types';
+import type {
+  YDatabaseField,
+  YDatabaseFields,
+  YDatabaseGroup,
+  YDatabaseGroups,
+  YDatabaseView,
+} from '@/application/types';
 
 import { getListGroupCellsData, ListRowActions } from '../ListRowActions';
 import { ListSortState } from '../ListSortState';
@@ -12,6 +18,7 @@ import { ListSortState } from '../ListSortState';
 jest.mock('@/application/database-yjs', () => ({
   FieldType: { Number: 1, SingleSelect: 3 },
   useDatabaseFields: jest.fn(),
+  useDatabaseView: jest.fn(),
 }));
 
 jest.mock('@/application/database-yjs/dispatch', () => ({
@@ -47,6 +54,7 @@ jest.mock('@/components/database/components/sorts/ClearSortingConfirm', () => ({
 }));
 
 const mockUseDatabaseFields = useDatabaseFields as jest.MockedFunction<typeof useDatabaseFields>;
+const mockUseDatabaseView = useDatabaseView as jest.MockedFunction<typeof useDatabaseView>;
 const mockUseDuplicateRowDispatch = useDuplicateRowDispatch as jest.MockedFunction<typeof useDuplicateRowDispatch>;
 const mockUseNewRowDispatch = useNewRowDispatch as jest.MockedFunction<typeof useNewRowDispatch>;
 
@@ -85,6 +93,7 @@ describe('ListRowActions', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockUseDatabaseFields.mockReturnValue(undefined);
+    mockUseDatabaseView.mockReturnValue(undefined);
     mockUseDuplicateRowDispatch.mockReturnValue(duplicateRow);
     mockUseNewRowDispatch.mockReturnValue(createRow);
   });
@@ -135,6 +144,40 @@ describe('ListRowActions', () => {
     await openMenu();
     fireEvent.click(screen.getByTestId('row-menu-delete'));
     expect((await screen.findByTestId('mock-delete-row-confirm')).getAttribute('data-row-ids')).toBe('row-a');
+  });
+
+  it('uses the current numeric range when adding a row after settings change', async () => {
+    const doc = new Y.Doc();
+    const fields = doc.getMap('fields') as YDatabaseFields;
+    const view = doc.getMap('view') as YDatabaseView;
+    const groups = new Y.Array<YDatabaseGroup>() as YDatabaseGroups;
+    const group = new Y.Map() as YDatabaseGroup;
+
+    fields.set('amount', createField('amount', FieldType.Number));
+    group.set(YjsDatabaseKey.field_id, 'amount');
+    group.set(YjsDatabaseKey.content, JSON.stringify({ mode: 2, range_interval: '10' }));
+    groups.push([group]);
+    view.set(YjsDatabaseKey.groups, groups);
+    mockUseDatabaseFields.mockReturnValue(fields);
+    mockUseDatabaseView.mockReturnValue(view);
+
+    render(
+      <ListSortState hasSorts={false}>
+        <ListRowActions
+          reorderable
+          groupFieldId='amount'
+          groupId='number_above_100'
+          rowId='row-a'
+          rowOrders={[{ height: 36, id: 'row-a' }]}
+        />
+      </ListSortState>
+    );
+
+    // The same Yjs view reference now carries new settings; the action must
+    // read them when clicked instead of retaining its render-time prefill.
+    group.set(YjsDatabaseKey.content, JSON.stringify({ mode: 2, range_interval: '25' }));
+    fireEvent.click(screen.getByTestId('list-row-add-below-row-a'));
+    await waitFor(() => expect(createRow).toHaveBeenCalledWith({ beforeRowId: 'row-a', cellsData: { amount: '125' } }));
   });
 
   it('requires sorting removal before inserting a row', async () => {


### PR DESCRIPTION
Number fields in Grid and List can now group by exact values or configurable ranges, matching [Desktop PR #1333](https://github.com/AppFlowy-IO/AppFlowy-Premium/pull/1333). Values such as priorities 1–5 form separate groups; Range defaults to Start 0, End 100, Interval 10.

### Feature Preview

- Add Exact value / Range settings, atomic Apply, decimal validation, and ascending/descending group sorting.
- Keep existing automatic ranges of 100 until the user changes mode. Retain saved range parameters across mode switches.
- Match desktop decimal identities and boundaries: missing stays distinct from zero, the final range includes End, and below/above values have separate groups.
- Preserve configured empty ranges and surviving visibility/color/collapse metadata. Read current range settings when creating grouped rows.
- Preserve partial-hydration protections and handle field type changes without using stale numeric metadata rules.

### Validation

- Full Web Jest suite: 4,154 tests passed across 426 suites, with coverage.
- `pnpm run lint` (TypeScript + ESLint) and `pnpm run build` passed.
- Playwright BDD: all 5 Chromium scenarios passed, with no retries or skips.
- Existing Grid grouping E2E: all 13 Chromium tests passed, covering membership, insertion, filters/sorts, field/view/layout changes, and repeated updates.
- Independent differential checks against desktop's locked Rust parser and actual grouping policy: 547 raw-number samples and 612 configurations matched, including canonical IDs, membership, precision validation, and new-row values.

### Checklist

- [x] Added regression tests and comments for compatibility and synchronization constraints.
- [x] Final unit, lint, build, and browser checks pass.

Browser validation uses Chromium on macOS with the local Cloud/GoTrue services.

## Summary by Sourcery

Match Desktop numeric grouping behavior across Web Grid and List views with exact-value and configurable range modes.

New Features:
- Support exact-value and configurable range grouping for number fields in Grid and List views, including persistent settings and group sorting.

Bug Fixes:
- Align numeric grouping, boundaries, decimal identity, raw-value parsing, and missing-value handling with Desktop behavior.
- Keep row insertion, grouping metadata, and field-type transitions synchronized with the current numeric grouping configuration.

Enhancements:
- Preserve configured empty ranges and group visibility, color, and collapse metadata across grouping updates.
- Add atomic range validation and resilient handling of partially hydrated grouping data and mode changes.

Tests:
- Add unit, component, integration, and Playwright BDD coverage for numeric grouping modes, validation, persistence, sorting, boundaries, row insertion, and synchronization.