### PR TITLE
feat: keep calendar cards local until committed

### DIFF
--- a/playwright/bdd/features/database/calendar-placeholder.feature
+++ b/playwright/bdd/features/database/calendar-placeholder.feature
@@ -1,0 +1,57 @@
+@calendar-placeholder @cloud
+Feature: Calendar cards stay local until the user keeps them
+  Clicking an empty calendar slot opens a local placeholder. Closing an
+  untouched placeholder must not insert a database row, including in cloud sync.
+
+  Scenario: Only committed month and week placeholders survive a fresh cloud login
+    Given a new cloud calendar is open for placeholder creation
+    When I click an empty day in the placeholder calendar
+    Then the calendar shows one local placeholder and no additional stored rows
+    When I dismiss the calendar placeholder with Escape
+    Then the calendar has no placeholder and 0 additional stored rows
+    When I click an empty day in the placeholder calendar
+    And I dismiss the calendar placeholder by clicking outside
+    Then the calendar has no placeholder and 0 additional stored rows
+
+    When I switch the placeholder calendar to "Week"
+    And I click the empty placeholder calendar slot at 9 hours
+    Then the calendar shows one local placeholder and no additional stored rows
+    When I dismiss the calendar placeholder with Escape
+    Then the calendar has no placeholder and 0 additional stored rows
+    When I click the empty placeholder calendar slot at 9 hours
+    And I dismiss the calendar placeholder by clicking outside
+    Then the calendar has no placeholder and 0 additional stored rows
+
+    When I click the empty placeholder calendar slot at 9 hours
+    And I name the calendar placeholder "Cloud timed card"
+    Then the calendar shows one local placeholder and no additional stored rows
+    When I dismiss the calendar placeholder with Escape
+    Then the calendar stores exactly one new card named "Cloud timed card" with its selected dates
+    And the calendar has no placeholder and 1 additional stored rows
+
+    When I switch the placeholder calendar to "Month"
+    And I click an empty day in the placeholder calendar
+    And I name the calendar placeholder "Cloud all-day card"
+    Then the calendar shows one local placeholder and no additional stored rows
+    When I dismiss the calendar placeholder by clicking outside
+    Then the calendar stores exactly one new card named "Cloud all-day card" with its selected dates
+    And the calendar has no placeholder and 2 additional stored rows
+
+    When I click an empty day in the placeholder calendar
+    And I explicitly submit the calendar placeholder
+    Then the calendar stores exactly one new card named "" with its selected dates
+    And the calendar has no placeholder and 3 additional stored rows
+    And only the committed calendar cards return in a fresh cloud browser session
+
+  Scenario: A property-only edit can save an unscheduled card and release the placeholder
+    Given a new cloud calendar is open for placeholder creation
+    When I click an empty day in the placeholder calendar
+    And I clear the calendar placeholder date
+    Then the calendar shows one local placeholder and no additional stored rows
+    When I dismiss the calendar placeholder with Escape
+    Then the calendar stores exactly one new unscheduled card
+    And the calendar has no placeholder and 1 additional stored rows
+    When I click an empty day in the placeholder calendar
+    Then the calendar shows one local placeholder and no additional stored rows
+    When I dismiss the calendar placeholder with Escape
+    Then the calendar has no placeholder and 1 additional stored rows

--- a/playwright/bdd/steps/calendar-placeholder.steps.ts
+++ b/playwright/bdd/steps/calendar-placeholder.steps.ts
@@ -1,0 +1,270 @@
+import { expect, type Page, type ElementHandle } from '@playwright/test';
+import { createBdd } from 'playwright-bdd';
+
+import { signInAndWaitForApp } from '../../support/auth-flow-helpers';
+import {
+  calendarDraftCards,
+  calendarDraftEditor,
+  calendarDraftTitle,
+  calendarStorageIdentity,
+  type CalendarStorageIdentity,
+  type CalendarStoredRow,
+  clickOutsideCalendarDraft,
+  expectCalendarRowsInCloud,
+  readCalendarStoredRows,
+  switchPlaceholderCalendarView,
+} from '../../support/calendar-placeholder-helpers';
+import { loginAndCreateCalendar } from '../../support/calendar-test-helpers';
+import { CalendarSelectors } from '../../support/selectors';
+import { generateRandomEmail } from '../../support/test-config';
+
+const { Given, When, Then } = createBdd();
+
+interface PlaceholderScenario {
+  email: string;
+  url: string;
+  identity: CalendarStorageIdentity;
+  baselineCount: number;
+  expectedRows: CalendarStoredRow[];
+  viewport?: { grid: ElementHandle<Element>; scroller: ElementHandle<Element>; scrollTop: number };
+  selected?: { start: string; end: string; includeTime: boolean };
+}
+
+const scenarios = new WeakMap<Page, PlaceholderScenario>();
+
+function scenario(page: Page): PlaceholderScenario {
+  const state = scenarios.get(page);
+
+  if (!state) throw new Error('Initialize the cloud calendar before creating placeholders');
+  return state;
+}
+
+async function rememberCalendarViewport(page: Page) {
+  const grid = await page.locator('.fc-view').elementHandle();
+  const scroller = await page.locator('.database-calendar').filter({ has: page.locator('.fc-view') }).evaluateHandle((element) => {
+    let parent = element.parentElement;
+
+    while (parent && !/(auto|scroll)/.test(getComputedStyle(parent).overflowY)) parent = parent.parentElement;
+    return parent ?? document.documentElement;
+  });
+  const scrollElement = scroller.asElement();
+
+  if (!grid || !scrollElement) throw new Error('Calendar viewport is unavailable');
+  scenario(page).viewport = {
+    grid,
+    scroller: scrollElement,
+    scrollTop: await scrollElement.evaluate((node) => node.scrollTop),
+  };
+}
+
+async function expectCalendarViewportUnchanged(page: Page) {
+  const viewport = scenario(page).viewport;
+
+  if (!viewport) throw new Error('Capture the calendar viewport before opening a placeholder');
+  expect(await viewport.grid.evaluate((node) => node.isConnected)).toBe(true);
+  expect(await viewport.scroller.evaluate((node) => node.isConnected)).toBe(true);
+  expect(await viewport.scroller.evaluate((node) => node.scrollTop)).toBeCloseTo(viewport.scrollTop, 0);
+}
+
+Given('a new cloud calendar is open for placeholder creation', async ({ page, request, $testInfo }) => {
+  $testInfo.setTimeout(240_000);
+  const email = generateRandomEmail();
+
+  await loginAndCreateCalendar(page, request, email);
+  const identity = await calendarStorageIdentity(page);
+  const expectedRows = await readCalendarStoredRows(page, identity);
+
+  scenarios.set(page, { email, url: page.url(), identity, baselineCount: expectedRows.length, expectedRows });
+  await expectCalendarRowsInCloud(page, request, identity, expectedRows);
+});
+
+When('I click an empty day in the placeholder calendar', async ({ page }) => {
+  const selected = await page.evaluate(() => {
+    const today = new Date();
+
+    today.setHours(0, 0, 0, 0);
+    const end = new Date(today);
+
+    end.setHours(23, 59, 0, 0);
+    return {
+      date: `${today.getFullYear()}-${String(today.getMonth() + 1).padStart(2, '0')}-${String(today.getDate()).padStart(
+        2,
+        '0'
+      )}`,
+      start: String(today.getTime() / 1000),
+      end: String(end.getTime() / 1000),
+      includeTime: false,
+    };
+  });
+  const cell = page.locator(`.fc-daygrid-day[data-date="${selected.date}"]`);
+
+  await cell.scrollIntoViewIfNeeded();
+  const box = await cell.boundingBox();
+
+  if (!box) throw new Error('Today has no calendar day cell');
+  // The header strip stays empty when previously committed cards occupy the day.
+  await rememberCalendarViewport(page);
+  await page.mouse.click(box.x + box.width / 2, box.y + 10);
+  await expect(calendarDraftEditor(page)).toBeVisible();
+  scenario(page).selected = selected;
+});
+
+When('I switch the placeholder calendar to {string}', async ({ page }, name: string) => {
+  await switchPlaceholderCalendarView(page, name);
+});
+
+When('I click the empty placeholder calendar slot at {int} hours', async ({ page }, hour: number) => {
+  const selected = await page.evaluate((hour) => {
+    const start = new Date();
+
+    start.setHours(hour, 0, 0, 0);
+    const end = new Date(start);
+
+    end.setHours(hour + 1);
+    return {
+      date: `${start.getFullYear()}-${String(start.getMonth() + 1).padStart(2, '0')}-${String(start.getDate()).padStart(
+        2,
+        '0'
+      )}`,
+      start: String(start.getTime() / 1000),
+      end: String(end.getTime() / 1000),
+      includeTime: true,
+    };
+  }, hour);
+  const slot = page.locator(`.fc-timegrid-slot-lane[data-time="${String(hour).padStart(2, '0')}:00:00"]`);
+
+  await slot.scrollIntoViewIfNeeded();
+  const slotBox = await slot.boundingBox();
+  const columnBox = await page.locator(`.fc-timegrid-col[data-date="${selected.date}"]`).boundingBox();
+
+  if (!slotBox || !columnBox) throw new Error('The selected calendar time slot is not visible');
+  await rememberCalendarViewport(page);
+  await page.mouse.click(columnBox.x + columnBox.width / 2, slotBox.y + 3);
+  await expect(calendarDraftEditor(page)).toBeVisible();
+  scenario(page).selected = selected;
+});
+
+When('I name the calendar placeholder {string}', async ({ page }, title: string) => {
+  await calendarDraftTitle(page).fill(title);
+  await expect(calendarDraftTitle(page)).toHaveValue(title);
+  await expect(calendarDraftCards(page)).toContainText(title);
+});
+
+Then('the calendar shows one local placeholder and no additional stored rows', async ({ page, request }) => {
+  const state = scenario(page);
+
+  await expect(calendarDraftEditor(page)).toBeVisible();
+  await expect(calendarDraftCards(page)).toHaveCount(1);
+  await expectCalendarViewportUnchanged(page);
+  expect(await readCalendarStoredRows(page, state.identity)).toEqual(state.expectedRows);
+  await expectCalendarRowsInCloud(page, request, state.identity, state.expectedRows);
+});
+
+When('I dismiss the calendar placeholder with Escape', async ({ page }) => {
+  await page.keyboard.press('Escape');
+  await expect(calendarDraftEditor(page)).toHaveCount(0);
+});
+
+When('I dismiss the calendar placeholder by clicking outside', async ({ page }) => {
+  await clickOutsideCalendarDraft(page);
+  await expect(calendarDraftEditor(page)).toHaveCount(0);
+});
+
+When('I explicitly submit the calendar placeholder', async ({ page }) => {
+  await calendarDraftTitle(page).press('Enter');
+  await expect(calendarDraftEditor(page)).toHaveCount(0);
+});
+
+Then('the calendar has no placeholder and {int} additional stored rows', async ({ page, request }, count: number) => {
+  const state = scenario(page);
+
+  await expect(calendarDraftEditor(page)).toHaveCount(0);
+  await expect(calendarDraftCards(page)).toHaveCount(0);
+  await expectCalendarViewportUnchanged(page);
+  expect(state.expectedRows).toHaveLength(state.baselineCount + count);
+  await expect.poll(() => readCalendarStoredRows(page, state.identity)).toEqual(state.expectedRows);
+  await expectCalendarRowsInCloud(page, request, state.identity, state.expectedRows);
+});
+
+Then(
+  'the calendar stores exactly one new card named {string} with its selected dates',
+  async ({ page }, title: string) => {
+    const state = scenario(page);
+    const previousIds = new Set(state.expectedRows.map((row) => row.id));
+
+    await expect
+      .poll(async () => (await readCalendarStoredRows(page, state.identity)).length)
+      .toBe(previousIds.size + 1);
+    const rows = await readCalendarStoredRows(page, state.identity);
+    const inserted = rows.filter((row) => !previousIds.has(row.id));
+
+    expect(inserted).toHaveLength(1);
+    expect(rows.filter((row) => previousIds.has(row.id))).toEqual(state.expectedRows);
+    const selected = state.selected;
+
+    if (!selected) throw new Error('No calendar slot was selected before committing');
+    expect(inserted[0]).toMatchObject({ title, start: selected.start, includeTime: selected.includeTime });
+    if (selected.includeTime) {
+      expect(inserted[0]).toMatchObject({ end: selected.end, isRange: true });
+    } else {
+      expect(inserted[0]).toMatchObject({ end: '', isRange: false });
+    }
+    await expect(
+      CalendarSelectors.event(page)
+        .filter({ hasText: title || 'Untitled' })
+        .first()
+    ).toBeVisible();
+    state.expectedRows = rows;
+  }
+);
+
+Then('only the committed calendar cards return in a fresh cloud browser session', async ({ page, request, browser }) => {
+  const state = scenario(page);
+
+  await expectCalendarRowsInCloud(page, request, state.identity, state.expectedRows);
+  // A new context has neither the first browser's tokens nor its IndexedDB rows.
+  const context = await browser.newContext({
+    baseURL: new URL(state.url).origin,
+    viewport: { width: 1440, height: 900 },
+  });
+
+  try {
+    const freshPage = await context.newPage();
+
+    await signInAndWaitForApp(freshPage, request, state.email);
+    await freshPage.goto(state.url);
+    await expect(CalendarSelectors.calendarContainer(freshPage).first()).toBeVisible({ timeout: 30_000 });
+    expect(await calendarStorageIdentity(freshPage)).toEqual(state.identity);
+    await expect.poll(() => readCalendarStoredRows(freshPage, state.identity)).toEqual(state.expectedRows);
+    await expect(calendarDraftEditor(freshPage)).toHaveCount(0);
+    await expect(calendarDraftCards(freshPage)).toHaveCount(0);
+    await expect(CalendarSelectors.event(freshPage)).toHaveCount(3);
+    await expect(CalendarSelectors.event(freshPage).filter({ hasText: 'Cloud timed card' })).toBeVisible();
+    await expect(CalendarSelectors.event(freshPage).filter({ hasText: 'Cloud all-day card' })).toBeVisible();
+    await expect(CalendarSelectors.event(freshPage).filter({ hasText: 'Untitled' })).toBeVisible();
+  } finally {
+    await context.close();
+  }
+});
+
+When('I clear the calendar placeholder date', async ({ page }) => {
+  const state = scenario(page);
+  const id = await calendarDraftCards(page).getAttribute('data-event-id');
+
+  await calendarDraftEditor(page).getByTestId(`datetime-cell-${id}-${state.identity.dateFieldId}`).click();
+  await page.getByTestId('clear-date-button').click();
+  await expect(page.getByTestId('datetime-picker-popover')).toHaveCount(0);
+});
+
+Then('the calendar stores exactly one new unscheduled card', async ({ page }) => {
+  const state = scenario(page);
+  const previousIds = new Set(state.expectedRows.map((row) => row.id));
+
+  await expect.poll(async () => (await readCalendarStoredRows(page, state.identity)).length).toBe(previousIds.size + 1);
+  const rows = await readCalendarStoredRows(page, state.identity);
+  const inserted = rows.filter((row) => !previousIds.has(row.id));
+
+  expect(inserted).toHaveLength(1);
+  expect(inserted[0]).toMatchObject({ title: '', start: '', end: '', isRange: false });
+  state.expectedRows = rows;
+});

