### PR TITLE
test: derive compatibility banner fixtures from the policy

### DIFF
--- a/src/components/app/compatibility/__tests__/ClientCompatibilityBanner.test.tsx
+++ b/src/components/app/compatibility/__tests__/ClientCompatibilityBanner.test.tsx
@@ -1,14 +1,23 @@
 import { fireEvent, render, screen } from '@testing-library/react';
 import { createInstance } from 'i18next';
 import { I18nextProvider } from 'react-i18next';
+import inc from 'semver/functions/inc';
 
 import en from '@/@types/translations/en.json';
+import policy from '@/application/compatibility/web-server-compatibility.json';
 import type { ServerInfo } from '@/application/services/js-services/http/auth-api';
 
 import { ClientCompatibilityProvider } from '../ClientCompatibility';
 import { ClientCompatibilityBanner } from '../ClientCompatibilityBanner';
 
 const i18n = createInstance();
+
+// Jest injects no build version, so the banner reports the policy's reviewed version. Derive the
+// fixtures from the policy so advancing it for a release does not break these tests.
+const CLIENT = policy.reviewed_through_client_version;
+const NEWER_CLIENT = inc(CLIENT, 'patch')!;
+const NEWEST_CLIENT = inc(NEWER_CLIENT, 'patch')!;
+const REQUIRED_SERVER = policy.rows[policy.rows.length - 1].min_server;
 
 beforeAll(async () => {
   await i18n.init({ lng: 'en', resources: { en: { translation: en } }, interpolation: { escapeValue: false } });
@@ -29,7 +38,7 @@ describe('compatibility banner', () => {
   it('shows server versions, leaves editing available, and stays dismissed across navigation and refreshes', () => {
     const view = render(app({ version: '0.17.0' }));
 
-    expect(screen.getByRole('status').textContent).toContain('AppFlowy Web 0.17.1 requires server 0.18.1');
+    expect(screen.getByRole('status').textContent).toContain(`AppFlowy Web ${CLIENT} requires server ${REQUIRED_SERVER}`);
     expect(screen.getByRole('status').textContent).toContain('Your server is 0.17.0');
     expect(screen.queryByRole('button', { name: 'Reload web app' })).toBeNull();
     fireEvent.change(screen.getByRole('textbox'), { target: { value: 'Still editable' } });
@@ -48,11 +57,11 @@ describe('compatibility banner', () => {
   });
 
   it('offers reload only when the required web client can work with the server', () => {
-    const view = render(app({ version: '0.18.1', min_web_client_version: '0.17.2' }));
+    const view = render(app({ version: REQUIRED_SERVER, min_web_client_version: NEWER_CLIENT }));
 
-    expect(screen.getByRole('status').textContent).toContain('requires AppFlowy Web 0.17.2');
+    expect(screen.getByRole('status').textContent).toContain(`requires AppFlowy Web ${NEWER_CLIENT}`);
     expect(screen.getByRole('button', { name: 'Reload web app' })).toBeTruthy();
-    view.rerender(app({ version: '0.17.0', min_web_client_version: '0.17.2' }));
+    view.rerender(app({ version: '0.17.0', min_web_client_version: NEWER_CLIENT }));
     expect(screen.getByRole('status').textContent).toContain('update both');
     expect(screen.queryByRole('button', { name: 'Reload web app' })).toBeNull();
   });
@@ -64,21 +73,21 @@ describe('compatibility banner', () => {
     expect(screen.queryByRole('status')).toBeNull();
     view.rerender(app({ version: '0.17.0' }));
     fireEvent.click(screen.getByRole('button', { name: 'Dismiss compatibility warning' }));
-    view.rerender(app({ version: '0.18.1' }));
+    view.rerender(app({ version: REQUIRED_SERVER }));
     view.rerender(app({ version: '0.17.0' }));
     expect(screen.getByRole('status')).toBeTruthy();
   });
 
   it('reopens for a new demand or server and ignores native-client minimums', () => {
-    const view = render(app({ version: '0.18.1', min_web_client_version: '0.17.2' }));
+    const view = render(app({ version: REQUIRED_SERVER, min_web_client_version: NEWER_CLIENT }));
 
     fireEvent.click(screen.getByRole('button', { name: 'Dismiss compatibility warning' }));
-    view.rerender(app({ version: '0.18.1', min_web_client_version: '0.17.3' }));
-    expect(screen.getByRole('status').textContent).toContain('0.17.3');
+    view.rerender(app({ version: REQUIRED_SERVER, min_web_client_version: NEWEST_CLIENT }));
+    expect(screen.getByRole('status').textContent).toContain(NEWEST_CLIENT);
     fireEvent.click(screen.getByRole('button', { name: 'Dismiss compatibility warning' }));
-    view.rerender(app({ version: '0.18.1', min_web_client_version: '0.17.3' }, 'https://other-server'));
+    view.rerender(app({ version: REQUIRED_SERVER, min_web_client_version: NEWEST_CLIENT }, 'https://other-server'));
     expect(screen.getByRole('status')).toBeTruthy();
-    view.rerender(app({ version: '0.18.1', ...{ min_client_version: '0.19.0' } }));
+    view.rerender(app({ version: REQUIRED_SERVER, ...{ min_client_version: '0.19.0' } }));
     expect(screen.queryByRole('status')).toBeNull();
   });
 });


### PR DESCRIPTION
## Why

The `Web Code Coverage` job on #536 failed three `compatibility banner` tests:

```
Expected substring: "AppFlowy Web 0.17.1 requires server 0.18.1"
Received string:    "AppFlowy Web 0.18.0 requires server 0.18.1 or later. ..."
```

Jest injects no `__APPFLOWY_WEB_VERSION__`, so the banner reports `reviewed_through_client_version` from `web-server-compatibility.json`. The tests hardcoded that as `0.17.1`, and `0.17.2` / `0.17.3` as server-demanded client floors that had to be above it. Bumping the reviewed version to 0.18.0 broke all three, and every automated review PR (starting with #537) would break them again.

## What

`ClientCompatibilityBanner.test.tsx` now reads the reviewed version and the current server floor from the policy, and derives the demanded client floors by incrementing the patch version. Version-only bumps keep the tests green.

Deliberately adding a new server-floor row still changes expectations in `evaluate.test.ts`, which asserts behaviour at specific versions. That is intended: a new row is a real behaviour change.

## Verification

- `jest src/components/app/compatibility src/application/compatibility`: 37/37 at the current policy (0.18.0), and 37/37 with the policy set to 0.18.1 as #537 will make it.
- `eslint` on the file and `pnpm run type-check` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013M1rm3ve4YutTy3Cwi9XRC

## Summary by Sourcery

Keep compatibility banner tests aligned with the active compatibility policy as versions advance.

Enhancements:
- Derive compatibility banner test fixtures from the server compatibility policy so reviewed-version updates do not require hardcoded test changes.

Tests:
- Update compatibility banner tests to cover policy-defined server requirements and dynamically incremented client versions.