### PR TITLE
fix(database): avoid unnecessary row document creation requests

### DIFF
--- a/.github/workflows/playwright-test.yml
+++ b/.github/workflows/playwright-test.yml
@@ -306,6 +306,24 @@ jobs:
           TEST_SHARD: ${{ matrix.test-group.shard }}
           TEST_SPEC: ${{ matrix.test-group.spec }}
 
+      - name: Report failed backend duplication tasks
+        if: failure()
+        continue-on-error: true
+        working-directory: AppFlowy-Cloud-Premium
+        run: |
+          docker compose -f docker-compose-web-ci.yml -f ../.github/docker-compose-web-ci.override.yml images
+
+          # The synchronous duplicate-document API returns only a generic 1017
+          # error. Preserve the Worker failure reason before CI deletes its DB.
+          docker compose -f docker-compose-web-ci.yml -f ../.github/docker-compose-web-ci.override.yml exec -T postgres \
+            sh -c 'psql -U "${POSTGRES_USER:-postgres}" -d "${POSTGRES_DB:-postgres}" -v ON_ERROR_STOP=1' <<'SQL'
+          SELECT task_id, workspace_id, status, left(error, 2000) AS error, created_at
+          FROM af_duplicate_task
+          WHERE error IS NOT NULL
+          ORDER BY created_at DESC
+          LIMIT 20;
+          SQL
+
       - name: Test summary
         if: always()
         run: |

