### PR TITLE
fix: improve popup dialog contrast

### DIFF
--- a/src/components/app/ViewModal.tsx
+++ b/src/components/app/ViewModal.tsx
@@ -335,7 +335,7 @@ function ViewModal({ viewId, open, onClose }: { viewId?: string; open: boolean; 
 
     return (
       <div
-        className={'sticky top-0 z-[10] flex w-full items-center justify-between gap-2 bg-background-primary px-4 py-4'}
+        className={'sticky top-0 z-[10] flex w-full items-center justify-between gap-2 bg-surface-primary px-4 py-4'}
       >
         <div className={'flex items-center gap-4'}>
           <Tooltip title={t('tooltip.openAsPage')}>

--- a/src/components/error/ErrorModal.tsx
+++ b/src/components/error/ErrorModal.tsx
@@ -11,7 +11,7 @@ export const ErrorModal = ({ message, onClose }: { message: string; onClose: () 
     <div className={'fixed inset-0 z-10 flex items-center justify-center bg-bg-mask backdrop-blur-sm'}>
       <div
         className={
-          'border-shade-5 relative flex flex-col items-center gap-8 rounded-xl border border-border-primary bg-background-primary px-16 py-8 shadow-md'
+          'relative flex flex-col items-center gap-8 rounded-xl border border-border-primary bg-surface-primary px-16 py-8 shadow-dialog'
         }
       >
         <button

--- a/src/components/main/AppTheme.tsx
+++ b/src/components/main/AppTheme.tsx
@@ -183,7 +183,9 @@ function AppTheme({ children }: { children: React.ReactNode }) {
               },
               paper: {
                 borderRadius: '12px',
-                backgroundColor: 'var(--background-primary)',
+                backgroundColor: 'var(--surface-primary)',
+                border: '1px solid var(--border-primary)',
+                boxShadow: 'var(--custom-shadow-md)',
               },
             },
             defaultProps: {

--- a/src/components/ui/alert-dialog.tsx
+++ b/src/components/ui/alert-dialog.tsx
@@ -52,7 +52,7 @@ function AlertDialogContent({
       <AlertDialogPrimitive.Content
         data-slot='alert-dialog-content'
         className={cn(
-          'fixed left-[50%] top-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-500 border bg-background-primary px-5 py-4 shadow-dialog duration-200 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-1/2 sm:max-w-lg',
+          'fixed left-[50%] top-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-500 border border-border-primary bg-surface-primary px-5 py-4 shadow-dialog duration-200 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-1/2 sm:max-w-lg',
           className
         )}
         {...props}

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -52,7 +52,7 @@ const DialogOverlay = forwardRef<HTMLDivElement>(
 const dialogVariants = cva(
   cn(
     // Base appearance
-    'bg-background-primary rounded-500 shadow-dialog',
+    'bg-surface-primary rounded-500 border border-border-primary shadow-dialog',
 
     // Positioning and sizing
     'fixed top-[50%] left-[50%] z-50',


### PR DESCRIPTION
### Description

Dark-mode popups used the page background and lacked a visible border, making their edges difficult to distinguish. Use desktop AFModal's surface color (`#272930`, versus the page's `#21232A`), a 1px theme border, and the medium dialog shadow across MUI and Radix dialogs. Keep the page popup header and error dialog consistent with that surface.

### Validation

- `pnpm type-check` passed.
- ESLint on all five changed files: no errors; seven existing warnings.
- Four existing Jest suites passed: 10 tests covering row details, normal/confirmation dialogs, and page-modal permission cleanup.
- Eight isolated Chromium previews passed across light/dark MUI, Radix, and alert dialogs, including MUI dialogs without a backdrop. Confirmed computed colors, borders, shadows, and no browser runtime errors.

### Checklist

- [x] Relevant behavior and desktop reference documented above.
- [ ] Additional browsers/operating systems tested (validation used Chromium on macOS).
- [x] Existing modal regression tests passed; no new tests added for this styling-only change.
- [x] Feature preview requirement not applicable: no feature added.

## Summary by Sourcery

Bug Fixes:
- Improve popup and dialog contrast by using the surface color, visible theme borders, and consistent dialog shadows across MUI, Radix, page, and error dialogs.