### PR TITLE
ci: merge the compatibility review PR and rebuild the tag automatically

### DIFF
--- a/.github/workflows/compatibility_review.yml
+++ b/.github/workflows/compatibility_review.yml
@@ -2,12 +2,14 @@ name: Compatibility Review PR
 run-name: Review web/server compatibility for ${{ inputs.version || github.ref_name }}
 
 # Vite refuses to build a release whose version is newer than
-# `reviewed_through_client_version` in web-server-compatibility.json. This workflow
-# opens a pull request that advances that boundary so the release can build.
+# `reviewed_through_client_version` in web-server-compatibility.json.
 #
-# Preferred: run it manually with the upcoming version BEFORE pushing the tag, merge the
-# PR, then tag. The Docker build then passes on the first try.
-# Fallback: it also runs on every release tag push, so a forgotten review still gets a PR.
+# On a release tag push this workflow advances that boundary in a pull request, merges it,
+# moves the tag onto the merged commit and starts the Docker build for it. The Docker
+# workflow skips its own build for an uncovered tag, so a release needs no manual step.
+#
+# Run it manually with a version to prepare the bump before tagging. Untick "merge" to get
+# a pull request you review by hand.
 
 on:
   push:
@@ -17,11 +19,17 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Web release version to review (e.g. 0.18.1). Run before pushing the tag.'
+        description: 'Web release version to review (e.g. 0.18.1).'
         required: true
         type: string
+      merge:
+        description: 'Merge the review PR automatically'
+        type: boolean
+        required: false
+        default: true
 
 permissions:
+  actions: write
   contents: write
   pull-requests: write
 
@@ -37,6 +45,7 @@ jobs:
       # start workflows on pull requests it opens.
       GH_TOKEN: ${{ secrets.CI_TOKEN || secrets.GITHUB_TOKEN }}
       BASE_BRANCH: ${{ github.event.repository.default_branch }}
+      AUTO_MERGE: ${{ github.event_name == 'push' || inputs.merge }}
     steps:
       - name: Check out ${{ github.event.repository.default_branch }}
         uses: actions/checkout@v4
@@ -56,12 +65,13 @@ jobs:
           echo "web-server-compatibility.json already covers ${{ steps.bump.outputs.version }} (reviewed through ${{ steps.bump.outputs.previous }}). No PR needed." >> "$GITHUB_STEP_SUMMARY"
 
       - name: Open pull request
+        id: pr
         if: steps.bump.outputs.changed == 'true'
         env:
           VERSION: ${{ steps.bump.outputs.version }}
           PREVIOUS: ${{ steps.bump.outputs.previous }}
           MIN_SERVER: ${{ steps.bump.outputs.min_server }}
-          TAG_ALREADY_PUSHED: ${{ github.event_name == 'push' }}
+          IS_TAG_PUSH: ${{ github.event_name == 'push' }}
           TAG_NAME: ${{ github.ref_name }}
         run: |
           BRANCH="chore/compatibility-review-${VERSION}"
@@ -75,22 +85,28 @@ jobs:
           # This branch belongs to the workflow; re-running regenerates it.
           git push --force origin "$BRANCH"
 
