### PR TITLE
fix(database): preserve number grouping submenu while editing

### DIFF
--- a/playwright/bdd/features/database/number-grouping.feature
+++ b/playwright/bdd/features/database/number-grouping.feature
@@ -170,3 +170,57 @@ Feature: Number grouping matches Desktop
       | = 1    | 1    |
       | = 10   | 1    |
       | = 11   | 1    |
+
+  Scenario: Numeric group order stays independent of the primary row sort after reopening
+    Given a Grid contains the following numbers for number grouping
+      | value   |
+      | 3       |
+      | 4       |
+      | 5       |
+      | 6       |
+      | <empty> |
+    When I group the Grid by its number field
+    And I apply number ranges with Start "1", End "5", and Interval "2"
+    And I sort number groups ascending
+    And I sort the Grid rows by its number field descending
+    Then number grouping uses Range with Start "1", End "5", and Interval "2"
+    And the displayed number groups are ordered as follows
+      | bucket |
+      | empty  |
+      | [3, 5] |
+      | > 5    |
+    And the number groups contain these row counts
+      | bucket | rows |
+      | empty  | 1    |
+      | [3, 5] | 3    |
+      | > 5    | 1    |
+    And number group "[3, 5]" contains numeric values in this order
+      | value |
+      | 5     |
+      | 4     |
+      | 3     |
+    When I sort number groups descending
+    And I sort the Grid rows by its number field ascending
+    Then the displayed number groups are ordered as follows
+      | bucket |
+      | empty  |
+      | > 5    |
+      | [3, 5] |
+    And number group "[3, 5]" contains numeric values in this order
+      | value |
+      | 3     |
+      | 4     |
+      | 5     |
+    When I reload the number-grouped Grid
+    Then number grouping uses Range with Start "1", End "5", and Interval "2"
+    And the numeric row sort is ascending
+    And the displayed number groups are ordered as follows
+      | bucket |
+      | empty  |
+      | > 5    |
+      | [3, 5] |
+    And number group "[3, 5]" contains numeric values in this order
+      | value |
+      | 3     |
+      | 4     |
+      | 5     |

--- a/playwright/bdd/steps/number-grouping.steps.ts
+++ b/playwright/bdd/steps/number-grouping.steps.ts
@@ -3,7 +3,14 @@ import { createBdd, DataTable } from 'playwright-bdd';
 
 import { waitForGridReady } from '../../support/database-ui-helpers';
 import { addFieldWithType, addRows, loginAndCreateGrid, typeTextIntoCell } from '../../support/field-type-helpers';
-import { DatabaseGridSelectors, FieldType } from '../../support/selectors';
+import { DatabaseGridSelectors, FieldType, SortSelectors } from '../../support/selectors';
+import {
+  addSortByFieldName,
+  changeSortDirection,
+  closeSortMenu,
+  openSortMenu,
+  SortDirection,
+} from '../../support/sort-test-helpers';
 import { generateRandomEmail, setupPageErrorHandling } from '../../support/test-config';
 
 const { Given, When, Then } = createBdd();
@@ -55,8 +62,11 @@ async function closeNumberGroupSettings(page: Page) {
 }
 
 async function fillRange(page: Page, start: string, end: string, interval: string) {
+  await numberControl(page, 'start').click();
   await numberControl(page, 'start').fill(start);
+  await numberControl(page, 'end').click();
   await numberControl(page, 'end').fill(end);
+  await numberControl(page, 'interval').click();
   await numberControl(page, 'interval').fill(interval);
 }
 
@@ -182,6 +192,45 @@ When('I sort number groups {word}', async ({ page }, direction: string) => {
   await expect(numberControl(page, `sort-${direction}`)).toHaveAttribute('aria-checked', 'true');
   await closeNumberGroupSettings(page);
 });
