### PR TITLE
feat: disable Form view creation on web behind a boolean flag

### DIFF
--- a/playwright/support/form-test-helpers.ts
+++ b/playwright/support/form-test-helpers.ts
@@ -74,6 +74,12 @@ export async function addFormViewToTabBar(page: Page): Promise<void> {
  * Same as `addFormViewToTabBar` but does NOT dismiss the auto-create
  * modal — exposes the same posture the desktop's
  * `form_from_tab_bar.feature` asserts on.
+ *
+ * NOTE: the `Form` option is only rendered while
+ * `FORM_VIEW_CREATION_ENABLED` (src/application/constants.ts) is `true`.
+ * Web currently ships with it `false` (legacy Desktop clients cannot open
+ * web-created Form views), so the form BDD features are excluded from CI
+ * and will fail locally until the flag is flipped back on.
  */
 export async function addFormViewToTabBarRaw(page: Page): Promise<void> {
   const addBtn = DatabaseViewSelectors.addViewButton(page);

--- a/src/application/constants.ts
+++ b/src/application/constants.ts
@@ -3,6 +3,16 @@ export const databasePrefix = 'af_database';
 export const HEADER_HEIGHT = 48;
 
 /**
+ * Temporarily hides every "create a Form view" entry point on web.
+ *
+ * Legacy Desktop clients cannot open workspaces that contain a Form view
+ * created by web, so until those clients are upgraded Form views may only be
+ * created from Desktop. Flip this back to `true` to restore the menu items.
+ * Existing Form views still open and work normally regardless of this flag.
+ */
+export const FORM_VIEW_CREATION_ENABLED = false;
+
+/**
  * Server error codes from AppFlowy Cloud ErrorCode enum.
  * See: libs/app-error/src/lib.rs in AppFlowy-Cloud
  *

--- a/src/components/app/view-actions/AddPageActions.tsx
+++ b/src/components/app/view-actions/AddPageActions.tsx
@@ -2,6 +2,7 @@ import { ReactNode, useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { toast } from 'sonner';
 
+import { FORM_VIEW_CREATION_ENABLED } from '@/application/constants';
 import { createDatabaseGalleryPageViaGrid } from '@/application/database-yjs/gallery-layout';
 import { createDatabaseListPageViaGrid } from '@/application/database-yjs/list-layout';
 import { View, ViewLayout } from '@/application/types';
@@ -206,12 +207,16 @@ function AddPageActions({ view, onImportClick }: { view: View; onImportClick?: (
           void handleAddPage(ViewLayout.Chart, t('document.plugins.database.newDatabase'));
         },
       },
-      {
-        label: t('form.menuName'),
-        icon: <ViewIcon layout={ViewLayout.Form} size={'small'} />,
-        testId: 'add-form-button',
-        onSelect: () => handleAddPage(ViewLayout.Form, t('document.plugins.database.newDatabase')),
-      },
+      ...(FORM_VIEW_CREATION_ENABLED
+        ? [
+            {
+              label: t('form.menuName'),
+              icon: <ViewIcon layout={ViewLayout.Form} size={'small'} />,
+              testId: 'add-form-button',
+              onSelect: () => handleAddPage(ViewLayout.Form, t('document.plugins.database.newDatabase')),
+            },
+          ]
+        : []),
       {
         label: t('list.menuName'),
         icon: <ViewIcon layout={ViewLayout.List} size={'small'} />,

--- a/src/components/app/view-actions/__tests__/AddPageActions.test.tsx
+++ b/src/components/app/view-actions/__tests__/AddPageActions.test.tsx
@@ -33,6 +33,14 @@ const mockUpdatePage = jest.fn();
 const mockFlush = jest.fn();
 const mockScheduleDeferredCleanup = jest.fn();
 const mockMenuSelectPreventDefault = jest.fn();
+let mockFormViewCreationEnabled = false;
+
+jest.mock('@/application/constants', () => ({
+  ...jest.requireActual('@/application/constants'),
+  get FORM_VIEW_CREATION_ENABLED() {
+    return mockFormViewCreationEnabled;
+  },
+}));
 
 jest.mock('react-i18next', () => ({
   useTranslation: () => ({
@@ -210,6 +218,7 @@ function createLinkedListUpdate(databaseDoc: YDoc): number[] {
 describe('AddPageActions', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockFormViewCreationEnabled = false;
     mockAddPage.mockReset();
     mockAddPage.mockResolvedValue({ view_id: 'chat-id' });
     mockUpdateChatSettings.mockResolvedValue(undefined);
@@ -226,12 +235,22 @@ describe('AddPageActions', () => {
     mockUpdatePage.mockResolvedValue(undefined);
   });
 
-  it('shows Form and creates it without checking a workspace subscription', async () => {
+  it('hides Form while form creation is disabled on web', () => {
+    renderActions(view({ view_id: 'parent-id' }));
+
+    expect(screen.queryByTestId('add-form-button')).toBeNull();
+    expect(screen.getByTestId('add-grid-button')).toBeTruthy();
+    expect(screen.getByTestId('add-list-button')).toBeTruthy();
+    expect(mockAddPage).not.toHaveBeenCalled();
+  });
+
+  it('shows Form and creates it without checking a workspace subscription once form creation is enabled', async () => {
     const parent = view({
       view_id: 'parent-id',
       children: [view({ view_id: 'last-child-id' })],
     });
 
+    mockFormViewCreationEnabled = true;
     mockAddPage.mockResolvedValueOnce({ view_id: 'form-view-id', database_id: 'database-id' });
     renderActions(parent);
 

--- a/src/components/database/components/tabs/AddViewButton.tsx
+++ b/src/components/database/components/tabs/AddViewButton.tsx
@@ -2,6 +2,7 @@ import { useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { toast } from 'sonner';
 
+import { FORM_VIEW_CREATION_ENABLED } from '@/application/constants';
 import { useAddDatabaseView } from '@/application/database-yjs/dispatch';
 import { DatabaseViewLayout, ViewLayout } from '@/application/types';
 import { ReactComponent as PlusIcon } from '@/assets/icons/plus.svg';
@@ -141,15 +142,17 @@ export function AddViewButton({ databasePageId, onBeforeAddView, onAfterAddView,
           {t('chart.menuName')}
         </DropdownMenuItem>
 
-        <DropdownMenuItem
-          data-testid='add-form-view-option'
-          onClick={() => {
-            void handleAddView(DatabaseViewLayout.Form, t('form.builderName', { defaultValue: 'Form builder' }));
-          }}
-        >
-          <ViewIcon layout={ViewLayout.Form} size={'small'} />
-          {t('form.builderName', { defaultValue: 'Form builder' })}
-        </DropdownMenuItem>
+        {FORM_VIEW_CREATION_ENABLED && (
+          <DropdownMenuItem
+            data-testid='add-form-view-option'
+            onClick={() => {
+              void handleAddView(DatabaseViewLayout.Form, t('form.builderName', { defaultValue: 'Form builder' }));
+            }}
+          >
+            <ViewIcon layout={ViewLayout.Form} size={'small'} />
+            {t('form.builderName', { defaultValue: 'Form builder' })}
+          </DropdownMenuItem>
+        )}
 
         <DropdownMenuItem
           data-testid='add-list-view-button'

--- a/src/components/database/components/tabs/__tests__/AddViewButton.test.tsx
+++ b/src/components/database/components/tabs/__tests__/AddViewButton.test.tsx
@@ -7,6 +7,14 @@ import { AddViewButton } from '@/components/database/components/tabs/AddViewButt
 import type { ButtonHTMLAttributes, ReactNode } from 'react';
 
 const mockAddView = jest.fn();
+let mockFormViewCreationEnabled = false;
+
+jest.mock('@/application/constants', () => ({
+  ...jest.requireActual('@/application/constants'),
+  get FORM_VIEW_CREATION_ENABLED() {
+    return mockFormViewCreationEnabled;
+  },
+}));
 
 jest.mock('@/application/database-yjs/dispatch', () => ({
   useAddDatabaseView: () => mockAddView,
@@ -56,6 +64,7 @@ jest.mock('@/components/ui/tooltip', () => ({
 describe('AddViewButton', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockFormViewCreationEnabled = false;
     mockAddView.mockResolvedValue('list-view-id');
     jest.spyOn(Date, 'now').mockReturnValueOnce(0).mockReturnValueOnce(300);
   });
@@ -116,7 +125,7 @@ describe('AddViewButton', () => {
     );
 
     mockAddView.mockReturnValue(createPending);
-    fireEvent.click(screen.getByTestId('add-form-view-option'));
+    fireEvent.click(screen.getByTestId('add-list-view-button'));
 
     rendered.rerender(
       <MemoryRouter>
@@ -128,11 +137,11 @@ describe('AddViewButton', () => {
       </MemoryRouter>
     );
 
-    await act(async () => resolveAdd('form-view-id'));
+    await act(async () => resolveAdd('list-view-id'));
 
-    await waitFor(() => expect(latestOnViewAdded).toHaveBeenCalledWith('form-view-id'));
+    await waitFor(() => expect(latestOnViewAdded).toHaveBeenCalledWith('list-view-id'));
     expect(initialOnViewAdded).not.toHaveBeenCalled();
-    expect(committedViewIds).toEqual([['view-a', 'concurrent-view', 'form-view-id']]);
+    expect(committedViewIds).toEqual([['view-a', 'concurrent-view', 'list-view-id']]);
     expect(latestOnAfterAddView).toHaveBeenCalledTimes(1);
     expect(initialOnAfterAddView).not.toHaveBeenCalled();
     expect(screen.getByTestId('add-view-button').hasAttribute('disabled')).toBe(false);
@@ -158,7 +167,7 @@ describe('AddViewButton', () => {
     );
 
     mockAddView.mockReturnValue(createPending);
-    fireEvent.click(screen.getByTestId('add-form-view-option'));
+    fireEvent.click(screen.getByTestId('add-list-view-button'));
 
     rendered.rerender(
       <MemoryRouter>
@@ -170,7 +179,7 @@ describe('AddViewButton', () => {
       </MemoryRouter>
     );
 
-    await act(async () => resolveAdd('stale-form-view-id'));
+    await act(async () => resolveAdd('stale-list-view-id'));
 
     expect(initialOnViewAdded).not.toHaveBeenCalled();
     expect(initialOnAfterAddView).not.toHaveBeenCalled();
@@ -178,9 +187,22 @@ describe('AddViewButton', () => {
     expect(nextOnAfterAddView).not.toHaveBeenCalled();
   });
 
-  it('creates a Form without checking a workspace subscription', async () => {
+  it('hides the Form option while form creation is disabled on web', () => {
+    render(
+      <MemoryRouter>
+        <AddViewButton databasePageId='database-page-id' onViewAdded={jest.fn()} />
+      </MemoryRouter>
+    );
+
+    expect(screen.queryByTestId('add-form-view-option')).toBeNull();
+    expect(screen.getByTestId('add-list-view-button')).toBeTruthy();
+    expect(mockAddView).not.toHaveBeenCalled();
+  });
+
+  it('creates a Form without checking a workspace subscription once form creation is enabled', async () => {
     const onViewAdded = jest.fn();
 
+    mockFormViewCreationEnabled = true;
     mockAddView.mockResolvedValue('form-view-id');
     render(
       <MemoryRouter>


### PR DESCRIPTION
## Summary

Legacy Desktop clients error when a workspace contains a Form view that was created by web. Until those clients are upgraded, Forms may only be created from Desktop.

This adds a single boolean, `FORM_VIEW_CREATION_ENABLED` (default `false`) in `src/application/constants.ts`, and hides the two web entry points that create Form views behind it:

- the "Form builder" item in the database tab-bar `+` menu (`AddViewButton.tsx`)
- the "Form" item in the sidebar add-page menu (`AddPageActions.tsx`)

Flip the constant to `true` to restore both items once Desktop is ready.

## Scope notes

- Existing Form views still open and render normally. Only creation is hidden.
- Duplicating an existing Form page (or a published template containing one) is intentionally left open. Any Form that exists was created on Desktop, so Desktop already handles it.
- The form BDD features under `playwright/bdd/features/form` create forms via the tab-bar menu and will fail locally while the flag is off. They are not part of any CI shard. A pointer comment was added in `playwright/support/form-test-helpers.ts`.

## Test plan

- [x] `AddViewButton.test.tsx` and `AddPageActions.test.tsx` mock the constant with a getter; new cases assert the Form option is absent when the flag is off, and the original creation cases run with the flag forced on
- [x] Surrounding suites in `src/components/database/components/tabs` and `src/components/app/view-actions` pass (17 suites, 182 tests)
- [x] `pnpm type-check` clean
- [x] eslint clean on all changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013ERijdq6ZqUt9XLJs5A4J9

## Summary by Sourcery

Temporarily disable web-based Form view creation until legacy Desktop clients can support web-created Form views.

Enhancements:
- Gate web Form view creation behind the disabled-by-default `FORM_VIEW_CREATION_ENABLED` flag, hiding both Form creation menu entries while preserving existing Form view behavior.

Tests:
- Update component tests to cover disabled and enabled Form creation states.

Chores:
- Document that Form-related Playwright BDD scenarios require the creation flag to be enabled.