### PR TITLE
fix(outline): scope sidebar expand state per workspace, expand selected page's ancestors

### DIFF
--- a/src/components/_shared/outline/OutlineItem.databaseContainer.test.tsx
+++ b/src/components/_shared/outline/OutlineItem.databaseContainer.test.tsx
@@ -9,6 +9,7 @@ jest.mock('react-i18next', () => ({
 
 jest.mock('@/components/app/app.hooks', () => ({
   useAIEnabled: () => true,
+  useCurrentWorkspaceIdOptional: () => undefined,
 }));
 
 jest.mock('@/components/_shared/outline/OutlineIcon', () => () => null);

--- a/src/components/_shared/outline/OutlineItem.tsx
+++ b/src/components/_shared/outline/OutlineItem.tsx
@@ -6,7 +6,7 @@ import { ReactComponent as PrivateIcon } from '@/assets/icons/lock.svg';
 import OutlineIcon from '@/components/_shared/outline/OutlineIcon';
 import OutlineItemContent from '@/components/_shared/outline/OutlineItemContent';
 import { getOutlineExpands, setOutlineExpands } from '@/components/_shared/outline/utils';
-import { useAIEnabled } from '@/components/app/app.hooks';
+import { useAIEnabled, useCurrentWorkspaceIdOptional } from '@/components/app/app.hooks';
 
 function OutlineItem({
   view,
@@ -29,13 +29,14 @@ function OutlineItem({
     selectedViewId === view.view_id ||
     (isDatabaseContainer(view) && Boolean(view.children?.some((child) => child.view_id === selectedViewId)));
   const aiEnabled = useAIEnabled();
+  const currentWorkspaceId = useCurrentWorkspaceIdOptional();
   const [isExpanded, setIsExpanded] = React.useState(() => {
-    return getOutlineExpands()[view.view_id] || false;
+    return getOutlineExpands(currentWorkspaceId)[view.view_id] || false;
   });
 
   useEffect(() => {
-    setOutlineExpands(view.view_id, isExpanded);
-  }, [isExpanded, view.view_id]);
+    setOutlineExpands(view.view_id, isExpanded, currentWorkspaceId);
+  }, [isExpanded, view.view_id, currentWorkspaceId]);
 
   const getIcon = useCallback(() => {
     return (

--- a/src/components/_shared/outline/utils.ts
+++ b/src/components/_shared/outline/utils.ts
@@ -177,8 +177,19 @@ export function flattenViews (views: View[]): View[] {
   return result;
 }
 
-export function getOutlineExpands () {
-  const expandView = localStorage.getItem('outline_expanded');
+const LEGACY_EXPAND_KEY = 'outline_expanded';
+
+const expandStorageKey = (workspaceId?: string) =>
+  workspaceId ? `${LEGACY_EXPAND_KEY}_${workspaceId}` : LEGACY_EXPAND_KEY;
+
+export function getOutlineExpands (workspaceId?: string) {
+  // Expand state is scoped per workspace: a single global entry meant that opening one
+  // workspace validated (and pruned) the restored ids of every other workspace, so a
+  // switch always collapsed the target workspace's spaces. Fall back to the legacy global
+  // entry so existing users keep their state; the next write migrates it to the scoped key.
+  const expandView =
+    localStorage.getItem(expandStorageKey(workspaceId)) ??
+    (workspaceId ? localStorage.getItem(LEGACY_EXPAND_KEY) : null);
 
   try {
     return JSON.parse(expandView || '{}');
@@ -187,8 +198,8 @@ export function getOutlineExpands () {
   }
 }
 
-export function setOutlineExpands (viewId: string, isExpanded: boolean) {
-  const expands = getOutlineExpands();
+export function setOutlineExpands (viewId: string, isExpanded: boolean, workspaceId?: string) {
+  const expands = getOutlineExpands(workspaceId);
 
   if (isExpanded) {
     expands[viewId] = true;
@@ -196,7 +207,30 @@ export function setOutlineExpands (viewId: string, isExpanded: boolean) {
     delete expands[viewId];
   }
 
-  localStorage.setItem('outline_expanded', JSON.stringify(expands));
+  localStorage.setItem(expandStorageKey(workspaceId), JSON.stringify(expands));
+}
+
+/**
+ * Return the chain of ancestor view ids for `targetId` within `data`, or null when the view
+ * is not in the tree. Used to expand the ancestors of a view that is already present in the
+ * outline (e.g. after a workspace switch), where no navigation hydration fetch is needed.
+ */
+export function findViewAncestorIds (data: View[], targetId: string, trail: string[] = []): string[] | null {
+  for (const item of data) {
+    if (item.view_id === targetId) {
+      return trail;
+    }
+
+    if (item.children) {
+      const result = findViewAncestorIds(item.children, targetId, [...trail, item.view_id]);
+
+      if (result) {
+        return result;
+      }
+    }
+  }
+
+  return null;
 }
 
 export function findShareWithMeSpace (views: View[]): View | null {

--- a/src/components/app/DatabaseView.tsx
+++ b/src/components/app/DatabaseView.tsx
@@ -306,7 +306,7 @@ function DatabaseView(props: DatabaseViewProps) {
 
         if (ancestorIds?.length) {
           // Hydration does not expand the sidebar. Persist for reloads and notify the mounted outline.
-          ancestorIds.forEach((id) => setOutlineExpands(id, true));
+          ancestorIds.forEach((id) => setOutlineExpands(id, true, workspaceId));
           eventEmitter.emit(APP_EVENTS.OUTLINE_EXPAND_PATH, { workspaceId, ancestorIds });
         }
       } catch (error) {

--- a/src/components/app/outline/Outline.tsx
+++ b/src/components/app/outline/Outline.tsx
@@ -7,7 +7,12 @@ import { Role, View, ViewLayout } from '@/application/types';
 import { isSpaceView } from '@/application/view-utils';
 import { ReactComponent as MoreIcon } from '@/assets/icons/more.svg';
 import { ReactComponent as PlusIcon } from '@/assets/icons/plus.svg';
-import { findView, getOutlineExpands, setOutlineExpands } from '@/components/_shared/outline/utils';
+import {
+  findView,
+  findViewAncestorIds,
+  getOutlineExpands,
+  setOutlineExpands,
+} from '@/components/_shared/outline/utils';
 import DirectoryStructure from '@/components/_shared/skeleton/DirectoryStructure';
 import {
   useAppOutline,
@@ -128,6 +133,7 @@ export function Outline({ width }: { width: number }) {
 
   const loadingViewIdsRef = useRef<Set<string>>(new Set());
   const navigationHydrationInFlightRef = useRef<Set<string>>(new Set());
+  const autoExpandedSelectedPathRef = useRef<Set<string>>(new Set());
   // Selected views that navigation hydration could not place in the outline
   // (not found server-side, or access denied), mapped to a retry-after
   // timestamp. Throttles re-fetching navigation on every `outline` change for
@@ -141,8 +147,12 @@ export function Outline({ width }: { width: number }) {
   const [loadingRevision, setLoadingRevision] = useState(0);
   const [nowMs, setNowMs] = useState(() => Date.now());
   const loadingViewIds = useMemo(() => loadingViewIdsRef.current, [loadingRevision]); // eslint-disable-line react-hooks/exhaustive-deps
-  const [expandViewIds, setExpandViewIds] = React.useState<string[]>(() => Object.keys(getOutlineExpands()));
-  const [pendingAutoLoadIds, setPendingAutoLoadIds] = useState<string[]>(() => Object.keys(getOutlineExpands()));
+  const [expandViewIds, setExpandViewIds] = React.useState<string[]>(() =>
+    Object.keys(getOutlineExpands(currentWorkspaceId))
+  );
+  const [pendingAutoLoadIds, setPendingAutoLoadIds] = useState<string[]>(() =>
+    Object.keys(getOutlineExpands(currentWorkspaceId))
+  );
   const expandViewIdsRef = useRef(expandViewIds);
   const sidebarRevalidationStateRef = useRef(createSidebarOutlineRevalidationScheduleState());
   const rescheduleSidebarRevalidationRef = useRef<() => void>(() => undefined);
@@ -178,7 +188,23 @@ export function Outline({ width }: { width: number }) {
 
   useEffect(() => {
     if (!selectedViewId || !outline || !ensureViewVisibleInOutline) return;
-    if (findView(outline, selectedViewId)) return;
+    if (findView(outline, selectedViewId)) {
+      // The page is already in the outline - e.g. right after a workspace switch, which
+      // navigates to the last-opened page contained in the deep outline - but its ancestors
+      // may be collapsed, which makes the containing space look empty. Expand the chain once
+      // per selected page so a deliberate manual collapse is not fought on later refreshes.
+      const presentAncestorIds = findViewAncestorIds(outline, selectedViewId) ?? [];
+      const autoExpandKey = `${currentWorkspaceId ?? ''}:${selectedViewId}`;
+
+      if (presentAncestorIds.length > 0 && !autoExpandedSelectedPathRef.current.has(autoExpandKey)) {
+        autoExpandedSelectedPathRef.current.add(autoExpandKey);
+        // Persist as well: the workspace-restore effect below rebuilds expandViewIds from
+        // localStorage after mount, which would otherwise clobber this expansion.
+        presentAncestorIds.forEach((id) => setOutlineExpands(id, true, currentWorkspaceId));
+        expandHydratedPath(presentAncestorIds);
+      }
+      return;
+    }
     if (navigationHydrationInFlightRef.current.has(selectedViewId)) return;
     if ((navigationHydrationRetryAfterRef.current.get(selectedViewId) ?? 0) > Date.now()) return;
 
@@ -196,7 +222,7 @@ export function Outline({ width }: { width: number }) {
         }
 
         navigationHydrationRetryAfterRef.current.delete(selectedViewId);
-        ancestorIds.forEach((id) => setOutlineExpands(id, true));
+        ancestorIds.forEach((id) => setOutlineExpands(id, true, currentWorkspaceId));
         expandHydratedPath(ancestorIds);
       })
       .catch((error) => {
@@ -209,7 +235,7 @@ export function Outline({ width }: { width: number }) {
       .finally(() => {
         navigationHydrationInFlightRef.current.delete(selectedViewId);
       });
-  }, [ensureViewVisibleInOutline, expandHydratedPath, outline, selectedViewId]);
+  }, [currentWorkspaceId, ensureViewVisibleInOutline, expandHydratedPath, outline, selectedViewId]);
 
   useEffect(() => {
     sidebarRevalidationStateRef.current = createSidebarOutlineRevalidationScheduleState();
@@ -217,7 +243,7 @@ export function Outline({ width }: { width: number }) {
   }, [outline]);
 
   useEffect(() => {
-    const restoredExpandedIds = Object.keys(getOutlineExpands());
+    const restoredExpandedIds = Object.keys(getOutlineExpands(currentWorkspaceId));
 
     setExpandViewIds(restoredExpandedIds);
     setPendingAutoLoadIds(restoredExpandedIds);
@@ -391,7 +417,7 @@ export function Outline({ width }: { width: number }) {
         const staleSet = new Set(staleIds);
 
         staleIds.forEach((id) => {
-          setOutlineExpands(id, false);
+          setOutlineExpands(id, false, currentWorkspaceId);
           loadingViewIdsRef.current.delete(id);
           autoLoadRetryAfterRef.current.delete(id);
         });
@@ -414,7 +440,7 @@ export function Outline({ width }: { width: number }) {
       .finally(() => {
         unknownIds.forEach((id) => validatingRestoreIdsRef.current.delete(id));
       });
-  }, [outline, pendingAutoLoadIds, loadViewChildrenBatch]);
+  }, [currentWorkspaceId, outline, pendingAutoLoadIds, loadViewChildrenBatch]);
 
   // Drop startup pending ids as soon as they are confirmed loaded.
   useEffect(() => {
@@ -534,10 +560,10 @@ export function Outline({ width }: { width: number }) {
       if (isExpanded) {
         sidebarRevalidationStateRef.current = createSidebarOutlineRevalidationScheduleState();
         rescheduleSidebarRevalidationRef.current();
-        setOutlineExpands(id, true);
+        setOutlineExpands(id, true, currentWorkspaceId);
         setExpandViewIds((prev) => (prev.includes(id) ? prev : [...prev, id]));
       } else {
-        collapsedSubtreeIds.forEach((viewId) => setOutlineExpands(viewId, false));
+        collapsedSubtreeIds.forEach((viewId) => setOutlineExpands(viewId, false, currentWorkspaceId));
         setExpandViewIds((prev) => {
           const next = prev.filter((viewId) => !collapsedSubtreeSet.has(viewId));
 

--- a/src/components/app/outline/__tests__/Outline.navigationContext.test.tsx
+++ b/src/components/app/outline/__tests__/Outline.navigationContext.test.tsx
@@ -243,7 +243,8 @@ describe('Outline navigation context hydration', () => {
     expect(screen.getByText('Target sibling')).toBeTruthy();
     expect(screen.getByText('Root sibling')).toBeTruthy();
     expect(screen.getByTestId(`page-${targetId}`).getAttribute('data-selected')).toBe('true');
-    expect(JSON.parse(localStorage.getItem('outline_expanded') || '{}')).toEqual({
+    // Hydration persists under the workspace-scoped expand key (AppFlowy-Web#526).
+    expect(JSON.parse(localStorage.getItem('outline_expanded_workspace-id') || '{}')).toEqual({
       [spaceId]: true,
       [rootId]: true,
       [parentId]: true,
@@ -291,7 +292,9 @@ describe('Outline navigation context hydration', () => {
 
     expect(global.__outlineNavigationTestEnsureViewVisible).not.toHaveBeenCalled();
     expect(screen.getByTestId(`page-${containerId}`)).toBeTruthy();
-    expect(screen.queryByTestId(`page-${databaseViewId}`)).toBeNull();
+    // The selected page is already present in the outline, so its ancestors are expanded
+    // automatically (AppFlowy-Web#526) without waiting for an expand-path event.
+    expect(screen.getByTestId(`page-${databaseViewId}`)).toBeTruthy();
 
     await act(async () => {
       global.__outlineNavigationTestEventEmitter?.emit(APP_EVENTS.OUTLINE_EXPAND_PATH, {
@@ -299,7 +302,8 @@ describe('Outline navigation context hydration', () => {
         ancestorIds: [spaceId, containerId],
       });
     });
-    expect(screen.queryByTestId(`page-${databaseViewId}`)).toBeNull();
+    // An expand-path event for another workspace is ignored and changes nothing.
+    expect(screen.getByTestId(`page-${databaseViewId}`)).toBeTruthy();
 
     // DatabaseView persists the hydrated path and asks the mounted sidebar to reveal it.
     await act(async () => {
@@ -319,6 +323,48 @@ describe('Outline navigation context hydration', () => {
       render(<Outline width={280} />);
     });
     expect(screen.getByTestId(`page-${databaseViewId}`).getAttribute('data-selected')).toBe('true');
+  });
+
+  it('does not auto-expand collapsed containers that do not contain the selected page', async () => {
+    const databaseViewId = 'hidden-database-view-id';
+    const containerId = 'hidden-container-id';
+    const otherPageId = 'other-page-id';
+
+    global.__outlineNavigationTestOutline = [
+      createView(spaceId, {
+        extra: { is_space: true },
+        children: [
+          createView(containerId, {
+            layout: ViewLayout.Grid,
+            extra: { is_database_container: true },
+            parent_view_id: spaceId,
+            children: [createView(databaseViewId, { layout: ViewLayout.Grid, parent_view_id: containerId })],
+          }),
+          createView(otherPageId, { layout: ViewLayout.Document, parent_view_id: spaceId }),
+        ],
+      }),
+    ];
+    global.__outlineNavigationTestSelectedViewId = otherPageId;
+    global.__outlineNavigationTestEnsureViewVisible = jest.fn().mockResolvedValue([]);
+    global.__outlineNavigationTestToView = jest.fn().mockResolvedValue(undefined);
+    setOutlineExpands(spaceId, true);
+
+    render(<Outline width={280} />);
+
+    // The selected page is visible, but the unrelated collapsed container stays collapsed.
+    expect(screen.getByTestId(`page-${otherPageId}`)).toBeTruthy();
+    expect(screen.queryByTestId(`page-${databaseViewId}`)).toBeNull();
+    expect(global.__outlineNavigationTestEnsureViewVisible).not.toHaveBeenCalled();
+
+    // The event-driven reveal path is unaffected.
+    await act(async () => {
+      global.__outlineNavigationTestEventEmitter?.emit(APP_EVENTS.OUTLINE_EXPAND_PATH, {
+        workspaceId: 'workspace-id',
+        ancestorIds: [spaceId, containerId],
+      });
+    });
+
+    expect(screen.getByTestId(`page-${databaseViewId}`)).toBeTruthy();
   });
 
   it('renders only visible spaces from mixed workspace-root views', () => {

--- a/src/pages/__tests__/DatabaseView.databaseContainer.test.tsx
+++ b/src/pages/__tests__/DatabaseView.databaseContainer.test.tsx
@@ -848,7 +848,13 @@ describe('DatabaseView database container', () => {
         ancestorIds: ['general-space-id', 'new-container-id'],
       });
     });
+    // Expand state is persisted per workspace (AppFlowy-Web#526): the legacy global entry
+    // keeps what was there before, and the hydrated path lands in the workspace-scoped entry
+    // (seeded from the legacy entry on first write).
     expect(getOutlineExpands()).toEqual({
+      'unrelated-expanded-view': true,
+    });
+    expect(getOutlineExpands('test-workspace')).toEqual({
       'unrelated-expanded-view': true,
       'general-space-id': true,
       'new-container-id': true,


### PR DESCRIPTION
Fixes #526.

Confirmed both causes from the report against current main and put together a fix:

1. Expand state is stored in a single global localStorage key (`outline_expanded` in `src/components/_shared/outline/utils.ts`). The validator effect in `Outline.tsx` prunes any restored id it can't find in the current workspace's outline - so after a switch, workspace A's leftover ids are validated against workspace B's tree and deleted, and each workspace's saved state keeps clobbering the other's.
2. On a workspace switch the app navigates to the last-opened page, which is already present in the freshly loaded deep outline. The navigation-hydration effect returns early on `if (findView(outline, selectedViewId)) return;`, so the ancestor-expansion path never runs and the space containing the selected page stays collapsed.

Changes:
- Scope expand state per workspace (`outline_expanded_<workspaceId>`) with a legacy-key read fallback so existing state migrates on first write.
- When the selected view is already in the outline, expand its ancestor chain - once per selected page (ref-gated), so manually collapsing a container containing the selected page still sticks.
- Thread the workspace id through Outline, OutlineItem (favorites/recents), and DatabaseView's hydration persistence.
- Tests: updated the navigation-context and database-container suites for the new behavior, plus a guard test that unrelated collapsed containers are never auto-expanded and the OUTLINE_EXPAND_PATH event flow is unchanged.

Verification: the three touched jest suites (OutlineItem.databaseContainer, Outline.navigationContext, DatabaseView.databaseContainer) run green locally, 25/25 passed (pnpm 10.9.0, `--no-coverage --maxWorkers=1`).

> Built by breken, your AI support engineer - breken.ai - this one's on us.

## Summary by Sourcery

Fix workspace outline state restoration and reveal the selected page’s containing hierarchy.

Bug Fixes:
- Scope outline expansion state to individual workspaces while preserving existing users’ legacy expansion data.
- Automatically expand the selected page’s ancestor chain when the page is already present in the loaded outline, including after workspace switches.

Enhancements:
- Thread workspace context through outline expansion persistence and maintain manual collapsing behavior after selected-page reveal.

Tests:
- Update outline navigation and database-container tests to cover workspace-scoped persistence, selected-page ancestor expansion, unrelated collapsed containers, and unchanged event-driven expansion.