--- a/playwright/e2e/database/row-template.spec.ts
+++ b/playwright/e2e/database/row-template.spec.ts
@@ -157,6 +157,10 @@ async function openRowWithDatabaseBlock(page: Page, rowId: string): Promise<{ ed
 
 async function addDatabaseView(page: Page, block: Locator, layout: 'Board' | 'Calendar' | 'Chart' = 'Board') {
   const tabs = block.locator('[data-testid^="view-tab-"]');
+
+  // The embedded block appears before its database finishes loading. Count the
+  // existing tabs only after the initial view has rendered.
+  await expect(tabs.first()).toBeVisible({ timeout: 30000 });
   const initialCount = await tabs.count();
   const addViewButton = block.getByTestId('add-view-button');
   const menu = page.locator('[data-slot="dropdown-menu-content"]:visible').last();

--- a/src/components/database/components/database-row/DatabaseRowSubDocument.tsx
+++ b/src/components/database/components/database-row/DatabaseRowSubDocument.tsx
@@ -912,35 +912,9 @@ export const DatabaseRowSubDocument = memo(function DatabaseRowSubDocument({
         return;
       }
 
-      if (isDocumentEmptyResolved) {
-        // Skip if doc is already loaded
-        if (docReadyRef.current && loadedDocumentIdRef.current === documentId) {
-          Log.debug('[DatabaseRowSubDocument] row meta says empty but doc already loaded, skipping', {
-            rowId,
-            documentId,
-          });
-          return;
-        }
-
-        // Document is empty, but the editor must still bind to a server-side
-        // collab before accepting edits. Otherwise a paste-and-close flow can
-        // enqueue the first update before the orphaned collab exists, then a
-        // fast reopen loads the still-empty server state over the local cache.
-        Log.debug('[DatabaseRowSubDocument] row meta says empty; creating row doc before opening editor', {
-          rowId,
-          documentId,
-        });
-        const createAttempt = await handleCreateDocument(documentId, false, isCurrentRequest);
-
-        if (createAttempt === 'retryable' && isCurrentRequest()) {
-          scheduleRetry();
-        }
-
-        return;
-      }
-
-      // meta.isEmptyDocument is false - document should exist on server
-      // If checkIfRowDocumentExists is not available, try to load directly.
+      // Empty content does not imply a missing server document. Check existence for both
+      // states so reopening an empty document can read it without taking the repair write path.
+      // Without an existence check, creation still confirms server readiness before binding.
       if (!checkIfRowDocumentExists) {
         const localHasContent = await hasLocalDocContent(documentId);
 
@@ -996,6 +970,18 @@ export const DatabaseRowSubDocument = memo(function DatabaseRowSubDocument({
 
           if (loadAttempt === 'retryable' && isCurrentRequest()) {
             scheduleRetry(CONFIRMED_ROW_DOCUMENT_LOAD_OPTIONS);
+          }
+
+          return;
+        }
+
+        if (isDocumentEmptyResolved) {
+          // A local document alone cannot admit edits: paste-and-close must wait until its
+          // server collab exists. Missing empty documents are created without the upload retry.
+          const createAttempt = await handleCreateDocument(documentId, false, isCurrentRequest);
+
+          if (createAttempt === 'retryable' && isCurrentRequest()) {
+            scheduleRetry();
           }
 
           return;

--- a/src/components/database/components/database-row/DatabaseRowSubDocument.tsx
+++ b/src/components/database/components/database-row/DatabaseRowSubDocument.tsx
@@ -437,8 +437,9 @@ export const DatabaseRowSubDocument = memo(function DatabaseRowSubDocument({
         return 'ready';
       } catch (e) {
         if (isPermissionDeniedError(e)) {
-          // An existing document may still need server-owned provenance repair. The caller
-          // decides whether to attempt that transition before displaying a terminal denial.
+          // The server handles eligible legacy recovery during reads, so a final denial must
+          // surface as no access instead of starting a separate create/repair request.
+          if (isCurrent()) markPermissionDenied(documentId);
           return 'forbidden';
         }
 
@@ -452,7 +453,7 @@ export const DatabaseRowSubDocument = memo(function DatabaseRowSubDocument({
         }
       }
     },
-    [loadRowDocument, rowDocumentSource, rowId]
+    [loadRowDocument, markPermissionDenied, rowDocumentSource, rowId]
   );
   // Open document with server-provided doc_state (Y.js update)
   const openDocumentWithState = useCallback(
@@ -621,7 +622,6 @@ export const DatabaseRowSubDocument = memo(function DatabaseRowSubDocument({
         if (loadRowDocument) {
           const loadAttempt = await handleOpenDocument(documentId, undefined, isCurrent);
 
-          if (loadAttempt === 'forbidden' && isCurrent()) markPermissionDenied(documentId);
           if (loadAttempt !== 'retryable') {
             return loadAttempt;
           }
@@ -647,29 +647,6 @@ export const DatabaseRowSubDocument = memo(function DatabaseRowSubDocument({
       rowDocumentSource,
       rowId,
     ]
-  );
-
-  const handleOpenExistingDocument = useCallback(
-    async (
-      documentId: string,
-      options: LoadRowDocumentOptions | undefined,
-      isCurrentRequest: IsCurrentRowDocumentRequest
-    ): Promise<RowDocumentAttempt> => {
-      const isCurrent = () => isCurrentRequest() && activeDocumentIdRef.current === documentId;
-      const attempt = await handleOpenDocument(documentId, options, isCurrent);
-
-      if (attempt !== 'forbidden' || !isCurrent()) return attempt;
-      if (!rowDocumentSource || !createRowDocument) {
-        markPermissionDenied(documentId);
-        return 'forbidden';
-      }
-
-      // A denied read can mean legacy provenance is missing. Temporary fetch failures and
-      // incomplete local state only retry the read; neither is evidence that repair is needed.
-      // The server verifies source access and provenance, and a denied repair remains terminal.
-      return handleCreateDocument(documentId, true, isCurrent);
-    },
-    [createRowDocument, handleCreateDocument, handleOpenDocument, markPermissionDenied, rowDocumentSource]
   );
 
   const scheduleEnsureRowDocumentExists = useCallback(() => {
@@ -893,9 +870,9 @@ export const DatabaseRowSubDocument = memo(function DatabaseRowSubDocument({
             return;
           }
 
-          // Existing documents use the read path. Only an explicit permission denial can
-          // trigger provenance repair; temporary failures remain bounded read retries.
-          const loadAttempt = await handleOpenExistingDocument(
+          // The server handles legacy recovery during reads. Temporary failures stay within
+          // the read retry budget instead of sending an explicit create/repair request.
+          const loadAttempt = await handleOpenDocument(
             documentId,
             CONFIRMED_ROW_DOCUMENT_LOAD_OPTIONS,
             isCurrentRequest
@@ -933,19 +910,7 @@ export const DatabaseRowSubDocument = memo(function DatabaseRowSubDocument({
         if (!isCurrentRequest()) return;
 
         if (isPermissionDeniedError(e)) {
-          // Existence is also permission-checked. A legacy row body can be denied here before
-          // its first fetch, so give the contextual repair endpoint the same bounded chance.
-          if (!rowDocumentSource || !createRowDocument) {
-            markPermissionDenied(documentId);
-            return;
-          }
-
-          const repairAttempt = await handleCreateDocument(documentId, true, isCurrentRequest);
-
-          if (repairAttempt === 'retryable' && isCurrentRequest()) {
-            scheduleRetry();
-          }
-
+          markPermissionDenied(documentId);
           return;
         }
 
@@ -964,12 +929,10 @@ export const DatabaseRowSubDocument = memo(function DatabaseRowSubDocument({
       clearRetryTimer();
     };
   }, [
-    handleOpenExistingDocument,
+    handleOpenDocument,
     documentId,
     handleCreateDocument,
     checkIfRowDocumentExists,
-    createRowDocument,
-    rowDocumentSource,
     isDocumentEmptyResolved,
     hasLocalDocContent,
     markPermissionDenied,

--- a/src/components/database/components/database-row/DatabaseRowSubDocument.tsx
+++ b/src/components/database/components/database-row/DatabaseRowSubDocument.tsx
@@ -658,14 +658,15 @@ export const DatabaseRowSubDocument = memo(function DatabaseRowSubDocument({
       const isCurrent = () => isCurrentRequest() && activeDocumentIdRef.current === documentId;
       const attempt = await handleOpenDocument(documentId, options, isCurrent);
 
-      if (attempt === 'ready' || !isCurrent()) return attempt;
-      if (attempt === 'forbidden' && (!rowDocumentSource || !createRowDocument)) {
+      if (attempt !== 'forbidden' || !isCurrent()) return attempt;
+      if (!rowDocumentSource || !createRowDocument) {
         markPermissionDenied(documentId);
         return 'forbidden';
       }
 
-      // Read permission is sufficient to request an eligible repair. The server verifies the
-      // source and existing document; a denied repair remains terminal and never becomes a loop.
+      // A denied read can mean legacy provenance is missing. Temporary fetch failures and
+      // incomplete local state only retry the read; neither is evidence that repair is needed.
+      // The server verifies source access and provenance, and a denied repair remains terminal.
       return handleCreateDocument(documentId, true, isCurrent);
     },
     [createRowDocument, handleCreateDocument, handleOpenDocument, markPermissionDenied, rowDocumentSource]
@@ -803,96 +804,32 @@ export const DatabaseRowSubDocument = memo(function DatabaseRowSubDocument({
       }
     };
 
-    const scheduleRetry = (loadOptions?: LoadRowDocumentOptions) => {
+    const scheduleRetry = () => {
       if (retryLoadTimerRef.current || deniedDocumentIdRef.current === documentId) return;
-      retryLoadTimerRef.current = setTimeout(async () => {
+      if (retryCount >= MAX_RETRIES) {
+        Log.warn('[DatabaseRowSubDocument] max retries reached; row document was not opened', {
+          rowId,
+          documentId,
+          retryCount,
+        });
+        setLoading(false);
+        return;
+      }
+
+      retryLoadTimerRef.current = setTimeout(() => {
+        retryLoadTimerRef.current = null;
         if (!isCurrentRequest() || deniedDocumentIdRef.current === documentId) return;
 
-        // If doc is already loaded (e.g., by handleCreateDocument), skip retry
-        // This prevents resetting the editor mid-typing
-        if (docReadyRef.current && loadedDocumentIdRef.current === documentId) {
-          Log.debug('[DatabaseRowSubDocument] skipping retry - doc already loaded', {
-            rowId,
-            documentId,
-          });
-          retryLoadTimerRef.current = null;
-          return;
-        }
-
         retryCount++;
-
-        // A newly-created row can reach this component before its row collab has
-        // propagated to the server. In that case the initial create request is
-        // rejected because the server cannot resolve the row yet. Retrying a
-        // load first is both unnecessary (the meta already says the document is
-        // empty) and slow enough to keep the editor skeleton visible for the
-        // entire retry window, so retry creation directly after propagation has
-        // had another chance to complete.
-        const retryingEmptyDocument = isDocumentEmptyResolved === true;
-        const retryAttempt = retryingEmptyDocument
-          ? await handleCreateDocument(documentId, false, isCurrentRequest)
-          : await handleOpenExistingDocument(documentId, loadOptions, isCurrentRequest);
-
-        if (retryAttempt !== 'retryable' || !isCurrentRequest()) {
-          return;
-        }
-
-        retryLoadTimerRef.current = null;
-
-        if (retryCount >= MAX_RETRIES) {
-          // Empty documents already attempted server creation on every retry.
-          // Stop here so a permanently rejected row cannot keep issuing an
-          // orphan-creation request every two seconds while the modal is open.
-          if (retryingEmptyDocument) {
-            Log.warn('[DatabaseRowSubDocument] max retries reached; row document creation rejected', {
-              rowId,
-              documentId,
-              retryCount,
-            });
-            return;
-          }
-
-          // For non-empty documents, make one final create attempt after the
-          // bounded load retries. The server doc_state remains the only source
-          // of the default document structure.
-          const localHasContent = await hasLocalDocContent(documentId);
-
-          if (!isCurrentRequest()) return;
-
-          if (localHasContent) {
-            Log.debug(
-              '[DatabaseRowSubDocument] max retries reached; local content found, creating server doc before binding',
-              {
-                rowId,
-                documentId,
-                retryCount,
-              }
-            );
-          }
-
-          Log.debug('[DatabaseRowSubDocument] max retries reached; creating document', {
-            rowId,
-            documentId,
-            retryCount,
-          });
-          const createAttempt = await handleCreateDocument(documentId, true, isCurrentRequest);
-
-          if (createAttempt === 'retryable' && isCurrentRequest()) {
-            Log.warn('[DatabaseRowSubDocument] final row document creation attempt rejected', {
-              rowId,
-              documentId,
-              retryCount,
-            });
-          }
-
-          return;
-        }
-
-        scheduleRetry(loadOptions);
-      }, 2000); // Reduced from 5000ms to 2000ms for faster response
+        // Re-evaluate server existence on every attempt. An empty-content flag or an exhausted
+        // read retry budget must never turn a temporary failure into a repair/create request.
+        void openRowDocument();
+      }, 2000);
     };
 
-    void (async () => {
+    const openRowDocument = async () => {
+      if (!isCurrentRequest() || deniedDocumentIdRef.current === documentId) return;
+
       // Skip if doc is already loaded - prevents reloading when meta changes
       if (docReadyRef.current && loadedDocumentIdRef.current === documentId && doc) {
         Log.debug('[DatabaseRowSubDocument] skipping effect - doc already loaded', {
@@ -927,13 +864,11 @@ export const DatabaseRowSubDocument = memo(function DatabaseRowSubDocument({
           });
         }
 
-        void (async () => {
-          const createAttempt = await handleCreateDocument(documentId, true, isCurrentRequest);
+        const createAttempt = await handleCreateDocument(documentId, true, isCurrentRequest);
 
-          if (createAttempt === 'retryable' && isCurrentRequest()) {
-            scheduleRetry();
-          }
-        })();
+        if (createAttempt === 'retryable' && isCurrentRequest()) {
+          scheduleRetry();
+        }
 
         return;
       }
@@ -958,10 +893,8 @@ export const DatabaseRowSubDocument = memo(function DatabaseRowSubDocument({
             return;
           }
 
-          // A positive existence check means the collab object is already
-          // present. Do one read attempt, then repair its row-document
-          // registration and open the returned state instead of waiting
-          // through the duplication-oriented backoff loop.
+          // Existing documents use the read path. Only an explicit permission denial can
+          // trigger provenance repair; temporary failures remain bounded read retries.
           const loadAttempt = await handleOpenExistingDocument(
             documentId,
             CONFIRMED_ROW_DOCUMENT_LOAD_OPTIONS,
@@ -969,16 +902,18 @@ export const DatabaseRowSubDocument = memo(function DatabaseRowSubDocument({
           );
 
           if (loadAttempt === 'retryable' && isCurrentRequest()) {
-            scheduleRetry(CONFIRMED_ROW_DOCUMENT_LOAD_OPTIONS);
+            scheduleRetry();
           }
 
           return;
         }
 
-        if (isDocumentEmptyResolved) {
+        if (isDocumentEmptyResolved || retryCount >= MAX_RETRIES) {
           // A local document alone cannot admit edits: paste-and-close must wait until its
           // server collab exists. Missing empty documents are created without the upload retry.
-          const createAttempt = await handleCreateDocument(documentId, false, isCurrentRequest);
+          // Nonempty documents may still be uploading. Create only if the final existence
+          // check still confirms absence after the bounded retry window.
+          const createAttempt = await handleCreateDocument(documentId, !isDocumentEmptyResolved, isCurrentRequest);
 
           if (createAttempt === 'retryable' && isCurrentRequest()) {
             scheduleRetry();
@@ -1008,7 +943,7 @@ export const DatabaseRowSubDocument = memo(function DatabaseRowSubDocument({
           const repairAttempt = await handleCreateDocument(documentId, true, isCurrentRequest);
 
           if (repairAttempt === 'retryable' && isCurrentRequest()) {
-            scheduleRetry(CONFIRMED_ROW_DOCUMENT_LOAD_OPTIONS);
+            scheduleRetry();
           }
 
           return;
@@ -1020,7 +955,9 @@ export const DatabaseRowSubDocument = memo(function DatabaseRowSubDocument({
         });
         scheduleRetry();
       }
-    })();
+    };
+
+    void openRowDocument();
 
     return () => {
       cancelled = true;

--- a/src/components/database/components/database-row/DatabaseRowSubDocument.tsx
+++ b/src/components/database/components/database-row/DatabaseRowSubDocument.tsx
@@ -437,7 +437,8 @@ export const DatabaseRowSubDocument = memo(function DatabaseRowSubDocument({
         return 'ready';
       } catch (e) {
         if (isPermissionDeniedError(e)) {
-          if (isCurrent()) markPermissionDenied(documentId);
+          // An existing document may still need server-owned provenance repair. The caller
+          // decides whether to attempt that transition before displaying a terminal denial.
           return 'forbidden';
         }
 
@@ -451,7 +452,7 @@ export const DatabaseRowSubDocument = memo(function DatabaseRowSubDocument({
         }
       }
     },
-    [loadRowDocument, markPermissionDenied, rowDocumentSource, rowId]
+    [loadRowDocument, rowDocumentSource, rowId]
   );
   // Open document with server-provided doc_state (Y.js update)
   const openDocumentWithState = useCallback(
@@ -620,6 +621,7 @@ export const DatabaseRowSubDocument = memo(function DatabaseRowSubDocument({
         if (loadRowDocument) {
           const loadAttempt = await handleOpenDocument(documentId, undefined, isCurrent);
 
+          if (loadAttempt === 'forbidden' && isCurrent()) markPermissionDenied(documentId);
           if (loadAttempt !== 'retryable') {
             return loadAttempt;
           }
@@ -645,6 +647,28 @@ export const DatabaseRowSubDocument = memo(function DatabaseRowSubDocument({
       rowDocumentSource,
       rowId,
     ]
+  );
+
+  const handleOpenExistingDocument = useCallback(
+    async (
+      documentId: string,
+      options: LoadRowDocumentOptions | undefined,
+      isCurrentRequest: IsCurrentRowDocumentRequest
+    ): Promise<RowDocumentAttempt> => {
+      const isCurrent = () => isCurrentRequest() && activeDocumentIdRef.current === documentId;
+      const attempt = await handleOpenDocument(documentId, options, isCurrent);
+
+      if (attempt === 'ready' || !isCurrent()) return attempt;
+      if (attempt === 'forbidden' && (!rowDocumentSource || !createRowDocument)) {
+        markPermissionDenied(documentId);
+        return 'forbidden';
+      }
+
+      // Read permission is sufficient to request an eligible repair. The server verifies the
+      // source and existing document; a denied repair remains terminal and never becomes a loop.
+      return handleCreateDocument(documentId, true, isCurrent);
+    },
+    [createRowDocument, handleCreateDocument, handleOpenDocument, markPermissionDenied, rowDocumentSource]
   );
 
   const scheduleEnsureRowDocumentExists = useCallback(() => {
@@ -807,7 +831,7 @@ export const DatabaseRowSubDocument = memo(function DatabaseRowSubDocument({
         const retryingEmptyDocument = isDocumentEmptyResolved === true;
         const retryAttempt = retryingEmptyDocument
           ? await handleCreateDocument(documentId, false, isCurrentRequest)
-          : await handleOpenDocument(documentId, loadOptions, isCurrentRequest);
+          : await handleOpenExistingDocument(documentId, loadOptions, isCurrentRequest);
 
         if (retryAttempt !== 'retryable' || !isCurrentRequest()) {
           return;
@@ -964,22 +988,14 @@ export const DatabaseRowSubDocument = memo(function DatabaseRowSubDocument({
           // present. Do one read attempt, then repair its row-document
           // registration and open the returned state instead of waiting
           // through the duplication-oriented backoff loop.
-          const loadAttempt = await handleOpenDocument(
+          const loadAttempt = await handleOpenExistingDocument(
             documentId,
             CONFIRMED_ROW_DOCUMENT_LOAD_OPTIONS,
             isCurrentRequest
           );
 
           if (loadAttempt === 'retryable' && isCurrentRequest()) {
-            Log.debug('[DatabaseRowSubDocument] repairing row document after load failure', {
-              rowId,
-              documentId,
-            });
-            const repairAttempt = await handleCreateDocument(documentId, true, isCurrentRequest);
-
-            if (repairAttempt === 'retryable' && isCurrentRequest()) {
-              scheduleRetry(CONFIRMED_ROW_DOCUMENT_LOAD_OPTIONS);
-            }
+            scheduleRetry(CONFIRMED_ROW_DOCUMENT_LOAD_OPTIONS);
           }
 
           return;
@@ -996,7 +1012,19 @@ export const DatabaseRowSubDocument = memo(function DatabaseRowSubDocument({
         if (!isCurrentRequest()) return;
 
         if (isPermissionDeniedError(e)) {
-          markPermissionDenied(documentId);
+          // Existence is also permission-checked. A legacy row body can be denied here before
+          // its first fetch, so give the contextual repair endpoint the same bounded chance.
+          if (!rowDocumentSource || !createRowDocument) {
+            markPermissionDenied(documentId);
+            return;
+          }
+
+          const repairAttempt = await handleCreateDocument(documentId, true, isCurrentRequest);
+
+          if (repairAttempt === 'retryable' && isCurrentRequest()) {
+            scheduleRetry(CONFIRMED_ROW_DOCUMENT_LOAD_OPTIONS);
+          }
+
           return;
         }
 
@@ -1013,10 +1041,12 @@ export const DatabaseRowSubDocument = memo(function DatabaseRowSubDocument({
       clearRetryTimer();
     };
   }, [
-    handleOpenDocument,
+    handleOpenExistingDocument,
     documentId,
     handleCreateDocument,
     checkIfRowDocumentExists,
+    createRowDocument,
+    rowDocumentSource,
     isDocumentEmptyResolved,
     hasLocalDocContent,
     markPermissionDenied,

--- a/src/components/database/components/database-row/__tests__/DatabaseRowSubDocument.test.tsx
+++ b/src/components/database/components/database-row/__tests__/DatabaseRowSubDocument.test.tsx
@@ -112,11 +112,13 @@ function createRowDocumentState(documentId: string) {
 
 function createDeferred<T>() {
   let resolve!: (value: T) => void;
-  const promise = new Promise<T>((resolvePromise) => {
+  let reject!: (reason: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
     resolve = resolvePromise;
+    reject = rejectPromise;
   });
 
-  return { promise, resolve };
+  return { promise, resolve, reject };
 }
 
 async function flushAsyncWork() {
@@ -327,6 +329,18 @@ describe('DatabaseRowSubDocument', () => {
 
     expect(screen.getByTestId('row-document-editor').getAttribute('data-read-only')).toBe('true');
     expect(loadRowDocument).toHaveBeenCalledTimes(2);
+
+    for (const attempt of [1, 2]) {
+      expect(loadRowDocument).toHaveBeenNthCalledWith(attempt, documentId, {
+        maxAttempts: 1,
+        rowDocumentSource: {
+          database_id: 'database-id',
+          database_view_id: 'database-view-id',
+          row_id: rowId,
+        },
+      });
+    }
+
     expect(createRowDocument).not.toHaveBeenCalled();
     expect(jest.getTimerCount()).toBe(0);
   });
@@ -432,12 +446,14 @@ describe('DatabaseRowSubDocument', () => {
     expect(await screen.findByTestId('row-document-editor')).not.toBeNull();
   });
 
-  it('repairs and opens an existing row document immediately after one denied page fetch', async () => {
+  it('reads an existing row document without creation', async () => {
     const rowId = 'row-id';
     const documentId = 'document-id';
     const cachedDoc = new Y.Doc({ guid: documentId }) as YDoc;
-    const loadRowDocument = jest.fn().mockRejectedValue({ code: 1012, message: 'document read denied' });
-    const createRowDocument = jest.fn().mockResolvedValue(createRowDocumentState(documentId));
+
+    Y.applyUpdate(cachedDoc, createRowDocumentState(documentId));
+    const loadRowDocument = jest.fn().mockResolvedValue(cachedDoc);
+    const createRowDocument = jest.fn();
     const checkIfRowDocumentExists = jest.fn().mockResolvedValue(true);
 
     configureRowDocumentTest({
@@ -465,70 +481,23 @@ describe('DatabaseRowSubDocument', () => {
       },
     });
     expect(loadRowDocument).toHaveBeenCalledTimes(1);
-    expect(createRowDocument).toHaveBeenCalledWith(documentId, {
-      database_id: 'database-id',
-      database_view_id: 'database-view-id',
-      row_id: rowId,
-    });
-    expect(createRowDocument).toHaveBeenCalledTimes(1);
-  });
-
-  it('keeps the one-attempt load policy when repair fails and a retry is scheduled', async () => {
-    jest.useFakeTimers();
-
-    const rowId = 'row-id';
-    const documentId = 'document-id';
-    const cachedDoc = new Y.Doc({ guid: documentId }) as YDoc;
-    const loadRowDocument = jest.fn().mockRejectedValue({ code: 1012, message: 'document read denied' });
-    const createRowDocument = jest.fn().mockResolvedValue(null);
-    const checkIfRowDocumentExists = jest.fn().mockResolvedValue(true);
-
-    configureRowDocumentTest({
-      documentIds: { [rowId]: documentId },
-      cachedDocs: new Map([[documentId, cachedDoc]]),
-      loadRowDocument,
-      createRowDocument,
-      checkIfRowDocumentExists,
-    });
-
-    render(<DatabaseRowSubDocument rowId={rowId} />);
-
-    await act(flushAsyncWork);
-
-    expect(loadRowDocument).toHaveBeenNthCalledWith(1, documentId, {
-      maxAttempts: 1,
-      rowDocumentSource: {
-        database_id: 'database-id',
-        database_view_id: 'database-view-id',
-        row_id: rowId,
-      },
-    });
-    expect(createRowDocument).toHaveBeenCalledTimes(1);
-    expect(jest.getTimerCount()).toBe(1);
-
-    await act(async () => {
-      await jest.advanceTimersByTimeAsync(2000);
-      await flushAsyncWork();
-    });
-
-    expect(loadRowDocument).toHaveBeenNthCalledWith(2, documentId, {
-      maxAttempts: 1,
-      rowDocumentSource: {
-        database_id: 'database-id',
-        database_view_id: 'database-view-id',
-        row_id: rowId,
-      },
-    });
+    expect(createRowDocument).not.toHaveBeenCalled();
   });
 
   it.each([
-    { deniedOperation: 'existence check', isEmptyDocument: false },
-    { deniedOperation: 'document fetch', isEmptyDocument: false },
-    { deniedOperation: 'existence check', isEmptyDocument: true },
-    { deniedOperation: 'document fetch', isEmptyDocument: true },
+    { deniedOperation: 'existence check', isEmptyDocument: false, readOnly: false },
+    { deniedOperation: 'document fetch', isEmptyDocument: false, readOnly: false },
+    { deniedOperation: 'existence check', isEmptyDocument: true, readOnly: false },
+    { deniedOperation: 'document fetch', isEmptyDocument: true, readOnly: false },
+    { deniedOperation: 'existence check', isEmptyDocument: false, readOnly: true },
+    { deniedOperation: 'document fetch', isEmptyDocument: false, readOnly: true },
+    { deniedOperation: 'existence check', isEmptyDocument: true, readOnly: true },
+    { deniedOperation: 'document fetch', isEmptyDocument: true, readOnly: true },
   ])(
-    'repairs a read-only row after a denied $deniedOperation (empty=$isEmptyDocument)',
-    async ({ deniedOperation, isEmptyDocument }) => {
+    'shows no access without repair after a denied $deniedOperation (empty=$isEmptyDocument, readOnly=$readOnly)',
+    async ({ deniedOperation, isEmptyDocument, readOnly }) => {
+      jest.useFakeTimers();
+
       const rowId = 'row-id';
       const documentId = 'document-id';
       const cachedDoc = new Y.Doc({ guid: documentId }) as YDoc;
@@ -546,76 +515,31 @@ describe('DatabaseRowSubDocument', () => {
         loadRowDocument,
         createRowDocument,
         checkIfRowDocumentExists,
-        readOnly: true,
+        readOnly,
         isEmptyDocument,
       });
 
       render(<DatabaseRowSubDocument rowId={rowId} />);
 
-      const editor = await screen.findByTestId('row-document-editor');
+      await act(flushAsyncWork);
 
-      expect(editor.getAttribute('data-read-only')).toBe('true');
-      expect(editor.getAttribute('data-can-write')).toBe('false');
-      expect(screen.queryByTestId('row-document-no-access')).toBeNull();
-      expect(createRowDocument).toHaveBeenCalledTimes(1);
-      expect(createRowDocument).toHaveBeenCalledWith(documentId, {
-        database_id: 'database-id',
-        database_view_id: 'database-view-id',
-        row_id: rowId,
+      expect(screen.getByTestId('row-document-no-access')).not.toBeNull();
+      expect(screen.queryByTestId('row-document-editor')).toBeNull();
+      expect(createRowDocument).not.toHaveBeenCalled();
+      expect(checkIfRowDocumentExists).toHaveBeenCalledTimes(1);
+      expect(loadRowDocument).toHaveBeenCalledTimes(deniedOperation === 'existence check' ? 0 : 1);
+      expect(jest.getTimerCount()).toBe(0);
+
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(10000);
+        await flushAsyncWork();
       });
+
+      expect(createRowDocument).not.toHaveBeenCalled();
+      expect(checkIfRowDocumentExists).toHaveBeenCalledTimes(1);
       expect(loadRowDocument).toHaveBeenCalledTimes(deniedOperation === 'existence check' ? 0 : 1);
     }
   );
-
-  it('shows no access without retrying when the contextual repair is also forbidden', async () => {
-    jest.useFakeTimers();
-
-    const rowId = 'row-id';
-    const documentId = 'document-id';
-    const cachedDoc = new Y.Doc({ guid: documentId }) as YDoc;
-    const loadRowDocument = jest
-      .fn()
-      .mockRejectedValue({ code: 1012, message: 'user is not allowed to access this view' });
-    const createRowDocument = jest
-      .fn()
-      .mockRejectedValue({ code: 1012, message: 'user is not allowed to access this view' });
-    const checkIfRowDocumentExists = jest.fn().mockResolvedValue(true);
-
-    configureRowDocumentTest({
-      documentIds: { [rowId]: documentId },
-      cachedDocs: new Map([[documentId, cachedDoc]]),
-      loadRowDocument,
-      createRowDocument,
-      checkIfRowDocumentExists,
-      readOnly: true,
-    });
-
-    render(<DatabaseRowSubDocument rowId={rowId} />);
-
-    await act(flushAsyncWork);
-
-    expect(screen.getByTestId('row-document-no-access')).not.toBeNull();
-    expect(checkIfRowDocumentExists).toHaveBeenCalledTimes(1);
-    expect(loadRowDocument).toHaveBeenCalledTimes(1);
-    expect(loadRowDocument).toHaveBeenCalledWith(documentId, {
-      maxAttempts: 1,
-      rowDocumentSource: {
-        database_id: 'database-id',
-        database_view_id: 'database-view-id',
-        row_id: rowId,
-      },
-    });
-    expect(createRowDocument).toHaveBeenCalledTimes(1);
-    expect(jest.getTimerCount()).toBe(0);
-
-    await act(async () => {
-      await jest.advanceTimersByTimeAsync(10000);
-      await flushAsyncWork();
-    });
-
-    expect(loadRowDocument).toHaveBeenCalledTimes(1);
-    expect(createRowDocument).toHaveBeenCalledTimes(1);
-  });
 
   it('shows no access without retrying when empty row document creation is forbidden', async () => {
     jest.useFakeTimers();
@@ -656,7 +580,7 @@ describe('DatabaseRowSubDocument', () => {
     expect(createRowDocument).toHaveBeenCalledTimes(1);
   });
 
-  it('ignores a stale repair response after switching rows', async () => {
+  it('ignores a stale creation response after switching rows', async () => {
     const firstRowId = 'row-a';
     const secondRowId = 'row-b';
     const firstDocumentId = 'document-a';
@@ -667,13 +591,13 @@ describe('DatabaseRowSubDocument', () => {
       [firstDocumentId, firstCachedDoc],
       [secondDocumentId, secondCachedDoc],
     ]);
-    const firstRepair = createDeferred<Uint8Array | null>();
-    const loadRowDocument = jest.fn().mockRejectedValue({ code: 1012, message: 'document read denied' });
+    const firstCreation = createDeferred<Uint8Array | null>();
+    const loadRowDocument = jest.fn();
     const createRowDocument = jest.fn((documentId: string) => {
-      if (documentId === firstDocumentId) return firstRepair.promise;
+      if (documentId === firstDocumentId) return firstCreation.promise;
       return Promise.resolve(createRowDocumentState(documentId));
     });
-    const checkIfRowDocumentExists = jest.fn().mockResolvedValue(true);
+    const checkIfRowDocumentExists = jest.fn().mockResolvedValue(false);
 
     configureRowDocumentTest({
       documentIds: {
@@ -684,6 +608,7 @@ describe('DatabaseRowSubDocument', () => {
       loadRowDocument,
       createRowDocument,
       checkIfRowDocumentExists,
+      isEmptyDocument: true,
     });
 
     const { rerender } = render(<DatabaseRowSubDocument rowId={firstRowId} />);
@@ -700,7 +625,7 @@ describe('DatabaseRowSubDocument', () => {
     });
 
     await act(async () => {
-      firstRepair.resolve(createRowDocumentState(firstDocumentId));
+      firstCreation.resolve(createRowDocumentState(firstDocumentId));
       await flushAsyncWork();
     });
 
@@ -709,6 +634,48 @@ describe('DatabaseRowSubDocument', () => {
     expect(editor.getAttribute('data-view-id')).toBe(secondDocumentId);
     expect(editor.getAttribute('data-doc-id')).toBe(secondDocumentId);
     expect(firstCachedDoc.getMap(YjsEditorKey.data_section).has(YjsEditorKey.document)).toBe(false);
+  });
+
+  it('ignores a stale read denial after switching rows', async () => {
+    const firstRowId = 'row-a';
+    const secondRowId = 'row-b';
+    const firstDocumentId = 'document-a';
+    const secondDocumentId = 'document-b';
+    const firstCachedDoc = new Y.Doc({ guid: firstDocumentId }) as YDoc;
+    const secondCachedDoc = new Y.Doc({ guid: secondDocumentId }) as YDoc;
+
+    Y.applyUpdate(secondCachedDoc, createRowDocumentState(secondDocumentId));
+    const firstRead = createDeferred<YDoc>();
+    const loadRowDocument = jest.fn((documentId: string) =>
+      documentId === firstDocumentId ? firstRead.promise : Promise.resolve(secondCachedDoc)
+    );
+    const createRowDocument = jest.fn();
+
+    configureRowDocumentTest({
+      documentIds: { [firstRowId]: firstDocumentId, [secondRowId]: secondDocumentId },
+      cachedDocs: new Map([
+        [firstDocumentId, firstCachedDoc],
+        [secondDocumentId, secondCachedDoc],
+      ]),
+      loadRowDocument,
+      createRowDocument,
+      checkIfRowDocumentExists: jest.fn().mockResolvedValue(true),
+    });
+
+    const { rerender } = render(<DatabaseRowSubDocument rowId={firstRowId} />);
+
+    await waitFor(() => expect(loadRowDocument).toHaveBeenCalledWith(firstDocumentId, expect.any(Object)));
+    rerender(<DatabaseRowSubDocument rowId={secondRowId} />);
+    expect((await screen.findByTestId('row-document-editor')).getAttribute('data-doc-id')).toBe(secondDocumentId);
+
+    await act(async () => {
+      firstRead.reject({ code: 1012, message: 'document read denied' });
+      await flushAsyncWork();
+    });
+
+    expect(screen.getByTestId('row-document-editor').getAttribute('data-doc-id')).toBe(secondDocumentId);
+    expect(screen.queryByTestId('row-document-no-access')).toBeNull();
+    expect(createRowDocument).not.toHaveBeenCalled();
   });
 
   it('preserves inherited comment-only access in the row document editor', async () => {

--- a/src/components/database/components/database-row/__tests__/DatabaseRowSubDocument.test.tsx
+++ b/src/components/database/components/database-row/__tests__/DatabaseRowSubDocument.test.tsx
@@ -243,6 +243,165 @@ describe('DatabaseRowSubDocument', () => {
     }
   });
 
+  it.each([
+    { failure: 'fetch error', isEmptyDocument: false },
+    { failure: 'fetch error', isEmptyDocument: true },
+    { failure: 'incomplete document', isEmptyDocument: false },
+    { failure: 'incomplete document', isEmptyDocument: true },
+    { failure: 'existence error', isEmptyDocument: false },
+    { failure: 'existence error', isEmptyDocument: true },
+  ])('does not repair after a $failure, including retries (empty=$isEmptyDocument)', async ({ failure, isEmptyDocument }) => {
+    jest.useFakeTimers();
+
+    const rowId = 'row-id';
+    const documentId = 'document-id';
+    const cachedDoc = new Y.Doc({ guid: documentId }) as YDoc;
+
+    if (failure !== 'incomplete document') {
+      Y.applyUpdate(cachedDoc, createRowDocumentState(documentId));
+    }
+
+    const transientError = new Error('temporary request failure');
+    const loadRowDocument = failure === 'fetch error'
+      ? jest.fn().mockRejectedValue(transientError)
+      : jest.fn().mockResolvedValue(cachedDoc);
+    const checkIfRowDocumentExists = failure === 'existence error'
+      ? jest.fn().mockRejectedValue(transientError)
+      : jest.fn().mockResolvedValue(true);
+    const createRowDocument = jest.fn().mockResolvedValue(createRowDocumentState(documentId));
+
+    configureRowDocumentTest({
+      documentIds: { [rowId]: documentId },
+      cachedDocs: new Map([[documentId, cachedDoc]]),
+      loadRowDocument,
+      createRowDocument,
+      checkIfRowDocumentExists,
+      isEmptyDocument,
+      readOnly: true,
+    });
+    render(<DatabaseRowSubDocument rowId={rowId} />);
+    await act(flushAsyncWork);
+
+    expect(createRowDocument).not.toHaveBeenCalled();
+    await act(async () => {
+      await jest.advanceTimersByTimeAsync(10000);
+      await flushAsyncWork();
+    });
+
+    expect(createRowDocument).not.toHaveBeenCalled();
+    expect(screen.queryByTestId('row-document-editor')).toBeNull();
+    expect(screen.queryByTestId('row-document-no-access')).toBeNull();
+    expect(jest.getTimerCount()).toBe(0);
+  });
+
+  it.each([false, true])('recovers from a temporary fetch failure by reading again (empty=%s)', async (isEmptyDocument) => {
+    jest.useFakeTimers();
+
+    const rowId = 'row-id';
+    const documentId = 'document-id';
+    const cachedDoc = new Y.Doc({ guid: documentId }) as YDoc;
+
+    Y.applyUpdate(cachedDoc, createRowDocumentState(documentId));
+    const loadRowDocument = jest.fn()
+      .mockRejectedValueOnce(new Error('temporary fetch failure'))
+      .mockResolvedValue(cachedDoc);
+    const createRowDocument = jest.fn().mockResolvedValue(createRowDocumentState(documentId));
+
+    configureRowDocumentTest({
+      documentIds: { [rowId]: documentId },
+      cachedDocs: new Map([[documentId, cachedDoc]]),
+      loadRowDocument,
+      createRowDocument,
+      checkIfRowDocumentExists: jest.fn().mockResolvedValue(true),
+      isEmptyDocument,
+      readOnly: true,
+    });
+    render(<DatabaseRowSubDocument rowId={rowId} />);
+    await act(flushAsyncWork);
+
+    expect(createRowDocument).not.toHaveBeenCalled();
+    await act(async () => {
+      await jest.advanceTimersByTimeAsync(2000);
+      await flushAsyncWork();
+    });
+
+    expect(screen.getByTestId('row-document-editor').getAttribute('data-read-only')).toBe('true');
+    expect(loadRowDocument).toHaveBeenCalledTimes(2);
+    expect(createRowDocument).not.toHaveBeenCalled();
+    expect(jest.getTimerCount()).toBe(0);
+  });
+
+  it('reads an empty document that appears before a failed creation is retried', async () => {
+    jest.useFakeTimers();
+
+    const rowId = 'row-id';
+    const documentId = 'document-id';
+    const cachedDoc = new Y.Doc({ guid: documentId }) as YDoc;
+
+    Y.applyUpdate(cachedDoc, createRowDocumentState(documentId));
+    const loadRowDocument = jest.fn().mockResolvedValue(cachedDoc);
+    const createRowDocument = jest.fn().mockResolvedValue(null);
+    const checkIfRowDocumentExists = jest.fn().mockResolvedValueOnce(false).mockResolvedValue(true);
+
+    configureRowDocumentTest({
+      documentIds: { [rowId]: documentId },
+      cachedDocs: new Map([[documentId, cachedDoc]]),
+      loadRowDocument,
+      createRowDocument,
+      checkIfRowDocumentExists,
+      isEmptyDocument: true,
+    });
+    render(<DatabaseRowSubDocument rowId={rowId} />);
+    await act(flushAsyncWork);
+    expect(createRowDocument).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      await jest.advanceTimersByTimeAsync(2000);
+      await flushAsyncWork();
+    });
+
+    expect(screen.getByTestId('row-document-editor')).not.toBeNull();
+    expect(loadRowDocument).toHaveBeenCalledTimes(1);
+    expect(createRowDocument).toHaveBeenCalledTimes(1);
+  });
+
+  it('creates a nonempty row document only after missing-document retries are exhausted', async () => {
+    jest.useFakeTimers();
+
+    const rowId = 'row-id';
+    const documentId = 'document-id';
+    const cachedDoc = new Y.Doc({ guid: documentId }) as YDoc;
+    const loadRowDocument = jest.fn().mockResolvedValue(cachedDoc);
+    const createRowDocument = jest.fn().mockResolvedValue(createRowDocumentState(documentId));
+    const checkIfRowDocumentExists = jest.fn().mockResolvedValue(false);
+
+    configureRowDocumentTest({
+      documentIds: { [rowId]: documentId },
+      cachedDocs: new Map([[documentId, cachedDoc]]),
+      loadRowDocument,
+      createRowDocument,
+      checkIfRowDocumentExists,
+    });
+    render(<DatabaseRowSubDocument rowId={rowId} />);
+    await act(flushAsyncWork);
+    expect(createRowDocument).not.toHaveBeenCalled();
+
+    await act(async () => {
+      await jest.advanceTimersByTimeAsync(2000);
+      await flushAsyncWork();
+    });
+    expect(createRowDocument).not.toHaveBeenCalled();
+
+    await act(async () => {
+      await jest.advanceTimersByTimeAsync(10000);
+      await flushAsyncWork();
+    });
+
+    expect(screen.getByTestId('row-document-editor')).not.toBeNull();
+    expect(createRowDocument).toHaveBeenCalledTimes(1);
+    expect(jest.getTimerCount()).toBe(0);
+  });
+
   it('waits for server creation before binding an empty row that exists only locally', async () => {
     const rowId = 'row-id';
     const documentId = 'document-id';
@@ -273,11 +432,11 @@ describe('DatabaseRowSubDocument', () => {
     expect(await screen.findByTestId('row-document-editor')).not.toBeNull();
   });
 
-  it('repairs and opens an existing row document immediately after one failed page fetch', async () => {
+  it('repairs and opens an existing row document immediately after one denied page fetch', async () => {
     const rowId = 'row-id';
     const documentId = 'document-id';
     const cachedDoc = new Y.Doc({ guid: documentId }) as YDoc;
-    const loadRowDocument = jest.fn().mockResolvedValue(cachedDoc);
+    const loadRowDocument = jest.fn().mockRejectedValue({ code: 1012, message: 'document read denied' });
     const createRowDocument = jest.fn().mockResolvedValue(createRowDocumentState(documentId));
     const checkIfRowDocumentExists = jest.fn().mockResolvedValue(true);
 
@@ -320,7 +479,7 @@ describe('DatabaseRowSubDocument', () => {
     const rowId = 'row-id';
     const documentId = 'document-id';
     const cachedDoc = new Y.Doc({ guid: documentId }) as YDoc;
-    const loadRowDocument = jest.fn().mockResolvedValue(cachedDoc);
+    const loadRowDocument = jest.fn().mockRejectedValue({ code: 1012, message: 'document read denied' });
     const createRowDocument = jest.fn().mockResolvedValue(null);
     const checkIfRowDocumentExists = jest.fn().mockResolvedValue(true);
 
@@ -509,7 +668,7 @@ describe('DatabaseRowSubDocument', () => {
       [secondDocumentId, secondCachedDoc],
     ]);
     const firstRepair = createDeferred<Uint8Array | null>();
-    const loadRowDocument = jest.fn((documentId: string) => Promise.resolve(cachedDocs.get(documentId) ?? null));
+    const loadRowDocument = jest.fn().mockRejectedValue({ code: 1012, message: 'document read denied' });
     const createRowDocument = jest.fn((documentId: string) => {
       if (documentId === firstDocumentId) return firstRepair.promise;
       return Promise.resolve(createRowDocumentState(documentId));
@@ -557,6 +716,8 @@ describe('DatabaseRowSubDocument', () => {
     const documentId = 'document-id';
     const cachedDoc = new Y.Doc({ guid: documentId }) as YDoc;
 
+    Y.applyUpdate(cachedDoc, createRowDocumentState(documentId));
+
     configureRowDocumentTest({
       documentIds: { [rowId]: documentId },
       cachedDocs: new Map([[documentId, cachedDoc]]),
@@ -581,6 +742,8 @@ describe('DatabaseRowSubDocument', () => {
     const rowId = 'row-id';
     const documentId = 'document-id';
     const cachedDoc = new Y.Doc({ guid: documentId }) as YDoc;
+
+    Y.applyUpdate(cachedDoc, createRowDocumentState(documentId));
     const updateRowMeta = jest.fn();
     let pendingFlush: (() => void) | null = null;
 
@@ -620,6 +783,8 @@ describe('DatabaseRowSubDocument', () => {
     const rowId = 'row-id';
     const documentId = 'document-id';
     const cachedDoc = new Y.Doc({ guid: documentId }) as YDoc;
+
+    Y.applyUpdate(cachedDoc, createRowDocumentState(documentId));
     let pendingFlush: (() => void) | null = null;
     const { rows } = configureRowDocumentTest({
       documentIds: { [rowId]: documentId },

--- a/src/components/database/components/database-row/__tests__/DatabaseRowSubDocument.test.tsx
+++ b/src/components/database/components/database-row/__tests__/DatabaseRowSubDocument.test.tsx
@@ -210,6 +210,69 @@ describe('DatabaseRowSubDocument', () => {
     jest.useRealTimers();
   });
 
+  it.each([false, true])('reopens a persisted empty row document without repair (readOnly=%s)', async (readOnly) => {
+    const rowId = 'row-id';
+    const documentId = 'document-id';
+    const cachedDoc = new Y.Doc({ guid: documentId }) as YDoc;
+
+    Y.applyUpdate(cachedDoc, createRowDocumentState(documentId));
+    const loadRowDocument = jest.fn().mockResolvedValue(cachedDoc);
+    const createRowDocument = jest.fn();
+    const checkIfRowDocumentExists = jest.fn().mockResolvedValue(true);
+
+    configureRowDocumentTest({
+      documentIds: { [rowId]: documentId },
+      cachedDocs: new Map([[documentId, cachedDoc]]),
+      loadRowDocument,
+      createRowDocument,
+      checkIfRowDocumentExists,
+      isEmptyDocument: true,
+      readOnly,
+    });
+
+    for (let open = 1; open <= 2; open++) {
+      const view = render(<DatabaseRowSubDocument rowId={rowId} />);
+      const editor = await screen.findByTestId('row-document-editor');
+
+      expect(editor.getAttribute('data-read-only')).toBe(String(readOnly));
+      expect(editor.getAttribute('data-can-write')).toBe(String(!readOnly));
+      expect(checkIfRowDocumentExists).toHaveBeenCalledTimes(open);
+      expect(loadRowDocument).toHaveBeenCalledTimes(open);
+      expect(createRowDocument).not.toHaveBeenCalled();
+      view.unmount();
+    }
+  });
+
+  it('waits for server creation before binding an empty row that exists only locally', async () => {
+    const rowId = 'row-id';
+    const documentId = 'document-id';
+    const cachedDoc = new Y.Doc({ guid: documentId }) as YDoc;
+
+    Y.applyUpdate(cachedDoc, createRowDocumentState(documentId));
+    const creation = createDeferred<Uint8Array>();
+    const loadRowDocument = jest.fn().mockResolvedValue(cachedDoc);
+    const createRowDocument = jest.fn().mockReturnValue(creation.promise);
+
+    configureRowDocumentTest({
+      documentIds: { [rowId]: documentId },
+      cachedDocs: new Map([[documentId, cachedDoc]]),
+      loadRowDocument,
+      createRowDocument,
+      checkIfRowDocumentExists: jest.fn().mockResolvedValue(false),
+      isEmptyDocument: true,
+    });
+    render(<DatabaseRowSubDocument rowId={rowId} />);
+    await waitFor(() => expect(createRowDocument).toHaveBeenCalledTimes(1));
+    expect(screen.queryByTestId('row-document-editor')).toBeNull();
+    expect(loadRowDocument).not.toHaveBeenCalled();
+
+    await act(async () => {
+      creation.resolve(createRowDocumentState(documentId));
+      await flushAsyncWork();
+    });
+    expect(await screen.findByTestId('row-document-editor')).not.toBeNull();
+  });
+
   it('repairs and opens an existing row document immediately after one failed page fetch', async () => {
     const rowId = 'row-id';
     const documentId = 'document-id';
@@ -299,9 +362,14 @@ describe('DatabaseRowSubDocument', () => {
     });
   });
 
-  it.each(['existence check', 'document fetch'])(
-    'repairs an existing row document for a read-only member after a denied %s',
-    async (deniedOperation) => {
+  it.each([
+    { deniedOperation: 'existence check', isEmptyDocument: false },
+    { deniedOperation: 'document fetch', isEmptyDocument: false },
+    { deniedOperation: 'existence check', isEmptyDocument: true },
+    { deniedOperation: 'document fetch', isEmptyDocument: true },
+  ])(
+    'repairs a read-only row after a denied $deniedOperation (empty=$isEmptyDocument)',
+    async ({ deniedOperation, isEmptyDocument }) => {
       const rowId = 'row-id';
       const documentId = 'document-id';
       const cachedDoc = new Y.Doc({ guid: documentId }) as YDoc;
@@ -320,6 +388,7 @@ describe('DatabaseRowSubDocument', () => {
         createRowDocument,
         checkIfRowDocumentExists,
         readOnly: true,
+        isEmptyDocument,
       });
 
       render(<DatabaseRowSubDocument rowId={rowId} />);
@@ -399,7 +468,7 @@ describe('DatabaseRowSubDocument', () => {
     const createRowDocument = jest
       .fn()
       .mockRejectedValue({ code: 1012, message: 'user is not allowed to access this view' });
-    const checkIfRowDocumentExists = jest.fn();
+    const checkIfRowDocumentExists = jest.fn().mockResolvedValue(false);
 
     configureRowDocumentTest({
       documentIds: { [rowId]: documentId },
@@ -417,7 +486,7 @@ describe('DatabaseRowSubDocument', () => {
     expect(screen.getByTestId('row-document-no-access')).not.toBeNull();
     expect(createRowDocument).toHaveBeenCalledTimes(1);
     expect(loadRowDocument).not.toHaveBeenCalled();
-    expect(checkIfRowDocumentExists).not.toHaveBeenCalled();
+    expect(checkIfRowDocumentExists).toHaveBeenCalledTimes(1);
     expect(jest.getTimerCount()).toBe(0);
 
     await act(async () => {

--- a/src/components/database/components/database-row/__tests__/DatabaseRowSubDocument.test.tsx
+++ b/src/components/database/components/database-row/__tests__/DatabaseRowSubDocument.test.tsx
@@ -299,7 +299,47 @@ describe('DatabaseRowSubDocument', () => {
     });
   });
 
-  it('shows no access without repairing or retrying when an existing row document is forbidden', async () => {
+  it.each(['existence check', 'document fetch'])(
+    'repairs an existing row document for a read-only member after a denied %s',
+    async (deniedOperation) => {
+      const rowId = 'row-id';
+      const documentId = 'document-id';
+      const cachedDoc = new Y.Doc({ guid: documentId }) as YDoc;
+      const denied = { code: 1012, message: 'user is not allowed to access this view' };
+      const loadRowDocument = jest.fn().mockRejectedValue(denied);
+      const createRowDocument = jest.fn().mockResolvedValue(createRowDocumentState(documentId));
+      const checkIfRowDocumentExists =
+        deniedOperation === 'existence check'
+          ? jest.fn().mockRejectedValue(denied)
+          : jest.fn().mockResolvedValue(true);
+
+      configureRowDocumentTest({
+        documentIds: { [rowId]: documentId },
+        cachedDocs: new Map([[documentId, cachedDoc]]),
+        loadRowDocument,
+        createRowDocument,
+        checkIfRowDocumentExists,
+        readOnly: true,
+      });
+
+      render(<DatabaseRowSubDocument rowId={rowId} />);
+
+      const editor = await screen.findByTestId('row-document-editor');
+
+      expect(editor.getAttribute('data-read-only')).toBe('true');
+      expect(editor.getAttribute('data-can-write')).toBe('false');
+      expect(screen.queryByTestId('row-document-no-access')).toBeNull();
+      expect(createRowDocument).toHaveBeenCalledTimes(1);
+      expect(createRowDocument).toHaveBeenCalledWith(documentId, {
+        database_id: 'database-id',
+        database_view_id: 'database-view-id',
+        row_id: rowId,
+      });
+      expect(loadRowDocument).toHaveBeenCalledTimes(deniedOperation === 'existence check' ? 0 : 1);
+    }
+  );
+
+  it('shows no access without retrying when the contextual repair is also forbidden', async () => {
     jest.useFakeTimers();
 
     const rowId = 'row-id';
@@ -308,7 +348,9 @@ describe('DatabaseRowSubDocument', () => {
     const loadRowDocument = jest
       .fn()
       .mockRejectedValue({ code: 1012, message: 'user is not allowed to access this view' });
-    const createRowDocument = jest.fn();
+    const createRowDocument = jest
+      .fn()
+      .mockRejectedValue({ code: 1012, message: 'user is not allowed to access this view' });
     const checkIfRowDocumentExists = jest.fn().mockResolvedValue(true);
 
     configureRowDocumentTest({
@@ -317,6 +359,7 @@ describe('DatabaseRowSubDocument', () => {
       loadRowDocument,
       createRowDocument,
       checkIfRowDocumentExists,
+      readOnly: true,
     });
 
     render(<DatabaseRowSubDocument rowId={rowId} />);
@@ -334,7 +377,7 @@ describe('DatabaseRowSubDocument', () => {
         row_id: rowId,
       },
     });
-    expect(createRowDocument).not.toHaveBeenCalled();
+    expect(createRowDocument).toHaveBeenCalledTimes(1);
     expect(jest.getTimerCount()).toBe(0);
 
     await act(async () => {
@@ -343,7 +386,7 @@ describe('DatabaseRowSubDocument', () => {
     });
 
     expect(loadRowDocument).toHaveBeenCalledTimes(1);
-    expect(createRowDocument).not.toHaveBeenCalled();
+    expect(createRowDocument).toHaveBeenCalledTimes(1);
   });
 
   it('shows no access without retrying when empty row document creation is forbidden', async () => {


### PR DESCRIPTION
### Description

Opening an existing empty row document called the orphan creation endpoint on every reopen. Temporary read failures could also turn into creation or repair requests. Existing documents now use normal reads, including empty documents, and temporary failures retry those reads with a bounded budget. Each retry checks server existence again before deciding to create anything.

A final permission denial shows “No access” without a separate Web repair request. Legacy recovery during normal reads is handled by [Cloud PR #1155](https://github.com/AppFlowy-IO/AppFlowy-Cloud-Premium/pull/1155). Web retains creation for missing documents, waits for server creation before binding the editor, and gives nonempty documents a bounded upload grace period. Read-only and comment-only editor permissions are preserved, and stale responses cannot replace the newly selected row.

Template E2E setup also waits for the initial embedded database tab before counting existing views, avoiding a race where adding a Board produced two tabs while the test expected one. Failed CI jobs now report bounded Worker duplication failure messages and backend image identities before database cleanup.

### Validation

- **56 tests pass across five focused suites:** `DatabaseRowSubDocument.test.tsx`, `view-loader.test.ts`, `useDatabaseOperations.rowPermission.test.tsx`, row-document `lifecycle.test.ts`, and JS-services `fetch.test.ts`.
- Eight denial cases first failed on the previous Web implementation and now pass: denied existence checks and document fetches show no access and send no repair/create request, for empty and nonempty rows with read-only and writable editor contexts.
- Retained coverage verifies empty-document reopening, temporary failures and incomplete local state, read retry limits, missing-document creation, inherited permissions, and stale creation/read-denial responses after switching rows.
- `pnpm type-check`, targeted ESLint using the repository's `--quiet` setting, and `git diff --check` pass.

- Chromium on macOS: both affected row-template scenarios passed before the test-helper change, then passed **four runs with two workers and retries disabled** after the change. The scenarios cover inline database copy independence and linked database sharing after template deletion.
- Workflow YAML and shell syntax validated; the failure-diagnostics SELECT ran successfully against local PostgreSQL. Playwright files are excluded from the repository ESLint/type-check configuration.
- CI run [34682288485](https://github.com/AppFlowy-IO/AppFlowy-Web/actions/runs/34682288485/job/103523173223) confirms the tab-loading race is resolved. Its remaining inline-template failure came from a Worker singleton Database read exhausting the bounded batch replay scan (`context=batch_full_collab`, `reason=ScanLimited`), which caused `duplicate-document` to return code `1017`.
- The backend fix is in [Cloud PR #1155](https://github.com/AppFlowy-IO/AppFlowy-Cloud-Premium/pull/1155), commit `ab9f7badf`. A server regression with 2,304 unrelated updates and a real field edit after them fails on the previous Worker and passes with the fix; it verifies the copied data and independence. Both affected Chromium scenarios also pass against the fixed stack with two workers and retries disabled (3.1 minutes).
- The CI check still needs a confirming rerun with a rebuilt Worker image containing that commit. This workflow uses the prebuilt `latest-amd64` backend; pushing the server source does not update that image.

### Checklist

#### General

- [x] Included comments explaining normal reads, terminal denials, and creation decisions.
- [ ] Tested in multiple browsers/operating systems. Validation used automated tests and Chromium on macOS; other browsers and operating systems were not tested.

#### Testing

- [x] Updated tests for the final behavior and removed obsolete Web repair coverage.

#### Feature-Specific

- Preview: not applicable to this bug fix.
- [x] Verified integration with row-document loading, lifecycle, permissions, and fetch behavior through the focused suites.

