### PR TITLE
fix(publish): prevent overlapping publish operations

### DIFF
--- a/src/components/app/hooks/__tests__/usePageOperations.publish.test.tsx
+++ b/src/components/app/hooks/__tests__/usePageOperations.publish.test.tsx
@@ -60,6 +60,17 @@ function createView(overrides: Partial<View>): View {
   };
 }
 
+function deferredPublish() {
+  let resolve!: () => void;
+  let reject!: (reason: unknown) => void;
+  const promise = new Promise<void>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+
+  return { promise, resolve, reject };
+}
+
 function renderUsePageOperations(options?: {
   outlineRef?: MutableRefObject<View[] | undefined>;
   loadOutline?: (workspaceId: string, force?: boolean) => Promise<void>;
@@ -148,6 +159,82 @@ describe('usePageOperations publish', () => {
     expect(PublishService.publish).toHaveBeenCalledTimes(1);
   });
 
+  it('shares an in-flight publish for the same page until the operation finishes', async () => {
+    const pendingPublish = deferredPublish();
+
+    jest.mocked(PublishService.publish).mockReturnValue(pendingPublish.promise);
+    const { result, loadOutline } = renderUsePageOperations();
+    const view = createView({ view_id: 'document-view-id' });
+    const firstPublish = result.current.publish(view);
+    const repeatedPublish = result.current.publish(view);
+
+    try {
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      expect(PublishService.publish).toHaveBeenCalledTimes(1);
+    } finally {
+      await act(async () => {
+        pendingPublish.resolve();
+        await Promise.all([firstPublish, repeatedPublish]);
+      });
+    }
+
+    expect(loadOutline).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      await result.current.publish(view);
+    });
+
+    expect(PublishService.publish).toHaveBeenCalledTimes(2);
+  });
+
+  it('waits for each publish request to finish before starting its retry delay', async () => {
+    jest.useFakeTimers();
+    const firstAttempt = deferredPublish();
+    const retryAttempt = deferredPublish();
+
+    jest
+      .mocked(PublishService.publish)
+      .mockReturnValueOnce(firstAttempt.promise)
+      .mockReturnValueOnce(retryAttempt.promise);
+
+    const { result } = renderUsePageOperations();
+    const publishPromise = result.current.publish(createView({ view_id: 'document-view-id' }));
+
+    try {
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(30000);
+      });
+      expect(PublishService.publish).toHaveBeenCalledTimes(1);
+
+      await act(async () => {
+        firstAttempt.reject({ code: -2, message: 'Record not found: view is not projected yet' });
+        await jest.advanceTimersByTimeAsync(249);
+      });
+      expect(PublishService.publish).toHaveBeenCalledTimes(1);
+
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(1);
+      });
+      expect(PublishService.publish).toHaveBeenCalledTimes(2);
+
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(30000);
+      });
+      expect(PublishService.publish).toHaveBeenCalledTimes(2);
+    } finally {
+      await act(async () => {
+        firstAttempt.resolve();
+        retryAttempt.resolve();
+        await jest.runAllTimersAsync();
+        await publishPromise;
+      });
+      jest.useRealTimers();
+    }
+  });
+
   it('retries document publishing while the folder projection is pending', async () => {
     jest.useFakeTimers();
 
@@ -214,6 +301,12 @@ describe('usePageOperations publish', () => {
     });
 
     expect(PublishService.publish).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      await result.current.publish(createView({ view_id: 'document-view-id' }));
+    });
+
+    expect(PublishService.publish).toHaveBeenCalledTimes(2);
   });
 
   it('resolves canonical database id before publishing legacy database views', async () => {

--- a/src/components/app/hooks/usePageOperations.ts
+++ b/src/components/app/hooks/usePageOperations.ts
@@ -1,4 +1,4 @@
-import { MutableRefObject, useCallback } from 'react';
+import { MutableRefObject, useCallback, useRef } from 'react';
 import { toast } from 'sonner';
 
 import { BillingService, FileService, PageService, PublishService, ViewService } from '@/application/services/domains';
@@ -99,6 +99,7 @@ export function usePageOperations({
 }) {
   const { currentWorkspaceId, userWorkspaceInfo } = useAuthInternal();
   const role = userWorkspaceInfo?.selectedWorkspace.role;
+  const pendingPublishesRef = useRef(new Map<string, Promise<void>>());
 
   // Add a new page
   const addPage = useCallback(
@@ -481,7 +482,7 @@ export function usePageOperations({
   }, [currentWorkspaceId]);
 
   // Publish view
-  const publish = useCallback(
+  const performPublish = useCallback(
     async (view: View, publishName?: string, visibleViewIds?: string[]) => {
       if (!currentWorkspaceId) return;
       const viewId = view.view_id;
@@ -592,6 +593,28 @@ export function usePageOperations({
       await loadOutline?.(currentWorkspaceId, false);
     },
     [currentWorkspaceId, loadOutline, flushAllSync, syncAllToServer, outlineRef, getDatabaseIdForViewId]
+  );
+
+  const publish = useCallback(
+    (view: View, publishName?: string, visibleViewIds?: string[]): Promise<void> => {
+      if (!currentWorkspaceId) return Promise.resolve();
+
+      const key = `${currentWorkspaceId}:${view.view_id}`;
+      const pendingPublishes = pendingPublishesRef.current;
+      const pendingPublish = pendingPublishes.get(key);
+
+      if (pendingPublish) return pendingPublish;
+
+      // Share the entire operation, including sync and retries, so repeated
+      // triggers cannot start another publish while this page is still busy.
+      const publishPromise = performPublish(view, publishName, visibleViewIds).finally(() => {
+        pendingPublishes.delete(key);
+      });
+
+      pendingPublishes.set(key, publishPromise);
+      return publishPromise;
+    },
+    [currentWorkspaceId, performPublish]
   );
 
   // Unpublish view


### PR DESCRIPTION
### Description

Reopening Share and clicking Publish while an earlier publish is pending can start another request and a separate retry loop for the same page. Keep one pending operation per workspace and page, and share it across repeated triggers until synchronization, publishing, retries, and the outline refresh finish. Clear the pending entry after success or failure so a later Publish action can proceed.

The existing missing-record retry count and delays are preserved. Each retry waits for the preceding request to settle.

### Validation

- Added a regression that failed before the fix: two concurrent Publish calls sent two requests instead of one.
- Added timing coverage proving that unresolved requests do not trigger retries, plus coverage for publishing again after success or failure.
- All 20 focused publish hook and panel tests passed.
- `pnpm type-check` passed.
- ESLint passed for both changed files; `git diff --check` passed.
- Chrome: held the first POST open, reopened Share, and clicked Publish again. Exactly one POST was sent, and publishing succeeded after releasing it. The disposable page was unpublished and moved to Trash afterward.

### Checklist

#### General

- [x] I've included relevant documentation or comments for the changes introduced.
- [ ] I've tested the changes in multiple environments (validated in Chrome on macOS).

#### Testing

- [x] I've added or updated tests to validate the changes introduced for AppFlowy Web.

#### Feature-Specific

- Feature preview: not applicable; this is a bug fix.
- [x] I've verified that this change integrates with the existing Publish flow.

## Summary by Sourcery

Prevent overlapping page publish operations by sharing one in-flight operation per workspace and page until it completes.

Bug Fixes:
- Prevent concurrent Publish triggers from starting duplicate operations for the same workspace and page.
- Ensure publish retries wait for the preceding request to settle before applying retry delays.

Enhancements:
- Share the complete in-flight publish operation, including synchronization, retries, and outline refresh, across repeated triggers and allow publishing again after completion.

Tests:
- Add regression coverage for concurrent publishes, request-settlement timing during retries, and subsequent publishes after success or failure.