-          if [ "$TAG_ALREADY_PUSHED" = "true" ]; then
+          if [ "$IS_TAG_PUSH" = "true" ]; then
             NEXT_STEPS=$(cat <<STEPS
-          The Docker build for tag \`${TAG_NAME}\` ran against the old policy and failed at the
-          compatibility gate. After merging, move the tag onto the merged commit to rebuild:
+          This PR is merged automatically. The workflow then moves tag \`${TAG_NAME}\` onto the
+          merged commit and starts the Docker build for it; the build that ran on the original
+          tag push skipped itself.
+          STEPS
+          )
+          elif [ "$AUTO_MERGE" = "true" ]; then
+            NEXT_STEPS=$(cat <<STEPS
+          This PR is merged automatically. Then create the release tag from \`${BASE_BRANCH}\`;
+          its Docker build passes the compatibility gate:
 
           \`\`\`
           git fetch origin ${BASE_BRANCH}
-          git tag -f ${TAG_NAME} origin/${BASE_BRANCH}
-          git push -f origin ${TAG_NAME}
+          git tag ${VERSION} origin/${BASE_BRANCH}
+          git push origin ${VERSION}
           \`\`\`
           STEPS
           )
           else
             NEXT_STEPS=$(cat <<STEPS
-          After merging, push the release tag from \`${BASE_BRANCH}\`. The Docker build will pass
-          the compatibility gate:
+          Review and merge this PR, then create the release tag from \`${BASE_BRANCH}\`:
 
           \`\`\`
           git fetch origin ${BASE_BRANCH}
@@ -106,14 +122,11 @@ jobs:
           (\`${PREVIOUS}\`), so \`vite build\` refuses to produce it. This PR advances
           \`reviewed_through_client_version\` to \`${VERSION}\`.
 
-          ## Review before merging
+          The current server floor is AppFlowy-Cloud \`${MIN_SERVER}\`. If web ${VERSION} needs a
+          newer server, add a row to \`src/application/compatibility/web-server-compatibility.json\`
+          with \`client_from: "${VERSION}"\`, the new \`min_server\` and a reason.
 
-          - [ ] Does web ${VERSION} need a newer AppFlowy-Cloud than the current floor (\`${MIN_SERVER}\`)?
-                If so, add a row to \`src/application/compatibility/web-server-compatibility.json\`
-                with \`client_from: "${VERSION}"\`, the new \`min_server\`, and a reason.
-          - [ ] If the server requirement is unchanged, this version bump alone is enough.
-
-          ## After merging
+          ## Next
 
           ${NEXT_STEPS}
 
@@ -127,8 +140,70 @@ jobs:
 
           if [ -n "$EXISTING" ]; then
             gh pr edit "$EXISTING" --title "$TITLE" --body "$BODY"
-            echo "Updated existing PR: $EXISTING" >> "$GITHUB_STEP_SUMMARY"
+            URL="$EXISTING"
+            echo "Updated existing PR: $URL" >> "$GITHUB_STEP_SUMMARY"
           else
             URL=$(gh pr create --base "$BASE_BRANCH" --head "$BRANCH" --title "$TITLE" --body "$BODY")
             echo "Opened PR: $URL" >> "$GITHUB_STEP_SUMMARY"
           fi
+
+          echo "url=$URL" >> "$GITHUB_OUTPUT"
+
+      - name: Merge pull request
+        id: merge
+        if: steps.bump.outputs.changed == 'true' && env.AUTO_MERGE == 'true'
+        env:
+          PR_URL: ${{ steps.pr.outputs.url }}
+        run: |
+          # GitHub computes mergeability shortly after a PR opens; retry briefly.
+          for attempt in $(seq 1 12); do
+            if gh pr merge "$PR_URL" --squash 2> merge-error.txt; then
+              break
+            fi
+            if [ "$attempt" = 12 ]; then
+              cat merge-error.txt
+              echo "::error::Could not merge ${PR_URL}. Merge it by hand, then move the release tag onto the merged commit and re-run the Docker build."
+              exit 1
+            fi
+            sleep 5
+          done
+
+          MERGE_SHA=""
+          for attempt in $(seq 1 12); do
+            MERGE_SHA=$(gh pr view "$PR_URL" --json mergeCommit --jq '.mergeCommit.oid // empty')
+            [ -n "$MERGE_SHA" ] && break
+            sleep 5
+          done
+
+          if [ -z "$MERGE_SHA" ]; then
+            echo "::error::${PR_URL} merged, but its merge commit could not be read."
+            exit 1
+          fi
+
+          echo "sha=$MERGE_SHA" >> "$GITHUB_OUTPUT"
+          echo "Merged ${PR_URL} as \`${MERGE_SHA}\`." >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Move the release tag onto the merged commit
+        if: github.event_name == 'push' && steps.merge.outputs.sha != ''
+        env:
+          # The default token never triggers workflows, so this does not start a second Docker
+          # build or re-run this workflow. The build is dispatched explicitly below.
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG_NAME: ${{ github.ref_name }}
+          MERGE_SHA: ${{ steps.merge.outputs.sha }}
+        run: |
+          gh api --method PATCH "repos/${GITHUB_REPOSITORY}/git/refs/tags/${TAG_NAME}" -f sha="$MERGE_SHA" -F force=true --silent
+          echo "Moved tag \`${TAG_NAME}\` to \`${MERGE_SHA}\`." >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Build the Docker image
+        if: github.event_name == 'push' && steps.merge.outputs.sha != ''
+        env:
+          TAG_NAME: ${{ github.ref_name }}
+        run: |
+          gh workflow run web_docker.yml --ref "$BASE_BRANCH" \
+            -f tag_name="$TAG_NAME" \
+            -f appflowy_web_branch="$TAG_NAME" \
+            -f build_arm64=true \
+            -f tag_latest=true \
+            -f test=false
+          echo "Started the Docker build for \`${TAG_NAME}\`: https://github.com/${GITHUB_REPOSITORY}/actions/workflows/web_docker.yml" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/web_docker.yml
+++ b/.github/workflows/web_docker.yml
@@ -37,7 +37,49 @@ env:
   LATEST_TAG: latest
 
 jobs:
+  # A release tag whose version is newer than the reviewed boundary in
+  # web-server-compatibility.json cannot build (vite.config.ts throws). Instead of failing
+  # here, skip: the Compatibility Review PR workflow advances the boundary, moves the tag and
+  # dispatches this workflow again.
+  compatibility_gate:
+    runs-on: ubuntu-22.04
+    outputs:
+      build: ${{ steps.gate.outputs.build }}
+    steps:
+      - name: Check out the repository
+        if: github.event_name == 'push'
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref }}
+          fetch-depth: 1
+
+      - name: Check the tag against the compatibility policy
+        id: gate
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          TAG_NAME: ${{ github.ref_name }}
+        run: |
+          if [ "$EVENT_NAME" != "push" ]; then
+            echo "build=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # A version the script cannot parse is left to the build itself, as before.
+          if node scripts/review-compatibility.cjs "$TAG_NAME" --check > gate.txt && grep -q '^changed=true$' gate.txt; then
+            echo "build=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::web-server-compatibility.json does not cover ${TAG_NAME} yet. The Compatibility Review PR workflow advances it, moves the tag and starts a new build."
+            {
+              echo "### Build skipped"
+              echo ""
+              echo "The compatibility policy is not reviewed for \`${TAG_NAME}\`. The Compatibility Review PR workflow advances it, moves the tag onto the merged commit and starts a new build."
+            } >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "build=true" >> "$GITHUB_OUTPUT"
+          fi
+
   appflowy_web_image:
+    needs: [compatibility_gate]
+    if: needs.compatibility_gate.outputs.build == 'true'
     runs-on: ${{ matrix.job.os }}
     strategy:
       fail-fast: false

--- a/doc/web-server-compatibility.md
+++ b/doc/web-server-compatibility.md
@@ -18,14 +18,18 @@ web 0.17.1. Unknown/unreviewed web versions do not produce old-server warnings.
 There is no appcast or native update gate on web.
 
 The "Compatibility Review PR" workflow
-(`.github/workflows/compatibility_review.yml`) makes that bump for you. Run it
-from the Actions tab with the upcoming version before tagging, or let it run on
-the release tag push. It opens a pull request that advances the reviewed
-boundary; check whether the release needs a new `min_server` row, merge, then
-push (or move) the release tag. Locally,
+(`.github/workflows/compatibility_review.yml`) makes that bump for you. On a
+release tag push it opens a pull request that advances the reviewed boundary,
+merges it, moves the tag onto the merged commit and starts the Docker build for
+it; the Docker workflow skips its own build for a tag the policy does not cover
+yet. Creating a release from the GitHub UI is therefore enough. You can also run
+the workflow from the Actions tab with the upcoming version before tagging, and
+untick "merge" to review the pull request by hand. Locally,
 `node scripts/review-compatibility.cjs <version>` applies the same change. The
 script refuses a version at or above `max_enforceable_client_floor`; raise that
-cap by hand first.
+cap by hand first. Because the bump merges without review, a release that needs
+a newer server must add its `min_server` row in the feature change that
+introduces the dependency.
 
 `GET /api/server-info`, with `x-platform: web`, must expose:
 


### PR DESCRIPTION
## Why

Creating a release from the GitHub UI currently yields a failed Docker build plus a review PR to merge by hand, after which the tag has to be moved. Creating a *new* tag instead lands one version ahead of the policy and repeats the cycle (0.18.0 → #537 → 0.18.1 → #539 → 0.18.2). This makes the tag-first path finish on its own.

## What

**`compatibility_review.yml`**, on a release tag push, after opening or refreshing the bump PR:

1. Merges it with `gh pr merge --squash`, retrying briefly while GitHub computes mergeability. A refused merge fails the job with an actionable error.
2. Moves the tag onto the merge commit via the REST API using the default `GITHUB_TOKEN`, which never triggers workflows, so nothing double-runs.
3. Dispatches `web_docker.yml` for that tag with the same inputs the push path uses (arm64 on, `latest` on).

Manual runs get a `merge` input (default on). Untick it to get a PR you review by hand. The PR body now describes the automatic flow.

**`web_docker.yml`** gains a `compatibility_gate` job. On a tag push it runs `scripts/review-compatibility.cjs <tag> --check`; if the policy does not cover the tag, the build job is skipped with a summary note instead of failing at the Vite gate, and the review workflow rebuilds it. Dispatch runs and unparseable versions build as before.

**`doc/web-server-compatibility.md`** describes the flow and notes that, because the bump merges without review, a release that needs a newer server must add its `min_server` row in the feature change that introduces the dependency.

## Release flow after this

Create the release in the GitHub UI. That's it. The original Docker run skips, the review workflow bumps, merges, moves the tag, and starts the real build.

## Things to know

- The `main` ruleset requires a PR but zero approvals, so the bot merge should be allowed. It also enables "require extra approval for unattributed changes"; if that blocks the `github-actions[bot]` commit, the merge step fails with a clear message and the fallback is the manual flow. The first release after this merges will tell.
- Auto-merging removes the human review the gate was designed to force. The gate still guarantees the runtime banner works for every shipped version.

## Verification

- Both workflows parse; every `run` script passes `bash -n`.
- The tag-push chain was dry-run with stubbed `git`/`gh`: PR URL captured, merge retried past simulated "mergeability unknown" errors, merge SHA read, `PATCH git/refs/tags/<tag>` and `gh workflow run` called with the expected inputs. The merge-failure path exits 1 with the error annotation.
- PR bodies rendered for all three trigger cases.
- Docker gate dry-run: covered, `v`-prefixed, unparseable, cap-violating and dispatch cases build; an uncovered version skips with the summary note.
- Not run: actionlint (not installed locally). The workflows can only be exercised end to end on the next release tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013M1rm3ve4YutTy3Cwi9XRC

## Summary by Sourcery

Automate compatibility-policy updates and Docker rebuilds for release tags while preserving a manual review option for manually triggered runs.

New Features:
- Automatically merge compatibility review pull requests, move pushed release tags to the merge commit, and dispatch the Docker build with release settings.
- Add a Docker compatibility gate that skips uncovered release tags and lets the compatibility workflow rebuild them after policy updates.
- Allow manual compatibility reviews to opt out of automatic merging.

Bug Fixes:
- Prevent release Docker builds from failing solely because the compatibility policy has not yet been advanced.

Enhancements:
- Document the fully automated tag-first release flow and require server compatibility rows to be added alongside features that introduce newer server dependencies.

CI:
- Update release workflows to coordinate compatibility-policy updates, tag correction, and Docker rebuilds without duplicate push-triggered runs.

Documentation:
- Document automatic compatibility review merging, tag-based rebuild behavior, and the implications for server compatibility changes.