### PR TITLE
chore: review web/server compatibility for 0.18.1

### DIFF
--- a/src/application/compatibility/web-server-compatibility.json
+++ b/src/application/compatibility/web-server-compatibility.json
@@ -1,6 +1,6 @@
 {
   "_comment": "Web and desktop have independent release versions. Review this table when releasing web; rows specify the minimum AppFlowy-Cloud version for each web release range.",
-  "reviewed_through_client_version": "0.18.0",
+  "reviewed_through_client_version": "0.18.1",
   "max_enforceable_client_floor": "0.20.0",
   "rows": [
     {


### PR DESCRIPTION
Web `0.18.1` is newer than the reviewed web/server compatibility boundary
(`0.18.0`), so `vite build` refuses to produce it. This PR advances
`reviewed_through_client_version` to `0.18.1`.

## Review before merging

- [ ] Does web 0.18.1 need a newer AppFlowy-Cloud than the current floor (`0.18.1`)?
      If so, add a row to `src/application/compatibility/web-server-compatibility.json`
      with `client_from: "0.18.1"`, the new `min_server`, and a reason.
- [ ] If the server requirement is unchanged, this version bump alone is enough.

## After merging

The Docker build for tag `0.18.1` ran against the old policy and failed at the
compatibility gate. After merging, move the tag onto the merged commit to rebuild:

```
git fetch origin main
git tag -f 0.18.1 origin/main
git push -f origin 0.18.1
```

See `doc/web-server-compatibility.md` for how the policy works.

_Opened automatically by the Compatibility Review PR workflow._

## Summary by Sourcery

Enhancements:
- Advance the reviewed web/server compatibility boundary to web version 0.18.1.