### PR TITLE
fix: code block clipboard and sidebar permission refresh

### DIFF
--- a/playwright/bdd/features/app/sidebar-permission-refresh.feature
+++ b/playwright/bdd/features/app/sidebar-permission-refresh.feature
@@ -1,0 +1,17 @@
+@sidebar-permission-refresh
+Feature: Sidebar stability after a page permission change
+  Changing access to one page should preserve unrelated expanded sidebar branches.
+
+  Scenario Outline: Refresh a page permission without reloading sibling branches
+    Given I have expanded sidebar branches for permission refresh testing
+    When a remote "<notification>" notification says the page access was "<access>"
+    Then unrelated sidebar branches stay mounted while permission refresh is pending
+    When the sidebar permission refresh finishes
+    Then the sidebar reflects the "<access>" page access without remounting unrelated branches
+
+    Examples:
+      | notification | access  |
+      | permission   | changed |
+      | share        | changed |
+      | permission   | revoked |
+      | share        | revoked |

--- a/playwright/bdd/features/editor/code-block-clipboard.feature
+++ b/playwright/bdd/features/editor/code-block-clipboard.feature
@@ -1,0 +1,71 @@
+Feature: Code block copy and paste
+  Pasting copied AppFlowy content into a code block inserts literal text at
+  the selection, preserving indentation and line breaks without adding blocks.
+
+  Background:
+    Given a blank document page is open
+
+  Scenario: Native keyboard copy and paste preserves multiline code and supports undo and redo
+    When I choose slash command "code"
+    And I type the following text in the editor:
+      """
+      const message = "hello";
+        console.log(message);
+      """
+    And I press "ControlOrMeta+a"
+    And I press "ControlOrMeta+c"
+    And I press "ArrowRight"
+    And I press "ControlOrMeta+v"
+    Then the editor has exactly 1 top-level block
+    And code block 0 contains exactly:
+      """
+      const message = "hello";
+        console.log(message);const message = "hello";
+        console.log(message);
+      """
+    When I undo the editor change
+    Then code block 0 contains exactly:
+      """
+      const message = "hello";
+        console.log(message);
+      """
+    When I redo the editor change
+    Then the editor has exactly 1 top-level block
+    And code block 0 contains exactly:
+      """
+      const message = "hello";
+        console.log(message);const message = "hello";
+        console.log(message);
+      """
+
+  Scenario Outline: Copied code respects the destination selection
+    When I choose slash command "code"
+    And I type "const source = target;" in the editor
+    And I select text from offset 6 to offset 12 in editor block 0
+    And I copy the current editor selection
+    And I select text from offset 15 to offset <end> in editor block 0
+    And I paste the copied content at the current caret
+    Then the editor has exactly 1 top-level block
+    And code block 0 contains exactly:
+      """
+      <expected>
+      """
+
+    Examples:
+      | end | expected                    |
+      | 15  | const source = sourcetarget; |
+      | 21  | const source = source;       |
+
+  Scenario: Copied paragraph text fills an empty code block without changing its type
+    When I type "paragraph source" in the editor
+    And I select text from offset 0 to offset 16 in editor block 0
+    And I copy the current editor selection
+    And I type "" in the editor
+    And I choose slash command "code"
+    And I select text from offset 0 to offset 0 in editor block 0
+    And I paste the copied content at the current caret
+    Then the editor has exactly 1 top-level block
+    And code block 0 contains exactly:
+      """
+      paragraph source
+      """

--- a/playwright/bdd/steps/code-block-clipboard.steps.ts
+++ b/playwright/bdd/steps/code-block-clipboard.steps.ts
@@ -1,0 +1,18 @@
+import { expect } from '@playwright/test';
+import { createBdd } from 'playwright-bdd';
+
+import { BlockSelectors, EditorSelectors } from '../../support/selectors';
+
+const { When, Then } = createBdd();
+
+When('I type the following text in the editor:', async ({ page }, text: string) => {
+  await EditorSelectors.slateEditor(page).focus();
+  await page.keyboard.insertText(text);
+});
+
+Then('code block {int} contains exactly:', async ({ page }, blockIndex: number, text: string) => {
+  const code = BlockSelectors.blockByType(page, 'code').nth(blockIndex).locator('code');
+
+  // Compare literal text so whitespace normalization cannot hide lost indentation.
+  await expect.poll(() => code.innerText()).toBe(text);
+});