+
+async function expectNumericRowSort(page: Page, direction: string) {
+  expect(['ascending', 'descending']).toContain(direction);
+  await openSortMenu(page);
+  await expect(SortSelectors.sortItem(page)).toHaveCount(1);
+  await expect(
+    SortSelectors.sortItem(page).getByRole('button', { name: new RegExp(`^${direction}$`, 'i') })
+  ).toBeVisible();
+  await closeSortMenu(page);
+}
+
+When('I sort the Grid rows by its number field {word}', async ({ page }, direction: string) => {
+  expect(['ascending', 'descending']).toContain(direction);
+  if ((await SortSelectors.sortCondition(page).count()) === 0) {
+    // The fixture adds one Number property through the UI with its default name.
+    await addSortByFieldName(page, 'Number');
+  }
+
+  await openSortMenu(page);
+  await changeSortDirection(page, 0, direction === 'ascending' ? SortDirection.Ascending : SortDirection.Descending);
+  await closeSortMenu(page);
+  await expectNumericRowSort(page, direction);
+});
+
+Then('the numeric row sort is {word}', async ({ page }, direction: string) => {
+  await expectNumericRowSort(page, direction);
+});
+
+Then(
+  'number group {string} contains numeric values in this order',
+  async ({ page }, bucket: string, table: DataTable) => {
+    const id = bucketId(page, bucket);
+    const cells = page.locator(
+      `[data-index][data-row-key^="group:${id}:row:"] .grid-row-cell[data-column-id="${numberFieldId(page)}"]`
+    );
+
+    await expect(cells).toHaveText(table.hashes().map(({ value }) => value));
+  }
+);
 
 When('I reload the number-grouped Grid', async ({ page }) => {
   await page.reload({ waitUntil: 'domcontentloaded' });

--- a/src/components/database/components/settings/GridSettingGroup.tsx
+++ b/src/components/database/components/settings/GridSettingGroup.tsx
@@ -1,4 +1,4 @@
-import { type KeyboardEvent, useMemo, useState } from 'react';
+import { type KeyboardEvent, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { DateGroupCondition, FieldType, usePropertiesSelector } from '@/application/database-yjs';
@@ -254,6 +254,7 @@ export function DatabaseSettingGroup({
   testIdPrefix,
 }: DatabaseSettingGroupProps) {
   const { t } = useTranslation();
+  const contentRef = useRef<HTMLDivElement>(null);
   const { properties: allProperties } = usePropertiesSelector(true);
   const properties = useMemo(
     () => allProperties.filter((property) => DATABASE_GROUPABLE_FIELD_TYPES.includes(property.type)),
@@ -267,12 +268,22 @@ export function DatabaseSettingGroup({
 
   return (
     <DropdownMenuSub>
-      <DropdownMenuSubTrigger data-testid={`${testIdPrefix}-group-settings-trigger`}>
+      <DropdownMenuSubTrigger
+        data-testid={`${testIdPrefix}-group-settings-trigger`}
+        onPointerLeave={(event) => {
+          // Entering the portaled editor must not focus the parent menu and
+          // dismiss the draft when Radix's geometric hover grace area is missed.
+          if (event.relatedTarget instanceof Node && contentRef.current?.contains(event.relatedTarget)) {
+            event.preventDefault();
+          }
+        }}
+      >
         <GroupIcon />
         {t('grid.settings.group', 'Group')}
       </DropdownMenuSubTrigger>
       <DropdownMenuPortal>
         <DropdownMenuSubContent
+          ref={contentRef}
           className='appflowy-scroller max-h-[520px] max-w-[280px] overflow-y-auto'
           data-testid={`${testIdPrefix}-group-settings-menu`}
         >

--- a/src/components/database/components/settings/__tests__/GridSettingGroup.test.tsx
+++ b/src/components/database/components/settings/__tests__/GridSettingGroup.test.tsx
@@ -26,13 +26,14 @@ import type {
 } from '@/application/types';
 import { SelectOptionColorMap, SelectOptionFgColorMap } from '@/components/database/components/cell/cell.const';
 import {
+  DatabaseSettingGroup,
   GRID_GROUP_VISIBILITY_LIMIT,
   GridGroupVisibilityActions,
   GridGroupVisibilityList,
   getGridGroupVisibilityGroups,
 } from '@/components/database/components/settings/GridSettingGroup';
 import { GridGroupingProvider, useGridGrouping } from '@/components/database/grid/GridGroupingContext';
-import { DropdownMenu, DropdownMenuContent, DropdownMenuTrigger } from '@/components/ui/dropdown-menu';
+import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from '@/components/ui/dropdown-menu';
 
 import type { ComponentProps } from 'react';
 
@@ -187,6 +188,77 @@ async function openMenuWithKeyboard() {
   fireEvent.keyDown(trigger, { key: 'ArrowDown' });
   await waitFor(() => expect(screen.getByTestId('grid-show-all-groups')).toBeTruthy());
 }
+
+describe('DatabaseSettingGroup submenu', () => {
+  it('keeps the numeric draft and validation visible when the pointer enters its portaled editor', async () => {
+    const fixture = createLiveColorFixture();
+    const updateNumberConfiguration = jest.fn();
+    const { unmount } = render(
+      <DatabaseContext.Provider value={fixture.contextValue}>
+        <DropdownMenu>
+          <DropdownMenuTrigger>Settings</DropdownMenuTrigger>
+          <DropdownMenuContent>
+            <DatabaseSettingGroup
+              grouping={{
+                isGrouped: true,
+                fieldId: 'status',
+                fieldType: FieldType.Number,
+                content: JSON.stringify(defaultNumberGroupConfiguration(NumberGroupMode.Range)),
+                activeGroupIds: [],
+                groups: [],
+                visibleGroups: [],
+                hideEmptyGroups: true,
+                ready: true,
+              }}
+              groupBy={jest.fn()}
+              clearGrouping={jest.fn()}
+              toggleHideEmpty={jest.fn()}
+              setVisibility={jest.fn()}
+              setAllVisibility={jest.fn()}
+              updateDateCondition={jest.fn()}
+              updateNumberConfiguration={updateNumberConfiguration}
+              testIdPrefix='grid'
+            />
+            <DropdownMenuItem>Other setting</DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </DatabaseContext.Provider>
+    );
+
+    const settingsTrigger = screen.getByRole('button', { name: 'Settings' });
+
+    settingsTrigger.focus();
+    fireEvent.keyDown(settingsTrigger, { key: 'ArrowDown' });
+    const groupTrigger = await screen.findByTestId('grid-group-settings-trigger');
+
+    fireEvent.click(groupTrigger);
+    const interval = await screen.findByRole('textbox', { name: 'Interval' });
+
+    fireEvent.change(interval, { target: { value: '0' } });
+    const apply = screen.getByRole('button', { name: 'Apply' });
+    // A direct pointer transition can miss Radix's geometric hover grace area.
+    const pointerOut = new MouseEvent('pointerout', { bubbles: true, relatedTarget: apply, clientX: 100, clientY: 100 });
+
+    Object.defineProperty(pointerOut, 'pointerType', { value: 'mouse' });
+    fireEvent(groupTrigger, pointerOut);
+    await waitFor(() => expect(screen.getByTestId('grid-group-settings-menu')).toBeTruthy());
+    fireEvent.click(apply);
+    expect(screen.getByRole('alert').textContent).toBe('Interval must be greater than zero.');
+    expect(screen.getByRole('textbox', { name: 'Interval' }).value).toBe('0');
+    expect(updateNumberConfiguration).not.toHaveBeenCalled();
+
+    const otherSetting = screen.getByRole('menuitem', { name: 'Other setting' });
+
+    act(() => otherSetting.focus());
+    await waitFor(() => expect(screen.queryByTestId('grid-group-settings-menu')).toBeNull());
+    expect(screen.getByRole('menuitem', { name: 'Other setting' })).toBeTruthy();
+    fireEvent.keyDown(otherSetting, { key: 'Escape' });
+    await waitFor(() => expect(screen.queryByRole('menu')).toBeNull());
+    unmount();
+    fixture.databaseDoc.destroy();
+    fixture.rowDoc.destroy();
+  });
+});
 
 describe('GridGroupVisibilityList', () => {
   it('supports stable List visibility identifiers without changing Grid defaults', async () => {


### PR DESCRIPTION
### Description

Moving the pointer from Group into its portaled settings editor could focus the parent Settings menu and dismiss the editor before a range could be edited or validated. Keep direct pointer transitions inside the same Group submenu without changing outside-focus or Escape dismissal.

Add the matching desktop regression for Start 1, End 5, Interval 2: ascending groups keep `3–5` before `Above 5` under a descending number row sort. Verify both opposing sort directions, row order inside groups, missing values, and reload persistence. Companion desktop changes: [AppFlowy-Premium #1333](https://github.com/AppFlowy-IO/AppFlowy-Premium/pull/1333).

### Validation

- Nested-menu regression fails before the fix and passes afterward; it checks retained invalid drafts, visible validation, no configuration write, and normal dismissal.
- Full Jest suite: 4,155 tests passed across 426 suites.
- Playwright numeric grouping BDD: all 6 Chromium scenarios passed in 4.5 minutes, with no retries or skips.
- Full TypeScript/ESLint checks and production build passed.

Browser validation ran on Chromium/macOS against the local Cloud/GoTrue services.

### Checklist

- [x] Added a comment explaining the pointer/focus constraint.
- [x] Added component and BDD regression coverage.
- [x] Verified integration with existing grouping, sorting, and validation behavior.

## Summary by Sourcery

Keep numeric grouping settings open during direct pointer transitions into the editor and verify grouping behavior across sorting and reload scenarios.

Bug Fixes:
- Preserve the Group settings submenu when the pointer moves into its portaled editor, allowing drafts and validation to remain available without changing normal outside-focus or Escape dismissal.

Enhancements:
- Add regression coverage for retaining invalid numeric grouping drafts and preventing unintended configuration writes.

Tests:
- Add end-to-end coverage confirming numeric group ordering, row ordering, empty and overflow buckets, opposing sort directions, and persistence after reload.