### PR TITLE
fix: preserve number grouping types and refresh shared group members

### DIFF
--- a/playwright/e2e/database/row-template.spec.ts
+++ b/playwright/e2e/database/row-template.spec.ts
@@ -1,4 +1,8 @@
 import { expect, Locator, Page, test } from '@playwright/test';
+import * as Y from 'yjs';
+
+import { Types } from '../../../src/application/types';
+import type { DatabaseTestWindow } from '../../../src/components/database/database-test-context';
 
 import {
   createNamedGridPage,
@@ -23,7 +27,7 @@ import {
   FieldType,
   PropertyMenuSelectors,
 } from '../../support/selectors';
-import { generateRandomEmail, setupPageErrorHandling } from '../../support/test-config';
+import { generateRandomEmail, setupPageErrorHandling, TestConfig } from '../../support/test-config';
 
 const TEMPLATE_MENU = 'database-template-menu';
 const TEMPLATE_EDITOR = 'database-template-editor';
@@ -365,6 +369,69 @@ async function expectRowCover(page: Page, rowId: string): Promise<void> {
 
   await expect(rowDialog.locator('.row-header-cover img')).toBeVisible({ timeout: 15000 });
   await closeRowDetailWithEscape(page);
+}
+
+async function waitForTemplateRowsOnServer(page: Page, rowIds: string[]): Promise<void> {
+  const { token, snapshots } = await page.evaluate((ids) => {
+    const testWindow = window as DatabaseTestWindow & { Y?: typeof Y };
+    const context = testWindow.__TEST_DATABASE_CONTEXT__;
+    const yjs = testWindow.Y;
+
+    if (!context?.databaseDoc || !yjs) throw new Error('Database test context is unavailable');
+
+    const docs = [context.databaseDoc, ...ids.map((id) => context.rowMap?.[id])];
+    const token = JSON.parse(localStorage.getItem('token') || 'null')?.access_token;
+
+    if (!token) throw new Error('No access token for checking row persistence');
+
+    return {
+      token,
+      snapshots: docs.map((doc) => {
+        if (!doc) throw new Error('A template row has not loaded');
+        return { objectId: doc.guid, stateVector: Array.from(yjs.encodeStateVector(doc)) };
+      }),
+    };
+  }, rowIds);
+  const workspaceId = new URL(page.url()).pathname.split('/')[2];
+
+  // Local cells and decorations render before their separate row/database
+  // collabs reach the server. Wait for both before reload can fetch a blob
+  // built from an incomplete row order or row payload.
+  await expect
+    .poll(
+      () =>
+        Promise.all(
+          snapshots.map(async ({ objectId, stateVector }, index) => {
+            const response = await page.request.get(
+              `${TestConfig.apiUrl}/api/workspace/v1/${workspaceId}/collab/${objectId}`,
+              {
+                params: { collab_type: index === 0 ? Types.Database : Types.DatabaseRow, _t: Date.now() },
+                headers: { Authorization: `Bearer ${token}`, 'Cache-Control': 'no-cache' },
+              }
+            );
+
+            if (!response.ok()) return `${objectId}: HTTP ${response.status()}`;
+            const body = (await response.json()) as { code?: number; data?: { doc_state?: number[] } };
+
+            if (body.code !== 0 || !body.data?.doc_state) return `${objectId}: collab is not available`;
+            const serverDoc = new Y.Doc();
+
+            try {
+              Y.applyUpdate(serverDoc, new Uint8Array(body.data.doc_state));
+              const serverVector = Y.decodeStateVector(Y.encodeStateVector(serverDoc));
+              const expectedVector = Y.decodeStateVector(new Uint8Array(stateVector));
+
+              return Array.from(expectedVector).every(([clientId, clock]) => (serverVector.get(clientId) ?? 0) >= clock)
+                ? 'persisted'
+                : `${objectId}: server is behind local edits`;
+            } finally {
+              serverDoc.destroy();
+            }
+          })
+        ),
+      { timeout: 30000, intervals: [250, 500, 1000], message: 'Waiting for template rows and row order to reach the server' }
+    )
+    .toEqual(snapshots.map(() => 'persisted'));
 }
 
 test.describe('Database row templates (Desktop parity)', () => {
@@ -710,6 +777,7 @@ test.describe('Database row templates (Desktop parity)', () => {
     await expect(page.getByTestId(`row-document-icon-${coverOnlyRowId}`)).toHaveCount(0);
     await expectRowCover(page, coverOnlyRowId);
 
+    await waitForTemplateRowsOnServer(page, [iconOnlyRowId, iconCoverRowId, coverOnlyRowId]);
     await page.reload({ waitUntil: 'domcontentloaded' });
     await waitForGridReady(page);
     await expect(DatabaseGridSelectors.rowById(page, iconOnlyRowId).locator('.custom-icon')).toContainText(

--- a/src/application/database-yjs/__tests__/group.test.ts
+++ b/src/application/database-yjs/__tests__/group.test.ts
@@ -1,5 +1,7 @@
 import * as Y from 'yjs';
 
+import { parseYDatabaseCellToCell } from '@/application/database-yjs/cell.parse';
+
 jest.mock('@/utils/runtime-config', () => ({
   getConfigValue: (_key: string, defaultValue: string) => defaultValue,
 }));
@@ -214,6 +216,41 @@ describe('desktop-model lazy conversion grouping', () => {
     expect([...result.keys()]).toEqual([fieldId]);
     expect(result.get(fieldId)?.map((row) => row.id)).toEqual(['row-a']);
   });
+
+  it.each([NumberGroupMode.Legacy, NumberGroupMode.Exact, NumberGroupMode.Range])(
+    'keeps unsupported lazy conversions in No Number in mode %s',
+    (mode) => {
+      const fieldId = 'converted-number';
+      const field = createField(fieldId, FieldType.Number);
+      const inputs = {
+        date: createCell(FieldType.DateTime, '1710000000'),
+        select: createCell(FieldType.SingleSelect, 'option-12'),
+        url: createCell(FieldType.URL, 'https://example.com/42'),
+        legacyDate: createCell(FieldType.Number, '1710000000', FieldType.DateTime),
+        text: createCell(FieldType.RichText, '12.50'),
+        number: createCell(FieldType.Number, '12.5'),
+      };
+      const rows: Row[] = Object.keys(inputs).map((id) => ({ id, height: 36 }));
+      const rowMetas = Object.fromEntries(
+        Object.entries(inputs).map(([id, input]) => [id, createRowDoc(id, databaseId, { [fieldId]: input })])
+      );
+      const emptyRowIds = ['date', 'select', 'url', 'legacyDate'];
+
+      for (const id of emptyRowIds) {
+        const row = rowMetas[id].getMap(YjsEditorKey.data_section).get(YjsEditorKey.database_row) as YDatabaseRow;
+
+        expect(parseYDatabaseCellToCell(row.get(YjsDatabaseKey.cells).get(fieldId), field).data).toBe('');
+      }
+
+      const content = JSON.stringify(defaultNumberGroupConfiguration(mode));
+      const result = groupByNumber(rows, rowMetas, field, content);
+
+      expect(result.get(fieldId)?.map(({ id }) => id)).toEqual(emptyRowIds);
+      expect(result.get(getNumberGroupId('12.5', content)!)?.map(({ id }) => id)).toEqual(['text', 'number']);
+      Object.values(rowMetas).forEach((doc) => doc.destroy());
+      field.doc?.destroy();
+    }
+  );
 });
 
 describe('group by field fallback', () => {

--- a/src/application/database-yjs/__tests__/useMoveCardDispatch.test.tsx
+++ b/src/application/database-yjs/__tests__/useMoveCardDispatch.test.tsx
@@ -33,7 +33,8 @@ describe('useMoveCardDispatch', () => {
     [NumberGroupMode.Range, 'number_interval_0_10', 'number_above_100', '110'],
     [NumberGroupMode.Exact, 'number_value_1.25', 'number_value_-0.5', '-0.5'],
     [NumberGroupMode.Legacy, 'number_range_0_100', 'number_range_-100_0', '-100'],
-  ])('writes the numeric representative in mode %s and preserves same-group values', (mode, start, finish, value) => {
+    [NumberGroupMode.Exact, 'amount', 'number_value_1710000000', '1710000000', FieldType.DateTime, '1710000000'],
+  ])('writes the numeric representative in mode %s from %s to %s and preserves same-group values', (mode, start, finish, value, storedType = FieldType.Number, rawValue = '1.25') => {
     const databaseId = 'numeric-database';
     const viewId = 'numeric-view';
     const fieldId = 'amount';
@@ -60,7 +61,7 @@ describe('useMoveCardDispatch', () => {
     database.set(YjsDatabaseKey.fields, fields);
     database.set(YjsDatabaseKey.views, views);
     databaseDoc.getMap(YjsEditorKey.data_section).set(YjsEditorKey.database, database);
-    const rowDoc = createRowDoc(rowId, databaseId, { [fieldId]: createCell(FieldType.Number, '1.25') });
+    const rowDoc = createRowDoc(rowId, databaseId, { [fieldId]: createCell(storedType, rawValue) });
     const row = rowDoc.getMap(YjsEditorKey.data_section).get(YjsEditorKey.database_row) as YDatabaseRow;
     const cell = row.get(YjsDatabaseKey.cells).get(fieldId);
     const contextValue = {

--- a/src/application/database-yjs/dispatch/row.ts
+++ b/src/application/database-yjs/dispatch/row.ts
@@ -42,7 +42,7 @@ import {
   normalizeFilterNode,
   relationFilterFillData,
 } from '@/application/database-yjs/filter';
-import { normalizeGroupIdentifiers } from '@/application/database-yjs/group';
+import { getNumberGroupingCellData, normalizeGroupIdentifiers } from '@/application/database-yjs/group';
 import {
   createDatabaseHistoryGroup,
   executeDatabaseOperations as executeOperations,
@@ -257,7 +257,7 @@ export function useMoveCardDispatch() {
                   const group = view.get(YjsDatabaseKey.groups)?.toArray()
                     .find((candidate) => candidate.get(YjsDatabaseKey.field_id) === fieldId);
                   const policy = createNumberGroupingPolicy(group?.get(YjsDatabaseKey.content));
-                  const currentGroupId = policy.groupIdForCell(cell?.get(YjsDatabaseKey.data)) ?? fieldId;
+                  const currentGroupId = policy.groupIdForCell(getNumberGroupingCellData(cell)) ?? fieldId;
 
                   // Reordering within a numeric bucket must preserve its actual
                   // value, including values away from the bucket's lower bound.

--- a/src/application/database-yjs/group.ts
+++ b/src/application/database-yjs/group.ts
@@ -1,5 +1,5 @@
 import { getStoredCellFieldType } from '@/application/database-yjs/cell.field-type';
-import { parseYDatabaseCellToCell } from '@/application/database-yjs/cell.parse';
+import { isCellDataTransformable, parseYDatabaseCellToCell } from '@/application/database-yjs/cell.parse';
 import { getRowConditionSnapshot, hasRowConditionData } from '@/application/database-yjs/condition-value-cache';
 import { getCell } from '@/application/database-yjs/const';
 import { DateGroupCondition, FieldType } from '@/application/database-yjs/database.type';
@@ -14,7 +14,7 @@ import { checkboxFilterCheck, selectOptionFilterCheck } from '@/application/data
 import { createNumberGroupingPolicy, getNumberGroupLabel } from '@/application/database-yjs/number-grouping';
 import { getRelationRowIdsFromCell } from '@/application/database-yjs/relation/cell';
 import type { Row } from '@/application/database-yjs/selector';
-import { RowId, YDatabaseField, YDatabaseFilter, YDoc, YjsDatabaseKey } from '@/application/types';
+import { RowId, YDatabaseCell, YDatabaseField, YDatabaseFilter, YDoc, YjsDatabaseKey } from '@/application/types';
 import { canonicalizeUserUid } from '@/application/user-uid';
 
 export const DATABASE_GROUPABLE_FIELD_TYPES: readonly FieldType[] = [
@@ -277,6 +277,16 @@ export function getNumberGroupId(value: unknown, groupContent?: string): string 
   return createNumberGroupingPolicy(groupContent).groupIdForCell(value);
 }
 
+export function getNumberGroupingCellData(cell?: YDatabaseCell) {
+  if (!cell) return undefined;
+
+  const storedType = getStoredCellFieldType(cell, FieldType.Number);
+
+  // Field switches preserve the original payload. Honor the renderer's
+  // conversion eligibility while keeping Percent/Currency values unformatted.
+  return isCellDataTransformable(storedType, FieldType.Number) ? cell.get(YjsDatabaseKey.data) : undefined;
+}
+
 export function groupByNumber(rows: Row[], rowMetas: Record<RowId, YDoc>, field: YDatabaseField, groupContent?: string) {
   const fieldId = field.get(YjsDatabaseKey.id);
   const policy = createNumberGroupingPolicy(groupContent);
@@ -286,9 +296,7 @@ export function groupByNumber(rows: Row[], rowMetas: Record<RowId, YDoc>, field:
   rows.forEach((row) => {
     if (!hasRowConditionData(rowMetas[row.id])) return;
 
-    // Formatting a Percent or Currency cell changes its apparent numeric value.
-    // Desktop groups its raw stored string independently of the field format.
-    const groupId = policy.groupIdForCell(getCell(row.id, fieldId, rowMetas)?.get(YjsDatabaseKey.data));
+    const groupId = policy.groupIdForCell(getNumberGroupingCellData(getCell(row.id, fieldId, rowMetas)));
 
     if (!groupId) {
       ungroupedRows.push(row);

--- a/src/components/app/share/GroupItem.tsx
+++ b/src/components/app/share/GroupItem.tsx
@@ -25,6 +25,8 @@ interface GroupItemProps {
   peopleByEmail: ReadonlyMap<string, IPeopleWithAccessType>;
   /** Whether the current user may list the group's members. The server allows workspace owners only. */
   canExploreMembers?: boolean;
+  /** Advances when a permission notification invalidates cached group membership. */
+  membersRevision?: number;
   /** The scrollable access list; an expanded group scrolls itself into view inside it. */
   scrollContainerRef?: RefObject<HTMLElement | null>;
   canModify: boolean;
@@ -38,10 +40,11 @@ function normalizeEmail(email: string) {
   return email.trim().toLowerCase();
 }
 
-/** A loaded group roster together with the member count it was fetched for. */
+/** A loaded group roster together with the membership snapshot it was fetched for. */
 interface GroupRoster {
   members: WorkspaceGroupMember[];
   memberCount: number;
+  revision: number;
 }
 
 const loadingIndicator = (
@@ -60,6 +63,7 @@ export function GroupItem({
   group,
   peopleByEmail,
   canExploreMembers = false,
+  membersRevision = 0,
   scrollContainerRef,
   canModify,
   currentUserHasFullAccess,
@@ -74,9 +78,10 @@ export function GroupItem({
   const [roster, setRoster] = useState<GroupRoster | null>(null);
   const wrapperRef = useRef<HTMLDivElement>(null);
   const showMembers = canExploreMembers && expanded;
-  // The server-side member count is part of the group projection, so a changed count is a
-  // cheap signal that an already loaded roster is stale.
-  const rosterStale = roster === null || roster.memberCount !== group.member_count;
+  // Replacing a member can leave the count unchanged. Permission notifications
+  // also invalidate rosters, including those in collapsed rows or still loading.
+  const rosterStale =
+    roster === null || roster.memberCount !== group.member_count || roster.revision !== membersRevision;
   // Derived rather than stored: a fetch is in flight exactly while the row is open and the
   // roster is stale, so no extra state or render is needed to track it.
   const loading = showMembers && rosterStale && Boolean(currentWorkspaceId);
@@ -94,7 +99,7 @@ export function GroupItem({
         const result = await WorkspaceService.getWorkspaceGroupMembers(currentWorkspaceId, group.group_id);
 
         if (cancelled) return;
-        setRoster({ members: result?.members ?? [], memberCount: group.member_count });
+        setRoster({ members: result?.members ?? [], memberCount: group.member_count, revision: membersRevision });
       } catch (error) {
         if (cancelled) return;
         console.error(error);
@@ -106,7 +111,7 @@ export function GroupItem({
     return () => {
       cancelled = true;
     };
-  }, [currentWorkspaceId, group.group_id, group.member_count, loadFailedMessage, rosterStale, showMembers]);
+  }, [currentWorkspaceId, group.group_id, group.member_count, loadFailedMessage, membersRevision, rosterStale, showMembers]);
 
   const toggleExpanded = useCallback(() => setExpanded((value) => !value), []);
   const toggleLabel = t(expanded ? 'shareAction.hideGroupMembers' : 'shareAction.showGroupMembers', {

--- a/src/components/app/share/PeopleWithAccess.tsx
+++ b/src/components/app/share/PeopleWithAccess.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useRef } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 
@@ -61,10 +61,25 @@ export function PeopleWithAccess({
   const { t } = useTranslation();
   const currentUser = useCurrentUser();
   const listRef = useRef<HTMLDivElement>(null);
+  const [groupMembersRevision, setGroupMembersRevision] = useState(0);
 
   const currentWorkspaceId = useCurrentWorkspaceId();
   const navigate = useNavigate();
   const eventEmitter = useEventEmitter();
+
+  useEffect(() => {
+    if (!canExploreGroupMembers || !eventEmitter) return;
+
+    // Share one listener across the list. Membership notifications may not
+    // identify a group, so invalidate every roster and let open rows reload.
+    const invalidateGroupMembers = () => setGroupMembersRevision((revision) => revision + 1);
+
+    eventEmitter.on(APP_EVENTS.PERMISSION_CHANGED, invalidateGroupMembers);
+    return () => {
+      eventEmitter.off(APP_EVENTS.PERMISSION_CHANGED, invalidateGroupMembers);
+    };
+  }, [canExploreGroupMembers, eventEmitter]);
+
   const handleAccessLevelChange = useCallback(
     async (personEmail: string, newAccessLevel: AccessLevel) => {
       if (!currentWorkspaceId) return;
@@ -210,6 +225,7 @@ export function PeopleWithAccess({
             group={group}
             peopleByEmail={peopleByEmail}
             canExploreMembers={canExploreGroupMembers}
+            membersRevision={groupMembersRevision}
             scrollContainerRef={listRef}
             canModify={canManageGroupAccess && editableGroupIds.has(group.group_id)}
             currentUserHasFullAccess={hasFullAccess}

--- a/src/components/app/share/__tests__/PeopleWithAccess.test.tsx
+++ b/src/components/app/share/__tests__/PeopleWithAccess.test.tsx
@@ -1,12 +1,14 @@
 import EventEmitter from 'events';
 
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 
+import { APP_EVENTS } from '@/application/constants';
 import {
   AccessLevel,
   IPeopleWithAccessType,
   Role,
   SharedUserAccessSource,
+  WorkspaceGroupMembers,
   WorkspaceGroupViewPermission,
 } from '@/application/types';
 import { PeopleWithAccess } from '@/components/app/share/PeopleWithAccess';
@@ -18,6 +20,7 @@ const mockRevokeGroupAccess = jest.fn();
 const mockNavigate = jest.fn();
 const mockEventEmitter = new EventEmitter();
 const mockGroupMutationResult = jest.fn();
+const mockGetWorkspaceGroupMembers = jest.fn();
 
 jest.mock('react-i18next', () => ({
   useTranslation: () => ({ t: (key: string) => key }),
@@ -36,7 +39,7 @@ jest.mock('@/application/services/domains', () => ({
     turnIntoMember: jest.fn(),
   },
   WorkspaceService: {
-    getWorkspaceGroupMembers: jest.fn(),
+    getWorkspaceGroupMembers: (...args: unknown[]) => mockGetWorkspaceGroupMembers(...args),
   },
 }));
 
@@ -133,6 +136,27 @@ const directPerson: IPeopleWithAccessType = {
   access_source: SharedUserAccessSource.DirectShare,
 };
 
+function renderExplorableGroups() {
+  return render(
+    <PeopleWithAccess
+      viewId='view-1'
+      people={[groupOnlyPerson]}
+      groups={[{ ...sharedGroup, member_count: 1 }, { ...sharedGroup, group_id: 'group-2', member_count: 1 }]}
+      editableGroupIds={new Set()}
+      isLoading={false}
+      onPeopleChange={async () => undefined}
+      onPersonRemoved={jest.fn()}
+      updateGroupInAccessList={jest.fn()}
+      hasFullAccess
+      canManageGroupAccess
+      canManageFullAccess
+      canGrantFullAccess
+      canExploreGroupMembers
+      sectionType={ShareSectionType.Shared}
+    />
+  );
+}
+
 describe('PeopleWithAccess', () => {
   beforeEach(() => {
     mockRevokeAccess.mockReset();
@@ -143,6 +167,64 @@ describe('PeopleWithAccess', () => {
     mockRevokeGroupAccess.mockResolvedValue(undefined);
     mockNavigate.mockReset();
     mockGroupMutationResult.mockReset();
+    mockGetWorkspaceGroupMembers.mockReset();
+  });
+
+  it.each([true, false])('refreshes replaced group members with an unchanged count (expanded: %s)', async (expanded) => {
+    mockGetWorkspaceGroupMembers
+      .mockResolvedValueOnce({ members: [{ uid: 'old', email: groupOnlyPerson.email, name: 'Old member' }] })
+      .mockResolvedValueOnce({ members: [{ uid: 'new', email: 'new@appflowy.io', name: 'New member' }] });
+
+    const { unmount } = renderExplorableGroups();
+    const toggle = screen.getByTestId('share-group-toggle-group-1');
+
+    fireEvent.click(toggle);
+    await screen.findByTestId('share-group-member-old');
+    if (!expanded) fireEvent.click(toggle);
+
+    act(() => {
+      mockEventEmitter.emit(APP_EVENTS.PERMISSION_CHANGED, { objectId: sharedGroup.group_id });
+    });
+
+    if (!expanded) {
+      expect(mockGetWorkspaceGroupMembers).toHaveBeenCalledTimes(1);
+      fireEvent.click(toggle);
+    }
+
+    await screen.findByTestId('share-group-member-new');
+    expect(screen.queryByTestId('share-group-member-old')).toBeNull();
+    expect(mockGetWorkspaceGroupMembers).toHaveBeenCalledTimes(2);
+    // All group rows share one subscription, and collapsed groups stay lazy.
+    expect(mockEventEmitter.listenerCount(APP_EVENTS.PERMISSION_CHANGED)).toBe(1);
+    unmount();
+    expect(mockEventEmitter.listenerCount(APP_EVENTS.PERMISSION_CHANGED)).toBe(0);
+  });
+
+  it('ignores a roster response started before a membership notification', async () => {
+    let resolveOldRoster!: (value: WorkspaceGroupMembers) => void;
+    const oldRoster = new Promise<WorkspaceGroupMembers>((resolve) => {
+      resolveOldRoster = resolve;
+    });
+
+    mockGetWorkspaceGroupMembers
+      .mockReturnValueOnce(oldRoster)
+      .mockResolvedValueOnce({ members: [{ uid: 'new', email: 'new@appflowy.io', name: 'New member' }] });
+    renderExplorableGroups();
+    fireEvent.click(screen.getByTestId('share-group-toggle-group-1'));
+    expect(mockGetWorkspaceGroupMembers).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      mockEventEmitter.emit(APP_EVENTS.PERMISSION_CHANGED, { objectId: sharedGroup.group_id });
+    });
+
+    await screen.findByTestId('share-group-member-new');
+    await act(async () => {
+      resolveOldRoster({ members: [{ uid: 'old', email: groupOnlyPerson.email, name: 'Old member' }] });
+      await oldRoster;
+    });
+    expect(screen.queryByTestId('share-group-member-old')).toBeNull();
+    expect(screen.getByTestId('share-group-member-new')).toBeTruthy();
+    expect(mockGetWorkspaceGroupMembers).toHaveBeenCalledTimes(2);
   });
 
   it('disables person access changes for a database row page', () => {


### PR DESCRIPTION
### Description

After converting Date, Select, or URL fields to Number, grouping used the preserved source payload even when the number cell displayed empty. Keep those rows in **No Number** by checking conversion eligibility before reading the unformatted value. Use the same check when dragging rows so a drop into a numeric group writes a Number cell correctly. Valid numeric/text values and Percent/Currency grouping retain their existing behavior.

Replacing a workspace-group member could leave the share panel showing the old roster because its cache only tracked member count. Invalidate rosters on permission notifications through one subscription per access list. Expanded groups reload, collapsed groups refresh when opened, and responses started before invalidation cannot overwrite the refreshed membership.

The row-template metadata reload test now waits until the server collabs contain the database and row edits before reloading. It compares Yjs state vectors for the database and all three template-created rows, preserving the existing UI assertions while removing the assumption that local rendering means synchronization has completed.

### Validation

- [CI database-3](https://github.com/AppFlowy-IO/AppFlowy-Web/actions/runs/34137846700/job/101793189676) passed: **73 passed, 4 skipped, 0 failures, 0 flaky tests**. The template-metadata reload regression passed on its first attempt (33.8 seconds).
- All seven added regression cases failed against the original implementation and passed with the fixes.
- 15 affected Jest suites passed: **261 tests**.
- `pnpm type-check` passed.
- ESLint passed for the modified TypeScript/TSX files covered by the project lint configuration.
- Row-template metadata reload regression passed in Chromium **5 times**, including four repetitions with two workers and no retries.
- TypeScript and ESLint passed for the updated Playwright spec using a temporary config that includes it.
- `git diff --check` passed.

### Checklist

#### General

- [x] Included relevant comments explaining the conversion and cache-invalidation behavior.
- [ ] Tested in multiple browsers/operating systems. Validation was automated on macOS, including Chromium Playwright tests; other browsers and operating systems were not exercised locally.

#### Testing

- [x] Added regression coverage for legacy/exact/range grouping, converted-cell drag operations, membership replacements while expanded/collapsed, and stale in-flight roster responses.

#### Feature-Specific

- Feature preview: not applicable; this PR fixes existing behavior.
- [x] Existing number-group settings, row actions, and share-panel tests pass.

## Summary by Sourcery

Preserve number grouping semantics for converted cells and keep shared group membership displays synchronized with permission changes.

Bug Fixes:
- Ensure converted non-numeric values remain in No Number groups and are handled correctly when moving rows between numeric groups.
- Refresh workspace-group member rosters after permission changes, including replacements that leave the member count unchanged, while preventing stale in-flight responses from restoring old members.

Enhancements:
- Centralize numeric grouping eligibility so grouping and row movement preserve existing valid numeric, Percent, and Currency behavior.

Tests:
- Add regression coverage for converted-cell number grouping and drag behavior, group-member refreshes in expanded and collapsed states, and stale roster responses.

