### PR TITLE
ci: open a compatibility review PR on release tags

### DIFF
--- a/.github/workflows/compatibility_review.yml
+++ b/.github/workflows/compatibility_review.yml
@@ -1,0 +1,134 @@
+name: Compatibility Review PR
+run-name: Review web/server compatibility for ${{ inputs.version || github.ref_name }}
+
+# Vite refuses to build a release whose version is newer than
+# `reviewed_through_client_version` in web-server-compatibility.json. This workflow
+# opens a pull request that advances that boundary so the release can build.
+#
+# Preferred: run it manually with the upcoming version BEFORE pushing the tag, merge the
+# PR, then tag. The Docker build then passes on the first try.
+# Fallback: it also runs on every release tag push, so a forgotten review still gets a PR.
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+      - '*.*.*'
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Web release version to review (e.g. 0.18.1). Run before pushing the tag.'
+        required: true
+        type: string
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ inputs.version || github.ref_name }}
+  cancel-in-progress: false
+
+jobs:
+  review-pr:
+    runs-on: ubuntu-latest
+    env:
+      # A personal access token lets Web-CI run on the PR; the default GITHUB_TOKEN cannot
+      # start workflows on pull requests it opens.
+      GH_TOKEN: ${{ secrets.CI_TOKEN || secrets.GITHUB_TOKEN }}
+      BASE_BRANCH: ${{ github.event.repository.default_branch }}
+    steps:
+      - name: Check out ${{ github.event.repository.default_branch }}
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          token: ${{ secrets.CI_TOKEN || secrets.GITHUB_TOKEN }}
+
+      - name: Advance reviewed_through_client_version
+        id: bump
+        env:
+          RELEASE_VERSION: ${{ inputs.version || github.ref_name }}
+        run: node scripts/review-compatibility.cjs "$RELEASE_VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Nothing to review
+        if: steps.bump.outputs.changed != 'true'
+        run: |
+          echo "web-server-compatibility.json already covers ${{ steps.bump.outputs.version }} (reviewed through ${{ steps.bump.outputs.previous }}). No PR needed." >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Open pull request
+        if: steps.bump.outputs.changed == 'true'
+        env:
+          VERSION: ${{ steps.bump.outputs.version }}
+          PREVIOUS: ${{ steps.bump.outputs.previous }}
+          MIN_SERVER: ${{ steps.bump.outputs.min_server }}
+          TAG_ALREADY_PUSHED: ${{ github.event_name == 'push' }}
+          TAG_NAME: ${{ github.ref_name }}
+        run: |
+          BRANCH="chore/compatibility-review-${VERSION}"
+          TITLE="chore: review web/server compatibility for ${VERSION}"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -B "$BRANCH"
+          git add src/application/compatibility/web-server-compatibility.json
+          git commit -m "$TITLE"
+          # This branch belongs to the workflow; re-running regenerates it.
+          git push --force origin "$BRANCH"
+
+          if [ "$TAG_ALREADY_PUSHED" = "true" ]; then
+            NEXT_STEPS=$(cat <<STEPS
+          The Docker build for tag \`${TAG_NAME}\` ran against the old policy and failed at the
+          compatibility gate. After merging, move the tag onto the merged commit to rebuild:
+
+          \`\`\`
+          git fetch origin ${BASE_BRANCH}
+          git tag -f ${TAG_NAME} origin/${BASE_BRANCH}
+          git push -f origin ${TAG_NAME}
+          \`\`\`
+          STEPS
+          )
+          else
+            NEXT_STEPS=$(cat <<STEPS
+          After merging, push the release tag from \`${BASE_BRANCH}\`. The Docker build will pass
+          the compatibility gate:
+
+          \`\`\`
+          git fetch origin ${BASE_BRANCH}
+          git tag ${VERSION} origin/${BASE_BRANCH}
+          git push origin ${VERSION}
+          \`\`\`
+          STEPS
+          )
+          fi
+
+          BODY=$(cat <<BODY
+          Web \`${VERSION}\` is newer than the reviewed web/server compatibility boundary
+          (\`${PREVIOUS}\`), so \`vite build\` refuses to produce it. This PR advances
+          \`reviewed_through_client_version\` to \`${VERSION}\`.
+
+          ## Review before merging
+
+          - [ ] Does web ${VERSION} need a newer AppFlowy-Cloud than the current floor (\`${MIN_SERVER}\`)?
+                If so, add a row to \`src/application/compatibility/web-server-compatibility.json\`
+                with \`client_from: "${VERSION}"\`, the new \`min_server\`, and a reason.
+          - [ ] If the server requirement is unchanged, this version bump alone is enough.
+
+          ## After merging
+
+          ${NEXT_STEPS}
+
+          See \`doc/web-server-compatibility.md\` for how the policy works.
+
+          _Opened automatically by the Compatibility Review PR workflow._
+          BODY
+          )
+
+          EXISTING=$(gh pr list --head "$BRANCH" --base "$BASE_BRANCH" --state open --json url --jq '.[0].url // empty')
+
+          if [ -n "$EXISTING" ]; then
+            gh pr edit "$EXISTING" --title "$TITLE" --body "$BODY"
+            echo "Updated existing PR: $EXISTING" >> "$GITHUB_STEP_SUMMARY"
+          else
+            URL=$(gh pr create --base "$BASE_BRANCH" --head "$BRANCH" --title "$TITLE" --body "$BODY")
+            echo "Opened PR: $URL" >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/doc/web-server-compatibility.md
+++ b/doc/web-server-compatibility.md
@@ -17,6 +17,16 @@ reviewed boundary is advanced. The initial policy requires server 0.18.1 for
 web 0.17.1. Unknown/unreviewed web versions do not produce old-server warnings.
 There is no appcast or native update gate on web.
 
+The "Compatibility Review PR" workflow
+(`.github/workflows/compatibility_review.yml`) makes that bump for you. Run it
+from the Actions tab with the upcoming version before tagging, or let it run on
+the release tag push. It opens a pull request that advances the reviewed
+boundary; check whether the release needs a new `min_server` row, merge, then
+push (or move) the release tag. Locally,
+`node scripts/review-compatibility.cjs <version>` applies the same change. The
+script refuses a version at or above `max_enforceable_client_floor`; raise that
+cap by hand first.
+
 `GET /api/server-info`, with `x-platform: web`, must expose:
 
 ```json

--- a/scripts/review-compatibility.cjs
+++ b/scripts/review-compatibility.cjs
@@ -1,0 +1,132 @@
+#!/usr/bin/env node
+/**
+ * Advance `reviewed_through_client_version` in web-server-compatibility.json to a web release version.
+ *
+ * Vite refuses to build a release whose version is newer than the reviewed boundary (see
+ * vite.config.ts), so every release must move it. The "Compatibility Review PR" workflow runs
+ * this in CI and opens a pull request with the result. Run it locally to prepare a release:
+ *
+ *   node scripts/review-compatibility.cjs 0.18.1          # update the policy file
+ *   node scripts/review-compatibility.cjs 0.18.1 --check  # report only, never write
+ *
+ * Stdout carries GitHub Actions outputs (`changed=`, `version=`, `previous=`, `min_server=`);
+ * human-readable messages go to stderr. Exits non-zero when the version is invalid or when the
+ * policy's `max_enforceable_client_floor` would no longer be above the reviewed version.
+ */
+const fs = require('fs');
+const path = require('path');
+
+const POLICY_PATH = path.resolve(__dirname, '../src/application/compatibility/web-server-compatibility.json');
+
+function log(message) {
+  process.stderr.write(`${message}\n`);
+}
+
+function fail(message) {
+  log(process.env.GITHUB_ACTIONS === 'true' ? `::error::${message}` : message);
+  process.exit(1);
+}
+
+function output(name, value) {
+  process.stdout.write(`${name}=${value}\n`);
+}
+
+/** Minimal SemVer parser matching how vite.config.ts and evaluate.ts normalize versions. */
+function parseVersion(raw) {
+  const match = /^[vV]?(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z.-]+))?(?:\+[0-9A-Za-z.-]+)?$/.exec(String(raw ?? '').trim());
+
+  if (!match) return null;
+
+  return {
+    main: [Number(match[1]), Number(match[2]), Number(match[3])],
+    prerelease: match[4] ? match[4].split('.') : [],
+    version: `${match[1]}.${match[2]}.${match[3]}${match[4] ? `-${match[4]}` : ''}`,
+  };
+}
+
+function compareIdentifiers(a, b) {
+  const aNumeric = /^\d+$/.test(a);
+  const bNumeric = /^\d+$/.test(b);
+
+  if (aNumeric && bNumeric) return Math.sign(Number(a) - Number(b));
+  if (aNumeric) return -1;
+  if (bNumeric) return 1;
+
+  return a < b ? -1 : a > b ? 1 : 0;
+}
+
+function compareVersions(a, b) {
+  for (let i = 0; i < 3; i += 1) {
+    if (a.main[i] !== b.main[i]) return a.main[i] < b.main[i] ? -1 : 1;
+  }
+
+  if (a.prerelease.length === 0 && b.prerelease.length === 0) return 0;
+  if (a.prerelease.length === 0) return 1;
+  if (b.prerelease.length === 0) return -1;
+
+  const length = Math.max(a.prerelease.length, b.prerelease.length);
+
+  for (let i = 0; i < length; i += 1) {
+    if (a.prerelease[i] === undefined) return -1;
+    if (b.prerelease[i] === undefined) return 1;
+
+    const result = compareIdentifiers(a.prerelease[i], b.prerelease[i]);
+
+    if (result !== 0) return result;
+  }
+
+  return 0;
+}
+
+function main() {
+  const args = process.argv.slice(2);
+  const checkOnly = args.includes('--check');
+  const rawVersion = args.find((arg) => !arg.startsWith('--'));
+
+  if (!rawVersion) fail('Usage: node scripts/review-compatibility.cjs <version> [--check]');
+
+  const release = parseVersion(rawVersion);
+
+  if (!release) fail(`"${rawVersion}" is not a release version (expected major.minor.patch).`);
+
+  const source = fs.readFileSync(POLICY_PATH, 'utf8');
+  const policy = JSON.parse(source);
+  const reviewed = parseVersion(policy.reviewed_through_client_version);
+  const cap = parseVersion(policy.max_enforceable_client_floor);
+  const lastRow = Array.isArray(policy.rows) ? policy.rows[policy.rows.length - 1] : undefined;
+
+  if (!reviewed || !cap || !lastRow?.min_server) fail(`${POLICY_PATH} is missing required fields.`);
+
+  output('version', release.version);
+  output('previous', reviewed.version);
+  output('min_server', lastRow.min_server);
+
+  if (compareVersions(release, reviewed) <= 0) {
+    output('changed', 'false');
+    log(`Already reviewed through ${reviewed.version}; nothing to do for ${release.version}.`);
+    return;
+  }
+
+  if (compareVersions(release, cap) >= 0) {
+    fail(
+      `max_enforceable_client_floor (${cap.version}) must stay above the reviewed version. ` +
+        `Raise it in web-server-compatibility.json before reviewing ${release.version}.`
+    );
+  }
+
+  output('changed', 'true');
+
+  if (checkOnly) {
+    log(`reviewed_through_client_version would move ${reviewed.version} -> ${release.version} (check only).`);
+    return;
+  }
+
+  const updated = source.replace(/("reviewed_through_client_version":\s*")[^"]*(")/, `$1${release.version}$2`);
+
+  if (updated === source) fail('Could not find reviewed_through_client_version in the policy file.');
+
+  fs.writeFileSync(POLICY_PATH, updated);
+  log(`reviewed_through_client_version: ${reviewed.version} -> ${release.version}`);
+}
+
+main();

--- a/src/application/compatibility/__tests__/evaluate.test.ts
+++ b/src/application/compatibility/__tests__/evaluate.test.ts
@@ -65,8 +65,10 @@ describe('web/server compatibility', () => {
   });
 
   it('fails open for an unknown or unreviewed installed build', () => {
+    const unreviewedClientVersion = normalizeVersion(policy.reviewed_through_client_version)!.inc('patch').version;
+
     expect(evaluate('0.1.0', undefined, 'manual-build')).toEqual({ type: 'unknown', reason: 'client-version' });
-    expect(evaluate('0.1.0', undefined, '0.17.2')).toEqual({ type: 'unknown', reason: 'unreviewed-client' });
+    expect(evaluate('0.1.0', undefined, unreviewedClientVersion)).toEqual({ type: 'unknown', reason: 'unreviewed-client' });
     expect(evaluate('0.18.1', '0.17.3', '0.17.2').type).toBe('client-too-old');
   });
 

--- a/src/application/compatibility/web-server-compatibility.json
+++ b/src/application/compatibility/web-server-compatibility.json
@@ -1,6 +1,6 @@
 {
   "_comment": "Web and desktop have independent release versions. Review this table when releasing web; rows specify the minimum AppFlowy-Cloud version for each web release range.",
-  "reviewed_through_client_version": "0.17.1",
+  "reviewed_through_client_version": "0.18.0",
   "max_enforceable_client_floor": "0.20.0",
   "rows": [
     {


### PR DESCRIPTION
## Why

The `0.18.0` Docker build ([run 34326260829](https://github.com/AppFlowy-IO/AppFlowy-Web/actions/runs/34326260829)) failed at the Vite compatibility gate added in #531:

```
Error: Review web-server-compatibility.json for web 0.18.0 before building this release.
```

The gate rejects any release version newer than `reviewed_through_client_version` in `web-server-compatibility.json`, so every release (patch releases included) needs that field bumped first. This PR automates the bump and unblocks 0.18.0.

## What

- **New workflow `Compatibility Review PR`** (`.github/workflows/compatibility_review.yml`)
  - Runs on the same release tag patterns as the Docker build, and manually via `workflow_dispatch` with a `version` input.
  - Checks out the default branch, runs the bump script, and opens a PR that advances `reviewed_through_client_version`. Re-runs update the existing PR instead of duplicating it. No PR if the policy already covers the version.
  - Uses `CI_TOKEN` so Web-CI runs on the PR it opens (the default `GITHUB_TOKEN` cannot start workflows on PRs it creates); falls back to `GITHUB_TOKEN`.
  - The PR body carries a review checklist (does this release need a new `min_server` row?) and the exact commands for after merging: push the tag, or move it if it was already pushed.
- **`scripts/review-compatibility.cjs`**: dependency-free bump script, also usable locally. `--check` reports without writing. Refuses a version at or above `max_enforceable_client_floor` (currently 0.20.0), which must be raised by hand.
- **Review 0.18.0** so the pending tag can build. The existing 0.18.1 server floor is unchanged.
- **`evaluate.test.ts`**: the "unreviewed client" case derives its version from the policy instead of a hardcoded `0.17.2`, so it no longer breaks on every bump.
- **`doc/web-server-compatibility.md`** documents the flow.

## Release flow after this

Preferred: run the workflow with the upcoming version, merge the PR, push the tag. The Docker build passes first time.

Fallback: push the tag first. The Docker build fails once, the workflow opens the PR, and after merging you move the tag onto the merged commit.

## Verification

- Script exercised on no-op, bump, `v` prefix, `--check`, prerelease, cap violation and invalid input.
- Workflow YAML parsed; the PR step was dry-run with stubbed `git`/`gh` for both trigger paths and rendered the expected body.
- `jest src/application/compatibility`: 33/33 pass.
- `APPFLOWY_WEB_VERSION=0.18.0 pnpm run build` exits 0.
- Not run: actionlint (not installed locally). The workflow itself can only be exercised once merged.

## After merging

Move the `0.18.0` tag onto the merged commit to rebuild the image:

```
git fetch origin main
git tag -f 0.18.0 origin/main
git push -f origin 0.18.0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013M1rm3ve4YutTy3Cwi9XRC

## Summary by Sourcery

Automate compatibility policy reviews before or after web releases so release builds are unblocked while preserving an explicit server-compatibility check.

New Features:
- Add an automated compatibility review workflow that opens or updates a pull request for release versions not yet covered by the compatibility policy.
- Add a reusable script for validating and advancing the reviewed client-version boundary, including dry-run support and enforcement-cap checks.

Bug Fixes:
- Review web version 0.18.0 so its release build can pass the compatibility gate.
- Make compatibility tests derive unreviewed versions from the policy instead of relying on a fixed version.

CI:
- Run compatibility review automatically on release tags or manually for an upcoming version, with release-specific guidance for completing the tag flow.

Documentation:
- Document the automated compatibility review and local version-review workflow.