--- a/playwright/e2e/calendar/calendar-basic.spec.ts
+++ b/playwright/e2e/calendar/calendar-basic.spec.ts
@@ -20,6 +20,7 @@ import {
   editEventTitle,
   deleteEventFromPopover,
   closeEventPopover,
+  submitEventPopover,
   assertTotalEventCount,
   assertEventExists,
   getToday,
@@ -101,8 +102,8 @@ test.describe('Calendar Basic Tests (Desktop Parity)', () => {
     // Event editor/popover should open
     await expect(page.locator('[data-radix-popper-content-wrapper]')).toBeVisible();
 
-    // Close the popover
-    await closeEventPopover(page);
+    // Explicitly keep the untitled placeholder.
+    await submitEventPopover(page);
 
     // Verify event was created
     await assertTotalEventCount(page, 1);
@@ -121,19 +122,14 @@ test.describe('Calendar Basic Tests (Desktop Parity)', () => {
     await CalendarSelectors.dayCellByDate(page, dateStr).hover();
     await page.waitForTimeout(500);
 
-    // Click the add button if visible, otherwise double-click
-    const addButton = page.locator('[data-testid="calendar-add-button"], .add-event-button');
-    const addButtonCount = await addButton.count();
-    if (addButtonCount > 0 && await addButton.first().isVisible()) {
-      await addButton.first().click({ force: true });
-    } else {
-      await doubleClickCalendarDay(page, today);
-    }
+    const addButton = page.locator('button.calendar-add-button[data-add-button]');
+    await expect(addButton).toBeVisible();
+    await addButton.click();
 
     await page.waitForTimeout(1000);
 
-    // Close any open popover
-    await closeEventPopover(page);
+    // Explicitly keep the untitled placeholder.
+    await submitEventPopover(page);
 
     // Verify event exists
     await expect(CalendarSelectors.event(page).first()).toBeVisible();

--- a/playwright/e2e/calendar/calendar-reschedule.spec.ts
+++ b/playwright/e2e/calendar/calendar-reschedule.spec.ts
@@ -73,8 +73,7 @@ test.describe('Calendar Reschedule Tests (Desktop Parity)', () => {
 
     const targetDay = today.getDate() === 15 ? 16 : 15;
 
-    // Calendar events default to range mode (End date ON).
-    // Disable it so clicking a day changes the single date, not the end date.
+    // If a range is enabled, change the single date rather than its end date.
     const pickerPopover = page.getByTestId('datetime-picker-popover');
     const endDateSwitch = pickerPopover.locator('button[role="switch"]').first();
     if ((await endDateSwitch.getAttribute('data-state')) === 'checked') {

--- a/playwright/support/calendar-placeholder-helpers.ts
+++ b/playwright/support/calendar-placeholder-helpers.ts
@@ -1,0 +1,174 @@
+import { expect, type APIRequestContext, type Page } from '@playwright/test';
+
+import { getCurrentDatabaseInfo, waitForDatabaseTestContext } from './relation-test-helpers';
+import { CalendarSelectors } from './selectors';
+import { TestConfig } from './test-config';
+
+export interface CalendarStoredRow {
+  id: string;
+  title: string;
+  start: string;
+  end: string;
+  includeTime: boolean;
+  isRange: boolean;
+}
+
+export interface CalendarStorageIdentity {
+  workspaceId: string;
+  databaseId: string;
+  viewId: string;
+  primaryFieldId: string;
+  dateFieldId: string;
+}
+
+export const calendarDraftEditor = (page: Page) => page.getByTestId('calendar-event-draft-editor');
+export const calendarDraftTitle = (page: Page) => calendarDraftEditor(page).getByTestId('calendar-event-title-input');
+export const calendarDraftCards = (page: Page) => page.getByTestId('calendar-draft-event');
+
+export async function calendarStorageIdentity(page: Page): Promise<CalendarStorageIdentity> {
+  const info = await getCurrentDatabaseInfo(page);
+  const workspaceId = new URL(page.url()).pathname.split('/')[2];
+  const dateFieldId = await page.evaluate(() => {
+    const ctx = (window as any).__TEST_DATABASE_CONTEXT__;
+    const database = ctx.databaseDoc.getMap('data').get('database');
+
+    return database.get('views').get(ctx.activeViewId).get('layout_settings').get('2').get('field_id') as string;
+  });
+
+  if (!workspaceId || !dateFieldId) throw new Error('Calendar cloud identity is incomplete');
+  return {
+    workspaceId,
+    databaseId: info.databaseId,
+    viewId: info.viewId,
+    primaryFieldId: info.primaryFieldId,
+    dateFieldId,
+  };
+}
+
+/** Read real rows, rather than counting the rendered cards (which include drafts). */
+export async function readCalendarStoredRows(
+  page: Page,
+  identity: CalendarStorageIdentity
+): Promise<CalendarStoredRow[]> {
+  await waitForDatabaseTestContext(page);
+  return page.evaluate(async ({ viewId, primaryFieldId, dateFieldId }) => {
+    const ctx = (window as any).__TEST_DATABASE_CONTEXT__;
+    const database = ctx.databaseDoc.getMap('data').get('database');
+    const orders = database.get('views').get(viewId).get('row_orders').toArray() as Array<{
+      id: string;
+      is_deleted?: boolean;
+    }>;
+    const rows: CalendarStoredRow[] = [];
+
+    for (const { id } of orders.filter((order) => !order.is_deleted)) {
+      const doc = ctx.rowMap?.[id] ?? (await ctx.ensureRow(id));
+
+      if (!doc) throw new Error(`Calendar row ${id} has not loaded`);
+      const cells = doc.getMap('data').get('data').get('cells');
+      const date = cells.get(dateFieldId);
+
+      rows.push({
+        id,
+        title: String(cells.get(primaryFieldId)?.get('data') ?? ''),
+        start: String(date?.get('data') ?? ''),
+        end: String(date?.get('end_timestamp') ?? ''),
+        includeTime: Boolean(date?.get('include_time')),
+        isRange: Boolean(date?.get('is_range')),
+      });
+    }
+
+    return rows.sort((left, right) => left.id.localeCompare(right.id));
+  }, identity);
+}
+
+type CloudCollab = Record<string, any>;
+
+async function readCloudCollab(
+  request: APIRequestContext,
+  token: string,
+  workspaceId: string,
+  objectId: string,
+  collabType: number
+): Promise<CloudCollab> {
+  const response = await request.get(`${TestConfig.apiUrl}/api/workspace/v1/${workspaceId}/collab/${objectId}/json`, {
+    headers: { Authorization: `Bearer ${token}` },
+    params: { collab_type: String(collabType) },
+    failOnStatusCode: false,
+  });
+
+  if (!response.ok()) throw new Error(`Cloud calendar snapshot failed: HTTP ${response.status()}`);
+  const envelope = await response.json();
+
+  if (envelope.code !== 0 || !envelope.data?.collab) {
+    throw new Error(`Cloud calendar snapshot failed: API code ${envelope.code}`);
+  }
+
+  return envelope.data.collab;
+}
+
+/** Authenticate against the real cloud snapshots; no request interception or injected rows. */
+export async function expectCalendarRowsInCloud(
+  page: Page,
+  request: APIRequestContext,
+  identity: CalendarStorageIdentity,
+  expected: CalendarStoredRow[]
+): Promise<void> {
+  const token = await page.evaluate(() => localStorage.getItem('af_auth_token'));
+
+  if (!token) throw new Error('Calendar placeholder tests require an authenticated cloud account');
+  await expect(async () => {
+    const { workspaceId, databaseId, viewId, primaryFieldId, dateFieldId } = identity;
+    const snapshot = await readCloudCollab(request, token, workspaceId, databaseId, 1);
+    const orders = snapshot.database?.views?.[viewId]?.row_orders as
+      | Array<{ id: string; is_deleted?: boolean }>
+      | undefined;
+
+    expect(orders, 'Cloud snapshot must contain the tested calendar view').toBeDefined();
+    const ids = orders!
+      .filter((row) => !row.is_deleted)
+      .map((row) => row.id)
+      .sort();
+
+    expect(ids, 'Cloud membership includes only intentional calendar rows').toEqual(
+      expected.map((row) => row.id).sort()
+    );
+    const rows = await Promise.all(
+      ids.map(async (id): Promise<CalendarStoredRow> => {
+        const rowSnapshot = await readCloudCollab(request, token, workspaceId, id, 4);
+        const row = rowSnapshot.data;
+
+        expect(row?.id).toBe(id);
+        expect(row?.database_id).toBe(databaseId);
+        const date = row.cells?.[dateFieldId];
+
+        return {
+          id,
+          title: String(row.cells?.[primaryFieldId]?.data ?? ''),
+          start: String(date?.data ?? ''),
+          end: String(date?.end_timestamp ?? ''),
+          includeTime: Boolean(date?.include_time),
+          isRange: Boolean(date?.is_range),
+        };
+      })
+    );
+
+    expect(rows).toEqual(expected);
+  }).toPass({ timeout: 45_000, intervals: [300, 500, 1000] });
+}
+
+export async function switchPlaceholderCalendarView(page: Page, name: string): Promise<void> {
+  if (name !== 'Month' && name !== 'Week') throw new Error(`Unsupported calendar view ${name}`);
+  const toolbar = CalendarSelectors.toolbar(page).filter({ visible: true }).first();
+
+  await toolbar.getByRole('button', { name, exact: true }).click();
+  await expect(page.locator(name === 'Month' ? '.fc-dayGridMonth-view' : '.fc-timeGridWeek-view')).toBeVisible();
+}
+
+export async function clickOutsideCalendarDraft(page: Page): Promise<void> {
+  const title = CalendarSelectors.title(page).filter({ visible: true }).first();
+  const box = await title.boundingBox();
+
+  if (!box) throw new Error('Calendar toolbar title is not visible');
+  // A modal popover owns the pointer barrier, so exercise the real outside click.
+  await page.mouse.click(box.x + box.width / 2, box.y + box.height / 2);
+}

--- a/playwright/support/calendar-test-helpers.ts
+++ b/playwright/support/calendar-test-helpers.ts
@@ -116,11 +116,19 @@ export async function clickEvent(page: Page, eventIndex: number = 0): Promise<vo
  * Edit event title in the popover
  */
 export async function editEventTitle(page: Page, newTitle: string): Promise<void> {
-  const popover = page.locator('[data-radix-popper-content-wrapper]').last();
-  const titleInput = popover.locator('input, textarea, [contenteditable="true"]').first();
+  const titleInput = page.getByTestId('calendar-event-title-input');
+  await expect(titleInput).toBeVisible();
   await titleInput.fill('');
   await titleInput.pressSequentially(newTitle, { delay: 30 });
   await page.waitForTimeout(500);
+}
+
+/** Explicit submission keeps an intentionally untitled calendar placeholder. */
+export async function submitEventPopover(page: Page): Promise<void> {
+  const titleInput = page.getByTestId('calendar-event-title-input');
+  await expect(titleInput).toBeVisible();
+  await titleInput.press('Enter');
+  await expect(titleInput).toHaveCount(0);
 }
 
 /**

--- a/playwright/support/relation-test-helpers.ts
+++ b/playwright/support/relation-test-helpers.ts
@@ -141,7 +141,7 @@ export async function getCurrentDatabaseInfo(page: Page): Promise<DatabaseFixtur
     )
     .toBe(true);
 
-  return currentInfo as DatabaseFixtureInfo;
+  return currentInfo as unknown as DatabaseFixtureInfo;
 }
 
 export async function createNamedGridDatabase(

--- a/src/application/database-yjs/__tests__/useNewRowTemplateDispatch.test.tsx
+++ b/src/application/database-yjs/__tests__/useNewRowTemplateDispatch.test.tsx
@@ -6,6 +6,7 @@ import { FieldType, RowMetaKey } from '@/application/database-yjs/database.type'
 import { useNewRowDispatch } from '@/application/database-yjs/dispatch/row';
 import { TextFilterCondition } from '@/application/database-yjs/fields';
 import { createRelationField } from '@/application/database-yjs/fields/relation/utils';
+import { initialDatabaseRow } from '@/application/database-yjs/row';
 import { getMetaIdMap, getRowKey } from '@/application/database-yjs/row_meta';
 import { DatabaseRowTemplateStore } from '@/application/database-yjs/template';
 import templateInterop from '@/application/database-yjs/template/__tests__/fixtures/row_template_interop.json';
@@ -16,6 +17,7 @@ import {
   ViewIconType,
   ViewLayout,
   YDatabase,
+  YDatabaseCell,
   YDatabaseField,
   YDatabaseFilter,
   YDatabaseRow,
@@ -142,6 +144,113 @@ function createWrapper(context: DatabaseContextState): ({ children }: { children
 }
 
 describe('useNewRowDispatch database templates', () => {
+  it('retries a published calendar draft with its latest edits and repairs reciprocal links without duplicating it', async () => {
+    const { doc, database } = createDatabaseDoc(DatabaseViewLayout.Calendar);
+    const template = addTemplate(database, { empty: false });
+    const rowId = '40000000-0000-4000-8000-000000000004';
+    const relatedRowId = '50000000-0000-4000-8000-000000000005';
+    const relationFieldId = 'relation-field';
+    const reciprocalFieldId = 'reciprocal-field';
+
+    database.get(YjsDatabaseKey.fields).set(relationFieldId, createRelationField(relationFieldId, {
+      database_id: databaseId,
+      is_two_way: true,
+      reciprocal_field_id: reciprocalFieldId,
+    }));
+    database.get(YjsDatabaseKey.fields).set(reciprocalFieldId, createRelationField(reciprocalFieldId));
+    database.get(YjsDatabaseKey.views).forEach((view) => {
+      view.get(YjsDatabaseKey.row_orders).push([{ id: relatedRowId, height: 36 }]);
+    });
+
+    const draftDoc = new Y.Doc() as YDoc;
+
+    initialDatabaseRow(rowId, databaseId, draftDoc);
+    const cells = rowFrom(draftDoc).get(YjsDatabaseKey.cells);
+    const titleCell = new Y.Map() as YDatabaseCell;
+    const relationCell = new Y.Map() as YDatabaseCell;
+    const relationData = new Y.Array<string>();
+
+    titleCell.set(YjsDatabaseKey.field_type, FieldType.RichText);
+    titleCell.set(YjsDatabaseKey.data, 'Before retry');
+    relationCell.set(YjsDatabaseKey.field_type, FieldType.Relation);
+    relationData.push([relatedRowId]);
+    relationCell.set(YjsDatabaseKey.data, relationData);
+    cells.set(nameFieldId, titleCell);
+    cells.set(relationFieldId, relationCell);
+    const draft = {
+      id: rowId,
+      cells,
+      meta: draftDoc.getMap(YjsEditorKey.data_section).get(YjsEditorKey.meta) as Y.Map<unknown>,
+    };
+    const relatedKey = getRowKey(databaseDocId, relatedRowId);
+    const relatedDoc = new Y.Doc({ guid: relatedKey }) as YDoc;
+
+    initialDatabaseRow(relatedRowId, databaseId, relatedDoc);
+    const createdRows = new Map<string, YDoc>([[relatedKey, relatedDoc]]);
+    const sourceDocument = new Y.Doc({ guid: template.docViewId }) as YDoc;
+
+    sourceDocument.getMap(YjsEditorKey.data_section).set(YjsEditorKey.document, new Y.Map());
+    const duplicateRowDocument = jest.fn(async () => undefined);
+    let relatedLoadAttempts = 0;
+    const context: DatabaseContextState = {
+      readOnly: false,
+      databaseDoc: doc,
+      databasePageId: viewId,
+      activeViewId: viewId,
+      rowMap: {},
+      workspaceId: 'workspace-id',
+      createRow: async (key) => {
+        if (key === relatedKey && ++relatedLoadAttempts === 1) {
+          throw new Error('Related row temporarily unavailable');
+        }
+
+        let rowDoc = createdRows.get(key);
+
+        if (!rowDoc) {
+          rowDoc = new Y.Doc({ guid: key }) as YDoc;
+          createdRows.set(key, rowDoc);
+        }
+
+        return rowDoc;
+      },
+      loadRowDocument: async () => sourceDocument,
+      duplicateRowDocument,
+    };
+    const { result } = renderHook(() => useNewRowDispatch(), { wrapper: createWrapper(context) });
+    const request = { draft, templateId: template.templateId, tailing: true, suppressAutoOpen: true };
+
+    await act(async () => {
+      await expect(result.current(request)).rejects.toThrow('Related row temporarily unavailable');
+    });
+
+    const savedDoc = createdRows.get(getRowKey(databaseDocId, rowId)) as YDoc;
+
+    expect(cellData(savedDoc, nameFieldId)).toBe('Before retry');
+    expect(cellData(relatedDoc, reciprocalFieldId)).toBeUndefined();
+    database.get(YjsDatabaseKey.views).forEach((view) => {
+      expect(view.get(YjsDatabaseKey.row_orders).toJSON()).toEqual([
+        { id: relatedRowId, height: 36 },
+        { id: rowId, height: 36 },
+      ]);
+    });
+
+    titleCell.set(YjsDatabaseKey.data, 'Edited after the failed save');
+    await act(async () => {
+      await expect(result.current(request)).resolves.toBe(rowId);
+    });
+
+    expect(cellData(savedDoc, nameFieldId)).toBe('Edited after the failed save');
+    expect((cellData(relatedDoc, reciprocalFieldId) as Y.Array<string>).toArray()).toEqual([rowId]);
+    expect(relatedLoadAttempts).toBe(2);
+    expect(duplicateRowDocument).toHaveBeenCalledTimes(1);
+    database.get(YjsDatabaseKey.views).forEach((view) => {
+      expect(view.get(YjsDatabaseKey.row_orders).toJSON()).toEqual([
+        { id: relatedRowId, height: 36 },
+        { id: rowId, height: 36 },
+      ]);
+    });
+  });
+
   it('writes grouped relation prefills as canonical relation data before reciprocal handling', async () => {
     const { doc, database } = createDatabaseDoc();
     const relationFieldId = 'relation-field-id';

--- a/src/application/database-yjs/dispatch/new-row-cells.ts
+++ b/src/application/database-yjs/dispatch/new-row-cells.ts
@@ -1,0 +1,277 @@
+import dayjs from 'dayjs';
+import * as Y from 'yjs';
+
+import { cloneDatabaseCell } from '@/application/database-yjs/cell.clone';
+import { FieldType, FilterType, isAttributionFieldType } from '@/application/database-yjs/database.type';
+import { parseRelationTypeOption } from '@/application/database-yjs/fields/relation/parse';
+import { RelationLimit } from '@/application/database-yjs/fields/relation/relation.type';
+import {
+  dateFilterFillData,
+  filterFillData,
+  getFilterChildren,
+  normalizeFilterNode,
+  relationFilterFillData,
+} from '@/application/database-yjs/filter';
+import { normalizeGroupIdentifiers } from '@/application/database-yjs/group';
+import { applyTemplateCellsToRow, DatabaseRowTemplate } from '@/application/database-yjs/template';
+import {
+  FieldId,
+  YDatabase,
+  YDatabaseCell,
+  YDatabaseCells,
+  YDatabaseFilter,
+  YDatabaseFilters,
+  YDatabaseRow,
+  YjsDatabaseKey,
+} from '@/application/types';
+
+export type NewRowCellsData = Record<
+  FieldId,
+  | string
+  | {
+      data: string;
+      endTimestamp?: string;
+      isRange?: boolean;
+      includeTime?: boolean;
+      reminderId?: string;
+    }
+>;
+
+export function collectNewRowPrefillFilters(filters: YDatabaseFilters | undefined): YDatabaseFilter[] {
+  if (!filters) return [];
+
+  const leaves: YDatabaseFilter[] = [];
+  const visit = (rawNode: unknown) => {
+    const node = normalizeFilterNode(rawNode);
+
+    if (!node) return;
+
+    const rawType = node.get(YjsDatabaseKey.filter_type);
+    const parsedType = Number(rawType);
+    const type =
+      rawType === undefined || rawType === null || !Number.isFinite(parsedType) ? FilterType.Data : parsedType;
+
+    if (type === FilterType.Data) {
+      leaves.push(node);
+      return;
+    }
+
+    const children = getFilterChildren(node);
+
+    if (type === FilterType.And) {
+      children.forEach(visit);
+      return;
+    }
+
+    if (type === FilterType.Or && children.length > 0) {
+      visit(children[0]);
+    }
+  };
+
+  filters.toArray().forEach(visit);
+  return leaves;
+}
+
+/** Shared by ephemeral calendar drafts and persisted row creation. */
+export function populateNewRowCells({
+  row,
+  database,
+  filters,
+  template,
+  cellsData,
+  initialCells,
+  calendarFieldId,
+}: {
+  row: YDatabaseRow;
+  database: YDatabase;
+  filters?: YDatabaseFilters;
+  template?: DatabaseRowTemplate;
+  cellsData?: NewRowCellsData;
+  initialCells?: YDatabaseCells;
+  calendarFieldId?: string;
+}) {
+  const cells = row.get(YjsDatabaseKey.cells);
+  const filterArray = collectNewRowPrefillFilters(filters);
+  let shouldOpenRowModal = (filters?.length ?? 0) > 0;
+  const relationPrefills = new Map<FieldId, string[]>();
+
+  if (template) {
+    const appliedCells = applyTemplateCellsToRow(row, database, template.defaultCells);
+
+    // Template relation defaults join the same reciprocal-backfill queue
+    // as filter prefills. A later filter prefill on the same field
+    // overwrites both the cell and this queue entry, so the backfill
+    // always mirrors the final cell state.
+    Object.entries(appliedCells).forEach(([fieldId, value]) => {
+      if (value.type === 'relation' && value.value.length > 0) {
+        relationPrefills.set(fieldId, value.value);
+      }
+    });
+  }
+
+  filterArray.forEach((filter) => {
+    const cell = new Y.Map() as YDatabaseCell;
+    const fieldId = filter.get(YjsDatabaseKey.field_id);
+    const field = database.get(YjsDatabaseKey.fields)?.get(fieldId);
+
+    if (!field) {
+      return;
+    }
+
+    // Desktop deliberately leaves the primary title empty when a row is
+    // created under an active filter. The filtered-out row is completed
+    // through the row detail page; secondary fields can still inherit
+    // their filter values.
+    if (field.get(YjsDatabaseKey.is_primary)) {
+      return;
+    }
+
+    if (calendarFieldId === fieldId) {
+      shouldOpenRowModal = true;
+    }
+
+    const type = Number(field.get(YjsDatabaseKey.type));
+
+    if (isAttributionFieldType(type)) {
+      shouldOpenRowModal = true;
+      return;
+    }
+
+    if (type === FieldType.DateTime) {
+      const { data, endTimestamp, isRange } = dateFilterFillData(filter);
+
+      if (data !== null) {
+        cell.set(YjsDatabaseKey.data, data);
+      }
+
+      if (endTimestamp) {
+        cell.set(YjsDatabaseKey.end_timestamp, endTimestamp);
+      }
+
+      if (isRange) {
+        cell.set(YjsDatabaseKey.is_range, isRange);
+      }
+    } else if ([FieldType.CreatedTime, FieldType.LastEditedTime].includes(type)) {
+      shouldOpenRowModal = true;
+      return;
+    } else if (type === FieldType.Relation) {
+      const rowIds = relationFilterFillData(
+        String(filter.get(YjsDatabaseKey.content) ?? ''),
+        Number(filter.get(YjsDatabaseKey.condition))
+      );
+
+      if (!rowIds) {
+        return;
+      }
+
+      // Enforce source_limit synchronously so OneOnly relations don't
+      // silently end up with multiple linked rows when the filter has
+      // several values selected.
+      const typeOption = parseRelationTypeOption(field);
+      const limitedRowIds =
+        typeOption.source_limit === RelationLimit.OneOnly && rowIds.length > 1 ? [rowIds[rowIds.length - 1]] : rowIds;
+
+      const data = new Y.Array<string>();
+
+      if (limitedRowIds.length > 0) {
+        data.push([...limitedRowIds]);
+        relationPrefills.set(fieldId, limitedRowIds);
+      } else {
+        // An earlier filter on this same field may have queued IDs;
+        // an empty later filter must clear that queue so the backfill
+        // doesn't write reciprocals to rows the source no longer links.
+        relationPrefills.delete(fieldId);
+      }
+
+      cell.set(YjsDatabaseKey.data, data);
+    } else {
+      const data = filterFillData(filter, field);
+
+      if (data === null) {
+        return;
+      }
+
+      cell.set(YjsDatabaseKey.data, data);
+    }
+
+    cell.set(YjsDatabaseKey.created_at, String(dayjs().unix()));
+    cell.set(YjsDatabaseKey.field_type, type);
+
+    cells.set(fieldId, cell);
+  });
+
+  if (cellsData) {
+    Object.entries(cellsData).forEach(([fieldId, data]) => {
+      const cell = new Y.Map() as YDatabaseCell;
+      const field = database.get(YjsDatabaseKey.fields)?.get(fieldId);
+
+      if (!field) return;
+
+      // The raw cell payload replaces whatever a template or filter
+      // wrote for this field, so any queued reciprocal backfill for it
+      // would no longer match the final cell state.
+      relationPrefills.delete(fieldId);
+
+      const type = Number(field.get(YjsDatabaseKey.type));
+
+      if (isAttributionFieldType(type)) return;
+
+      const rawData = typeof data === 'object' ? data.data : data;
+
+      cell.set(YjsDatabaseKey.created_at, String(dayjs().unix()));
+      cell.set(YjsDatabaseKey.field_type, type);
+
+      if (type === FieldType.Relation) {
+        const relationOption = parseRelationTypeOption(field);
+        const identifiers = normalizeGroupIdentifiers(rawData);
+        const rowIds =
+          relationOption.source_limit === RelationLimit.OneOnly && identifiers.length > 1
+            ? [identifiers[identifiers.length - 1]]
+            : identifiers;
+        const relationData = new Y.Array<string>();
+
+        if (rowIds.length > 0) {
+          relationData.push(rowIds);
+          relationPrefills.set(fieldId, rowIds);
+        }
+
+        cell.set(YjsDatabaseKey.data, relationData);
+      } else if (typeof data === 'object') {
+        cell.set(YjsDatabaseKey.data, data.data);
+        cell.set(YjsDatabaseKey.end_timestamp, data.endTimestamp);
+        cell.set(YjsDatabaseKey.is_range, data.isRange);
+        cell.set(YjsDatabaseKey.include_time, data.includeTime);
+        cell.set(YjsDatabaseKey.reminder_id, data.reminderId);
+      } else {
+        cell.set(YjsDatabaseKey.data, data);
+      }
+
+      cells.set(fieldId, cell);
+    });
+  }
+
+  // Draft cells override defaults as a complete snapshot, including explicit
+  // empty values and nested Y.Array data used by media, people and relations.
+  if (initialCells) {
+    cells.clear();
+    relationPrefills.clear();
+    initialCells.forEach((value, fieldId) => {
+      const cell = value as YDatabaseCell;
+      const field = database.get(YjsDatabaseKey.fields)?.get(fieldId);
+
+      if (!field) return;
+      const type = Number(field.get(YjsDatabaseKey.type));
+
+      if (isAttributionFieldType(type) || type === FieldType.CreatedTime || type === FieldType.LastEditedTime) return;
+      cells.set(fieldId, cloneDatabaseCell(type, cell));
+      if (type === FieldType.Relation) {
+        const data = cell.get(YjsDatabaseKey.data);
+        const ids = data instanceof Y.Array ? data.toArray() : normalizeGroupIdentifiers(data);
+
+        if (ids.length) relationPrefills.set(fieldId, ids);
+      }
+    });
+  }
+
+  return { relationPrefills, shouldOpenRowModal };
+}

--- a/src/application/database-yjs/dispatch/row.ts
+++ b/src/application/database-yjs/dispatch/row.ts
@@ -30,19 +30,10 @@ import {
   useRowMap,
   useSharedRoot,
 } from '@/application/database-yjs/context';
-import { FieldType, FilterType, isAttributionFieldType, RowMetaKey } from '@/application/database-yjs/database.type';
+import { FieldType, isAttributionFieldType, RowMetaKey } from '@/application/database-yjs/database.type';
 import { createCheckboxCell } from '@/application/database-yjs/fields/checkbox/utils';
-import { parseRelationTypeOption } from '@/application/database-yjs/fields/relation/parse';
-import { RelationLimit } from '@/application/database-yjs/fields/relation/relation.type';
 import { createSelectOptionCell } from '@/application/database-yjs/fields/select-option/utils';
-import {
-  dateFilterFillData,
-  filterFillData,
-  getFilterChildren,
-  normalizeFilterNode,
-  relationFilterFillData,
-} from '@/application/database-yjs/filter';
-import { getNumberGroupingCellData, normalizeGroupIdentifiers } from '@/application/database-yjs/group';
+import { getNumberGroupingCellData } from '@/application/database-yjs/group';
 import {
   createDatabaseHistoryGroup,
   executeDatabaseOperations as executeOperations,
@@ -55,7 +46,6 @@ import { initialDatabaseRow } from '@/application/database-yjs/row';
 import { generateRowMeta, getMetaIdMap, getMetaJSON, getRowKey } from '@/application/database-yjs/row_meta';
 import { getPrimaryFieldId, useCalendarLayoutSetting, useDatabaseViewLayout } from '@/application/database-yjs/selector';
 import {
-  applyTemplateCellsToRow,
   DatabaseRowTemplateStore,
   initializeTemplateSourceRow,
   mergeTemplateViewDecorations,
@@ -78,8 +68,7 @@ import {
   DatabaseViewLayout,
   FieldId,
   YDatabaseCell,
-  YDatabaseFilter,
-  YDatabaseFilters,
+  YDatabaseCells,
   YDatabaseRow,
   YDatabaseView,
   YDoc,
@@ -90,44 +79,12 @@ import {
 import { useCurrentUserOptional } from '@/components/main/app.hooks';
 import { Log } from '@/utils/log';
 
+import { populateNewRowCells, NewRowCellsData } from './new-row-cells';
 import { applyRelationReciprocalInserts } from './relation';
 import { removeRowsFromDatabase, softDeleteRowsInDatabase } from './row-lifecycle';
 import { executeOperationWithAllViews } from './utils';
 
-export function collectNewRowPrefillFilters(filters: YDatabaseFilters | undefined): YDatabaseFilter[] {
-  if (!filters) return [];
-
-  const leaves: YDatabaseFilter[] = [];
-  const visit = (rawNode: unknown) => {
-    const node = normalizeFilterNode(rawNode);
-
-    if (!node) return;
-
-    const rawType = node.get(YjsDatabaseKey.filter_type);
-    const parsedType = Number(rawType);
-    const type =
-      rawType === undefined || rawType === null || !Number.isFinite(parsedType) ? FilterType.Data : parsedType;
-
-    if (type === FilterType.Data) {
-      leaves.push(node);
-      return;
-    }
-
-    const children = getFilterChildren(node);
-
-    if (type === FilterType.And) {
-      children.forEach(visit);
-      return;
-    }
-
-    if (type === FilterType.Or && children.length > 0) {
-      visit(children[0]);
-    }
-  };
-
-  filters.toArray().forEach(visit);
-  return leaves;
-}
+export { collectNewRowPrefillFilters } from './new-row-cells';
 
 /**
  * Helper: Reorder a row within a view's row_orders
@@ -255,7 +212,9 @@ export function useMoveCardDispatch() {
                 let cell = cells.get(fieldId);
 
                 if (fieldType === FieldType.Number) {
-                  const group = view.get(YjsDatabaseKey.groups)?.toArray()
+                  const group = view
+                    .get(YjsDatabaseKey.groups)
+                    ?.toArray()
                     .find((candidate) => candidate.get(YjsDatabaseKey.field_id) === fieldId);
                   const policy = createNumberGroupingPolicy(group?.get(YjsDatabaseKey.content));
                   const currentGroupId = policy.groupIdForCell(getNumberGroupingCellData(cell)) ?? fieldId;
@@ -599,19 +558,15 @@ export function useNewRowDispatch() {
       templateId,
       skipDefaultTemplate = false,
       openAfterCreate = false,
+      draft,
+      suppressAutoOpen = false,
     }: {
       beforeRowId?: string;
-      cellsData?: Record<
-        FieldId,
-        | string
-        | {
-            data: string;
-            endTimestamp?: string;
-            isRange?: boolean;
-            includeTime?: boolean;
-            reminderId?: string;
-          }
-      >;
+      cellsData?: NewRowCellsData;
+      /** Publish an edited local draft with its original identity and raw cells. */
+      draft?: { id: string; cells: YDatabaseCells; meta: Y.Map<unknown> };
+      /** The calendar draft already owns its editor, including under filters. */
+      suppressAutoOpen?: boolean;
       tailing?: boolean;
       historyGroup?: object;
       /** Explicit template selection. An unknown id is an error, matching Desktop. */
@@ -642,9 +597,10 @@ export function useNewRowDispatch() {
       // Decode before creating even an unpublished row. Snapshot bytes are
       // authoritative when legacy isDocumentEmpty metadata is stale.
       const documentSnapshot = decodeTemplateDocumentSnapshot(storedTemplate?.documentData);
-      const effectiveTemplate = storedTemplate && documentSnapshot
-        ? { ...storedTemplate, isDocumentEmpty: documentSnapshot.isDocumentEmpty }
-        : storedTemplate;
+      const effectiveTemplate =
+        storedTemplate && documentSnapshot
+          ? { ...storedTemplate, isDocumentEmpty: documentSnapshot.isDocumentEmpty }
+          : storedTemplate;
       const templatePromise = (async () => {
         if (!effectiveTemplate) return undefined;
 
@@ -669,13 +625,21 @@ export function useNewRowDispatch() {
         return effectiveTemplate;
       })();
 
-      const rowId = uuidv4();
+      const rowId = draft?.id ?? uuidv4();
+
+      // A reciprocal-link failure may occur after publication. A retry still
+      // applies the latest draft and repairs links, without duplicating the row.
+      const alreadyPublished =
+        !!draft &&
+        currentView
+          .get(YjsDatabaseKey.row_orders)
+          .toArray()
+          .some((row) => row.id === rowId);
       const rowKey = getRowKey(guid, rowId);
       const [selectedTemplate, rowDoc] = await Promise.all([templatePromise, createRow(rowKey)]);
       // Snapshot the filter array once: Y.Array.toArray() allocates a fresh
       // JS array on each call, and we read it twice (length check + forEach).
       const hasActiveFilters = (filters?.length ?? 0) > 0;
-      const filterArray = collectNewRowPrefillFilters(filters);
       // Open the row detail page whenever filters are active so the user can
       // see and complete the new row (its primary "Name" cell is always empty,
       // and other cells get pre-filled from filters but still need user input).
@@ -694,164 +658,18 @@ export function useNewRowDispatch() {
         const row = rowSharedRoot.get(YjsEditorKey.database_row);
         const meta = rowSharedRoot.get(YjsEditorKey.meta);
 
-        const cells = row.get(YjsDatabaseKey.cells);
-
-        if (selectedTemplate) {
-          const appliedCells = applyTemplateCellsToRow(row, database, selectedTemplate.defaultCells);
-
-          // Template relation defaults join the same reciprocal-backfill queue
-          // as filter prefills. A later filter prefill on the same field
-          // overwrites both the cell and this queue entry, so the backfill
-          // always mirrors the final cell state.
-          Object.entries(appliedCells).forEach(([fieldId, value]) => {
-            if (value.type === 'relation' && value.value.length > 0) {
-              relationPrefills.set(fieldId, value.value);
-            }
-          });
-        }
-
-        filterArray.forEach((filter) => {
-          const cell = new Y.Map() as YDatabaseCell;
-          const fieldId = filter.get(YjsDatabaseKey.field_id);
-          const field = database.get(YjsDatabaseKey.fields)?.get(fieldId);
-
-          if (!field) {
-            return;
-          }
-
-          // Desktop deliberately leaves the primary title empty when a row is
-          // created under an active filter. The filtered-out row is completed
-          // through the row detail page; secondary fields can still inherit
-          // their filter values.
-          if (field.get(YjsDatabaseKey.is_primary)) {
-            return;
-          }
-
-          if (isCalendar && calendarSetting?.fieldId === fieldId) {
-            shouldOpenRowModal = true;
-          }
-
-          const type = Number(field.get(YjsDatabaseKey.type));
-
-          if (isAttributionFieldType(type)) {
-            shouldOpenRowModal = true;
-            return;
-          }
-
-          if (type === FieldType.DateTime) {
-            const { data, endTimestamp, isRange } = dateFilterFillData(filter);
-
-            if (data !== null) {
-              cell.set(YjsDatabaseKey.data, data);
-            }
-
-            if (endTimestamp) {
-              cell.set(YjsDatabaseKey.end_timestamp, endTimestamp);
-            }
-
-            if (isRange) {
-              cell.set(YjsDatabaseKey.is_range, isRange);
-            }
-          } else if ([FieldType.CreatedTime, FieldType.LastEditedTime].includes(type)) {
-            shouldOpenRowModal = true;
-            return;
-          } else if (type === FieldType.Relation) {
-            const rowIds = relationFilterFillData(
-              String(filter.get(YjsDatabaseKey.content) ?? ''),
-              Number(filter.get(YjsDatabaseKey.condition))
-            );
-
-            if (!rowIds) {
-              return;
-            }
-
-            // Enforce source_limit synchronously so OneOnly relations don't
-            // silently end up with multiple linked rows when the filter has
-            // several values selected.
-            const typeOption = parseRelationTypeOption(field);
-            const limitedRowIds =
-              typeOption.source_limit === RelationLimit.OneOnly && rowIds.length > 1
-                ? [rowIds[rowIds.length - 1]]
-                : rowIds;
-
-            const data = new Y.Array<string>();
-
-            if (limitedRowIds.length > 0) {
-              data.push([...limitedRowIds]);
-              relationPrefills.set(fieldId, limitedRowIds);
-            } else {
-              // An earlier filter on this same field may have queued IDs;
-              // an empty later filter must clear that queue so the backfill
-              // doesn't write reciprocals to rows the source no longer links.
-              relationPrefills.delete(fieldId);
-            }
-
-            cell.set(YjsDatabaseKey.data, data);
-          } else {
-            const data = filterFillData(filter, field);
-
-            if (data === null) {
-              return;
-            }
-
-            cell.set(YjsDatabaseKey.data, data);
-          }
-
-          cell.set(YjsDatabaseKey.created_at, String(dayjs().unix()));
-          cell.set(YjsDatabaseKey.field_type, type);
-
-          cells.set(fieldId, cell);
+        const prefill = populateNewRowCells({
+          row,
+          database,
+          filters,
+          template: selectedTemplate,
+          cellsData,
+          initialCells: draft?.cells,
+          calendarFieldId: isCalendar ? calendarSetting?.fieldId : undefined,
         });
 
-        if (cellsData) {
-          Object.entries(cellsData).forEach(([fieldId, data]) => {
-            const cell = new Y.Map() as YDatabaseCell;
-            const field = database.get(YjsDatabaseKey.fields)?.get(fieldId);
-
-            if (!field) return;
-
-            // The raw cell payload replaces whatever a template or filter
-            // wrote for this field, so any queued reciprocal backfill for it
-            // would no longer match the final cell state.
-            relationPrefills.delete(fieldId);
-
-            const type = Number(field.get(YjsDatabaseKey.type));
-
-            if (isAttributionFieldType(type)) return;
-
-            const rawData = typeof data === 'object' ? data.data : data;
-
-            cell.set(YjsDatabaseKey.created_at, String(dayjs().unix()));
-            cell.set(YjsDatabaseKey.field_type, type);
-
-            if (type === FieldType.Relation) {
-              const relationOption = parseRelationTypeOption(field);
-              const identifiers = normalizeGroupIdentifiers(rawData);
-              const rowIds =
-                relationOption.source_limit === RelationLimit.OneOnly && identifiers.length > 1
-                  ? [identifiers[identifiers.length - 1]]
-                  : identifiers;
-              const relationData = new Y.Array<string>();
-
-              if (rowIds.length > 0) {
-                relationData.push(rowIds);
-                relationPrefills.set(fieldId, rowIds);
-              }
-
-              cell.set(YjsDatabaseKey.data, relationData);
-            } else if (typeof data === 'object') {
-              cell.set(YjsDatabaseKey.data, data.data);
-              cell.set(YjsDatabaseKey.end_timestamp, data.endTimestamp);
-              cell.set(YjsDatabaseKey.is_range, data.isRange);
-              cell.set(YjsDatabaseKey.include_time, data.includeTime);
-              cell.set(YjsDatabaseKey.reminder_id, data.reminderId);
-            } else {
-              cell.set(YjsDatabaseKey.data, data);
-            }
-
-            cells.set(fieldId, cell);
-          });
-        }
+        shouldOpenRowModal = prefill.shouldOpenRowModal;
+        prefill.relationPrefills.forEach((ids, fieldId) => relationPrefills.set(fieldId, ids));
 
         const newMeta = generateRowMeta(rowId, {
           [RowMetaKey.IsDocumentEmpty]: selectedTemplate?.isDocumentEmpty ?? true,
@@ -866,9 +684,10 @@ export function useNewRowDispatch() {
             meta.set(key, value);
           }
         });
+        draft?.meta.forEach((value, key) => meta.set(key, value));
       });
 
-      if (selectedTemplate && !selectedTemplate.isDocumentEmpty) {
+      if (!alreadyPublished && selectedTemplate && !selectedTemplate.isDocumentEmpty) {
         if (!duplicateRowDocument) {
           throw new Error('Template document duplication is unavailable');
         } else {
@@ -893,8 +712,8 @@ export function useNewRowDispatch() {
 
             initializeTemplateSourceRow(sourceRowDoc, database, selectedTemplate);
 
-            const clientDocStateB64 = documentSnapshot?.encodedState ??
-              (sourceDocument ? encodeTemplateDocument(sourceDocument) : undefined);
+            const clientDocStateB64 =
+              documentSnapshot?.encodedState ?? (sourceDocument ? encodeTemplateDocument(sourceDocument) : undefined);
 
             const databaseId = database.get(YjsDatabaseKey.id);
             const sourceDocumentId = rowDocumentIdFromRowId(selectedTemplate.templateId);
@@ -929,6 +748,7 @@ export function useNewRowDispatch() {
             throw new Error(`Row orders not found`);
           }
 
+          if (draft && rowOrders.toArray().some((row) => row.id === rowId)) return;
           const row = {
             id: rowId,
             height: 36,
@@ -946,7 +766,7 @@ export function useNewRowDispatch() {
         historyGroup
       );
 
-      if (shouldOpenRowModal || openAfterCreate) {
+      if ((!suppressAutoOpen && shouldOpenRowModal) || openAfterCreate) {
         navigateToRow?.(rowId);
       }
 
@@ -971,7 +791,7 @@ export function useNewRowDispatch() {
         )
       );
 
-      if (isCalendar && shouldOpenRowModal) {
+      if (isCalendar && shouldOpenRowModal && !suppressAutoOpen) {
         return null;
       }
 

--- a/src/components/database/components/cell/date/DateTimeCellPicker.tsx
+++ b/src/components/database/components/cell/date/DateTimeCellPicker.tsx
@@ -7,6 +7,7 @@ import {
   FieldType,
   getFieldDateTimeFormats,
   getTypeOptions,
+  useDatabaseContext,
   useDatabaseViewLayout,
   useFieldSelector,
 } from '@/application/database-yjs';
@@ -45,6 +46,9 @@ function DateTimeCellPicker({
 }) {
   const currentUser = useCurrentUser();
   const { t } = useTranslation();
+  const { templateEditingRowId } = useDatabaseContext();
+  // Isolated row editors stage cell values, not database-wide date formats.
+  const canEditFieldFormat = templateEditingRowId !== rowId;
 
   const [isRange, setIsRange] = useState<boolean>(() => {
     if (!cell) return false;
@@ -329,22 +333,24 @@ function DateTimeCellPicker({
           </div>
         </div>
         <Separator className={'my-2'} />
-        <div className={'px-2'}>
-          <DateTimeFormatMenu fieldId={fieldId}>
-            <div
-              className={cn(
-                dropdownMenuItemVariants({
-                  variant: 'default',
-                }),
-                'w-full'
-              )}
-            >
-              {`${t('datePicker.dateFormat')} & ${t('datePicker.timeFormat')}`}
+        {canEditFieldFormat && (
+          <div className={'px-2'}>
+            <DateTimeFormatMenu fieldId={fieldId}>
+              <div
+                className={cn(
+                  dropdownMenuItemVariants({
+                    variant: 'default',
+                  }),
+                  'w-full'
+                )}
+              >
+                {`${t('datePicker.dateFormat')} & ${t('datePicker.timeFormat')}`}
 
-              <ChevronRight className={'ml-auto h-5 w-5 text-text-tertiary'} />
-            </div>
-          </DateTimeFormatMenu>
-        </div>
+                <ChevronRight className={'ml-auto h-5 w-5 text-text-tertiary'} />
+              </div>
+            </DateTimeFormatMenu>
+          </div>
+        )}
         <div className={'px-2 pb-2'}>
           <div
             data-testid="clear-date-button"

--- a/src/components/database/components/cell/relation/RelationCellMenu.tsx
+++ b/src/components/database/components/cell/relation/RelationCellMenu.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 
+import { useDatabaseContext } from '@/application/database-yjs/context';
 import { RelationCell as RelationCellType, RelationCellData } from '@/application/database-yjs/cell.type';
 import { useUpdateRelationCell } from '@/application/database-yjs/dispatch/relation';
 import LoadingDots from '@/components/_shared/LoadingDots';
@@ -25,6 +26,7 @@ function RelationCellMenu ({
   open?: boolean;
   onOpenChange?: (open: boolean) => void;
 }) {
+  const { templateEditingRowId } = useDatabaseContext();
   const data = cell?.data;
   const relationRowIds = useMemo(() => (data?.toJSON() as RelationCellData) ?? [], [data]);
 
@@ -83,18 +85,23 @@ function RelationCellMenu ({
             <LoadingDots />
           </div>
         ) : !relatedDatabaseId ? (
-          <NoDatabaseSelectedContent
-            loading={loading}
-            views={views}
-            onSelect={(view) => {
-              setSelectedView(view);
-              const databaseId = Object.entries(relations || []).find(([, id]) => id === view.view_id)?.[0];
+          // Choosing a target changes field schema and may create reciprocal
+          // fields. Isolated row editors only stage cell selections.
+          <fieldset disabled={!!templateEditingRowId} className='min-w-0 disabled:opacity-50'>
+            <NoDatabaseSelectedContent
+              loading={loading}
+              views={views}
+              onSelect={(view) => {
+                if (templateEditingRowId) return;
+                setSelectedView(view);
+                const databaseId = Object.entries(relations || []).find(([, id]) => id === view.view_id)?.[0];
 
-              if (databaseId) {
-                void onUpdateDatabaseId(databaseId);
-              }
-            }}
-          />
+                if (databaseId) {
+                  void onUpdateDatabaseId(databaseId);
+                }
+              }}
+            />
+          </fieldset>
         ) : (
           <RelationCellMenuContent
             relationRowIds={relationRowIds}

--- a/src/components/database/components/cell/relation/RelationCellMenuContent.tsx
+++ b/src/components/database/components/cell/relation/RelationCellMenuContent.tsx
@@ -80,7 +80,7 @@ function RelationCellMenuContentForTarget({
   const { t } = useTranslation();
   const currentUser = useCurrentUserOptional();
   const actorUid = resolveUserAttributionUid(currentUser);
-  const { navigateToView, loadView, navigateToRow, createRow, bindViewSync } = useDatabaseContext();
+  const { navigateToView, loadView, navigateToRow, createRow, bindViewSync, templateEditingRowId } = useDatabaseContext();
   const [element, setElement] = useState<HTMLElement | null>(null);
   const selectedViewId = selectedView?.view_id;
   const openRelatedRow = useCallback(
@@ -487,12 +487,14 @@ function RelationCellMenuContentForTarget({
   // any non-empty query exposes the create affordance, even when the live
   // results already match. The user shouldn't have to clear partial matches
   // to create a new row that happens to share a substring.
-  const showCreateAndLink = trimmedSearch.length > 0 && !isLoadingRows && !noAccess && primaryFieldId !== null;
+  // Isolated editors may select existing rows, but cannot publish new related
+  // rows before the owning draft or template is committed.
+  const showCreateAndLink = !templateEditingRowId && trimmedSearch.length > 0 && !isLoadingRows && !noAccess && primaryFieldId !== null;
 
   const handleCreateAndLink = useCallback(async () => {
     const targetDoc = targetDocRef.current;
 
-    if (!targetDoc || !primaryFieldId || !trimmedSearch) return;
+    if (templateEditingRowId || !targetDoc || !primaryFieldId || !trimmedSearch) return;
     if (isCreatingRef.current) return;
     isCreatingRef.current = true;
     setIsCreatingAndLinking(true);
@@ -522,7 +524,7 @@ function RelationCellMenuContentForTarget({
       isCreatingRef.current = false;
       setIsCreatingAndLinking(false);
     }
-  }, [actorUid, bindViewSync, createRow, onAddRelationRowId, primaryFieldId, selectedViewId, trimmedSearch]);
+  }, [actorUid, bindViewSync, createRow, onAddRelationRowId, primaryFieldId, selectedViewId, templateEditingRowId, trimmedSearch]);
 
   const renderCreateAndLink = useMemo(() => {
     if (!showCreateAndLink) return null;

--- a/src/components/database/components/cell/relation/__tests__/RelationCellMenu.isolated.test.tsx
+++ b/src/components/database/components/cell/relation/__tests__/RelationCellMenu.isolated.test.tsx
@@ -1,0 +1,97 @@
+import { act, fireEvent, render, screen } from '@testing-library/react';
+
+import RelationCellMenu from '../RelationCellMenu';
+
+import type { ReactNode } from 'react';
+
+const mockContext = { templateEditingRowId: undefined as string | undefined };
+const mockUpdateRelationCell = jest.fn();
+const mockRelationData = {
+  loading: false,
+  relations: { 'related-database': 'related-view' },
+  selectedView: { view_id: 'related-view', name: 'Related tasks' },
+  setSelectedView: jest.fn(),
+  onUpdateDatabaseId: jest.fn(),
+  views: [{ view_id: 'related-view', name: 'Related tasks' }],
+  relatedDatabaseId: '' as string,
+};
+
+jest.mock('@/application/database-yjs/context', () => ({
+  useDatabaseContext: () => mockContext,
+}));
+
+jest.mock('@/application/database-yjs/dispatch/relation', () => ({
+  useUpdateRelationCell: () => mockUpdateRelationCell,
+}));
+
+jest.mock('@/components/database/components/property/relation/useRelationData', () => ({
+  useRelationData: () => mockRelationData,
+}));
+
+jest.mock('@/components/database/components/cell/relation/NoDatabaseSelectedContent', () => ({
+  __esModule: true,
+  default: ({ onSelect }: { onSelect: (view: { view_id: string }) => void }) => (
+    <button onClick={() => onSelect({ view_id: 'related-view' })}>Configure related database</button>
+  ),
+}));
+
+jest.mock('@/components/database/components/cell/relation/RelationCellMenuContent', () => ({
+  __esModule: true,
+  default: ({ onAddRelationRowId }: { onAddRelationRowId: (id: string) => void }) => (
+    <button onClick={() => onAddRelationRowId('existing-task')}>Existing task</button>
+  ),
+}));
+
+jest.mock('@/components/ui/popover', () => ({
+  Popover: ({ children }: { children: ReactNode }) => <>{children}</>,
+  PopoverContent: ({ children }: { children: ReactNode }) => <>{children}</>,
+  PopoverTrigger: () => null,
+}));
+
+describe('RelationCellMenu isolated editing', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.clearAllMocks();
+    mockContext.templateEditingRowId = 'draft-row';
+    mockRelationData.relatedDatabaseId = '';
+  });
+
+  afterEach(() => jest.useRealTimers());
+
+  function openMenu() {
+    render(<RelationCellMenu open rowId='draft-row' fieldId='relation-field' />);
+    act(() => {
+      jest.advanceTimersByTime(100);
+    });
+  }
+
+  it('blocks target schema configuration until the isolated row is saved', () => {
+    openMenu();
+    const configure = screen.getByRole('button', { name: 'Configure related database' });
+
+    expect(configure.closest('fieldset')?.disabled).toBe(true);
+    fireEvent.click(configure);
+    expect(mockRelationData.setSelectedView).not.toHaveBeenCalled();
+    expect(mockRelationData.onUpdateDatabaseId).not.toHaveBeenCalled();
+  });
+
+  it('keeps configured relations editable through the row cell dispatcher', () => {
+    mockRelationData.relatedDatabaseId = 'related-database';
+    openMenu();
+    fireEvent.click(screen.getByRole('button', { name: 'Existing task' }));
+
+    expect(mockUpdateRelationCell).toHaveBeenCalledWith({ insertedRowIds: ['existing-task'] });
+    expect(mockRelationData.onUpdateDatabaseId).not.toHaveBeenCalled();
+  });
+
+  it('preserves target schema configuration for persisted rows', () => {
+    mockContext.templateEditingRowId = undefined;
+    openMenu();
+    const configure = screen.getByRole('button', { name: 'Configure related database' });
+
+    expect(configure.closest('fieldset')?.disabled).toBe(false);
+    fireEvent.click(configure);
+    expect(mockRelationData.setSelectedView).toHaveBeenCalledWith({ view_id: 'related-view' });
+    expect(mockRelationData.onUpdateDatabaseId).toHaveBeenCalledWith('related-database');
+  });
+});

--- a/src/components/database/components/cell/relation/__tests__/RelationCellMenuContent.loading.test.tsx
+++ b/src/components/database/components/cell/relation/__tests__/RelationCellMenuContent.loading.test.tsx
@@ -1,4 +1,4 @@
-import { act, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import * as Y from 'yjs';
 
 import { FieldType } from '@/application/database-yjs';
@@ -16,6 +16,7 @@ const mockDatabaseContext = {
   bindViewSync: jest.fn(),
   loadView: jest.fn(),
   createRow: jest.fn(),
+  templateEditingRowId: undefined as string | undefined,
 };
 
 jest.mock('@/application/database-yjs', () => ({
@@ -136,6 +137,47 @@ function skeletons() {
 describe('RelationCellMenuContent loading states', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockDatabaseContext.templateEditingRowId = undefined;
+  });
+
+  it('loads and selects existing related rows in an isolated editor without offering target creation', async () => {
+    mockDatabaseContext.templateEditingRowId = 'calendar-draft';
+    const target = createTargetDoc(['row-1', 'row-2']);
+    const originalTarget = Y.encodeStateAsUpdate(target);
+    const onAddRelationRowId = jest.fn();
+
+    mockDatabaseContext.loadView.mockResolvedValue(target);
+    mockDatabaseContext.createRow.mockImplementation(async (key: string) => {
+      const id = rowIdFromKey(key);
+
+      return createTitledRowDoc(id, id === 'row-1' ? 'Existing task' : 'Another task');
+    });
+    render(
+      <RelationCellMenuContent
+        relationRowIds={[]}
+        selectedView={{ view_id: VIEW_ID, name: 'Tasks' } as View}
+        relatedDatabaseId={DATABASE_ID}
+        onAddRelationRowId={onAddRelationRowId}
+        onRemoveRelationRowId={jest.fn()}
+      />
+    );
+
+    fireEvent.click(await screen.findByText('Existing task'));
+    expect(onAddRelationRowId).toHaveBeenCalledWith('row-1');
+    await screen.findByText('Another task');
+    expect(skeletons()).toHaveLength(0);
+
+    const search = screen.getByPlaceholderText('searchLabel');
+
+    fireEvent.change(search, { target: { value: 'New target row' } });
+    await screen.findByText(NO_RESULT);
+    expect(screen.queryByTestId('relation-create-and-link')).toBeNull();
+    fireEvent.keyDown(search, { key: 'Enter', code: 'Enter' });
+    expect(mockDatabaseContext.createRow.mock.calls.map(([key]) => key).sort()).toEqual([
+      `${VIEW_ID}_rows_row-1`, `${VIEW_ID}_rows_row-2`,
+    ]);
+    expect(onAddRelationRowId).toHaveBeenCalledTimes(1);
+    expect(Y.encodeStateAsUpdate(target)).toEqual(originalTarget);
   });
 
   it('holds a placeholder per row until its title arrives, rather than reading "Untitled"', async () => {

--- a/src/components/database/components/database-row/RowPropertyPrimitive.tsx
+++ b/src/components/database/components/database-row/RowPropertyPrimitive.tsx
@@ -1,3 +1,5 @@
+import { useTranslation } from 'react-i18next';
+
 import { FieldType, useFieldSelector, useReadOnly } from '@/application/database-yjs';
 import { Cell } from '@/application/database-yjs/cell.type';
 import { YjsDatabaseKey } from '@/application/types';
@@ -8,7 +10,6 @@ import PropertyMenu from '@/components/database/components/property/PropertyMenu
 import { isFieldEditingDisabled } from '@/components/database/utils/field-editing';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { cn } from '@/lib/utils';
-import { useTranslation } from 'react-i18next';
 
 function RowPropertyPrimitive({
   fieldId,
@@ -18,6 +19,7 @@ function RowPropertyPrimitive({
   onCellUpdated,
   showPropertyName = true,
   templateStyle = false,
+  disableFieldEditing = false,
 }: {
   fieldId: string;
   rowId: string;
@@ -26,6 +28,7 @@ function RowPropertyPrimitive({
   setActivePropertyId: (id: string | null) => void;
   showPropertyName?: boolean;
   templateStyle?: boolean;
+  disableFieldEditing?: boolean;
 }) {
   const readOnly = useReadOnly();
   const { t } = useTranslation();
@@ -50,7 +53,7 @@ function RowPropertyPrimitive({
       <PropertyMenu
         open={isActive}
         onOpenChange={(status) => {
-          if (status && (readOnly || isEditingDisabled)) {
+          if (status && (readOnly || isEditingDisabled || disableFieldEditing)) {
             return;
           }
 

--- a/src/components/database/fullcalendar/CalendarContent.tsx
+++ b/src/components/database/fullcalendar/CalendarContent.tsx
@@ -11,6 +11,8 @@ import './FullCalendar.styles.scss';
 import { useDatabaseContext } from '@/application/database-yjs';
 import { useConditionsContext } from '@/components/database/components/conditions/context';
 import { AddButton } from '@/components/database/fullcalendar/AddButton';
+import { useCalendarDraft } from '@/components/database/fullcalendar/draft/useCalendarDraft';
+import { CalendarDraftContext } from '@/components/database/fullcalendar/event/CalendarDraftContext';
 import { MoreLinkContent } from '@/components/database/fullcalendar/event/MoreLinkContent';
 import { useFullCalendarSetup } from '@/components/database/fullcalendar/FullCalendar.hooks';
 import {
@@ -34,7 +36,7 @@ import { dateToUnixTimestamp } from '@/utils/time';
 import EventWithPopover from './event/EventWithPopover';
 import { CalendarViewType } from './types';
 
-import type { CalendarApi, EventContentArg, MoreLinkContentArg } from '@fullcalendar/core';
+import type { CalendarApi, DateSelectArg, EventContentArg, MoreLinkContentArg } from '@fullcalendar/core';
 
 import { EventDef } from '@fullcalendar/core/internal';
 
@@ -104,8 +106,6 @@ export function CalendarContent({ onDataChange, normalToolbarRef, onDragEnd }: C
     handleMoreLinkClick,
     handleEventDrop,
     handleEventResize,
-    handleSelect: originalHandleSelect,
-    handleAdd: originalHandleAdd,
     updateEventTime,
     morelinkInfo,
     closeMorePopover,
@@ -118,6 +118,12 @@ export function CalendarContent({ onDataChange, normalToolbarRef, onDragEnd }: C
     updateEventRowIds,
     currentView
   );
+  const { draft, event: draftEvent, startDraft, finishDraft, discardDraft } = useCalendarDraft(events, emptyEvents);
+  const calendarEvents = useMemo(
+    () => (draftEvent ? [...events.filter((event) => event.id !== draftEvent.id), draftEvent] : events),
+    [draftEvent, events]
+  );
+  const draftContext = useMemo(() => ({ draft, finishDraft, discardDraft }), [draft, finishDraft, discardDraft]);
 
   // Time formatting hook
   const { formatSlotLabel } = useTimeFormat();
@@ -126,7 +132,7 @@ export function CalendarContent({ onDataChange, normalToolbarRef, onDragEnd }: C
   const expanded = conditionsContext?.expanded ?? false;
 
   // Calendar permissions and behavior based on field type
-  const { permissions, isAddButtonEnabled, createEvent } = useCalendarPermissions();
+  const { permissions, isAddButtonEnabled } = useCalendarPermissions();
   // Calendar reference for API access
   const calendarRef = useRef<FullCalendar>(null);
 
@@ -167,63 +173,37 @@ export function CalendarContent({ onDataChange, normalToolbarRef, onDragEnd }: C
     });
   }, []);
 
-  // Wrap handleAdd to mark event as new after creating
+  // Empty slots remain local until the user edits or explicitly submits the editor.
   const handleAdd = useCallback(
     async (date: Date) => {
-      let rowId: string | null = null;
-
-      if (createEvent) {
-        // For created/modified time fields, use custom dispatch
-        rowId = await createEvent();
-      } else {
-        // For regular date fields, use the original handler
-        rowId = await originalHandleAdd(date);
-      }
-
-      if (rowId) {
-        // Mark this event as newly created
-        setNewEventRowIds((prev) => new Set(prev).add(rowId!));
-      }
-
-      return rowId;
+      if (!isAddButtonEnabled(date)) return null;
+      return startDraft({ start: date, allDay: true });
     },
-    [originalHandleAdd, createEvent]
+    [isAddButtonEnabled, startDraft]
   );
 
   // Create debounced version of the select handler to prevent double-click issues
   const debouncedSelectHandler = useMemo(
     () =>
       debounce(
-        async (selectInfo: Parameters<typeof originalHandleSelect>[0]) => {
-          let rowId: string | null = null;
-
-          if (createEvent) {
-            // For created/modified time fields, use custom dispatch
-            rowId = await createEvent();
-          } else {
-            // For regular date fields, use the original handler
-            rowId = await originalHandleSelect(selectInfo);
-          }
-
-          if (rowId) {
-            // Mark this event as newly created
-            setNewEventRowIds((prev) => new Set(prev).add(rowId!));
-          }
-
-          return rowId;
-        },
+        (selectInfo: DateSelectArg) =>
+          startDraft({ start: selectInfo.start, end: selectInfo.end, allDay: selectInfo.allDay }),
         300,
         { leading: true, trailing: false }
       ), // Leading edge trigger to prevent double-click
-    [originalHandleSelect, createEvent]
+    [startDraft]
   );
+
+  useEffect(() => () => debouncedSelectHandler.cancel(), [debouncedSelectHandler]);
 
   // Wrap handleSelect to use debounced version
   const handleSelect = useCallback(
-    (selectInfo: Parameters<typeof originalHandleSelect>[0]) => {
+    (selectInfo: DateSelectArg) => {
+      selectInfo.view.calendar.unselect();
+      if (!permissions.selectable) return;
       return debouncedSelectHandler(selectInfo);
     },
-    [debouncedSelectHandler]
+    [debouncedSelectHandler, permissions.selectable]
   );
 
   // Handle external event creation (FullCalendar eventReceive callback)
@@ -505,63 +485,65 @@ export function CalendarContent({ onDataChange, normalToolbarRef, onDragEnd }: C
   );
 
   return (
-    <EventContext.Provider
-      value={{ clearNewEvent, setOpenEventRowId, markEventAsNew, markEventAsUpdate, clearUpdateEvent }}
-    >
-      <div ref={setContainerRef} style={containerStyle} className={containerClassName}>
-        <FullCalendar
-          initialView={currentView}
-          viewDidMount={updateDayMaxEventRows}
-          ref={calendarRef}
-          plugins={calendarPlugins}
-          headerToolbar={false}
-          dayHeaders={false}
-          events={events}
-          slotEventOverlap={false}
-          firstDay={firstDayOfWeek}
-          dayMaxEventRows={currentView === CalendarViewType.TIME_GRID_WEEK ? 3 : dayMaxEventRows}
-          eventDisplay='block'
-          showNonCurrentDates={true}
-          height={'auto'}
-          scrollTimeReset={false}
-          slotMinTime='00:00:00'
-          slotMaxTime='24:00:00'
-          snapDuration='00:30:00'
-          slotDuration='00:30:00'
-          slotLabelContent={slotLabelContent}
-          dayHeaderFormat={currentView === CalendarViewType.TIME_GRID_WEEK ? dayHeaderFormat : undefined}
-          dayHeaderContent={currentView === CalendarViewType.TIME_GRID_WEEK ? dayHeaderContent : undefined}
-          dayCellContent={currentView === CalendarViewType.DAY_GRID_MONTH ? dayCellContentCallback : undefined}
-          nowIndicator={true}
-          datesSet={memoizedHandleDatesSet}
-          eventContent={eventContent}
-          moreLinkClick={handleMoreLinkClick}
-          moreLinkContent={renderMoreLinkContent}
-          dayPopoverFormat={dayPopoverFormat}
-          // eslint-disable-next-line
-          eventOrder={currentView === CalendarViewType.TIME_GRID_WEEK ? ['start', 'title'] : (eventOrder as any)}
-          eventOrderStrict={false}
-          editable={permissions.editable}
-          selectable={permissions.selectable}
-          droppable={permissions.droppable}
-          eventResizableFromStart={permissions.eventResizable}
-          eventDrop={handleEventDrop}
-          eventResize={handleEventResize}
-          eventReceive={handleEventReceive}
-          select={handleSelect}
-          fixedMirrorParent={document.body}
-          dragScroll={true}
+    <CalendarDraftContext.Provider value={draftContext}>
+      <EventContext.Provider
+        value={{ clearNewEvent, setOpenEventRowId, markEventAsNew, markEventAsUpdate, clearUpdateEvent }}
+      >
+        <div ref={setContainerRef} style={containerStyle} className={containerClassName}>
+          <FullCalendar
+            initialView={currentView}
+            viewDidMount={updateDayMaxEventRows}
+            ref={calendarRef}
+            plugins={calendarPlugins}
+            headerToolbar={false}
+            dayHeaders={false}
+            events={calendarEvents}
+            slotEventOverlap={false}
+            firstDay={firstDayOfWeek}
+            dayMaxEventRows={currentView === CalendarViewType.TIME_GRID_WEEK ? 3 : dayMaxEventRows}
+            eventDisplay='block'
+            showNonCurrentDates={true}
+            height={'auto'}
+            scrollTimeReset={false}
+            slotMinTime='00:00:00'
+            slotMaxTime='24:00:00'
+            snapDuration='00:30:00'
+            slotDuration='00:30:00'
+            slotLabelContent={slotLabelContent}
+            dayHeaderFormat={currentView === CalendarViewType.TIME_GRID_WEEK ? dayHeaderFormat : undefined}
+            dayHeaderContent={currentView === CalendarViewType.TIME_GRID_WEEK ? dayHeaderContent : undefined}
+            dayCellContent={currentView === CalendarViewType.DAY_GRID_MONTH ? dayCellContentCallback : undefined}
+            nowIndicator={true}
+            datesSet={memoizedHandleDatesSet}
+            eventContent={eventContent}
+            moreLinkClick={handleMoreLinkClick}
+            moreLinkContent={renderMoreLinkContent}
+            dayPopoverFormat={dayPopoverFormat}
+            // eslint-disable-next-line
+            eventOrder={currentView === CalendarViewType.TIME_GRID_WEEK ? ['start', 'title'] : (eventOrder as any)}
+            eventOrderStrict={false}
+            editable={permissions.editable}
+            selectable={permissions.selectable}
+            droppable={permissions.droppable}
+            eventResizableFromStart={permissions.eventResizable}
+            eventDrop={handleEventDrop}
+            eventResize={handleEventResize}
+            eventReceive={handleEventReceive}
+            select={handleSelect}
+            fixedMirrorParent={document.body}
+            dragScroll={true}
+          />
+        </div>
+        <AddButton
+          ref={addButtonRef}
+          visible={addButtonState.visible}
+          position={addButtonState.position}
+          date={addButtonState.date}
+          onClick={handleAddButtonClick}
+          onMouseLeave={handleAddButtonMouseLeave}
+          container={calendarElement}
         />
-      </div>
-      <AddButton
-        ref={addButtonRef}
-        visible={addButtonState.visible}
-        position={addButtonState.position}
-        date={addButtonState.date}
-        onClick={handleAddButtonClick}
-        onMouseLeave={handleAddButtonMouseLeave}
-        container={calendarElement}
-      />
-    </EventContext.Provider>
+      </EventContext.Provider>
+    </CalendarDraftContext.Provider>
   );
 }

--- a/src/components/database/fullcalendar/draft/CalendarEventDraft.test.ts
+++ b/src/components/database/fullcalendar/draft/CalendarEventDraft.test.ts
@@ -1,0 +1,370 @@
+import dayjs from 'dayjs';
+import * as Y from 'yjs';
+
+import { DatabaseContextState } from '@/application/database-yjs/context';
+import { FieldType, RowMetaKey } from '@/application/database-yjs/database.type';
+import { parseSelectOptionTypeOptions } from '@/application/database-yjs/fields/select-option/parse';
+import { getTypeOptions } from '@/application/database-yjs/fields/type_option';
+import { getMetaIdMap } from '@/application/database-yjs/row_meta';
+import { DatabaseRowTemplateStore } from '@/application/database-yjs/template/store';
+import { DatabaseRowTemplate } from '@/application/database-yjs/template/types';
+import { YDatabase, YDatabaseCell, YDatabaseField, YDatabaseRowOrders, YDatabaseView, YDoc, YjsDatabaseKey, YjsEditorKey } from '@/application/types';
+
+import { CalendarDraftSelection, CalendarDraftSnapshot, CalendarEventDraft } from './CalendarEventDraft';
+
+jest.unmock('lodash-es/isEqual');
+
+const selection: CalendarDraftSelection = { start: new Date(2026, 8, 11), end: new Date(2026, 8, 12), allDay: true };
+const drafts: CalendarEventDraft[] = [];
+const docs: Y.Doc[] = [];
+const originalCreateObjectURL = Object.getOwnPropertyDescriptor(URL, 'createObjectURL');
+const originalRevokeObjectURL = Object.getOwnPropertyDescriptor(URL, 'revokeObjectURL');
+
+function field(id: string, type: FieldType): YDatabaseField {
+  const value = new Y.Map() as YDatabaseField;
+
+  value.set(YjsDatabaseKey.id, id);
+  value.set(YjsDatabaseKey.name, id);
+  value.set(YjsDatabaseKey.type, type);
+  value.set(YjsDatabaseKey.is_primary, id === 'title');
+  if (type === FieldType.MultiSelect) {
+    const options = new Y.Map<Y.Map<unknown>>();
+    const content = new Y.Map<unknown>();
+
+    content.set(YjsDatabaseKey.content, JSON.stringify({ options: [{ id: 'existing', name: 'Existing', color: 0 }] }));
+    options.set(String(type), content);
+    value.set(YjsDatabaseKey.type_option, options);
+  }
+
+  return value;
+}
+
+function fixture(template?: DatabaseRowTemplate) {
+  const databaseDoc = new Y.Doc() as YDoc;
+  const database = new Y.Map() as YDatabase;
+  const fields = new Y.Map<YDatabaseField>();
+  const view = new Y.Map() as YDatabaseView;
+  const views = new Y.Map<YDatabaseView>();
+  const orders: YDatabaseRowOrders = Y.Array.from([{ id: 'existing-row', height: 36 }]);
+
+  docs.push(databaseDoc);
+  fields.set('title', field('title', FieldType.RichText));
+  fields.set('notes', field('notes', FieldType.RichText));
+  fields.set('date', field('date', FieldType.DateTime));
+  fields.set('check', field('check', FieldType.Checkbox));
+  fields.set('tags', field('tags', FieldType.MultiSelect));
+  fields.set('relation', field('relation', FieldType.Relation));
+  fields.set('person', field('person', FieldType.Person));
+  fields.set('media', field('media', FieldType.Media));
+  fields.set('checklist', field('checklist', FieldType.Checklist));
+  view.set(YjsDatabaseKey.row_orders, orders);
+  views.set('calendar-view', view);
+  database.set(YjsDatabaseKey.id, 'database-id');
+  database.set(YjsDatabaseKey.fields, fields);
+  database.set(YjsDatabaseKey.views, views);
+  database.set(YjsDatabaseKey.metas, new Y.Map());
+  databaseDoc.getMap(YjsEditorKey.data_section).set(YjsEditorKey.database, database);
+  if (template) {
+    const store = new DatabaseRowTemplateStore(database);
+
+    store.upsert(template);
+    store.setDefault(template.templateId);
+  }
+
+  const source: DatabaseContextState = {
+    readOnly: false, canWrite: true, databaseDoc, databasePageId: 'calendar-page',
+    activeViewId: 'calendar-view', workspaceId: 'workspace-id', rowMap: {},
+    ensureRow: jest.fn(), bindRowSync: jest.fn(), bindViewSync: jest.fn(),
+    createRow: jest.fn(), loadRowDocument: jest.fn(), createRowDocument: jest.fn(),
+    duplicateRowDocument: jest.fn(), markCellLocalMutation: jest.fn(),
+    uploadFile: jest.fn().mockResolvedValue('https://files.appflowy.io/uploaded'),
+  };
+
+  return { source, database, orders };
+}
+
+function createDraft(source: DatabaseContextState, dates = selection) {
+  const draft = new CalendarEventDraft(source, 'date', dates);
+
+  drafts.push(draft);
+  return draft;
+}
+
+function setCell(draft: CalendarEventDraft, id: string, data: unknown) {
+  const cell = new Y.Map() as YDatabaseCell;
+
+  cell.set(YjsDatabaseKey.field_type, draft.database.get(YjsDatabaseKey.fields).get(id).get(YjsDatabaseKey.type));
+  cell.set(YjsDatabaseKey.data, data);
+  draft.cells.set(id, cell);
+  return cell;
+}
+
+afterEach(() => {
+  drafts.splice(0).forEach((draft) => draft.dispose());
+  docs.splice(0).forEach((doc) => doc.destroy());
+  jest.restoreAllMocks();
+  if (originalCreateObjectURL) Object.defineProperty(URL, 'createObjectURL', originalCreateObjectURL);
+  else Reflect.deleteProperty(URL, 'createObjectURL');
+  if (originalRevokeObjectURL) Object.defineProperty(URL, 'revokeObjectURL', originalRevokeObjectURL);
+  else Reflect.deleteProperty(URL, 'revokeObjectURL');
+});
+
+describe('CalendarEventDraft persistence boundary', () => {
+  it('edits isolated documents without publishing row orders, row bindings, or metadata changes', async () => {
+    const { source, database, orders } = fixture();
+    const before = Y.encodeStateAsUpdate(source.databaseDoc);
+    const liveUpdate = jest.fn();
+
+    source.databaseDoc.on('update', liveUpdate);
+    const draft = createDraft(source);
+
+    setCell(draft, 'title', 'Local title');
+    setCell(draft, 'relation', Y.Array.from(['related-row']));
+    draft.meta.set(getMetaIdMap(draft.id).get(RowMetaKey.IconId)!, '📆');
+    draft.database.get(YjsDatabaseKey.fields).get('title').set(YjsDatabaseKey.name, 'Local name');
+
+    expect(draft.databaseDoc).not.toBe(source.databaseDoc);
+    expect(draft.context.rowMap).toEqual({ [draft.id]: draft.rowDoc });
+    expect(draft.context.templateEditingRowId).toBe(draft.id);
+    await expect(draft.context.ensureRow?.(draft.id)).resolves.toBe(draft.rowDoc);
+    await expect(draft.context.ensureRow?.('existing-row')).resolves.toBeUndefined();
+    expect(source.ensureRow).not.toHaveBeenCalled();
+    expect(draft.context.bindRowSync).toBeUndefined();
+    expect(draft.context.bindViewSync).toBeUndefined();
+    await expect(draft.context.createRow?.(`${source.databaseDoc.guid}_rows_${draft.id}`)).resolves.toBe(draft.rowDoc);
+    expect(draft.context.markCellLocalMutation).toBeUndefined();
+    expect(source.createRow).not.toHaveBeenCalled();
+    expect(source.rowMap).toEqual({});
+    expect(orders.toArray()).toEqual([{ id: 'existing-row', height: 36 }]);
+    expect(draft.database.get(YjsDatabaseKey.views).get('calendar-view').get(YjsDatabaseKey.row_orders).length).toBe(0);
+    expect(database.get(YjsDatabaseKey.fields).get('title').get(YjsDatabaseKey.name)).toBe('title');
+    expect(liveUpdate).not.toHaveBeenCalled();
+    expect(Y.encodeStateAsUpdate(source.databaseDoc)).toEqual(before);
+  });
+
+  it('loads existing related rows while keeping its own row entirely local', async () => {
+    const { source, orders } = fixture();
+    const relatedDoc = new Y.Doc() as YDoc;
+
+    docs.push(relatedDoc);
+    source.createRow = jest.fn().mockResolvedValue(relatedDoc);
+    const draft = createDraft(source);
+
+    await expect(draft.context.createRow?.(`related-view_rows_${draft.id}`)).resolves.toBe(draft.rowDoc);
+    expect(source.createRow).not.toHaveBeenCalled();
+    await expect(draft.context.createRow?.('related-view_rows_existing-related-row')).resolves.toBe(relatedDoc);
+    expect(source.createRow).toHaveBeenCalledTimes(1);
+    expect(source.createRow).toHaveBeenCalledWith('related-view_rows_existing-related-row');
+    expect(orders.toArray()).toEqual([{ id: 'existing-row', height: 36 }]);
+    expect(draft.dirty).toBe(false);
+  });
+
+  it('discards an untouched draft but allows explicit submission of an untitled card', async () => {
+    const draft = createDraft(fixture().source);
+    const persist = jest.fn(async (snapshot: CalendarDraftSnapshot) => snapshot.id);
+
+    expect(draft.dirty).toBe(false);
+    await expect(draft.commit(persist)).resolves.toBeNull();
+    expect(persist).not.toHaveBeenCalled();
+    await expect(draft.commit(persist, true)).resolves.toBe(draft.id);
+    await expect(draft.commit(persist, true)).resolves.toBe(draft.id);
+    expect(persist).toHaveBeenCalledTimes(1);
+  });
+
+  it('ignores timestamp bookkeeping but recognizes a property-only edit', async () => {
+    const draft = createDraft(fixture().source);
+    const date = draft.cells.get('date')!;
+
+    date.set(YjsDatabaseKey.created_at, '999');
+    date.set(YjsDatabaseKey.last_modified, '999');
+    expect(draft.dirty).toBe(false);
+    date.set(YjsDatabaseKey.include_time, true);
+    expect(draft.dirty).toBe(true);
+    const persist = jest.fn(async (snapshot: CalendarDraftSnapshot) => snapshot.id);
+
+    await expect(draft.commit(persist)).resolves.toBe(draft.id);
+    expect(persist).toHaveBeenCalledTimes(1);
+  });
+
+  it('coalesces overlapping close and submit requests into one save', async () => {
+    const draft = createDraft(fixture().source);
+
+    setCell(draft, 'title', 'Edited');
+    let resolveSave!: (id: string) => void;
+    const persist = jest.fn(() => new Promise<string>((resolve) => { resolveSave = resolve; }));
+    const first = draft.commit(persist);
+    const second = draft.commit(persist, true);
+
+    expect(first).toBe(second);
+    expect(draft.saving).toBe(true);
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(persist).toHaveBeenCalledTimes(1);
+    resolveSave(draft.id);
+    await expect(first).resolves.toBe(draft.id);
+    expect(draft.saving).toBe(false);
+  });
+
+  it('retains edits and the same row ID after a rejected or empty save result', async () => {
+    const draft = createDraft(fixture().source);
+
+    setCell(draft, 'title', 'Retry me');
+    const attempts: string[] = [];
+    const persist = jest.fn(async (snapshot: CalendarDraftSnapshot) => {
+      attempts.push(snapshot.id);
+      if (attempts.length === 1) throw new Error('Offline');
+      if (attempts.length === 2) return null;
+      expect(snapshot.cells.get('title')?.get(YjsDatabaseKey.data)).toBe('Retry me');
+      return snapshot.id;
+    });
+
+    await expect(draft.commit(persist)).rejects.toThrow('Offline');
+    expect(draft.saving).toBe(false);
+    expect(draft.savedId).toBeNull();
+    expect(draft.dirty).toBe(true);
+    await expect(draft.commit(persist)).rejects.toThrow('could not be saved');
+    await expect(draft.commit(persist)).resolves.toBe(draft.id);
+    expect(attempts).toEqual([draft.id, draft.id, draft.id]);
+  });
+});
+
+describe('CalendarEventDraft defaults and properties', () => {
+  it('copies cloud bigint filter values without copying row orders or changing the live schema', () => {
+    const { source, database, orders } = fixture();
+    const filters = Y.Array.from([
+      { id: 'notes-filter', field_id: 'notes', filter_type: BigInt(2), condition: BigInt(0), ty: BigInt(0), content: 'Inherited' },
+      { id: 'title-filter', field_id: 'title', filter_type: BigInt(2), condition: BigInt(0), ty: BigInt(0), content: 'Filtered title' },
+    ]);
+
+    database.get(YjsDatabaseKey.views).get('calendar-view').set(YjsDatabaseKey.filters, filters);
+    const before = Y.encodeStateAsUpdate(source.databaseDoc);
+    const draft = createDraft(source);
+
+    expect(draft.cells.get('notes')?.get(YjsDatabaseKey.data)).toBe('Inherited');
+    expect(draft.cells.has('title')).toBe(false);
+    expect(draft.dirty).toBe(false);
+    expect(draft.database.get(YjsDatabaseKey.views).get('calendar-view').get(YjsDatabaseKey.row_orders).length).toBe(0);
+    expect(orders.toArray()).toEqual([{ id: 'existing-row', height: 36 }]);
+    expect(Y.encodeStateAsUpdate(source.databaseDoc)).toEqual(before);
+  });
+
+  it('normalizes exclusive all-day ranges and expands a short timed click to one hour', () => {
+    const { source } = fixture();
+    const oneDay = createDraft(source);
+    const range = createDraft(source, { ...selection, end: new Date(2026, 8, 15) });
+    const start = new Date(2026, 8, 11, 17);
+    const timed = createDraft(source, { start, end: new Date(2026, 8, 11, 17, 30), allDay: false });
+
+    expect(oneDay.cells.get('date')?.toJSON()).toMatchObject({
+      data: String(dayjs(selection.start).unix()), is_range: false, include_time: false,
+    });
+    expect(oneDay.cells.get('date')?.get(YjsDatabaseKey.end_timestamp)).toBeUndefined();
+    expect(range.cells.get('date')?.toJSON()).toMatchObject({
+      end_timestamp: String(dayjs(new Date(2026, 8, 14, 23, 59)).unix()), is_range: true, include_time: false,
+    });
+    expect(timed.cells.get('date')?.toJSON()).toMatchObject({
+      data: String(dayjs(start).unix()), end_timestamp: String(dayjs(new Date(2026, 8, 11, 18)).unix()),
+      is_range: true, include_time: true,
+    });
+  });
+
+  it('treats template defaults as untouched without loading or copying template documents', async () => {
+    const { source } = fixture({
+      templateId: 'template-id', name: 'Default', docViewId: 'template-document',
+      isDocumentEmpty: false, embeddedDatabases: [], createdAtMs: 1, updatedAtMs: 1,
+      icon: '📆', cover: '{"data":"#123456","cover_type":0}',
+      defaultCells: { title: { type: 'text', value: 'Template title' }, check: { type: 'checkbox', value: true } },
+    });
+    const draft = createDraft(source);
+    const persist = jest.fn();
+
+    expect(draft.templateId).toBe('template-id');
+    expect(draft.cells.get('title')?.get(YjsDatabaseKey.data)).toBe('Template title');
+    expect(draft.cells.get('check')?.get(YjsDatabaseKey.data)).toBe('true');
+    expect(draft.meta.get(getMetaIdMap(draft.id).get(RowMetaKey.IconId)!)).toBe('📆');
+    expect(draft.dirty).toBe(false);
+    await expect(draft.commit(persist)).resolves.toBeNull();
+    expect(persist).not.toHaveBeenCalled();
+    expect(source.loadRowDocument).not.toHaveBeenCalled();
+    expect(source.createRowDocument).not.toHaveBeenCalled();
+    expect(source.duplicateRowDocument).not.toHaveBeenCalled();
+  });
+
+  it('keeps nested advanced cell values and explicit empty properties in the save snapshot', async () => {
+    const draft = createDraft(fixture().source);
+    const related = ['0a67d8f8-4e07-4a2f-9c26-1b8a34cfd6b1'];
+    const tasks = [JSON.stringify({ id: 'task-1', name: 'Check card', isSelected: true })];
+
+    setCell(draft, 'relation', Y.Array.from(related));
+    setCell(draft, 'checklist', Y.Array.from(tasks));
+    setCell(draft, 'person', JSON.stringify(['cloud-person-id']));
+    setCell(draft, 'title', '');
+    const persist = jest.fn(async (snapshot: CalendarDraftSnapshot) => {
+      expect(snapshot.cells).not.toBe(draft.cells);
+      expect(snapshot.cells.toJSON()).toEqual(draft.cells.toJSON());
+      expect(snapshot.cells.get('relation')?.get(YjsDatabaseKey.data)).toBeInstanceOf(Y.Array);
+      expect(snapshot.cells.get('checklist')?.get(YjsDatabaseKey.data)).toBeInstanceOf(Y.Array);
+      expect(snapshot.cells.get('title')?.get(YjsDatabaseKey.data)).toBe('');
+      return snapshot.id;
+    });
+
+    await expect(draft.commit(persist)).resolves.toBe(draft.id);
+  });
+
+  it('uploads staged files only on commit and reuses completed uploads on save retry', async () => {
+    Object.defineProperty(URL, 'createObjectURL', { configurable: true, value: jest.fn(() => 'blob:calendar-file') });
+    Object.defineProperty(URL, 'revokeObjectURL', { configurable: true, value: jest.fn() });
+    const { source } = fixture();
+    const draft = createDraft(source);
+    const file = new File(['image'], 'image.png', { type: 'image/png' });
+    const localUrl = await draft.context.uploadFile!(file);
+
+    setCell(draft, 'media', Y.Array.from([JSON.stringify({ name: 'image.png', url: localUrl, file_type: 0 })]));
+    expect(source.uploadFile).not.toHaveBeenCalled();
+    const persist = jest.fn(async (snapshot: CalendarDraftSnapshot) => {
+      const data = snapshot.cells.get('media')?.get(YjsDatabaseKey.data) as Y.Array<string>;
+
+      expect(JSON.parse(data.get(0)).url).toBe('https://files.appflowy.io/uploaded');
+      if (persist.mock.calls.length === 1) throw new Error('Save failed after upload');
+      return snapshot.id;
+    });
+
+    await expect(draft.commit(persist)).rejects.toThrow('Save failed after upload');
+    await expect(draft.commit(persist)).resolves.toBe(draft.id);
+    expect(source.uploadFile).toHaveBeenCalledTimes(1);
+    expect(source.uploadFile).toHaveBeenCalledWith(file);
+    const localData = draft.cells.get('media')?.get(YjsDatabaseKey.data) as Y.Array<string>;
+
+    expect(JSON.parse(localData.get(0)).url).toBe(localUrl);
+  });
+
+  it('releases a discarded file preview without uploading the attachment', async () => {
+    Object.defineProperty(URL, 'createObjectURL', { configurable: true, value: jest.fn(() => 'blob:discarded') });
+    Object.defineProperty(URL, 'revokeObjectURL', { configurable: true, value: jest.fn() });
+    const { source } = fixture();
+    const draft = createDraft(source);
+
+    await draft.context.uploadFile!(new File(['image'], 'discard.png'));
+    draft.dispose();
+    expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:discarded');
+    expect(source.uploadFile).not.toHaveBeenCalled();
+    drafts.splice(drafts.indexOf(draft), 1);
+  });
+
+  it('stages new select options and preserves concurrently added remote options when saved', async () => {
+    const { source, database } = fixture();
+    const draft = createDraft(source);
+    const localField = draft.database.get(YjsDatabaseKey.fields).get('tags');
+    const liveField = database.get(YjsDatabaseKey.fields).get('tags');
+    const existing = { id: 'existing', name: 'Existing', color: 0 };
+    const local = { id: 'local', name: 'Local', color: 1 };
+    const remote = { id: 'remote', name: 'Remote', color: 2 };
+
+    getTypeOptions(localField)!.set(YjsDatabaseKey.content, JSON.stringify({ options: [existing, local] }));
+    setCell(draft, 'tags', 'local');
+    expect(parseSelectOptionTypeOptions(liveField).options).toEqual([existing]);
+    getTypeOptions(liveField)!.set(YjsDatabaseKey.content, JSON.stringify({ options: [existing, remote] }));
+    await draft.commit(async (snapshot) => snapshot.id);
+    expect(parseSelectOptionTypeOptions(liveField).options).toEqual([existing, remote, local]);
+  });
+});

--- a/src/components/database/fullcalendar/draft/CalendarEventDraft.ts
+++ b/src/components/database/fullcalendar/draft/CalendarEventDraft.ts
@@ -1,0 +1,321 @@
+import dayjs from 'dayjs';
+import { v4 as uuidv4 } from 'uuid';
+import * as Y from 'yjs';
+
+import { DatabaseContextState } from '@/application/database-yjs/context';
+import { FieldType, RowMetaKey } from '@/application/database-yjs/database.type';
+import { populateNewRowCells } from '@/application/database-yjs/dispatch/new-row-cells';
+import { parseSelectOptionTypeOptions } from '@/application/database-yjs/fields/select-option/parse';
+import { getTypeOptions } from '@/application/database-yjs/fields/type_option';
+import { initialDatabaseRow } from '@/application/database-yjs/row';
+import { generateRowMeta } from '@/application/database-yjs/row_meta';
+import { readDatabaseRowTemplateState } from '@/application/database-yjs/template';
+import {
+  YDatabase,
+  YDatabaseCell,
+  YDatabaseCells,
+  YDatabaseRow,
+  YDoc,
+  YjsDatabaseKey,
+  YjsEditorKey,
+} from '@/application/types';
+import { correctAllDayEndForStorage } from '@/utils/time';
+
+export interface CalendarDraftSelection {
+  start: Date;
+  /** FullCalendar's exclusive end for all-day selections. */
+  end?: Date;
+  allDay: boolean;
+}
+
+export interface CalendarDraftSnapshot {
+  id: string;
+  cells: YDatabaseCells;
+  meta: Y.Map<unknown>;
+}
+
+function meaningfulValue(value: unknown): unknown {
+  if (typeof value === 'bigint') return value.toString();
+  if (Array.isArray(value)) return value.map(meaningfulValue);
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value)
+        .filter(([key]) => key !== 'created_at' && key !== 'last_modified')
+        .sort(([a], [b]) => a.localeCompare(b))
+        .map(([key, item]) => [key, meaningfulValue(item)])
+    );
+  }
+
+  return value;
+}
+
+// Cloud Yjs integers can be bigint values, which Y.Map.clone cannot integrate.
+// Copy only editor schema, omitting row orders before allocating their contents.
+function cloneDraftSchema(value: unknown): unknown {
+  if (typeof value === 'bigint') return value.toString();
+  if (value instanceof Y.Map) {
+    const copy = new Y.Map<unknown>();
+
+    value.forEach((child, key) =>
+      copy.set(key, key === YjsDatabaseKey.row_orders ? new Y.Array() : cloneDraftSchema(child))
+    );
+    return copy;
+  }
+
+  if (value instanceof Y.Array) {
+    const copy = new Y.Array<unknown>();
+
+    copy.push(value.toArray().map(cloneDraftSchema));
+    return copy;
+  }
+
+  if (value instanceof Uint8Array) return value.slice();
+  if (Array.isArray(value)) return value.map(cloneDraftSchema);
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(Object.entries(value).map(([key, item]) => [key, cloneDraftSchema(item)]));
+  }
+
+  return value;
+}
+
+/** An ephemeral editing environment: no row binding, IndexedDB or outbox. */
+export class CalendarEventDraft {
+  readonly id = uuidv4();
+  readonly databaseDoc = new Y.Doc() as YDoc;
+  readonly rowDoc = new Y.Doc({ guid: this.id }) as YDoc;
+  readonly context: DatabaseContextState;
+  readonly database: YDatabase;
+  readonly cells: YDatabaseCells;
+  readonly meta: Y.Map<unknown>;
+  readonly selection: CalendarDraftSelection;
+  readonly templateId?: string;
+  saving = false;
+  savedId: string | null = null;
+  private baseline: string;
+  private pending?: Promise<string | null>;
+  private readonly files = new Map<string, { file: File; remote?: string }>();
+  private readonly originalOptions = new Map<string, ReturnType<typeof parseSelectOptionTypeOptions>>();
+
+  constructor(readonly source: DatabaseContextState, readonly dateFieldId: string, selection: CalendarDraftSelection) {
+    const database = source.databaseDoc.getMap(YjsEditorKey.data_section).get(YjsEditorKey.database) as YDatabase;
+
+    this.database = new Y.Map() as YDatabase;
+    this.database.set(YjsDatabaseKey.id, database.get(YjsDatabaseKey.id));
+    this.database.set(YjsDatabaseKey.fields, cloneDraftSchema(database.get(YjsDatabaseKey.fields)));
+    this.database.set(YjsDatabaseKey.views, cloneDraftSchema(database.get(YjsDatabaseKey.views)));
+    this.databaseDoc.getMap(YjsEditorKey.data_section).set(YjsEditorKey.database, this.database);
+    const fields = this.database.get(YjsDatabaseKey.fields);
+
+    fields.forEach((field, id) => this.originalOptions.set(id, parseSelectOptionTypeOptions(field)));
+    initialDatabaseRow(this.id, database.get(YjsDatabaseKey.id), this.rowDoc);
+    const root = this.rowDoc.getMap(YjsEditorKey.data_section);
+    const row = root.get(YjsEditorKey.database_row) as YDatabaseRow;
+
+    this.cells = row.get(YjsDatabaseKey.cells);
+    this.meta = root.get(YjsEditorKey.meta) as Y.Map<unknown>;
+    const templates = readDatabaseRowTemplateState(database);
+    const template = templates.templates.find((item) => item.templateId === templates.defaultTemplateId);
+
+    this.templateId = template?.templateId;
+    const start = selection.allDay ? dayjs(selection.start).startOf('day').toDate() : selection.start;
+    let end = selection.end;
+
+    if (selection.allDay && end && dayjs(end).diff(dayjs(start), 'day') <= 1) end = undefined;
+    if (!selection.allDay && (!end || end.getTime() - start.getTime() <= 30 * 60 * 1000)) {
+      end = new Date(start.getTime() + 60 * 60 * 1000);
+    }
+
+    this.selection = { start, end, allDay: selection.allDay };
+    const fieldType = Number(fields.get(dateFieldId)?.get(YjsDatabaseKey.type));
+    const isSystemTime = fieldType === FieldType.CreatedTime || fieldType === FieldType.LastEditedTime;
+    const storedEnd = selection.allDay && end ? correctAllDayEndForStorage(end) : end;
+    const dateData = {
+      data: String(dayjs(start).unix()),
+      endTimestamp: storedEnd ? String(dayjs(storedEnd).unix()) : undefined,
+      isRange: !!storedEnd,
+      includeTime: !selection.allDay,
+    };
+
+    this.rowDoc.transact(() => {
+      populateNewRowCells({
+        row,
+        database: this.database,
+        template,
+        filters: this.database.get(YjsDatabaseKey.views)?.get(source.activeViewId)?.get(YjsDatabaseKey.filters),
+        calendarFieldId: dateFieldId,
+        cellsData: isSystemTime ? undefined : { [dateFieldId]: dateData },
+      });
+      const meta = generateRowMeta(this.id, {
+        [RowMetaKey.IconId]: template?.icon ?? null,
+        [RowMetaKey.CoverId]: template?.cover ?? null,
+        [RowMetaKey.IsDocumentEmpty]: template?.isDocumentEmpty ?? true,
+      });
+
+      Object.entries(meta).forEach(([key, value]) => this.meta.set(key, value));
+    });
+
+    this.context = {
+      ...source,
+      databaseDoc: this.databaseDoc,
+      rowMap: { [this.id]: this.rowDoc },
+      // This existing isolated-row contract also suppresses reciprocal links.
+      templateEditingRowId: this.id,
+      ensureRow: async (id) => (id === this.id ? this.rowDoc : undefined),
+      loadRowFromSeed: undefined,
+      peekRowDocFromSeed: undefined,
+      bindRowSync: undefined,
+      markCellLocalMutation: undefined,
+      hasCellLocalMutation: undefined,
+      getCellLocalMutationRevision: undefined,
+      subscribeToCellLocalMutations: undefined,
+      // Relation pickers use this callback to load existing row documents.
+      // Keep the draft itself local; isolated pickers disable target creation.
+      createRow: async (key) => {
+        if (key.endsWith(`_rows_${this.id}`)) return this.rowDoc;
+        if (!source.createRow) throw new Error('Related row loading is unavailable');
+        return source.createRow(key);
+      },
+      navigateToRow: undefined,
+      bindViewSync: undefined,
+      loadRowDocument: undefined,
+      createRowDocument: undefined,
+      duplicateRowDocument: undefined,
+      checkIfRowDocumentExists: async () => false,
+      uploadFile: async (file) => {
+        const url = URL.createObjectURL(file);
+
+        this.files.set(url, { file });
+        return url;
+      },
+    };
+    this.baseline = this.fingerprint();
+  }
+
+  private fingerprint() {
+    return JSON.stringify(
+      meaningfulValue({
+        cells: this.cells.toJSON(),
+        meta: this.meta.toJSON(),
+        fields: this.database.get(YjsDatabaseKey.fields).toJSON(),
+      })
+    );
+  }
+
+  get dirty() {
+    return this.fingerprint() !== this.baseline;
+  }
+
+  /** Share a single in-flight save across Escape, blur and explicit submission. */
+  commit(persist: (snapshot: CalendarDraftSnapshot) => Promise<string | null>, force = false): Promise<string | null> {
+    if (this.pending) return this.pending;
+    if (this.savedId) return Promise.resolve(this.savedId);
+    if (!force && !this.dirty) return Promise.resolve(null);
+    this.saving = true;
+    this.pending = (async () => {
+      const snapshotDoc = new Y.Doc();
+      const cells = this.cells.clone() as YDatabaseCells;
+
+      const meta = this.meta.clone() as Y.Map<unknown>;
+
+      snapshotDoc.getMap('snapshot').set('cells', cells);
+      snapshotDoc.getMap('snapshot').set('meta', meta);
+      try {
+        await this.resolveUploads(cells);
+        this.commitOptions();
+        const id = await persist({ id: this.id, cells, meta });
+
+        if (!id) throw new Error('The calendar row could not be saved');
+        this.savedId = id;
+        return id;
+      } catch (error) {
+        // Publication is the ownership boundary. A later reciprocal-link error
+        // must never leave a real row offering the local-only discard action.
+        const liveDatabase = this.source.databaseDoc.getMap(YjsEditorKey.data_section).get(YjsEditorKey.database) as YDatabase;
+        const orders = liveDatabase.get(YjsDatabaseKey.views).get(this.source.activeViewId)?.get(YjsDatabaseKey.row_orders);
+
+        if (orders?.toArray().some((row) => row.id === this.id)) this.savedId = this.id;
+        throw error;
+      } finally {
+        snapshotDoc.destroy();
+        this.saving = false;
+        this.pending = undefined;
+      }
+    })();
+    return this.pending;
+  }
+
+  private async resolveUploads(cells: YDatabaseCells) {
+    const replacements: Array<Promise<void>> = [];
+
+    cells.forEach((value, fieldId) => {
+      const cell = value as YDatabaseCell;
+      const field = this.database.get(YjsDatabaseKey.fields).get(fieldId);
+
+      if (Number(field?.get(YjsDatabaseKey.type)) !== FieldType.Media) return;
+      const data = cell.get(YjsDatabaseKey.data);
+
+      if (!(data instanceof Y.Array)) return;
+      replacements.push(
+        (async () => {
+          const items = await Promise.all(
+            data.toArray().map(async (raw) => {
+              const item = JSON.parse(raw);
+              const pending = this.files.get(item.url);
+
+              if (!pending) return raw;
+              if (!this.source.uploadFile) throw new Error('File upload is unavailable');
+              pending.remote ??= await this.source.uploadFile(pending.file);
+              return JSON.stringify({ ...item, url: pending.remote });
+            })
+          );
+
+          data.delete(0, data.length);
+          data.push(items);
+        })()
+      );
+    });
+    await Promise.all(replacements);
+  }
+
+  private commitOptions() {
+    const liveDatabase = this.source.databaseDoc
+      .getMap(YjsEditorKey.data_section)
+      .get(YjsEditorKey.database) as YDatabase;
+
+    this.source.databaseDoc.transact(() => {
+      this.database.get(YjsDatabaseKey.fields).forEach((field, id) => {
+        const type = Number(field.get(YjsDatabaseKey.type));
+
+        if (type !== FieldType.SingleSelect && type !== FieldType.MultiSelect) return;
+        const baseline = this.originalOptions.get(id)?.options ?? [];
+        const local = parseSelectOptionTypeOptions(field).options ?? [];
+
+        if (JSON.stringify(baseline) === JSON.stringify(local)) return;
+        const live = liveDatabase.get(YjsDatabaseKey.fields).get(id);
+
+        if (!live || Number(live.get(YjsDatabaseKey.type)) !== type) return;
+        const current = parseSelectOptionTypeOptions(live);
+        const removed = new Set(
+          baseline.filter((option) => !local.some((item) => item.id === option.id)).map((item) => item.id)
+        );
+        const options = (current.options ?? []).filter((option) => !removed.has(option.id));
+
+        local.forEach((option) => {
+          if (JSON.stringify(option) === JSON.stringify(baseline.find((item) => item.id === option.id))) return;
+          const index = options.findIndex((item) => item.id === option.id);
+
+          if (index === -1) options.push(option);
+          else options[index] = option;
+        });
+        getTypeOptions(live)?.set(YjsDatabaseKey.content, JSON.stringify({ ...current, options }));
+      });
+    });
+  }
+
+  dispose() {
+    this.files.forEach((_, url) => URL.revokeObjectURL(url));
+    this.files.clear();
+    this.rowDoc.destroy();
+    this.databaseDoc.destroy();
+  }
+}

--- a/src/components/database/fullcalendar/draft/useCalendarDraft.test.tsx
+++ b/src/components/database/fullcalendar/draft/useCalendarDraft.test.tsx
@@ -1,0 +1,266 @@
+import { EventInput } from '@fullcalendar/core';
+import { act, cleanup, renderHook } from '@testing-library/react';
+import * as Y from 'yjs';
+
+import { useCalendarLayoutSetting, useDatabaseContext, usePrimaryFieldId } from '@/application/database-yjs';
+import { DatabaseContextState } from '@/application/database-yjs/context';
+import { FieldType } from '@/application/database-yjs/database.type';
+import { useNewRowDispatch } from '@/application/database-yjs/dispatch/row';
+import { YDatabase, YDatabaseField, YDatabaseView, YDoc, YjsDatabaseKey, YjsEditorKey } from '@/application/types';
+
+import { CalendarDraftSnapshot } from './CalendarEventDraft';
+import { useCalendarDraft } from './useCalendarDraft';
+
+jest.mock('@/application/database-yjs', () => ({
+  useCalendarLayoutSetting: jest.fn(),
+  useDatabaseContext: jest.fn(),
+  usePrimaryFieldId: jest.fn(),
+}));
+jest.mock('@/application/database-yjs/dispatch/row', () => ({ useNewRowDispatch: jest.fn() }));
+
+const selection = { start: new Date(2026, 8, 11, 17), end: new Date(2026, 8, 11, 18), allDay: false };
+const emptyProps: { events: EventInput[]; emptyEvents: EventInput[] } = { events: [], emptyEvents: [] };
+const mockContext = useDatabaseContext as jest.MockedFunction<typeof useDatabaseContext>;
+const mockCreateRow = jest.fn<Promise<string | null>, [{ draft: CalendarDraftSnapshot }]>();
+let sourceDoc: YDoc;
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (error: Error) => void;
+  const promise = new Promise<T>((res, rej) => { resolve = res; reject = rej; });
+
+  return { promise, resolve, reject };
+}
+
+function createContext(): DatabaseContextState {
+  sourceDoc = new Y.Doc() as YDoc;
+  const database = new Y.Map() as YDatabase;
+  const fields = new Y.Map<YDatabaseField>();
+  const views = new Y.Map<YDatabaseView>();
+  const view = new Y.Map() as YDatabaseView;
+
+  for (const [id, type] of [['title', FieldType.RichText], ['date', FieldType.DateTime]] as const) {
+    const field = new Y.Map() as YDatabaseField;
+
+    field.set(YjsDatabaseKey.id, id);
+    field.set(YjsDatabaseKey.type, type);
+    field.set(YjsDatabaseKey.is_primary, id === 'title');
+    fields.set(id, field);
+  }
+
+  view.set(YjsDatabaseKey.row_orders, new Y.Array());
+  views.set('calendar', view);
+  database.set(YjsDatabaseKey.id, 'database');
+  database.set(YjsDatabaseKey.fields, fields);
+  database.set(YjsDatabaseKey.views, views);
+  database.set(YjsDatabaseKey.metas, new Y.Map());
+  sourceDoc.getMap(YjsEditorKey.data_section).set(YjsEditorKey.database, database);
+
+  return {
+    readOnly: false, canWrite: true, databaseDoc: sourceDoc, rowMap: {},
+    databasePageId: 'calendar', activeViewId: 'calendar', workspaceId: 'workspace',
+  };
+}
+
+beforeEach(() => {
+  jest.useFakeTimers();
+  jest.clearAllMocks();
+  mockContext.mockReturnValue(createContext());
+  (useCalendarLayoutSetting as jest.Mock).mockReturnValue({ fieldId: 'date' });
+  (usePrimaryFieldId as jest.Mock).mockReturnValue('title');
+  (useNewRowDispatch as jest.Mock).mockReturnValue(mockCreateRow);
+  mockCreateRow.mockImplementation(async ({ draft }) => draft.id);
+});
+
+afterEach(() => {
+  cleanup();
+  act(() => { jest.runOnlyPendingTimers(); });
+  sourceDoc.destroy();
+  jest.useRealTimers();
+});
+
+describe('useCalendarDraft handoff', () => {
+  it.each(['events', 'emptyEvents'] as const)('keeps the placeholder until the saved row appears in %s, then permits another card', async (list) => {
+    const { result, rerender } = renderHook(({ events, emptyEvents }) => useCalendarDraft(events, emptyEvents), {
+      initialProps: emptyProps,
+    });
+
+    act(() => { result.current.startDraft(selection); });
+    const firstId = result.current.draft!.id;
+    const rowDoc = result.current.draft!.context.rowMap![firstId];
+    const destroy = jest.spyOn(rowDoc, 'destroy');
+
+    await act(async () => { await result.current.finishDraft(true); });
+    expect(mockCreateRow).toHaveBeenCalledTimes(1);
+    expect(result.current.event?.id).toBe(firstId);
+    expect(result.current.event?.start).toEqual(selection.start);
+    expect(result.current.event?.end).toEqual(selection.end);
+    expect(destroy).not.toHaveBeenCalled();
+
+    rerender({ ...emptyProps, [list]: [{ id: firstId, title: 'Saved card' }] });
+    expect(result.current.draft).toBeNull();
+    expect(result.current.event).toBeNull();
+    act(() => { jest.runOnlyPendingTimers(); });
+    expect(destroy).toHaveBeenCalledTimes(1);
+    act(() => { result.current.startDraft(selection); });
+    expect(result.current.draft!.id).not.toBe(firstId);
+    expect(mockCreateRow).toHaveBeenCalledTimes(1);
+  });
+
+  it('releases a saved card hidden by an active filter without waiting for a visible event', async () => {
+    const database = sourceDoc.getMap(YjsEditorKey.data_section).get(YjsEditorKey.database) as YDatabase;
+
+    database.get(YjsDatabaseKey.views).get('calendar').set(YjsDatabaseKey.filters, Y.Array.from([
+      { id: 'title-filter', field_id: 'title', filter_type: 2, condition: 2, ty: 0, content: 'Visible' },
+    ]));
+    const { result } = renderHook(() => useCalendarDraft([], []));
+
+    act(() => { result.current.startDraft(selection); });
+    const firstId = result.current.draft!.id;
+
+    await act(async () => { await result.current.finishDraft(true); });
+    expect(mockCreateRow).toHaveBeenCalledTimes(1);
+    expect(result.current.draft).toBeNull();
+    expect(result.current.event).toBeNull();
+    act(() => { result.current.startDraft(selection); });
+    expect(result.current.draft!.id).not.toBe(firstId);
+  });
+
+  it('coalesces repeated selection, dismiss, and submit callbacks while persistence is pending', async () => {
+    const pending = deferred<string>();
+
+    mockCreateRow.mockReturnValue(pending.promise);
+    const { result } = renderHook(() => useCalendarDraft([], []));
+    let id: string | null = null;
+    let repeatedId: string | null = null;
+
+    act(() => {
+      id = result.current.startDraft(selection);
+      repeatedId = result.current.startDraft(selection);
+    });
+    expect(id).not.toBeNull();
+    expect(repeatedId).toBe(id);
+    let firstSave!: Promise<string | null>;
+    let secondSave!: Promise<string | null>;
+
+    act(() => {
+      firstSave = result.current.finishDraft(true);
+      secondSave = result.current.finishDraft(false);
+    });
+    await act(async () => { await Promise.resolve(); });
+    expect(mockCreateRow).toHaveBeenCalledTimes(1);
+    expect(result.current.draft!.saving).toBe(true);
+    expect(result.current.draft!.context.readOnly).toBe(true);
+    act(() => { result.current.discardDraft(); });
+    expect(result.current.draft!.id).toBe(id);
+
+    await act(async () => {
+      pending.resolve(id!);
+      await expect(Promise.all([firstSave, secondSave])).resolves.toEqual([id, id]);
+    });
+    expect(mockCreateRow).toHaveBeenCalledTimes(1);
+    expect(result.current.draft!.saving).toBe(true);
+    expect(result.current.draft!.context.readOnly).toBe(true);
+  });
+
+  it('locks a published row after a reciprocal-link failure until the authoritative event replaces it', async () => {
+    const database = sourceDoc.getMap(YjsEditorKey.data_section).get(YjsEditorKey.database) as YDatabase;
+    const orders = database.get(YjsDatabaseKey.views).get('calendar').get(YjsDatabaseKey.row_orders);
+    const error = new Error('Reciprocal relation update failed');
+
+    mockCreateRow.mockImplementation(async ({ draft }) => {
+      orders.push([{ id: draft.id, height: 36 }]);
+      throw error;
+    });
+    const { result, rerender } = renderHook(({ events, emptyEvents }) => useCalendarDraft(events, emptyEvents), {
+      initialProps: emptyProps,
+    });
+
+    act(() => { result.current.startDraft(selection); });
+    const publishedId = result.current.draft!.id;
+
+    await act(async () => {
+      await expect(result.current.finishDraft(true)).rejects.toBe(error);
+    });
+    expect(orders.toArray()).toEqual([{ id: publishedId, height: 36 }]);
+    expect(result.current.draft!.id).toBe(publishedId);
+    expect(result.current.draft!.saving).toBe(true);
+    expect(result.current.draft!.context.readOnly).toBe(true);
+    expect(result.current.event?.editable).toBe(false);
+    act(() => { result.current.discardDraft(); });
+    expect(result.current.draft!.id).toBe(publishedId);
+
+    await act(async () => {
+      await expect(result.current.finishDraft(true)).resolves.toBe(publishedId);
+    });
+    expect(mockCreateRow).toHaveBeenCalledTimes(1);
+    expect(orders.length).toBe(1);
+
+    rerender({ events: [{ id: publishedId, title: 'Published card' }], emptyEvents: [] });
+    expect(result.current.draft).toBeNull();
+    expect(result.current.event).toBeNull();
+    act(() => { result.current.startDraft(selection); });
+    expect(result.current.draft!.id).not.toBe(publishedId);
+    expect(result.current.draft!.saving).toBe(false);
+    expect(result.current.draft!.context.readOnly).toBe(false);
+    expect(mockCreateRow).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('useCalendarDraft lifecycle', () => {
+  it.each(['success', 'failure'] as const)('disposes an unmounted draft after an in-flight save finishes with %s', async (outcome) => {
+    const pending = deferred<string>();
+
+    mockCreateRow.mockReturnValue(pending.promise);
+    const { result, unmount } = renderHook(() => useCalendarDraft([], []));
+
+    act(() => { result.current.startDraft(selection); });
+    const draft = result.current.draft!;
+    const rowDoc = draft.context.rowMap![draft.id];
+    const databaseDoc = draft.context.databaseDoc;
+    const destroyed = jest.fn();
+    const databaseDestroyed = jest.fn();
+
+    rowDoc.on('destroy', destroyed);
+    databaseDoc.on('destroy', databaseDestroyed);
+    let save!: Promise<string | null>;
+
+    act(() => { save = result.current.finishDraft(true); });
+    // Attach a rejection handler before driving the asynchronous rejection.
+    const settled = save.then((id) => ({ id }), (error: Error) => ({ error }));
+
+    await act(async () => { await Promise.resolve(); });
+    expect(mockCreateRow).toHaveBeenCalledTimes(1);
+    unmount();
+    act(() => { jest.runOnlyPendingTimers(); });
+    expect(destroyed).not.toHaveBeenCalled();
+    expect(databaseDestroyed).not.toHaveBeenCalled();
+    const error = new Error('Cloud unavailable');
+
+    await act(async () => {
+      if (outcome === 'success') pending.resolve(draft.id);
+      else pending.reject(error);
+      await expect(settled).resolves.toEqual(outcome === 'success' ? { id: draft.id } : { error });
+    });
+    act(() => { jest.runOnlyPendingTimers(); });
+    expect(destroyed).toHaveBeenCalledTimes(1);
+    expect(databaseDestroyed).toHaveBeenCalledTimes(1);
+    expect(mockCreateRow).toHaveBeenCalledTimes(1);
+  });
+
+  it('disposes an untouched draft on unmount without creating a cloud row', () => {
+    const { result, unmount } = renderHook(() => useCalendarDraft([], []));
+
+    act(() => { result.current.startDraft(selection); });
+    const draft = result.current.draft!;
+    const rowDoc = draft.context.rowMap![draft.id];
+    const destroyRow = jest.spyOn(rowDoc, 'destroy');
+    const destroyDatabase = jest.spyOn(draft.context.databaseDoc, 'destroy');
+
+    unmount();
+    act(() => { jest.runOnlyPendingTimers(); });
+    expect(destroyRow).toHaveBeenCalledTimes(1);
+    expect(destroyDatabase).toHaveBeenCalledTimes(1);
+    expect(mockCreateRow).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/database/fullcalendar/draft/useCalendarDraft.ts
+++ b/src/components/database/fullcalendar/draft/useCalendarDraft.ts
@@ -1,0 +1,178 @@
+import { EventInput } from '@fullcalendar/core';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+import { useCalendarLayoutSetting, useDatabaseContext, usePrimaryFieldId } from '@/application/database-yjs';
+import { useNewRowDispatch } from '@/application/database-yjs/dispatch/row';
+import { YDatabase, YjsDatabaseKey, YjsEditorKey } from '@/application/types';
+
+import { CalendarDraftSelection, CalendarEventDraft } from './CalendarEventDraft';
+
+export interface CalendarDraft {
+  id: string;
+  context: CalendarEventDraft['context'];
+  saving: boolean;
+}
+
+export function useCalendarDraft(events: EventInput[], emptyEvents: EventInput[]) {
+  const context = useDatabaseContext();
+  const setting = useCalendarLayoutSetting();
+  const primary = usePrimaryFieldId();
+  const createRow = useNewRowDispatch();
+  const active = useRef<CalendarEventDraft | null>(null);
+  const [model, setModel] = useState<CalendarEventDraft | null>(null);
+  const [revision, setRevision] = useState(0);
+  const mounted = useRef(true);
+
+  const remove = useCallback((target: CalendarEventDraft) => {
+    if (active.current !== target) return;
+    active.current = null;
+    if (mounted.current) setModel(null);
+    // Wait for the editor to release its row observers before destroying them.
+    setTimeout(() => target.dispose(), 0);
+  }, []);
+
+  const finishDraft = useCallback(
+    async (force = false) => {
+      const target = active.current;
+
+      if (!target) return null;
+      if (context.readOnly || context.canWrite === false) {
+        remove(target);
+        return null;
+      }
+
+      const promise = target.commit(
+        (draft) =>
+          createRow({
+            draft,
+            tailing: true,
+            suppressAutoOpen: true,
+            templateId: target.templateId,
+            skipDefaultTemplate: !target.templateId,
+          }),
+        force
+      );
+
+      if (mounted.current) setRevision((value) => value + 1);
+      try {
+        const id = await promise;
+
+        if (!id) remove(target);
+        return id;
+      } finally {
+        if (mounted.current) setRevision((value) => value + 1);
+        else remove(target);
+      }
+    },
+    [context.readOnly, context.canWrite, createRow, remove]
+  );
+
+  const startDraft = useCallback(
+    (selection: CalendarDraftSelection) => {
+      if (context.readOnly || context.canWrite === false || !setting?.fieldId) return null;
+      // A modal editor owns the active draft. Repeated FullCalendar select
+      // callbacks must not create another one before that editor is dismissed.
+      if (active.current) return active.current.id;
+      const next = new CalendarEventDraft(context, setting.fieldId, selection);
+
+      active.current = next;
+      setModel(next);
+      return next.id;
+    },
+    [context, setting?.fieldId]
+  );
+
+  const discardDraft = useCallback(() => {
+    const target = active.current;
+
+    if (target && !target.saving && !target.savedId) remove(target);
+  }, [remove]);
+
+  useEffect(() => {
+    if (!model) return;
+    const changed = () => setRevision((value) => value + 1);
+
+    model.rowDoc.on('update', changed);
+    model.databaseDoc.on('update', changed);
+    return () => {
+      model.rowDoc.off('update', changed);
+      model.databaseDoc.off('update', changed);
+    };
+  }, [model]);
+
+  useEffect(() => {
+    if (!model) return;
+    const database = context.databaseDoc.getMap(YjsEditorKey.data_section).get(YjsEditorKey.database) as YDatabase;
+    const filters = database.get(YjsDatabaseKey.views).get(context.activeViewId)?.get(YjsDatabaseKey.filters);
+    const isListed = [...events, ...emptyEvents].some((event) => event.id === model.savedId);
+
+    // A saved row may be unscheduled or hidden by the view's filters. Such a
+    // row must not keep a placeholder alive while waiting for a dated event.
+    if (model.savedId && (isListed || (filters?.length ?? 0) > 0)) remove(model);
+    else if (
+      !model.saving &&
+      (context.readOnly || context.canWrite === false || model.context.activeViewId !== context.activeViewId)
+    )
+      remove(model);
+  }, [
+    context.activeViewId,
+    context.databaseDoc,
+    context.readOnly,
+    context.canWrite,
+    events,
+    emptyEvents,
+    model,
+    remove,
+    revision,
+  ]);
+
+  useEffect(() => {
+    mounted.current = true;
+    return () => {
+      mounted.current = false;
+      const target = active.current;
+
+      if (target && !target.saving) remove(target);
+    };
+  }, [remove]);
+
+  const saving = !!model && (model.saving || !!model.savedId);
+  const title = model && primary ? model.cells.get(primary)?.get(YjsDatabaseKey.data) : '';
+  const draft = useMemo<CalendarDraft | null>(
+    () =>
+      model
+        ? {
+            id: model.id,
+            context: { ...model.context, readOnly: saving },
+            saving,
+          }
+        : null,
+    [model, saving]
+  );
+
+  const event = useMemo<EventInput | null>(() => {
+    if (!model) return null;
+    const { start, end, allDay } = model.selection;
+
+    return {
+      id: model.id,
+      title: typeof title === 'string' ? title : '',
+      start,
+      end,
+      allDay,
+      editable: false,
+      classNames: ['fc-event-open'],
+      extendedProps: {
+        rowId: model.id,
+        isDraft: true,
+        isActiveRow: true,
+        isRange: !!end,
+        start,
+        end,
+        includeTime: !allDay,
+      },
+    };
+  }, [model, title]);
+
+  return { draft, event, startDraft, finishDraft, discardDraft };
+}

--- a/src/components/database/fullcalendar/event/CalendarDraftContext.ts
+++ b/src/components/database/fullcalendar/event/CalendarDraftContext.ts
@@ -1,0 +1,13 @@
+import { createContext, useContext } from 'react';
+
+import type { CalendarDraft } from '../draft/useCalendarDraft';
+
+interface CalendarDraftContextValue {
+  draft: CalendarDraft | null;
+  finishDraft: (force?: boolean) => Promise<string | null>;
+  discardDraft: () => void;
+}
+
+export const CalendarDraftContext = createContext<CalendarDraftContextValue | null>(null);
+
+export const useCalendarDraftContext = () => useContext(CalendarDraftContext);

--- a/src/components/database/fullcalendar/event/EventPopoverContent.tsx
+++ b/src/components/database/fullcalendar/event/EventPopoverContent.tsx
@@ -3,7 +3,13 @@ import { uniqBy } from 'lodash-es';
 import { useCallback, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import { FieldType, isAIFieldType, useFieldsSelector, useNavigateToRow, usePrimaryFieldId } from '@/application/database-yjs';
+import {
+  FieldType,
+  isAIFieldType,
+  useFieldsSelector,
+  useNavigateToRow,
+  usePrimaryFieldId,
+} from '@/application/database-yjs';
 import { Cell } from '@/application/database-yjs/cell.type';
 import { useReadOnly } from '@/application/database-yjs/context';
 import { useDuplicateRowDispatch } from '@/application/database-yjs/dispatch';
@@ -11,8 +17,8 @@ import { ReactComponent as CloseIcon } from '@/assets/icons/close.svg';
 import { ReactComponent as DeleteIcon } from '@/assets/icons/delete.svg';
 import { ReactComponent as DuplicateIcon } from '@/assets/icons/duplicate.svg';
 import { ReactComponent as ExpandMoreIcon } from '@/assets/icons/full_screen.svg';
-import RowPropertyPrimitive from '@/components/database/components/database-row/RowPropertyPrimitive';
 import { useAIEnabled } from '@/components/app/app.hooks';
+import RowPropertyPrimitive from '@/components/database/components/database-row/RowPropertyPrimitive';
 import { EventTitle } from '@/components/database/fullcalendar/event/EventTitle';
 import { Button } from '@/components/ui/button';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
@@ -25,8 +31,14 @@ function EventPopoverContent({
   onCloseEvent,
   onGotoDate,
   onRequestDelete,
+  onSubmit,
+  onExpand,
+  isDraft = false,
 }: {
   rowId: string;
+  isDraft?: boolean;
+  onSubmit?: () => void;
+  onExpand?: () => void;
   onCloseEvent: () => void;
   onGotoDate: (date: Date) => void;
   onRequestDelete: () => void;
@@ -77,20 +89,24 @@ function EventPopoverContent({
   const handleCellUpdated = useCallback(
     (cell: Cell) => {
       if (cell.fieldType === FieldType.DateTime) {
+        if (isDraft) return;
         markEventAsUpdate(rowId);
         if (cell.data) {
           onGotoDate(dayjs.unix(Number(cell.data)).toDate());
         }
       }
     },
-    [markEventAsUpdate, onGotoDate, rowId]
+    [isDraft, markEventAsUpdate, onGotoDate, rowId]
   );
 
   return (
-    <div className={'appflowy-scroller max-h-[560px] w-[360px] overflow-y-auto px-3 py-2'}>
+    <div
+      data-testid={isDraft ? 'calendar-event-draft-editor' : undefined}
+      className={'appflowy-scroller max-h-[560px] w-[360px] overflow-y-auto px-3 py-2'}
+    >
       <div className={'sticky top-0 flex w-full items-center justify-end gap-1'}>
         {/* Duplicate button */}
-        {!readOnly && (
+        {!readOnly && !isDraft && (
           <Tooltip>
             <TooltipTrigger asChild>
               <Button variant='ghost' size='icon' onClick={handleDuplicate}>
@@ -104,7 +120,13 @@ function EventPopoverContent({
         {!readOnly && (
           <Tooltip>
             <TooltipTrigger asChild>
-              <Button data-testid='calendar-event-delete' variant='ghost' size='icon' className='hover:text-text-error' onClick={handleDelete}>
+              <Button
+                data-testid='calendar-event-delete'
+                variant='ghost'
+                size='icon'
+                className='hover:text-text-error'
+                onClick={handleDelete}
+              >
                 <DeleteIcon className='h-5 w-5' />
               </Button>
             </TooltipTrigger>
@@ -120,6 +142,11 @@ function EventPopoverContent({
               variant={'ghost'}
               onClick={(e) => {
                 e.stopPropagation();
+                if (onExpand) {
+                  onExpand();
+                  return;
+                }
+
                 onCloseEvent();
                 navigateToRow?.(rowId);
               }}
@@ -141,7 +168,9 @@ function EventPopoverContent({
         </Tooltip>
       </div>
       <div className={'event-properties flex w-full flex-1 flex-col overflow-y-auto px-0.5'}>
-        {primaryFieldId && <EventTitle onCloseEvent={onCloseEvent} rowId={rowId} fieldId={primaryFieldId} />}
+        {primaryFieldId && (
+          <EventTitle onSubmit={onSubmit} onCloseEvent={onCloseEvent} rowId={rowId} fieldId={primaryFieldId} />
+        )}
         {filteredFields.map((field) => {
           return (
             <RowPropertyPrimitive
@@ -152,6 +181,7 @@ function EventPopoverContent({
               key={field.fieldId}
               onCellUpdated={handleCellUpdated}
               showPropertyName={false}
+              disableFieldEditing={isDraft}
             />
           );
         })}

--- a/src/components/database/fullcalendar/event/EventTitle.tsx
+++ b/src/components/database/fullcalendar/event/EventTitle.tsx
@@ -1,12 +1,21 @@
-import { memo, useRef } from "react";
+import { memo, useRef } from 'react';
 
-import { useCellSelector, useReadOnly, useUpdateCellDispatch } from "@/application/database-yjs";
-import { TextCell } from "@/application/database-yjs/cell.type";
-import { Input } from "@/components/ui/input";
-
+import { useCellSelector, useReadOnly, useUpdateCellDispatch } from '@/application/database-yjs';
+import { TextCell } from '@/application/database-yjs/cell.type';
+import { Input } from '@/components/ui/input';
 
 export const EventTitle = memo(
-  ({ rowId, fieldId, onCloseEvent }: { rowId: string; fieldId: string; onCloseEvent?: () => void }) => {
+  ({
+    rowId,
+    fieldId,
+    onCloseEvent,
+    onSubmit,
+  }: {
+    rowId: string;
+    fieldId: string;
+    onCloseEvent?: () => void;
+    onSubmit?: () => void;
+  }) => {
     const readOnly = useReadOnly();
     const cell = useCellSelector({ rowId, fieldId }) as TextCell;
     const value = cell?.data;
@@ -16,6 +25,7 @@ export const EventTitle = memo(
     return (
       <div className='flex w-full items-center gap-2'>
         <Input
+          data-testid='calendar-event-title-input'
           readOnly={readOnly}
           autoFocus
           ref={inputRef}
@@ -24,10 +34,10 @@ export const EventTitle = memo(
               e.stopPropagation();
               e.preventDefault();
               updateCell((e.target as HTMLInputElement).value);
-              onCloseEvent?.();
+              (onSubmit ?? onCloseEvent)?.();
             }
           }}
-          value={value}
+          value={value ?? ''}
           onChange={(e) => {
             updateCell(e.target.value);
           }}

--- a/src/components/database/fullcalendar/event/EventWithPopover.tsx
+++ b/src/components/database/fullcalendar/event/EventWithPopover.tsx
@@ -1,11 +1,14 @@
 import { EventApi, EventContentArg } from '@fullcalendar/core';
 import { memo, useCallback, useEffect, useState } from 'react';
+import { toast } from 'sonner';
 
+import { DatabaseContext, useNavigateToRow } from '@/application/database-yjs/context';
 import DeleteRowConfirm from '@/components/database/components/database-row/DeleteRowConfirm';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 
 import { useEventContext } from '../CalendarContent';
 
+import { useCalendarDraftContext } from './CalendarDraftContext';
 import { EventDisplay } from './EventDisplay';
 import EventPopoverContent from './EventPopoverContent';
 
@@ -15,7 +18,7 @@ interface EventWithPopoverProps {
   isWeekView?: boolean;
 }
 
-export const EventWithPopover = memo(({ event, eventInfo, isWeekView = false }: EventWithPopoverProps) => {
+const PersistedEventWithPopover = memo(({ event, eventInfo, isWeekView = false }: EventWithPopoverProps) => {
   const [isOpen, setIsOpen] = useState(false);
   const [deleteConfirmationPending, setDeleteConfirmationPending] = useState(false);
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
@@ -129,5 +132,97 @@ export const EventWithPopover = memo(({ event, eventInfo, isWeekView = false }: 
     </>
   );
 });
+
+export const EventWithPopover = memo((props: EventWithPopoverProps) => {
+  const draftContext = useCalendarDraftContext();
+  const navigateToRow = useNavigateToRow();
+  const draft = draftContext?.draft;
+
+  if (draftContext && props.event.extendedProps.isDraft && draft?.id === props.event.id) {
+    return (
+      <DatabaseContext.Provider value={draft.context}>
+        <DraftEventWithPopover
+          {...props}
+          saving={draft.saving}
+          finish={draftContext.finishDraft}
+          discard={draftContext.discardDraft}
+          navigateToRow={navigateToRow}
+        />
+      </DatabaseContext.Provider>
+    );
+  }
+
+  return <PersistedEventWithPopover {...props} />;
+});
+
+function DraftEventWithPopover({
+  event,
+  eventInfo,
+  isWeekView,
+  saving,
+  finish,
+  discard,
+  navigateToRow,
+}: EventWithPopoverProps & {
+  saving: boolean;
+  finish: (force?: boolean) => Promise<string | null>;
+  discard: () => void;
+  navigateToRow?: (id: string) => void;
+}) {
+  const [open, setOpen] = useState(eventInfo.isStart);
+  const complete = useCallback(
+    async (force = false, expand = false) => {
+      if (saving) return;
+      try {
+        const id = await finish(force);
+
+        setOpen(false);
+        if (expand && id) navigateToRow?.(id);
+      } catch (error) {
+        toast.error(error instanceof Error ? error.message : String(error));
+      }
+    },
+    [finish, navigateToRow, saving]
+  );
+
+  return (
+    <div className='relative h-full w-full' data-testid='calendar-draft-event' data-event-id={event.id}>
+      <EventDisplay event={event} eventInfo={eventInfo} isWeekView={isWeekView} onClick={() => setOpen(true)} />
+      {open && (
+        <Popover
+          open
+          modal
+          onOpenChange={(next) => {
+            if (!next) void complete();
+          }}
+        >
+          <PopoverTrigger asChild>
+            <div className='absolute left-0 top-0 h-full w-full' />
+          </PopoverTrigger>
+          <PopoverContent
+            collisionPadding={20}
+            side='left'
+            align='center'
+            sideOffset={8}
+            onCloseAutoFocus={(event) => event.preventDefault()}
+          >
+            <EventPopoverContent
+              rowId={event.id}
+              isDraft
+              onCloseEvent={() => void complete()}
+              onSubmit={() => void complete(true)}
+              onExpand={() => void complete(true, true)}
+              onRequestDelete={() => {
+                discard();
+                setOpen(false);
+              }}
+              onGotoDate={() => undefined}
+            />
+          </PopoverContent>
+        </Popover>
+      )}
+    </div>
+  );
+}
 
 export default EventWithPopover;

--- a/src/components/database/fullcalendar/event/__tests__/EventWithPopover.test.tsx
+++ b/src/components/database/fullcalendar/event/__tests__/EventWithPopover.test.tsx
@@ -16,6 +16,11 @@ jest.mock('@/application/database-yjs', () => ({
   useDatabaseViewLayout: () => undefined,
 }));
 
+jest.mock('@/application/database-yjs/context', () => ({
+  ...jest.requireActual('@/application/database-yjs/context'),
+  useNavigateToRow: () => undefined,
+}));
+
 jest.mock('@/application/database-yjs/dispatch', () => ({
   useTrashAwareDeleteRowsDispatch: () => mockDeleteRows,
 }));

--- a/src/components/database/fullcalendar/hooks/useAddButton.ts
+++ b/src/components/database/fullcalendar/hooks/useAddButton.ts
@@ -41,7 +41,10 @@ export function useAddButton({
         const dateAttr = dayCell.getAttribute('data-date');
 
         if (dateAttr) {
-          const date = new Date(dateAttr);
+          // FullCalendar's date-only attributes describe a local calendar day.
+          // Parsing them as ISO dates would shift west-of-UTC users to yesterday.
+          const [year, month, day] = dateAttr.split('-').map(Number);
+          const date = new Date(year, month - 1, day);
           
           // Check if add button should be enabled for this date
           const enabled = isAddButtonEnabled ? isAddButtonEnabled(date) : true;


### PR DESCRIPTION
### Description

Clicking an empty calendar day, time slot, or hover add button now opens a local placeholder. Escape or outside dismissal removes an untouched card without inserting a row or syncing it to the server. Editing the title or properties commits the card on dismissal; Enter and expand explicitly keep an untitled card.

The draft reuses existing field editors in isolated Yjs documents and shares template/filter initialization with normal row creation. Attachments and option edits stay local until commit, existing related rows remain selectable, and draft actions cannot create related rows or change field configuration. The saved card retains its UUID, and the calendar keeps its grid and scroll position during the handoff. Save retries, unscheduled cards, and disposal during pending saves are covered.

### Validation

Tested on macOS with Chromium against local AppFlowy Cloud using real GoTrue accounts.

- Two Playwright BDD scenarios pass: month/week dismissal, edited and explicit submission, property-only edits, cloud row snapshots, fresh-session persistence, and unchanged grid/scroll position.
- 78 focused Jest tests pass across eight suites.
- All 16 active existing calendar tests pass across runs; one existing skipped test remains. Three failures during source reload/setup passed in isolated reruns after source edits stopped.
- Application TypeScript, targeted strict TypeScript for Playwright files, ESLint for changed source files, and `git diff --check` pass.

BDD feature: [`calendar-placeholder.feature`](https://github.com/AppFlowy-IO/AppFlowy-Web/blob/codex/calendar-placeholder-drafts/playwright/bdd/features/database/calendar-placeholder.feature).

Generate and run against a configured local web/cloud environment:

```sh
pnpm exec bddgen test -c playwright.bdd.config.ts
pnpm exec playwright test -c playwright.bdd.config.ts --grep @calendar-placeholder --workers=1
```

### Checklist

- [x] Relevant behavior and lifecycle constraints are documented in comments and BDD scenarios.
- [ ] Tested in multiple browser/OS environments (Chromium on macOS only).
- [x] Added and updated regression tests.
- [x] Verified integration with existing calendar behavior.