--- a/playwright/bdd/steps/sidebar-permission-refresh.steps.ts
+++ b/playwright/bdd/steps/sidebar-permission-refresh.steps.ts
@@ -1,0 +1,246 @@
+import { expect, type Page, type Route } from '@playwright/test';
+import { createBdd } from 'playwright-bdd';
+
+import { signInAndWaitForApp } from '../../support/auth-flow-helpers';
+import { generateRandomEmail } from '../../support/test-config';
+
+const { Given, When, Then, After } = createBdd();
+const ids = {
+  space: '11111111-1111-4111-8111-111111111112',
+  changed: '22222222-2222-4222-8222-222222222223',
+  oldChild: '33333333-3333-4333-8333-333333333334',
+  freshChild: '44444444-4444-4444-8444-444444444445',
+  sibling: '55555555-5555-4555-8555-555555555556',
+  siblingChild: '66666666-6666-4666-8666-666666666667',
+  otherSpace: '77777777-7777-4777-8777-777777777778',
+  otherChild: '88888888-8888-4888-8888-888888888889',
+};
+
+type SidebarView = {
+  view_id: string;
+  name: string;
+  layout: number;
+  icon: null;
+  extra: { is_space: true } | null;
+  children: SidebarView[];
+  has_children: boolean;
+  is_published: boolean;
+  is_private: boolean;
+};
+
+type RefreshState = {
+  email: string;
+  refreshing: boolean;
+  revoked: boolean;
+  rootRequests: number;
+  subtreeRequests: string[];
+  release: () => void;
+};
+
+type ObservedWindow = Window & {
+  __APPFLOWY_EVENT_EMITTER__?: { emit: (event: string, payload: unknown) => void };
+  __sidebarPermissionObserver?: MutationObserver;
+  __sidebarPermissionRows?: Element[];
+  __sidebarPermissionRowsRemoved?: boolean;
+};
+
+const states = new WeakMap<Page, RefreshState>();
+
+function view(viewId: string, name: string, children: SidebarView[] = [], space = false): SidebarView {
+  return {
+    view_id: viewId,
+    name,
+    layout: 0,
+    icon: null,
+    extra: space ? { is_space: true } : null,
+    children,
+    has_children: children.length > 0,
+    is_published: false,
+    is_private: false,
+  };
+}
+
+async function respond(route: Route, data: unknown) {
+  await route.fulfill({ json: { code: 0, message: 'success', data } });
+}
+
+Given('I have expanded sidebar branches for permission refresh testing', async ({ page, request }) => {
+  const email = generateRandomEmail();
+
+  await signInAndWaitForApp(page, request, email);
+  const [, workspaceId, activeViewId] = new URL(page.url()).pathname.match(/\/app\/([^/]+)\/([^/?#]+)/) ?? [];
+
+  expect(workspaceId).toBeTruthy();
+  expect(activeViewId).toBeTruthy();
+  let release!: () => void;
+  const pendingRefresh = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  const state: RefreshState = {
+    email,
+    refreshing: false,
+    revoked: false,
+    rootRequests: 0,
+    subtreeRequests: [],
+    release,
+  };
+
+  states.set(page, state);
+  const fixture = () => {
+    const changedPage = view(ids.changed, state.refreshing ? 'Permission refreshed page' : 'Permission target', [
+      state.refreshing
+        ? view(ids.freshChild, 'Authorized child after refresh')
+        : view(ids.oldChild, 'Previously cached child'),
+    ]);
+
+    return view(workspaceId, 'Workspace', [
+      view(
+        ids.space,
+        'Permission fixture space',
+        [
+          view(activeViewId, 'Open page'),
+          ...(state.revoked ? [] : [changedPage]),
+          view(ids.sibling, 'Unaffected sibling', [view(ids.siblingChild, 'Unaffected nested child')]),
+        ],
+        true
+      ),
+      view(ids.otherSpace, 'Unaffected space', [view(ids.otherChild, 'Unaffected space child')], true),
+    ]);
+  };
+  const shallowView = (viewId: string): SidebarView | undefined => {
+    const find = (node: SidebarView): SidebarView | undefined =>
+      node.view_id === viewId ? node : node.children.map(find).find(Boolean);
+    const node = find(fixture());
+
+    return node && { ...node, children: node.children.map((child) => ({ ...child, children: [] })) };
+  };
+
+  await page.route(`**/api/workspace/${workspaceId}/**`, async (route) => {
+    const url = new URL(route.request().url());
+    const prefix = `/api/workspace/${workspaceId}`;
+
+    if (url.pathname === `${prefix}/view/${workspaceId}`) {
+      if (state.refreshing) {
+        state.rootRequests += 1;
+        await pendingRefresh;
+      }
+      await respond(route, shallowView(workspaceId));
+      return;
+    }
+
+    const batch = url.pathname === `${prefix}/views`;
+    const singleId = url.pathname.match(/\/view\/([^/]+)$/)?.[1];
+    const requestedIds = batch ? (url.searchParams.get('view_ids') ?? '').split(',') : singleId ? [singleId] : [];
+
+    // Startup can batch cached navigation ancestors with fixture branches.
+    // Serve the fixture IDs even when they share a request with a cached view.
+    const fixtureIds = requestedIds.filter((id) => id === activeViewId || Object.values(ids).includes(id));
+
+    if (fixtureIds.length) {
+      if (state.refreshing) {
+        state.subtreeRequests.push(...fixtureIds);
+        await pendingRefresh;
+      }
+      const views = fixtureIds.map(shallowView);
+
+      if (views.some((node) => !node)) {
+        await route.fulfill({ json: { code: 1003, message: 'not enough permissions' } });
+      } else {
+        await respond(route, batch ? { views } : views[0]);
+      }
+      return;
+    }
+
+    if (url.pathname === `${prefix}/view/${ids.changed}/navigation`) {
+      if (state.revoked) {
+        await route.fulfill({ json: { code: 1003, message: 'not enough permissions' } });
+      } else {
+        await respond(route, shallowView(ids.changed));
+      }
+      return;
+    }
+
+    await route.continue();
+  });
+
+  await page.evaluate(
+    (expandedIds) => {
+      localStorage.setItem('outline_expanded', JSON.stringify(Object.fromEntries(expandedIds.map((id) => [id, true]))));
+    },
+    [ids.space, ids.changed, ids.sibling, ids.otherSpace]
+  );
+  await page.reload({ waitUntil: 'domcontentloaded' });
+  for (const id of [ids.oldChild, ids.siblingChild, ids.otherChild]) {
+    await expect(page.getByTestId(`page-${id}`)).toBeVisible({ timeout: 30000 });
+  }
+
+  // Track DOM identity throughout the event and delayed HTTP responses. Checking
+  // only the final text would miss a branch disappearing and being recreated.
+  await page.evaluate(
+    (unaffectedIds) => {
+      const win = window as ObservedWindow;
+      win.__sidebarPermissionRows = unaffectedIds.map((id) => document.querySelector(`[data-testid="page-${id}"]`)!);
+      win.__sidebarPermissionRowsRemoved = false;
+      win.__sidebarPermissionObserver = new MutationObserver(() => {
+        if (win.__sidebarPermissionRows?.some((row) => !row.isConnected)) win.__sidebarPermissionRowsRemoved = true;
+      });
+      win.__sidebarPermissionObserver.observe(document.body, { childList: true, subtree: true });
+    },
+    [ids.sibling, ids.siblingChild, ids.otherChild]
+  );
+});
+
+When(
+  'a remote {string} notification says the page access was {string}',
+  async ({ page }, notification: string, access: string) => {
+    const state = states.get(page)!;
+    state.refreshing = true;
+    state.revoked = access === 'revoked';
+    await page.evaluate(
+      ({ notification, email, viewId }) => {
+        const emitter = (window as ObservedWindow).__APPFLOWY_EVENT_EMITTER__;
+        if (!emitter) throw new Error('Workspace notification emitter is unavailable');
+        emitter.emit(
+          notification === 'permission' ? 'permission-changed' : 'share-views-changed',
+          notification === 'permission' ? { objectId: viewId } : { viewId, emails: [email] }
+        );
+      },
+      { notification, email: state.email, viewId: ids.changed }
+    );
+  }
+);
+
+Then('unrelated sidebar branches stay mounted while permission refresh is pending', async ({ page }) => {
+  await expect.poll(() => states.get(page)!.rootRequests).toBeGreaterThan(0);
+  await expect(page.getByTestId(`page-${ids.oldChild}`)).toHaveCount(0);
+  for (const id of [ids.siblingChild, ids.otherChild]) {
+    await expect(page.getByTestId(`page-${id}`)).toBeVisible();
+  }
+  expect(await page.evaluate(() => (window as ObservedWindow).__sidebarPermissionRowsRemoved)).toBe(false);
+});
+
+When('the sidebar permission refresh finishes', async ({ page }) => {
+  states.get(page)!.release();
+});
+
+Then(
+  'the sidebar reflects the {string} page access without remounting unrelated branches',
+  async ({ page }, access: string) => {
+    if (access === 'revoked') {
+      await expect(page.getByTestId(`page-${ids.changed}`)).toHaveCount(0);
+    } else {
+      await expect(page.getByTestId(`page-${ids.changed}`)).toContainText('Permission refreshed page');
+      await expect(page.getByTestId(`page-${ids.freshChild}`)).toBeVisible();
+    }
+    expect(await page.evaluate(() => (window as ObservedWindow).__sidebarPermissionRowsRemoved)).toBe(false);
+    expect(states.get(page)!.subtreeRequests).not.toEqual(expect.arrayContaining([ids.sibling]));
+    expect(states.get(page)!.subtreeRequests).not.toEqual(expect.arrayContaining([ids.otherSpace]));
+  }
+);
+
+After({ tags: '@sidebar-permission-refresh' }, async ({ page }) => {
+  states.get(page)?.release();
+  states.delete(page);
+  await page.unrouteAll({ behavior: 'wait' });
+  await page.evaluate(() => (window as ObservedWindow).__sidebarPermissionObserver?.disconnect());
+});

--- a/src/components/app/hooks/__tests__/useWorkspaceData.sidebarRevalidation.test.tsx
+++ b/src/components/app/hooks/__tests__/useWorkspaceData.sidebarRevalidation.test.tsx
@@ -324,67 +324,170 @@ describe('useWorkspaceData sidebar outline revalidation', () => {
     expect(result.current.loadedViewIds?.has(siblingSpaceId)).toBe(true);
   });
 
-  it('restarts a superseded sibling load without letting the stale request clear its marker', async () => {
+  it.each([
+    [APP_EVENTS.PERMISSION_CHANGED, false],
+    [APP_EVENTS.SHARE_VIEWS_CHANGED, false],
+    [APP_EVENTS.PERMISSION_CHANGED, true],
+    [APP_EVENTS.SHARE_VIEWS_CHANGED, true],
+  ])('preserves sibling branches during %s for a page (revoked: %s)', async (event, revoked) => {
     const eventEmitter = new EventEmitter();
-    const loadingSpaceId = 'loading-space-id';
-    const changedSpaceId = 'changed-space-id';
-    const staleLoad = createDeferred<View[]>();
-    const replacementLoad = createDeferred<View[]>();
-    const shallowRoot = [
-      createView(loadingSpaceId, { extra: { is_space: true }, has_children: true }),
-      createView(changedSpaceId, { extra: { is_space: true }, has_children: true }),
-    ];
-
-    (ViewService.getOutline as jest.Mock).mockResolvedValue({ outline: shallowRoot, folderRid: '1-1' });
-
-    const { result } = renderHook(() => useWorkspaceData(), {
-      wrapper: createWrapper(eventEmitter),
+    const changed = createView('changed-page', { children: [createView('old-child')], has_children: true });
+    const sibling = createView('sibling-page', { children: [createView('sibling-child')], has_children: true });
+    const space = createView('space', { children: [changed, sibling], is_space: true, has_children: true });
+    const otherSpace = createView('other-space', {
+      children: [createView('other-space-child')],
+      is_space: true,
+      has_children: true,
     });
+    const shallowRoot = [space, otherSpace].map((view) => ({ ...view, children: [] }));
+    const rootRefresh = createDeferred<{ outline: View[]; folderRid: string }>();
+    const parentRefresh = createDeferred<View[]>();
+
+    (ViewService.getOutline as jest.Mock)
+      .mockResolvedValueOnce({ outline: shallowRoot, folderRid: '1-1' })
+      .mockReturnValue(rootRefresh.promise);
+    (ViewService.getMultiple as jest.Mock).mockResolvedValue([
+      { ...space, children: [changed, sibling].map((view) => ({ ...view, children: [] })) },
+      otherSpace,
+      changed,
+      sibling,
+    ]);
+    const { result } = renderHook(() => useWorkspaceData(), { wrapper: createWrapper(eventEmitter) });
 
     await waitFor(() => expect(result.current.outline).toEqual(shallowRoot));
+    await act(async () => {
+      await result.current.loadViewChildrenBatch?.([space.view_id, otherSpace.view_id, changed.view_id, sibling.view_id]);
+    });
+    const originalSibling = findView(result.current.outline ?? [], sibling.view_id);
+    const originalOtherSpace = findView(result.current.outline ?? [], otherSpace.view_id);
+    const freshChanged = { ...changed, children: [createView('fresh-child')] };
+
     (ViewService.getMultiple as jest.Mock).mockClear();
-    (ViewService.getMultiple as jest.Mock)
-      .mockImplementationOnce(() => staleLoad.promise)
-      .mockImplementationOnce(() => replacementLoad.promise);
-    let originalLoad: Promise<View[]> | undefined;
+    (ViewService.getMultiple as jest.Mock).mockImplementation((_workspaceId: string, viewIds: string[]) => {
+      if (viewIds[0] === space.view_id) return parentRefresh.promise;
+      if (viewIds[0] === changed.view_id) {
+        return revoked ? Promise.reject({ code: ERROR_CODE.NOT_HAS_PERMISSION }) : Promise.resolve([freshChanged]);
+      }
+
+      return Promise.resolve([]);
+    });
+    if (revoked) (ViewService.getNavigation as jest.Mock).mockRejectedValue({ code: ERROR_CODE.NOT_HAS_PERMISSION });
 
     act(() => {
-      originalLoad = result.current.loadViewChildrenBatch?.([loadingSpaceId]);
-    });
-    await waitFor(() => expect(ViewService.getMultiple).toHaveBeenCalledTimes(1));
-
-    act(() => {
-      eventEmitter.emit(APP_EVENTS.PERMISSION_CHANGED, { objectId: changedSpaceId });
-    });
-
-    await waitFor(() => expect(ViewService.getMultiple).toHaveBeenCalledTimes(2));
-    expect(ViewService.getMultiple).toHaveBeenNthCalledWith(2, workspaceId, [loadingSpaceId], 1);
-
-    await act(async () => {
-      staleLoad.resolve([createView(loadingSpaceId, { children: [createView('stale-child-id')] })]);
-      await staleLoad.promise;
-      await originalLoad;
+      eventEmitter.emit(
+        event,
+        event === APP_EVENTS.PERMISSION_CHANGED
+          ? { objectId: changed.view_id }
+          : { viewId: changed.view_id, emails: ['current-user@appflowy.io'] }
+      );
     });
 
-    // The stale request's finally handler must not clear the replacement
-    // request's marker and permit a third concurrent request.
-    await act(async () => {
-      await result.current.loadViewChildrenBatch?.([loadingSpaceId]);
-    });
-    expect(ViewService.getMultiple).toHaveBeenCalledTimes(2);
+    // Assert while both root and parent requests are pending, so a transient
+    // sidebar collapse cannot be hidden by a fast successful response.
+    expect(findView(result.current.outline ?? [], 'old-child')).toBeNull();
+    expect(findView(result.current.outline ?? [], sibling.view_id)).toBe(originalSibling);
+    expect(findView(result.current.outline ?? [], otherSpace.view_id)).toBe(originalOtherSpace);
+    expect(result.current.loadedViewIds?.has(sibling.view_id)).toBe(true);
+    expect(result.current.loadedViewIds?.has(otherSpace.view_id)).toBe(true);
+    expect(ViewService.getMultiple).toHaveBeenCalledWith(workspaceId, [space.view_id], 1);
 
     await act(async () => {
-      replacementLoad.resolve([createView(loadingSpaceId, { children: [createView('fresh-child-id')] })]);
-      await replacementLoad.promise;
+      parentRefresh.resolve([
+        {
+          ...space,
+          children: [
+            ...(revoked ? [] : [{ ...changed, children: [] }]),
+            { ...sibling, children: [] },
+          ],
+        },
+      ]);
+      await parentRefresh.promise;
     });
-    await waitFor(() => expect(findView(result.current.outline ?? [], 'fresh-child-id')).not.toBeNull());
-    expect(findView(result.current.outline ?? [], 'stale-child-id')).toBeNull();
-
+    await waitFor(() => {
+      expect(findView(result.current.outline ?? [], revoked ? changed.view_id : 'fresh-child') === null).toBe(revoked);
+    });
     await act(async () => {
-      await result.current.loadViewChildrenBatch?.([loadingSpaceId]);
+      rootRefresh.resolve({ outline: shallowRoot, folderRid: '1-2' });
+      await rootRefresh.promise;
     });
-    expect(ViewService.getMultiple).toHaveBeenCalledTimes(3);
+
+    expect(findView(result.current.outline ?? [], 'old-child')).toBeNull();
+    expect(findView(result.current.outline ?? [], 'sibling-child')).not.toBeNull();
+    expect(findView(result.current.outline ?? [], 'other-space-child')).not.toBeNull();
+    expect(ViewService.getMultiple).not.toHaveBeenCalledWith(workspaceId, [sibling.view_id], 1);
+    expect(ViewService.getMultiple).not.toHaveBeenCalledWith(workspaceId, [otherSpace.view_id], 1);
+    if (revoked) expect(findView(result.current.outline ?? [], changed.view_id)).toBeNull();
   });
+
+  it.each([APP_EVENTS.PERMISSION_CHANGED, APP_EVENTS.SHARE_VIEWS_CHANGED])(
+    'restarts a superseded sibling load after %s without letting the stale request clear its marker',
+    async (event) => {
+      const eventEmitter = new EventEmitter();
+      const loadingSpaceId = 'loading-space-id';
+      const changedSpaceId = 'changed-space-id';
+      const staleLoad = createDeferred<View[]>();
+      const replacementLoad = createDeferred<View[]>();
+      const shallowRoot = [
+        createView(loadingSpaceId, { extra: { is_space: true }, has_children: true }),
+        createView(changedSpaceId, { extra: { is_space: true }, has_children: true }),
+      ];
+
+      (ViewService.getOutline as jest.Mock).mockResolvedValue({ outline: shallowRoot, folderRid: '1-1' });
+
+      const { result } = renderHook(() => useWorkspaceData(), {
+        wrapper: createWrapper(eventEmitter),
+      });
+
+      await waitFor(() => expect(result.current.outline).toEqual(shallowRoot));
+      (ViewService.getMultiple as jest.Mock).mockClear();
+      (ViewService.getMultiple as jest.Mock)
+        .mockImplementationOnce(() => staleLoad.promise)
+        .mockImplementationOnce(() => replacementLoad.promise);
+      let originalLoad: Promise<View[]> | undefined;
+
+      act(() => {
+        originalLoad = result.current.loadViewChildrenBatch?.([loadingSpaceId]);
+      });
+      await waitFor(() => expect(ViewService.getMultiple).toHaveBeenCalledTimes(1));
+
+      act(() => {
+        eventEmitter.emit(
+          event,
+          event === APP_EVENTS.PERMISSION_CHANGED
+            ? { objectId: changedSpaceId }
+            : { viewId: changedSpaceId, emails: ['current-user@appflowy.io'] }
+        );
+      });
+
+      await waitFor(() => expect(ViewService.getMultiple).toHaveBeenCalledTimes(2));
+      expect(ViewService.getMultiple).toHaveBeenNthCalledWith(2, workspaceId, [loadingSpaceId], 1);
+
+      await act(async () => {
+        staleLoad.resolve([createView(loadingSpaceId, { children: [createView('stale-child-id')] })]);
+        await staleLoad.promise;
+        await originalLoad;
+      });
+
+      // The stale request's finally handler must not clear the replacement
+      // request's marker and permit a third concurrent request.
+      await act(async () => {
+        await result.current.loadViewChildrenBatch?.([loadingSpaceId]);
+      });
+      expect(ViewService.getMultiple).toHaveBeenCalledTimes(2);
+
+      await act(async () => {
+        replacementLoad.resolve([createView(loadingSpaceId, { children: [createView('fresh-child-id')] })]);
+        await replacementLoad.promise;
+      });
+      await waitFor(() => expect(findView(result.current.outline ?? [], 'fresh-child-id')).not.toBeNull());
+      expect(findView(result.current.outline ?? [], 'stale-child-id')).toBeNull();
+
+      await act(async () => {
+        await result.current.loadViewChildrenBatch?.([loadingSpaceId]);
+      });
+      expect(ViewService.getMultiple).toHaveBeenCalledTimes(3);
+    }
+  );
 
   it('drops a loaded deep subtree that a permission refresh omits from the shallow root', async () => {
     const eventEmitter = new EventEmitter();

--- a/src/components/app/hooks/useWorkspaceData.ts
+++ b/src/components/app/hooks/useWorkspaceData.ts
@@ -28,7 +28,7 @@ import {
   reorderChildrenInOutline,
   updateViewInOutline,
 } from '@/components/_shared/outline/mergeOutline';
-import { findShareWithMeSpace, findView, findViewByLayout } from '@/components/_shared/outline/utils';
+import { findParentView, findShareWithMeSpace, findView, findViewByLayout } from '@/components/_shared/outline/utils';
 import {
   limitSidebarOutlineExpandedViewIds,
   type SidebarOutlineRevalidationResult,
@@ -1867,24 +1867,24 @@ export function useWorkspaceData() {
       void loadOutline(currentWorkspaceId, false);
     };
 
-    const evictAccessDerivedSubtrees = (targetSpaceId?: string) => {
+    const evictAccessDerivedSubtrees = (targetViewId?: string) => {
       if (!currentWorkspaceId) return { staleSubtreeIds: [], viewDepths: new Map<string, number>() };
 
       const viewDepths = buildViewDepthIndex(stableOutlineRef.current);
       const staleSubtreeIdSet = new Set([...loadedViewIdsRef.current, ...loadingViewIdsRef.current]);
-      const targetSpace = targetSpaceId ? findView(stableOutlineRef.current, targetSpaceId) : null;
-      const targetSubtreeIds = targetSpace ? collectOutlineViewIds([targetSpace]) : null;
+      const targetView = targetViewId ? findView(stableOutlineRef.current, targetViewId) : null;
+      const targetSubtreeIds = targetView ? collectOutlineViewIds([targetView]) : null;
 
       if (targetSubtreeIds) {
         for (const viewId of staleSubtreeIdSet) {
           if (!targetSubtreeIds.has(viewId)) staleSubtreeIdSet.delete(viewId);
         }
 
-        // Root responses are shallow. If this space currently has materialized
+        // Root responses are shallow. If this view currently has materialized
         // children without a lazy-load marker, clear and refresh it as well so
         // a revoke cannot leave those children visible until the root request
         // finishes.
-        if (targetSpace?.children?.length) staleSubtreeIdSet.add(targetSpace.view_id);
+        if (targetView?.children?.length) staleSubtreeIdSet.add(targetView.view_id);
       }
 
       const staleSubtreeIds = Array.from(staleSubtreeIdSet);
@@ -1974,16 +1974,10 @@ export function useWorkspaceData() {
       const cachedDatabaseId = changedView?.extra?.database_id;
 
       if (accessMayAffectCurrentUser) {
-        // Fence root/lazy responses that started before this share event.
-        // Sharing an ancestor can alter inherited descendant access.
-        permissionRefreshRevisionRef.current += 1;
-        ViewService.invalidateDatabaseCatalog?.(currentWorkspaceId);
-        ViewService.invalidateWorkspaceMemoryCache?.(currentWorkspaceId);
-        markWorkspaceViewMetadataOutlineUntrusted(currentWorkspaceId);
+        refreshPermissionSubtrees(changedViewId ?? undefined);
+      } else {
+        refreshPermissionDerivedState();
       }
-
-      if (accessMayAffectCurrentUser) evictAccessDerivedSubtrees();
-      refreshPermissionDerivedState();
 
       if (!changedViewId || !affectsCurrentUser) return;
 
@@ -2029,7 +2023,7 @@ export function useWorkspaceData() {
         });
     };
 
-    const handlePermissionChanged = (payload?: notification.IPermissionChanged) => {
+    const refreshPermissionSubtrees = (changedViewId?: string) => {
       if (!currentWorkspaceId) return;
 
       ViewService.invalidateDatabaseCatalog?.(currentWorkspaceId);
@@ -2038,13 +2032,18 @@ export function useWorkspaceData() {
 
       // AppBusinessLayer handles the same event separately because it owns the
       // active route/modal IDs and can re-probe and purge either rendered view.
-      // `objectId` can identify a workspace group rather than a view. Target
-      // the refresh only when the current outline proves it is a space; keep
-      // the workspace-wide fallback for group, page, missing and unknown IDs.
-      // This preserves expanded sibling spaces after an ACL edit without
-      // weakening the conservative behavior for ambiguous notifications.
-      const changedView = payload?.objectId ? findView(stableOutlineRef.current, payload.objectId) : null;
-      const targetSpaceId = isSpaceView(changedView) ? changedView?.view_id : undefined;
+      // A permission object can also be a workspace group. Scope eviction to a
+      // known view, retaining the broad fallback for unknown or missing IDs.
+      const changedView = changedViewId ? findView(stableOutlineRef.current, changedViewId) : null;
+      const targetViewId = changedView?.view_id;
+      // A shallow root refresh cannot remove a revoked page below its depth
+      // boundary. Refresh its parent without clearing the parent's children:
+      // the authoritative child list removes that page while preserving loaded
+      // sibling branches throughout the request.
+      const parentView =
+        changedView && !isSpaceView(changedView)
+          ? findParentView(stableOutlineRef.current, changedView.view_id)
+          : null;
 
       // Invalidate every affected subtree that could otherwise be grafted onto
       // the depth-limited root response, and supersede lazy-load responses that
@@ -2054,11 +2053,11 @@ export function useWorkspaceData() {
       permissionRefreshRevisionRef.current += 1;
       const permissionRevision = permissionRefreshRevisionRef.current;
       const workspaceId = currentWorkspaceId;
-      const { staleSubtreeIds, viewDepths } = evictAccessDerivedSubtrees(targetSpaceId);
+      const { staleSubtreeIds, viewDepths } = evictAccessDerivedSubtrees(targetViewId);
       const staleSubtreeWaves = new Map<number, string[]>();
 
       // The permission revision above makes every captured request stale. A
-      // targeted eviction clears markers inside the changed space, but must not
+      // targeted eviction clears markers inside the changed view, but must not
       // leave an in-flight sibling permanently marked as loading. Release all
       // superseded markers before replacement requests claim them. Stale
       // request finally handlers are revision-gated, so they cannot clear a
@@ -2071,6 +2070,11 @@ export function useWorkspaceData() {
       // permission revision superseded. Parent depths run first so a nested
       // request always has an outline node to merge into.
       const rehydrateViewIds = new Set([...staleSubtreeIds, ...supersededLoadingViewIds]);
+
+      if (parentView && !parentView.extra?.is_hidden_space) {
+        ViewService.invalidateCache(workspaceId, parentView.view_id);
+        rehydrateViewIds.add(parentView.view_id);
+      }
 
       for (const viewId of rehydrateViewIds) {
         const depth = viewDepths.get(viewId) ?? Number.MAX_SAFE_INTEGER;
@@ -2115,6 +2119,10 @@ export function useWorkspaceData() {
           await Promise.all(viewIds.map(rehydrateView));
         }
       })();
+    };
+
+    const handlePermissionChanged = (payload?: notification.IPermissionChanged) => {
+      refreshPermissionSubtrees(payload?.objectId ?? undefined);
     };
 
     if (eventEmitter) {

--- a/src/components/editor/plugins/__tests__/codeBlockClipboard.test.ts
+++ b/src/components/editor/plugins/__tests__/codeBlockClipboard.test.ts
@@ -1,0 +1,137 @@
+import { createEditor, Element, Node } from 'slate';
+import { withReact } from 'slate-react';
+
+import { withYjs, YjsEditor } from '@/application/slate-yjs';
+import { withTestingYDoc } from '@/application/slate-yjs/__tests__/withTestingYjsEditor';
+import { slateContentInsertToYData, yDocToSlateContent } from '@/application/slate-yjs/utils/convert';
+import { BlockType, CollabOrigin, YjsEditorKey } from '@/application/types';
+import { clipboardFormatKey } from '@/components/editor/plugins/withCopy';
+import { withInsertData } from '@/components/editor/plugins/withInsertData';
+import { withPasted } from '@/components/editor/plugins/withPasted';
+
+jest.mock('@/components/editor/parsers/html-parser', () => ({ parseHTML: jest.fn() }));
+jest.mock('@/components/editor/parsers/markdown-parser', () => ({ parseMarkdown: jest.fn() }));
+
+const code = '  const message = "你好 👋";\n\tconsole.log(message);\n';
+
+function block(type: BlockType, text: string): Element {
+  return {
+    type,
+    data: type === BlockType.CodeBlock ? { language: 'javascript' } : {},
+    children: [{ type: YjsEditorKey.text, children: [{ text }] }],
+  } as Element;
+}
+
+function clipboardData(values: Record<string, string>): DataTransfer {
+  return {
+    files: [],
+    types: Object.keys(values),
+    getData: (type: string) => values[type] ?? '',
+  } as unknown as DataTransfer;
+}
+
+function richClipboardData(format: string, sourceType: BlockType): DataTransfer {
+  const encoded = window.btoa(encodeURIComponent(JSON.stringify([block(sourceType, code)])));
+
+  return clipboardData({
+    'text/plain': code,
+    [format]: format === 'text/html' ? `<span data-slate-fragment="${encoded}">code</span>` : encoded,
+  });
+}
+
+describe('code block clipboard', () => {
+  const editors: YjsEditor[] = [];
+
+  afterEach(() => {
+    for (const editor of editors.splice(0)) {
+      editor.disconnect();
+      editor.sharedRoot.doc?.destroy();
+    }
+  });
+
+  function createPasteEditor(text: string, start: number, end = start, type = BlockType.CodeBlock) {
+    const doc = withTestingYDoc('clipboard-page');
+
+    slateContentInsertToYData('clipboard-page', 0, [block(type, text)], doc);
+
+    const editor = withInsertData(
+      withPasted(
+        withReact(withYjs(createEditor(), doc, { readOnly: false, localOrigin: CollabOrigin.Local }), clipboardFormatKey)
+      )
+    ) as YjsEditor;
+
+    editor.connect();
+    editor.select({ anchor: { path: [0, 0, 0], offset: start }, focus: { path: [0, 0, 0], offset: end } });
+    editors.push(editor);
+    return editor;
+  }
+
+  function expectCode(editor: YjsEditor, expected: string, originalBlockId?: string) {
+    expect(editor.children).toHaveLength(1);
+    expect(editor.children[0]).toMatchObject({ type: BlockType.CodeBlock, data: { language: 'javascript' } });
+    expect(Node.string(editor.children[0])).toBe(expected);
+    if (originalBlockId) expect((editor.children[0] as Element).blockId).toBe(originalBlockId);
+
+    editor.flushLocalChanges();
+    const saved = yDocToSlateContent(editor.sharedRoot.doc!);
+
+    expect(saved.children).toHaveLength(1);
+    expect(Node.string(saved.children[0])).toBe(expected);
+  }
+
+  it.each(['application/x-appflowy-fragment', 'application/x-slate-fragment', 'text/html'])(
+    'pastes %s into the code block at the caret, preserving whitespace and surrounding text',
+    (format) => {
+      const editor = createPasteEditor('before AFTER', 7);
+      const originalBlockId = (editor.children[0] as Element).blockId;
+
+      editor.insertData(richClipboardData(format, BlockType.CodeBlock));
+
+      expectCode(editor, `before ${code}AFTER`, originalBlockId);
+      expect(editor.selection?.anchor).toEqual({ path: [0, 0, 0], offset: 7 + code.length });
+      expect(editor.selection?.focus).toEqual(editor.selection?.anchor);
+    }
+  );
+
+  it('keeps an empty code block and its language when pasting copied paragraph text', () => {
+    const editor = createPasteEditor('', 0);
+    const originalBlockId = (editor.children[0] as Element).blockId;
+
+    editor.insertData(richClipboardData('application/x-appflowy-fragment', BlockType.Paragraph));
+
+    expectCode(editor, code, originalBlockId);
+  });
+
+  it('replaces selected code with copied text without creating another block', () => {
+    const editor = createPasteEditor('before REPLACE after', 7, 14);
+
+    editor.insertData(richClipboardData('application/x-appflowy-fragment', BlockType.CodeBlock));
+
+    expectCode(editor, `before ${code} after`);
+  });
+
+  it.each([{ 'text/plain': code }, { 'text/plain': code, 'text/html': '<pre><code>formatted code</code></pre>' }])(
+    'continues to paste external clipboard text literally inside code blocks',
+    (values) => {
+      const editor = createPasteEditor('', 0);
+
+      editor.insertData(clipboardData(values));
+
+      expectCode(editor, code);
+    }
+  );
+
+  it('preserves a copied code block when pasted after paragraph text', () => {
+    const editor = createPasteEditor('paragraph', 9, 9, BlockType.Paragraph);
+
+    editor.insertData(richClipboardData('application/x-appflowy-fragment', BlockType.CodeBlock));
+
+    expect(editor.children).toHaveLength(2);
+    expect(editor.children[0]).toMatchObject({ type: BlockType.Paragraph });
+    expect(Node.string(editor.children[0])).toBe('paragraph');
+    expect(editor.children[1]).toMatchObject({ type: BlockType.CodeBlock, data: { language: 'javascript' } });
+    expect(Node.string(editor.children[1])).toBe(code);
+    editor.flushLocalChanges();
+    expect(yDocToSlateContent(editor.sharedRoot.doc!).children.map(Node.string)).toEqual(['paragraph', code]);
+  });
+});

--- a/src/components/editor/plugins/withInsertData.ts
+++ b/src/components/editor/plugins/withInsertData.ts
@@ -3,7 +3,7 @@ import { ReactEditor } from 'slate-react';
 
 import { YjsEditor } from '@/application/slate-yjs';
 import { CustomEditor } from '@/application/slate-yjs/command';
-import { TEXT_BLOCK_TYPES } from '@/application/slate-yjs/command/const';
+import { SOFT_BREAK_TYPES, TEXT_BLOCK_TYPES } from '@/application/slate-yjs/command/const';
 import { findSlateEntryByBlockId, getBlockEntry, isInsideSimpleTableCell } from '@/application/slate-yjs/utils/editor';
 import {
   BlockType,
@@ -31,12 +31,20 @@ export const withInsertData = (editor: ReactEditor) => {
   const e = editor as YjsEditor;
 
   editor.insertData = (data: DataTransfer) => {
+    const entry = getBlockEntry(e);
+
+    // Internal copies also carry rich fragments. Code blocks must consume the
+    // plain text first so those fragments cannot replace the block or create siblings.
+    if (entry && SOFT_BREAK_TYPES.includes(entry[0].type as BlockType) && data.getData('text/plain')) {
+      editor.insertTextData(data);
+      return;
+    }
+
     const richFragment = extractAppFlowyClipboardFragment(data);
 
     // When pasting inside a table cell, check if the fragment contains table blocks
     // and prevent nesting tables. Instead, extract text and fill adjacent cells.
-    const tableCheckEntry = getBlockEntry(e);
-    const tableCheckBlockId = tableCheckEntry ? (tableCheckEntry[0] as BlockElement).blockId : undefined;
+    const tableCheckBlockId = entry ? (entry[0] as BlockElement).blockId : undefined;
 
     if (tableCheckBlockId && isInsideSimpleTableCell(e, tableCheckBlockId)) {
       // Check plain text for TSV (tab-separated values)
@@ -122,7 +130,6 @@ export const withInsertData = (editor: ReactEditor) => {
     // Do something with the data...
     const fileArray = Array.from(data.files);
     const { selection } = editor;
-    const entry = getBlockEntry(e);
 
     if (!entry) return;
 


### PR DESCRIPTION
### Description

Copying text from AppFlowy and pasting it inside a code block could create a sibling block or change the destination's type because rich clipboard fragments bypassed the code-block paste handler. Process plain text first when the destination is a code block, preserving the caret position, selected-text replacement, indentation, and line breaks.

Add four Playwright BDD scenarios covering native keyboard copy/paste with undo/redo, insertion at the caret, selection replacement, and copied paragraph text pasted into an empty code block. Unit tests also cover AppFlowy/Slate/HTML clipboard formats and persisted Yjs content.

### Validation

- Code-block clipboard Playwright BDD feature: **4 passed** against the local app in Chromium on macOS.
- Clipboard unit suites: **27 passed**, including 8 new regression cases.
- `pnpm type-check`: passed.
- `pnpm exec eslint --quiet src/components/editor/plugins/withInsertData.ts`: passed.

### Checklist

#### General
- [x] Included relevant comments explaining the clipboard routing.
- [ ] Tested in multiple browsers/operating systems. Validated Chromium on macOS; other browser/OS combinations were not run.

#### Testing
- [x] Added unit tests and Playwright BDD regression coverage.

#### Feature-Specific
- Feature preview: not applicable; this is a bug fix.
- [x] Verified existing external paste and whole-code-block clipboard behavior.

## Summary by Sourcery

Preserve code-block paste behavior and stabilize sidebar state during permission-driven refreshes.

Bug Fixes:
- Preserve code-block type, formatting, caret position, and selection replacement when pasting rich clipboard content as literal text.
- Keep unrelated sidebar branches mounted during page permission and sharing updates while refreshing affected views and handling revoked access.

Enhancements:
- Scope permission refreshes to affected views and their parents while retaining correct subtree invalidation and stale-request handling.

Tests:
- Add clipboard unit coverage for AppFlowy, Slate, HTML, and external text formats, including persisted Yjs content.
- Add Playwright BDD coverage for code-block clipboard behavior and sidebar stability during permission refreshes.